### PR TITLE
feat(ns): namespace backtrace (#39)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/math/");
     println!("cargo:rerun-if-changed=src/namespaces/num/");
     println!("cargo:rerun-if-changed=src/namespaces/mem/");
+    println!("cargo:rerun-if-changed=src/namespaces/backtrace/");
     println!("cargo:rerun-if-changed=src/namespaces/bigfloat/");
     println!("cargo:rerun-if-changed=src/namespaces/time/");
     println!("cargo:rerun-if-changed=src/namespaces/env/");

--- a/builtin/rts-types/rts.d.ts
+++ b/builtin/rts-types/rts.d.ts
@@ -880,6 +880,17 @@ declare module "rts" {
      * Debug info em runtime: carrega .ometa, resolve PC → source location, formata erros.
      */
     /**
+     * Captura de stack traces via std::backtrace::Backtrace.
+     */
+    export namespace backtrace {
+      export function capture(): number;
+      export function capture_if_enabled(): number;
+      export function is_enabled(): boolean;
+      export function to_string(handle: number): number;
+      export function free(handle: number): void;
+    }
+
+    /**
      * std::mem: layout (size_of/align_of), swap, drop, forget.
      */
     export namespace mem {

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -32,6 +32,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::math::abi::SPEC,
     &crate::namespaces::num::abi::SPEC,
     &crate::namespaces::mem::abi::SPEC,
+    &crate::namespaces::backtrace::abi::SPEC,
     &crate::namespaces::bigfloat::abi::SPEC,
     &crate::namespaces::time::abi::SPEC,
     &crate::namespaces::env::abi::SPEC,

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -289,6 +289,28 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_NS_MEM_REPLACE_I64", m::__RTS_FN_NS_MEM_REPLACE_I64);
     }
 
+    // ── namespaces::backtrace ─────────────────────────────────────────
+    {
+        use crate::namespaces::backtrace::ops as bt;
+        add_fn!(
+            "__RTS_FN_NS_BACKTRACE_CAPTURE",
+            bt::__RTS_FN_NS_BACKTRACE_CAPTURE
+        );
+        add_fn!(
+            "__RTS_FN_NS_BACKTRACE_CAPTURE_IF_ENABLED",
+            bt::__RTS_FN_NS_BACKTRACE_CAPTURE_IF_ENABLED
+        );
+        add_fn!(
+            "__RTS_FN_NS_BACKTRACE_IS_ENABLED",
+            bt::__RTS_FN_NS_BACKTRACE_IS_ENABLED
+        );
+        add_fn!(
+            "__RTS_FN_NS_BACKTRACE_TO_STRING",
+            bt::__RTS_FN_NS_BACKTRACE_TO_STRING
+        );
+        add_fn!("__RTS_FN_NS_BACKTRACE_FREE", bt::__RTS_FN_NS_BACKTRACE_FREE);
+    }
+
     // ── namespaces::crypto ────────────────────────────────────────────
     {
         use crate::namespaces::crypto::*;

--- a/src/namespaces/backtrace/abi.rs
+++ b/src/namespaces/backtrace/abi.rs
@@ -1,0 +1,62 @@
+//! `backtrace` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "capture",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_BACKTRACE_CAPTURE",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Captura backtrace do call stack atual. Retorna handle.",
+        ts_signature: "capture(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "capture_if_enabled",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_BACKTRACE_CAPTURE_IF_ENABLED",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Captura backtrace se RUST_BACKTRACE estiver set; retorna 0 caso contrario.",
+        ts_signature: "capture_if_enabled(): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "is_enabled",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_BACKTRACE_IS_ENABLED",
+        args: &[],
+        returns: AbiType::Bool,
+        doc: "True se RUST_BACKTRACE=1 (ou full) esta no env.",
+        ts_signature: "is_enabled(): boolean",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "to_string",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_BACKTRACE_TO_STRING",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Formata o backtrace em string. Retorna handle de string GC.",
+        ts_signature: "to_string(handle: number): number",
+        intrinsic: None,
+    },
+    NamespaceMember {
+        name: "free",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_BACKTRACE_FREE",
+        args: &[AbiType::Handle],
+        returns: AbiType::Void,
+        doc: "Libera a backtrace.",
+        ts_signature: "free(handle: number): void",
+        intrinsic: None,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "backtrace",
+    doc: "Captura de stack traces via std::backtrace::Backtrace.",
+    members: MEMBERS,
+};

--- a/src/namespaces/backtrace/mod.rs
+++ b/src/namespaces/backtrace/mod.rs
@@ -1,0 +1,8 @@
+//! `backtrace` namespace — captura de stack trace via std::backtrace.
+//!
+//! Backtraces sao armazenadas no HandleTable como Entry::Backtrace.
+//! to_string formata em string handle. is_enabled checa se
+//! RUST_BACKTRACE esta set.
+
+pub mod abi;
+pub mod ops;

--- a/src/namespaces/backtrace/ops.rs
+++ b/src/namespaces/backtrace/ops.rs
@@ -1,0 +1,47 @@
+//! `backtrace` runtime ops.
+
+use super::super::gc::handles::{Entry, table};
+use std::backtrace::{Backtrace, BacktraceStatus};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_BACKTRACE_CAPTURE() -> u64 {
+    let bt = Backtrace::force_capture();
+    table().lock().unwrap().alloc(Entry::Backtrace(Box::new(bt)))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_BACKTRACE_CAPTURE_IF_ENABLED() -> u64 {
+    let bt = Backtrace::capture();
+    if matches!(bt.status(), BacktraceStatus::Captured) {
+        table().lock().unwrap().alloc(Entry::Backtrace(Box::new(bt)))
+    } else {
+        0
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_BACKTRACE_IS_ENABLED() -> i64 {
+    // Backtrace::capture() retorna Captured ou Disabled/Unsupported.
+    // Forcar capture e checar status é o jeito portavel.
+    match Backtrace::capture().status() {
+        BacktraceStatus::Captured => 1,
+        _ => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_BACKTRACE_TO_STRING(handle: u64) -> u64 {
+    let s = {
+        let guard = table().lock().unwrap();
+        match guard.get(handle) {
+            Some(Entry::Backtrace(bt)) => format!("{}", bt),
+            _ => return 0,
+        }
+    };
+    table().lock().unwrap().alloc(Entry::String(s.into_bytes()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_BACKTRACE_FREE(handle: u64) {
+    let _ = table().lock().unwrap().free(handle);
+}

--- a/src/namespaces/backtrace/rt.rs
+++ b/src/namespaces/backtrace/rt.rs
@@ -1,0 +1,1 @@
+pub mod ops;

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -40,6 +40,8 @@ pub enum Entry {
     Vec(Box<Vec<i64>>),
     /// Regex compilada — namespace `regex`.
     Regex(Box<regex::Regex>),
+    /// Stack trace capturada — namespace `backtrace`.
+    Backtrace(Box<std::backtrace::Backtrace>),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -4,6 +4,7 @@
 //! [`crate::abi::SPECS`]. No legacy dispatch path remains: every callee is
 //! resolved to a canonical `__RTS_*` extern "C" symbol and called directly.
 
+pub mod backtrace;
 pub mod bigfloat;
 pub mod buffer;
 pub mod collections;

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -10,6 +10,8 @@ pub mod math;
 pub mod num;
 #[path = "mem/rt.rs"]
 pub mod mem;
+#[path = "backtrace/rt.rs"]
+pub mod backtrace;
 #[path = "bigfloat/rt.rs"]
 pub mod bigfloat;
 #[path = "time/rt.rs"]

--- a/tests/codegen_fixtures.rs
+++ b/tests/codegen_fixtures.rs
@@ -927,3 +927,13 @@ fn fixture_mem_layout() {
 fn fixture_mem_handles() {
     run_fixture("mem_handles");
 }
+
+#[test]
+fn fixture_backtrace_basic() {
+    run_fixture("backtrace_basic");
+}
+
+#[test]
+fn fixture_backtrace_disabled() {
+    run_fixture("backtrace_disabled");
+}

--- a/tests/fixtures/backtrace_basic.out
+++ b/tests/fixtures/backtrace_basic.out
@@ -1,0 +1,3 @@
+captured
+formatted
+freed

--- a/tests/fixtures/backtrace_basic.ts
+++ b/tests/fixtures/backtrace_basic.ts
@@ -1,0 +1,22 @@
+// backtrace.capture + to_string: nao podemos comparar conteudo
+// (varia por build/OS), so validamos que capture retorna handle
+// nao-zero e que to_string produz string GC.
+import { io, gc, backtrace } from "rts";
+
+const bt = backtrace.capture();
+if (bt == 0) {
+  io.print("FAIL: capture retornou 0");
+} else {
+  io.print("captured");
+}
+
+const s = backtrace.to_string(bt);
+if (s == 0) {
+  io.print("FAIL: to_string retornou 0");
+} else {
+  io.print("formatted");
+  gc.string_free(s);
+}
+
+backtrace.free(bt);
+io.print("freed");

--- a/tests/fixtures/backtrace_disabled.out
+++ b/tests/fixtures/backtrace_disabled.out
@@ -1,0 +1,1 @@
+disabled

--- a/tests/fixtures/backtrace_disabled.ts
+++ b/tests/fixtures/backtrace_disabled.ts
@@ -1,0 +1,11 @@
+// capture_if_enabled retorna 0 quando RUST_BACKTRACE nao esta set.
+// Nos testes ele nao esta — checamos comportamento.
+import { io, backtrace } from "rts";
+
+const bt = backtrace.capture_if_enabled();
+if (bt == 0) {
+  io.print("disabled");
+} else {
+  io.print("enabled");
+  backtrace.free(bt);
+}


### PR DESCRIPTION
## Summary
- 5 funcoes em \`backtrace\`: capture, capture_if_enabled, is_enabled, to_string, free.
- Adiciona \`Entry::Backtrace\` ao HandleTable.
- to_string produz string handle GC com format do std.

## Test plan
- [x] 2 fixtures: backtrace_basic, backtrace_disabled
- [x] 155 fixtures totais

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)