### PR TITLE
docs: refresh pos 13 namespaces + codegen atual

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -12,7 +12,8 @@ Agentes automatizados e humanos devem consultar, nesta ordem:
 
 ## Notas especificas para agentes
 
-- Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
+- Namespaces ativos (13): `io`, `fs`, `gc`, `math`, `bigfloat`, `time`, `env`,
+  `path`, `buffer`, `string`, `process`, `os`, `collections`.
 - Contrato ABI unico vive em `src/abi/` (`SPECS`, `NamespaceMember`, `AbiType`, `Intrinsic`,
   simbolos `__RTS_FN_NS_<NS>_<NAME>` e dados `__RTS_DATA_NS_<NS>_<NAME>`). Nao ha mais
   `dispatch()` por namespace, nem `JsValue` no limite, nem `__rts_call_dispatch`.
@@ -24,8 +25,10 @@ Agentes automatizados e humanos devem consultar, nesta ordem:
   ver `lower_intrinsic` em `src/codegen/lower/expr.rs`.
 - User functions usam `CallConv::Tail` (para TCO); `__RTS_MAIN` usa platform default
   porque e chamado por C extern.
-- Namespaces removidos (net, process, crypto, buffer, promise, task, global) serao
-  reintroduzidos sobre o contrato novo — nao assumir que estao disponiveis.
+- Namespaces ainda nao implementados (net, thread, sync, crypto, regex, fmt, hash,
+  ffi, atomic, mem, ptr, num, hint, alloc, task, mpmc, simd, backtrace) serao
+  reintroduzidos sobre o contrato novo. Ver issues #16-#39 — nao assumir que
+  estao disponiveis.
 
 Qualquer duplicacao de conteudo entre este arquivo e `CLAUDE.md` deve ser resolvida
 a favor de `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,9 @@ atual a medida que o pipeline estabiliza. Ver issues #12-#39 para o backlog.
 - `fs/` — read, read_all, write, append, exists, is_file, is_dir, size, modified_ms,
   create_dir(_all), remove_dir(_all), remove_file, rename, copy
 - `gc/` — handles e string pool: string_from_{i64,f64,static}, string_{new,concat,len,ptr,free},
-  `HandleTable` slab-based com 16-bit geracao + 48-bit slot (`u64` handle); `Entry` enumera
-  tipos armazenados (`String`, `BigFixed`, `Free`)
+  `HandleTable` slab-based com 16-bit geracao + 48-bit slot (`u64` handle);
+  `Entry` enumera tipos armazenados (`String`, `BigFixed`, `Buffer`, `ProcessChild`,
+  `Map`, `Vec`, `Free`)
 - `math/` — basic (floor/ceil/round/trunc/sqrt/cbrt/pow/exp/ln/log2/log10/abs_f64/abs_i64),
   trig (sin/cos/tan/asin/acos/atan/atan2), minmax (min/max/clamp_f64/i64), consts
   (PI/E/INFINITY/NAN como `MemberKind::Constant`), random (xorshift64 com estado em
@@ -102,6 +103,24 @@ atual a medida que o pipeline estabiliza. Ver issues #12-#39 para o backlog.
 - `bigfloat/` — decimal fixed-point via i128 (scale decimal ate 36). Operacoes:
   zero/from_f64/from_i64/from_str/to_f64/to_string/add/sub/mul/div/neg/sqrt/free.
   Usado para pi com 29+ digitos via Machin + atan de Maclaurin
+- `time/` — now_ms/now_ns (Instant monotonico), unix_ms/unix_ns (SystemTime),
+  sleep_ms/sleep_ns
+- `env/` — get_var, set_var, remove_var, args_count, arg_at, cwd, set_cwd
+- `path/` — join, parent, file_name, stem, ext, is_absolute, normalize, with_ext
+  (operacoes puras, sem I/O)
+- `buffer/` — Vec<u8> via HandleTable: alloc/alloc_zeroed/free/len/ptr,
+  read/write u8/i32/i64/f64 little-endian, copy/fill, to_string (UTF-8)
+- `string/` — search (contains/starts_with/ends_with/find), transform
+  (to_upper/to_lower/trim/trim_start/trim_end/repeat), replace/replacen,
+  char_count/byte_len/char_at/char_code_at (Unicode-aware)
+- `process/` — exit/abort, pid, args_count/arg_at (alias de env), spawn
+  (args separados por \\n), wait (consume handle), kill. Child handle via
+  `Entry::ProcessChild`
+- `os/` — platform/arch/family/eol (std::env::consts + cfg!), home_dir,
+  temp_dir, config_dir, cache_dir (XDG no Unix, APPDATA/LOCALAPPDATA no
+  Windows)
+- `collections/` — HashMap<string, i64> (`map_*`) e Vec<i64> (`vec_*`) via
+  HandleTable. Valor sempre i64 — caller interpreta como int/handle/bool
 
 ## Convencoes
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -3,33 +3,59 @@
 ## Status atual
 
 Etapa 1 (reancorar) e Etapa 2 (plugar API nova) estao **concluidas** — pipeline por grafo,
-cache incremental, runtime support embutido, `abi::SPECS` como fonte unica, `io`/`fs`/`gc`
-estaveis e `math`/`bigfloat` adicionados.
+cache incremental, runtime support embutido, `abi::SPECS` como fonte unica, namespaces core
+(`io`/`fs`/`gc`) estaveis e novos namespaces adicionados.
 
-Etapa 3 (migracao incremental de melhorias de codegen) em andamento — ver **Progresso recente**
-abaixo.
+Etapa 3 (migracao incremental de melhorias de codegen + expansao de namespaces) em andamento —
+ver **Progresso recente** abaixo.
 
-## Progresso recente (codegen + capacidades)
+## Progresso recente
 
+### Codegen + capacidades TS
 - **JIT mode** (#95): `RTS_JIT=1 rts run` compila para memoria executavel, ~14x mais rapido
-  que AOT no startup
+  que AOT no startup. Ambos paths via `&mut dyn Module`
 - **Tail call optimization** (#93): recursao profunda sem stack overflow via `return_call`
 - **First-class function pointers** (#97 fase 1): funcoes como valores, `call_indirect` no use
 - **Intrinsics inline** (#87): `math.sqrt`, `math.random_f64`, etc. emitidos como IR direto
 - **f64 modulo correto** (#89): via `fmod` libc
 - **Jump table switch** (#91), **imm forms** (#94), **MemFlags::trusted** (#98),
   **stack_slot helper** (#99)
-- **Namespaces novos**: `math` (27 membros + 4 constantes) e `bigfloat` (decimal 30 digitos
-  via i128)
 - **Capacidades TS**: template literals, ternario, bitwise ops, arrow/fn expressions,
-  let/const scoping correto
+  let/const scoping correto, compound assign (#48), `typeof`/`void`/`delete` (#51),
+  `??` e optional call (#50), exponentiation (#52)
+
+### Namespaces novos (13 total)
+- **math** (#20) — 27 membros + 4 constantes (`MemberKind::Constant`)
+- **bigfloat** — decimal fixed-point i128, pi com 29 digitos via Machin
+- **time** (#14) — monotonic clock, wall clock, sleep
+- **env** (#12) — vars, argv, cwd
+- **path** (#13) — join/parent/normalize sem I/O
+- **buffer** (#22) — Vec<u8> via HandleTable
+- **string** (#25) — search/transform/replace/char ops
+- **process** (#15) — exit/abort/pid/spawn/wait/kill
+- **os** (#19) — platform/arch/home_dir/config_dir/cache_dir
+- **collections** (#26) — HashMap<string, i64>, Vec<i64>
 
 ## Backlog priorizado
 
+### Codegen
 - **#97 fases 2/3** — arrow em qualquer posicao + captura imutavel/mutavel (depende #99 ✅)
-- **#96 DWARF** — debug info no ObjectModule
+- **#96 DWARF** — debug info no ObjectModule (investigacao complexa, ver comentario da issue)
 - **#90 loop block params** — deferred; impl atual ja produz SSA correto via frontend
 - **#92 autovec** — fechada como inviavel (Cranelift nao tem loop vectorizer)
+- **#53 object literals**, **#54 array literals** — grande, desbloqueia classes, destructuring,
+  `Array.prototype.*`
+- **#62 try/catch/throw** — error handling idiomatico
+- **#60/#61 for-of/for-in** — dependem de arrays/objects
+
+### Namespaces pendentes
+- **#23 fmt** — parse + format numerico (printf-like)
+- **#21 hash** — SipHash (std::hash)
+- **#24 crypto** — SHA/HMAC/AEAD (depende #22 ✅)
+- **#28 regex** — pattern matching
+- **#16 net** — TCP/UDP/HTTP (depende #22 ✅)
+- **#17 thread**, **#18 channel**, **#27 sync** — concorrencia
+- **#29-#39** — nicho (ffi, atomic, mem, ptr, num, hint, alloc, task, mpmc, simd, backtrace)
 
 ## Direcao alvo
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ os namespaces builtin. Ha dois caminhos de execucao:
 - **AOT** (`rts compile`) — emite object file, linka com o linker do sistema,
   produz executavel standalone.
 
-Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
+Namespaces ativos (13): `io`, `fs`, `gc`, `math`, `bigfloat`, `time`, `env`, `path`,
+`buffer`, `string`, `process`, `os`, `collections`.
+
+**Observação de perf (Windows, `rts_simple.ts`, 10 runs):**
+
+| Runner          | Mediana | vs Bun           |
+|-----------------|---------|------------------|
+| RTS (compiled)  |  15 ms  | **5.9× faster**  |
+| RTS (run, JIT)  |  22 ms  | **4.1× faster**  |
+| Bun             |  88 ms  | —                |
+| Node            | 118 ms  | 0.75× slower     |
 
 ## Arquitetura
 
@@ -31,9 +41,18 @@ src/
   namespaces/        Implementacoes dos namespaces builtin
     io/              print, eprint, stdout/stderr/stdin
     fs/              read, write, metadata, dir, copy, rename, ...
-    gc/              HandleTable (slab + generation) + string pool
+    gc/              HandleTable (slab + generation) + string pool;
+                     Entry enumera String/BigFixed/Buffer/ProcessChild/Map/Vec
     math/            f64/i64 intrinsics + xorshift64 PRNG + constantes
     bigfloat/        decimal fixed-point via i128 (~30 digitos)
+    time/            monotonic clock, wall clock, sleep
+    env/             get/set/remove vars, argv, cwd
+    path/            join, parent, file_name, stem, ext, normalize, with_ext
+    buffer/          Vec<u8> via HandleTable (alloc/read/write/copy/fill)
+    string/          contains, trim, to_upper/lower, replace, char_count, find
+    process/         exit/abort/pid, argv aliases, spawn/wait/kill
+    os/              platform, arch, family, home/temp/config/cache_dir
+    collections/     HashMap<string, i64> e Vec<i64> via HandleTable
     <ns>/mod.rs      import map
     <ns>/abi.rs      tabela estatica de NamespaceMember
     <ns>/rt.rs       re-exports para o runtime staticlib
@@ -55,7 +74,8 @@ Pipeline JIT: `Source TS -> Parser (SWC) -> Codegen Cranelift -> JITModule in-me
 ## Contrato ABI
 
 - Fonte unica: `src/abi/`.
