### PR TITLE
fix(ui): segfault em callback de classe — calling convention errada

### DIFF
--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -1469,7 +1469,18 @@ fn ts_type_to_val_ty(ty: &TsType) -> Option<ValTy> {
 /// use the platform default calling convention.
 #[inline]
 fn is_lifted_callback(name: &str) -> bool {
-    name.starts_with("__lifted_arrow_")
+    // Trampolins simples (sem captura de `this`): `__lifted_arrow_N`.
+    // Trampolins de classe (capturam `this`/`super`): `__class_C_lifted_arrow_N`.
+    // Ambos atravessam a fronteira C ABI quando invocados pelo FLTK.
+    if name.starts_with("__lifted_arrow_") {
+        return true;
+    }
+    if let Some(rest) = name.strip_prefix("__class_") {
+        if rest.contains("_lifted_arrow_") {
+            return true;
+        }
+    }
+    false
 }
 
 /// User-defined functions generally use the Tail calling convention so codegen


### PR DESCRIPTION
## Summary

Bug crítico encontrado durante validação manual: \`closure_demo.ts\` segfaultava ao clicar qualquer botão (e às vezes no próprio startup).

## Causa raiz

\`is_lifted_callback\` em \`src/codegen/lower/func.rs\` só detectava o prefixo \`__lifted_arrow_\`. Trampolins gerados pelo lifter quando a arrow captura \`this\`/\`super\` recebem nome mangled \`__class_C_lifted_arrow_N\` — esses caíam no \`else\` do \`user_call_conv\` e ganhavam \`CallConv::Tail\`.

\`Tail\` ≠ ABI C. FLTK invoca o callback como \`extern \"C\" fn(u64)\`. Chamar uma função compilada com Tail via convenção C resulta em acesso inválido a stack/registradores → SIGSEGV imediato.

## Fix

\`is_lifted_callback\` agora reconhece também \`__class_<C>_lifted_arrow_<N>\`:

\`\`\`rust
fn is_lifted_callback(name: &str) -> bool {
    if name.starts_with(\"__lifted_arrow_\") { return true; }
    if let Some(rest) = name.strip_prefix(\"__class_\") {
        if rest.contains(\"_lifted_arrow_\") { return true; }
    }
    false
}
\`\`\`

Esses trampolins agora usam \`module.isa().default_call_conv()\` (ABI C), batendo com a expectativa do FFI.

## Validação

- [x] \`closure_demo.ts\` (4 casos: field, method, nested, super) — todos os botões funcionam, fechamento limpo.
- [x] \`cargo test --release\` — 53 pass / 7 fail pré-existentes / 6 ignored. Sem regressão.
- [x] Suite \`closure_*\` (com display) — 5/5 OK.

Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)