### PR TITLE
feat(codegen): try/catch/throw fase 1 (#62)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -91,6 +91,14 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         };
     }
 
+    // ── runtime error slot (used by try/catch/throw in codegen) ──────
+    {
+        use crate::namespaces::gc::error::*;
+        add_fn!("__RTS_FN_RT_ERROR_SET", __RTS_FN_RT_ERROR_SET);
+        add_fn!("__RTS_FN_RT_ERROR_GET", __RTS_FN_RT_ERROR_GET);
+        add_fn!("__RTS_FN_RT_ERROR_CLEAR", __RTS_FN_RT_ERROR_CLEAR);
+    }
+
     // ── namespaces::gc ────────────────────────────────────────────────
     use crate::namespaces::gc::string_pool::*;
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/src/codegen/lower/stmt.rs
+++ b/src/codegen/lower/stmt.rs
@@ -408,6 +408,31 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
 
         Stmt::Empty(_) => Ok(false),
 
+        // ── Throw ─────────────────────────────────────────────────────────
+        // Fase 1 de #62: seta o slot global thread-local com o handle
+        // da string de erro e **segue o fluxo normal**. O caller (seja
+        // try/catch ou a funcao raiz) eh responsavel por checar o slot
+        // apos call sites sensiveis. Semantica imperfeita mas pragmatica
+        // — codigo apos `throw` no mesmo bloco ainda executa. Fase 2
+        // integra unwind real via Cranelift invoke.
+        Stmt::Throw(throw_stmt) => {
+            let tv = lower_expr(ctx, &throw_stmt.arg)?;
+            let handle = ctx.coerce_to_handle(tv)?;
+            let set_fref = ctx.get_extern("__RTS_FN_RT_ERROR_SET", &[cl::I64], None)?;
+            ctx.builder.ins().call(set_fref, &[handle.val]);
+            // Retorna false — fluxo continua normalmente. A diferenca
+            // de comportamento fica com o try/catch que enxerga o
+            // slot apos o body.
+            Ok(false)
+        }
+
+        // ── Try / catch / finally ─────────────────────────────────────────
+        // Fase 1: zera slot antes do body, roda body; apos o body,
+        // checa slot != 0 → pula para catch com binding = handle
+        // corrente; zera slot no inicio do catch. Finally roda
+        // em qualquer caminho (normal e apos catch).
+        Stmt::Try(try_stmt) => lower_try(ctx, try_stmt),
+
         other => Err(anyhow!("unsupported statement: {}", stmt_kind_name(other))),
     }
 }
@@ -457,6 +482,105 @@ fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {
         return Some(ValTy::from_annotation(name));
     }
     None
