### PR TITLE
feat(codegen): ternary operator (#49)

### DIFF
--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -88,6 +88,9 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
         // ── Template literal ──────────────────────────────────────────────
         Expr::Tpl(tpl) => lower_tpl(ctx, tpl),
 
+        // ── Ternary (a ? b : c) ───────────────────────────────────────────
+        Expr::Cond(cond) => lower_cond(ctx, cond),
+
         // ── Member (e.g. `io.print` used as expression) ───────────────────
         Expr::Member(_) => Err(anyhow!("bare member expression not supported as value")),
 
@@ -342,6 +345,51 @@ fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
 
         op => Err(anyhow!("unsupported binary op: {op:?}")),
     }
+}
+
+fn lower_cond(ctx: &mut FnCtx, cond: &swc_ecma_ast::CondExpr) -> Result<TypedVal> {
+    // Evaluate test, branch into cons/alt, merge in i64 slot.
+    let test = lower_expr(ctx, &cond.test)?;
+    let test_i64 = ctx.coerce_to_i64(test);
+    let zero = ctx.builder.ins().iconst(cl::I64, 0);
+    let is_truthy = ctx.builder.ins().icmp(IntCC::NotEqual, test_i64.val, zero);
+
+    let cons_block = ctx.builder.create_block();
+    let alt_block = ctx.builder.create_block();
+    let merge_block = ctx.builder.create_block();
+    let result_var = ctx.builder.declare_var(cl::I64);
+
+    ctx.builder
+        .ins()
+        .brif(is_truthy, cons_block, &[], alt_block, &[]);
+
+    ctx.builder.switch_to_block(cons_block);
+    ctx.builder.seal_block(cons_block);
+    let cons = lower_expr(ctx, &cond.cons)?;
+    let cons_ty = cons.ty;
+    let cons_i64 = ctx.coerce_to_i64(cons);
+    ctx.builder.def_var(result_var, cons_i64.val);
+    ctx.builder.ins().jump(merge_block, &[]);
+
+    ctx.builder.switch_to_block(alt_block);
+    ctx.builder.seal_block(alt_block);
+    let alt = lower_expr(ctx, &cond.alt)?;
+    let alt_ty = alt.ty;
+    let alt_i64 = ctx.coerce_to_i64(alt);
+    ctx.builder.def_var(result_var, alt_i64.val);
+    ctx.builder.ins().jump(merge_block, &[]);
+
+    ctx.builder.switch_to_block(merge_block);
+    ctx.builder.seal_block(merge_block);
+    let result = ctx.builder.use_var(result_var);
+    // Slot is i64; if both branches report Handle/Bool (also i64-backed in
+    // Cranelift) we keep the tag so downstream code skips redundant work.
+    let ty = match (cons_ty, alt_ty) {
+        (ValTy::Handle, ValTy::Handle) => ValTy::Handle,
+        (ValTy::Bool, ValTy::Bool) => ValTy::Bool,
+        _ => ValTy::I64,
+    };
+    Ok(TypedVal::new(result, ty))
 }
 
 fn lower_logical(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -235,6 +235,12 @@ fn infer_expr_ty(expr: Option<&Expr>) -> ValTy {
                 ValTy::I64
             }
         }
+        Expr::Cond(c) => {
+            let l = infer_expr_ty(Some(&c.cons));
+            let r = infer_expr_ty(Some(&c.alt));
+            if l == r { l } else { ValTy::I64 }
+        }
+        Expr::Paren(p) => infer_expr_ty(Some(&p.expr)),
         _ => ValTy::I64,
     }
 }

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -119,3 +119,8 @@ fn fixture_arrow_functions() {
 fn fixture_bitwise_ops() {
     run_fixture("bitwise_ops");
 }
+
+#[test]
+fn fixture_ternary() {
+    run_fixture("ternary");
+}

--- a/tests/fixtures/ternary.out
+++ b/tests/fixtures/ternary.out
@@ -1,0 +1,4 @@
+big
+abs = 10
+zero
+y = 10

--- a/tests/fixtures/ternary.ts
+++ b/tests/fixtures/ternary.ts
@@ -1,0 +1,16 @@
+import { io } from "rts";
+
+const x = 10;
+const label = x > 5 ? "big" : "small";
+io.print(label);
+
+const abs = x < 0 ? -x : x;
+io.print(`abs = ${abs}`);
+
+const n = 0;
+const sign = n > 0 ? "pos" : n < 0 ? "neg" : "zero";
+io.print(sign);
+
+function half(v: i32): i32 { return v / 2; }
+const y = true ? half(20) : 0;
+io.print(`y = ${y}`);


### PR DESCRIPTION
## Summary

Implementa ternário `a ? b : c` (#49 — P1-essential) reutilizando o padrão de `brif + merge block` do `lower_logical`.

## Implementação

- `lower_cond`: avalia `test`, ramifica para `cons`/`alt`, slot de resultado em i64, merge block.
- Tipo retornado preserva `Handle` ou `Bool` quando ambas as branches concordam — importante para ternário de string (`cond ? "big" : "small"`); senão cai em `I64`.
- `infer_expr_ty` aprende `Expr::Cond` (recursivo em `cons`/`alt`) e `Expr::Paren`. Sem isso, const top-level com ternário de string é declarado como `I64` global e `io.print` lê lixo.

## Cobertura (fixture `ternary`)

- Ternário de string: `x > 5 ? "big" : "small"`
- Ternário aninhado: `n > 0 ? "pos" : n < 0 ? "neg" : "zero"`
- Ternário com expressão numérica: `x < 0 ? -x : x`
- Branch com chamada de função: `true ? half(20) : 0`

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --test codegen_fixtures fixture_ternary` passa
- [x] Sem regressão em `template_literals`, `arrow_functions`, `bitwise_ops`, etc.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)