### PR TITLE
perf(codegen): MemFlags::trusted (#98)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -209,10 +209,14 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             .builder
             .ins()
             .global_value(self.module.isa().pointer_type(), gv);
+        // Module globals are declared with natural alignment (4/8 bytes)
+        // and always initialised before first read (top-level emits the
+        // initialiser before any reader). `trusted()` = aligned + notrap
+        // lets the backend pick the widest load instruction.
         let val = self
             .builder
             .ins()
-            .load(global.ty.cl_type(), MemFlags::new(), ptr, 0);
+            .load(global.ty.cl_type(), MemFlags::trusted(), ptr, 0);
         Some(TypedVal::new(val, global.ty))
     }
 
@@ -235,7 +239,9 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
                 .ins()
                 .global_value(self.module.isa().pointer_type(), gv);
             let casted = self.coerce_value_to_ty(val, global.ty);
-            self.builder.ins().store(MemFlags::new(), casted, ptr, 0);
+            self.builder
+                .ins()
+                .store(MemFlags::trusted(), casted, ptr, 0);
             return Ok(());
         }
 

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -856,14 +856,16 @@ fn lower_intrinsic(
             let ptr_ty = ctx.module.isa().pointer_type();
             let ptr = ctx.builder.ins().global_value(ptr_ty, gv);
 
-            let x0 = ctx.builder.ins().load(cl::I64, MemFlags::new(), ptr, 0);
+            // RNG state is a static u64: naturally aligned and always
+            // valid storage. `trusted()` unlocks the tightest load/store.
+            let x0 = ctx.builder.ins().load(cl::I64, MemFlags::trusted(), ptr, 0);
             let s13 = ctx.builder.ins().ishl_imm(x0, 13);
             let x1 = ctx.builder.ins().bxor(x0, s13);
             let s7 = ctx.builder.ins().ushr_imm(x1, 7);
             let x2 = ctx.builder.ins().bxor(x1, s7);
             let s17 = ctx.builder.ins().ishl_imm(x2, 17);
             let x3 = ctx.builder.ins().bxor(x2, s17);
-            ctx.builder.ins().store(MemFlags::new(), x3, ptr, 0);
+            ctx.builder.ins().store(MemFlags::trusted(), x3, ptr, 0);
 
             // Take top 53 bits and divide by 2^53 as f64.
             let bits = ctx.builder.ins().ushr_imm(x3, 11);


### PR DESCRIPTION
## Summary

Troca \`MemFlags::new()\` por \`MemFlags::trusted()\` (aligned + notrap) nos 4 call sites existentes:

- \`ctx.rs\` read_local (global read)
- \`ctx.rs\` write_local (global write)
- \`expr.rs\` intrinsic \`RandomF64\` load + store do state

Todos os casos atendem as invariantes: globais são naturalmente alinhados (4/8 bytes), sempre inicializados antes do primeiro read, endereços estáveis. Nada é readonly (todos mutáveis).

Cranelift backend pode emitir MOV alinhado (ex: MOVQ/MOVSD direto) em vez de acesso genérico byte-a-byte.

## Test plan

- [x] \`cargo build --release\`
- [x] Regressão: 7 fixtures meus passam; 7 pré-existentes continuam falhando pelo mesmo motivo (\`.out\` ausente)
- [x] Monte Carlo: determinístico preservado

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)