### PR TITLE
feat(ns): path namespace (#13)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/bigfloat/");
     println!("cargo:rerun-if-changed=src/namespaces/time/");
     println!("cargo:rerun-if-changed=src/namespaces/env/");
+    println!("cargo:rerun-if-changed=src/namespaces/path/");
     println!("cargo:rerun-if-changed=src/namespaces/rt_all.rs");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -33,6 +33,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::bigfloat::abi::SPEC,
     &crate::namespaces::time::abi::SPEC,
     &crate::namespaces::env::abi::SPEC,
+    &crate::namespaces::path::abi::SPEC,
 ];
 
 /// Locates a member by its fully qualified name (e.g. `"io.print"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -171,6 +171,17 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_MATH_INFINITY", consts::__RTS_FN_NS_MATH_INFINITY);
     add_fn!("__RTS_FN_NS_MATH_NAN", consts::__RTS_FN_NS_MATH_NAN);
 
+    // ── namespaces::path ──────────────────────────────────────────────
+    use crate::namespaces::path::*;
+    add_fn!("__RTS_FN_NS_PATH_JOIN", join::__RTS_FN_NS_PATH_JOIN);
+    add_fn!("__RTS_FN_NS_PATH_PARENT", components::__RTS_FN_NS_PATH_PARENT);
+    add_fn!("__RTS_FN_NS_PATH_FILE_NAME", components::__RTS_FN_NS_PATH_FILE_NAME);
+    add_fn!("__RTS_FN_NS_PATH_STEM", components::__RTS_FN_NS_PATH_STEM);
+    add_fn!("__RTS_FN_NS_PATH_EXT", components::__RTS_FN_NS_PATH_EXT);
+    add_fn!("__RTS_FN_NS_PATH_IS_ABSOLUTE", join::__RTS_FN_NS_PATH_IS_ABSOLUTE);
+    add_fn!("__RTS_FN_NS_PATH_NORMALIZE", join::__RTS_FN_NS_PATH_NORMALIZE);
+    add_fn!("__RTS_FN_NS_PATH_WITH_EXT", join::__RTS_FN_NS_PATH_WITH_EXT);
+
     // ── namespaces::env ───────────────────────────────────────────────
     use crate::namespaces::env::*;
     add_fn!("__RTS_FN_NS_ENV_GET_VAR", vars::__RTS_FN_NS_ENV_GET_VAR);

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -10,4 +10,5 @@ pub mod fs;
 pub mod gc;
 pub mod io;
 pub mod math;
+pub mod path;
 pub mod time;

--- a/src/namespaces/path/abi.rs
+++ b/src/namespaces/path/abi.rs
@@ -1,0 +1,92 @@
+//! `path` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "join",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_JOIN",
+        args: &[AbiType::StrPtr, AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Joins a base path with a relative fragment.",
+        ts_signature: "join(base: string, part: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "parent",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_PARENT",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Parent directory; 0 when path has no parent (e.g. root or bare filename).",
+        ts_signature: "parent(path: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "file_name",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_FILE_NAME",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Final component of the path (file name with extension).",
+        ts_signature: "file_name(path: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "stem",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_STEM",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "File name without extension.",
+        ts_signature: "stem(path: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "ext",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_EXT",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "File extension without leading dot; 0 when absent.",
+        ts_signature: "ext(path: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "is_absolute",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_IS_ABSOLUTE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Bool,
+        doc: "True when path is absolute for the current target.",
+        ts_signature: "is_absolute(path: string): boolean",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "normalize",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_NORMALIZE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Removes `.` and collapses `..` without touching the filesystem.",
+        ts_signature: "normalize(path: string): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "with_ext",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PATH_WITH_EXT",
+        args: &[AbiType::StrPtr, AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Returns the path with the extension replaced (or added).",
+        ts_signature: "with_ext(path: string, ext: string): string",
+        intrinsic: None,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "path",
+    doc: "Pure path manipulation — no filesystem calls.",
+    members: MEMBERS,
+};

--- a/src/namespaces/path/components.rs
+++ b/src/namespaces/path/components.rs
@@ -1,0 +1,73 @@
+//! Extracao de partes de um caminho (parent, file_name, stem, ext).
+//!
+//! Todas as operacoes sao puras sobre a string — nao fazem I/O, nao
+//! resolvem symlinks. Retornam handles de string via
+//! `gc::string_pool::__RTS_FN_NS_GC_STRING_NEW`. Handle 0 significa
+//! "nao existe" (ex: arquivo sem extensao, caminho sem parent).
+
+use std::path::Path;
+
+unsafe extern "C" {
+    fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
+}
+
+fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
+    if ptr.is_null() || len < 0 {
+        return None;
+    }
+    // SAFETY: caller contract — UTF-8 valido cobrindo `len` bytes.
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    std::str::from_utf8(slice).ok()
+}
+
+fn intern(s: &str) -> u64 {
+    unsafe { __RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_PARENT(ptr: *const u8, len: i64) -> u64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return 0;
+    };
+    Path::new(s)
+        .parent()
+        .and_then(|p| p.to_str())
+        .map(intern)
+        .unwrap_or(0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_FILE_NAME(ptr: *const u8, len: i64) -> u64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return 0;
+    };
+    Path::new(s)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(intern)
+        .unwrap_or(0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_STEM(ptr: *const u8, len: i64) -> u64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return 0;
+    };
+    Path::new(s)
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .map(intern)
+        .unwrap_or(0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_EXT(ptr: *const u8, len: i64) -> u64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return 0;
+    };
+    Path::new(s)
+        .extension()
+        .and_then(|n| n.to_str())
+        .map(intern)
+        .unwrap_or(0)
+}

