### PR TITLE
feat(ns): os namespace (#19)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/buffer/");
     println!("cargo:rerun-if-changed=src/namespaces/string/");
     println!("cargo:rerun-if-changed=src/namespaces/process/");
+    println!("cargo:rerun-if-changed=src/namespaces/os/");
     println!("cargo:rerun-if-changed=src/namespaces/rt_all.rs");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -37,6 +37,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::buffer::abi::SPEC,
     &crate::namespaces::string::abi::SPEC,
     &crate::namespaces::process::abi::SPEC,
+    &crate::namespaces::os::abi::SPEC,
 ];
 
 /// Locates a member by its fully qualified name (e.g. `"io.print"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -171,6 +171,19 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_MATH_INFINITY", consts::__RTS_FN_NS_MATH_INFINITY);
     add_fn!("__RTS_FN_NS_MATH_NAN", consts::__RTS_FN_NS_MATH_NAN);
 
+    // ── namespaces::os ────────────────────────────────────────────────
+    {
+        use crate::namespaces::os::*;
+        add_fn!("__RTS_FN_NS_OS_PLATFORM", info::__RTS_FN_NS_OS_PLATFORM);
+        add_fn!("__RTS_FN_NS_OS_ARCH", info::__RTS_FN_NS_OS_ARCH);
+        add_fn!("__RTS_FN_NS_OS_FAMILY", info::__RTS_FN_NS_OS_FAMILY);
+        add_fn!("__RTS_FN_NS_OS_EOL", info::__RTS_FN_NS_OS_EOL);
+        add_fn!("__RTS_FN_NS_OS_HOME_DIR", dirs::__RTS_FN_NS_OS_HOME_DIR);
+        add_fn!("__RTS_FN_NS_OS_TEMP_DIR", dirs::__RTS_FN_NS_OS_TEMP_DIR);
+        add_fn!("__RTS_FN_NS_OS_CONFIG_DIR", dirs::__RTS_FN_NS_OS_CONFIG_DIR);
+        add_fn!("__RTS_FN_NS_OS_CACHE_DIR", dirs::__RTS_FN_NS_OS_CACHE_DIR);
+    }
+
     // ── namespaces::process ───────────────────────────────────────────
     {
         use crate::namespaces::process::*;

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -11,6 +11,7 @@ pub mod fs;
 pub mod gc;
 pub mod io;
 pub mod math;
+pub mod os;
 pub mod path;
 pub mod process;
 pub mod string;

--- a/src/namespaces/os/abi.rs
+++ b/src/namespaces/os/abi.rs
@@ -1,0 +1,92 @@
+//! `os` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "platform",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_PLATFORM",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Canonical OS name: 'windows', 'linux', 'macos', 'ios', 'android', ...",
+        ts_signature: "platform(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "arch",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_ARCH",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "CPU architecture: 'x86_64', 'aarch64', 'x86', ...",
+        ts_signature: "arch(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "family",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_FAMILY",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "OS family: 'unix' or 'windows'.",
+        ts_signature: "family(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "eol",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_EOL",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Native line ending: '\\r\\n' on Windows, '\\n' elsewhere.",
+        ts_signature: "eol(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "home_dir",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_HOME_DIR",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "User home directory. Empty string if unresolvable.",
+        ts_signature: "home_dir(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "temp_dir",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_TEMP_DIR",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "System temporary directory.",
+        ts_signature: "temp_dir(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "config_dir",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_CONFIG_DIR",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Per-user config dir (%APPDATA% / XDG_CONFIG_HOME / ~/.config).",
+        ts_signature: "config_dir(): string",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "cache_dir",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_OS_CACHE_DIR",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Per-user cache dir (%LOCALAPPDATA% / XDG_CACHE_HOME / ~/.cache).",
+        ts_signature: "cache_dir(): string",
+        intrinsic: None,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "os",
+    doc: "OS and environment info: platform, arch, special directories.",
+    members: MEMBERS,
+};