-- `abi::SPECS` lista os namespaces ativos (hoje: `io`, `fs`, `gc`, `math`, `bigfloat`).
+- `abi::SPECS` lista os 13 namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`,
+  `time`, `env`, `path`, `buffer`, `string`, `process`, `os`, `collections`.
 - Cada membro declara nome, parametros, retorno via `AbiType`, e opcionalmente
   um `Intrinsic` que permite ao codegen emitir IR inline ao inves de call extern
   (usado em `math.sqrt`, `math.random_f64`, etc).
@@ -81,22 +101,29 @@ Suportadas no codegen:
 
 - **Controle de fluxo**: if/else, while, do-while, for, switch (com jump table
   nativa quando todos os cases sao literais inteiros), break/continue.
-- **Expressoes**: aritmetica (+ - * / %), bitwise (`& | ^ ~ << >> >>>`),
-  ternario (`a ? b : c`), logicos (&& ||), comparacoes, assignment, template
-  literals (com interpolacao de qualquer tipo).
+- **Expressoes**: aritmetica (`+ - * / % **`), bitwise (`& | ^ ~ << >> >>>`),
+  ternario (`a ? b : c`), logicos (`&& || ??`), comparacoes, assignment,
+  compound assignment (`+= -= *= ... **=`), template literals (com
+  interpolacao de qualquer tipo), `typeof` / `void` / `delete`, optional
+  call (`fn?.()`), exponenciacao (`a ** b` via libc pow), modulo f64
+  (`a % b` via libc fmod).
 - **Funcoes**: declaracao, `function` expression, arrow functions (bloco ou
   expressao), tail call optimization (`return f(x)` vira `return_call`),
-  ponteiros de funcao como valores de primeira classe (callbacks).
+  ponteiros de funcao como valores de primeira classe (callbacks, higher-
+  order functions como `apply(fn, x)` e `compose(f, g, x)`).
 - **Escopo**: `let`/`const`/`var` com semantica de bloco; `const` impede
   reassignment.
 - **Namespaces**: `import { io, math, ... } from "rts"` + `io.print(...)`,
   `math.sqrt(x)`, etc. Constantes via `math.PI`, `math.E`, sem parens.
 - **Big decimal**: `bigfloat.add/sub/mul/div/sqrt` com handles de ~30 digitos
-  decimais. Suficiente para calcular pi com 29 digitos corretos.
+  decimais. Suficiente para calcular pi com 29 digitos corretos via Machin.
+- **Containers**: `collections.map_*` e `collections.vec_*` via handles
+  (HashMap<string, i64> e Vec<i64>), `buffer.alloc/read/write` pra bytes.
 
 Nao suportado ainda: `class`, `try/catch`, `async/await`, generators,
-destructuring, spread/rest, regex, object e array literals. Closures com
-captura de variaveis externas estao em fase 1 (ponteiros de funcao sem env).
+destructuring, spread/rest, regex, object e array literals nativos.
+Closures com captura de variaveis externas estao em fase 1 (ponteiros de
+funcao sem env).
 
 ## CLI
 
@@ -137,11 +164,15 @@ cargo run -- apis
   `bigfloat`. Resultado `3.141592653589793238462643383280` (29 digitos corretos,
   f64 entrega 16).
 
-Suite tradicional:
+Suite `bench/benchmark.ps1` compara 5 runners (RTS compiled / RTS run
+JIT / RTS run AOT / Bun / Node) em `bench/rts_simple.ts`:
 
 ```bash
-powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
+powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1 -Runs 10 -Warmup 2
 ```
+
+Numeros tipicos (Windows, 10 runs): `RTS compiled ~15 ms`, `RTS JIT ~22 ms`,
+`Bun ~88 ms`, `Node ~118 ms`. **RTS JIT ~4× mais rapido que Bun.**
 
 ## Runtime vs Compile (AOT)
 

--- a/ROAD_MAP.md
+++ b/ROAD_MAP.md
@@ -24,7 +24,8 @@ Convergir para o modelo da `main` (pipeline completo + cache), mantendo a organi
 - [x] Namespaces `io`, `fs`, `gc` completos no fluxo novo.
 - [x] Declaracoes TypeScript sincronizadas a partir da ABI nova.
 - [x] Namespaces adicionais consolidados: `math` (27 membros + 4 constantes),
-      `bigfloat` (decimal 30 digitos).
+      `bigfloat` (decimal 30 digitos), `time`, `env`, `path`, `buffer`,
+      `string`, `process`, `os`, `collections` — 13 namespaces total.
 
 ---
 
@@ -32,6 +33,7 @@ Convergir para o modelo da `main` (pipeline completo + cache), mantendo a organi
 
 ### Concluido
 
+Codegen:
 - [x] Intrinsics inline (#87)
 - [x] f64 modulo via fmod (#89)
 - [x] Switch jump table (#91)
@@ -41,14 +43,36 @@ Convergir para o modelo da `main` (pipeline completo + cache), mantendo a organi
 - [x] First-class function pointers (#97 fase 1)
 - [x] MemFlags::trusted (#98)
 - [x] stack_slot helper (#99)
+- [x] Compound assign (#48)
+- [x] Ternario (#49)
+- [x] Bitwise ops (#47)
+- [x] Exponentiation (#52)
+- [x] `typeof`/`void`/`delete` (#51)
+- [x] `??` e optional call `?.()` (#50)
+- [x] Template literals (#46)
+- [x] let/const scoping (#44)
+- [x] Function/arrow expressions (#55, #56)
+
+Namespaces:
+- [x] math (#20), time (#14), env (#12), path (#13)
+- [x] buffer (#22), string (#25), process (#15), os (#19)
+- [x] collections (#26), bigfloat
 
 ### Pendente
 
+Codegen:
 - [ ] #96 DWARF debug info
 - [ ] #97 fases 2/3 — arrow como valor + captura de escopo externo
 - [ ] #90 loop block params — deferred; SSA atual ja funcional
-- [ ] Novos namespaces sobre o contrato atual (#12-#39: env, path, time, process,
-      net, thread, etc)
+- [ ] #92 autovec — fechada como inviavel sem loop vectorizer
+- [ ] #53 object literals, #54 array literals — desbloqueia classes/HOF idiomatico
+- [ ] #62 try/catch/throw — error handling
+- [ ] #60/#61 for-of / for-in
+
+Namespaces:
+- [ ] #23 fmt, #21 hash, #24 crypto, #28 regex
+- [ ] #16 net, #17 thread, #18 channel, #27 sync
+- [ ] #29-#39 (ffi, atomic, mem, ptr, num, hint, alloc, task, mpmc, simd, backtrace)
 
 Regra: nao juntar refactor grande e mudanca de comportamento no mesmo lote.
 


### PR DESCRIPTION
Atualiza README/CLAUDE/AGENT/NEXT_STEPS/ROAD_MAP para refletir os PRs #110-#123. Lista canonica dos 13 namespaces, capacidades TS atuais, backlog reorganizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)