### PR TITLE
docs: refresh pos trilhas A/B + JIT

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -12,12 +12,18 @@ Agentes automatizados e humanos devem consultar, nesta ordem:
 
 ## Notas especificas para agentes
 
-- Branch atual: `feat/remake-namespaces`. Namespaces ativos: `io`, `fs`, `gc`.
-- Contrato ABI unico vive em `src/abi/` (`SPECS`, `NamespaceMember`, `AbiType`,
-  simbolos `__RTS_FN_NS_<NS>_<NAME>`). Nao ha mais `dispatch()` por namespace,
-  nem `JsValue` no limite, nem `__rts_call_dispatch`.
+- Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
+- Contrato ABI unico vive em `src/abi/` (`SPECS`, `NamespaceMember`, `AbiType`, `Intrinsic`,
+  simbolos `__RTS_FN_NS_<NS>_<NAME>` e dados `__RTS_DATA_NS_<NS>_<NAME>`). Nao ha mais
+  `dispatch()` por namespace, nem `JsValue` no limite, nem `__rts_call_dispatch`.
 - Sem HIR/MIR separados: codegen consome AST direto em `src/codegen/lower/`.
+- Dois paths de execucao: `ObjectModule` (AOT, default) e `JITModule` (opt-in via
+  `RTS_JIT=1`). `FnCtx.module` e `&mut dyn Module` — ambos passam pelo mesmo codegen.
 - Build e via `cargo` puro (sem `xtask`). Artefatos do usuario ficam em `node_modules/.rts/`.
+- `Intrinsic` em `NamespaceMember.intrinsic` permite emitir IR inline em vez de `call`;
+  ver `lower_intrinsic` em `src/codegen/lower/expr.rs`.
+- User functions usam `CallConv::Tail` (para TCO); `__RTS_MAIN` usa platform default
+  porque e chamado por C extern.
 - Namespaces removidos (net, process, crypto, buffer, promise, task, global) serao
   reintroduzidos sobre o contrato novo — nao assumir que estao disponiveis.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ RTS e um compilador/runtime TypeScript-to-native usando Cranelift como backend d
 O objetivo e compilar TS/JS para binarios nativos com runtime minimo em Rust, distribuido como
 toolchain standalone (sem runtime support library externa).
 
-A branch atual (`feat/remake-namespaces`) reorganiza a camada de runtime em torno do novo
-contrato `src/abi/` + `SPECS`, e converge o pipeline com o modelo da `main` (grafo de modulos
-+ cache incremental), preservando a superficie nova da ABI.
+A camada de runtime e organizada em torno do contrato `src/abi/` + `SPECS`, com pipeline
+por grafo de modulos + cache incremental. Dois caminhos de execucao coexistem: AOT via
+`cranelift_object::ObjectModule` (linker externo) e JIT via `cranelift_jit::JITModule`
+(memoria executavel direta, ativado por `RTS_JIT=1`).
 
 Consultar `NEXT_STEPS.md` e `ROAD_MAP.md` para a direcao vigente.
 
@@ -16,26 +17,32 @@ Consultar `NEXT_STEPS.md` e `ROAD_MAP.md` para a direcao vigente.
 
 ```
 src/
-  abi/          — contrato unico de ABI (SPECS, tipos, simbolos, guards, assinaturas)
-  codegen/      — Cranelift codegen (object emit, lower de expr/stmt/func)
-  linker/       — link nativo (system linker com fallback)
-  namespaces/   — implementacoes dos namespaces runtime: io, fs, gc
+  abi/          — contrato unico de ABI (SPECS, tipos, simbolos, guards, assinaturas, Intrinsic)
+  codegen/      — Cranelift codegen
+    emit.rs     — ObjectModule emitter (AOT)
+    jit.rs      — JITModule emitter (rts run com RTS_JIT=1)
+    lower/      — lower de expr/stmt/func sobre &mut dyn Module
+  linker/       — link nativo (system linker com fallback object backend)
+  namespaces/   — implementacoes dos namespaces runtime: io, fs, gc, math, bigfloat
   runtime/      — builtin module "rts" + submodulos "rts:<ns>"
   module/       — resolver de modulos e grafo de dependencias
-  parser/       — SWC parse + AST interno
+  parser/       — SWC parse + AST interno; converte arrow/fn expressions em Item::Function
+                  top-level
   type_system/  — type checker, registry, resolver
   diagnostics/  — erros estruturados
   cli/          — CLI (run, compile, apis, repl, eval)
-  pipeline.rs   — orquestra build/run
+  pipeline.rs   — orquestra build/run; inclui run_jit para path JIT
   lib.rs        — API publica
-  runtime_objects.rs — resolucao dos objetos de runtime support (.o/.obj)
+  runtime_objects.rs — resolucao dos objetos de runtime support (.o/.obj, AOT)
   main.rs       — entrypoint do binario `rts`
 ```
 