--- a/src/namespaces/os/dirs.rs
+++ b/src/namespaces/os/dirs.rs
@@ -1,0 +1,108 @@
+//! Diretorios especiais do usuario — home, temp, config, cache.
+//!
+//! Implementacao sem deps externas. `home_dir` le HOME (Unix) ou
+//! USERPROFILE (Windows). `config_dir`/`cache_dir` seguem XDG no
+//! Unix com fallbacks; em Windows usam APPDATA / LOCALAPPDATA.
+
+unsafe extern "C" {
+    fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
+}
+
+fn intern(s: &str) -> u64 {
+    unsafe { __RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64) }
+}
+
+fn env_or_empty(key: &str) -> String {
+    std::env::var(key).unwrap_or_default()
+}
+
+/// Home do usuario. Vazio se nao conseguir resolver.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_HOME_DIR() -> u64 {
+    #[cfg(target_os = "windows")]
+    let home = env_or_empty("USERPROFILE");
+    #[cfg(not(target_os = "windows"))]
+    let home = env_or_empty("HOME");
+    intern(&home)
+}
+
+/// Diretorio temporario do sistema.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_TEMP_DIR() -> u64 {
+    let path = std::env::temp_dir();
+    intern(&path.to_string_lossy())
+}
+
+/// Config dir do usuario.
+/// - Windows: %APPDATA% (ex: C:\Users\foo\AppData\Roaming)
+/// - macOS:   $HOME/Library/Application Support
+/// - Linux:   $XDG_CONFIG_HOME ou $HOME/.config
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_CONFIG_DIR() -> u64 {
+    #[cfg(target_os = "windows")]
+    let dir = env_or_empty("APPDATA");
+
+    #[cfg(target_os = "macos")]
+    let dir = {
+        let home = env_or_empty("HOME");
+        if home.is_empty() {
+            String::new()
+        } else {
+            format!("{home}/Library/Application Support")
+        }
+    };
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let dir = {
+        let xdg = env_or_empty("XDG_CONFIG_HOME");
+        if !xdg.is_empty() {
+            xdg
+        } else {
+            let home = env_or_empty("HOME");
+            if home.is_empty() {
+                String::new()
+            } else {
+                format!("{home}/.config")
+            }
+        }
+    };
+
+    intern(&dir)
+}
+
+/// Cache dir do usuario.
+/// - Windows: %LOCALAPPDATA%
+/// - macOS:   $HOME/Library/Caches
+/// - Linux:   $XDG_CACHE_HOME ou $HOME/.cache
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_CACHE_DIR() -> u64 {
+    #[cfg(target_os = "windows")]
+    let dir = env_or_empty("LOCALAPPDATA");
+
+    #[cfg(target_os = "macos")]
+    let dir = {
+        let home = env_or_empty("HOME");
+        if home.is_empty() {
+            String::new()
+        } else {
+            format!("{home}/Library/Caches")
+        }
+    };
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let dir = {
+        let xdg = env_or_empty("XDG_CACHE_HOME");
+        if !xdg.is_empty() {
+            xdg
+        } else {
+            let home = env_or_empty("HOME");
+            if home.is_empty() {
+                String::new()
+            } else {
+                format!("{home}/.cache")
+            }
+        }
+    };
+
+    intern(&dir)
+}

--- a/src/namespaces/os/info.rs
+++ b/src/namespaces/os/info.rs
@@ -1,0 +1,40 @@
+//! Plataforma / arquitetura / familia — constantes resolvidas em
+//! compile-time via std::env::consts.
+
+unsafe extern "C" {
+    fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
+}
+
+fn intern(s: &str) -> u64 {
+    unsafe { __RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64) }
+}
+
+/// Nome canonico do SO: "windows", "linux", "macos", "ios", "android",
+/// etc. Retorna string handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_PLATFORM() -> u64 {
+    intern(std::env::consts::OS)
+}
+
+/// Arquitetura: "x86_64", "aarch64", "x86", etc.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_ARCH() -> u64 {
+    intern(std::env::consts::ARCH)
+}
+
+/// Familia: "unix" ou "windows".
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_FAMILY() -> u64 {
+    intern(std::env::consts::FAMILY)
+}
+
+/// Line ending convencional para o target: "\r\n" em Windows, "\n"
+/// em Unix.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_OS_EOL() -> u64 {
+    #[cfg(target_os = "windows")]
+    let eol: &str = "\r\n";
+    #[cfg(not(target_os = "windows"))]
+    let eol: &str = "\n";
+    intern(eol)
+}

--- a/src/namespaces/os/mod.rs
+++ b/src/namespaces/os/mod.rs
@@ -1,0 +1,5 @@
+//! `os` namespace — info do sistema operacional.
+
+pub mod abi;
+pub mod dirs;
+pub mod info;

--- a/src/namespaces/os/rt.rs
+++ b/src/namespaces/os/rt.rs
@@ -1,0 +1,2 @@
+pub mod dirs;
+pub mod info;

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -20,3 +20,5 @@ pub mod buffer;
 pub mod string;
 #[path = "process/rt.rs"]
 pub mod process;
+#[path = "os/rt.rs"]
+pub mod os;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -68,6 +68,7 @@ pub fn rts_pending_apis() -> &'static [&'static str] {
 const RTS_EXPORTS: &[&str] = &[
     "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "isize", "usize", "f32", "f64", "bool",
     "str", "fs", "io", "math", "bigfloat", "time", "env", "path", "buffer", "string", "process",
+    "os",
 ];
 
 const COMPILER_DEPENDENCIES: &[&str] = &[


### PR DESCRIPTION
Closes #19. 8 membros: platform, arch, family, eol, home/temp/config/cache_dir. Sem deps externas — resolve via std::env::var com convencoes por plataforma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)