### PR TITLE
feat(ns): time namespace (#14)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/fs/");
     println!("cargo:rerun-if-changed=src/namespaces/math/");
     println!("cargo:rerun-if-changed=src/namespaces/bigfloat/");
+    println!("cargo:rerun-if-changed=src/namespaces/time/");
     println!("cargo:rerun-if-changed=src/namespaces/rt_all.rs");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -31,6 +31,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::fs::abi::SPEC,
     &crate::namespaces::math::abi::SPEC,
     &crate::namespaces::bigfloat::abi::SPEC,
+    &crate::namespaces::time::abi::SPEC,
 ];
 
 /// Locates a member by its fully qualified name (e.g. `"io.print"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -171,6 +171,15 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_MATH_INFINITY", consts::__RTS_FN_NS_MATH_INFINITY);
     add_fn!("__RTS_FN_NS_MATH_NAN", consts::__RTS_FN_NS_MATH_NAN);
 
+    // ── namespaces::time ──────────────────────────────────────────────
+    use crate::namespaces::time::*;
+    add_fn!("__RTS_FN_NS_TIME_NOW_MS", instant::__RTS_FN_NS_TIME_NOW_MS);
+    add_fn!("__RTS_FN_NS_TIME_NOW_NS", instant::__RTS_FN_NS_TIME_NOW_NS);
+    add_fn!("__RTS_FN_NS_TIME_UNIX_MS", system::__RTS_FN_NS_TIME_UNIX_MS);
+    add_fn!("__RTS_FN_NS_TIME_UNIX_NS", system::__RTS_FN_NS_TIME_UNIX_NS);
+    add_fn!("__RTS_FN_NS_TIME_SLEEP_MS", sleep::__RTS_FN_NS_TIME_SLEEP_MS);
+    add_fn!("__RTS_FN_NS_TIME_SLEEP_NS", sleep::__RTS_FN_NS_TIME_SLEEP_NS);
+
     // ── namespaces::bigfloat ──────────────────────────────────────────
     use crate::namespaces::bigfloat::ops::*;
     add_fn!("__RTS_FN_NS_BIGFLOAT_ZERO", __RTS_FN_NS_BIGFLOAT_ZERO);

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -9,3 +9,4 @@ pub mod fs;
 pub mod gc;
 pub mod io;
 pub mod math;
+pub mod time;

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -8,3 +8,5 @@ pub mod fs;
 pub mod math;
 #[path = "bigfloat/rt.rs"]
 pub mod bigfloat;
+#[path = "time/rt.rs"]
+pub mod time;

--- a/src/namespaces/time/abi.rs
+++ b/src/namespaces/time/abi.rs
@@ -1,0 +1,72 @@
+//! `time` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "now_ms",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_NOW_MS",
+        args: &[],
+        returns: AbiType::I64,
+        doc: "Monotonic milliseconds since process start.",
+        ts_signature: "now_ms(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "now_ns",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_NOW_NS",
+        args: &[],
+        returns: AbiType::I64,
+        doc: "Monotonic nanoseconds since process start.",
+        ts_signature: "now_ns(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "unix_ms",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_UNIX_MS",
+        args: &[],
+        returns: AbiType::I64,
+        doc: "Wall-clock milliseconds since the UNIX epoch.",
+        ts_signature: "unix_ms(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "unix_ns",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_UNIX_NS",
+        args: &[],
+        returns: AbiType::I64,
+        doc: "Wall-clock nanoseconds since the UNIX epoch.",
+        ts_signature: "unix_ns(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "sleep_ms",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_SLEEP_MS",
+        args: &[AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Sleeps the current thread for `ms` milliseconds.",
+        ts_signature: "sleep_ms(ms: number): void",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "sleep_ns",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_TIME_SLEEP_NS",
+        args: &[AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Sleeps the current thread for `ns` nanoseconds.",
+        ts_signature: "sleep_ns(ns: number): void",
+        intrinsic: None,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "time",
+    doc: "Monotonic and wall-clock timestamps, plus blocking sleeps.",
+    members: MEMBERS,
+};

--- a/src/namespaces/time/instant.rs
+++ b/src/namespaces/time/instant.rs
@@ -1,0 +1,26 @@
+//! Monotonic timestamps anchored at process start.
+//!
+//! Uses a `std::sync::OnceLock` to fix the anchor on first call so that
+//! repeated calls return an elapsed time that only grows forward, even
+//! across suspended laptops or NTP adjustments (`std::time::Instant`
+//! guarantees monotonicity). i64 return fits ~292 years in nanoseconds
+//! and ~292 million years in milliseconds; the i64 cast is lossless
+//! for any realistic process lifetime.
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+fn anchor() -> Instant {
+    static ANCHOR: OnceLock<Instant> = OnceLock::new();
+    *ANCHOR.get_or_init(Instant::now)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_NOW_MS() -> i64 {
+    anchor().elapsed().as_millis() as i64
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_NOW_NS() -> i64 {
+    anchor().elapsed().as_nanos() as i64
+}

--- a/src/namespaces/time/mod.rs
+++ b/src/namespaces/time/mod.rs
@@ -1,0 +1,6 @@
+//! `time` namespace — monotonic clock, wall clock, sleep.
+
+pub mod abi;
+pub mod instant;
+pub mod sleep;
+pub mod system;

--- a/src/namespaces/time/rt.rs
+++ b/src/namespaces/time/rt.rs
@@ -1,0 +1,3 @@
+pub mod instant;
+pub mod sleep;
+pub mod system;

--- a/src/namespaces/time/sleep.rs
+++ b/src/namespaces/time/sleep.rs
@@ -1,0 +1,18 @@
+//! Blocking sleeps via `std::thread::sleep`.
+
+use std::thread;
+use std::time::Duration;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_SLEEP_MS(ms: i64) {
+    if ms > 0 {
+        thread::sleep(Duration::from_millis(ms as u64));
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_SLEEP_NS(ns: i64) {
+    if ns > 0 {
+        thread::sleep(Duration::from_nanos(ns as u64));
+    }
+}

--- a/src/namespaces/time/system.rs
+++ b/src/namespaces/time/system.rs
@@ -1,0 +1,24 @@
+//! Wall-clock timestamps measured from the UNIX epoch.
+//!
+//! Unlike `instant::*` these can jump backward when the user adjusts
+//! their system clock. Use only when communicating time externally
+//! (logs, protocols) — for measuring elapsed time, prefer the
+//! monotonic `now_*` helpers.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_UNIX_MS() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_TIME_UNIX_NS() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -67,7 +67,7 @@ pub fn rts_pending_apis() -> &'static [&'static str] {
 
 const RTS_EXPORTS: &[&str] = &[
     "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "isize", "usize", "f32", "f64", "bool",
-    "str", "fs", "io", "math", "bigfloat",
+    "str", "fs", "io", "math", "bigfloat", "time",
 ];
 
 const COMPILER_DEPENDENCIES: &[&str] = &[


### PR DESCRIPTION
Closes #14. 6 membros: now_ms/ns (monotonic), unix_ms/ns (wall clock), sleep_ms/ns. Registrado em SPECS + JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)