-Pipeline: `Source TS → Parser(SWC) → type_system → codegen(Cranelift) → Object → Linker → .exe`
+Pipeline AOT: `Source TS → Parser(SWC) → type_system → codegen(Cranelift) → Object → Linker → .exe`
+Pipeline JIT: `Source TS → Parser(SWC) → type_system → codegen(Cranelift) → JITModule → call __RTS_MAIN`
 
-Nao existem mais camadas HIR/MIR separadas nesta branch — o codegen consome direto a AST
-(com tipagem resolvida) e emite Cranelift IR em `src/codegen/lower/`.
+`FnCtx.module` e `&mut dyn Module` para servir ambos os paths sem duplicar codegen. Nao
+existem mais camadas HIR/MIR separadas — o codegen consome direto a AST (com tipagem
+resolvida) e emite Cranelift IR em `src/codegen/lower/`.
 
 ## ABI (`src/abi/`) — contrato unico
 
@@ -43,10 +50,13 @@ Toda a superficie entre codegen e runtime passa por `src/abi/`. Nao existe mais
 `SPEC/MEMBERS/dispatch()` por namespace e nao existe mais `__rts_call_dispatch`.
 
 - `abi::SPECS` (`mod.rs`) — slice estatico com a `NamespaceSpec` de cada namespace registrado
-  (`io`, `fs`, `gc`). E a fonte unica consumida por codegen, runtime e gerador de `rts.d.ts`.
+  (`io`, `fs`, `gc`, `math`, `bigfloat`). Fonte unica consumida por codegen, runtime, JIT e
+  gerador de `rts.d.ts`.
 - `abi::lookup(qualified)` — resolve `"io.print"` → `&NamespaceMember` com simbolo e assinatura.
-- `member.rs` — `NamespaceSpec` e `NamespaceMember` como tabelas `const` estaticas. Cada membro
-  declara `name`, `kind` (Function|Constant), `symbol`, `args[]`, `returns`, `doc`, `ts_signature`.
+- `member.rs` — `NamespaceSpec`, `NamespaceMember` (const estaticos) e `Intrinsic` (enum das
+  ops inlinaveis). Cada membro declara `name`, `kind` (Function|Constant), `symbol`, `args[]`,
+  `returns`, `doc`, `ts_signature`, `intrinsic: Option<Intrinsic>`. Quando `intrinsic` e
+  `Some`, codegen emite IR Cranelift direto em vez de `call <symbol>`.
 - `types.rs` — `AbiType`: `Void | Bool | I32 | I64 | U64 | F64 | StrPtr | Handle`. `StrPtr`
   expande para dois slots Cranelift (`ptr` + `len`).
 - `signature.rs` — `lower_member()` converte a spec em `LoweredSignature` Cranelift.
@@ -72,9 +82,9 @@ Regras:
 - Cada arquivo operacional agrupa funcoes por responsabilidade (io/r-w/dir/metadata/…)
 - Nao existe `dispatch()` por namespace — cada funcao e um `#[no_mangle] extern "C"` direto
 
-Namespaces ativos nesta branch: `io`, `fs`, `gc`.
-Os demais (net, process, crypto, buffer, promise, task, global) estao removidos aqui e serao
-reintroduzidos sobre o contrato novo a medida que o pipeline principal estabiliza.
+Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
+Demais (net, process, crypto, buffer, thread, etc) serao reintroduzidos sobre o contrato
+atual a medida que o pipeline estabiliza. Ver issues #12-#39 para o backlog.
 
 ### Namespaces existentes
 
@@ -82,7 +92,16 @@ reintroduzidos sobre o contrato novo a medida que o pipeline principal estabiliz
 - `fs/` — read, read_all, write, append, exists, is_file, is_dir, size, modified_ms,
   create_dir(_all), remove_dir(_all), remove_file, rename, copy
 - `gc/` — handles e string pool: string_from_{i64,f64,static}, string_{new,concat,len,ptr,free},
-  `HandleTable` slab-based com 16-bit geracao + 48-bit slot (`u64` handle)
+  `HandleTable` slab-based com 16-bit geracao + 48-bit slot (`u64` handle); `Entry` enumera
+  tipos armazenados (`String`, `BigFixed`, `Free`)
+- `math/` — basic (floor/ceil/round/trunc/sqrt/cbrt/pow/exp/ln/log2/log10/abs_f64/abs_i64),
+  trig (sin/cos/tan/asin/acos/atan/atan2), minmax (min/max/clamp_f64/i64), consts
+  (PI/E/INFINITY/NAN como `MemberKind::Constant`), random (xorshift64 com estado em
+  `__RTS_DATA_NS_MATH_RNG_STATE`). Intrinsics: sqrt/abs_f64/min_f64/max_f64/abs_i64/
+  min_i64/max_i64/random_f64
+- `bigfloat/` — decimal fixed-point via i128 (scale decimal ate 36). Operacoes:
+  zero/from_f64/from_i64/from_str/to_f64/to_string/add/sub/mul/div/neg/sqrt/free.
+  Usado para pi com 29+ digitos via Machin + atan de Maclaurin
 
 ## Convencoes
 
