### PR TITLE
fix(js): operator overload em method calls e member access

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -108,6 +108,10 @@ pub struct ClassMeta {
     /// para tipar o resultado de `obj.field` quando a classe da var e
     /// conhecida.
     pub field_types: HashMap<String, ValTy>,
+    /// Nome textual cru do tipo de cada field (ex: `"Vec3"`, `"i32"`).
+    /// Permite descobrir quando o field e instancia de outra classe
+    /// registrada — habilita overload em `this.field + x`.
+    pub field_class_names: HashMap<String, String>,
     /// True quando a classe tem constructor proprio (mesmo se vazio).
     pub has_constructor: bool,
 }

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -553,20 +553,47 @@ fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
         Expr::This(_) => ctx.current_class.clone(),
         Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
         Expr::Paren(p) => lhs_static_class(ctx, &p.expr),
-        // Encadeamento: `a + b - c`. Se `a + b` resolve a um overload
-        // de classe X que define `add` retornando X (assumido por
-        // convencao), entao o LHS do `- c` tambem e classe X.
-        // Sem type system mais completo, pressupomos que metodos de
-        // operador retornam a mesma classe do receiver — e o caso
-        // canonico em Rust e o que a infraestrutura suporta.
+        // Encadeamento: `a + b - c`. Pressupomos que metodos de
+        // operador retornam a mesma classe do receiver (convencao Rust).
         Expr::Bin(b) => {
             if operator_method_name(b.op).is_none() {
                 return None;
             }
             let cls = lhs_static_class(ctx, &b.left)?;
-            // Confirma que o metodo existe na classe (cadeia de heranca).
             let method = operator_method_name(b.op)?;
             resolve_method_owner(ctx, &cls, method).map(|_| cls)
+        }
+        // Resultado de chamada de metodo: `obj.m()` herda a classe do
+        // receiver assumindo que o metodo retorna a propria classe.
+        // Cobre `a.add(b) - c` e usos similares.
+        Expr::Call(call) => {
+            if let swc_ecma_ast::Callee::Expr(callee) = &call.callee {
+                if let Expr::Member(m) = callee.as_ref() {
+                    let recv_cls = lhs_static_class(ctx, &m.obj)?;
+                    if let MemberProp::Ident(method_id) = &m.prop {
+                        let method = method_id.sym.as_str();
+                        return resolve_method_owner(ctx, &recv_cls, method).map(|_| recv_cls);
+                    }
+                }
+            }
+            None
+        }
+        // Member access em receiver de classe conhecida: `this.field`,
+        // `obj.field` quando o field tem tipo declarado de outra classe.
+        Expr::Member(m) => {
+            let recv_cls = lhs_static_class(ctx, &m.obj)?;
+            let field_name = match &m.prop {
+                MemberProp::Ident(id) => id.sym.as_str().to_string(),
+                MemberProp::Computed(c) => {
+                    if let Expr::Lit(Lit::Str(s)) = c.expr.as_ref() {
+                        s.value.to_string_lossy().to_string()
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            };
+            field_class_in_hierarchy(ctx, &recv_cls, &field_name)
         }
         _ => None,
     }
@@ -2031,6 +2058,25 @@ fn field_type_in_hierarchy(ctx: &FnCtx, class: &str, field: &str) -> Option<ValT
         let meta = ctx.classes.get(&cur)?;
         if let Some(ty) = meta.field_types.get(field).copied() {
             return Some(ty);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
+/// Quando o tipo declarado de um field bate com uma classe registrada,
+/// retorna o nome da classe. Permite tratar `this.v` como instancia
+/// quando v: V e V e classe.
+fn field_class_in_hierarchy(ctx: &FnCtx, class: &str, field: &str) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if let Some(ann) = meta.field_class_names.get(field) {
+            if ctx.classes.contains_key(ann) {
+                return Some(ann.clone());
+            }
         }
         match &meta.super_class {
             Some(parent) => cur = parent.clone(),

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -608,6 +608,7 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
     let mut methods: Vec<String> = Vec::new();
     let mut fns: Vec<FunctionDecl> = Vec::new();
     let mut field_types: HashMap<String, ValTy> = HashMap::new();
+    let mut field_class_names: HashMap<String, String> = HashMap::new();
     let mut has_constructor = false;
 
     for member in &class.members {
@@ -650,7 +651,9 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
             }
             ClassMember::Property(prop) => {
                 if let Some(ann) = prop.type_annotation.as_deref() {
+                    let ann = ann.trim();
                     field_types.insert(prop.name.clone(), ValTy::from_annotation(ann));
+                    field_class_names.insert(prop.name.clone(), ann.to_string());
                 }
             }
         }
@@ -661,6 +664,7 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
         super_class: class.super_class.clone(),
         methods,
         field_types,
+        field_class_names,
         has_constructor,
     };
     (meta, fns)


### PR DESCRIPTION
Dois bugs descobertos via bateria de testes:

1. `a.add(b) - c` caia em zero — LHS Call nao detectado.
2. `this.v + this.v` dentro de metodo de classe — LHS Member em receiver de classe nao detectado.

Fix em `lhs_static_class`: desce recursivamente em Expr::Call (assume retorno da classe do receiver) e Expr::Member (consulta novo `field_class_names` em ClassMeta).

Test plan:
- [x] Bateria de testes que originalmente falhava agora passa.
- [x] cargo test --release sem regressao.
- [x] POC OK.