### PR TITLE
feat(codegen): bitwise operators (#47)

### DIFF
--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -171,6 +171,13 @@ fn lower_unary(ctx: &mut FnCtx, u: &swc_ecma_ast::UnaryExpr) -> Result<TypedVal>
             // Numeric identity — coerce to i64 if needed
             Ok(ctx.coerce_to_i64(operand))
         }
+        UnaryOp::Tilde => {
+            let as_i64 = ctx.coerce_to_i64(operand);
+            Ok(TypedVal::new(
+                ctx.builder.ins().bnot(as_i64.val),
+                ValTy::I64,
+            ))
+        }
         op => Err(anyhow!("unsupported unary op: {op:?}")),
     }
 }
@@ -306,6 +313,33 @@ fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
             TypedVal::new(rv, ty),
         )),
 
+        // Bitwise — always operate on i64. JS spec truncates to i32 but the
+        // rest of the codebase works in i64; matching existing conventions.
+        BinaryOp::BitAnd => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().band(li, ri), ValTy::I64))
+        }
+        BinaryOp::BitOr => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().bor(li, ri), ValTy::I64))
+        }
+        BinaryOp::BitXor => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().bxor(li, ri), ValTy::I64))
+        }
+        BinaryOp::LShift => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().ishl(li, ri), ValTy::I64))
+        }
+        BinaryOp::RShift => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().sshr(li, ri), ValTy::I64))
+        }
+        BinaryOp::ZeroFillRShift => {
+            let (li, ri) = (coerce_bits_i64(ctx, lv, ty), coerce_bits_i64(ctx, rv, ty));
+            Ok(TypedVal::new(ctx.builder.ins().ushr(li, ri), ValTy::I64))
+        }
+
         op => Err(anyhow!("unsupported binary op: {op:?}")),
     }
 }
@@ -404,6 +438,21 @@ fn promote_numeric(
     let lv = ctx.coerce_to_i64(lhs).val;
     let rv = ctx.coerce_to_i64(rhs).val;
     (lv, rv, ValTy::I64)
+}
+
+/// Coerces a raw Cranelift value (of type `ty` as seen by promote_numeric)
+/// into an i64 suitable for bitwise ops. F64 is reinterpreted by converting
+/// to signed integer (JS spec would ToInt32; we use i64 for consistency).
+fn coerce_bits_i64(
+    ctx: &mut FnCtx,
+    val: cranelift_codegen::ir::Value,
+    ty: ValTy,
+) -> cranelift_codegen::ir::Value {
+    if ty == ValTy::F64 {
+        ctx.builder.ins().fcvt_to_sint_sat(cl::I64, val)
+    } else {
+        val
+    }
 }
 
 fn to_f64(ctx: &mut FnCtx, tv: TypedVal) -> cranelift_codegen::ir::Value {

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -109,3 +109,8 @@ fn fixture_let_const_var() {
 fn fixture_function_expressions() {
     run_fixture("function_expressions");
 }
+
+#[test]
+fn fixture_bitwise_ops() {
+    run_fixture("bitwise_ops");
+}

--- a/tests/fixtures/bitwise_ops.out
+++ b/tests/fixtures/bitwise_ops.out
@@ -1,0 +1,8 @@
+and  = 0
+or   = 255
+xor  = 255
+not  = -1
+shl  = 16
+shr  = 64
+ushr = 4
+mask = 10

--- a/tests/fixtures/bitwise_ops.ts
+++ b/tests/fixtures/bitwise_ops.ts
@@ -1,0 +1,13 @@
+import { io } from "rts";
+
+const a = 0xF0;
+const b = 0x0F;
+
+io.print(`and  = ${a & b}`);
+io.print(`or   = ${a | b}`);
+io.print(`xor  = ${a ^ b}`);
+io.print(`not  = ${~0}`);
+io.print(`shl  = ${1 << 4}`);
+io.print(`shr  = ${256 >> 2}`);
+io.print(`ushr = ${16 >>> 2}`);
+io.print(`mask = ${(0xAB >> 4) & 0xF}`);


### PR DESCRIPTION
## Summary

Implementa operadores bitwise (#47 — P1-essential) via instruções nativas Cranelift.

- Binary: `&` `|` `^` `<<` `>>` `>>>` — `band` / `bor` / `bxor` / `ishl` / `sshr` / `ushr`
- Unary: `~` — `bnot`

## Semântica

Opera em `i64` (o resto do codegen trabalha em i64). JS spec reduziria para i32 antes do op e depois do op; aqui fica i64 direto. Para os valores usuais de bitmasks que cabem em i32 o resultado bate bit-a-bit; valores fora desse range divergem (não é usado em TS idiomático).

Helper `coerce_bits_i64` trata F64 via `fcvt_to_sint_sat` — raro, mas evita panic do verifier em expressões mistas com floats.

## Cobertura (fixture bitwise_ops)

`& | ^ ~ << >> >>>` + expressão composta `(0xAB >> 4) & 0xF`.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --test codegen_fixtures` — `fixture_bitwise_ops` passa (4 passed, 7 falhas pré-existentes)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)