@@ -96,20 +115,43 @@ reintroduzidos sobre o contrato novo a medida que o pipeline principal estabiliz
 ## Como testar
 
 ```bash
-cargo test                                        # testes unitarios
+cargo test                                        # testes unitarios + fixtures
 cargo build --release                             # build release
-target/release/rts.exe run file.ts                # executar (runtime)
+target/release/rts.exe run file.ts                # executar (AOT default)
+RTS_JIT=1 target/release/rts.exe run file.ts      # executar via JIT in-memory
 target/release/rts.exe compile -p file.ts output  # compilar nativo (AOT)
 target/release/rts.exe apis                       # listar APIs disponiveis
 ```
 
+Fixtures de codegen vivem em `tests/fixtures/*.{ts,out}`. O teste
+`codegen_fixtures` compila o `.ts` e compara stdout com o `.out`
+byte-a-byte. Para adicionar nova fixture:
+
+1. `tests/fixtures/<name>.ts` — programa
+2. `tests/fixtures/<name>.out` — saida esperada (LF, sem CRLF)
+3. `#[test] fn fixture_<name>() { run_fixture("<name>") }` em
+   `tests/codegen_fixtures.rs`
+
 ## Benchmarks
+
+Benches canonicos em `bench/`:
+
+- `monte_carlo_pi.ts` — estimacao de pi por Monte Carlo 10M (xorshift64 inline)
+- `pi_bigfloat.ts` — pi via Machin 30 digitos usando `bigfloat`
+- `pi_machin.ts` — pi via Machin em f64 (16 digitos)
+
+Placar atual (AOT + JIT vs Bun/Node, medianas):
+
+| Bench            | RTS JIT | RTS AOT | Bun    | Node   |
+|------------------|---------|---------|--------|--------|
+| Monte Carlo 10M  | 119 ms  | 156 ms  | 173 ms | 281 ms |
+| Machin bigfloat  | 47 ms   | 48 ms   | 109 ms | 108 ms |
+
+Suite completa:
 
 ```bash
 powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
 ```
-
-Compara RTS (run), RTS (compiled), Bun e Node.
 
 ## Regras
 
@@ -156,16 +198,48 @@ Cada funcao de namespace e um simbolo `extern "C"` tipado.
   leitura via `gc::string_ptr(handle)` + `gc::string_len(handle)`
 - Call sites com argumentos `any` passam por `abi::guards::guard_for(...)` para decidir coerce/trap
 
-## Runtime vs Compile (AOT)
+## Runtime vs Compile (AOT) vs JIT
 
-Runtime e AOT sao unificados — ambos geram `.o` via Cranelift. A diferenca e de escopo:
+Tres rotas de execucao compartilhando o mesmo codegen Cranelift:
 
-- **Runtime (`rts run`)**: inclui todos os modulos builtin nos objects
-- **Compile (`rts compile`)**: aplica slicing, gera apenas os objects dos modulos efetivamente
-  usados; produz o binario final
+- **`rts run` (AOT, default)**: inclui todos os modulos builtin nos objects; escreve `.o`,
+  chama linker do sistema, executa o binario linkado. Cache em `node_modules/.rts/`.
+- **`rts run` com `RTS_JIT=1`**: compila direto para memoria executavel via `JITModule`.
+  Sem disco, sem linker externo. Startup drasticamente mais rapido para dev loop. Todos os
+  simbolos do ABI sao registrados em `JITBuilder::symbol` no startup do modulo JIT
+  (`src/codegen/jit.rs`).
+- **`rts compile`**: aplica slicing por uso, gera apenas os objects dos modulos efetivamente
+  utilizados, produz binario final.
 
