### PR TITLE
feat(js): object + array literals (#53 + #54)

### DIFF
--- a/examples/poc_toolkit.ts
+++ b/examples/poc_toolkit.ts
@@ -1,0 +1,288 @@
+// POC — exercita os 16 namespaces ativos no RTS + capacidades TS.
+//
+// Simula uma ferramenta de CLI que:
+//   1. imprime info de ambiente (os, env, process)
+//   2. calcula pi via Machin (math + bigfloat)
+//   3. mantem contadores por chave (collections.map)
+//   4. escreve e le um arquivo temp com um texto processado
+//      (path + fs + string + buffer + crypto + fmt)
+//   5. usa try/catch pra lidar com erro de parse (fmt + gc error slot)
+//   6. usa ?? / ?. / tail call / first-class fns / compound assign
+//      para exercitar o codegen
+//
+// Executavel via:
+//   target\release\rts.exe run examples\poc_toolkit.ts
+//   RTS_JIT=1 target\release\rts.exe run examples\poc_toolkit.ts
+//   target\release\rts.exe compile -p examples\poc_toolkit.ts out && ./out.exe
+
+import {
+  bigfloat,
+  buffer,
+  collections,
+  crypto,
+  env,
+  fmt,
+  fs,
+  hash,
+  io,
+  math,
+  os,
+  path,
+  process,
+  string,
+  time,
+} from "rts";
+
+// ── 1. Info de ambiente ─────────────────────────────────────────────
+function section(title: string): void {
+  io.print(`\n── ${string.to_upper(title)} ──`);
+}
+
+function showEnv(): void {
+  section("env");
+  io.print(`platform = ${os.platform()}/${os.arch()} (${os.family()})`);
+  io.print(`pid = ${process.pid()}`);
+  io.print(`cwd = ${env.cwd()}`);
+  io.print(`home = ${os.home_dir()}`);
+
+  const rtsJit = env.get_var("RTS_JIT");
+  io.print(`RTS_JIT = "${rtsJit}" (vazio significa AOT)`);
+}
+
+// ── 2. Pi via Machin (30 digitos) ───────────────────────────────────
+//
+// Demonstra: bigfloat handles, first-class fn pointer, tail-style loop,
+// compound assign em i32, ternario.
+
+const PREC: i32 = 30;
+
+function atanInverseTail(n: i32, result: u64, power: u64, sign: i32, i: i32, terms: i32): u64 {
+  if (i >= terms) { return result; }
+
+  const n_big = bigfloat.from_i64(n, PREC);
+  const n_sq = bigfloat.mul(n_big, n_big);
+
+  const next_power = bigfloat.div(power, n_sq);
+  bigfloat.free(power);
+
+  const denom = bigfloat.from_i64(2 * i + 1, PREC);
+  const term = bigfloat.div(next_power, denom);
+  bigfloat.free(denom);
+
+  const new_result = sign > 0 ? bigfloat.add(result, term) : bigfloat.sub(result, term);
+  bigfloat.free(result);
+  bigfloat.free(term);
+
+  bigfloat.free(n_big);
+  bigfloat.free(n_sq);
+
+  // Tail call — nao estoura stack mesmo em 80+ iteracoes.
+  return atanInverseTail(n, new_result, next_power, -sign, i + 1, terms);
+}
+
+function atanInverse(n: i32, terms: i32): u64 {
+  const zero = bigfloat.zero(PREC);
+  const one = bigfloat.from_i64(1, PREC);
+  const n_big = bigfloat.from_i64(n, PREC);
+  const power0 = bigfloat.div(one, n_big);
+  const result0 = bigfloat.add(zero, power0);
+  bigfloat.free(zero);
+  bigfloat.free(one);
+  bigfloat.free(n_big);
+  return atanInverseTail(n, result0, power0, -1, 1, terms);
+}
+
+function showPi(): void {
+  section("pi via machin");
+  const atan_1_5: u64 = atanInverse(5, 80);
+  const atan_1_239: u64 = atanInverse(239, 20);
+  const sixteen = bigfloat.from_i64(16, PREC);
+  const four = bigfloat.from_i64(4, PREC);
+  const a = bigfloat.mul(sixteen, atan_1_5);
+  const b = bigfloat.mul(four, atan_1_239);
+  const pi = bigfloat.sub(a, b);
+
+  io.print(`pi (30 digitos) = ${bigfloat.to_string(pi)}`);
+  io.print(`pi (f64)        = ${math.PI}`);
+  io.print(`diff f64        = ${bigfloat.to_f64(pi) - math.PI}`);
+
+  bigfloat.free(atan_1_5);
+  bigfloat.free(atan_1_239);
+  bigfloat.free(sixteen);
+  bigfloat.free(four);
+  bigfloat.free(a);
+  bigfloat.free(b);
+  bigfloat.free(pi);
+}
+
+// ── 3. Contadores por chave (collections.map) ───────────────────────
+function tally(tokens: string, counts: u64): void {
+  // Comparacao via code-point (i64) porque string == string ainda
+  // compara handles, nao conteudo (issue follow-up).
+  const SPACE: i32 = 32;
+  const n: i32 = string.char_count(tokens);
+  let word = "";
+  let wordLen: i32 = 0;
+  let i: i32 = 0;
+  while (i < n) {
+    const code = string.char_code_at(tokens, i);
+    if (code == SPACE) {
+      if (wordLen > 0) {
+        const prev = collections.map_get(counts, word);
+        collections.map_set(counts, word, prev + 1);
+        word = "";
+        wordLen = 0;
+      }
+    } else {
+      word = word + string.char_at(tokens, i);
+      wordLen += 1;
+    }
+    i += 1;
+  }
+  if (wordLen > 0) {
+    const prev = collections.map_get(counts, word);
+    collections.map_set(counts, word, prev + 1);
+  }
+}
+
+function showCounts(): void {
+  section("collections");
+  const counts = collections.map_new();
+  tally("foo bar foo baz bar foo", counts);
+  io.print(`foo count = ${collections.map_get(counts, "foo")}`);
+  io.print(`bar count = ${collections.map_get(counts, "bar")}`);
+  io.print(`baz count = ${collections.map_get(counts, "baz")}`);
+  io.print(`unknown ?? 0 = ${collections.map_get(counts, "nope") ?? 0}`);
+  io.print(`map len = ${collections.map_len(counts)}`);
+  collections.map_free(counts);
+}
+
+// ── 4. Fluxo real de arquivo ────────────────────────────────────────
+function showFileRoundTrip(): void {
+  section("file round trip");
+
+  const tmpRoot = os.temp_dir();
+  const fileName = `rts_poc_${process.pid()}.txt`;
+  const fullPath = path.join(tmpRoot, fileName);
+
+  const payload = "hello from RTS POC\n";
+  fs.write(fullPath, payload);
+  io.print(`size on disk: ${fs.size(fullPath)} bytes`);
+
+  // Le bytes brutos para um buffer pre-alocado
+  const sizeOnDisk: i32 = fs.size(fullPath);
+  const buf = buffer.alloc(sizeOnDisk);
+  const n: i32 = fs.read(fullPath, buffer.ptr(buf), sizeOnDisk);
+  io.print(`read ${n} bytes`);
+
+  // Hash + base64 direto sobre os bytes do buffer
+  io.print(`sha256 = ${crypto.sha256_bytes(buffer.ptr(buf), n)}`);
+  io.print(`base64 = ${crypto.base64_encode(buffer.ptr(buf), n)}`);
+  io.print(`hex    = ${crypto.hex_encode(buffer.ptr(buf), n)}`);
+
+  // Buffer.to_string converte UTF-8 para string handle
+  io.print(`text   = ${buffer.to_string(buf)}`);
+
+  buffer.free(buf);
+  fs.remove_file(fullPath);
+}
+
+// ── 5. Parse + try/catch ────────────────────────────────────────────
+function parseOr(s: string, fallback: i32): i32 {
+  const v = fmt.parse_i64(s);
+  // i64::MIN e o sentinel de erro do parse_i64
+  if (v == -9223372036854775808) {
+    throw `invalid int: "${s}"`;
+  }
+  return v;
+}
+
+function showParse(): void {
+  section("parse + try/catch");
+  // try/catch fase 1 (issue #128): throw nao interrompe fluxo, so seta
+  // slot de erro. Por isso testamos o slot manualmente em vez de
+  // confiar em catch. Quando #128 for resolvido, voltar ao padrao
+  // try/catch idiomatico.
+  try {
+    const a = parseOr("42", 0);
+    io.print(`parsed 42 → ${a}`);
+  } catch (e) {
+    io.print(`caught: ${e}`);
+  } finally {
+    io.print(`finally: parse section done`);
+  }
+
+  io.print(`hex(255) = ${fmt.fmt_hex(255)}`);
+  io.print(`bin(10)  = ${fmt.fmt_bin(10)}`);
+  io.print(`pi 4dp   = ${fmt.fmt_f64_prec(math.PI, 4)}`);
+}
+
+// ── 6. First-class functions ────────────────────────────────────────
+function double(x: i32): i32 { return x * 2; }
+function triple(x: i32): i32 { return x * 3; }
+function apply(fn: i64, x: i32): i32 { return fn(x); }
+
+function showCallbacks(): void {
+  section("first-class fns");
+  io.print(`apply(double, 7) = ${apply(double, 7)}`);
+  io.print(`apply(triple, 7) = ${apply(triple, 7)}`);
+}
+
+// ── 7. Hash / random ────────────────────────────────────────────────
+function showCrypto(): void {
+  section("crypto + hash");
+  const h1 = hash.hash_str("hello");
+  const h2 = hash.hash_str("hello");
+  io.print(`hash_str deterministico: ${h1 == h2}`);
+
+  const r1 = crypto.random_i64();
+  const r2 = crypto.random_i64();
+  io.print(`CSPRNG dois valores diferentes: ${r1 != r2}`);
+
+  io.print(`sha256("abc") = ${crypto.sha256_str("abc")}`);
+}
+
+// ── 8. Timing ───────────────────────────────────────────────────────
+function timed(label: string, fn: i64): void {
+  const t0 = time.now_ms();
+  fn(0);  // apply-style, arg ignorado
+  const elapsed = time.now_ms() - t0;
+  io.print(`${label}: ${elapsed} ms`);
+}
+
+function heavy(_x: i32): i32 {
+  let acc: i64 = 0;
+  let j: i32 = 0;
+  while (j < 1000000) {
+    acc += j;
+    j += 1;
+  }
+  return acc;
+}
+
+function sleeper(_x: i32): i32 {
+  time.sleep_ms(10);
+  return 0;
+}
+
+function showTimings(): void {
+  section("timings");
+  timed("1M add loop", heavy);
+  timed("sleep 10 ms ", sleeper);
+}
+
+// ── main ────────────────────────────────────────────────────────────
+function main(): void {
+  io.print("RTS POC — todos os namespaces");
+  showEnv();
+  showPi();
+  showCounts();
+  showFileRoundTrip();
+  showParse();
+  showCallbacks();
+  showCrypto();
+  showTimings();
+  io.print("\n== done ==");
+}
+
+main();

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -150,22 +150,22 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
         // ── Ternary (a ? b : c) ───────────────────────────────────────────
         Expr::Cond(cond) => lower_cond(ctx, cond),
 
+        // ── Array literal ─────────────────────────────────────────────────
+        // `[a, b, c]` desugar em `vec_new` + `vec_push` por elemento.
+        // Holes (sparse: `[1,,3]`) viram 0. Spread nao suportado no MVP.
+        Expr::Array(arr) => lower_array_lit(ctx, arr),
+
+        // ── Object literal ────────────────────────────────────────────────
+        // `{k: v, x}` desugar em `map_new` + `map_set` por entrada. Apenas
+        // chaves Ident/Str sao aceitas no MVP (sem computed/method/spread).
+        Expr::Object(obj) => lower_object_lit(ctx, obj),
+
         // ── Member ────────────────────────────────────────────────────────
-        // Resolves `ns.CONST` into a direct call to the constant's accessor
-        // symbol. Regular function references like `io.print` (without a
-        // call) are rejected.
-        Expr::Member(_) => {
-            let qualified = qualified_member_name(expr)
-                .ok_or_else(|| anyhow!("bare member expression not supported as value"))?;
-            let (_spec, member) = lookup(&qualified)
-                .ok_or_else(|| anyhow!("unknown namespace member `{qualified}`"))?;
-            if !matches!(member.kind, crate::abi::MemberKind::Constant) {
-                return Err(anyhow!(
-                    "`{qualified}` is a function, not a constant — use `{qualified}(...)`"
-                ));
-            }
-            emit_constant_load(ctx, member)
-        }
+        // Tres casos:
+        // 1. Namespace constant (math.PI): emit constant load.
+        // 2. Computed access em runtime handle: obj[expr] → vec_get/map_get.
+        // 3. Static access em runtime handle: obj.foo → map_get(obj, "foo").
+        Expr::Member(m) => lower_member_expr(ctx, m),
 
         // ── Optional chain (a?.b, a?.()) ─────────────────────────────────
         // Member access (`a?.b`) precisa de objects (#53) — rejeita com
@@ -1334,6 +1334,177 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
             ValTy::I64,
         ))
     }
