### PR TITLE
feat(js): super.method + static methods + getters/setters

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -102,7 +102,7 @@ pub struct UserFnAbi {
 pub struct ClassMeta {
     pub name: String,
     pub super_class: Option<String>,
-    /// Nomes de metodos definidos diretamente nesta classe.
+    /// Nomes de metodos definidos diretamente nesta classe (instance).
     pub methods: Vec<String>,
     /// Tipo declarado de cada field (via `class { x: string }`). Usado
     /// para tipar o resultado de `obj.field` quando a classe da var e
@@ -112,6 +112,16 @@ pub struct ClassMeta {
     /// Permite descobrir quando o field e instancia de outra classe
     /// registrada — habilita overload em `this.field + x`.
     pub field_class_names: HashMap<String, String>,
+    /// Nomes de static methods (chamados via `C.method()`).
+    pub static_methods: Vec<String>,
+    /// Nomes de static fields (acessados via `C.field`).
+    pub static_fields: Vec<String>,
+    /// Nomes de getters definidos diretamente — ler `obj.x` chama
+    /// __class_C_get_x(this).
+    pub getters: Vec<String>,
+    /// Nomes de setters definidos diretamente — `obj.x = v` chama
+    /// __class_C_set_x(this, v).
+    pub setters: Vec<String>,
     /// True quando a classe tem constructor proprio (mesmo se vazio).
     pub has_constructor: bool,
 }

--- a/src/codegen/lower/expr.rs
+++ b/src/codegen/lower/expr.rs
@@ -18,6 +18,7 @@ use crate::abi::signature::lower_member;
 use crate::abi::types::AbiType;
 
 use super::ctx::{FnCtx, TypedVal, ValTy};
+use super::func::{class_getter_name, class_setter_name, class_static_method_name};
 
 /// Compiles a SWC expression and returns a typed Cranelift value.
 pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
@@ -120,6 +121,37 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
                 };
                 let rhs = lower_expr(ctx, &final_rhs_expr)?;
                 let rhs_i64 = ctx.coerce_to_i64(rhs).val;
+                // Setter: `obj.x = v` quando classe define `set x(v)` —
+                // chama __class_C_set_x(this, v) em vez de map_set.
+                if let MemberProp::Ident(id) = &m.prop {
+                    if let Some(cls) = lhs_static_class(ctx, &m.obj) {
+                        let prop_name = id.sym.as_str();
+                        if let Some(setter_owner) = resolve_setter_owner(ctx, &cls, prop_name) {
+                            let obj_tv = lower_expr(ctx, &m.obj)?;
+                            let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                            // Coerce rhs ao tipo do parametro do setter.
+                            let setter_fn_name = class_setter_name(&setter_owner, prop_name);
+                            let setter_abi = ctx
+                                .user_fns
+                                .get(&setter_fn_name)
+                                .ok_or_else(|| anyhow!("setter `{setter_fn_name}` nao registrada"))?
+                                .clone();
+                            let param_ty = setter_abi
+                                .params
+                                .get(1)
+                                .copied()
+                                .unwrap_or(ValTy::I64);
+                            let rhs_tv = TypedVal::new(rhs_i64, ValTy::I64);
+                            let coerced = match param_ty {
+                                ValTy::I32 => ctx.coerce_to_i32(rhs_tv).val,
+                                ValTy::F64 => to_f64(ctx, rhs_tv),
+                                _ => rhs_i64,
+                            };
+                            emit_named_method_call(ctx, &setter_fn_name, obj_h, &[coerced])?;
+                            return Ok(TypedVal::new(rhs_i64, ValTy::I64));
+                        }
+                    }
+                }
                 let obj_tv = lower_expr(ctx, &m.obj)?;
                 let obj_h = ctx.coerce_to_i64(obj_tv).val;
                 let set_fn = ctx.get_extern(
@@ -1218,13 +1250,24 @@ fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
     // namespace do ABI. Quando `ns` e um local com classe estatica
     // conhecida, despacha para `__class_<C>_<method>`.
     if let Callee::Expr(callee) = &call.callee {
+        // super.method(args) — SWC representa como Expr::SuperProp.
+        if let Expr::SuperProp(sp) = callee.as_ref() {
+            return lower_super_method_call(ctx, sp, call);
+        }
         if let Expr::Member(m) = callee.as_ref() {
-            // super.method(args)
-            if matches!(m.obj.as_ref(), Expr::SuperProp(_)) {
-                return Err(anyhow!("super.method via SuperProp ainda nao suportado — use super(args) no constructor"));
-            }
-            if let Expr::SuperProp(sp) = m.obj.as_ref() {
-                let _ = sp;
+            // Static method: `C.method(args)` quando obj e ident de
+            // classe registrada e classe tem static_method com esse nome.
+            if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                let cn = obj_id.sym.as_str();
+                if let Some(meta) = ctx.classes.get(cn) {
+                    if let MemberProp::Ident(method_id) = &m.prop {
+                        let mn = method_id.sym.as_str();
+                        if meta.static_methods.iter().any(|m| m == mn) {
+                            let fn_name = class_static_method_name(cn, mn);
+                            return lower_user_call(ctx, &fn_name, call);
+                        }
+                    }
+                }
             }
             // Detecta `super.method(args)` (SWC representa como Member
             // com obj = Expr::Super... na verdade sao callees diferentes)
@@ -1328,6 +1371,70 @@ fn is_subclass_of(ctx: &FnCtx, child: &str, ancestor: &str) -> bool {
             Some(parent) => cur = parent.clone(),
             None => return false,
         }
+    }
+}
+
+/// Retorna a classe (na cadeia de heranca) que define um getter
+/// para `prop`. None se nenhum ancestral o define.
+fn resolve_getter_owner(ctx: &FnCtx, class: &str, prop: &str) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if meta.getters.iter().any(|g| g == prop) {
+            return Some(cur);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
+/// Idem para setter.
+fn resolve_setter_owner(ctx: &FnCtx, class: &str, prop: &str) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if meta.setters.iter().any(|s| s == prop) {
+            return Some(cur);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
+/// Chama uma user fn pelo nome ja mangled, com receiver direto.
+/// Usado por getter/setter dispatch.
+fn emit_named_method_call(
+    ctx: &mut FnCtx,
+    fn_name: &str,
+    recv_i64: cranelift_codegen::ir::Value,
+    arg_values: &[cranelift_codegen::ir::Value],
+) -> Result<TypedVal> {
+    let abi = ctx
+        .user_fns
+        .get(fn_name)
+        .ok_or_else(|| anyhow!("user fn `{fn_name}` nao registrada"))?
+        .clone();
+    let mangled: &'static str = Box::leak(format!("__user_{fn_name}").into_boxed_str());
+    let fn_id = *ctx
+        .extern_cache
+        .get(mangled)
+        .ok_or_else(|| anyhow!("mangled `{mangled}` nao registrado"))?;
+    let fref = ctx.module.declare_func_in_func(fn_id, ctx.builder.func);
+
+    let mut args = Vec::with_capacity(arg_values.len() + 1);
+    args.push(recv_i64);
+    args.extend_from_slice(arg_values);
+    let inst = ctx.builder.ins().call(fref, &args);
+    let results = ctx.builder.inst_results(inst);
+    if let Some(&v) = results.first() {
+        let ret_ty = abi.ret.unwrap_or(ValTy::I64);
+        Ok(TypedVal::new(v, ret_ty))
+    } else {
+        Ok(TypedVal::new(ctx.builder.ins().iconst(cl::I64, 0), ValTy::I64))
     }
 }
 
@@ -1500,6 +1607,71 @@ fn lower_super_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
     }
     ctx.builder.ins().call(fref, &args);
     Ok(TypedVal::new(ctx.builder.ins().iconst(cl::I64, 0), ValTy::I64))
+}
+
+fn lower_super_method_call(
+    ctx: &mut FnCtx,
+    sp: &swc_ecma_ast::SuperPropExpr,
+    call: &CallExpr,
+) -> Result<TypedVal> {
+    let class_name = ctx
+        .current_class
+        .clone()
+        .ok_or_else(|| anyhow!("`super.method()` fora de metodo de classe"))?;
+    let parent = ctx
+        .classes
+        .get(&class_name)
+        .and_then(|m| m.super_class.clone())
+        .ok_or_else(|| anyhow!("`super.method()` em classe sem extends"))?;
+
+    let method_name = match &sp.prop {
+        swc_ecma_ast::SuperProp::Ident(id) => id.sym.as_str().to_string(),
+        swc_ecma_ast::SuperProp::Computed(_) => {
+            return Err(anyhow!("computed em super[expr]() nao suportado"));
+        }
+    };
+
+    let owner = resolve_method_owner(ctx, &parent, &method_name).ok_or_else(|| {
+        anyhow!(
+            "super.{method_name}() — metodo nao encontrado em ancestrais de `{class_name}`"
+        )
+    })?;
+
+    // Le `this` para usar como receiver do call estatico (sem
+    // dispatch virtual — super pula a virtual table propositalmente).
+    let this_val = ctx
+        .read_local("this")
+        .ok_or_else(|| anyhow!("`this` indisponivel em super.method()"))?;
+    let recv_i64 = ctx.coerce_to_i64(this_val).val;
+
+    let fn_name = format!("__class_{owner}_{method_name}");
+    let abi = ctx
+        .user_fns
+        .get(&fn_name)
+        .ok_or_else(|| anyhow!("metodo `{owner}.{method_name}` nao registrado"))?
+        .clone();
+    let expected = abi.params.len().saturating_sub(1);
+    if call.args.len() != expected {
+        return Err(anyhow!(
+            "super.{method_name}() espera {} argumento(s), recebeu {}",
+            expected,
+            call.args.len()
+        ));
+    }
+    let mut arg_values: Vec<cranelift_codegen::ir::Value> = Vec::with_capacity(expected);
+    for (a, expected_ty) in call.args.iter().zip(abi.params.iter().skip(1).copied()) {
+        if a.spread.is_some() {
+            return Err(anyhow!("spread em super.method() nao suportado"));
+        }
+        let tv = lower_expr(ctx, &a.expr)?;
+        let value = match expected_ty {
+            ValTy::I32 => ctx.coerce_to_i32(tv).val,
+            ValTy::F64 => to_f64(ctx, tv),
+            _ => ctx.coerce_to_i64(tv).val,
+        };
+        arg_values.push(value);
+    }
+    emit_method_call(ctx, &owner, &method_name, recv_i64, &arg_values)
 }
 
 fn lower_class_method_call_with_recv(
@@ -2226,11 +2398,25 @@ fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -> Result<Ty
     // Resolve a classe estatica do receiver (this ou local tipado), se
     // houver. Permite tipar o resultado de map_get conforme o field
     // declarado da classe (ex: `: string` retorna Handle).
-    let receiver_class: Option<String> = match m.obj.as_ref() {
-        Expr::This(_) => ctx.current_class.clone(),
-        Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
-        _ => None,
-    };
+    let receiver_class: Option<String> = lhs_static_class(ctx, &m.obj);
+
+    // Getter: `obj.x` quando classe define `get x()` — chama
+    // __class_C_get_x(this) em vez de map_get.
+    if let MemberProp::Ident(id) = &m.prop {
+        if let Some(cls) = receiver_class.as_deref() {
+            let prop_name = id.sym.as_str();
+            if let Some(getter_owner) = resolve_getter_owner(ctx, cls, prop_name) {
+                let recv_tv = lower_expr(ctx, &m.obj)?;
+                let recv_i64 = ctx.coerce_to_i64(recv_tv).val;
+                return emit_named_method_call(
+                    ctx,
+                    &class_getter_name(&getter_owner, prop_name),
+                    recv_i64,
+                    &[],
+                );
+            }
+        }
+    }
 
     // Caso 2/3: runtime member access. obj precisa virar handle.
     let obj_tv = lower_expr(ctx, &m.obj)?;

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -14,7 +14,8 @@ use cranelift_module::{DataDescription, Linkage, Module};
 use swc_ecma_ast::{Decl, Expr, Lit, Pat, Stmt, TsType, TsTypeRef};
 
 use crate::parser::ast::{
-    ClassDecl, ClassMember, FunctionDecl, Item, MemberModifiers, Parameter, Program, Statement,
+    ClassDecl, ClassMember, FunctionDecl, Item, MemberModifiers, MethodRole, Parameter, Program,
+    Statement,
 };
 
 use super::ctx::{ClassMeta, FnCtx, GlobalVar, UserFnAbi, ValTy};
@@ -499,6 +500,11 @@ fn compile_user_fn(
         builder.append_block_params_for_function_params(entry);
         builder.switch_to_block(entry);
         builder.seal_block(entry);
+        // Force layout insertion para body vazio nao crashar Cranelift.
+        // Sem nenhum opcode/terminator, builder.finalize() pode deixar
+        // o entry block fora do layout, e remove_constant_phis explode
+        // em "entry block unknown".
+        builder.func.layout.append_block(entry);
 
         let mut fn_ctx = FnCtx::new(
             &mut builder,
@@ -558,10 +564,15 @@ fn compile_user_fn(
             }
         }
 
-        // If we did not hit a return, emit one.
+        // If we did not hit a return, emit one. Body vazio: o entry
+        // block precisa ter terminator obrigatorio para Cranelift.
         if !terminated && !fn_ctx.builder.is_unreachable() {
-            if info.ret.is_some() {
-                let zero = fn_ctx.builder.ins().iconst(cl::I64, 0);
+            if let Some(rt) = info.ret {
+                let zero = match rt {
+                    ValTy::F64 => fn_ctx.builder.ins().f64const(0.0),
+                    ValTy::I32 => fn_ctx.builder.ins().iconst(cl::I32, 0),
+                    _ => fn_ctx.builder.ins().iconst(cl::I64, 0),
+                };
                 fn_ctx.builder.ins().return_(&[zero]);
             } else {
                 fn_ctx.builder.ins().return_(&[]);
@@ -691,6 +702,10 @@ fn compile_main_entry_shim(
 /// Retorna o ClassMeta usado pelo codegen para resolver `new` e dispatch.
 fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
     let mut methods: Vec<String> = Vec::new();
+    let mut getters: Vec<String> = Vec::new();
+    let mut setters: Vec<String> = Vec::new();
+    let mut static_methods: Vec<String> = Vec::new();
+    let mut static_fields: Vec<String> = Vec::new();
     let mut fns: Vec<FunctionDecl> = Vec::new();
     let mut field_types: HashMap<String, ValTy> = HashMap::new();
     let mut field_class_names: HashMap<String, String> = HashMap::new();
@@ -700,9 +715,6 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
         match member {
             ClassMember::Constructor(ctor) => {
                 has_constructor = true;
-                // Heuristica: parametros do constructor com nome igual a
-                // um field comum sao frequentemente atribuidos a `this.x`.
-                // Capturamos o tipo declarado para fallback.
                 for p in &ctor.parameters {
                     if let Some(ann) = p.type_annotation.as_deref() {
                         field_types
@@ -722,20 +734,46 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
                 });
             }
             ClassMember::Method(method) => {
-                methods.push(method.name.clone());
-                let mut params = Vec::with_capacity(method.parameters.len() + 1);
-                params.push(this_param(method.span));
-                params.extend(method.parameters.iter().cloned());
-                fns.push(FunctionDecl {
-                    name: class_method_name(&class.name, &method.name),
-                    parameters: params,
-                    return_type: method.return_type.clone(),
-                    body: method.body.clone(),
-                    span: method.span,
-                });
+                if method.modifiers.is_static {
+                    static_methods.push(method.name.clone());
+                    fns.push(FunctionDecl {
+                        name: class_static_method_name(&class.name, &method.name),
+                        parameters: method.parameters.clone(),
+                        return_type: method.return_type.clone(),
+                        body: method.body.clone(),
+                        span: method.span,
+                    });
+                } else {
+                    let synth_name = match method.role {
+                        MethodRole::Getter => {
+                            getters.push(method.name.clone());
+                            class_getter_name(&class.name, &method.name)
+                        }
+                        MethodRole::Setter => {
+                            setters.push(method.name.clone());
+                            class_setter_name(&class.name, &method.name)
+                        }
+                        MethodRole::Method => {
+                            methods.push(method.name.clone());
+                            class_method_name(&class.name, &method.name)
+                        }
+                    };
+                    let mut params = Vec::with_capacity(method.parameters.len() + 1);
+                    params.push(this_param(method.span));
+                    params.extend(method.parameters.iter().cloned());
+                    fns.push(FunctionDecl {
+                        name: synth_name,
+                        parameters: params,
+                        return_type: method.return_type.clone(),
+                        body: method.body.clone(),
+                        span: method.span,
+                    });
+                }
             }
             ClassMember::Property(prop) => {
-                if let Some(ann) = prop.type_annotation.as_deref() {
+                if prop.modifiers.is_static {
+                    static_fields.push(prop.name.clone());
+                } else if let Some(ann) = prop.type_annotation.as_deref() {
                     let ann = ann.trim();
                     field_types.insert(prop.name.clone(), ValTy::from_annotation(ann));
                     field_class_names.insert(prop.name.clone(), ann.to_string());
@@ -750,6 +788,10 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
         methods,
         field_types,
         field_class_names,
+        static_methods,
+        static_fields,
+        getters,
+        setters,
         has_constructor,
     };
     (meta, fns)
@@ -771,6 +813,18 @@ pub(super) fn class_init_name(class: &str) -> String {
 
 pub(super) fn class_method_name(class: &str, method: &str) -> String {
     format!("__class_{class}_{method}")
+}
+
+pub(super) fn class_static_method_name(class: &str, method: &str) -> String {
+    format!("__class_{class}_static_{method}")
+}
+
+pub(super) fn class_getter_name(class: &str, prop: &str) -> String {
+    format!("__class_{class}_get_{prop}")
+}
+
+pub(super) fn class_setter_name(class: &str, prop: &str) -> String {
+    format!("__class_{class}_set_{prop}")
 }
 
 /// Inverso de `class_init_name`/`class_method_name`: extrai o nome da

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -62,6 +62,13 @@ pub struct ConstructorDecl {
     pub span: Span,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodRole {
+    Method,
+    Getter,
+    Setter,
+}
+
 #[derive(Debug, Clone)]
 pub struct MethodDecl {
     pub name: String,
@@ -69,6 +76,7 @@ pub struct MethodDecl {
     pub parameters: Vec<Parameter>,
     pub return_type: Option<String>,
     pub body: Vec<Statement>,
+    pub role: MethodRole,
     pub span: Span,
 }
 

--- a/src/parser/lowering_decls.rs
+++ b/src/parser/lowering_decls.rs
@@ -33,6 +33,12 @@ fn lower_class(cm: &Lrc<SourceMap>, name: &str, class: &SwcClass, span: SwcSpan)
 
                 let body = lower_block_body(cm, method.function.body.as_ref());
 
+                let role = match method.kind {
+                    swc_ecma_ast::MethodKind::Method => MethodRole::Method,
+                    swc_ecma_ast::MethodKind::Getter => MethodRole::Getter,
+                    swc_ecma_ast::MethodKind::Setter => MethodRole::Setter,
+                };
+
                 members.push(ClassMember::Method(MethodDecl {
                     name,
                     modifiers: MemberModifiers {
@@ -47,6 +53,7 @@ fn lower_class(cm: &Lrc<SourceMap>, name: &str, class: &SwcClass, span: SwcSpan)
                         .as_ref()
                         .map(|annotation| normalize_type_annotation(cm, annotation)),
                     body,
+                    role,
                     span: convert_span(cm, method.span),
                 }));
             }
@@ -74,6 +81,7 @@ fn lower_class(cm: &Lrc<SourceMap>, name: &str, class: &SwcClass, span: SwcSpan)
                         .as_ref()
                         .map(|annotation| normalize_type_annotation(cm, annotation)),
                     body,
+                    role: MethodRole::Method,
                     span: convert_span(cm, method.span),
                 }));
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,8 +19,8 @@ use crate::diagnostics::source_store::{self, FileId};
 
 use ast::{
     ClassDecl, ClassMember, ConstructorDecl, FieldDecl, FunctionDecl, ImportDecl, InterfaceDecl,
-    Item, MemberModifiers, MethodDecl, Parameter, Program, PropertyDecl, RawStmt, Statement,
-    Visibility,
+    Item, MemberModifiers, MethodDecl, MethodRole, Parameter, Program, PropertyDecl, RawStmt,
+    Statement, Visibility,
 };
 use span::{Position, Span};
 

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -204,3 +204,8 @@ fn fixture_operator_overload() {
 fn fixture_class_virtual_dispatch() {
     run_fixture("class_virtual_dispatch");
 }
+
+#[test]
+fn fixture_class_extras() {
+    run_fixture("class_extras");
+}

--- a/tests/fixtures/class_extras.out
+++ b/tests/fixtures/class_extras.out
@@ -1,0 +1,11 @@
+base
+mid
+top
+---
+double=14
+add=7
+init=10
+set50=50
+clamped=0
+area=12
+empty-method-ok

--- a/tests/fixtures/class_extras.ts
+++ b/tests/fixtures/class_extras.ts
@@ -1,0 +1,68 @@
+import { io } from "rts";
+
+// super.method()
+class Base {
+  hi(): void { io.print("base"); }
+}
+class Mid extends Base {
+  hi(): void {
+    super.hi();
+    io.print("mid");
+  }
+}
+class Top extends Mid {
+  hi(): void {
+    super.hi();
+    io.print("top");
+  }
+}
+new Top().hi();
+io.print("---");
+
+// static methods
+class Util {
+  static double(n: i32): i32 { return n * 2; }
+  static add(a: i32, b: i32): i32 { return a + b; }
+}
+io.print(`double=${Util.double(7)}`);
+io.print(`add=${Util.add(3, 4)}`);
+
+// getters / setters
+class Box {
+  _value: i32;
+  constructor(v: i32) { this._value = v; }
+  get value(): i32 { return this._value; }
+  set value(v: i32) {
+    if (v < 0) {
+      this._value = 0;
+    } else {
+      this._value = v;
+    }
+  }
+}
+const b: Box = new Box(10);
+io.print(`init=${b.value}`);
+b.value = 50;
+io.print(`set50=${b.value}`);
+b.value = -5;
+io.print(`clamped=${b.value}`);
+
+// computed getter
+class Rect {
+  w: i32;
+  h: i32;
+  constructor(w: i32, h: i32) {
+    this.w = w;
+    this.h = h;
+  }
+  get area(): i32 { return this.w * this.h; }
+}
+const r: Rect = new Rect(3, 4);
+io.print(`area=${r.area}`);
+
+// empty body method
+class NoOp {
+  do(): void {}
+}
+new NoOp().do();
+io.print("empty-method-ok");


### PR DESCRIPTION
Resolve tres das limitacoes documentadas em classes:

```ts
// 1. super.method() encadeado
class Base { hi() { io.print('base'); } }
class Mid extends Base { hi() { super.hi(); io.print('mid'); } }
class Top extends Mid { hi() { super.hi(); io.print('top'); } }
new Top().hi();  // base / mid / top

// 2. static methods
class Util {
  static double(n: i32): i32 { return n * 2; }
}
Util.double(7);  // 14

// 3. getters/setters
class Box {
  _v: i32;
  get value(): i32 { return this._v; }
  set value(v: i32) { this._v = v < 0 ? 0 : v; }
}
const b = new Box(); b.value = -5;  // clamped via setter
```

**Bonus**: crash de Cranelift em function com body vazio (`function f(): void {}` ou `do(): void {}`) tambem corrigido.

Fixture nova `class_extras` cobre tudo.