+}
+
+/// Lowers `try { ... } catch (e) { ... } finally { ... }`.
+///
+/// Estrategia simples (fase 1 de #62): zera o slot de erro antes do
+/// body, roda o body, checa o slot depois. Sem unwind real —
+/// captura so funciona para `throw` cujo caminho de execucao
+/// retorna ao fim do body `try` com o slot setado (ex: throw
+/// direto no try, ou throw dentro de funcao chamada do try que
+/// retornou).
+fn lower_try(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Result<bool> {
+    use cranelift_codegen::ir::condcodes::IntCC;
+
+    let has_catch = t.handler.is_some();
+    let has_finally = t.finalizer.is_some();
+
+    // Clear do slot antes do body.
+    let clear_fref = ctx.get_extern("__RTS_FN_RT_ERROR_CLEAR", &[], None)?;
+    ctx.builder.ins().call(clear_fref, &[]);
+
+    // Compila body. Depois dele, verifica slot.
+    lower_block(ctx, &t.block)?;
+
+    // Blocos de orchestration.
+    let catch_block = if has_catch {
+        Some(ctx.builder.create_block())
+    } else {
+        None
+    };
+    let finally_block = if has_finally {
+        Some(ctx.builder.create_block())
+    } else {
+        None
+    };
+    let after_block = ctx.builder.create_block();
+
+    // Se o body ja terminou (return/throw), nao emite check — mas
+    // se o body caiu pro fluxo normal, emite check do slot.
+    if !ctx.builder.is_unreachable() {
+        let get_fref =
+            ctx.get_extern("__RTS_FN_RT_ERROR_GET", &[], Some(cl::I64))?;
+        let inst = ctx.builder.ins().call(get_fref, &[]);
+        let err_handle = ctx.builder.inst_results(inst)[0];
+        let zero = ctx.builder.ins().iconst(cl::I64, 0);
+        let is_err = ctx
+            .builder
+            .ins()
+            .icmp(IntCC::NotEqual, err_handle, zero);
+
+        // Branch: se erro, catch (se existir); senao finally/after.
+        let ok_target = finally_block.unwrap_or(after_block);
+        let err_target = catch_block.unwrap_or(ok_target);
+        ctx.builder
+            .ins()
+            .brif(is_err, err_target, &[], ok_target, &[]);
+    }
+
+    // Emite catch block.
+    if let Some(cb) = catch_block {
+        ctx.builder.switch_to_block(cb);
+        ctx.builder.seal_block(cb);
+
+        // Binding: le slot, atribui a variavel (se houver param), limpa.
+        let handler = t.handler.as_ref().unwrap();
+        if let Some(param) = &handler.param {
+            if let swc_ecma_ast::Pat::Ident(id) = param {
+                let name = id.id.sym.as_str();
+                let get_fref =
+                    ctx.get_extern("__RTS_FN_RT_ERROR_GET", &[], Some(cl::I64))?;
+                let inst = ctx.builder.ins().call(get_fref, &[]);
+                let err_handle = ctx.builder.inst_results(inst)[0];
+                ctx.declare_local(name, ValTy::Handle, err_handle);
+            }
+        }
+        let clear_fref =
+            ctx.get_extern("__RTS_FN_RT_ERROR_CLEAR", &[], None)?;
+        ctx.builder.ins().call(clear_fref, &[]);
+
+        lower_block(ctx, &handler.body)?;
+        if !ctx.builder.is_unreachable() {
+            let next = finally_block.unwrap_or(after_block);
+            ctx.builder.ins().jump(next, &[]);
+        }
+    }
+
+    // Emite finally block.
+    if let Some(fb) = finally_block {
+        ctx.builder.switch_to_block(fb);
+        ctx.builder.seal_block(fb);
+        let finalizer = t.finalizer.as_ref().unwrap();
+        lower_block(ctx, finalizer)?;
+        if !ctx.builder.is_unreachable() {
+            ctx.builder.ins().jump(after_block, &[]);
+        }
+    }
+
+    ctx.builder.switch_to_block(after_block);
+    ctx.builder.seal_block(after_block);
+    Ok(false)
 }
 
 /// Extracts an integer case label for jump-table switch lowering.

--- a/src/namespaces/gc/error.rs
+++ b/src/namespaces/gc/error.rs
@@ -1,0 +1,38 @@
+//! Thread-local error slot para `try/catch/throw` do codegen.
+//!
+//! Modelo intencionalmente simples (fase 1 de #62): um slot global
+//! thread-local guarda o handle de string da exception pendente, 0
+//! quando nao ha. `throw` seta o slot; o inicio de cada `try` zera;
+//! o final de cada statement em body de `try` checa o slot e pula
+//! para `catch` se nao-zero.
+//!
+//! Nao ha unwind real — se o throw estiver dentro de uma funcao que
+//! nao coopere (ou dentro de call extern nao-TS), o erro fica
+//! pendente mas nao propaga. Suficiente para throw/catch em user
+//! code tipico; insuficiente para exceptions cruzando FFI.
+//!
+//! Fase 2/3 quando/se necessario: cranelift `invoke` + SEH/DWARF.
+
+use std::cell::Cell;
+
+thread_local! {
+    static ERROR_SLOT: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Seta o handle de erro pendente. Usado por `throw`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_ERROR_SET(handle: u64) {
+    ERROR_SLOT.with(|s| s.set(handle));
+}
+
+/// Le o handle pendente. 0 significa sem erro.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_ERROR_GET() -> u64 {
+    ERROR_SLOT.with(|s| s.get())
+}
+
+/// Limpa o slot. Usado no catch apos ler o valor.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_ERROR_CLEAR() {
+    ERROR_SLOT.with(|s| s.set(0));
+}

--- a/src/namespaces/gc/mod.rs
+++ b/src/namespaces/gc/mod.rs
@@ -5,5 +5,6 @@
 //! across the codebase ultimately calls into this module's tables.
 
 pub mod abi;
+pub mod error;
 pub mod handles;
 pub mod string_pool;

--- a/src/namespaces/gc/rt.rs
+++ b/src/namespaces/gc/rt.rs
@@ -1,2 +1,3 @@
+pub mod error;
 pub mod handles;
 pub mod string_pool;

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -156,6 +156,11 @@ fn fixture_nullish_optional() {
 }
 
 #[test]
+fn fixture_try_catch() {
+    run_fixture("try_catch");
+}
+
+#[test]
 fn fixture_tail_call() {
     run_fixture("tail_call");
 }

--- a/tests/fixtures/try_catch.out
+++ b/tests/fixtures/try_catch.out
@@ -1,0 +1,7 @@
+a
+caught: first
+finally1
+b
+c
+finally3
+end

--- a/tests/fixtures/try_catch.ts
+++ b/tests/fixtures/try_catch.ts
@@ -1,0 +1,31 @@
+import { io } from "rts";
+
+function main() {
+  // try com throw direto
+  try {
+    io.print("a");
+    throw "first";
+  } catch (e) {
+    io.print(`caught: ${e}`);
+  } finally {
+    io.print("finally1");
+  }
+
+  // try sem throw
+  try {
+    io.print("b");
+  } catch (e) {
+    io.print(`nope: ${e}`);
+  }
+
+  // try sem catch (so finally)
+  try {
+    io.print("c");
+  } finally {
+    io.print("finally3");
+  }
+
+  io.print("end");
+}
+
+main();


### PR DESCRIPTION
Fase 1 minimalista: slot thread-local global via __RTS_FN_RT_ERROR_{SET,GET,CLEAR}. Throw seta + segue; try checa depois do body. Cobre o idioma comum throw/catch sem unwind real.

Limitacoes documentadas no commit. Unwind real fica pra fase 2 (Cranelift invoke + SEH/DWARF).

Fixture try_catch cobre 3 shapes.

Refs #62 (fase 1 completa, fases 2/3 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)