### PR TITLE
test(try-catch): expande cobertura de throw/try/catch/finally

### DIFF
--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -552,3 +552,23 @@ fn fixture_enum_explicit() {
 fn fixture_enum_compare() {
     run_fixture("enum_compare");
 }
+
+#[test]
+fn fixture_try_catch_no_binding() {
+    run_fixture("try_catch_no_binding");
+}
+
+#[test]
+fn fixture_try_catch_propagation() {
+    run_fixture("try_catch_propagation");
+}
+
+#[test]
+fn fixture_try_catch_nested() {
+    run_fixture("try_catch_nested");
+}
+
+#[test]
+fn fixture_try_catch_rethrow() {
+    run_fixture("try_catch_rethrow");
+}

--- a/tests/fixtures/try_catch_nested.out
+++ b/tests/fixtures/try_catch_nested.out
@@ -1,0 +1,3 @@
+inner caught: inner
+after inner
+end

--- a/tests/fixtures/try_catch_nested.ts
+++ b/tests/fixtures/try_catch_nested.ts
@@ -1,0 +1,15 @@
+// try/catch aninhado: catch interno absorve, catch externo continua sem erro.
+import { io } from "rts";
+
+try {
+    try {
+        throw "inner";
+    } catch (e) {
+        io.print(`inner caught: ${e}`);
+    }
+    io.print("after inner");
+} catch (e2) {
+    io.print(`outer would catch: ${e2}`);  // não deve disparar
+}
+
+io.print("end");

--- a/tests/fixtures/try_catch_no_binding.out
+++ b/tests/fixtures/try_catch_no_binding.out
@@ -1,0 +1,3 @@
+try
+caught
+end

--- a/tests/fixtures/try_catch_no_binding.ts
+++ b/tests/fixtures/try_catch_no_binding.ts
@@ -1,0 +1,11 @@
+// catch sem binding (ES2019): `catch { ... }` em vez de `catch (e) { ... }`.
+import { io } from "rts";
+
+try {
+    io.print("try");
+    throw "err";
+} catch {
+    io.print("caught");
+}
+
+io.print("end");

--- a/tests/fixtures/try_catch_propagation.out
+++ b/tests/fixtures/try_catch_propagation.out
@@ -1,0 +1,3 @@
+inner-before
+caught: boom
+end

--- a/tests/fixtures/try_catch_propagation.ts
+++ b/tests/fixtures/try_catch_propagation.ts
@@ -1,0 +1,20 @@
+// throw dentro de fn deve propagar até o try/catch do caller.
+// Nota: fase 1 não tem unwind real — o body continua até o ponto de
+// observação (try/catch ou call site). Este teste exercita o caso onde
+// o body da fn imprime ANTES do throw, e o caller observa o erro.
+import { io } from "rts";
+
+function inner(): void {
+    io.print("inner-before");
+    throw "boom";
+    // statements após throw na fase 1 ainda executam — mas evitamos
+    // testar isso; aqui o body é puro até o throw.
+}
+
+try {
+    inner();
+} catch (e) {
+    io.print(`caught: ${e}`);
+}
+
+io.print("end");

--- a/tests/fixtures/try_catch_rethrow.out
+++ b/tests/fixtures/try_catch_rethrow.out
@@ -1,0 +1,3 @@
+inner: first
+outer: rethrown
+end

--- a/tests/fixtures/try_catch_rethrow.ts
+++ b/tests/fixtures/try_catch_rethrow.ts
@@ -1,0 +1,15 @@
+// catch que faz rethrow — outer catch pega.
+import { io } from "rts";
+
+try {
+    try {
+        throw "first";
+    } catch (e) {
+        io.print(`inner: ${e}`);
+        throw "rethrown";
+    }
+} catch (e2) {
+    io.print(`outer: ${e2}`);
+}
+
+io.print("end");


### PR DESCRIPTION
## Summary

A fase 1 de try/catch já existia no codegen (slot global thread-local em \`stmt.rs::lower_try\`). Esta mudança apenas adiciona fixtures que cobrem variantes adicionais — todas passando com a impl atual.

## Casos cobertos (4)

| Fixture | Cenário |
|---|---|
| \`try_catch_no_binding\` | \`catch { }\` (ES2019, sem binding) |
| \`try_catch_propagation\` | throw em fn aninhada, catch no caller |
| \`try_catch_nested\` | try interno absorve, externo não dispara |
| \`try_catch_rethrow\` | catch que rethrow, outer pega |

\`try_catch.ts\` (pré-existente) já cobria: throw direto, try sem catch, try sem throw, finally em todos os caminhos.

## Limitação documentada

Fase 1 tem semântica imperfeita — code após \`throw\` no mesmo bloco ainda executa porque não há unwind real. Fase 2 (#128) integra \`invoke\` do Cranelift.

## Test plan

- [x] \`cargo test --release\` — 80 pass / 0 fail. Sem regressão.

Resolve #62 (fase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)