### PR TITLE
feat(parser,codegen): function expressions (#56)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -107,6 +107,9 @@ pub struct FnCtx<'m, 'fb> {
     pub user_fns: &'fb HashMap<String, UserFnAbi>,
     /// True when lowering top-level statements in `main`.
     pub module_scope: bool,
+    /// Declared return type of the surrounding function, used to coerce
+    /// `return <expr>` to the correct Cranelift type.
+    pub return_ty: Option<ValTy>,
 
     /// Cranelift variable counter.
     var_counter: u32,
@@ -134,6 +137,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             globals,
             user_fns,
             module_scope,
+            return_ty: None,
             var_counter: 0,
             loop_stack: Vec::new(),
         }
@@ -387,6 +391,21 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
                 let as_i64 = self.builder.ins().fcvt_to_sint_sat(cl::I64, tv.val);
                 TypedVal::new(self.builder.ins().ireduce(cl::I32, as_i64), ValTy::I32)
             }
+        }
+    }
+
+    /// Coerces a value to F64.
+    pub fn coerce_to_f64(&mut self, tv: TypedVal) -> TypedVal {
+        match tv.ty {
+            ValTy::F64 => tv,
+            ValTy::I32 => TypedVal::new(
+                self.builder.ins().fcvt_from_sint(cl::F64, tv.val),
+                ValTy::F64,
+            ),
+            ValTy::I64 | ValTy::Bool | ValTy::Handle => TypedVal::new(
+                self.builder.ins().fcvt_from_sint(cl::F64, tv.val),
+                ValTy::F64,
+            ),
         }
     }
 

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -346,6 +346,7 @@ fn compile_user_fn(
             user_fns,
             false,
         );
