### PR TITLE
feat(codegen): let/const scope semantics (#44)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Fixture files are compared byte-for-byte — keep LF across platforms.
+tests/fixtures/*.out text eol=lf
+tests/fixtures/*.ts  text eol=lf

--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -73,6 +73,8 @@ impl TypedVal {
 pub struct LocalVar {
     pub var: Variable,
     pub ty: ValTy,
+    /// True when declared with `const` — reassignment must be rejected.
+    pub is_const: bool,
 }
 
 /// Module-scope global lowered to a data symbol.
@@ -96,8 +98,9 @@ pub struct FnCtx<'m, 'fb> {
     pub extern_cache: &'fb mut HashMap<&'static str, cranelift_module::FuncId>,
     pub data_counter: &'fb mut u32,
 
-    /// Local variables in scope.
-    pub locals: HashMap<String, LocalVar>,
+    /// Stack of scopes. The first entry is the function scope (where `var`
+    /// declarations live); subsequent entries are block scopes for `let`/`const`.
+    pub locals: Vec<HashMap<String, LocalVar>>,
     /// Module-scope globals visible from functions.
     pub globals: &'fb HashMap<String, GlobalVar>,
     /// User-defined function signatures by source name.
@@ -127,7 +130,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             module,
             extern_cache,
             data_counter,
-            locals: HashMap::new(),
+            locals: vec![HashMap::new()],
             globals,
             user_fns,
             module_scope,
@@ -142,16 +145,54 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         self.builder.declare_var(ty.cl_type())
     }
 
-    /// Declares a named local and initializes it.
+    /// Pushes a new block scope. Variables declared with `let`/`const` go here.
+    pub fn push_scope(&mut self) {
+        self.locals.push(HashMap::new());
+    }
+
+    /// Pops the current block scope.
+    pub fn pop_scope(&mut self) {
+        if self.locals.len() > 1 {
+            self.locals.pop();
+        }
+    }
+
+    /// Declares a named local in the current (top-most) scope.
     pub fn declare_local(&mut self, name: &str, ty: ValTy, init: Value) {
+        self.declare_local_kind(name, ty, init, false, false);
+    }
+
+    /// Declares a named local with control over mutability and scope target.
+    ///
+    /// `function_scope = true` places the binding in the function-level scope
+    /// (used for `var`); otherwise it lands in the current block scope.
+    pub fn declare_local_kind(
+        &mut self,
+        name: &str,
+        ty: ValTy,
+        init: Value,
+        is_const: bool,
+        function_scope: bool,
+    ) {
         let var = self.new_var(ty);
         self.builder.def_var(var, init);
-        self.locals.insert(name.to_string(), LocalVar { var, ty });
+        let slot = LocalVar { var, ty, is_const };
+        let idx = if function_scope { 0 } else { self.locals.len() - 1 };
+        self.locals[idx].insert(name.to_string(), slot);
+    }
+
+    fn find_local(&self, name: &str) -> Option<LocalVar> {
+        for scope in self.locals.iter().rev() {
+            if let Some(slot) = scope.get(name) {
+                return Some(slot.clone());
+            }
+        }
+        None
     }
 
     /// Reads a named local or module global.
     pub fn read_local(&mut self, name: &str) -> Option<TypedVal> {
-        if let Some(local) = self.locals.get(name).cloned() {
+        if let Some(local) = self.find_local(name) {
             let val = self.builder.use_var(local.var);
             return Some(TypedVal::new(val, local.ty));
         }
@@ -173,7 +214,10 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
 
     /// Writes to a named local or module global.
     pub fn write_local(&mut self, name: &str, val: Value) -> Result<()> {
-        if let Some(local) = self.locals.get(name).cloned() {
+        if let Some(local) = self.find_local(name) {
+            if local.is_const {
+                return Err(anyhow!("assignment to const variable `{name}`"));
+            }
             self.builder.def_var(local.var, val);
             return Ok(());
         }
@@ -196,8 +240,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
 
     /// Returns the declared type of a local/global variable.
     pub fn var_ty(&self, name: &str) -> Option<ValTy> {
-        self.locals
-            .get(name)
+        self.find_local(name)
             .map(|local| local.ty)
             .or_else(|| self.globals.get(name).map(|global| global.ty))
     }

--- a/src/codegen/lower/stmt.rs
+++ b/src/codegen/lower/stmt.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Result, anyhow};
 use cranelift_codegen::ir::{InstBuilder, condcodes::IntCC, types as cl};
-use swc_ecma_ast::{BlockStmt, Decl, Pat, Stmt, VarDeclOrExpr};
+use swc_ecma_ast::{BlockStmt, Decl, Pat, Stmt, VarDeclKind, VarDeclOrExpr};
 
 use super::ctx::{FnCtx, TypedVal, ValTy};
 use super::expr::lower_expr;
@@ -67,7 +67,9 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
                     // Top-level declarations initialize module globals.
                     ctx.write_local(&name, init_coerced)?;
                 } else {
-                    ctx.declare_local(&name, ty, init_coerced);
+                    let is_const = matches!(var_decl.kind, VarDeclKind::Const);
+                    let function_scope = matches!(var_decl.kind, VarDeclKind::Var);
+                    ctx.declare_local_kind(&name, ty, init_coerced, is_const, function_scope);
                 }
             }
             Ok(false)
@@ -378,13 +380,27 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
 }
 
 pub fn lower_block(ctx: &mut FnCtx, block: &BlockStmt) -> Result<bool> {
+    ctx.push_scope();
+    let mut exited = false;
+    let mut err = None;
     for s in &block.stmts {
-        let exits = lower_stmt(ctx, s)?;
-        if exits {
-            return Ok(true);
+        match lower_stmt(ctx, s) {
+            Ok(true) => {
+                exited = true;
+                break;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                err = Some(e);
+                break;
+            }
         }
     }
-    Ok(false)
+    ctx.pop_scope();
+    if let Some(e) = err {
+        return Err(e);
+    }
+    Ok(exited)
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -99,3 +99,8 @@ fn fixture_string_concat() {
 fn fixture_template_literals() {
     run_fixture("template_literals");
 }
+
+#[test]
+fn fixture_let_const_var() {
+    run_fixture("let_const_var");
+}

--- a/tests/fixtures/let_const_var.out
+++ b/tests/fixtures/let_const_var.out
@@ -1,0 +1,5 @@
+inner: 2
+outer: 1
+b = 20
+c = 3
+v = 7

--- a/tests/fixtures/let_const_var.ts
+++ b/tests/fixtures/let_const_var.ts
@@ -1,0 +1,24 @@
+import { io } from "rts";
+
+function main() {
+  let a = 1;
+  {
+    let a = 2;
+    io.print(`inner: ${a}`);
+  }
+  io.print(`outer: ${a}`);
+
+  let b = 10;
+  b = 20;
+  io.print(`b = ${b}`);
+
+  const c = 3;
+  io.print(`c = ${c}`);
+
+  {
+    var v = 7;
+  }
+  io.print(`v = ${v}`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Implementa semântica de escopo para `let`/`const`/`var` (issue #44 — P0-blocker).

- **Scope stack**: `FnCtx.locals` agora é `Vec<HashMap<String, LocalVar>>`. `lower_block` chama `push_scope`/`pop_scope`.
- **`let`/`const`**: declarações vão para o scope atual (do bloco). Saem do escopo no fim do bloco.
- **`const`**: `LocalVar.is_const` sinalizado pelo `VarDeclKind`; `write_local` rejeita `assignment to const variable ...`.
- **`var`**: vai direto para o scope de função (índice 0) — hoisting clássico, vaza de blocos internos.
- **Shadowing**: `let` no bloco sombreia outer; quando o bloco fecha, o nome original volta.

## Cobertura

Fixture `let_const_var` cobre:
- Shadowing: outer=1, inner=2, outer=1 após bloco
- Reassign de `let`: `b = 20` ok
- `const`: usado sem reassign
- `var` declarado em bloco e lido fora da função — v=7

Erros de compilação validados manualmente (não cabem no framework de fixture `.out`):
- `const y = 42; y = 99` → `assignment to const variable y`
- `let x` em bloco, uso fora → `undefined variable x`

Fora de escopo (não bloqueia a feature):
- TDZ real (erro em uso antes da decl — hoje cai no catch-all `undefined variable`)
- Top-level `let`/`const` em `main` ainda usa globals do módulo (comportamento pré-existente do pipeline)

## Bonus

- `chore: pin fixture files to LF` + regrava `template_literals.out` em LF, consertando regressão em Windows por `autocrlf`.

## Arquivos

- `src/codegen/lower/ctx.rs` — scope stack, `push_scope`/`pop_scope`, `declare_local_kind`, `find_local`, check de `is_const` em `write_local`
- `src/codegen/lower/stmt.rs` — `VarDecl` lê `VarDeclKind` e decide (const/fn-scope); `lower_block` faz push/pop
- `tests/fixtures/let_const_var.{ts,out}` + test em `codegen_fixtures.rs`
- `.gitattributes` — `tests/fixtures/*` pinned em LF

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --test codegen_fixtures` — `fixture_let_const_var` e `fixture_template_literals` passam
- [x] `rts run` valida const-error, let-block-escape, shadowing, var-hoist
- [ ] Revisar se TDZ merece follow-up próprio

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)