-O pipeline de codegen e o mesmo nos dois casos. Convencao de nomes: `<module>.o` (e `.m` quando
-houver metadata associado para cache incremental).
+`FnCtx.module` e `&mut dyn Module` — `ObjectModule` e `JITModule` implementam o mesmo trait
+e passam pelo mesmo pipeline de `compile_program`.
+
+Convencao de nomes de object: `<module>.o` (e `.m` quando houver metadata para cache
+incremental).
+
+## Otimizacoes de codegen notaveis
+
+- **Intrinsics inline** (`abi::Intrinsic`): `sqrt`, `abs_f64`, `min/max_f64`, `abs_i64`,
+  `min/max_i64`, `random_f64` — emitidos como IR Cranelift direto em `lower_intrinsic`
+- **Tail call optimization**: user functions em `CallConv::Tail`; `return f(x)` em posicao de
+  tail emite `return_call` (exige `preserve_frame_pointers=true` em x86-64)
+- **First-class function pointers** (#97 fase 1): `Expr::Ident` resolvendo a user fn
+  materializa `func_addr` como i64; call via ident local/param faz `call_indirect` com
+  signature provisoria Tail
+- **Jump table switch**: quando todos os non-default cases sao literais inteiros, usa
+  `cranelift_frontend::Switch` (backend decide `br_table` vs binary search)
+- **Imm forms**: `x + N` / `x & MASK` / `x << K` emitem `iadd_imm` / `band_imm` / `ishl_imm`
+  sem iconst intermediario
+- **MemFlags::trusted** em loads/stores de globals e RNG state
+- **f64 modulo** via libc `fmod` (antes truncava via i64 perdendo a parte fracionaria)
+- **Constantes como propriedades** (`math.PI` sem parens) via `MemberKind::Constant` +
+  `emit_constant_load`
+
+## Otimizacoes pendentes / backlog
+
+Ver issues abertas #90, #96, #97 (fases 2/3). #92 autovec foi fechada como inviavel sem
+loop vectorizer proprio (Cranelift nao tem um); Bun ganha em Monte Carlo >1B iter por
+autovec do V8.
 
 ## Layout de Artefatos do Usuario
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,5 +1,36 @@
 # RTS - Next Steps
 
+## Status atual
+
+Etapa 1 (reancorar) e Etapa 2 (plugar API nova) estao **concluidas** — pipeline por grafo,
+cache incremental, runtime support embutido, `abi::SPECS` como fonte unica, `io`/`fs`/`gc`
+estaveis e `math`/`bigfloat` adicionados.
+
+Etapa 3 (migracao incremental de melhorias de codegen) em andamento — ver **Progresso recente**
+abaixo.
+
+## Progresso recente (codegen + capacidades)
+
+- **JIT mode** (#95): `RTS_JIT=1 rts run` compila para memoria executavel, ~14x mais rapido
+  que AOT no startup
+- **Tail call optimization** (#93): recursao profunda sem stack overflow via `return_call`
+- **First-class function pointers** (#97 fase 1): funcoes como valores, `call_indirect` no use
+- **Intrinsics inline** (#87): `math.sqrt`, `math.random_f64`, etc. emitidos como IR direto
+- **f64 modulo correto** (#89): via `fmod` libc
+- **Jump table switch** (#91), **imm forms** (#94), **MemFlags::trusted** (#98),
+  **stack_slot helper** (#99)
+- **Namespaces novos**: `math` (27 membros + 4 constantes) e `bigfloat` (decimal 30 digitos
+  via i128)
+- **Capacidades TS**: template literals, ternario, bitwise ops, arrow/fn expressions,
+  let/const scoping correto
+
+## Backlog priorizado
+
+- **#97 fases 2/3** — arrow em qualquer posicao + captura imutavel/mutavel (depende #99 ✅)
+- **#96 DWARF** — debug info no ObjectModule
+- **#90 loop block params** — deferred; impl atual ja produz SSA correto via frontend
+- **#92 autovec** — fechada como inviavel (Cranelift nao tem loop vectorizer)
+
 ## Direcao alvo
 
 Seguir a mesma ideia arquitetural da `main`, mas mantendo a API nova organizada.

--- a/README.md
+++ b/README.md
@@ -1,73 +1,108 @@
 # RTS
 
-Compilador e runtime TypeScript-to-native baseado em Cranelift. O objetivo e
-compilar TS/JS para binarios nativos com runtime minimo em Rust e um contrato
-ABI unico para os namespaces builtin.
+Compilador e runtime TypeScript-to-native baseado em Cranelift. Compila TS/JS
+para binarios nativos com runtime minimo em Rust e um contrato ABI unico para
+os namespaces builtin. Ha dois caminhos de execucao:
 
-Branch atual: `feat/remake-namespaces` — reconstrucao dos namespaces sobre a
-camada `src/abi/`. Somente `io`, `fs` e `gc` estao ativos nesta branch; os
-demais serao reintroduzidos gradualmente sobre o novo contrato.
+- **AOT** (`rts compile`) — emite object file, linka com o linker do sistema,
+  produz executavel standalone.
+- **JIT** (`RTS_JIT=1 rts run`) — compila direto para memoria executavel via
+  `cranelift_jit`, sem disco e sem linker externo. Latencia de startup drastica-
+  mente menor, ideal para dev loop.
+
+Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
 
 ## Arquitetura
 
 ```
 src/
-  parser/          SWC parse + AST interno
-  codegen/         Cranelift codegen direto a partir do AST (sem HIR/MIR)
-    lower/         Lowering de expressoes e statements
-  abi/             Contrato ABI unico
-    member         NamespaceMember / NamespaceSpec
-    types          AbiType
-    signature      Assinaturas de chamada
-    symbols        Nomes oficiais dos simbolos
-    guards         Validacoes estaticas
-    mod.rs         SPECS - registro dos namespaces ativos
-  namespaces/      Namespaces builtin
-    io/            print, println, ...
-    fs/            read, write, ...
-    gc/            primitivas de coleta
-    <ns>/mod.rs    import map
-    <ns>/abi.rs    tabela estatica de NamespaceMember
-    <ns>/<op>.rs   implementacao operacional (um arquivo por grupo de funcao)
-  linker/          Link nativo (linker do sistema com fallback)
+  parser/            SWC parse + AST interno
+  codegen/           Cranelift codegen direto sobre o AST (sem HIR/MIR)
+    lower/           Lowering de expressoes/statements
+    emit.rs          Object emitter (AOT)
+    jit.rs           JIT emitter (rts run com RTS_JIT=1)
+  abi/               Contrato ABI unico
+    member.rs        NamespaceMember / NamespaceSpec / Intrinsic
+    types.rs         AbiType
+    signature.rs     Assinaturas Cranelift
+    symbols.rs       Nomes oficiais dos simbolos
+    guards.rs        Validacoes estaticas
+    mod.rs           SPECS - registro dos namespaces ativos
+  namespaces/        Implementacoes dos namespaces builtin
+    io/              print, eprint, stdout/stderr/stdin
+    fs/              read, write, metadata, dir, copy, rename, ...
+    gc/              HandleTable (slab + generation) + string pool
+    math/            f64/i64 intrinsics + xorshift64 PRNG + constantes
+    bigfloat/        decimal fixed-point via i128 (~30 digitos)
+    <ns>/mod.rs      import map
+    <ns>/abi.rs      tabela estatica de NamespaceMember
+    <ns>/rt.rs       re-exports para o runtime staticlib
+  linker/            Link nativo (linker do sistema com fallback object)
   runtime_objects.rs Resolucao dos objetos de runtime support (.o/.obj)
-  pipeline.rs      Orquestra build/run
-  cli/             CLI (run, compile, apis, init)
+  pipeline.rs        Orquestra compile/link/run (inclui run_jit)
+  cli/               CLI (run, compile, apis, init)
 
 builtin/
-  console/         Package TS sobre o modulo "rts"
-  globals/         Globais compartilhadas
+  console/           Package TS sobre o modulo "rts"
+  globals/           Globais compartilhadas
   rts-types/
-    rts.d.ts       Declaracoes TS geradas a partir de abi::SPECS (CI linta)
+    rts.d.ts         Declaracoes TS geradas a partir de abi::SPECS
 ```
 
-Pipeline: `Source TS -> Parser (SWC) -> Codegen Cranelift -> Object -> Link -> binario`.
+Pipeline AOT: `Source TS -> Parser (SWC) -> Codegen Cranelift -> Object -> Link -> binario`
+Pipeline JIT: `Source TS -> Parser (SWC) -> Codegen Cranelift -> JITModule in-memory -> call __RTS_MAIN`
 
 ## Contrato ABI
 
 - Fonte unica: `src/abi/`.
-- `abi::SPECS` lista os namespaces ativos (`io`, `fs`, `gc`).
-- Cada membro declara nome, parametros e retorno via `AbiType`.
+- `abi::SPECS` lista os namespaces ativos (hoje: `io`, `fs`, `gc`, `math`, `bigfloat`).
+- Cada membro declara nome, parametros, retorno via `AbiType`, e opcionalmente
+  um `Intrinsic` que permite ao codegen emitir IR inline ao inves de call extern
+  (usado em `math.sqrt`, `math.random_f64`, etc).
 - Cada funcao de namespace vira um simbolo nativo:
   `__RTS_FN_NS_<NS>_<NAME>` (uppercase ASCII).
-- Codegen consulta `SPECS` para resolver simbolo e assinatura da chamada; nao
-  existe dispatcher central nem boxing no limite extern "C".
-- `rts.d.ts` em `builtin/rts-types/` e gerado a partir dos `SPECS`. Somente
-  `declare module "rts"`.
+- Dados expostos ao codegen (ex: estado do PRNG): `__RTS_DATA_NS_<NS>_<NAME>`.
+- Codegen consulta `SPECS` para resolver simbolo e assinatura; nao existe
+  dispatcher central nem boxing no limite `extern "C"`.
+- `rts.d.ts` em `builtin/rts-types/` e gerado a partir dos `SPECS`.
 
 Tipos primitivos no limite ABI:
 
-| TS       | ABI          | Convencao                                       |
-|----------|--------------|-------------------------------------------------|
-| `number` | `i64` / `f64`| bits nativos, sem boxing                        |
-| `bool`   | `i64`        | 0 = false, 1 = true                             |
-| `string` | `(i64, i64)` | `(ptr, len)` UTF-8 estatica do codegen          |
-| handle   | `u64`        | indice opaco para recursos (buffers, strings dinamicas) |
+| TS       | ABI          | Convencao                                                |
+|----------|--------------|----------------------------------------------------------|
+| `number` | `i64` / `f64`| bits nativos, sem boxing                                 |
+| `bool`   | `i64`        | 0 = false, 1 = true                                      |
+| `string` | `(i64, i64)` | `(ptr, len)` UTF-8 — literal estatica OU handle GC       |
+| handle   | `u64`        | indice opaco para recursos (strings dinamicas, bigfloat) |
+
+## Capacidades da linguagem
+
+Suportadas no codegen:
+
+- **Controle de fluxo**: if/else, while, do-while, for, switch (com jump table
+  nativa quando todos os cases sao literais inteiros), break/continue.
+- **Expressoes**: aritmetica (+ - * / %), bitwise (`& | ^ ~ << >> >>>`),
+  ternario (`a ? b : c`), logicos (&& ||), comparacoes, assignment, template
+  literals (com interpolacao de qualquer tipo).
+- **Funcoes**: declaracao, `function` expression, arrow functions (bloco ou
+  expressao), tail call optimization (`return f(x)` vira `return_call`),
+  ponteiros de funcao como valores de primeira classe (callbacks).
+- **Escopo**: `let`/`const`/`var` com semantica de bloco; `const` impede
+  reassignment.
+- **Namespaces**: `import { io, math, ... } from "rts"` + `io.print(...)`,
+  `math.sqrt(x)`, etc. Constantes via `math.PI`, `math.E`, sem parens.
+- **Big decimal**: `bigfloat.add/sub/mul/div/sqrt` com handles de ~30 digitos
+  decimais. Suficiente para calcular pi com 29 digitos corretos.
+
+Nao suportado ainda: `class`, `try/catch`, `async/await`, generators,
+destructuring, spread/rest, regex, object e array literals. Closures com
+captura de variaveis externas estao em fase 1 (ponteiros de funcao sem env).
 
 ## CLI
 
 ```bash
-rts run file.ts                       # executa (runtime, todos os builtins)
+rts run file.ts                       # executa via AOT (compile + link + exec)
+RTS_JIT=1 rts run file.ts             # executa via JIT in-memory (mais rapido)
 rts compile -p file.ts output         # AOT com slicing por modulo usado
 rts apis                              # lista APIs registradas em abi::SPECS
 rts init                              # gera projeto base
@@ -78,38 +113,83 @@ Tambem funciona via Cargo:
 
 ```bash
 cargo run -- run examples/console.ts
+RTS_JIT=1 cargo run -- run examples/console.ts
 cargo run -- compile -p examples/console.ts target/console
 cargo run -- apis
 ```
 
+## Benchmarks
+
+`bench/monte_carlo_pi.ts` (10M pontos, xorshift64 PRNG inline) e
+`bench/pi_bigfloat.ts` (pi via formula de Machin com 30 digitos):
+
+```
+┌──────────────────┬──────────┬──────────┬────────┬────────┐
+│       Bench      │ RTS JIT  │ RTS AOT  │  Bun   │  Node  │
+├──────────────────┼──────────┼──────────┼────────┼────────┤
+│ Monte Carlo 10M  │  119 ms  │  156 ms  │ 173 ms │ 281 ms │
+├──────────────────┼──────────┼──────────┼────────┼────────┤
+│ Machin bigfloat  │   47 ms  │   48 ms  │ 109 ms │ 108 ms │
+└──────────────────┴──────────┴──────────┴────────┴────────┘
+```
+
+- Monte Carlo: xorshift64 inline via intrinsic (`math.random_f64`). Mesmo
+  `inside = 7854393` deterministico em AOT e JIT.
+- Machin: pi = 16·atan(1/5) - 4·atan(1/239), atan via serie de Maclaurin em
+  `bigfloat`. Resultado `3.141592653589793238462643383280` (29 digitos corretos,
+  f64 entrega 16).
+
+Suite tradicional:
+
+```bash
+powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
+```
+
 ## Runtime vs Compile (AOT)
 
-Runtime e AOT compartilham o mesmo pipeline de codegen. A diferenca e o escopo:
+Runtime (`rts run`) e AOT (`rts compile`) compartilham o mesmo pipeline de
+codegen. Diferencas:
 
-- `rts run` gera objects completos dos modulos builtin (todos os namespaces
-  ativos presentes).
-- `rts compile` aplica slicing e gera somente os objects efetivamente usados,
-  emitindo o binario final.
+- `rts run` (AOT default): objects completos dos modulos builtin, cache em
+  `node_modules/.rts/`.
+- `rts run` (JIT, `RTS_JIT=1`): compila para memoria executavel, sem disco.
+  Todos os simbolos do ABI sao registrados em `JITBuilder::symbol` no
+  startup; nao passa pelo linker do sistema.
+- `rts compile`: aplica slicing por uso, emite objects + binario final.
 
-Runtime support e resolvido por objetos `.o/.obj` precompilados
-(`runtime_objects.rs`). Nao ha download de runtime support e nao ha fallback
-para `cargo build --lib` no ambiente do usuario.
+Runtime support AOT e resolvido por objetos `.o/.obj` precompilados
+(`runtime_objects.rs` + `runtime_support.a` produzido por `build.rs`). Nao ha
+download de runtime support.
 
 Artefatos auxiliares vivem em `node_modules/.rts/`:
 
 ```
 node_modules/.rts/
-  objs/            cache de objetos (.o) + metadata por modulo
-  modules/         modulos resolvidos
+  objs/              cache de objetos (.o) + metadata por modulo
+  modules/           modulos resolvidos
 ```
 
-(Layout alvo da Fase 1 do road map; ver `ROAD_MAP.md`.)
+## Codegen — otimizacoes notaveis
+
+- **Intrinsics inline** (`abi::Intrinsic`): `sqrt`, `abs`, `min`, `max`,
+  `random_f64` emitidos como IR Cranelift direto no call site.
+- **Tail call optimization**: user functions usam `CallConv::Tail`;
+  `return f(x)` emite `return_call`. Recursao profunda nao estoura stack.
+- **First-class function pointers**: `const f = double; f(5)` funciona.
+  Indireto via `call_indirect` com signature provisoria Tail.
+- **Jump table switch**: cases com inteiros literais viram `br_table` via
+  `cranelift_frontend::Switch`.
+- **Imm forms**: `x + 1` emite `iadd_imm` direto.
+- **MemFlags::trusted**: loads/stores de globals e estado runtime.
+- **f64 modulo**: via libc `fmod` (antes truncava via i64).
+- **Constantes como propriedades**: `math.PI` (sem parens) resolve em
+  `MemberKind::Constant`.
 
 ## Pacotes TS suportados
 
 - import relativo (`./`, `../`)
 - import de pacote do workspace (`import { log } from "console"`)
-- import builtin (`import { print } from "rts"`)
+- import builtin (`import { io } from "rts"`)
 - import de URL externa (`https://...`)
 - dependencia em `package.json` (`npm:<versao>`, URL externa, path local)
 
@@ -132,44 +212,36 @@ Configuracoes auxiliares:
 - `RTS_TARGET=<target-triple>` escolhe target explicitamente.
 - `RTS_TOOLCHAINS_PATH=<path>` altera o cache local de toolchains.
 
-## GC
+## GC / Handles
 
-Usa o crate `gc-arena` como sistema deterministico. `safe_collect()` e chamado
-em pontos de quiescencia (retorno de funcoes, fim de metodos, fim de escopo de
-closures), nao de forma periodica.
+`src/namespaces/gc/handles.rs` implementa uma `HandleTable` slab-based com
+generation de 16 bits + slot de 48 bits. Usada para strings dinamicas, big
+decimals e qualquer recurso runtime que precise de handle opaco `u64`.
+Desalocacao explicita via `*_free(handle)`.
+
+Para codigo que precisa de escopo deterministico em memoria nativa, o crate
+`gc-arena` e dependencia disponivel mas o runtime principal nao faz uso
+periodico — coleta acontece em pontos de quiescencia quando e aplicavel.
 
 ## Build e testes
 
 ```bash
-cargo test                                    # testes unitarios
+cargo test                                    # testes unitarios + fixtures
 cargo build --release                         # build release
-target/release/rts.exe run file.ts            # executar
+target/release/rts.exe run file.ts            # executar (AOT)
+RTS_JIT=1 target/release/rts.exe run file.ts  # executar (JIT)
 target/release/rts.exe compile -p file.ts o   # compilar AOT
 target/release/rts.exe apis                   # listar APIs
 ```
 
-Build padrao e via `cargo` puro — sem `xtask`.
-
-## Benchmarks
-
-```bash
-powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
-```
-
-Compara `rts run`, `rts compile`, Bun e Node.
+Fixtures de codegen vivem em `tests/fixtures/*.{ts,out}` — o teste compila o
+`.ts` e compara stdout com o `.out` byte-a-byte.
 
 ## Direcao
 
-Ver `NEXT_STEPS.md` e `ROAD_MAP.md`. Resumo:
+Ver `NEXT_STEPS.md` e `ROAD_MAP.md`. Issues de codegen priorizadas em trilhas
+paralelas (A peephole, B loops/TCO, C closures, D modulo, E perf avancada) —
+ver comentarios nas issues para dependencias e ordem.
 
-- Fase 1: reancorar no fluxo da `main` — pipeline por grafo de modulos
-  (`compile_graph`), cache incremental de `.o` + metadata, runtime support
-  interno, artefatos em `node_modules/.rts`.
-- Fase 2: consolidar a API nova — `abi::SPECS` como fonte unica para codegen,
-  runtime e tipos; `io`, `fs`, `gc` completos no fluxo novo; `rts.d.ts`
-  sincronizado.
-- Fase 3: migracao gradual das melhorias de codegen da bench nova, medindo
-  impacto por lote.
-
-Guardrails: sem `xtask`, sem download de runtime support, sem dependencia de
-Rust/Cargo no ambiente de uso final.
+Guardrails: sem `xtask`, sem download de runtime support em tempo de build,
+sem dependencia de Rust/Cargo no ambiente de uso final do binario AOT.

--- a/ROAD_MAP.md
+++ b/ROAD_MAP.md
@@ -6,34 +6,49 @@ Convergir para o modelo da `main` (pipeline completo + cache), mantendo a organi
 
 ---
 
-## Fase 1 - Alinhamento de arquitetura (paridade com main)
+## Fase 1 - Alinhamento de arquitetura (paridade com main) — **CONCLUIDA**
 
-- [ ] Pipeline por grafo de modulos (`compile_graph`).
-- [ ] Cache de objetos e metadados por modulo.
-- [ ] Runtime support resolvido por payload interno do proprio `rts`.
-- [ ] Remover caminho de download de runtime support library.
-- [ ] Remover fallback para `cargo build --lib` no fluxo de uso.
-- [ ] Fluxo `node_modules/.rts` para artefatos auxiliares.
-
-Resultado esperado: base de compilacao equivalente a `main`, sem perder a estrutura nova da ABI e sem dependencia de runtime externo.
-
----
-
-## Fase 2 - Consolidacao da API nova organizada
-
-- [ ] `abi::SPECS` como fonte unica para codegen/runtime/types.
-- [ ] Namespaces `io`, `fs`, `gc` completos no fluxo novo.
-- [ ] Declaracoes TypeScript sincronizadas a partir da ABI nova.
-
-Resultado esperado: arquitetura da `main` + superficie de API nova limpa e extensivel.
+- [x] Pipeline por grafo de modulos (`compile_graph`).
+- [x] Cache de objetos e metadados por modulo.
+- [x] Runtime support resolvido por payload interno do proprio `rts`
+      (runtime_support.a embutido via build.rs).
+- [x] Remover caminho de download de runtime support library.
+- [x] Remover fallback para `cargo build --lib` no fluxo de uso.
+- [x] Fluxo `node_modules/.rts` para artefatos auxiliares.
 
 ---
 
-## Fase 3 - Migracao gradual da nova bench
+## Fase 2 - Consolidacao da API nova organizada — **CONCLUIDA**
 
-- [ ] Integrar melhorias de codegen em lotes pequenos.
-- [ ] Validar benchmark e regressao a cada lote.
-- [ ] Medir compile time, tamanho final e estabilidade.
+- [x] `abi::SPECS` como fonte unica para codegen/runtime/types.
+- [x] Namespaces `io`, `fs`, `gc` completos no fluxo novo.
+- [x] Declaracoes TypeScript sincronizadas a partir da ABI nova.
+- [x] Namespaces adicionais consolidados: `math` (27 membros + 4 constantes),
+      `bigfloat` (decimal 30 digitos).
+
+---
+
+## Fase 3 - Migracao gradual de melhorias de codegen — **em andamento**
+
+### Concluido
+
+- [x] Intrinsics inline (#87)
+- [x] f64 modulo via fmod (#89)
+- [x] Switch jump table (#91)
+- [x] Tail call optimization (#93)
+- [x] Imm forms (#94)
+- [x] JIT mode (#95)
+- [x] First-class function pointers (#97 fase 1)
+- [x] MemFlags::trusted (#98)
+- [x] stack_slot helper (#99)
+
+### Pendente
+
+- [ ] #96 DWARF debug info
+- [ ] #97 fases 2/3 — arrow como valor + captura de escopo externo
+- [ ] #90 loop block params — deferred; SSA atual ja funcional
+- [ ] Novos namespaces sobre o contrato atual (#12-#39: env, path, time, process,
+      net, thread, etc)
 
 Regra: nao juntar refactor grande e mudanca de comportamento no mesmo lote.
 


### PR DESCRIPTION
Atualiza README, CLAUDE.md, AGENT.md, NEXT_STEPS.md, ROAD_MAP.md para refletir o estado atual — namespaces adicionados (math, bigfloat), dois paths AOT/JIT, otimizacoes de codegen documentadas, tabela de bench, fases 1-2 do roadmap concluidas, fase 3 em andamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)