### PR TITLE
docs: refresh — 16 namespaces, classes completas, overload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,10 @@ Regras:
 - Cada arquivo operacional agrupa funcoes por responsabilidade (io/r-w/dir/metadata/…)
 - Nao existe `dispatch()` por namespace — cada funcao e um `#[no_mangle] extern "C"` direto
 
-Namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`.
-Demais (net, process, crypto, buffer, thread, etc) serao reintroduzidos sobre o contrato
-atual a medida que o pipeline estabiliza. Ver issues #12-#39 para o backlog.
+Namespaces ativos (16): `io`, `fs`, `gc`, `math`, `bigfloat`, `time`, `env`, `path`,
+`buffer`, `string`, `process`, `os`, `collections`, `hash`, `fmt`, `crypto`.
+Demais (net, thread, sync, atomic, etc) serao reintroduzidos sobre o contrato
+atual a medida que o pipeline estabiliza. Ver issues #16-#39 para o backlog.
 
 ### Namespaces existentes
 
@@ -121,6 +122,25 @@ atual a medida que o pipeline estabiliza. Ver issues #12-#39 para o backlog.
   Windows)
 - `collections/` — HashMap<string, i64> (`map_*`) e Vec<i64> (`vec_*`) via
   HandleTable. Valor sempre i64 — caller interpreta como int/handle/bool
+- `hash/` — SipHash-2-4 deterministico para str/i64/bytes (hash_str,
+  hash_i64, hash_bytes)
+- `fmt/` — parse_i64/f64 (tolerante), fmt_hex/oct/bin/f64_prec
+- `crypto/` — SHA-256 inline (FIPS 180-4), base64/hex encode+decode,
+  CSPRNG via BCryptGenRandom (Windows) / /dev/urandom (Unix)
+
+### Capacidades de linguagem ativas (codegen)
+
+- Object/array literals: `{k: v}` e `[1,2,3]` via `collections.map_*`/`vec_*`.
+- Classes: constructor, method, this, extends, super(args), super.method(args),
+  static methods, getters/setters. Instance armazena `__rts_class` para
+  dispatch virtual real (override em subclasse roteado via comparacao de
+  string sobre o tag de runtime).
+- Operator overload Rust-style: `a + b` vira `a.add(b)` em compile-time
+  quando classe define o metodo (`add`/`sub`/`mul`/.../`eq`/`lt`/`bit_*`).
+- for...of em arrays; bind herda classe quando array tem anotacao `: C[]`.
+- try/catch/finally fase 1: slot de erro thread-local, sem unwind real
+  (#128 rastreia fase 2).
+- String equality: `s1 == s2` compara conteudo via `gc.string_eq`.
 
 ## Convencoes
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ os namespaces builtin. Ha dois caminhos de execucao:
 - **AOT** (`rts compile`) — emite object file, linka com o linker do sistema,
   produz executavel standalone.
 
-Namespaces ativos (13): `io`, `fs`, `gc`, `math`, `bigfloat`, `time`, `env`, `path`,
-`buffer`, `string`, `process`, `os`, `collections`.
+Namespaces ativos (16): `io`, `fs`, `gc`, `math`, `bigfloat`, `time`, `env`, `path`,
+`buffer`, `string`, `process`, `os`, `collections`, `hash`, `fmt`, `crypto`.
 
 **Observação de perf (Windows, `rts_simple.ts`, 10 runs):**
 
@@ -53,6 +53,9 @@ src/
     process/         exit/abort/pid, argv aliases, spawn/wait/kill
     os/              platform, arch, family, home/temp/config/cache_dir
     collections/     HashMap<string, i64> e Vec<i64> via HandleTable
+    hash/            SipHash-2-4 deterministico (str/i64/bytes)
+    fmt/             parse_i64/f64, fmt_hex/oct/bin, fmt_f64_prec
+    crypto/          SHA-256 inline, base64/hex encode/decode, CSPRNG
     <ns>/mod.rs      import map
     <ns>/abi.rs      tabela estatica de NamespaceMember
     <ns>/rt.rs       re-exports para o runtime staticlib
@@ -74,8 +77,9 @@ Pipeline JIT: `Source TS -> Parser (SWC) -> Codegen Cranelift -> JITModule in-me
 ## Contrato ABI
 
 - Fonte unica: `src/abi/`.