+}
+
+// ── Array / Object literals ───────────────────────────────────────────────
+
+fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> Result<TypedVal> {
+    let new_fn = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+    let inst = ctx.builder.ins().call(new_fn, &[]);
+    let handle = ctx.builder.inst_results(inst)[0];
+
+    let push_fn = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+        &[cl::I64, cl::I64],
+        None,
+    )?;
+
+    for elem in &arr.elems {
+        let value = match elem {
+            Some(e) => {
+                if e.spread.is_some() {
+                    return Err(anyhow!("spread em array literal nao suportado (MVP)"));
+                }
+                let tv = lower_expr(ctx, &e.expr)?;
+                ctx.coerce_to_i64(tv).val
+            }
+            None => ctx.builder.ins().iconst(cl::I64, 0),
+        };
+        ctx.builder.ins().call(push_fn, &[handle, value]);
+    }
+
+    Ok(TypedVal::new(handle, ValTy::Handle))
+}
+
+fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -> Result<TypedVal> {
+    use swc_ecma_ast::{Prop, PropName, PropOrSpread};
+
+    let new_fn = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_MAP_NEW", &[], Some(cl::I64))?;
+    let inst = ctx.builder.ins().call(new_fn, &[]);
+    let handle = ctx.builder.inst_results(inst)[0];
+
+    let set_fn = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+        &[cl::I64, cl::I64, cl::I64, cl::I64],
+        None,
+    )?;
+
+    for prop in &obj.props {
+        let p = match prop {
+            PropOrSpread::Prop(p) => p,
+            PropOrSpread::Spread(_) => {
+                return Err(anyhow!("spread em object literal nao suportado (MVP)"));
+            }
+        };
+
+        let (key_str, value_expr): (String, Box<Expr>) = match p.as_ref() {
+            Prop::KeyValue(kv) => {
+                let k = match &kv.key {
+                    PropName::Ident(id) => id.sym.as_str().to_string(),
+                    PropName::Str(s) => s.value.to_string_lossy().to_string(),
+                    PropName::Num(n) => n.value.to_string(),
+                    PropName::Computed(_) | PropName::BigInt(_) => {
+                        return Err(anyhow!("computed/bigint key em object literal nao suportado (MVP)"));
+                    }
+                };
+                (k, kv.value.clone())
+            }
+            Prop::Shorthand(id) => {
+                let name = id.sym.as_str().to_string();
+                let synthetic = Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                    span: id.span,
+                    ctxt: Default::default(),
+                    sym: name.as_str().into(),
+                    optional: false,
+                }));
+                (name, synthetic)
+            }
+            Prop::Method(_) | Prop::Getter(_) | Prop::Setter(_) | Prop::Assign(_) => {
+                return Err(anyhow!("method/get/set/assign em object literal nao suportado (MVP)"));
+            }
+        };
+
+        let value_tv = lower_expr(ctx, &value_expr)?;
+        let value_i64 = ctx.coerce_to_i64(value_tv).val;
+        let (kptr, klen) = ctx.emit_str_literal(key_str.as_bytes())?;
+        ctx.builder.ins().call(set_fn, &[handle, kptr, klen, value_i64]);
+    }
+
+    Ok(TypedVal::new(handle, ValTy::Handle))
+}
+
+fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -> Result<TypedVal> {
+    // Caso 1: namespace constant (math.PI). qualified_member_name so
+    // resolve quando obj e ident e prop e ident.
+    if let Some(qualified) = qualified_member_name(&Expr::Member(m.clone())) {
+        if let Some((_spec, member)) = lookup(&qualified) {
+            if !matches!(member.kind, crate::abi::MemberKind::Constant) {
+                return Err(anyhow!(
+                    "`{qualified}` is a function, not a constant — use `{qualified}(...)`"
+                ));
+            }
+            return emit_constant_load(ctx, member);
+        }
+    }
+
+    // Caso 2/3: runtime member access. obj precisa virar handle.
+    let obj_tv = lower_expr(ctx, &m.obj)?;
+    let obj_handle = ctx.coerce_to_i64(obj_tv).val;
+
+    match &m.prop {
+        // obj.foo → map_get(obj, "foo")
+        MemberProp::Ident(id) => {
+            let key = id.sym.as_str();
+            map_get_static(ctx, obj_handle, key.as_bytes())
+        }
+        // obj["foo"] ou obj[i]
+        MemberProp::Computed(c) => {
+            // Detecta string literal estatica para usar map_get direto.
+            if let Expr::Lit(Lit::Str(s)) = c.expr.as_ref() {
+                return map_get_static(ctx, obj_handle, s.value.as_bytes());
+            }
+            // Indexa por valor: avalia e decide pela natureza do valor.
+            let idx_tv = lower_expr(ctx, &c.expr)?;
+            match idx_tv.ty {
+                ValTy::Handle => {
+                    // String dinamica como chave de map.
+                    let ptr_fref = ctx
+                        .get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+                    let len_fref = ctx
+                        .get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+                    let pi = ctx.builder.ins().call(ptr_fref, &[idx_tv.val]);
+                    let kptr = ctx.builder.inst_results(pi)[0];
+                    let li = ctx.builder.ins().call(len_fref, &[idx_tv.val]);
+                    let klen = ctx.builder.inst_results(li)[0];
+                    let get_fn = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_GET",
+                        &[cl::I64, cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(get_fn, &[obj_handle, kptr, klen]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    Ok(TypedVal::new(v, ValTy::I64))
+                }
+                _ => {
+                    // Indice numerico: vec_get.
+                    let idx = ctx.coerce_to_i64(idx_tv).val;
+                    let get_fn = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_VEC_GET",
+                        &[cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(get_fn, &[obj_handle, idx]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    Ok(TypedVal::new(v, ValTy::I64))
+                }
+            }
+        }
+        MemberProp::PrivateName(_) => {
+            Err(anyhow!("private name access nao suportado"))
+        }
+    }
+}
+
+fn map_get_static(ctx: &mut FnCtx, obj_handle: cranelift_codegen::ir::Value, key: &[u8]) -> Result<TypedVal> {
+    let (kptr, klen) = ctx.emit_str_literal(key)?;
+    let get_fn = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_MAP_GET",
+        &[cl::I64, cl::I64, cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst = ctx.builder.ins().call(get_fn, &[obj_handle, kptr, klen]);
+    let v = ctx.builder.inst_results(inst)[0];
+    Ok(TypedVal::new(v, ValTy::I64))
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/namespaces/buffer/ops.rs
+++ b/src/namespaces/buffer/ops.rs
@@ -259,8 +259,11 @@ pub extern "C" fn __RTS_FN_NS_BUFFER_FILL(handle: u64, byte: i32, len: i64) {
 /// `gc::string_pool`. Conteudo invalido volta como string vazia.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_BUFFER_TO_STRING(handle: u64) -> u64 {
-    with_buffer(handle, 0, |b| {
-        let text = std::str::from_utf8(b).unwrap_or("");
-        unsafe { __RTS_FN_NS_GC_STRING_NEW(text.as_ptr(), text.len() as i64) }
-    })
+    // Clona os bytes antes de chamar STRING_NEW: o callback de
+    // with_buffer segura o lock do HandleTable, e STRING_NEW tambem
+    // tenta adquirir o mesmo lock — chamar dentro do callback gera
+    // deadlock.
+    let bytes = with_buffer(handle, Vec::new(), |b| b.clone());
+    let text = std::str::from_utf8(&bytes).unwrap_or("");
+    unsafe { __RTS_FN_NS_GC_STRING_NEW(text.as_ptr(), text.len() as i64) }
 }

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -169,3 +169,8 @@ fn fixture_tail_call() {
 fn fixture_first_class_functions() {
     run_fixture("first_class_functions");
 }
+
+#[test]
+fn fixture_object_array_literals() {
+    run_fixture("object_array_literals");
+}

--- a/tests/fixtures/object_array_literals.out
+++ b/tests/fixtures/object_array_literals.out
@@ -1,0 +1,10 @@
+vec_len=3
+nums[0]=10
+nums[2]=30
+point.x=1 point.y=2
+point["y"]=2
+sh.x=7 sh.y=8
+matrix[0][0]=1 matrix[1][1]=4
+objs[0].v=100
+objs[1].v=200
+data.items[1]=22

--- a/tests/fixtures/object_array_literals.ts
+++ b/tests/fixtures/object_array_literals.ts
@@ -1,0 +1,28 @@
+import { io, collections } from "rts";
+
+const nums = [10, 20, 30];
+io.print(`vec_len=${collections.vec_len(nums)}`);
+io.print(`nums[0]=${nums[0]}`);
+io.print(`nums[2]=${nums[2]}`);
+
+const point = { x: 1, y: 2 };
+io.print(`point.x=${point.x} point.y=${point.y}`);
+io.print(`point["y"]=${point["y"]}`);
+
+const x = 7;
+const y = 8;
+const sh = { x, y };
+io.print(`sh.x=${sh.x} sh.y=${sh.y}`);
+
+const matrix = [[1, 2], [3, 4]];
+const row0 = matrix[0];
+const row1 = matrix[1];
+io.print(`matrix[0][0]=${row0[0]} matrix[1][1]=${row1[1]}`);
+
+const objs = [{ v: 100 }, { v: 200 }];
+io.print(`objs[0].v=${objs[0].v}`);
+io.print(`objs[1].v=${objs[1].v}`);
+
+const data = { items: [11, 22, 33] };
+const items = data.items;
+io.print(`data.items[1]=${items[1]}`);


### PR DESCRIPTION
## Summary
- Destrava os dois P0-blockers em uma branch unica (compartilham decisao de runtime: handle no slot i64).
- Array literal via `collections.vec_*`; object literal via `collections.map_*`.
- Member access estatico (`obj.foo`), dinamico (`obj[\"foo\"]`) e subscript (`arr[i]`).
- Aninhamento livre: arrays de objects (`[{a:1},{a:2}]`) e objects com arrays (`{list:[1,2,3]}`).

## Limitacoes (follow-up)
- Spread em array/object.
- Computed keys (`{[k]: v}`).
- Method/get/set/assign em object literals.
- Sparse arrays com holes preservados.
- Valores tipados: `map_get`/`vec_get` sempre retorna i64; caller interpreta handle quando necessario.

## Test plan
- [x] Nova fixture `tests/fixtures/object_array_literals.{ts,out}` cobre arrays, objects, shorthand, nested, subscripts.
- [x] POC `examples/poc_toolkit.ts` continua passando end-to-end.
- [x] `cargo test --release fixture_object_array` ✓
- [x] Sem regressao nos 15 fixtures pre-existentes que ja passavam.

Closes #53.
Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)