+        fn_ctx.return_ty = info.ret;
 
         // Bind parameters as locals.
         for (i, param) in fn_decl.parameters.iter().enumerate() {

--- a/src/codegen/lower/stmt.rs
+++ b/src/codegen/lower/stmt.rs
@@ -345,8 +345,14 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
         Stmt::Return(ret_stmt) => {
             if let Some(arg) = &ret_stmt.arg {
                 let tv = lower_expr(ctx, arg)?;
-                let as_i64 = ctx.coerce_to_i64(tv);
-                ctx.builder.ins().return_(&[as_i64.val]);
+                let coerced = match ctx.return_ty {
+                    Some(ValTy::I32) => ctx.coerce_to_i32(tv),
+                    Some(ValTy::F64) => ctx.coerce_to_f64(tv),
+                    Some(ValTy::Handle) => ctx.coerce_to_handle(tv)?,
+                    // Default and I64/Bool lanes share i64 storage.
+                    _ => ctx.coerce_to_i64(tv),
+                };
+                ctx.builder.ins().return_(&[coerced.val]);
             } else {
                 ctx.builder.ins().return_(&[]);
             }

--- a/src/parser/lowering_items.rs
+++ b/src/parser/lowering_items.rs
@@ -83,12 +83,78 @@ fn lower_decl(cm: &Lrc<SourceMap>, decl: &Decl, out: &mut Vec<Item>) {
         Decl::TsInterface(interface_decl) => {
             out.push(Item::Interface(lower_interface_decl(cm, interface_decl)));
         }
+        Decl::Var(var_decl) if try_lower_fn_expr_decl(cm, var_decl, out) => {
+            // All declarators were function/arrow expressions and have been
+            // emitted as Item::Function above.
+        }
         _ => {
             // Preserve non-function/class declarations (e.g. let/const) as a
             // real SWC statement so codegen can lower module-scope globals.
             let stmt = Stmt::Decl(decl.clone());
             push_raw_statement_with_stmt(cm, decl.span(), Some(&stmt), out);
         }
+    }
+}
+
+/// Rewrites `const NAME = function(...) { ... }` (or arrow with block body)
+/// into a synthetic `Item::Function` so callers can invoke it like a regular
+/// named function. Returns true only if *every* declarator was a supported
+/// function expression; otherwise the caller falls back to the statement path.
+fn try_lower_fn_expr_decl(cm: &Lrc<SourceMap>, var_decl: &VarDecl, out: &mut Vec<Item>) -> bool {
+    let mut pending = Vec::new();
+    for decl in &var_decl.decls {
+        let Pat::Ident(binding) = &decl.name else {
+            return false;
+        };
+        let Some(init) = &decl.init else {
+            return false;
+        };
+        let name = binding.id.sym.to_string();
+
+        match init.as_ref() {
+            Expr::Fn(fn_expr) => {
+                let span = fn_expr.function.span;
+                pending.push(lower_function(cm, &name, &fn_expr.function, span));
+            }
+            Expr::Arrow(arrow) if matches!(&*arrow.body, swc_ecma_ast::BlockStmtOrExpr::BlockStmt(_)) => {
+                let synthetic = arrow_to_function(arrow);
+                pending.push(lower_function(cm, &name, &synthetic, arrow.span));
+            }
+            _ => return false,
+        }
+    }
+    for fn_decl in pending {
+        out.push(Item::Function(fn_decl));
+    }
+    true
+}
+
+/// Builds a `swc_ecma_ast::Function` from an `ArrowExpr` so it can flow
+/// through the same lowering path as regular function declarations.
+fn arrow_to_function(arrow: &ArrowExpr) -> SwcFunction {
+    let body = match &*arrow.body {
+        swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => Some(block.clone()),
+        _ => None,
+    };
+    let params = arrow
+        .params
+        .iter()
+        .map(|pat| swc_ecma_ast::Param {
+            span: pat.span(),
+            decorators: Vec::new(),
+            pat: pat.clone(),
+        })
+        .collect();
+    SwcFunction {
+        params,
+        decorators: Vec::new(),
+        span: arrow.span,
+        ctxt: arrow.ctxt,
+        body,
+        is_generator: false,
+        is_async: arrow.is_async,
+        type_params: arrow.type_params.clone(),
+        return_type: arrow.return_type.clone(),
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,12 +5,12 @@ pub mod span;
 use anyhow::{Result, anyhow};
 use swc_common::{FileName, SourceMap, SourceMapper, Span as SwcSpan, Spanned, sync::Lrc};
 use swc_ecma_ast::{
-    Accessibility, BlockStmt, Class as SwcClass, ClassDecl as SwcClassDecl,
+    Accessibility, ArrowExpr, BlockStmt, Class as SwcClass, ClassDecl as SwcClassDecl,
     ClassMember as SwcClassMember, Decl, DefaultDecl, Expr, FnDecl as SwcFnDecl,
     Function as SwcFunction, ImportDecl as SwcImportDecl, ImportSpecifier, Lit, ModuleDecl,
     ModuleExportName, ModuleItem, Param as SwcParam, ParamOrTsParamProp, Pat,
     Program as SwcProgram, PropName, Stmt, TsInterfaceDecl as SwcTsInterfaceDecl, TsParamProp,
-    TsParamPropParam, TsTypeAnn, TsTypeElement,
+    TsParamPropParam, TsTypeAnn, TsTypeElement, VarDecl,
 };
 use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
 

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -104,3 +104,8 @@ fn fixture_template_literals() {
 fn fixture_let_const_var() {
     run_fixture("let_const_var");
 }
+
+#[test]
+fn fixture_function_expressions() {
+    run_fixture("function_expressions");
+}

--- a/tests/fixtures/function_expressions.out
+++ b/tests/fixtures/function_expressions.out
@@ -1,0 +1,4 @@
+hello world
+hello RTS
+double(5) = 10
+triple(7) = 21

--- a/tests/fixtures/function_expressions.ts
+++ b/tests/fixtures/function_expressions.ts
@@ -1,0 +1,18 @@
+import { io } from "rts";
+
+const greet = function(name: string): void {
+  io.print(`hello ${name}`);
+};
+
+const double = function doubleImpl(n: i32): i32 {
+  return n * 2;
+};
+
+const triple = (n: i32): i32 => {
+  return n * 3;
+};
+
+greet("world");
+greet("RTS");
+io.print(`double(5) = ${double(5)}`);
+io.print(`triple(7) = ${triple(7)}`);


### PR DESCRIPTION
## Summary

Implementa function expressions atribuídas a bindings (#56 — P0-blocker) + fix de um bug preexistente no `return`.

### Function expressions

`const NAME = function(...) { ... }` e `const NAME = (...) => { ... }` (arrow com bloco) são interceptados no parser e reescritos como `Item::Function`, reutilizando toda a pipeline existente de `declare_user_fn`/`compile_user_fn`. Nome interno da forma `function fImpl()` é ignorado — o binding externo vence.

### Fix colateral: return com tipo

Return sempre coerçava para `i64`, quebrando qualquer função com assinatura `: i32` ou `: number` (F64) — bug reprodutível na main. Agora `FnCtx.return_ty` propaga o tipo declarado e `Stmt::Return` coerça corretamente. Inclui `coerce_to_f64`.

Sem esse fix, o fixture novo não compila — por isso vai junto.

## Cobertura

Fixture `function_expressions`:
- Anônima: `const greet = function(name: string): void { ... }`
- Nomeada inline: `const double = function doubleImpl(n: i32): i32 { ... }`
- Arrow com bloco: `const triple = (n: i32): i32 => { ... }`

## Fora de escopo (follow-ups)

- IIFE `(function(){})()` — `Expr::Fn` em posição de callee continua caindo em `unsupported expression kind`
- Closures (captura do outer scope)
- Arrow expression sem bloco: `(x) => x + 1`

## Arquivos

- `src/parser/mod.rs` — import de `ArrowExpr`, `VarDecl`
- `src/parser/lowering_items.rs` — `try_lower_fn_expr_decl`, `arrow_to_function`
- `src/codegen/lower/ctx.rs` — `FnCtx.return_ty`, `coerce_to_f64`
- `src/codegen/lower/func.rs` — seta `return_ty` no contexto
- `src/codegen/lower/stmt.rs` — `Stmt::Return` coerça pro tipo certo
- `tests/fixtures/function_expressions.{ts,out}` + test

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --test codegen_fixtures` — `fixture_function_expressions` passa (3 passed, 7 falhas pré-existentes)
- [x] Fixtures anteriores (`template_literals`, `let_const_var`) continuam passando
- [ ] Avaliar se o fix de return merece PR separado para ficar cirúrgico

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)