--- a/src/namespaces/path/join.rs
+++ b/src/namespaces/path/join.rs
@@ -1,0 +1,96 @@
+//! Composicao, normalizacao e testes de caminho.
+
+use std::path::{Component, Path, PathBuf};
+
+unsafe extern "C" {
+    fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
+}
+
+fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
+    if ptr.is_null() || len < 0 {
+        return None;
+    }
+    // SAFETY: caller contract.
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    std::str::from_utf8(slice).ok()
+}
+
+fn intern(s: &str) -> u64 {
+    unsafe { __RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_JOIN(
+    base_ptr: *const u8,
+    base_len: i64,
+    part_ptr: *const u8,
+    part_len: i64,
+) -> u64 {
+    let Some(base) = str_from_abi(base_ptr, base_len) else {
+        return 0;
+    };
+    let Some(part) = str_from_abi(part_ptr, part_len) else {
+        return 0;
+    };
+    let joined = PathBuf::from(base).join(part);
+    joined.to_str().map(intern).unwrap_or(0)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_IS_ABSOLUTE(ptr: *const u8, len: i64) -> i64 {
+    match str_from_abi(ptr, len) {
+        Some(s) if Path::new(s).is_absolute() => 1,
+        _ => 0,
+    }
+}
+
+/// Normaliza removendo componentes `.` e resolvendo `..` onde possivel
+/// (sem tocar o filesystem; preserva `..` iniciais que apontam para
+/// fora do caminho base).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_NORMALIZE(ptr: *const u8, len: i64) -> u64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return 0;
+    };
+    let mut out = PathBuf::new();
+    for comp in Path::new(s).components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // So apaga o ultimo se ele for um componente "normal";
+                // senao preserva o `..` (ex: path relativo fora da
+                // raiz corrente).
+                let pop_ok = out
+                    .components()
+                    .next_back()
+                    .map(|c| matches!(c, Component::Normal(_)))
+                    .unwrap_or(false);
+                if pop_ok {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    let rendered = out.to_string_lossy();
+    intern(&rendered)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PATH_WITH_EXT(
+    path_ptr: *const u8,
+    path_len: i64,
+    ext_ptr: *const u8,
+    ext_len: i64,
+) -> u64 {
+    let Some(path) = str_from_abi(path_ptr, path_len) else {
+        return 0;
+    };
+    let Some(ext) = str_from_abi(ext_ptr, ext_len) else {
+        return 0;
+    };
+    let result = Path::new(path).with_extension(ext);
+    result.to_str().map(intern).unwrap_or(0)
+}

--- a/src/namespaces/path/mod.rs
+++ b/src/namespaces/path/mod.rs
@@ -1,0 +1,5 @@
+//! `path` namespace — manipulacao de caminhos pura, sem tocar filesystem.
+
+pub mod abi;
+pub mod components;
+pub mod join;

--- a/src/namespaces/path/rt.rs
+++ b/src/namespaces/path/rt.rs
@@ -1,0 +1,2 @@
+pub mod components;
+pub mod join;

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -12,3 +12,5 @@ pub mod bigfloat;
 pub mod time;
 #[path = "env/rt.rs"]
 pub mod env;
+#[path = "path/rt.rs"]
+pub mod path;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -67,7 +67,7 @@ pub fn rts_pending_apis() -> &'static [&'static str] {
 
 const RTS_EXPORTS: &[&str] = &[
     "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "isize", "usize", "f32", "f64", "bool",
-    "str", "fs", "io", "math", "bigfloat", "time", "env",
+    "str", "fs", "io", "math", "bigfloat", "time", "env", "path",
 ];
 
 const COMPILER_DEPENDENCIES: &[&str] = &[


### PR DESCRIPTION
Closes #13. 8 membros de manipulacao pura de path (join/parent/file_name/stem/ext/is_absolute/normalize/with_ext). Retorno como string handle. Registrado AOT + JIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)