### PR TITLE
feat(js): classes + new + extends/super (#66 + #68)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -93,6 +93,25 @@ pub struct UserFnAbi {
     pub ret: Option<ValTy>,
 }
 
+/// Metadata estatica de uma classe TS/JS, consumida pelo codegen para
+/// resolver `new C(...)`, `obj.method(...)` e dispatch de `super`.
+///
+/// Usado em compile-time apenas — runtime nao conhece classes, apenas
+/// handles de map/vec.
+#[derive(Debug, Clone)]
+pub struct ClassMeta {
+    pub name: String,
+    pub super_class: Option<String>,
+    /// Nomes de metodos definidos diretamente nesta classe.
+    pub methods: Vec<String>,
+    /// Tipo declarado de cada field (via `class { x: string }`). Usado
+    /// para tipar o resultado de `obj.field` quando a classe da var e
+    /// conhecida.
+    pub field_types: HashMap<String, ValTy>,
+    /// True quando a classe tem constructor proprio (mesmo se vazio).
+    pub has_constructor: bool,
+}
+
 /// Per-function compilation context.
 ///
 /// `module` is stored as `&mut dyn Module` so the same codegen plumbing
@@ -112,6 +131,17 @@ pub struct FnCtx<'m, 'fb> {
     pub globals: &'fb HashMap<String, GlobalVar>,
     /// User-defined function signatures by source name.
     pub user_fns: &'fb HashMap<String, UserFnAbi>,
+    /// Classes registradas no programa, indexadas pelo nome da classe.
+    /// Permite resolver `new C(args)`, `super(args)` e `super.method(args)`
+    /// em compile-time sem vtable.
+    pub classes: &'fb HashMap<String, ClassMeta>,
+    /// Tipo estatico declarado de cada local conhecido como instancia
+    /// de classe — povoado quando a anotacao do bind e `: ClassName`.
+    /// Permite dispatch estatico de `obj.method(...)`.
+    pub local_class_ty: HashMap<String, String>,
+    /// Nome da classe atualmente sendo lowered (quando dentro de um
+    /// metodo ou constructor). Usado para resolver `super`.
+    pub current_class: Option<String>,
     /// True when lowering top-level statements in `main`.
     pub module_scope: bool,
     /// Declared return type of the surrounding function, used to coerce
@@ -141,6 +171,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         data_counter: &'fb mut u32,
         globals: &'fb HashMap<String, GlobalVar>,
         user_fns: &'fb HashMap<String, UserFnAbi>,
+        classes: &'fb HashMap<String, ClassMeta>,
         module_scope: bool,
     ) -> Self {
         Self {
@@ -151,6 +182,9 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             locals: vec![HashMap::new()],
             globals,
             user_fns,
+            classes,
+            local_class_ty: HashMap::new(),
+            current_class: None,
             module_scope,
             return_ty: None,
             in_tail_position: false,

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -75,6 +75,50 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
         // ── Assignment ────────────────────────────────────────────────────
         Expr::Assign(a) => {
             use swc_ecma_ast::{AssignOp, AssignTarget};
+
+            // Member assignment: obj.field = v / obj[key] = v
+            // Suportado apenas para `=` simples (sem compound) no MVP.
+            if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Member(m)) = &a.left {
+                if !matches!(a.op, AssignOp::Assign) {
+                    return Err(anyhow!("compound assign em member access nao suportado"));
+                }
+                let rhs = lower_expr(ctx, &a.right)?;
+                let rhs_i64 = ctx.coerce_to_i64(rhs).val;
+                let obj_tv = lower_expr(ctx, &m.obj)?;
+                let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                let set_fn = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+                    &[cl::I64, cl::I64, cl::I64, cl::I64],
+                    None,
+                )?;
+                match &m.prop {
+                    MemberProp::Ident(id) => {
+                        let (kp, kl) = ctx.emit_str_literal(id.sym.as_bytes())?;
+                        ctx.builder.ins().call(set_fn, &[obj_h, kp, kl, rhs_i64]);
+                    }
+                    MemberProp::Computed(c) => {
+                        if let Expr::Lit(Lit::Str(s)) = c.expr.as_ref() {
+                            let (kp, kl) = ctx.emit_str_literal(s.value.as_bytes())?;
+                            ctx.builder.ins().call(set_fn, &[obj_h, kp, kl, rhs_i64]);
+                        } else {
+                            // indice numerico → vec_set
+                            let idx_tv = lower_expr(ctx, &c.expr)?;
+                            let idx = ctx.coerce_to_i64(idx_tv).val;
+                            let vec_set = ctx.get_extern(
+                                "__RTS_FN_NS_COLLECTIONS_VEC_SET",
+                                &[cl::I64, cl::I64, cl::I64],
+                                None,
+                            )?;
+                            ctx.builder.ins().call(vec_set, &[obj_h, idx, rhs_i64]);
+                        }
+                    }
+                    MemberProp::PrivateName(_) => {
+                        return Err(anyhow!("atribuicao a private name nao suportada"));
+                    }
+                }
+                return Ok(TypedVal::new(rhs_i64, ValTy::I64));
+            }
+
             let name = match &a.left {
                 AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Ident(id)) => {
                     id.sym.as_str().to_string()
@@ -172,6 +216,21 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
         // mensagem clara. Optional call (`fn?.()`) funciona porque
         // callee resolve a i64 funcptr; basta checar se e 0 e pular.
         Expr::OptChain(opt) => lower_opt_chain(ctx, opt),
+
+        // ── this ─────────────────────────────────────────────────────────
+        // `this` em metodo/constructor de classe resolve para o primeiro
+        // parametro implicito (handle do receiver). Fora de classes,
+        // erro.
+        Expr::This(_) => {
+            if ctx.current_class.is_none() {
+                return Err(anyhow!("`this` so e valido dentro de metodo/constructor de classe"));
+            }
+            ctx.read_local("this")
+                .ok_or_else(|| anyhow!("`this` nao disponivel no contexto atual"))
+        }
+
+        // ── new C(args) ──────────────────────────────────────────────────
+        Expr::New(new_expr) => lower_new(ctx, new_expr),
 
         other => Err(anyhow!(
             "unsupported expression kind: {}",
@@ -937,8 +996,57 @@ fn lower_icmp(ctx: &mut FnCtx, cc: IntCC, lhs: TypedVal, rhs: TypedVal) -> Typed
 // ── Calls ─────────────────────────────────────────────────────────────────
 
 fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
-    // Namespace call: `ns.fn(...)`
+    // super(args) — chamada ao constructor da classe pai.
+    if matches!(&call.callee, Callee::Super(_)) {
+        return lower_super_call(ctx, call);
+    }
+    // Namespace call: `ns.fn(...)` — apenas quando `ns` resolve a
+    // namespace do ABI. Quando `ns` e um local com classe estatica
+    // conhecida, despacha para `__class_<C>_<method>`.
     if let Callee::Expr(callee) = &call.callee {
+        if let Expr::Member(m) = callee.as_ref() {
+            // super.method(args)
+            if matches!(m.obj.as_ref(), Expr::SuperProp(_)) {
+                return Err(anyhow!("super.method via SuperProp ainda nao suportado — use super(args) no constructor"));
+            }
+            if let Expr::SuperProp(sp) = m.obj.as_ref() {
+                let _ = sp;
+            }
+            // Detecta `super.method(args)` (SWC representa como Member
+            // com obj = Expr::Super... na verdade sao callees diferentes)
+            if let Some(qualified) = qualified_member_name(callee) {
+                if lookup(&qualified).is_some() {
+                    return lower_ns_call(ctx, &qualified, call);
+                }
+            }
+            // obj.method(args) com obj = ident local de classe conhecida
+            if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                let obj_name = obj_id.sym.as_str();
+                if let Some(class_name) = ctx.local_class_ty.get(obj_name).cloned() {
+                    if let MemberProp::Ident(method_id) = &m.prop {
+                        let method_name = method_id.sym.as_str();
+                        return lower_class_method_call(
+                            ctx,
+                            &class_name,
+                            method_name,
+                            obj_name,
+                            call,
+                        );
+                    }
+                }
+            }
+            // this.method(args)
+            if matches!(m.obj.as_ref(), Expr::This(_)) {
+                if let MemberProp::Ident(method_id) = &m.prop {
+                    let method_name = method_id.sym.as_str();
+                    let class_name = ctx
+                        .current_class
+                        .clone()
+                        .ok_or_else(|| anyhow!("`this.method()` fora de classe"))?;
+                    return lower_class_method_call(ctx, &class_name, method_name, "this", call);
+                }
+            }
+        }
         if let Some(qualified) = qualified_member_name(callee) {
             return lower_ns_call(ctx, &qualified, call);
         }
@@ -958,6 +1066,222 @@ fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         }
     }
     Err(anyhow!("unsupported call expression form"))
+}
+
+// ── Class operations ─────────────────────────────────────────────────────
+
+/// Resolve o nome do metodo `m` na classe `c`, descendo pela hierarquia
+/// de heranca quando filho nao define o proprio. Retorna o nome da
+/// classe que efetivamente provê o metodo, ou None se nao encontrar.
+fn resolve_method_owner<'a>(
+    ctx: &'a FnCtx,
+    class: &str,
+    method: &str,
+) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if meta.methods.iter().any(|m| m == method) {
+            return Some(cur);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
+/// Sobe a hierarquia ate achar uma classe que define constructor proprio.
+/// Quando nenhuma classe da cadeia define, retorna None — chamada de
+/// `__init` e elidida.
+fn resolve_init_owner(ctx: &FnCtx, class: &str) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if meta.has_constructor {
+            return Some(cur);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
+fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Result<TypedVal> {
+    let class_name = match new_expr.callee.as_ref() {
+        Expr::Ident(id) => id.sym.as_str().to_string(),
+        _ => return Err(anyhow!("`new` so suporta callee identifier (sem `new (expr)()`)")),
+    };
+    let _meta = ctx
+        .classes
+        .get(&class_name)
+        .ok_or_else(|| anyhow!("classe `{class_name}` nao declarada"))?
+        .clone();
+
+    // Aloca map handle para a instancia.
+    let new_fn = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_MAP_NEW", &[], Some(cl::I64))?;
+    let inst = ctx.builder.ins().call(new_fn, &[]);
+    let handle = ctx.builder.inst_results(inst)[0];
+
+    // Chama o constructor (se a classe ou algum ancestral definir).
+    if let Some(init_owner) = resolve_init_owner(ctx, &class_name) {
+        let init_fn_name = format!("__class_{init_owner}__init");
+        let abi = ctx
+            .user_fns
+            .get(&init_fn_name)
+            .ok_or_else(|| anyhow!("init de classe `{init_owner}` nao registrado"))?
+            .clone();
+        let mangled: &'static str =
+            Box::leak(format!("__user_{init_fn_name}").into_boxed_str());
+        let fn_id = *ctx
+            .extern_cache
+            .get(mangled)
+            .ok_or_else(|| anyhow!("init mangled `{mangled}` faltando"))?;
+        let fref = ctx.module.declare_func_in_func(fn_id, ctx.builder.func);
+
+        // abi.params[0] e o `this` (i64); pulamos no zip com call.args.
+        let user_args: &[swc_ecma_ast::ExprOrSpread] = new_expr
+            .args
+            .as_ref()
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        let expected = abi.params.len().saturating_sub(1);
+        if user_args.len() != expected {
+            return Err(anyhow!(
+                "constructor de `{class_name}` espera {} argumento(s), recebeu {}",
+                expected,
+                user_args.len()
+            ));
+        }
+        let mut args = vec![handle];
+        for (a, expected_ty) in user_args.iter().zip(abi.params.iter().skip(1).copied()) {
+            if a.spread.is_some() {
+                return Err(anyhow!("spread em `new` nao suportado"));
+            }
+            let tv = lower_expr(ctx, &a.expr)?;
+            let value = match expected_ty {
+                ValTy::I32 => ctx.coerce_to_i32(tv).val,
+                ValTy::F64 => to_f64(ctx, tv),
+                _ => ctx.coerce_to_i64(tv).val,
+            };
+            args.push(value);
+        }
+        ctx.builder.ins().call(fref, &args);
+    }
+
+    Ok(TypedVal::new(handle, ValTy::Handle))
+}
+
+fn lower_super_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
+    let class_name = ctx
+        .current_class
+        .clone()
+        .ok_or_else(|| anyhow!("`super(...)` fora de metodo de classe"))?;
+    let parent = ctx
+        .classes
+        .get(&class_name)
+        .and_then(|m| m.super_class.clone())
+        .ok_or_else(|| anyhow!("`super(...)` em classe sem extends"))?;
+    let init_owner = resolve_init_owner(ctx, &parent).unwrap_or(parent);
+
+    let init_fn_name = format!("__class_{init_owner}__init");
+    let abi = ctx
+        .user_fns
+        .get(&init_fn_name)
+        .ok_or_else(|| anyhow!("super init de `{init_owner}` nao registrado"))?
+        .clone();
+    let mangled: &'static str = Box::leak(format!("__user_{init_fn_name}").into_boxed_str());
+    let fn_id = *ctx
+        .extern_cache
+        .get(mangled)
+        .ok_or_else(|| anyhow!("super init mangled `{mangled}` faltando"))?;
+    let fref = ctx.module.declare_func_in_func(fn_id, ctx.builder.func);
+
+    let this_val = ctx
+        .read_local("this")
+        .ok_or_else(|| anyhow!("`this` indisponivel em super(...)"))?;
+    let mut args = vec![this_val.val];
+    let expected = abi.params.len().saturating_sub(1);
+    if call.args.len() != expected {
+        return Err(anyhow!(
+            "super(...) espera {} argumento(s), recebeu {}",
+            expected,
+            call.args.len()
+        ));
+    }
+    for (a, expected_ty) in call.args.iter().zip(abi.params.iter().skip(1).copied()) {
+        if a.spread.is_some() {
+            return Err(anyhow!("spread em super(...) nao suportado"));
+        }
+        let tv = lower_expr(ctx, &a.expr)?;
+        let value = match expected_ty {
+            ValTy::I32 => ctx.coerce_to_i32(tv).val,
+            ValTy::F64 => to_f64(ctx, tv),
+            _ => ctx.coerce_to_i64(tv).val,
+        };
+        args.push(value);
+    }
+    ctx.builder.ins().call(fref, &args);
+    Ok(TypedVal::new(ctx.builder.ins().iconst(cl::I64, 0), ValTy::I64))
+}
+
+fn lower_class_method_call(
+    ctx: &mut FnCtx,
+    class_name: &str,
+    method_name: &str,
+    receiver_local: &str,
+    call: &CallExpr,
+) -> Result<TypedVal> {
+    let owner = resolve_method_owner(ctx, class_name, method_name).ok_or_else(|| {
+        anyhow!("metodo `{method_name}` nao encontrado em `{class_name}` ou ancestrais")
+    })?;
+
+    let fn_name = format!("__class_{owner}_{method_name}");
+    let abi = ctx
+        .user_fns
+        .get(&fn_name)
+        .ok_or_else(|| anyhow!("metodo `{owner}.{method_name}` nao registrado"))?
+        .clone();
+    let mangled: &'static str = Box::leak(format!("__user_{fn_name}").into_boxed_str());
+    let fn_id = *ctx
+        .extern_cache
+        .get(mangled)
+        .ok_or_else(|| anyhow!("metodo mangled `{mangled}` faltando"))?;
+    let fref = ctx.module.declare_func_in_func(fn_id, ctx.builder.func);
+
+    let recv = ctx
+        .read_local(receiver_local)
+        .ok_or_else(|| anyhow!("receiver `{receiver_local}` indisponivel"))?;
+    let mut args = vec![ctx.coerce_to_i64(recv).val];
+    let expected = abi.params.len().saturating_sub(1);
+    if call.args.len() != expected {
+        return Err(anyhow!(
+            "metodo `{owner}.{method_name}` espera {} argumento(s), recebeu {}",
+            expected,
+            call.args.len()
+        ));
+    }
+    for (a, expected_ty) in call.args.iter().zip(abi.params.iter().skip(1).copied()) {
+        if a.spread.is_some() {
+            return Err(anyhow!("spread em chamada de metodo nao suportado"));
+        }
+        let tv = lower_expr(ctx, &a.expr)?;
+        let value = match expected_ty {
+            ValTy::I32 => ctx.coerce_to_i32(tv).val,
+            ValTy::F64 => to_f64(ctx, tv),
+            _ => ctx.coerce_to_i64(tv).val,
+        };
+        args.push(value);
+    }
+    let inst = ctx.builder.ins().call(fref, &args);
+    let results = ctx.builder.inst_results(inst);
+    if let Some(&v) = results.first() {
+        let ret_ty = abi.ret.unwrap_or(ValTy::I64);
+        Ok(TypedVal::new(v, ret_ty))
+    } else {
+        Ok(TypedVal::new(ctx.builder.ins().iconst(cl::I64, 0), ValTy::I64))
+    }
 }
 
 /// Materialises the address of a user-defined function as an i64 value.
@@ -1464,6 +1788,15 @@ fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -> Result<Ty
         }
     }
 
