### PR TITLE
feat(ts): union types resolvendo para tipo concreto (#74)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -37,13 +37,48 @@ impl ValTy {
     }
 
     pub fn from_annotation(ann: &str) -> Self {
-        match ann.trim() {
-            "i32" | "I32" => ValTy::I32,
-            "f64" | "F64" | "number" => ValTy::F64,
-            "bool" | "boolean" => ValTy::Bool,
-            "string" | "str" => ValTy::Handle,
-            _ => ValTy::I64,
+        let trimmed = ann.trim();
+        match trimmed {
+            "i32" | "I32" => return ValTy::I32,
+            "f64" | "F64" | "number" => return ValTy::F64,
+            "bool" | "boolean" => return ValTy::Bool,
+            "string" | "str" => return ValTy::Handle,
+            _ => {}
         }
+        // Union types raw da source: tenta resolver para um tipo unico
+        // se todos os ramos sao do mesmo. Usa parsing textual simples.
+        if trimmed.contains('|') {
+            let parts: Vec<&str> = trimmed
+                .split('|')
+                .map(|s| s.trim().trim_start_matches('(').trim_end_matches(')').trim())
+                .filter(|s| !s.is_empty() && *s != "null" && *s != "undefined")
+                .collect();
+            if !parts.is_empty() {
+                let mut acc: Option<ValTy> = None;
+                for p in parts {
+                    // Cada parte: pode ser keyword, string literal "...",
+                    // numero literal, etc.
+                    let cur = if p.starts_with('"') && p.ends_with('"') {
+                        ValTy::Handle
+                    } else if p.starts_with('\'') && p.ends_with('\'') {
+                        ValTy::Handle
+                    } else if p.parse::<f64>().is_ok() {
+                        ValTy::I64
+                    } else {
+                        ValTy::from_annotation(p)
+                    };
+                    match acc {
+                        None => acc = Some(cur),
+                        Some(prev) if prev == cur => {}
+                        _ => return ValTy::I64,
+                    }
+                }
+                if let Some(t) = acc {
+                    return t;
+                }
+            }
+        }
+        ValTy::I64
     }
 
     pub fn from_abi(abi: AbiType) -> Self {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -2554,7 +2554,7 @@ fn infer_abi_member_ty(expr: &Expr) -> Option<ValTy> {
 }
 
 fn ts_type_to_val_ty(ty: &TsType) -> Option<ValTy> {
-    use swc_ecma_ast::TsKeywordTypeKind;
+    use swc_ecma_ast::{TsKeywordTypeKind, TsLit, TsLitType, TsUnionOrIntersectionType};
 
     if let TsType::TsKeywordType(kw) = ty {
         return Some(match kw.kind {
@@ -2566,12 +2566,47 @@ fn ts_type_to_val_ty(ty: &TsType) -> Option<ValTy> {
         });
     }
 
+    if let TsType::TsLitType(TsLitType { lit, .. }) = ty {
+        return Some(match lit {
+            TsLit::Str(_) | TsLit::Tpl(_) => ValTy::Handle,
+            TsLit::Number(_) => ValTy::I64,
+            TsLit::Bool(_) => ValTy::Bool,
+            TsLit::BigInt(_) => ValTy::I64,
+        });
+    }
+
     if let TsType::TsTypeRef(TsTypeRef { type_name, .. }) = ty {
         let name = match type_name {
             swc_ecma_ast::TsEntityName::Ident(id) => id.sym.as_str(),
             _ => return None,
         };
         return Some(ValTy::from_annotation(name));
+    }
+
+    if let TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(u)) = ty {
+        let mut acc: Option<ValTy> = None;
+        for member in &u.types {
+            if let TsType::TsKeywordType(k) = member.as_ref() {
+                if matches!(
+                    k.kind,
+                    TsKeywordTypeKind::TsNullKeyword
+                        | TsKeywordTypeKind::TsUndefinedKeyword
+                ) {
+                    continue;
+                }
+            }
+            let mt = ts_type_to_val_ty(member)?;
+            match acc {
+                None => acc = Some(mt),
+                Some(prev) if prev == mt => {}
+                _ => return None,
+            }
+        }
+        return acc;
+    }
+
+    if let TsType::TsParenthesizedType(p) = ty {
+        return ts_type_to_val_ty(&p.type_ann);
     }
 
     None

--- a/src/codegen/lower/statements/decls.rs
+++ b/src/codegen/lower/statements/decls.rs
@@ -133,7 +133,7 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
 }
 
 pub(super) fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {
-    use swc_ecma_ast::{TsKeywordTypeKind, TsType};
+    use swc_ecma_ast::{TsKeywordTypeKind, TsLit, TsLitType, TsType, TsUnionOrIntersectionType};
     if let TsType::TsKeywordType(kw) = ty {
         return Some(match kw.kind {
             TsKeywordTypeKind::TsNumberKeyword => ValTy::I32,
@@ -143,12 +143,47 @@ pub(super) fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {
             _ => return None,
         });
     }
+    if let TsType::TsLitType(TsLitType { lit, .. }) = ty {
+        return Some(match lit {
+            TsLit::Str(_) | TsLit::Tpl(_) => ValTy::Handle,
+            TsLit::Number(_) => ValTy::I64,
+            TsLit::Bool(_) => ValTy::Bool,
+            TsLit::BigInt(_) => ValTy::I64,
+        });
+    }
     if let TsType::TsTypeRef(r) = ty {
         let name = match &r.type_name {
             swc_ecma_ast::TsEntityName::Ident(id) => id.sym.as_str(),
             _ => return None,
         };
         return Some(ValTy::from_annotation(name));
+    }
+    if let TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(u)) = ty {
+        // Union: se todos os ramos resolvem para o mesmo ValTy, usa ele.
+        // Ramos null/undefined sao ignorados (covers `T | null`).
+        let mut acc: Option<ValTy> = None;
+        for member in &u.types {
+            // Skip null/undefined branches.
+            if let TsType::TsKeywordType(k) = member.as_ref() {
+                if matches!(
+                    k.kind,
+                    TsKeywordTypeKind::TsNullKeyword
+                        | TsKeywordTypeKind::TsUndefinedKeyword
+                ) {
+                    continue;
+                }
+            }
+            let mt = ts_type_to_val_ty(member)?;
+            match acc {
+                None => acc = Some(mt),
+                Some(prev) if prev == mt => {}
+                _ => return None, // tipos misturados — codegen trata como I64.
+            }
+        }
+        return acc;
+    }
+    if let TsType::TsParenthesizedType(p) = ty {
+        return ts_type_to_val_ty(&p.type_ann);
     }
     None
 }

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -817,3 +817,28 @@ fn fixture_enum_mixed() {
 fn fixture_enum_string_switch() {
     run_fixture("enum_string_switch");
 }
+
+#[test]
+fn fixture_union_string_literal() {
+    run_fixture("union_string_literal");
+}
+
+#[test]
+fn fixture_union_nullable_string() {
+    run_fixture("union_nullable_string");
+}
+
+#[test]
+fn fixture_union_status_codes() {
+    run_fixture("union_status_codes");
+}
+
+#[test]
+fn fixture_union_number_literal() {
+    run_fixture("union_number_literal");
+}
+
+#[test]
+fn fixture_intersection_extended() {
+    run_fixture("intersection_extended");
+}

--- a/tests/fixtures/intersection_extended.out
+++ b/tests/fixtures/intersection_extended.out
@@ -1,0 +1,1 @@
+Mario com 35

--- a/tests/fixtures/intersection_extended.ts
+++ b/tests/fixtures/intersection_extended.ts
@@ -1,0 +1,11 @@
+// Intersection eh type-only (TS structural). Runtime usa o object literal.
+import { io, gc } from "rts";
+
+interface HasName { name: string; }
+interface HasAge { age: i64; }
+
+// Apenas valida que TS aceita a anotacao em type alias / declaration site.
+const obj: HasName & HasAge = { name: "Mario", age: 35 };
+const ageStr = gc.string_from_i64(obj.age);
+io.print(obj.name + " com " + ageStr);
+gc.string_free(ageStr);

--- a/tests/fixtures/union_nullable_string.out
+++ b/tests/fixtures/union_nullable_string.out
@@ -1,0 +1,3 @@
+ola Mario
+ola desconhecido
+ola Ana

--- a/tests/fixtures/union_nullable_string.ts
+++ b/tests/fixtures/union_nullable_string.ts
@@ -1,0 +1,11 @@
+// `string | null`: Handle nullable. Branch null → fallback.
+import { io } from "rts";
+
+function greet(name: string | null): string {
+  if (name == null) return "ola desconhecido";
+  return "ola " + name;
+}
+
+io.print(greet("Mario"));
+io.print(greet(null));
+io.print(greet("Ana"));

--- a/tests/fixtures/union_number_literal.out
+++ b/tests/fixtures/union_number_literal.out
@@ -1,0 +1,3 @@
+ruim
+medio
+bom

--- a/tests/fixtures/union_number_literal.ts
+++ b/tests/fixtures/union_number_literal.ts
@@ -1,0 +1,12 @@
+// Union de literais numericos.
+import { io, gc } from "rts";
+
+function rate(stars: 1 | 2 | 3 | 4 | 5): string {
+  if (stars <= 2) return "ruim";
+  if (stars == 3) return "medio";
+  return "bom";
+}
+
+io.print(rate(1));
+io.print(rate(3));
+io.print(rate(5));

--- a/tests/fixtures/union_status_codes.out
+++ b/tests/fixtures/union_status_codes.out
@@ -1,0 +1,3 @@
+preparando
+em execucao
+finalizado

--- a/tests/fixtures/union_status_codes.ts
+++ b/tests/fixtures/union_status_codes.ts
@@ -1,0 +1,17 @@
+// String literal union como discriminante de estado.
+import { io } from "rts";
+
+function progress(state: "init" | "running" | "done"): string {
+  if (state == "init") return "preparando";
+  if (state == "running") return "em execucao";
+  return "finalizado";
+}
+
+const states: string[] = [];
+states.push("init");
+states.push("running");
+states.push("done");
+
+for (const s of states) {
+  io.print(progress(s));
+}

--- a/tests/fixtures/union_string_literal.out
+++ b/tests/fixtures/union_string_literal.out
@@ -1,0 +1,3 @@
+high-perf
+low-power
+balanced

--- a/tests/fixtures/union_string_literal.ts
+++ b/tests/fixtures/union_string_literal.ts
@@ -1,0 +1,12 @@
+// String literal union inline (sem type alias).
+import { io } from "rts";
+
+function settings(m: "fast" | "slow" | "auto"): string {
+  if (m == "fast") return "high-perf";
+  if (m == "slow") return "low-power";
+  return "balanced";
+}
+
+io.print(settings("fast"));
+io.print(settings("slow"));
+io.print(settings("auto"));


### PR DESCRIPTION
## Summary
- Union de literais homogêneos agora resolve para um ValTy: \`\"a\" | \"b\"\` -> Handle, \`1 | 2 | 3\` -> I64, \`string | null\` -> Handle.
- Implementação em \`from_annotation\` (textual, params) e \`ts_type_to_val_ty\` (AST swc, locals/globals).
- Trata TsLitType, TsUnionType (com null/undefined skip) e TsParenthesizedType.

## Limitações conhecidas
- Type aliases (\`type X = A | B\`) ainda não resolvem — anotação precisa estar inline.
- Union mista (\`string | i64\`) sem narrowing por \`typeof\` ainda cai em I64.

## Test plan
- [x] 5 fixtures novas: union_string_literal, union_nullable_string, union_status_codes, union_number_literal, intersection_extended
- [x] 136 fixtures totais passam

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)