### PR TITLE
feat(ns): hash namespace (#21)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,6 +50,8 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/string/");
     println!("cargo:rerun-if-changed=src/namespaces/process/");
     println!("cargo:rerun-if-changed=src/namespaces/os/");
+    println!("cargo:rerun-if-changed=src/namespaces/collections/");
+    println!("cargo:rerun-if-changed=src/namespaces/hash/");
     println!("cargo:rerun-if-changed=src/namespaces/rt_all.rs");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -39,6 +39,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::process::abi::SPEC,
     &crate::namespaces::os::abi::SPEC,
     &crate::namespaces::collections::abi::SPEC,
+    &crate::namespaces::hash::abi::SPEC,
 ];
 
 /// Locates a member by its fully qualified name (e.g. `"io.print"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -171,6 +171,15 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_MATH_INFINITY", consts::__RTS_FN_NS_MATH_INFINITY);
     add_fn!("__RTS_FN_NS_MATH_NAN", consts::__RTS_FN_NS_MATH_NAN);
 
+    // ── namespaces::hash ──────────────────────────────────────────────
+    {
+        use crate::namespaces::hash::ops as h;
+        add_fn!("__RTS_FN_NS_HASH_HASH_STR", h::__RTS_FN_NS_HASH_HASH_STR);
+        add_fn!("__RTS_FN_NS_HASH_HASH_BYTES", h::__RTS_FN_NS_HASH_HASH_BYTES);
+        add_fn!("__RTS_FN_NS_HASH_HASH_I64", h::__RTS_FN_NS_HASH_HASH_I64);
+        add_fn!("__RTS_FN_NS_HASH_HASH_COMBINE", h::__RTS_FN_NS_HASH_HASH_COMBINE);
+    }
+
     // ── namespaces::collections ───────────────────────────────────────
     {
         use crate::namespaces::collections::*;

--- a/src/namespaces/hash/abi.rs
+++ b/src/namespaces/hash/abi.rs
@@ -1,0 +1,52 @@
+//! `hash` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "hash_str",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_HASH_HASH_STR",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::I64,
+        doc: "SipHash de uma string UTF-8.",
+        ts_signature: "hash_str(s: string): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "hash_bytes",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_HASH_HASH_BYTES",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::I64,
+        doc: "SipHash de uma regiao de memoria (ptr + len). Use com buffer.ptr(handle).",
+        ts_signature: "hash_bytes(ptr: number, len: number): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "hash_i64",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_HASH_HASH_I64",
+        args: &[AbiType::I64],
+        returns: AbiType::I64,
+        doc: "SipHash de um inteiro de 64 bits.",
+        ts_signature: "hash_i64(value: number): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "hash_combine",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_HASH_HASH_COMBINE",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::I64,
+        doc: "Combina dois hashes preservando entropia (estilo boost::hash_combine).",
+        ts_signature: "hash_combine(h1: number, h2: number): number",
+        intrinsic: None,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "hash",
+    doc: "Non-cryptographic hashing via std::hash::DefaultHasher (SipHash-1-3).",
+    members: MEMBERS,
+};

--- a/src/namespaces/hash/mod.rs
+++ b/src/namespaces/hash/mod.rs
@@ -1,0 +1,9 @@
+//! `hash` namespace — hash nao-criptografico (SipHash via DefaultHasher).
+//!
+//! Uso principal: chaves de HashMap proprio, deduplicacao, checksums
+//! rapidos. **Nao use para seguranca** — SipHash resiste a HashDoS mas
+//! nao e pre-image resistente. Para SHA/BLAKE veja namespace `crypto`
+//! (#24).
+
+pub mod abi;
+pub mod ops;

--- a/src/namespaces/hash/ops.rs
+++ b/src/namespaces/hash/ops.rs
@@ -1,0 +1,54 @@
+//! Hash operations backed by std::hash::DefaultHasher (SipHash-1-3).
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+fn hash_slice(bytes: &[u8]) -> i64 {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish() as i64
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_HASH_HASH_STR(ptr: *const u8, len: i64) -> i64 {
+    if ptr.is_null() || len < 0 {
+        return 0;
+    }
+    // SAFETY: caller contract — UTF-8 valido cobrindo `len` bytes.
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    hash_slice(slice)
+}
+
+/// Hash de um bloco de bytes arbitrarios. `ptr` pode ser qualquer
+/// endereco valido (ex: `buffer.ptr(handle)`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_HASH_HASH_BYTES(ptr: i64, len: i64) -> i64 {
+    if ptr == 0 || len < 0 {
+        return 0;
+    }
+    // SAFETY: caller passou um ponteiro valido vindo de buffer/gc.
+    let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
+    hash_slice(slice)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_HASH_HASH_I64(value: i64) -> i64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish() as i64
+}
+
+/// Combina dois hashes em um novo. Usa mistura estilo boost::hash_combine —
+/// preserva entropia dos dois operandos sem ser comutativo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_HASH_HASH_COMBINE(h1: i64, h2: i64) -> i64 {
+    // Constante = golden ratio truncada. Aritmetica bitwise em u64
+    // pra preservar os bits altos; shift << 6 em i64 sinalizado seria
+    // ambiguo em valores negativos.
+    let (a, b) = (h1 as u64, h2 as u64);
+    let combined = a
+        ^ b.wrapping_add(0x517c_c1b7_2722_0a95)
+            .wrapping_add(a << 6)
+            .wrapping_add(a >> 2);
+    combined as i64
+}

--- a/src/namespaces/hash/rt.rs
+++ b/src/namespaces/hash/rt.rs
@@ -1,0 +1,1 @@
+pub mod ops;

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -10,6 +10,7 @@ pub mod collections;
 pub mod env;
 pub mod fs;
 pub mod gc;
+pub mod hash;
 pub mod io;
 pub mod math;
 pub mod os;

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -24,3 +24,5 @@ pub mod process;
 pub mod os;
 #[path = "collections/rt.rs"]
 pub mod collections;
+#[path = "hash/rt.rs"]
+pub mod hash;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub fn rts_pending_apis() -> &'static [&'static str] {
 const RTS_EXPORTS: &[&str] = &[
     "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "isize", "usize", "f32", "f64", "bool",
     "str", "fs", "io", "math", "bigfloat", "time", "env", "path", "buffer", "string", "process",
-    "os", "collections",
+    "os", "collections", "hash",
 ];
 
 const COMPILER_DEPENDENCIES: &[&str] = &[


### PR DESCRIPTION
Closes #21. SipHash-1-3 via DefaultHasher. 4 membros: hash_str, hash_bytes, hash_i64, hash_combine. Retornos em I64 para evitar conflito com mapping U64 → Handle do codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)