+    // Resolve a classe estatica do receiver (this ou local tipado), se
+    // houver. Permite tipar o resultado de map_get conforme o field
+    // declarado da classe (ex: `: string` retorna Handle).
+    let receiver_class: Option<String> = match m.obj.as_ref() {
+        Expr::This(_) => ctx.current_class.clone(),
+        Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
+        _ => None,
+    };
+
     // Caso 2/3: runtime member access. obj precisa virar handle.
     let obj_tv = lower_expr(ctx, &m.obj)?;
     let obj_handle = ctx.coerce_to_i64(obj_tv).val;
@@ -1472,7 +1805,12 @@ fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -> Result<Ty
         // obj.foo → map_get(obj, "foo")
         MemberProp::Ident(id) => {
             let key = id.sym.as_str();
-            map_get_static(ctx, obj_handle, key.as_bytes())
+            // Se conhecemos a classe + tipo do field, retornamos com o
+            // tipo declarado em vez do default I64.
+            let field_ty = receiver_class
+                .as_deref()
+                .and_then(|c| field_type_in_hierarchy(ctx, c, key));
+            map_get_static_typed(ctx, obj_handle, key.as_bytes(), field_ty)
         }
         // obj["foo"] ou obj[i]
         MemberProp::Computed(c) => {
@@ -1523,6 +1861,15 @@ fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -> Result<Ty
 }
 
 fn map_get_static(ctx: &mut FnCtx, obj_handle: cranelift_codegen::ir::Value, key: &[u8]) -> Result<TypedVal> {
+    map_get_static_typed(ctx, obj_handle, key, None)
+}
+
+fn map_get_static_typed(
+    ctx: &mut FnCtx,
+    obj_handle: cranelift_codegen::ir::Value,
+    key: &[u8],
+    declared_ty: Option<ValTy>,
+) -> Result<TypedVal> {
     let (kptr, klen) = ctx.emit_str_literal(key)?;
     let get_fn = ctx.get_extern(
         "__RTS_FN_NS_COLLECTIONS_MAP_GET",
@@ -1531,7 +1878,35 @@ fn map_get_static(ctx: &mut FnCtx, obj_handle: cranelift_codegen::ir::Value, key
     )?;
     let inst = ctx.builder.ins().call(get_fn, &[obj_handle, kptr, klen]);
     let v = ctx.builder.inst_results(inst)[0];
-    Ok(TypedVal::new(v, ValTy::I64))
+    // map_get devolve sempre i64 (lane fisica). Coerce conforme o tipo
+    // declarado do field (Handle, I32, F64, ...). Default I64 quando
+    // nao sabemos.
+    match declared_ty {
+        Some(ValTy::I32) => {
+            let narrowed = ctx.builder.ins().ireduce(cl::I32, v);
+            Ok(TypedVal::new(narrowed, ValTy::I32))
+        }
+        Some(ValTy::Handle) => Ok(TypedVal::new(v, ValTy::Handle)),
+        Some(ValTy::Bool) => Ok(TypedVal::new(v, ValTy::Bool)),
+        // F64 nao suportado como field no MVP — coerce_to_i64 perde
+        // precisao numerica. Usuario que precise pode usar `number` (i64).
+        _ => Ok(TypedVal::new(v, ValTy::I64)),
+    }
+}
+
+/// Procura o tipo declarado de um field na cadeia de heranca da classe.
+fn field_type_in_hierarchy(ctx: &FnCtx, class: &str, field: &str) -> Option<ValTy> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if let Some(ty) = meta.field_types.get(field).copied() {
+            return Some(ty);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -13,9 +13,11 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{DataDescription, Linkage, Module};
 use swc_ecma_ast::{Decl, Expr, Lit, Pat, Stmt, TsType, TsTypeRef};
 
-use crate::parser::ast::{FunctionDecl, Item, Program, Statement};
+use crate::parser::ast::{
+    ClassDecl, ClassMember, FunctionDecl, Item, MemberModifiers, Parameter, Program, Statement,
+};
 
-use super::ctx::{FnCtx, GlobalVar, UserFnAbi, ValTy};
+use super::ctx::{ClassMeta, FnCtx, GlobalVar, UserFnAbi, ValTy};
 use super::stmt::lower_stmt;
 
 const RUNTIME_MAIN_SYMBOL: &str = "__RTS_MAIN";
@@ -39,8 +41,34 @@ pub fn compile_program(
 
     let globals = collect_module_globals(program, module)?;
 
-    // Collect function declarations.
-    let fn_decls: Vec<&FunctionDecl> = program
+    // Collect class declarations e expande em FunctionDecl sinteticos.
+    // Cada classe `C` gera:
+    //   - `__class_C__init(this, ...args)` para o constructor
+    //   - `__class_C_<method>(this, ...args)` para cada metodo
+    // O nome mangled e usado como `FunctionDecl.name`. Nao colide com
+    // identifier TS valido (sem `__` no inicio em codigo de usuario).
+    let class_decls: Vec<&ClassDecl> = program
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let Item::Class(c) = item {
+                Some(c)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut classes: HashMap<String, ClassMeta> = HashMap::new();
+    let mut synthetic_fns: Vec<FunctionDecl> = Vec::new();
+    for class in &class_decls {
+        let (meta, fns) = synthesize_class_fns(class);
+        classes.insert(class.name.clone(), meta);
+        synthetic_fns.extend(fns);
+    }
+
+    // Collect function declarations (originais + sinteticos das classes).
+    let mut fn_decls: Vec<&FunctionDecl> = program
         .items
         .iter()
         .filter_map(|item| {
@@ -51,6 +79,9 @@ pub fn compile_program(
             }
         })
         .collect();
+    for f in &synthetic_fns {
+        fn_decls.push(f);
+    }
 
     // Phase 1: declare all user functions so forward calls resolve.
     let mut user_fns: HashMap<String, UserFn> = HashMap::new();
@@ -79,14 +110,20 @@ pub fn compile_program(
         let info = user_fns
             .get(&fn_decl.name)
             .ok_or_else(|| anyhow!("missing user function metadata for `{}`", fn_decl.name))?;
+        // Determina se a function pertence a uma classe (mangled name
+        // `__class_<C>_*` ou `__class_<C>__init`) — usado para resolver
+        // `super` no body do metodo.
+        let owner_class = extract_class_owner(&fn_decl.name);
         compile_user_fn(
             module,
             extern_cache,
             data_counter,
             &globals,
             &user_fn_abis,
+            &classes,
             fn_decl,
             info,
+            owner_class,
         )
         .with_context(|| format!("in function `{}`", fn_decl.name))?;
     }
@@ -122,6 +159,7 @@ pub fn compile_program(
         data_counter,
         &globals,
         &user_fn_abis,
+        &classes,
         &top_stmts,
         &mut warnings,
     )
@@ -377,8 +415,10 @@ fn compile_user_fn(
     data_counter: &mut u32,
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,
+    classes: &HashMap<String, ClassMeta>,
     fn_decl: &FunctionDecl,
     info: &UserFn,
+    current_class: Option<String>,
 ) -> Result<()> {
     let mut ctx = ClContext::new();
     ctx.func.signature = {
@@ -407,10 +447,12 @@ fn compile_user_fn(
             data_counter,
             globals,
             user_fns,
+            classes,
             false,
         );
         fn_ctx.return_ty = info.ret;
         fn_ctx.is_tail_conv = true;
+        fn_ctx.current_class = current_class.clone();
 
         // Bind parameters as locals.
         for (i, param) in fn_decl.parameters.iter().enumerate() {
@@ -461,6 +503,7 @@ fn compile_main(
     data_counter: &mut u32,
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,
+    classes: &HashMap<String, ClassMeta>,
     stmts: &[&Stmt],
     warnings: &mut Vec<String>,
 ) -> Result<()> {
@@ -488,6 +531,7 @@ fn compile_main(
             data_counter,
             globals,
             user_fns,
+            classes,
             true,
         );
 
@@ -552,4 +596,108 @@ fn compile_main_entry_shim(
         .context("failed to define exported entrypoint `main`")?;
 
     Ok(())
+}
+
+
+// ── Class lowering ────────────────────────────────────────────────────────
+
+/// Sintetiza os FunctionDecl para uma classe: constructor + cada metodo
+/// vira uma funcao independente que recebe `this` como primeiro parametro.
+/// Retorna o ClassMeta usado pelo codegen para resolver `new` e dispatch.
+fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
+    let mut methods: Vec<String> = Vec::new();
+    let mut fns: Vec<FunctionDecl> = Vec::new();
+    let mut field_types: HashMap<String, ValTy> = HashMap::new();
+    let mut has_constructor = false;
+
+    for member in &class.members {
+        match member {
+            ClassMember::Constructor(ctor) => {
+                has_constructor = true;
+                // Heuristica: parametros do constructor com nome igual a
+                // um field comum sao frequentemente atribuidos a `this.x`.
+                // Capturamos o tipo declarado para fallback.
+                for p in &ctor.parameters {
+                    if let Some(ann) = p.type_annotation.as_deref() {
+                        field_types
+                            .entry(p.name.clone())
+                            .or_insert(ValTy::from_annotation(ann));
+                    }
+                }
+                let mut params = Vec::with_capacity(ctor.parameters.len() + 1);
+                params.push(this_param(ctor.span));
+                params.extend(ctor.parameters.iter().cloned());
+                fns.push(FunctionDecl {
+                    name: class_init_name(&class.name),
+                    parameters: params,
+                    return_type: None,
+                    body: ctor.body.clone(),
+                    span: ctor.span,
+                });
+            }
+            ClassMember::Method(method) => {
+                methods.push(method.name.clone());
+                let mut params = Vec::with_capacity(method.parameters.len() + 1);
+                params.push(this_param(method.span));
+                params.extend(method.parameters.iter().cloned());
+                fns.push(FunctionDecl {
+                    name: class_method_name(&class.name, &method.name),
+                    parameters: params,
+                    return_type: method.return_type.clone(),
+                    body: method.body.clone(),
+                    span: method.span,
+                });
+            }
+            ClassMember::Property(prop) => {
+                if let Some(ann) = prop.type_annotation.as_deref() {
+                    field_types.insert(prop.name.clone(), ValTy::from_annotation(ann));
+                }
+            }
+        }
+    }
+
+    let meta = ClassMeta {
+        name: class.name.clone(),
+        super_class: class.super_class.clone(),
+        methods,
+        field_types,
+        has_constructor,
+    };
+    (meta, fns)
+}
+
+fn this_param(span: crate::parser::span::Span) -> Parameter {
+    Parameter {
+        name: "this".to_string(),
+        type_annotation: None,
+        modifiers: MemberModifiers::default(),
+        variadic: false,
+        span,
+    }
+}
+
+pub(super) fn class_init_name(class: &str) -> String {
+    format!("__class_{class}__init")
+}
+
+pub(super) fn class_method_name(class: &str, method: &str) -> String {
+    format!("__class_{class}_{method}")
+}
+
+/// Inverso de `class_init_name`/`class_method_name`: extrai o nome da
+/// classe quando o function name segue a convencao de mangle.
+fn extract_class_owner(fn_name: &str) -> Option<String> {
+    let rest = fn_name.strip_prefix("__class_")?;
+    // Variantes: `<C>__init` e `<C>_<method>`. Como `<C>` pode conter
+    // `_`, procuramos pelo separador double-underscore primeiro.
+    if let Some(idx) = rest.find("__init") {
+        return Some(rest[..idx].to_string());
+    }
+    // Para metodos: o ultimo `_` separa classe de metodo. Mas o nome da
+    // classe tambem pode ter `_`; usamos a primeira ocorrencia que ainda
+    // mantem um sufixo de metodo nao vazio.
+    if let Some(idx) = rest.rfind('_') {
+        return Some(rest[..idx].to_string());
+    }
+    None
 }

--- a/src/codegen/lower/stmt.rs
+++ b/src/codegen/lower/stmt.rs
@@ -36,6 +36,33 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
                     _ => None,
                 };
 
+                // Trackeia tipo estatico de classe quando o bind tem
+                // anotacao `: ClassName` cuja classe esta registrada.
+                // Usado para dispatch de `obj.method(...)`.
+                if let Pat::Ident(id) = &decl.name {
+                    if let Some(ann) = id.type_ann.as_ref() {
+                        if let Some(cn) = class_name_from_annotation(&ann.type_ann) {
+                            if ctx.classes.contains_key(&cn) {
+                                ctx.local_class_ty.insert(name.clone(), cn);
+                            }
+                        }
+                    }
+                }
+                // Heuristica: quando o init e `new C(...)`, a var herda
+                // a classe sem precisar de anotacao explicita.
+                if !ctx.local_class_ty.contains_key(&name) {
+                    if let Some(init) = decl.init.as_ref() {
+                        if let swc_ecma_ast::Expr::New(ne) = init.as_ref() {
+                            if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
+                                let cn = cid.sym.as_str().to_string();
+                                if ctx.classes.contains_key(&cn) {
+                                    ctx.local_class_ty.insert(name.clone(), cn);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let (init_val, inferred_ty) = if let Some(init) = &decl.init {
                     let tv = lower_expr(ctx, init)?;
                     (tv.val, tv.ty)
@@ -614,6 +641,18 @@ fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {
             _ => return None,
         };
         return Some(ValTy::from_annotation(name));
+    }
+    None
+}
+
+/// Extrai `ClassName` de uma anotacao `: ClassName`. Retorna None
+/// quando a anotacao nao e um simple ident.
+fn class_name_from_annotation(ty: &swc_ecma_ast::TsType) -> Option<String> {
+    use swc_ecma_ast::TsType;
+    if let TsType::TsTypeRef(r) = ty {
+        if let swc_ecma_ast::TsEntityName::Ident(id) = &r.type_name {
+            return Some(id.sym.as_str().to_string());
+        }
     }
     None
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -41,6 +41,9 @@ pub struct FieldDecl {
 #[derive(Debug, Clone)]
 pub struct ClassDecl {
     pub name: String,
+    /// Classe pai em `class C extends P`. Resolve em codegen para
+    /// dispatch estatico de super().
+    pub super_class: Option<String>,
     pub members: Vec<ClassMember>,
     pub span: Span,
 }

--- a/src/parser/lowering_decls.rs
+++ b/src/parser/lowering_decls.rs
@@ -136,8 +136,17 @@ fn lower_class(cm: &Lrc<SourceMap>, name: &str, class: &SwcClass, span: SwcSpan)
         }
     }
 
+    let super_class = class.super_class.as_ref().and_then(|expr| {
+        if let swc_ecma_ast::Expr::Ident(id) = expr.as_ref() {
+            Some(id.sym.as_str().to_string())
+        } else {
+            None
+        }
+    });
+
     ClassDecl {
         name: name.to_string(),
+        super_class,
         members,
         span: convert_span(cm, span),
     }

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -184,3 +184,13 @@ fn fixture_for_of() {
 fn fixture_string_eq() {
     run_fixture("string_eq");
 }
+
+#[test]
+fn fixture_class_basic() {
+    run_fixture("class_basic");
+}
+
+#[test]
+fn fixture_class_inheritance() {
+    run_fixture("class_inheritance");
+}

--- a/tests/fixtures/class_basic.out
+++ b/tests/fixtures/class_basic.out
@@ -1,0 +1,4 @@
+sum=7
+(3, 4)
+q.x=10 q.sum=30
+counter=3

--- a/tests/fixtures/class_basic.ts
+++ b/tests/fixtures/class_basic.ts
@@ -1,0 +1,42 @@
+import { io } from "rts";
+
+class Point {
+  x: i32;
+  y: i32;
+  constructor(x: i32, y: i32) {
+    this.x = x;
+    this.y = y;
+  }
+  sum(): i32 {
+    return this.x + this.y;
+  }
+  describe(): void {
+    io.print(`(${this.x}, ${this.y})`);
+  }
+}
+
+const p: Point = new Point(3, 4);
+io.print(`sum=${p.sum()}`);
+p.describe();
+
+const q: Point = new Point(10, 20);
+io.print(`q.x=${q.x} q.sum=${q.sum()}`);
+
+class Counter {
+  n: i32;
+  constructor() {
+    this.n = 0;
+  }
+  inc(): void {
+    this.n = this.n + 1;
+  }
+  value(): i32 {
+    return this.n;
+  }
+}
+
+const c: Counter = new Counter();
+c.inc();
+c.inc();
+c.inc();
+io.print(`counter=${c.value()}`);

--- a/tests/fixtures/class_inheritance.out
+++ b/tests/fixtures/class_inheritance.out
@@ -1,0 +1,5 @@
+I am Rex
+Woof! I am a Husky
+I am Buddy
+Woof! I am a Lab
+I am Buddy, a 1yo Lab

--- a/tests/fixtures/class_inheritance.ts
+++ b/tests/fixtures/class_inheritance.ts
@@ -1,0 +1,42 @@
+import { io } from "rts";
+
+class Animal {
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  describe(): void {
+    io.print(`I am ${this.name}`);
+  }
+}
+
+class Dog extends Animal {
+  breed: string;
+  constructor(name: string, breed: string) {
+    super(name);
+    this.breed = breed;
+  }
+  bark(): void {
+    io.print(`Woof! I am a ${this.breed}`);
+  }
+}
+
+class Puppy extends Dog {
+  age: i32;
+  constructor(name: string, breed: string, age: i32) {
+    super(name, breed);
+    this.age = age;
+  }
+  introduce(): void {
+    io.print(`I am ${this.name}, a ${this.age}yo ${this.breed}`);
+  }
+}
+
+const d: Dog = new Dog("Rex", "Husky");
+d.describe();
+d.bark();
+
+const p: Puppy = new Puppy("Buddy", "Lab", 1);
+p.describe();
+p.bark();
+p.introduce();


### PR DESCRIPTION
## Summary
Implementa classes TS/JS de ponta a ponta no codegen: declaracao, \`new\`, \`this\`, metodos, fields tipados, heranca via \`extends\` e \`super(...)\`. Sem runtime novo — instances sao map handles via \`collections.map_*\` (paralelo ao approach de #53).

## O que funciona
- \`class C { constructor() {...} m() {...} }\` (constructors + metodos + property decls).
- \`new C(args)\` retorna handle de instancia.
- \`this.field = v\` / \`this.field\`, \`this.method(args)\`.
- \`extends Parent\`, \`super(args)\` no constructor, dispatch heredado de metodos.
- Tipos de fields (\`class { name: string }\`) trackeados em compile-time para tipar o resultado de \`obj.field\` (string vira Handle, i32 vira I32 narrow, etc).

## Estrategia
Classes nao geram runtime novo. Cada classe \`C\` e desugarada em FunctionDecls sinteticos (\`__class_C__init\`, \`__class_C_method\`) consumidos pela infra existente de \`compile_user_fn\`. Dispatch de metodo e estatico via \`local_class_ty\`/\`current_class\` no FnCtx — sem vtable.

## Limitacoes (follow-up)
- static members, getters/setters, abstract.
- parameter properties (\`constructor(public x)\`).
- decorators, generics.
- Classes em escopo aninhado / como expressao.
- Fields F64 (perde precisao no map_set).

## Test plan
- [x] Nova fixture \`class_basic\` (constructor/this/methods/multi-instance/contador).
- [x] Nova fixture \`class_inheritance\` (3 niveis de extends, super, dispatch heredado).
- [x] \`cargo test --release\` ✓ (20 fixtures passando, mesmos 7 pre-existentes faltando .out).
- [x] POC \`examples/poc_toolkit.ts\` continua passando.

Closes #66.
Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)