-- `abi::SPECS` lista os 13 namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`,
-  `time`, `env`, `path`, `buffer`, `string`, `process`, `os`, `collections`.
+- `abi::SPECS` lista os 16 namespaces ativos: `io`, `fs`, `gc`, `math`, `bigfloat`,
+  `time`, `env`, `path`, `buffer`, `string`, `process`, `os`, `collections`,
+  `hash`, `fmt`, `crypto`.
 - Cada membro declara nome, parametros, retorno via `AbiType`, e opcionalmente
   um `Intrinsic` que permite ao codegen emitir IR inline ao inves de call extern
   (usado em `math.sqrt`, `math.random_f64`, etc).
@@ -119,11 +123,29 @@ Suportadas no codegen:
   decimais. Suficiente para calcular pi com 29 digitos corretos via Machin.
 - **Containers**: `collections.map_*` e `collections.vec_*` via handles
   (HashMap<string, i64> e Vec<i64>), `buffer.alloc/read/write` pra bytes.
+- **Object/array literals**: `{ k: v }` desugar em `map_*`, `[1, 2, 3]` em
+  `vec_*`. Member access (`obj.x`, `obj["x"]`, `arr[i]`) e atribuicao
+  (`obj.x = v`) suportados. Aninhamento livre.
+- **Classes**: `class C { constructor(...) {...} method() {...} field: T }`,
+  `new C(args)`, `this`, `extends`/`super(args)`, `super.method(args)`,
+  static methods (`static m()` chamados via `C.m()`), getters/setters
+  (`get x()`, `set x(v)`), dispatch virtual real (instancia armazena
+  `__rts_class`; metodos overrideados em subclasses sao despachados via
+  string-eq sobre o tag de runtime). Operator overload Rust-style: `a + b`
+  vira `a.add(b)` em compile-time quando classe define o metodo
+  (`add`/`sub`/`mul`/`div`/`rem`/`eq`/`ne`/`lt`/`le`/`gt`/`ge`/`bit_*`/`shl`/`shr`).
+- **for...of**: itera sobre arrays (`vec_*`); bind herda classe quando
+  array tem anotacao `: C[]` para habilitar dispatch de metodo.
+- **try / catch / throw / finally** (fase 1): captura via slot de erro
+  thread-local checado ao fim do try. Sem unwind real ainda — `throw` nao
+  interrompe o fluxo (#128 rastreia fase 2 com Cranelift invoke).
+- **String equality**: `s1 == s2` compara conteudo via `gc.string_eq`
+  quando ambos os operandos sao Handle.
 
-Nao suportado ainda: `class`, `try/catch`, `async/await`, generators,
-destructuring, spread/rest, regex, object e array literals nativos.
-Closures com captura de variaveis externas estao em fase 1 (ponteiros de
-funcao sem env).
+Nao suportado ainda: `async/await`, generators, destructuring, spread/rest,
+regex, decorators, generics, abstract classes, satisfies, enum, default
+parameters. Closures com captura de variaveis externas estao em fase 1
+(ponteiros de funcao sem env).
 
 ## CLI
 

--- a/ROAD_MAP.md
+++ b/ROAD_MAP.md
@@ -25,7 +25,8 @@ Convergir para o modelo da `main` (pipeline completo + cache), mantendo a organi
 - [x] Declaracoes TypeScript sincronizadas a partir da ABI nova.
 - [x] Namespaces adicionais consolidados: `math` (27 membros + 4 constantes),
       `bigfloat` (decimal 30 digitos), `time`, `env`, `path`, `buffer`,
-      `string`, `process`, `os`, `collections` — 13 namespaces total.
+      `string`, `process`, `os`, `collections`, `hash`, `fmt`, `crypto`
+      — 16 namespaces total.
 
 ---
 


### PR DESCRIPTION
Sincroniza README + CLAUDE.md + ROAD_MAP.md com o estado atual do codegen apos PRs #131-#141: classes (extends/super/super.method/static/get/set/dispatch virtual), operator overload, object/array literals, for-of, try/catch fase 1, string ==, e os 3 namespaces hash/fmt/crypto.