### PR TITLE
feat(parser): arrow functions (#55)

### DIFF
--- a/src/parser/lowering_items.rs
+++ b/src/parser/lowering_items.rs
@@ -116,7 +116,7 @@ fn try_lower_fn_expr_decl(cm: &Lrc<SourceMap>, var_decl: &VarDecl, out: &mut Vec
                 let span = fn_expr.function.span;
                 pending.push(lower_function(cm, &name, &fn_expr.function, span));
             }
-            Expr::Arrow(arrow) if matches!(&*arrow.body, swc_ecma_ast::BlockStmtOrExpr::BlockStmt(_)) => {
+            Expr::Arrow(arrow) => {
                 let synthetic = arrow_to_function(arrow);
                 pending.push(lower_function(cm, &name, &synthetic, arrow.span));
             }
@@ -131,10 +131,24 @@ fn try_lower_fn_expr_decl(cm: &Lrc<SourceMap>, var_decl: &VarDecl, out: &mut Vec
 
 /// Builds a `swc_ecma_ast::Function` from an `ArrowExpr` so it can flow
 /// through the same lowering path as regular function declarations.
+///
+/// For expression-bodied arrows (`(x) => x * 2`) the single expression is
+/// wrapped in a synthetic `{ return <expr>; }` so downstream codegen only
+/// needs to know how to handle block-bodied functions.
 fn arrow_to_function(arrow: &ArrowExpr) -> SwcFunction {
     let body = match &*arrow.body {
         swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => Some(block.clone()),
-        _ => None,
+        swc_ecma_ast::BlockStmtOrExpr::Expr(expr) => {
+            let return_stmt = Stmt::Return(swc_ecma_ast::ReturnStmt {
+                span: arrow.span,
+                arg: Some(expr.clone()),
+            });
+            Some(BlockStmt {
+                span: arrow.span,
+                ctxt: arrow.ctxt,
+                stmts: vec![return_stmt],
+            })
+        }
     };
     let params = arrow
         .params

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -109,3 +109,8 @@ fn fixture_let_const_var() {
 fn fixture_function_expressions() {
     run_fixture("function_expressions");
 }
+
+#[test]
+fn fixture_arrow_functions() {
+    run_fixture("arrow_functions");
+}

--- a/tests/fixtures/arrow_functions.out
+++ b/tests/fixtures/arrow_functions.out
@@ -1,0 +1,5 @@
+double(5) = 10
+sum(3, 4) = 7
+hello arrow
+answer = 42
+triple(7) = 21

--- a/tests/fixtures/arrow_functions.ts
+++ b/tests/fixtures/arrow_functions.ts
@@ -1,0 +1,16 @@
+import { io } from "rts";
+
+const double = (x: i32): i32 => x * 2;
+const sum = (a: i32, b: i32): i32 => a + b;
+const greet = (name: string): string => `hello ${name}`;
+const answer = (): i32 => 42;
+
+const triple = (x: i32): i32 => {
+  return x * 3;
+};
+
+io.print(`double(5) = ${double(5)}`);
+io.print(`sum(3, 4) = ${sum(3, 4)}`);
+io.print(greet("arrow"));
+io.print(`answer = ${answer()}`);
+io.print(`triple(7) = ${triple(7)}`);


### PR DESCRIPTION
## Summary

Completa suporte a arrow functions (#55 — P0-blocker). O PR #56 já fez block-body; este adiciona expression-body envolvendo a expressão em `{ return <expr>; }` sintético.

## Cobertura (fixture arrow_functions)

- Expr-body: `(x) => x * 2`
- Multi-param: `(a, b) => a + b`
- Zero-param: `() => 42`
- Retorno de string/template
- Block-body (regressão do PR #56)

## Fora de escopo

- Closures (captura do escopo externo)
- Arrow como callback (`arr.map(x => x * 2)`) — depende de first-class function values / arrays (#54)

## Arquivos

- `src/parser/lowering_items.rs` — `arrow_to_function` agora trata `BlockStmtOrExpr::Expr`; `try_lower_fn_expr_decl` aceita arrow sem restrição de body
- `tests/fixtures/arrow_functions.{ts,out}` + test

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --test codegen_fixtures` — 4 passed (incluindo `fixture_arrow_functions`), 7 falhas pré-existentes

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)