### PR TITLE
fix(js): overload em function returns, globais e method chains

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -135,6 +135,10 @@ pub struct FnCtx<'m, 'fb> {
     pub globals: &'fb HashMap<String, GlobalVar>,
     /// User-defined function signatures by source name.
     pub user_fns: &'fb HashMap<String, UserFnAbi>,
+    /// Classe retornada por user functions cujo return_type bate com
+    /// uma classe registrada. Permite `const x: V = makeV()` e
+    /// `this.doubled() + this.doubled()` detectarem o tipo.
+    pub fn_class_returns: &'fb HashMap<String, String>,
     /// Classes registradas no programa, indexadas pelo nome da classe.
     /// Permite resolver `new C(args)`, `super(args)` e `super.method(args)`
     /// em compile-time sem vtable.
@@ -143,6 +147,11 @@ pub struct FnCtx<'m, 'fb> {
     /// de classe — povoado quando a anotacao do bind e `: ClassName`.
     /// Permite dispatch estatico de `obj.method(...)`.
     pub local_class_ty: HashMap<String, String>,
+    /// Tipo estatico de globais module-scope que sao instancias de
+    /// classe. Populado uma vez em compile_program e compartilhado
+    /// entre todos os FnCtx — permite dispatch de overload em funcoes
+    /// top-level que referenciam `const a: V = new V(...)` global.
+    pub global_class_ty: &'fb HashMap<String, String>,
     /// Nome da classe atualmente sendo lowered (quando dentro de um
     /// metodo ou constructor). Usado para resolver `super`.
     pub current_class: Option<String>,
@@ -176,6 +185,8 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         globals: &'fb HashMap<String, GlobalVar>,
         user_fns: &'fb HashMap<String, UserFnAbi>,
         classes: &'fb HashMap<String, ClassMeta>,
+        global_class_ty: &'fb HashMap<String, String>,
+        fn_class_returns: &'fb HashMap<String, String>,
         module_scope: bool,
     ) -> Self {
         Self {
@@ -186,8 +197,10 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             locals: vec![HashMap::new()],
             globals,
             user_fns,
+            fn_class_returns,
             classes,
             local_class_ty: HashMap::new(),
+            global_class_ty,
             current_class: None,
             module_scope,
             return_ty: None,

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -551,7 +551,13 @@ fn operator_method_name(op: BinaryOp) -> Option<&'static str> {
 fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
     match expr {
         Expr::This(_) => ctx.current_class.clone(),
-        Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
+        Expr::Ident(id) => {
+            let name = id.sym.as_str();
+            ctx.local_class_ty
+                .get(name)
+                .or_else(|| ctx.global_class_ty.get(name))
+                .cloned()
+        }
         Expr::Paren(p) => lhs_static_class(ctx, &p.expr),
         // Encadeamento: `a + b - c`. Pressupomos que metodos de
         // operador retornam a mesma classe do receiver (convencao Rust).
@@ -563,16 +569,31 @@ fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
             let method = operator_method_name(b.op)?;
             resolve_method_owner(ctx, &cls, method).map(|_| cls)
         }
-        // Resultado de chamada de metodo: `obj.m()` herda a classe do
-        // receiver assumindo que o metodo retorna a propria classe.
-        // Cobre `a.add(b) - c` e usos similares.
+        // Resultado de chamada: prioridade
+        //   1. user fn top-level cujo return_type bate com classe (fn_class_returns)
+        //   2. metodo de classe declarado: usa o return_type do metodo
+        //      via fn_class_returns sob o nome mangled `__class_C_m`
+        //   3. fallback: assume retorno da classe do receiver (overload-friendly)
         Expr::Call(call) => {
             if let swc_ecma_ast::Callee::Expr(callee) = &call.callee {
+                // Caso 1: chamada simples a user fn
+                if let Expr::Ident(id) = callee.as_ref() {
+                    if let Some(cls) = ctx.fn_class_returns.get(id.sym.as_str()) {
+                        return Some(cls.clone());
+                    }
+                }
                 if let Expr::Member(m) = callee.as_ref() {
                     let recv_cls = lhs_static_class(ctx, &m.obj)?;
                     if let MemberProp::Ident(method_id) = &m.prop {
                         let method = method_id.sym.as_str();
-                        return resolve_method_owner(ctx, &recv_cls, method).map(|_| recv_cls);
+                        let owner = resolve_method_owner(ctx, &recv_cls, method)?;
+                        // Caso 2: metodo declarado com return_type explicito
+                        let mangled = format!("__class_{owner}_{method}");
+                        if let Some(cls) = ctx.fn_class_returns.get(&mangled) {
+                            return Some(cls.clone());
+                        }
+                        // Caso 3: fallback assume mesma classe do receiver
+                        return Some(recv_cls);
                     }
                 }
             }

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -105,6 +105,60 @@ pub fn compile_program(
         })
         .collect();
 
+    // Mapeia funcoes que retornam classe registrada — usado para
+    // dispatch de overload em `const x: V = makeV()` e
+    // `obj.m() + obj.m()`. Le `return_type` textual do FunctionDecl.
+    let mut fn_class_returns: HashMap<String, String> = HashMap::new();
+    for fn_decl in &fn_decls {
+        if let Some(ret) = fn_decl.return_type.as_deref() {
+            let ret_trim = ret.trim();
+            if classes.contains_key(ret_trim) {
+                fn_class_returns.insert(fn_decl.name.clone(), ret_trim.to_string());
+            }
+        }
+    }
+
+    // Mapeia globais module-scope cuja anotacao bate com classe
+    // registrada. Permite funcoes top-level acessarem globais como
+    // instancias e participarem de overload.
+    let mut global_class_ty: HashMap<String, String> = HashMap::new();
+    for item in &program.items {
+        let Item::Statement(Statement::Raw(raw)) = item else {
+            continue;
+        };
+        let Some(Stmt::Decl(Decl::Var(var_decl))) = raw.stmt.as_ref() else {
+            continue;
+        };
+        for d in &var_decl.decls {
+            let Pat::Ident(id) = &d.name else { continue };
+            let name = id.sym.as_str().to_string();
+            // Anotacao explicita
+            if let Some(ann) = id.type_ann.as_ref() {
+                if let swc_ecma_ast::TsType::TsTypeRef(r) = ann.type_ann.as_ref() {
+                    if let swc_ecma_ast::TsEntityName::Ident(t) = &r.type_name {
+                        let t_name = t.sym.as_str();
+                        if classes.contains_key(t_name) {
+                            global_class_ty.insert(name.clone(), t_name.to_string());
+                        }
+                    }
+                }
+            }
+            // Heuristica: init = new C(...)
+            if !global_class_ty.contains_key(&name) {
+                if let Some(init) = d.init.as_ref() {
+                    if let swc_ecma_ast::Expr::New(ne) = init.as_ref() {
+                        if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
+                            let cn = cid.sym.as_str();
+                            if classes.contains_key(cn) {
+                                global_class_ty.insert(name, cn.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // Phase 2: compile user function bodies.
     for fn_decl in &fn_decls {
         let info = user_fns
@@ -121,6 +175,8 @@ pub fn compile_program(
             &globals,
             &user_fn_abis,
             &classes,
+            &global_class_ty,
+            &fn_class_returns,
             fn_decl,
             info,
             owner_class,
@@ -160,6 +216,8 @@ pub fn compile_program(
         &globals,
         &user_fn_abis,
         &classes,
+        &global_class_ty,
+        &fn_class_returns,
         &top_stmts,
         &mut warnings,
     )
@@ -416,6 +474,8 @@ fn compile_user_fn(
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,
     classes: &HashMap<String, ClassMeta>,
+    global_class_ty: &HashMap<String, String>,
+    fn_class_returns: &HashMap<String, String>,
     fn_decl: &FunctionDecl,
     info: &UserFn,
     current_class: Option<String>,
@@ -448,11 +508,32 @@ fn compile_user_fn(
             globals,
             user_fns,
             classes,
+            global_class_ty,
+            fn_class_returns,
             false,
         );
         fn_ctx.return_ty = info.ret;
         fn_ctx.is_tail_conv = true;
         fn_ctx.current_class = current_class.clone();
+        // Em metodos/constructors, o param `this` e instancia da classe
+        // dona — populamos local_class_ty pra que `this.field`/dispatch
+        // tipicos funcionem (e overload em `this.x + ...`).
+        if let Some(cls) = current_class.as_deref() {
+            fn_ctx
+                .local_class_ty
+                .insert("this".to_string(), cls.to_string());
+        }
+        // Parametros tipados como classe registrada → trackear.
+        for p in &fn_decl.parameters {
+            if let Some(ann) = p.type_annotation.as_deref() {
+                let ann = ann.trim();
+                if classes.contains_key(ann) {
+                    fn_ctx
+                        .local_class_ty
+                        .insert(p.name.clone(), ann.to_string());
+                }
+            }
+        }
 
         // Bind parameters as locals.
         for (i, param) in fn_decl.parameters.iter().enumerate() {
@@ -504,6 +585,8 @@ fn compile_main(
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,
     classes: &HashMap<String, ClassMeta>,
+    global_class_ty: &HashMap<String, String>,
+    fn_class_returns: &HashMap<String, String>,
     stmts: &[&Stmt],
     warnings: &mut Vec<String>,
 ) -> Result<()> {
@@ -532,6 +615,8 @@ fn compile_main(
             globals,
             user_fns,
             classes,
+            global_class_ty,
+            fn_class_returns,
             true,
         );
 

--- a/src/codegen/lower/stmt.rs
+++ b/src/codegen/lower/stmt.rs
@@ -60,6 +60,17 @@ pub fn lower_stmt(ctx: &mut FnCtx, stmt: &Stmt) -> Result<bool> {
                                 }
                             }
                         }
+                        // Quando init e chamada `f(...)` cujo return_type
+                        // e classe registrada, herda essa classe.
+                        if let swc_ecma_ast::Expr::Call(call) = init.as_ref() {
+                            if let swc_ecma_ast::Callee::Expr(cb) = &call.callee {
+                                if let swc_ecma_ast::Expr::Ident(fid) = cb.as_ref() {
+                                    if let Some(cn) = ctx.fn_class_returns.get(fid.sym.as_str()) {
+                                        ctx.local_class_ty.insert(name.clone(), cn.clone());
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
Tres lacunas descobertas via bateria de testes:

- `const x: V = makeV()` perdia a classe (function returns nao mapeados).
- Funcoes top-level que referenciam globais `const a: V = new V(...)` nao detectavam classe.
- `this.doubled() + this.doubled()` falhava no encadeamento.

Solucao:
- `fn_class_returns` mapeia user fns -> classe declarada como retorno.
- `global_class_ty` mapeia globais module-scope.
- Both passados via FnCtx, consultados em `lhs_static_class`.
- Bonus: params de classe e `this` agora populam local_class_ty automaticamente.