### PR TITLE
feat(parallel): Level-1 silent parallelism + HandleTable sharding + thread/atomic/sync infra

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -99,7 +99,8 @@
       "Bash(git merge feat/runtime-namespace --no-ff -m ' *)",
       "Bash(cargo run *)",
       "Bash(git pull *)",
-      "Bash(target/debug/rts.exe test *)"
+      "Bash(target/debug/rts.exe test *)",
+      "Bash(git log *)"
     ]
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,18 @@ fn main() {
             deps_dir.display()
         )
     });
+    let rayon_rlib = find_rlib_named(&deps_dir, "librayon-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate rayon rlib under {} (required for parallel runtime symbols)",
+            deps_dir.display()
+        )
+    });
+    let rayon_core_rlib = find_rlib_named(&deps_dir, "librayon_core-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate rayon_core rlib under {} (required for parallel runtime symbols)",
+            deps_dir.display()
+        )
+    });
 
     let mut cmd = Command::new(&rustc);
     cmd.args([
@@ -54,6 +66,10 @@ fn main() {
         .arg(format!("fltk={}", fltk_rlib.display()));
     cmd.arg("--extern")
         .arg(format!("regex={}", regex_rlib.display()));
+    cmd.arg("--extern")
+        .arg(format!("rayon={}", rayon_rlib.display()));
+    cmd.arg("--extern")
+        .arg(format!("rayon_core={}", rayon_core_rlib.display()));
 
     let status = cmd
         .status()
@@ -94,6 +110,10 @@ fn main() {
     println!("cargo:rerun-if-changed=src/namespaces/regex/");
     println!("cargo:rerun-if-changed=src/namespaces/ui/");
     println!("cargo:rerun-if-changed=src/namespaces/runtime/");
+    println!("cargo:rerun-if-changed=src/namespaces/atomic/");
+    println!("cargo:rerun-if-changed=src/namespaces/sync/");
+    println!("cargo:rerun-if-changed=src/namespaces/thread/");
+    println!("cargo:rerun-if-changed=src/namespaces/parallel/");
     println!("cargo:rerun-if-changed=src/namespaces/rt_all.rs");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/builtin/rts-types/rts.d.ts
+++ b/builtin/rts-types/rts.d.ts
@@ -491,27 +491,31 @@ declare module "rts" {
   }
 
   /**
-   * Captura de stack traces via std::backtrace::Backtrace.
+   * RTS stack trace and debug tooling. Push/pop TS call frames; capture trace without error.
    */
-  export namespace backtrace {
+  export namespace trace {
     /**
-     * Captura backtrace do call stack atual. Retorna handle.
+     * Push a TS call frame onto the trace stack.
+     */
+    export function push_frame(file: string, fn_name: string, line: number, col: number): void;
+    /**
+     * Pop the top TS call frame from the trace stack.
+     */
+    export function pop_frame(): void;
+    /**
+     * Capture current trace as a GC string handle. Returns 0 if stack is empty.
      */
     export function capture(): number;
     /**
-     * Captura backtrace se RUST_BACKTRACE estiver set; retorna 0 caso contrario.
+     * Print current trace stack to stderr.
      */
-    export function capture_if_enabled(): number;
+    export function print(): void;
     /**
-     * True se RUST_BACKTRACE=1 (ou full) esta no env.
+     * Returns current trace stack depth.
      */
-    export function is_enabled(): boolean;
+    export function depth(): number;
     /**
-     * Formata o backtrace em string. Retorna handle de string GC.
-     */
-    export function to_string(handle: number): number;
-    /**
-     * Libera a backtrace.
+     * Free a captured trace handle.
      */
     export function free(handle: number): void;
   }
@@ -1729,13 +1733,25 @@ declare module "rts" {
   }
 
   /**
-   * Primitivas de threads (spawn/join/detach/id/sleep) baseadas em std::thread.
+   * Primitivas de threads (spawn/join/detach/scope/id/sleep) baseadas em std::thread.
    */
   export namespace thread {
     /**
      * Cria uma nova thread executando `fn_ptr(arg)`. `fn_ptr` e um ponteiro para `extern "C" fn(u64) -> u64`. Retorna handle do JoinHandle, 0 em falha.
      */
     export function spawn(fn_ptr: number, arg: number): number;
+    /**
+     * Variante de `spawn` que passa um `userdata` (ex: handle de `this`) como primeiro argumento da fn. `fn_ptr` aponta para `extern "C" fn(u64, u64) -> u64` (ud, arg).
+     */
+    export function spawn_with_ud(fn_ptr: number, arg: number, userdata: number): number;
+    /**
+     * Roda `body()` num escopo que aguarda automaticamente todas as threads spawnadas durante sua execucao. Analogo a `std::thread::scope`.
+     */
+    export function scope(body: () => void): void;
+    /**
+     * Variante com userdata para `thread.scope` quando o body captura `this`.
+     */
+    export function scope_with_ud(body: number, userdata: number): void;
     /**
      * Aguarda a thread terminar e retorna o valor retornado por ela. Consome o handle. 0 se handle invalido ou a thread fez panic.
      */
@@ -1752,6 +1768,28 @@ declare module "rts" {
      * Pausa a thread atual por `ms` milissegundos. Valores negativos sao tratados como 0.
      */
     export function sleep_ms(ms: number): void;
+  }
+
+  /**
+   * Paralelismo de dados via Rayon (map/for_each/reduce sobre Vec<i64>).
+   */
+  export namespace parallel {
+    /**
+     * Aplica `fn_ptr(x)` em paralelo sobre cada elemento do Vec<i64> `vec_handle`. Retorna novo Vec<i64> com os resultados. `fn_ptr` e `extern "C" fn(i64) -> i64`.
+     */
+    export function map(vec_handle: number, fn_ptr: number): number;
+    /**
+     * Executa `fn_ptr(x)` em paralelo para cada elemento do Vec<i64> `vec_handle`. `fn_ptr` e `extern "C" fn(i64)`.
+     */
+    export function for_each(vec_handle: number, fn_ptr: number): void;
+    /**
+     * Reduz Vec<i64> `vec_handle` com `fn_ptr(acc, x) -> acc` em paralelo (divide-e-conquista). `identity` e o elemento neutro da operacao (0 para soma, 1 para produto). `fn_ptr` deve ser associativo.
+     */
+    export function reduce(vec_handle: number, identity: number, fn_ptr: number): number;
+    /**
+     * Retorna o numero de threads no pool Rayon global.
+     */
+    export function num_threads(): number;
   }
 
 }
@@ -2360,36 +2398,41 @@ declare module "rts:mem" {
   export default _default;
 }
 
-declare module "rts:backtrace" {
+declare module "rts:trace" {
   /**
-   * Captura de stack traces via std::backtrace::Backtrace.
+   * RTS stack trace and debug tooling. Push/pop TS call frames; capture trace without error.
    */
   /**
-   * Captura backtrace do call stack atual. Retorna handle.
+   * Push a TS call frame onto the trace stack.
+   */
+  export function push_frame(file: string, fn_name: string, line: number, col: number): void;
+  /**
+   * Pop the top TS call frame from the trace stack.
+   */
+  export function pop_frame(): void;
+  /**
+   * Capture current trace as a GC string handle. Returns 0 if stack is empty.
    */
   export function capture(): number;
   /**
-   * Captura backtrace se RUST_BACKTRACE estiver set; retorna 0 caso contrario.
+   * Print current trace stack to stderr.
    */
-  export function capture_if_enabled(): number;
+  export function print(): void;
   /**
-   * True se RUST_BACKTRACE=1 (ou full) esta no env.
+   * Returns current trace stack depth.
    */
-  export function is_enabled(): boolean;
+  export function depth(): number;
   /**
-   * Formata o backtrace em string. Retorna handle de string GC.
-   */
-  export function to_string(handle: number): number;
-  /**
-   * Libera a backtrace.
+   * Free a captured trace handle.
    */
   export function free(handle: number): void;
   const _default: {
-    capture: (typeof import("rts"))["backtrace"]["capture"];
-    capture_if_enabled: (typeof import("rts"))["backtrace"]["capture_if_enabled"];
-    is_enabled: (typeof import("rts"))["backtrace"]["is_enabled"];
-    to_string: (typeof import("rts"))["backtrace"]["to_string"];
-    free: (typeof import("rts"))["backtrace"]["free"];
+    push_frame: (typeof import("rts"))["trace"]["push_frame"];
+    pop_frame: (typeof import("rts"))["trace"]["pop_frame"];
+    capture: (typeof import("rts"))["trace"]["capture"];
+    print: (typeof import("rts"))["trace"]["print"];
+    depth: (typeof import("rts"))["trace"]["depth"];
+    free: (typeof import("rts"))["trace"]["free"];
   };
   export default _default;
 }
@@ -3944,12 +3987,24 @@ declare module "rts:test_core" {
 
 declare module "rts:thread" {
   /**
-   * Primitivas de threads (spawn/join/detach/id/sleep) baseadas em std::thread.
+   * Primitivas de threads (spawn/join/detach/scope/id/sleep) baseadas em std::thread.
    */
   /**
    * Cria uma nova thread executando `fn_ptr(arg)`. `fn_ptr` e um ponteiro para `extern "C" fn(u64) -> u64`. Retorna handle do JoinHandle, 0 em falha.
    */
   export function spawn(fn_ptr: number, arg: number): number;
+  /**
+   * Variante de `spawn` que passa um `userdata` (ex: handle de `this`) como primeiro argumento da fn. `fn_ptr` aponta para `extern "C" fn(u64, u64) -> u64` (ud, arg).
+   */
+  export function spawn_with_ud(fn_ptr: number, arg: number, userdata: number): number;
+  /**
+   * Roda `body()` num escopo que aguarda automaticamente todas as threads spawnadas durante sua execucao. Analogo a `std::thread::scope`.
+   */
+  export function scope(body: () => void): void;
+  /**
+   * Variante com userdata para `thread.scope` quando o body captura `this`.
+   */
+  export function scope_with_ud(body: number, userdata: number): void;
   /**
    * Aguarda a thread terminar e retorna o valor retornado por ela. Consome o handle. 0 se handle invalido ou a thread fez panic.
    */
@@ -3968,10 +4023,42 @@ declare module "rts:thread" {
   export function sleep_ms(ms: number): void;
   const _default: {
     spawn: (typeof import("rts"))["thread"]["spawn"];
+    spawn_with_ud: (typeof import("rts"))["thread"]["spawn_with_ud"];
+    scope: (typeof import("rts"))["thread"]["scope"];
+    scope_with_ud: (typeof import("rts"))["thread"]["scope_with_ud"];
     join: (typeof import("rts"))["thread"]["join"];
     detach: (typeof import("rts"))["thread"]["detach"];
     id: (typeof import("rts"))["thread"]["id"];
     sleep_ms: (typeof import("rts"))["thread"]["sleep_ms"];
+  };
+  export default _default;
+}
+
+declare module "rts:parallel" {
+  /**
+   * Paralelismo de dados via Rayon (map/for_each/reduce sobre Vec<i64>).
+   */
+  /**
+   * Aplica `fn_ptr(x)` em paralelo sobre cada elemento do Vec<i64> `vec_handle`. Retorna novo Vec<i64> com os resultados. `fn_ptr` e `extern "C" fn(i64) -> i64`.
+   */
+  export function map(vec_handle: number, fn_ptr: number): number;
+  /**
+   * Executa `fn_ptr(x)` em paralelo para cada elemento do Vec<i64> `vec_handle`. `fn_ptr` e `extern "C" fn(i64)`.
+   */
+  export function for_each(vec_handle: number, fn_ptr: number): void;
+  /**
+   * Reduz Vec<i64> `vec_handle` com `fn_ptr(acc, x) -> acc` em paralelo (divide-e-conquista). `identity` e o elemento neutro da operacao (0 para soma, 1 para produto). `fn_ptr` deve ser associativo.
+   */
+  export function reduce(vec_handle: number, identity: number, fn_ptr: number): number;
+  /**
+   * Retorna o numero de threads no pool Rayon global.
+   */
+  export function num_threads(): number;
+  const _default: {
+    map: (typeof import("rts"))["parallel"]["map"];
+    for_each: (typeof import("rts"))["parallel"]["for_each"];
+    reduce: (typeof import("rts"))["parallel"]["reduce"];
+    num_threads: (typeof import("rts"))["parallel"]["num_threads"];
   };
   export default _default;
 }

--- a/examples/parallel_purity.ts
+++ b/examples/parallel_purity.ts
@@ -1,0 +1,78 @@
+/**
+ * Level-1 Silent Parallelism — purity pass demo.
+ *
+ * The RTS compiler analyses pure `for...of` loops at compile time and
+ * rewrites them to `parallel.for_each` backed by a Rayon thread pool.
+ * No annotation required: if the body only calls pure namespace members
+ * and only touches the loop variable + inner decls, the rewrite happens
+ * automatically ("silent parallelism").
+ */
+
+import { math, parallel, collections, gc, io } from "rts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1) Silent rewrite: pure for...of → parallel.for_each
+//    Body only calls math.sin / math.cos — both pure. Compiler rewrites this
+//    loop to a Rayon parallel iteration automatically.
+// ─────────────────────────────────────────────────────────────────────────────
+const angles: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+
+for (const x of angles) {
+  const s = math.sin(x as number);
+  const c = math.cos(s);
+  // Results discarded — pure side-effect-free computation,
+  // each iteration fully independent.
+}
+io.print("silent parallel loop done");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2) Multiple independent pure loops — each gets its own Rayon job.
+// ─────────────────────────────────────────────────────────────────────────────
+const vals: number[] = [1, 4, 9, 16, 25, 36, 49, 64];
+
+for (const v of vals) {
+  const r = math.sqrt(v as number);
+}
+
+for (const v of vals) {
+  const l = math.log2(v as number);
+}
+io.print("multiple silent loops done");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3) Explicit parallel.map — square each element.
+// ─────────────────────────────────────────────────────────────────────────────
+function squareIt(x: number): number {
+  return x * x;
+}
+
+const sfp = squareIt as unknown as number;
+const src = [1, 2, 3, 4, 5, 6, 7, 8];
+const squared = parallel.map(src, sfp);
+
+const h0 = gc.string_from_i64(collections.vec_get(squared, 0));
+io.print(h0); gc.string_free(h0);   // 1
+
+const h7 = gc.string_from_i64(collections.vec_get(squared, 7));
+io.print(h7); gc.string_free(h7);   // 64
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4) Explicit parallel.reduce — sum of [1..8] = 36
+// ─────────────────────────────────────────────────────────────────────────────
+function addUp(acc: number, x: number): number {
+  return acc + x;
+}
+
+const afp = addUp as unknown as number;
+const total = parallel.reduce(src, 0, afp);
+
+const ht = gc.string_from_i64(total);
+io.print(ht); gc.string_free(ht);   // 36
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5) Thread count
+// ─────────────────────────────────────────────────────────────────────────────
+const nt = parallel.num_threads();
+const hnt = gc.string_from_i64(nt);
+io.print(hnt); gc.string_free(hnt);
+io.print("done");

--- a/src/abi/member.rs
+++ b/src/abi/member.rs
@@ -41,6 +41,12 @@ pub struct NamespaceMember {
     /// is still exported so callers that do not know the member statically
     /// (e.g. reflection, FFI) keep working.
     pub intrinsic: Option<Intrinsic>,
+
+    /// True if this member is pure: no I/O, no shared mutable state, no
+    /// non-determinism. Pure members are eligible for automatic parallelisation
+    /// (e.g. `for...of` body analysis in the purity pass). Conservative:
+    /// false-negative is safe (falls back to sequential path).
+    pub pure: bool,
 }
 
 /// Inlinable operations recognised by codegen.

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -56,6 +56,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::runtime::abi::SPEC,
     &crate::namespaces::test::abi::SPEC,
     &crate::namespaces::thread::abi::SPEC,
+    &crate::namespaces::parallel::abi::SPEC,
 ];
 
 /// Locates a member by its fully qualified name (e.g. `"io.print"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -760,7 +760,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
 
     // ── namespaces::atomic ────────────────────────────────────────────
     use crate::namespaces::atomic::{
-        bool as atomic_bool, fence as atomic_fence, int as atomic_int,
+        bool as atomic_bool, fence as atomic_fence, float as atomic_float, int as atomic_int,
     };
     add_fn!(
         "__RTS_FN_NS_ATOMIC_I64_NEW",
@@ -817,6 +817,26 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!(
         "__RTS_FN_NS_ATOMIC_BOOL_SWAP",
         atomic_bool::__RTS_FN_NS_ATOMIC_BOOL_SWAP
+    );
+    add_fn!(
+        "__RTS_FN_NS_ATOMIC_F64_NEW",
+        atomic_float::__RTS_FN_NS_ATOMIC_F64_NEW
+    );
+    add_fn!(
+        "__RTS_FN_NS_ATOMIC_F64_LOAD",
+        atomic_float::__RTS_FN_NS_ATOMIC_F64_LOAD
+    );
+    add_fn!(
+        "__RTS_FN_NS_ATOMIC_F64_STORE",
+        atomic_float::__RTS_FN_NS_ATOMIC_F64_STORE
+    );
+    add_fn!(
+        "__RTS_FN_NS_ATOMIC_F64_FETCH_ADD",
+        atomic_float::__RTS_FN_NS_ATOMIC_F64_FETCH_ADD
+    );
+    add_fn!(
+        "__RTS_FN_NS_ATOMIC_F64_SWAP",
+        atomic_float::__RTS_FN_NS_ATOMIC_F64_SWAP
     );
     add_fn!(
         "__RTS_FN_NS_ATOMIC_FENCE_ACQUIRE",
@@ -890,6 +910,18 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             thread_spawn::__RTS_FN_NS_THREAD_SPAWN
         );
         add_fn!(
+            "__RTS_FN_NS_THREAD_SPAWN_WITH_UD",
+            thread_spawn::__RTS_FN_NS_THREAD_SPAWN_WITH_UD
+        );
+        add_fn!(
+            "__RTS_FN_NS_THREAD_SCOPE",
+            thread_spawn::__RTS_FN_NS_THREAD_SCOPE
+        );
+        add_fn!(
+            "__RTS_FN_NS_THREAD_SCOPE_WITH_UD",
+            thread_spawn::__RTS_FN_NS_THREAD_SCOPE_WITH_UD
+        );
+        add_fn!(
             "__RTS_FN_NS_THREAD_JOIN",
             thread_join::__RTS_FN_NS_THREAD_JOIN
         );
@@ -901,6 +933,27 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!(
             "__RTS_FN_NS_THREAD_SLEEP_MS",
             thread_info::__RTS_FN_NS_THREAD_SLEEP_MS
+        );
+    }
+
+    // ── namespaces::parallel ──────────────────────────────────────────
+    {
+        use crate::namespaces::parallel::ops as parallel_ops;
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_MAP",
+            parallel_ops::__RTS_FN_NS_PARALLEL_MAP
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_FOR_EACH",
+            parallel_ops::__RTS_FN_NS_PARALLEL_FOR_EACH
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_REDUCE",
+            parallel_ops::__RTS_FN_NS_PARALLEL_REDUCE
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_NUM_THREADS",
+            parallel_ops::__RTS_FN_NS_PARALLEL_NUM_THREADS
         );
     }
 

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -11,7 +11,7 @@ use cranelift_codegen::ir::{AbiParam, InstBuilder, Signature, types as cl};
 use cranelift_codegen::isa::CallConv;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{DataDescription, Linkage, Module};
-use swc_ecma_ast::{Callee, Decl, Expr, Lit, MemberProp, Pat, Stmt, TsType, TsTypeRef};
+use swc_ecma_ast::{Callee, Decl, Expr, ForHead, Lit, MemberProp, Pat, Stmt, TsType, TsTypeRef};
 
 use crate::parser::ast::{
     ClassDecl, ClassMember, FunctionDecl, Item, MemberModifiers, MethodRole, Parameter, Program,
@@ -30,6 +30,243 @@ struct UserFn {
     id: cranelift_module::FuncId,
     params: Vec<ValTy>,
     ret: Option<ValTy>,
+}
+
+/// Builds the set of (namespace, member) pairs marked `pure: true` in SPECS.
+fn build_pure_ns_set() -> HashSet<(&'static str, &'static str)> {
+    let mut s = HashSet::new();
+    for spec in crate::abi::SPECS {
+        for member in spec.members {
+            if member.pure {
+                s.insert((spec.name, member.name));
+            }
+        }
+    }
+    s
+}
+
+/// Returns true if `e` is a pure expression in the context of a ForOf body.
+/// Pure: literals, the loop variable, inner-declared idents, arithmetic on
+/// pure sub-expressions, and calls to pure namespace members.
+fn is_pure_expr_for_parallel(
+    e: &Expr,
+    loop_var: &str,
+    inner: &HashSet<String>,
+    pure_ns: &HashSet<(&'static str, &'static str)>,
+) -> bool {
+    match e {
+        Expr::Lit(_) => true,
+        Expr::Ident(id) => {
+            let n = id.sym.as_str();
+            n == loop_var || inner.contains(n)
+        }
+        Expr::Bin(b) => {
+            is_pure_expr_for_parallel(&b.left, loop_var, inner, pure_ns)
+                && is_pure_expr_for_parallel(&b.right, loop_var, inner, pure_ns)
+        }
+        Expr::Unary(u) => is_pure_expr_for_parallel(&u.arg, loop_var, inner, pure_ns),
+        Expr::Paren(p) => is_pure_expr_for_parallel(&p.expr, loop_var, inner, pure_ns),
+        Expr::TsAs(a) => is_pure_expr_for_parallel(&a.expr, loop_var, inner, pure_ns),
+        Expr::TsTypeAssertion(a) => is_pure_expr_for_parallel(&a.expr, loop_var, inner, pure_ns),
+        Expr::TsNonNull(a) => is_pure_expr_for_parallel(&a.expr, loop_var, inner, pure_ns),
+        Expr::TsConstAssertion(a) => is_pure_expr_for_parallel(&a.expr, loop_var, inner, pure_ns),
+        Expr::Call(call) => {
+            let Callee::Expr(ce) = &call.callee else { return false };
+            let Expr::Member(m) = ce.as_ref() else { return false };
+            let Expr::Ident(ns_id) = m.obj.as_ref() else { return false };
+            let MemberProp::Ident(prop_id) = &m.prop else { return false };
+            if !pure_ns.contains(&(ns_id.sym.as_str(), prop_id.sym.as_str())) {
+                return false;
+            }
+            call.args.iter().all(|a| {
+                a.spread.is_none()
+                    && is_pure_expr_for_parallel(&a.expr, loop_var, inner, pure_ns)
+            })
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if the ForOf body is parallelisable: no assignments, no
+/// control flow escapes, only pure namespace calls, all idents are either
+/// the loop variable or declared within the body.
+fn analyze_for_of_body_pure(
+    body: &Stmt,
+    loop_var: &str,
+    pure_ns: &HashSet<(&'static str, &'static str)>,
+) -> bool {
+    let stmts: &[Stmt] = match body {
+        Stmt::Block(b) => &b.stmts,
+        Stmt::Expr(e) => {
+            return is_pure_expr_for_parallel(&e.expr, loop_var, &HashSet::new(), pure_ns);
+        }
+        _ => return false,
+    };
+    let mut inner: HashSet<String> = HashSet::new();
+    for stmt in stmts {
+        match stmt {
+            Stmt::Decl(Decl::Var(vd)) => {
+                for d in &vd.decls {
+                    let Pat::Ident(id) = &d.name else { return false };
+                    if let Some(init) = &d.init {
+                        if !is_pure_expr_for_parallel(init, loop_var, &inner, pure_ns) {
+                            return false;
+                        }
+                    }
+                    inner.insert(id.sym.as_str().to_string());
+                }
+            }
+            Stmt::Expr(e) => {
+                if !is_pure_expr_for_parallel(&e.expr, loop_var, &inner, pure_ns) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Builds a `parallel.for_each(arr_expr, fn_ident)` expression statement.
+fn make_par_foreach_stmt(arr_expr: &Expr, fn_name: &str) -> Stmt {
+    Stmt::Expr(swc_ecma_ast::ExprStmt {
+        span: Default::default(),
+        expr: Box::new(Expr::Call(swc_ecma_ast::CallExpr {
+            span: Default::default(),
+            ctxt: Default::default(),
+            callee: Callee::Expr(Box::new(Expr::Member(swc_ecma_ast::MemberExpr {
+                span: Default::default(),
+                obj: Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                    span: Default::default(),
+                    ctxt: Default::default(),
+                    sym: "parallel".into(),
+                    optional: false,
+                })),
+                prop: MemberProp::Ident(swc_ecma_ast::IdentName {
+                    span: Default::default(),
+                    sym: "for_each".into(),
+                }),
+            }))),
+            args: vec![
+                swc_ecma_ast::ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(arr_expr.clone()),
+                },
+                swc_ecma_ast::ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                        span: Default::default(),
+                        ctxt: Default::default(),
+                        sym: fn_name.to_string().into(),
+                        optional: false,
+                    })),
+                },
+            ],
+            type_args: None,
+        })),
+    })
+}
+
+/// Level-1 silent parallelism: rewrites pure top-level `for...of` loops into
+/// `parallel.for_each(arr, __par_forof_N)` calls backed by a Rayon thread
+/// pool. A ForOf is eligible when:
+///   - no assignments in the body
+///   - all function calls are to pure namespace members
+///   - all idents in the body are either the loop variable or inner decls
+///   - no break / continue / return / throw
+///
+/// For each eligible loop a synthetic `FunctionDecl` is prepended to the
+/// program, and the loop statement is replaced with the `for_each` call.
+/// Returns the set of synthetic function names so `compile_program` can give
+/// them C calling convention (required for Rayon worker invocations).
+fn purity_pass(program: &mut Program) -> HashSet<String> {
+    let pure_ns = build_pure_ns_set();
+    let mut counter = 0u32;
+    let mut par_fn_names: HashSet<String> = HashSet::new();
+
+    struct Transform {
+        idx: usize,
+        arr_expr: Expr,
+        body_stmt: Stmt,
+        loop_var: String,
+        fn_name: String,
+    }
+    let mut transforms: Vec<Transform> = Vec::new();
+
+    for (idx, item) in program.items.iter().enumerate() {
+        let Item::Statement(Statement::Raw(raw)) = item else { continue };
+        let Some(Stmt::ForOf(for_of)) = raw.stmt.as_ref() else { continue };
+        if for_of.is_await {
+            continue;
+        }
+        let loop_var = match &for_of.left {
+            ForHead::VarDecl(vd) => {
+                if vd.decls.len() != 1 {
+                    continue;
+                }
+                match &vd.decls[0].name {
+                    Pat::Ident(id) => id.sym.as_str().to_string(),
+                    _ => continue,
+                }
+            }
+            _ => continue,
+        };
+        if !analyze_for_of_body_pure(&for_of.body, &loop_var, &pure_ns) {
+            continue;
+        }
+        let fn_name = format!("__par_forof_{counter}");
+        counter += 1;
+        transforms.push(Transform {
+            idx,
+            arr_expr: for_of.right.as_ref().clone(),
+            body_stmt: for_of.body.as_ref().clone(),
+            loop_var,
+            fn_name,
+        });
+    }
+
+    if transforms.is_empty() {
+        return par_fn_names;
+    }
+
+    let mut new_fn_items: Vec<Item> = Vec::new();
+    for t in &transforms {
+        let body_stmts = vec![Statement::Raw(
+            RawStmt::new("<par-forof>".to_string(), Span::default())
+                .with_stmt(t.body_stmt.clone()),
+        )];
+        // Loop variable declared as i64: Rayon passes Vec<i64> elements as
+        // i64 via integer registers. Using "number" (f64) would mismatch.
+        new_fn_items.push(Item::Function(FunctionDecl {
+            name: t.fn_name.clone(),
+            parameters: vec![Parameter {
+                name: t.loop_var.clone(),
+                type_annotation: Some("i64".to_string()),
+                modifiers: MemberModifiers::default(),
+                variadic: false,
+                default: None,
+                span: Span::default(),
+            }],
+            return_type: Some("void".to_string()),
+            body: body_stmts,
+            span: Span::default(),
+        }));
+        par_fn_names.insert(t.fn_name.clone());
+    }
+
+    // Apply replacements before prepending (t.idx still valid for original positions).
+    for t in &transforms {
+        if let Item::Statement(Statement::Raw(raw)) = &mut program.items[t.idx] {
+            raw.stmt = Some(make_par_foreach_stmt(&t.arr_expr, &t.fn_name));
+        }
+    }
+
+    // Prepend synthetic functions in declaration order.
+    for fn_item in new_fn_items.into_iter().rev() {
+        program.items.insert(0, fn_item);
+    }
+
+    par_fn_names
 }
 
 /// Lifts inline `() => { ... }` arrow expressions that appear as `I64`-typed
@@ -1657,9 +1894,16 @@ impl LiftAcc {
             // tratado como callback candidato. Demais membros de ABI seguem
             // a regra padrao (apenas args I64).
             let is_thread_spawn = qualified == "thread.spawn";
+            let is_parallel_map = qualified == "parallel.map";
+            let is_parallel_for_each = qualified == "parallel.for_each";
+            let is_parallel_reduce = qualified == "parallel.reduce";
+            let is_parallel_op = is_parallel_map || is_parallel_for_each || is_parallel_reduce;
             for (arg_idx, (arg, &abi_ty)) in call.args.iter_mut().zip(member.args.iter()).enumerate() {
                 let is_callback_slot = if is_thread_spawn {
                     arg_idx == 0
+                } else if is_parallel_op {
+                    // fn_ptr slot is U64 in parallel.* ABIs
+                    abi_ty == AbiType::U64
                 } else {
                     abi_ty == AbiType::I64
                 };
@@ -1773,33 +2017,84 @@ impl LiftAcc {
                         if is_thread_spawn {
                             self.needs_c_callconv.insert(real_name.clone());
                         }
-                        let args: Vec<swc_ecma_ast::ExprOrSpread> = if pass_arg {
-                            vec![swc_ecma_ast::ExprOrSpread {
-                                spread: None,
-                                expr: Box::new(Expr::Ident(swc_ecma_ast::Ident {
+
+                        // parallel.* trampolim: adapts i64 ABI to user fn.
+                        // Rayon passes Vec<i64> elements as i64 (integer
+                        // registers). User fns may declare `number` (f64)
+                        // params — codegen coerces automatically via
+                        // `lower_user_call`. Trampolim bridges the gap.
+                        if is_parallel_op {
+                            fn par_ident(sym: &str) -> Expr {
+                                Expr::Ident(swc_ecma_ast::Ident {
                                     span: Default::default(),
                                     ctxt: Default::default(),
-                                    sym: "__rts_spawn_arg".into(),
+                                    sym: sym.to_string().into(),
                                     optional: false,
-                                })),
-                            }]
-                        } else {
-                            Vec::new()
-                        };
-                        let call_stmt = Stmt::Expr(swc_ecma_ast::ExprStmt {
-                            span: id.span,
-                            expr: Box::new(Expr::Call(swc_ecma_ast::CallExpr {
-                                span: id.span,
-                                ctxt: id.ctxt,
+                                })
+                            }
+                            fn par_arg(sym: &str) -> swc_ecma_ast::ExprOrSpread {
+                                swc_ecma_ast::ExprOrSpread {
+                                    spread: None,
+                                    expr: Box::new(par_ident(sym)),
+                                }
+                            }
+                            let call_args: Vec<swc_ecma_ast::ExprOrSpread> =
+                                if is_parallel_reduce {
+                                    vec![par_arg("__par_acc"), par_arg("__par_x")]
+                                } else {
+                                    vec![par_arg("__par_x")]
+                                };
+                            let call_expr = Expr::Call(swc_ecma_ast::CallExpr {
+                                span: Default::default(),
+                                ctxt: Default::default(),
                                 callee: Callee::Expr(Box::new(Expr::Ident(target_id))),
-                                args,
+                                args: call_args,
                                 type_args: None,
-                            })),
-                        });
-                        body_stmts = vec![Statement::Raw(
-                            RawStmt::new("<lifted>".to_string(), Span::default())
-                                .with_stmt(call_stmt),
-                        )];
+                            });
+                            let body_stmt = if is_parallel_for_each {
+                                Stmt::Expr(swc_ecma_ast::ExprStmt {
+                                    span: Default::default(),
+                                    expr: Box::new(call_expr),
+                                })
+                            } else {
+                                Stmt::Return(swc_ecma_ast::ReturnStmt {
+                                    span: Default::default(),
+                                    arg: Some(Box::new(call_expr)),
+                                })
+                            };
+                            body_stmts = vec![Statement::Raw(
+                                RawStmt::new("<par-tramp>".to_string(), Span::default())
+                                    .with_stmt(body_stmt),
+                            )];
+                        } else {
+                            let args: Vec<swc_ecma_ast::ExprOrSpread> = if pass_arg {
+                                vec![swc_ecma_ast::ExprOrSpread {
+                                    spread: None,
+                                    expr: Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                                        span: Default::default(),
+                                        ctxt: Default::default(),
+                                        sym: "__rts_spawn_arg".into(),
+                                        optional: false,
+                                    })),
+                                }]
+                            } else {
+                                Vec::new()
+                            };
+                            let call_stmt = Stmt::Expr(swc_ecma_ast::ExprStmt {
+                                span: id.span,
+                                expr: Box::new(Expr::Call(swc_ecma_ast::CallExpr {
+                                    span: id.span,
+                                    ctxt: id.ctxt,
+                                    callee: Callee::Expr(Box::new(Expr::Ident(target_id))),
+                                    args,
+                                    type_args: None,
+                                })),
+                            });
+                            body_stmts = vec![Statement::Raw(
+                                RawStmt::new("<lifted>".to_string(), Span::default())
+                                    .with_stmt(call_stmt),
+                            )];
+                        }
                     }
                     _ => continue,
                 };
@@ -1823,46 +2118,70 @@ impl LiftAcc {
                 // Trampolim recebe `this: ClassName` como parâmetro
                 // quando vamos passar `this` por userdata. Para
                 // `thread.spawn(fp, arg)` com worker arity≥1, recebe
-                // `__rts_spawn_arg: number`. Caso contrário, sem
-                // parâmetros (UI callbacks tradicionais).
-                let parameters: Vec<Parameter> = if use_userdata_callback {
-                    vec![Parameter {
-                        name: "this".to_string(),
-                        type_annotation: Some(class_name.to_string()),
-                        modifiers: MemberModifiers::default(),
-                        variadic: false,
-                        default: None,
-                        span: Span::default(),
-                    }]
-                } else if is_thread_spawn
-                    && matches!(peel_ts(arg.expr.as_ref()), Expr::Ident(id) if {
-                        let real = self.alias_to_real.get(id.sym.as_str()).cloned()
-                            .unwrap_or_else(|| id.sym.to_string());
-                        self.user_fn_arities.get(real.as_str()).copied().unwrap_or(0) >= 1
-                    })
-                {
-                    // Tipo `i64` — `thread.spawn` ABI passa o arg como
-                    // U64; o trampolim recebe como i64 inteiro e o
-                    // codegen converte para f64 quando worker declara
-                    // `arg: number`. Sem isso, Win64 procura o arg no
-                    // registrador XMM0 (float) em vez de RCX (int) e
-                    // pega lixo (#206).
-                    vec![Parameter {
-                        name: "__rts_spawn_arg".to_string(),
+                // `__rts_spawn_arg: number`. Parallel ops recebem
+                // parâmetros i64 (Rayon passa Vec<i64> elements).
+                // Caso contrário: sem parâmetros (UI callbacks tradicionais).
+                fn mk_i64_param(name: &str) -> Parameter {
+                    Parameter {
+                        name: name.to_string(),
                         type_annotation: Some("i64".to_string()),
                         modifiers: MemberModifiers::default(),
                         variadic: false,
                         default: None,
                         span: Span::default(),
-                    }]
-                } else {
-                    Vec::new()
-                };
+                    }
+                }
+                let (parameters, tramp_return_type): (Vec<Parameter>, &'static str) =
+                    if use_userdata_callback {
+                        (
+                            vec![Parameter {
+                                name: "this".to_string(),
+                                type_annotation: Some(class_name.to_string()),
+                                modifiers: MemberModifiers::default(),
+                                variadic: false,
+                                default: None,
+                                span: Span::default(),
+                            }],
+                            "void",
+                        )
+                    } else if is_parallel_reduce {
+                        (vec![mk_i64_param("__par_acc"), mk_i64_param("__par_x")], "i64")
+                    } else if is_parallel_map {
+                        (vec![mk_i64_param("__par_x")], "i64")
+                    } else if is_parallel_for_each {
+                        (vec![mk_i64_param("__par_x")], "void")
+                    } else if is_thread_spawn
+                        && matches!(peel_ts(arg.expr.as_ref()), Expr::Ident(id) if {
+                            let real = self.alias_to_real.get(id.sym.as_str()).cloned()
+                                .unwrap_or_else(|| id.sym.to_string());
+                            self.user_fn_arities.get(real.as_str()).copied().unwrap_or(0) >= 1
+                        })
+                    {
+                        // Tipo `i64` — `thread.spawn` ABI passa o arg como
+                        // U64; o trampolim recebe como i64 inteiro e o
+                        // codegen converte para f64 quando worker declara
+                        // `arg: number`. Sem isso, Win64 procura o arg no
+                        // registrador XMM0 (float) em vez de RCX (int) e
+                        // pega lixo (#206).
+                        (
+                            vec![Parameter {
+                                name: "__rts_spawn_arg".to_string(),
+                                type_annotation: Some("i64".to_string()),
+                                modifiers: MemberModifiers::default(),
+                                variadic: false,
+                                default: None,
+                                span: Span::default(),
+                            }],
+                            "void",
+                        )
+                    } else {
+                        (Vec::new(), "void")
+                    };
 
                 self.new_fns.push(Item::Function(FunctionDecl {
                     name: syn_name.clone(),
                     parameters,
-                    return_type: Some("void".to_string()),
+                    return_type: Some(tramp_return_type.to_string()),
                     body: body_stmts,
                     span: Span::default(),
                 }));
@@ -2591,6 +2910,7 @@ pub fn compile_program(
     extern_cache: &mut HashMap<&'static str, cranelift_module::FuncId>,
     data_counter: &mut u32,
 ) -> Result<Vec<String>> {
+    let par_fn_names = purity_pass(program);
     let lifted_needs_c_callconv = lift_arrow_callbacks(program);
     expand_destructuring(program);
     expand_default_args(program);
@@ -2701,6 +3021,8 @@ pub fn compile_program(
         collect_address_taken_fns(&fn_decls, program, &synthetic_fns);
     // União com fns chamadas de trampolins lifted C-callconv (#206).
     address_taken_fns.extend(lifted_needs_c_callconv.iter().cloned());
+    // Funções sintéticas do purity_pass (Level-1 parallel ForOf).
+    address_taken_fns.extend(par_fn_names.iter().cloned());
 
     // Phase 1: declare all user functions so forward calls resolve.
     let mut user_fns: HashMap<String, UserFn> = HashMap::new();

--- a/src/namespaces/alloc/abi.rs
+++ b/src/namespaces/alloc/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca size bytes alinhados a `align`. Retorna ponteiro ou 0 em falha.",
         ts_signature: "alloc(size: number, align: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "alloc_zeroed",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca size bytes zerados, alinhados a `align`.",
         ts_signature: "alloc_zeroed(size: number, align: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "dealloc",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera ptr previamente alocado com mesmo size/align.",
         ts_signature: "dealloc(ptr: number, size: number, align: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "realloc",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         ts_signature:
             "realloc(ptr: number, size_old: number, align: number, new_size: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/atomic/abi.rs
+++ b/src/namespaces/atomic/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um AtomicI64 inicializado com `value` e retorna o handle.",
         ts_signature: "i64_new(value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_load",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le o valor atual do AtomicI64 (SeqCst). 0 se handle invalido.",
         ts_signature: "i64_load(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_store",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve `value` no AtomicI64 (SeqCst). No-op se handle invalido.",
         ts_signature: "i64_store(handle: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_fetch_add",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Soma `delta` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_fetch_add(handle: number, delta: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_fetch_sub",
@@ -53,6 +57,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Subtrai `delta` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_fetch_sub(handle: number, delta: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_fetch_and",
@@ -63,6 +68,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "AND bit-a-bit com `mask` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_fetch_and(handle: number, mask: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_fetch_or",
@@ -73,6 +79,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "OR bit-a-bit com `mask` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_fetch_or(handle: number, mask: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_fetch_xor",
@@ -83,6 +90,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "XOR bit-a-bit com `mask` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_fetch_xor(handle: number, mask: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_swap",
@@ -93,6 +101,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Troca o valor por `value` e retorna o valor anterior. 0 se handle invalido.",
         ts_signature: "i64_swap(handle: number, value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "i64_cas",
@@ -103,6 +112,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Compare-and-swap. Se valor atual == `expected`, escreve `new`. Retorna o valor anterior.",
         ts_signature: "i64_cas(handle: number, expected: number, new_value: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── AtomicBool ─────────────────────────────────────────────────
     NamespaceMember {
@@ -114,6 +124,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um AtomicBool inicializado com `value` e retorna o handle.",
         ts_signature: "bool_new(value: boolean): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "bool_load",
@@ -124,6 +135,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le o valor atual do AtomicBool (SeqCst). false se handle invalido.",
         ts_signature: "bool_load(handle: number): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "bool_store",
@@ -134,6 +146,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve `value` no AtomicBool (SeqCst). No-op se handle invalido.",
         ts_signature: "bool_store(handle: number, value: boolean): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "bool_swap",
@@ -144,6 +157,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Troca o valor por `value` e retorna o valor anterior. false se handle invalido.",
         ts_signature: "bool_swap(handle: number, value: boolean): boolean",
         intrinsic: None,
+        pure: false,
     },
     // ── Fences ─────────────────────────────────────────────────────
     NamespaceMember {
@@ -155,6 +169,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Memory fence Acquire.",
         ts_signature: "fence_acquire(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "fence_release",
@@ -165,6 +180,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Memory fence Release.",
         ts_signature: "fence_release(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "fence_seq_cst",
@@ -175,6 +191,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Memory fence SeqCst.",
         ts_signature: "fence_seq_cst(): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/atomic/bool.rs
+++ b/src/namespaces/atomic/bool.rs
@@ -5,22 +5,23 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
 
 fn with_atomic_bool<R>(handle: u64, default: R, f: impl FnOnce(&AtomicBool) -> R) -> R {
-    let guard = table().lock().unwrap();
-    match guard.get(handle) {
-        Some(Entry::AtomicBool(a)) => f(a.as_ref()),
-        _ => default,
-    }
+    let ptr: *const AtomicBool = {
+        let guard = shard_for_handle(handle).lock().unwrap();
+        match guard.get(handle) {
+            Some(Entry::AtomicBool(a)) => a.as_ref() as *const _,
+            _ => return default,
+        }
+    }; // shard lock released — atomic op runs lock-free
+    // SAFETY: Box<AtomicBool> is heap-stable; same handle contract as AtomicI64.
+    f(unsafe { &*ptr })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_ATOMIC_BOOL_NEW(value: i64) -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::AtomicBool(Box::new(AtomicBool::new(value != 0))))
+    alloc_entry(Entry::AtomicBool(Box::new(AtomicBool::new(value != 0))))
 }
 
 #[unsafe(no_mangle)]

--- a/src/namespaces/atomic/float.rs
+++ b/src/namespaces/atomic/float.rs
@@ -1,0 +1,66 @@
+//! AtomicF64 — operacoes atomicas f64 emuladas via AtomicU64 + transmute
+//! de bits. Rust nao tem AtomicF64 nativo. Ordering::SeqCst pra simetria
+//! com i64/bool.
+//!
+//! O lock do shard e liberado ANTES de qualquer operacao atomica para
+//! que threads concorrentes possam operar lock-free apos o lookup.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
+
+fn with_atomic_f64<R>(handle: u64, default: R, f: impl FnOnce(&AtomicU64) -> R) -> R {
+    let ptr: *const AtomicU64 = {
+        let guard = shard_for_handle(handle).lock().unwrap();
+        match guard.get(handle) {
+            Some(Entry::AtomicF64(a)) => a.as_ref() as *const _,
+            _ => return default,
+        }
+    }; // shard lock released here — atomic op runs lock-free
+    // SAFETY: Box<AtomicU64> is heap-allocated and stable. Same contract
+    // as AtomicI64: caller must not free the handle during this call.
+    f(unsafe { &*ptr })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ATOMIC_F64_NEW(value: f64) -> u64 {
+    alloc_entry(Entry::AtomicF64(Box::new(AtomicU64::new(value.to_bits()))))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ATOMIC_F64_LOAD(handle: u64) -> f64 {
+    with_atomic_f64(handle, 0.0, |a| f64::from_bits(a.load(Ordering::SeqCst)))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ATOMIC_F64_STORE(handle: u64, value: f64) {
+    with_atomic_f64(handle, (), |a| a.store(value.to_bits(), Ordering::SeqCst));
+}
+
+/// CAS-loop para fetch_add: f64 nao e nativo em AtomicU64.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ATOMIC_F64_FETCH_ADD(handle: u64, delta: f64) -> f64 {
+    with_atomic_f64(handle, 0.0, |a| {
+        let mut prev_bits = a.load(Ordering::Relaxed);
+        loop {
+            let prev = f64::from_bits(prev_bits);
+            let new = prev + delta;
+            match a.compare_exchange_weak(
+                prev_bits,
+                new.to_bits(),
+                Ordering::SeqCst,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return prev,
+                Err(actual) => prev_bits = actual,
+            }
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ATOMIC_F64_SWAP(handle: u64, value: f64) -> f64 {
+    with_atomic_f64(handle, 0.0, |a| {
+        f64::from_bits(a.swap(value.to_bits(), Ordering::SeqCst))
+    })
+}

--- a/src/namespaces/atomic/int.rs
+++ b/src/namespaces/atomic/int.rs
@@ -2,22 +2,25 @@
 
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
 
 fn with_atomic_i64<R>(handle: u64, default: R, f: impl FnOnce(&AtomicI64) -> R) -> R {
-    let guard = table().lock().unwrap();
-    match guard.get(handle) {
-        Some(Entry::AtomicI64(a)) => f(a.as_ref()),
-        _ => default,
-    }
+    let ptr: *const AtomicI64 = {
+        let guard = shard_for_handle(handle).lock().unwrap();
+        match guard.get(handle) {
+            Some(Entry::AtomicI64(a)) => a.as_ref() as *const _,
+            _ => return default,
+        }
+    }; // shard lock released here — atomic op runs lock-free
+    // SAFETY: Box<AtomicI64> is heap-allocated and stable. The slot lives as
+    // long as the handle is valid; caller must not free the handle concurrently
+    // with this call (same contract as all handle-based ops).
+    f(unsafe { &*ptr })
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_ATOMIC_I64_NEW(value: i64) -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::AtomicI64(Box::new(AtomicI64::new(value))))
+    alloc_entry(Entry::AtomicI64(Box::new(AtomicI64::new(value))))
 }
 
 #[unsafe(no_mangle)]
@@ -60,14 +63,11 @@ pub extern "C" fn __RTS_FN_NS_ATOMIC_I64_SWAP(handle: u64, value: i64) -> i64 {
     with_atomic_i64(handle, 0, |a| a.swap(value, Ordering::SeqCst))
 }
 
-/// Compare-and-swap. Retorna o valor anterior — caller decide sucesso
-/// comparando com `expected`.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_ATOMIC_I64_CAS(handle: u64, expected: i64, new_value: i64) -> i64 {
+pub extern "C" fn __RTS_FN_NS_ATOMIC_I64_CAS(handle: u64, expected: i64, new: i64) -> i64 {
     with_atomic_i64(handle, 0, |a| {
-        match a.compare_exchange(expected, new_value, Ordering::SeqCst, Ordering::SeqCst) {
-            Ok(prev) => prev,
-            Err(actual) => actual,
+        match a.compare_exchange(expected, new, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(prev) | Err(prev) => prev,
         }
     })
 }

--- a/src/namespaces/atomic/mod.rs
+++ b/src/namespaces/atomic/mod.rs
@@ -8,4 +8,5 @@
 pub mod abi;
 pub mod bool;
 pub mod fence;
+pub mod float;
 pub mod int;

--- a/src/namespaces/atomic/rt.rs
+++ b/src/namespaces/atomic/rt.rs
@@ -1,0 +1,4 @@
+pub mod bool;
+pub mod fence;
+pub mod float;
+pub mod int;

--- a/src/namespaces/bigfloat/abi.rs
+++ b/src/namespaces/bigfloat/abi.rs
@@ -17,6 +17,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Allocates a zero big float with the given decimal precision.",
         ts_signature: "zero(precision: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "from_f64",
@@ -27,6 +28,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Converts an f64 into a big float rounded to `precision` digits.",
         ts_signature: "from_f64(x: number, precision: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "from_str",
@@ -37,6 +39,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Parses a decimal string into a big float with `precision` digits.",
         ts_signature: "from_str(s: string, precision: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "from_i64",
@@ -47,6 +50,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a big float from an integer with `precision` digits.",
         ts_signature: "from_i64(x: number, precision: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "to_f64",
@@ -57,6 +61,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Lossy conversion back to f64.",
         ts_signature: "to_f64(h: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "to_string",
@@ -67,6 +72,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Renders as a decimal string at full precision.",
         ts_signature: "to_string(h: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "add",
@@ -77,6 +83,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b.",
         ts_signature: "add(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sub",
@@ -87,6 +94,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b.",
         ts_signature: "sub(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mul",
@@ -97,6 +105,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b.",
         ts_signature: "mul(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "div",
@@ -107,6 +116,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a / b.",
         ts_signature: "div(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "neg",
@@ -117,6 +127,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "-a.",
         ts_signature: "neg(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sqrt",
@@ -127,6 +138,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Square root. Returns 0 for negative input.",
         ts_signature: "sqrt(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "free",
@@ -137,6 +149,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the handle.",
         ts_signature: "free(h: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/buffer/abi.rs
+++ b/src/namespaces/buffer/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Allocates a zero-initialised byte buffer of `size` bytes.",
         ts_signature: "alloc(size: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "alloc_zeroed",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Alias for alloc — Rust Vec::new already zeroes.",
         ts_signature: "alloc_zeroed(size: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "free",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the buffer handle. Subsequent reads/writes are no-ops.",
         ts_signature: "free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "len",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Buffer length in bytes, or -1 if the handle is invalid.",
         ts_signature: "len(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "ptr",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Raw pointer to the buffer start, or 0 when invalid. Unsafe — callers must not outlive the handle.",
         ts_signature: "ptr(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_u8",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads the byte at `offset`. Returns 0 out of bounds.",
         ts_signature: "read_u8(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_i32",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads a little-endian i32 at `offset`.",
         ts_signature: "read_i32(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_i64",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads a little-endian i64 at `offset`.",
         ts_signature: "read_i64(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_f64",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads a little-endian f64 at `offset`. NaN out of bounds.",
         ts_signature: "read_f64(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_u8",
@@ -102,6 +111,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes `val` as u8 at `offset`. No-op out of bounds.",
         ts_signature: "write_u8(handle: number, offset: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_i32",
@@ -112,6 +122,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes a little-endian i32 at `offset`.",
         ts_signature: "write_i32(handle: number, offset: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_i64",
@@ -122,6 +133,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes a little-endian i64 at `offset`.",
         ts_signature: "write_i64(handle: number, offset: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_f64",
@@ -132,6 +144,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes a little-endian f64 at `offset`.",
         ts_signature: "write_f64(handle: number, offset: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "copy",
@@ -148,6 +161,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Copies `len` bytes from src+srcOff to dst+dstOff. Safe with overlapping src/dst.",
         ts_signature: "copy(dst: number, dstOff: number, src: number, srcOff: number, len: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "fill",
@@ -158,6 +172,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Fills the first `len` bytes with `byte`.",
         ts_signature: "fill(handle: number, byte: number, len: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "to_string",
@@ -168,6 +183,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Interprets buffer contents as UTF-8 and returns a string handle.",
         ts_signature: "to_string(handle: number): string",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/collections/abi.rs
+++ b/src/namespaces/collections/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates an empty HashMap<string, number> and returns its handle.",
         ts_signature: "map_new(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_free",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the map handle.",
         ts_signature: "map_free(h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_len",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Number of entries; -1 if the handle is invalid.",
         ts_signature: "map_len(h: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_has",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True when the map contains `key`.",
         ts_signature: "map_has(h: number, key: string): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_get",
@@ -53,6 +57,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Value for `key`, or 0 when absent. Use map_has to distinguish.",
         ts_signature: "map_get(h: number, key: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_set",
@@ -63,6 +68,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Inserts/overwrites `key` with `value`.",
         ts_signature: "map_set(h: number, key: string, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_delete",
@@ -73,6 +79,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes `key`. Returns 1 if removed, 0 if absent.",
         ts_signature: "map_delete(h: number, key: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_clear",
@@ -83,6 +90,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes all entries.",
         ts_signature: "map_clear(h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "map_key_at",
@@ -93,6 +101,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the key at index in deterministic order (sorted). 0 if out of range.",
         ts_signature: "map_key_at(h: number, idx: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── Vec ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -104,6 +113,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates an empty Vec<number>.",
         ts_signature: "vec_new(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_free",
@@ -114,6 +124,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the vec handle.",
         ts_signature: "vec_free(h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_len",
@@ -124,6 +135,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Number of elements; -1 if the handle is invalid.",
         ts_signature: "vec_len(h: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_push",
@@ -134,6 +146,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Appends `value` to the end.",
         ts_signature: "vec_push(h: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_pop",
@@ -144,6 +157,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes and returns the last element; 0 when empty.",
         ts_signature: "vec_pop(h: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_get",
@@ -154,6 +168,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Element at `index`, or 0 out of range.",
         ts_signature: "vec_get(h: number, index: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_set",
@@ -164,6 +179,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes `value` at `index`. No-op out of range.",
         ts_signature: "vec_set(h: number, index: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "vec_clear",
@@ -174,6 +190,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes all elements.",
         ts_signature: "vec_clear(h: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/collections/vec.rs
+++ b/src/namespaces/collections/vec.rs
@@ -1,12 +1,12 @@
 //! Vec<i64> — lista ordenada de valores i64.
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 fn with_vec<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&Vec<i64>) -> R,
 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::Vec(v)) => f(v.as_ref()),
         _ => default,
@@ -17,8 +17,7 @@ fn with_vec_mut<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&mut Vec<i64>) -> R,
 {
-    let t = table();
-    let mut guard = t.lock().unwrap();
+    let mut guard = shard_for_handle(handle).lock().unwrap();
     match guard.get_mut(handle) {
         Some(Entry::Vec(v)) => f(v.as_mut()),
         _ => default,
@@ -27,15 +26,12 @@ where
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_NEW() -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::Vec(Box::new(Vec::new())))
+    alloc_entry(Entry::Vec(Box::new(Vec::new())))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }
 
 #[unsafe(no_mangle)]

--- a/src/namespaces/crypto/abi.rs
+++ b/src/namespaces/crypto/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Fills ptr..ptr+len with CSPRNG bytes. 0 ok, -1 err.",
         ts_signature: "random_bytes(ptr: number, len: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "random_i64",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Cryptographically secure i64.",
         ts_signature: "random_i64(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "random_buffer",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Allocates a buffer of `len` random bytes. Handle 0 on error.",
         ts_signature: "random_buffer(len: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sha256_str",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "SHA-256 of a UTF-8 string, returned as a 64-char hex string handle.",
         ts_signature: "sha256_str(s: string): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sha256_bytes",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "SHA-256 of a raw memory region. Use with buffer.ptr(h).",
         ts_signature: "sha256_bytes(ptr: number, len: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "hex_encode",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Lowercase hex of a memory region.",
         ts_signature: "hex_encode(ptr: number, len: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "hex_decode",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Decodes hex into a buffer handle. 0 on malformed input.",
         ts_signature: "hex_decode(s: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "base64_encode",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Base64 (RFC 4648 padded) of a memory region.",
         ts_signature: "base64_encode(ptr: number, len: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "base64_decode",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Decodes base64 into a buffer handle. 0 on malformed input.",
         ts_signature: "base64_decode(s: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/env/abi.rs
+++ b/src/namespaces/env/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns a string handle with the environment variable's value, or 0 when absent.",
         ts_signature: "get_var(name: string): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "set_var",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets an environment variable.",
         ts_signature: "set_var(name: string, value: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "remove_var",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes an environment variable.",
         ts_signature: "remove_var(name: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "args_count",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Number of command-line arguments (including argv[0]).",
         ts_signature: "args_count(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "arg_at",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the argv entry at `index` as a string handle; 0 when out of range.",
         ts_signature: "arg_at(index: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cwd",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the current working directory as a string handle.",
         ts_signature: "cwd(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "set_cwd",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Changes the current working directory. Returns 0 on success, -1 on error.",
         ts_signature: "set_cwd(path: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/ffi/abi.rs
+++ b/src/namespaces/ffi/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads a nul-terminated C string from `ptr` and returns a string handle (UTF-8 lossy).",
         ts_signature: "cstr_from_ptr(ptr: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cstr_len",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Length in bytes of the C string at `ptr`, excluding the nul terminator. -1 if ptr is null.",
         ts_signature: "cstr_len(ptr: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cstr_to_str",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Validates the C string at `ptr` as UTF-8 and returns a string handle. 0 if invalid.",
         ts_signature: "cstr_to_str(ptr: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── CString (owned nul-terminated buffer) ───────────────────────
     NamespaceMember {
@@ -44,6 +47,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Builds a nul-terminated CString from `s` and returns a handle. 0 if `s` contains an interior nul.",
         ts_signature: "cstring_new(s: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cstring_ptr",
@@ -54,6 +58,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Raw pointer to the CString bytes (nul-terminated). 0 if handle invalid. Unsafe — must not outlive handle.",
         ts_signature: "cstring_ptr(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cstring_free",
@@ -64,6 +69,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the CString handle.",
         ts_signature: "cstring_free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── OsString (platform-native string) ───────────────────────────
     NamespaceMember {
@@ -75,6 +81,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Builds an OsString from a UTF-8 source and returns a handle.",
         ts_signature: "osstr_from_str(s: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "osstr_to_str",
@@ -85,6 +92,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Converts the OsString handle to a UTF-8 string handle. 0 if not valid UTF-8.",
         ts_signature: "osstr_to_str(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "osstr_free",
@@ -95,6 +103,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Releases the OsString handle.",
         ts_signature: "osstr_free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/fmt/abi.rs
+++ b/src/namespaces/fmt/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Parses an integer. Returns i64::MIN on error.",
         ts_signature: "parse_i64(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "parse_f64",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Parses a float. Returns NaN on error.",
         ts_signature: "parse_f64(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "parse_bool",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Parses 'true'/'false'/'1'/'0' (case-insensitive). Returns -1 on error.",
         ts_signature: "parse_bool(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_i64",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Decimal string of an integer.",
         ts_signature: "fmt_i64(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_f64",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Shortest round-trippable decimal of a float.",
         ts_signature: "fmt_f64(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_bool",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "'true' when value is non-zero, 'false' otherwise.",
         ts_signature: "fmt_bool(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_hex",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Lowercase hex with `0x` prefix (bits as u64).",
         ts_signature: "fmt_hex(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_bin",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Binary with `0b` prefix.",
         ts_signature: "fmt_bin(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_oct",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Octal with `0o` prefix.",
         ts_signature: "fmt_oct(value: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "fmt_f64_prec",
@@ -102,6 +111,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Float formatted with a fixed number of decimal places.",
         ts_signature: "fmt_f64_prec(value: number, precision: number): string",
         intrinsic: None,
+        pure: true,
     },
 ];
 

--- a/src/namespaces/fs/abi.rs
+++ b/src/namespaces/fs/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads up to `bufLen` bytes from `path` into buffer. Returns byte count or -1.",
         ts_signature: "read(path: string, bufPtr: number, bufLen: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_all",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads entire file into buffer, truncating if needed. Returns bytes written or -1.",
         ts_signature: "read_all(path: string, bufPtr: number, bufLen: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes data to `path`, truncating existing contents. Returns bytes written or -1.",
         ts_signature: "write(path: string, data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "append",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Appends data to `path`, creating it when missing. Returns bytes written or -1.",
         ts_signature: "append(path: string, data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "exists",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns 1 if the path exists, 0 otherwise.",
         ts_signature: "exists(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "is_file",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns 1 if `path` is a regular file.",
         ts_signature: "is_file(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "is_dir",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns 1 if `path` is a directory.",
         ts_signature: "is_dir(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "size",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns file size in bytes, or -1 on error.",
         ts_signature: "size(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "modified_ms",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns last-modified milliseconds since UNIX epoch, or -1 on error.",
         ts_signature: "modified_ms(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "create_dir",
@@ -102,6 +111,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates the directory at `path`. Returns 0 on success, -1 on error.",
         ts_signature: "create_dir(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "create_dir_all",
@@ -112,6 +122,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates the directory and any missing parents.",
         ts_signature: "create_dir_all(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "remove_dir",
@@ -122,6 +133,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes an empty directory.",
         ts_signature: "remove_dir(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "remove_dir_all",
@@ -132,6 +144,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes a directory and all of its contents.",
         ts_signature: "remove_dir_all(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "remove_file",
@@ -142,6 +155,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes a file.",
         ts_signature: "remove_file(path: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rename",
@@ -152,6 +166,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Renames `from` to `to`. Returns 0 on success, -1 on error.",
         ts_signature: "rename(from: string, to: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "copy",
@@ -162,6 +177,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Copies file contents. Returns bytes copied or -1.",
         ts_signature: "copy(from: string, to: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/gc/abi.rs
+++ b/src/namespaces/gc/abi.rs
@@ -15,6 +15,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Converts an i64 to its decimal string and returns a handle.",
         ts_signature: "string_from_i64(value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_from_f64",
@@ -25,6 +26,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Converts an f64 to its decimal string and returns a handle.",
         ts_signature: "string_from_f64(value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_concat",
@@ -35,6 +37,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Concatenates two string handles and returns a new handle.",
         ts_signature: "string_concat(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_eq",
@@ -45,6 +48,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Compara dois string handles por conteudo (memcmp). 1 se iguais, 0 caso contrario.",
         ts_signature: "string_eq(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_from_static",
@@ -55,6 +59,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Promotes a static (ptr, len) string to a GC handle.",
         ts_signature: "string_from_static(data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_new",
@@ -65,6 +70,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Allocates a string handle from a (ptr, len) pair. Returns 0 on error.",
         ts_signature: "string_new(data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_len",
@@ -75,6 +81,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the byte length of the string, or -1 on invalid handle.",
         ts_signature: "string_len(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_ptr",
@@ -85,6 +92,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the raw pointer to the string buffer, or 0 on invalid handle.",
         ts_signature: "string_ptr(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "string_free",
@@ -95,6 +103,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Frees the string handle. Returns 1 on success, 0 if already invalid.",
         ts_signature: "string_free(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "env_alloc",
@@ -105,6 +114,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um environment record para closures com `slot_count` slots i64 inicializados em 0. Retorna o handle.",
         ts_signature: "env_alloc(slot_count: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "env_get",
@@ -115,6 +125,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Lê o slot `slot` do env record. Retorna 0 em handle inválido ou slot fora do range.",
         ts_signature: "env_get(env: number, slot: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "env_set",
@@ -125,6 +136,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve `value` no slot `slot` do env record. Retorna 1 em sucesso, 0 em erro.",
         ts_signature: "env_set(env: number, slot: number, value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_new",
@@ -135,6 +147,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca uma instancia com `size` bytes zerados e tag de classe `class_handle`. Retorna o handle ou 0 em erro.",
         ts_signature: "instance_new(size: number, class_handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_class",
@@ -145,6 +158,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Retorna o handle da classe (tag string `__rts_class`) da instancia. 0 em handle invalido.",
         ts_signature: "instance_class(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_free",
@@ -155,6 +169,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera a instancia. Retorna 1 em sucesso, 0 se ja invalido.",
         ts_signature: "instance_free(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_load_i64",
@@ -165,6 +180,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le um i64 little-endian no offset (em bytes). 0 em handle invalido ou offset fora do range.",
         ts_signature: "instance_load_i64(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_store_i64",
@@ -175,6 +191,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve um i64 little-endian no offset. Retorna 1 em sucesso, 0 em erro.",
         ts_signature: "instance_store_i64(handle: number, offset: number, value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_load_i32",
@@ -185,6 +202,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le um i32 little-endian no offset. 0 em handle invalido ou offset fora do range.",
         ts_signature: "instance_load_i32(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_store_i32",
@@ -195,6 +213,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve um i32 little-endian no offset. Retorna 1 em sucesso, 0 em erro.",
         ts_signature: "instance_store_i32(handle: number, offset: number, value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_load_f64",
@@ -205,6 +224,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le um f64 little-endian no offset. 0.0 em handle invalido ou offset fora do range.",
         ts_signature: "instance_load_f64(handle: number, offset: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "instance_store_f64",
@@ -215,6 +235,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve um f64 little-endian no offset. Retorna 1 em sucesso, 0 em erro.",
         ts_signature: "instance_store_f64(handle: number, offset: number, value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "env_free",
@@ -225,6 +246,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera o env record. Retorna 1 em sucesso, 0 se handle já inválido.",
         ts_signature: "env_free(env: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -1,20 +1,28 @@
 //! Slab-based handle table for runtime-managed values.
 //!
-//! Handles are opaque `u64` values returned from allocator functions
-//! (`__RTS_FN_NS_GC_STRING_NEW`, future object/array/buffer equivalents).
-//! The layout encodes a 16-bit generation and a 48-bit slot index so stale
-//! handles can be detected cheaply — a handle becomes invalid once its slot
-//! is reused with a bumped generation.
+//! Handles are opaque `u64` values. Layout:
 //!
-//! Threading model: a single global table behind a `Mutex`. Performance is
-//! acceptable for the current stage; a per-thread pool is a later concern.
+//! ```text
+//! [63..48] generation (16 bits)
+//! [47.. 5] per-shard table slot (43 bits)
+//! [ 4.. 0] shard index (5 bits, log2(N_SHARDS))
+//! ```
+//!
+//! Encoding the shard index in the low 5 bits of the slot field means
+//! `shard_for_handle` is O(1) and allocation round-robin always routes
+//! correctly: shard N only ever emits handles whose low bits equal N.
 
+use std::cell::Cell;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
 const GEN_SHIFT: u32 = 48;
 const SLOT_MASK: u64 = (1u64 << GEN_SHIFT) - 1;
 const SENTINEL_INVALID: u64 = 0;
+
+const N_SHARDS: usize = 32;
+const SHARD_BITS: u32 = 5; // log2(N_SHARDS)
+const SHARD_MASK: u64 = (N_SHARDS as u64) - 1;
 
 /// Value kinds stored behind a handle. Extensible as namespaces grow.
 #[derive(Debug)]
@@ -50,6 +58,10 @@ pub enum Entry {
     AtomicI64(Box<std::sync::atomic::AtomicI64>),
     /// AtomicBool owned — namespace `atomic` (bool_*).
     AtomicBool(Box<std::sync::atomic::AtomicBool>),
+    /// AtomicU64 backing an f64 via bit-transmute — namespace `atomic` (f64_*).
+    /// Stored as AtomicU64 because Rust has no AtomicF64; ops use
+    /// f64::to_bits / f64::from_bits.
+    AtomicF64(Box<std::sync::atomic::AtomicU64>),
     /// Mutex<i64> owned — namespace `sync` (mutex_*). Box estabiliza o
     /// endereco; guards sao armazenados em mapa thread-local para
     /// permitir lock/unlock atravessando chamadas extern "C".
@@ -105,50 +117,58 @@ pub struct HandleTable {
 }
 
 impl HandleTable {
+    /// Legacy: allocates in shard 0. Used by callers that still go through
+    /// `table().lock().unwrap().alloc(...)`. Prefer `alloc_entry` instead.
+    #[deprecated(note = "use alloc_entry")]
     pub fn alloc(&mut self, entry: Entry) -> u64 {
-        if let Some(idx) = self.free_list.pop() {
-            let slot = &mut self.slots[idx as usize];
+        self.alloc_in_shard(entry, 0)
+    }
+
+    /// Allocate `entry` in this shard. `shard_idx` is encoded in the low
+    /// SHARD_BITS of the slot field so `shard_for_handle` can route back
+    /// without extra metadata.
+    pub fn alloc_in_shard(&mut self, entry: Entry, shard_idx: usize) -> u64 {
+        if let Some(table_slot) = self.free_list.pop() {
+            let slot = &mut self.slots[table_slot as usize];
             slot.generation = slot.generation.wrapping_add(1);
             slot.entry = entry;
-            return encode(slot.generation, idx);
+            return encode(slot.generation, shard_idx, table_slot);
         }
-        let idx = self.slots.len() as u32;
+        let table_slot = self.slots.len() as u32;
         self.slots.push(Slot {
             generation: 1,
             entry,
         });
-        encode(1, idx)
+        encode(1, shard_idx, table_slot)
     }
 
     pub fn free(&mut self, handle: u64) -> bool {
-        let Some((expected_gen, idx)) = decode(handle) else {
+        let Some((expected_gen, _, table_slot)) = decode(handle) else {
             return false;
         };
-        let Some(slot) = self.slots.get_mut(idx as usize) else {
+        let Some(slot) = self.slots.get_mut(table_slot as usize) else {
             return false;
         };
         if slot.generation != expected_gen {
             return false;
         }
         slot.entry = Entry::Free;
-        self.free_list.push(idx);
+        self.free_list.push(table_slot);
         true
     }
 
     pub fn get(&self, handle: u64) -> Option<&Entry> {
-        let (expected_gen, idx) = decode(handle)?;
-        let slot = self.slots.get(idx as usize)?;
+        let (expected_gen, _, table_slot) = decode(handle)?;
+        let slot = self.slots.get(table_slot as usize)?;
         if slot.generation != expected_gen || matches!(slot.entry, Entry::Free) {
             return None;
         }
         Some(&slot.entry)
     }
 
-    /// Mutable variant of [`get`], used by namespaces that need in-place
-    /// edits (e.g. `buffer.write_u8`). Same validity checks apply.
     pub fn get_mut(&mut self, handle: u64) -> Option<&mut Entry> {
-        let (expected_gen, idx) = decode(handle)?;
-        let slot = self.slots.get_mut(idx as usize)?;
+        let (expected_gen, _, table_slot) = decode(handle)?;
+        let slot = self.slots.get_mut(table_slot as usize)?;
         if slot.generation != expected_gen || matches!(slot.entry, Entry::Free) {
             return None;
         }
@@ -156,24 +176,67 @@ impl HandleTable {
     }
 }
 
-fn encode(generation: u16, slot: u32) -> u64 {
-    ((generation as u64) << GEN_SHIFT) | (slot as u64 & SLOT_MASK)
+/// Encodes generation + shard_idx + per-shard table_slot into a u64 handle.
+fn encode(generation: u16, shard_idx: usize, table_slot: u32) -> u64 {
+    let slot_field = ((table_slot as u64) << SHARD_BITS) | (shard_idx as u64 & SHARD_MASK);
+    ((generation as u64) << GEN_SHIFT) | (slot_field & SLOT_MASK)
 }
 
-fn decode(handle: u64) -> Option<(u16, u32)> {
+/// Decodes a handle into (generation, shard_idx, per-shard table_slot).
+pub fn decode(handle: u64) -> Option<(u16, usize, u32)> {
     if handle == SENTINEL_INVALID {
         return None;
     }
     let generation = ((handle >> GEN_SHIFT) & 0xFFFF) as u16;
-    let slot = (handle & SLOT_MASK) as u32;
-    Some((generation, slot))
+    let slot_field = handle & SLOT_MASK;
+    let shard_idx = (slot_field & SHARD_MASK) as usize;
+    let table_slot = (slot_field >> SHARD_BITS) as u32;
+    Some((generation, shard_idx, table_slot))
 }
 
-/// Global table instance. Exposed to the rest of the runtime so sibling
-/// namespaces (bigfloat, etc) can allocate/query handles uniformly.
+// ── Sharded table ────────────────────────────────────────────────────────────
+
+fn shards() -> &'static [Mutex<HandleTable>; N_SHARDS] {
+    static SHARDS: OnceLock<[Mutex<HandleTable>; N_SHARDS]> = OnceLock::new();
+    SHARDS.get_or_init(|| std::array::from_fn(|_| Mutex::new(HandleTable::default())))
+}
+
+/// Returns the shard that owns `handle`. O(1) via the shard_idx encoded
+/// in the low SHARD_BITS of the slot field.
+pub fn shard_for_handle(handle: u64) -> &'static Mutex<HandleTable> {
+    let shard_idx = ((handle & SLOT_MASK) & SHARD_MASK) as usize;
+    &shards()[shard_idx]
+}
+
+thread_local! {
+    static ALLOC_SHARD: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Allocates `entry` in the next shard (round-robin per thread).
+/// The shard index is encoded in the returned handle so `shard_for_handle`
+/// routes correctly without any extra lookup.
+pub fn alloc_entry(entry: Entry) -> u64 {
+    let shard_idx = ALLOC_SHARD.with(|s| {
+        let v = s.get();
+        s.set((v + 1) % N_SHARDS);
+        v
+    });
+    shards()[shard_idx].lock().unwrap().alloc_in_shard(entry, shard_idx)
+}
+
+/// Frees a handle. Returns false if the handle is invalid or already freed.
+pub fn free_handle(handle: u64) -> bool {
+    shard_for_handle(handle).lock().unwrap().free(handle)
+}
+
+/// Legacy single-table accessor kept for call sites that have not been
+/// migrated to the sharded API yet. Points to shard 0.
+///
+/// Deprecated: migrate callers to `alloc_entry` / `free_handle` /
+/// `shard_for_handle`. This will be removed once all namespaces are updated.
+#[deprecated(note = "use alloc_entry / free_handle / shard_for_handle")]
 pub fn table() -> &'static Mutex<HandleTable> {
-    static TABLE: OnceLock<Mutex<HandleTable>> = OnceLock::new();
-    TABLE.get_or_init(|| Mutex::new(HandleTable::default()))
+    &shards()[0]
 }
 
 #[cfg(test)]
@@ -182,20 +245,56 @@ mod tests {
 
     #[test]
     fn roundtrip_string_entry() {
-        let mut t = HandleTable::default();
-        let h = t.alloc(Entry::String(b"hello".to_vec()));
-        assert!(matches!(t.get(h), Some(Entry::String(b)) if b == b"hello"));
-        assert!(t.free(h));
-        assert!(t.get(h).is_none());
+        let h = alloc_entry(Entry::String(b"hello".to_vec()));
+        let guard = shard_for_handle(h).lock().unwrap();
+        assert!(matches!(guard.get(h), Some(Entry::String(b)) if b == b"hello"));
+        drop(guard);
+        assert!(free_handle(h));
+        let guard2 = shard_for_handle(h).lock().unwrap();
+        assert!(guard2.get(h).is_none());
     }
 
     #[test]
     fn stale_handle_rejected_after_reuse() {
-        let mut t = HandleTable::default();
-        let h1 = t.alloc(Entry::String(b"first".to_vec()));
-        t.free(h1);
-        let h2 = t.alloc(Entry::String(b"second".to_vec()));
-        assert!(t.get(h1).is_none(), "stale handle must not resolve");
-        assert!(matches!(t.get(h2), Some(Entry::String(_))));
+        let h1 = alloc_entry(Entry::String(b"first".to_vec()));
+        free_handle(h1);
+        let h2 = alloc_entry(Entry::String(b"second".to_vec()));
+        let g1 = shard_for_handle(h1).lock().unwrap();
+        assert!(g1.get(h1).is_none(), "stale handle must not resolve");
+        drop(g1);
+        let g2 = shard_for_handle(h2).lock().unwrap();
+        assert!(matches!(g2.get(h2), Some(Entry::String(_))));
+    }
+
+    #[test]
+    fn shard_encoding_is_consistent() {
+        // Every handle allocated in shard N must route back to shard N.
+        for expected_shard in 0..N_SHARDS {
+            let h = shards()[expected_shard]
+                .lock()
+                .unwrap()
+                .alloc_in_shard(Entry::Free, expected_shard);
+            let actual_shard = ((h & SLOT_MASK) & SHARD_MASK) as usize;
+            assert_eq!(actual_shard, expected_shard);
+            free_handle(h);
+        }
+    }
+
+    #[test]
+    fn alloc_distributes_across_shards() {
+        // alloc_entry round-robins shards; N_SHARDS consecutive allocs
+        // from the same thread should hit all shards.
+        let mut shard_indices = std::collections::HashSet::new();
+        for _ in 0..N_SHARDS {
+            let h = alloc_entry(Entry::Free);
+            let shard = ((h & SLOT_MASK) & SHARD_MASK) as usize;
+            shard_indices.insert(shard);
+            free_handle(h);
+        }
+        assert_eq!(
+            shard_indices.len(),
+            N_SHARDS,
+            "alloc should visit every shard in one round"
+        );
     }
 }

--- a/src/namespaces/hash/abi.rs
+++ b/src/namespaces/hash/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "SipHash de uma string UTF-8.",
         ts_signature: "hash_str(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "hash_bytes",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "SipHash de uma regiao de memoria (ptr + len). Use com buffer.ptr(handle).",
         ts_signature: "hash_bytes(ptr: number, len: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "hash_i64",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "SipHash de um inteiro de 64 bits.",
         ts_signature: "hash_i64(value: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "hash_combine",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Combina dois hashes preservando entropia (estilo boost::hash_combine).",
         ts_signature: "hash_combine(h1: number, h2: number): number",
         intrinsic: None,
+        pure: true,
     },
 ];
 

--- a/src/namespaces/hint/abi.rs
+++ b/src/namespaces/hint/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Hint para spin-wait loop (PAUSE em x86, YIELD em ARM).",
         ts_signature: "spin_loop(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "black_box_i64",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Opaque pra otimizador — impede que o valor seja eliminado.",
         ts_signature: "black_box_i64(value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "black_box_f64",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Opaque pra otimizador (variante f64).",
         ts_signature: "black_box_f64(value: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "unreachable",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Marca codigo inalcancavel — em debug aborta, em release eh UB.",
         ts_signature: "unreachable(): never",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "assert_unchecked",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Assume cond=true sem verificar. Cond falsa = UB em release.",
         ts_signature: "assert_unchecked(cond: boolean): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/io/abi.rs
+++ b/src/namespaces/io/abi.rs
@@ -16,6 +16,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes a UTF-8 message followed by newline to stdout.",
         ts_signature: "print(message: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "eprint",
@@ -26,6 +27,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes a UTF-8 message followed by newline to stderr.",
         ts_signature: "eprint(message: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stdout_write",
@@ -36,6 +38,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes raw bytes to stdout, returns bytes written or -1 on error.",
         ts_signature: "stdout_write(data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stdout_flush",
@@ -46,6 +49,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Flushes stdout buffer. Returns 0 on success, -1 on error.",
         ts_signature: "stdout_flush(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stderr_write",
@@ -56,6 +60,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Writes raw bytes to stderr, returns bytes written or -1 on error.",
         ts_signature: "stderr_write(data: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stderr_flush",
@@ -66,6 +71,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Flushes stderr buffer. Returns 0 on success, -1 on error.",
         ts_signature: "stderr_flush(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stdin_read",
@@ -76,6 +82,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads up to `len` bytes from stdin into buffer. Returns byte count or -1.",
         ts_signature: "stdin_read(bufPtr: number, bufLen: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "stdin_read_line",
@@ -86,6 +93,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Reads a single line from stdin (no terminator) into buffer.",
         ts_signature: "stdin_read_line(bufPtr: number, bufLen: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/math/abi.rs
+++ b/src/namespaces/math/abi.rs
@@ -17,6 +17,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Largest integer <= x.",
         ts_signature: "floor(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "ceil",
@@ -27,6 +28,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Smallest integer >= x.",
         ts_signature: "ceil(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "round",
@@ -37,6 +39,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Rounds to nearest; ties go to +Infinity to match JS semantics.",
         ts_signature: "round(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "trunc",
@@ -47,6 +50,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Truncates fractional part (rounds toward zero).",
         ts_signature: "trunc(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "sqrt",
@@ -57,6 +61,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Square root.",
         ts_signature: "sqrt(x: number): number",
         intrinsic: Some(Intrinsic::Sqrt),
+        pure: true,
     },
     NamespaceMember {
         name: "cbrt",
@@ -67,6 +72,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Cube root.",
         ts_signature: "cbrt(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "pow",
@@ -77,6 +83,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "base raised to exp.",
         ts_signature: "pow(base: number, exp: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "exp",
@@ -87,6 +94,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "e^x.",
         ts_signature: "exp(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "ln",
@@ -97,6 +105,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Natural logarithm (base e).",
         ts_signature: "ln(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "log2",
@@ -107,6 +116,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Base-2 logarithm.",
         ts_signature: "log2(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "log10",
@@ -117,6 +127,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Base-10 logarithm.",
         ts_signature: "log10(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "abs_f64",
@@ -127,6 +138,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Absolute value (f64).",
         ts_signature: "abs_f64(x: number): number",
         intrinsic: Some(Intrinsic::AbsF64),
+        pure: true,
     },
     NamespaceMember {
         name: "abs_i64",
@@ -137,6 +149,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Absolute value (i64); i64::MIN maps to itself (wrapping).",
         ts_signature: "abs_i64(x: number): number",
         intrinsic: Some(Intrinsic::AbsI64),
+        pure: true,
     },
     // ── Trig ──────────────────────────────────────────────────────────────
     NamespaceMember {
@@ -148,6 +161,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sine (radians).",
         ts_signature: "sin(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "cos",
@@ -158,6 +172,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Cosine (radians).",
         ts_signature: "cos(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "tan",
@@ -168,6 +183,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tangent (radians).",
         ts_signature: "tan(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "asin",
@@ -178,6 +194,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Arc sine (returns radians).",
         ts_signature: "asin(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "acos",
@@ -188,6 +205,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Arc cosine (returns radians).",
         ts_signature: "acos(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "atan",
@@ -198,6 +216,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Arc tangent (returns radians).",
         ts_signature: "atan(x: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "atan2",
@@ -208,6 +227,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "atan2(y, x) — angle (radians) of the 2D vector (x, y).",
         ts_signature: "atan2(y: number, x: number): number",
         intrinsic: None,
+        pure: true,
     },
     // ── Min / max / clamp ─────────────────────────────────────────────────
     NamespaceMember {
@@ -219,6 +239,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Minimum of two f64 values (NaN-aware).",
         ts_signature: "min_f64(a: number, b: number): number",
         intrinsic: Some(Intrinsic::MinF64),
+        pure: true,
     },
     NamespaceMember {
         name: "max_f64",
@@ -229,6 +250,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Maximum of two f64 values (NaN-aware).",
         ts_signature: "max_f64(a: number, b: number): number",
         intrinsic: Some(Intrinsic::MaxF64),
+        pure: true,
     },
     NamespaceMember {
         name: "min_i64",
@@ -239,6 +261,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Minimum of two i64 values.",
         ts_signature: "min_i64(a: number, b: number): number",
         intrinsic: Some(Intrinsic::MinI64),
+        pure: true,
     },
     NamespaceMember {
         name: "max_i64",
@@ -249,6 +272,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Maximum of two i64 values.",
         ts_signature: "max_i64(a: number, b: number): number",
         intrinsic: Some(Intrinsic::MaxI64),
+        pure: true,
     },
     NamespaceMember {
         name: "clamp_f64",
@@ -259,6 +283,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Clamps x into [lo, hi]. NaN propagates.",
         ts_signature: "clamp_f64(x: number, lo: number, hi: number): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "clamp_i64",
@@ -269,6 +294,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Clamps x into [lo, hi].",
         ts_signature: "clamp_i64(x: number, lo: number, hi: number): number",
         intrinsic: None,
+        pure: true,
     },
     // ── Random ────────────────────────────────────────────────────────────
     NamespaceMember {
@@ -280,6 +306,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Uniform f64 in [0, 1) from a thread-local xorshift64 PRNG.",
         ts_signature: "random_f64(): number",
         intrinsic: Some(Intrinsic::RandomF64),
+        pure: false, // mutates global RNG state
     },
     NamespaceMember {
         name: "random_i64_range",
@@ -290,6 +317,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Uniform i64 in [lo, hi). Returns lo when lo >= hi.",
         ts_signature: "random_i64_range(lo: number, hi: number): number",
         intrinsic: None,
+        pure: false, // mutates global RNG state
     },
     NamespaceMember {
         name: "seed",
@@ -300,6 +328,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Seeds the PRNG. Zero is replaced by the default seed.",
         ts_signature: "seed(s: number): void",
         intrinsic: None,
+        pure: false, // mutates global RNG state
     },
     // ── Constants ─────────────────────────────────────────────────────────
     // Backed by zero-arg extern "C" fns in consts.rs; codegen resolves
@@ -313,6 +342,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Archimedes' constant.",
         ts_signature: "PI: number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "E",
@@ -323,6 +353,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Euler's number.",
         ts_signature: "E: number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "INFINITY",
@@ -333,6 +364,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Positive infinity.",
         ts_signature: "INFINITY: number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "NAN",
@@ -343,6 +375,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Quiet NaN.",
         ts_signature: "NAN: number",
         intrinsic: None,
+        pure: true,
     },
 ];
 

--- a/src/namespaces/mem/abi.rs
+++ b/src/namespaces/mem/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um i64 (= 8).",
         ts_signature: "size_of_i64: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "size_of_f64",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um f64 (= 8).",
         ts_signature: "size_of_f64: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "size_of_i32",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um i32 (= 4).",
         ts_signature: "size_of_i32: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "size_of_bool",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um bool (= 1).",
         ts_signature: "size_of_bool: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "align_of_i64",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Alinhamento de i64 (= 8).",
         ts_signature: "align_of_i64: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "align_of_f64",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Alinhamento de f64 (= 8).",
         ts_signature: "align_of_f64: number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "swap_i64",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Retorna `b` (use idiom: `let old = mem.swap_i64(a, b)`).",
         ts_signature: "swap_i64(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "drop_handle",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Forca free de um handle GC. Equivalente a gc.string_free / etc.",
         ts_signature: "drop_handle(h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "forget_handle",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Esquece handle sem rodar drop — vaza memoria intencionalmente.",
         ts_signature: "forget_handle(h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "replace_i64",
@@ -102,6 +111,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Idiom: `mem.replace_i64(slot, new)` — retorna slot e usa caller pra escrever.",
         ts_signature: "replace_i64(slot: number, new_val: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/mod.rs
+++ b/src/namespaces/mod.rs
@@ -27,6 +27,7 @@ pub mod path;
 pub mod process;
 pub mod ptr;
 pub mod regex;
+pub mod parallel;
 pub mod runtime;
 pub mod string;
 pub mod sync;

--- a/src/namespaces/num/abi.rs
+++ b/src/namespaces/num/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_add(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "checked_sub",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_sub(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "checked_mul",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_mul(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "checked_div",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a / b; retorna i64::MIN se b == 0 ou overflow (i64::MIN / -1).",
         ts_signature: "checked_div(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── saturating: clamp em i64::MIN/MAX ─────────────────────────────
     NamespaceMember {
@@ -54,6 +58,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_add(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "saturating_sub",
@@ -64,6 +69,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_sub(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "saturating_mul",
@@ -74,6 +80,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_mul(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── wrapping: comportamento modular ───────────────────────────────
     NamespaceMember {
@@ -85,6 +92,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b modulo 2^64.",
         ts_signature: "wrapping_add(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wrapping_sub",
@@ -95,6 +103,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b modulo 2^64.",
         ts_signature: "wrapping_sub(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wrapping_mul",
@@ -105,6 +114,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b modulo 2^64.",
         ts_signature: "wrapping_mul(a: number, b: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wrapping_neg",
@@ -115,6 +125,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "-a modulo 2^64 (i64::MIN.wrapping_neg() == i64::MIN).",
         ts_signature: "wrapping_neg(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wrapping_shl",
@@ -125,6 +136,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a << (n & 63) — shift count masked.",
         ts_signature: "wrapping_shl(a: number, n: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wrapping_shr",
@@ -135,6 +147,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a >> (n & 63) (arithmetic shift).",
         ts_signature: "wrapping_shr(a: number, n: number): number",
         intrinsic: None,
+        pure: false,
     },
     // ── bits ──────────────────────────────────────────────────────────
     NamespaceMember {
@@ -146,6 +159,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de bits 1 em a.",
         ts_signature: "count_ones(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "count_zeros",
@@ -156,6 +170,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de bits 0 em a.",
         ts_signature: "count_zeros(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "leading_zeros",
@@ -166,6 +181,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de zeros leading em a.",
         ts_signature: "leading_zeros(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "trailing_zeros",
@@ -176,6 +192,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de zeros trailing em a.",
         ts_signature: "trailing_zeros(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rotate_left",
@@ -186,6 +203,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a rotacionado n bits para a esquerda.",
         ts_signature: "rotate_left(a: number, n: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rotate_right",
@@ -196,6 +214,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a rotacionado n bits para a direita.",
         ts_signature: "rotate_right(a: number, n: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "reverse_bits",
@@ -206,6 +225,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Bits invertidos (LSB->MSB).",
         ts_signature: "reverse_bits(a: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "swap_bytes",
@@ -216,6 +236,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Bytes invertidos (endianness flip).",
         ts_signature: "swap_bytes(a: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/os/abi.rs
+++ b/src/namespaces/os/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Canonical OS name: 'windows', 'linux', 'macos', 'ios', 'android', ...",
         ts_signature: "platform(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "arch",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "CPU architecture: 'x86_64', 'aarch64', 'x86', ...",
         ts_signature: "arch(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "family",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "OS family: 'unix' or 'windows'.",
         ts_signature: "family(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "eol",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Native line ending: '\\r\\n' on Windows, '\\n' elsewhere.",
         ts_signature: "eol(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "home_dir",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "User home directory. Empty string if unresolvable.",
         ts_signature: "home_dir(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "temp_dir",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "System temporary directory.",
         ts_signature: "temp_dir(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "config_dir",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Per-user config dir (%APPDATA% / XDG_CONFIG_HOME / ~/.config).",
         ts_signature: "config_dir(): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "cache_dir",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Per-user cache dir (%LOCALAPPDATA% / XDG_CACHE_HOME / ~/.cache).",
         ts_signature: "cache_dir(): string",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/parallel/abi.rs
+++ b/src/namespaces/parallel/abi.rs
@@ -1,0 +1,56 @@
+//! `parallel` namespace — ABI registration.
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "map",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PARALLEL_MAP",
+        args: &[AbiType::Handle, AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Aplica `fn_ptr(x)` em paralelo sobre cada elemento do Vec<i64> `vec_handle`. Retorna novo Vec<i64> com os resultados. `fn_ptr` e `extern \"C\" fn(i64) -> i64`.",
+        ts_signature: "map(vec_handle: number, fn_ptr: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "for_each",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PARALLEL_FOR_EACH",
+        args: &[AbiType::Handle, AbiType::U64],
+        returns: AbiType::Void,
+        doc: "Executa `fn_ptr(x)` em paralelo para cada elemento do Vec<i64> `vec_handle`. `fn_ptr` e `extern \"C\" fn(i64)`.",
+        ts_signature: "for_each(vec_handle: number, fn_ptr: number): void",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "reduce",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PARALLEL_REDUCE",
+        args: &[AbiType::Handle, AbiType::I64, AbiType::U64],
+        returns: AbiType::I64,
+        doc: "Reduz Vec<i64> `vec_handle` com `fn_ptr(acc, x) -> acc` em paralelo (divide-e-conquista). `identity` e o elemento neutro da operacao (0 para soma, 1 para produto). `fn_ptr` deve ser associativo.",
+        ts_signature: "reduce(vec_handle: number, identity: number, fn_ptr: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "num_threads",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PARALLEL_NUM_THREADS",
+        args: &[],
+        returns: AbiType::I64,
+        doc: "Retorna o numero de threads no pool Rayon global.",
+        ts_signature: "num_threads(): number",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "parallel",
+    doc: "Paralelismo de dados via Rayon (map/for_each/reduce sobre Vec<i64>).",
+    members: MEMBERS,
+};

--- a/src/namespaces/parallel/mod.rs
+++ b/src/namespaces/parallel/mod.rs
@@ -1,0 +1,5 @@
+//! `parallel` namespace — Rayon-backed data parallelism.
+
+pub mod abi;
+pub mod ops;
+pub mod pool;

--- a/src/namespaces/parallel/ops.rs
+++ b/src/namespaces/parallel/ops.rs
@@ -1,0 +1,69 @@
+//! parallel::map / for_each / reduce — Rayon-backed data parallelism.
+
+use rayon::prelude::*;
+
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
+use super::pool::pool;
+
+fn snapshot_vec(handle: u64) -> Option<Vec<i64>> {
+    let guard = shard_for_handle(handle).lock().unwrap();
+    match guard.get(handle) {
+        Some(Entry::Vec(v)) => Some(v.as_ref().clone()),
+        _ => None,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_MAP(vec_handle: u64, fn_ptr: u64) -> u64 {
+    let Some(items) = snapshot_vec(vec_handle) else {
+        return 0;
+    };
+    if fn_ptr == 0 {
+        return 0;
+    }
+    // SAFETY: fn_ptr is `extern "C" fn(i64) -> i64` — contract with codegen.
+    // Each Rayon worker calls this independently; no shared mutable state.
+    let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let result: Vec<i64> = pool().install(|| items.par_iter().map(|&x| f(x)).collect());
+    alloc_entry(Entry::Vec(Box::new(result)))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_FOR_EACH(vec_handle: u64, fn_ptr: u64) {
+    let Some(items) = snapshot_vec(vec_handle) else {
+        return;
+    };
+    if fn_ptr == 0 {
+        return;
+    }
+    // SAFETY: fn_ptr is `extern "C" fn(i64)`.
+    let f: extern "C" fn(i64) = unsafe { std::mem::transmute(fn_ptr as usize) };
+    pool().install(|| items.par_iter().for_each(|&x| f(x)));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_REDUCE(
+    vec_handle: u64,
+    identity: i64,
+    fn_ptr: u64,
+) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else {
+        return identity;
+    };
+    if fn_ptr == 0 {
+        return identity;
+    }
+    // SAFETY: fn_ptr is `extern "C" fn(i64, i64) -> i64` (associative, commutative).
+    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    pool().install(|| {
+        items
+            .par_iter()
+            .copied()
+            .reduce(|| identity, |a, b| f(a, b))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_NUM_THREADS() -> i64 {
+    pool().current_num_threads() as i64
+}

--- a/src/namespaces/parallel/pool.rs
+++ b/src/namespaces/parallel/pool.rs
@@ -1,0 +1,18 @@
+//! Global Rayon thread pool, lazily initialised.
+
+use std::sync::OnceLock;
+
+static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+pub fn pool() -> &'static rayon::ThreadPool {
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(
+                std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(4),
+            )
+            .build()
+            .expect("rayon pool init failed")
+    })
+}

--- a/src/namespaces/parallel/rt.rs
+++ b/src/namespaces/parallel/rt.rs
@@ -1,0 +1,2 @@
+pub mod ops;
+pub mod pool;

--- a/src/namespaces/path/abi.rs
+++ b/src/namespaces/path/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Joins a base path with a relative fragment.",
         ts_signature: "join(base: string, part: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "parent",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Parent directory; 0 when path has no parent (e.g. root or bare filename).",
         ts_signature: "parent(path: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "file_name",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Final component of the path (file name with extension).",
         ts_signature: "file_name(path: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "stem",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "File name without extension.",
         ts_signature: "stem(path: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "ext",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "File extension without leading dot; 0 when absent.",
         ts_signature: "ext(path: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "is_absolute",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True when path is absolute for the current target.",
         ts_signature: "is_absolute(path: string): boolean",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "normalize",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes `.` and collapses `..` without touching the filesystem.",
         ts_signature: "normalize(path: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "with_ext",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the path with the extension replaced (or added).",
         ts_signature: "with_ext(path: string, ext: string): string",
         intrinsic: None,
+        pure: true,
     },
 ];
 

--- a/src/namespaces/process/abi.rs
+++ b/src/namespaces/process/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Termina o processo corrente com o exit code dado.",
         ts_signature: "exit(code: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "abort",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aborta o processo imediatamente (sem unwind).",
         ts_signature: "abort(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "pid",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "PID do processo corrente.",
         ts_signature: "pid(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "args_count",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Number of command-line arguments (inclui argv[0]).",
         ts_signature: "args_count(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "arg_at",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Argumento em `index` como string handle; 0 fora do range.",
         ts_signature: "arg_at(index: number): string",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "spawn",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Dispara `cmd` com argumentos separados por \\n. Retorna handle do filho, ou 0 em falha.",
         ts_signature: "spawn(cmd: string, args_newline_separated: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "wait",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aguarda o filho terminar e retorna o exit code. Consome o handle.",
         ts_signature: "wait(child: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "kill",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Mata o processo filho. 0 em sucesso, -1 em erro.",
         ts_signature: "kill(child: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/ptr/abi.rs
+++ b/src/namespaces/ptr/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Retorna ponteiro nulo (0).",
         ts_signature: "null(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "is_null",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True se ptr == 0.",
         ts_signature: "is_null(p: number): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_i64",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le i64 do endereco. UNSAFE: caller garante validade/alinhamento.",
         ts_signature: "read_i64(p: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_i32",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le i32 do endereco e estende para i64.",
         ts_signature: "read_i32(p: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_u8",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le u8 do endereco e estende para i64 (0..255).",
         ts_signature: "read_u8(p: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "read_f64",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Le f64 do endereco.",
         ts_signature: "read_f64(p: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_i64",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve i64 no endereco.",
         ts_signature: "write_i64(p: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_i32",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve i32 (low 32 bits) no endereco.",
         ts_signature: "write_i32(p: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_u8",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve u8 (low 8 bits) no endereco.",
         ts_signature: "write_u8(p: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_f64",
@@ -102,6 +111,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve f64 no endereco.",
         ts_signature: "write_f64(p: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "copy",
@@ -112,6 +122,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "memmove: copia n bytes de src para dst (overlapping ok).",
         ts_signature: "copy(dst: number, src: number, n: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "copy_nonoverlapping",
@@ -122,6 +133,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "memcpy: copia n bytes (regioes nao podem se sobrepor).",
         ts_signature: "copy_nonoverlapping(dst: number, src: number, n: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "write_bytes",
@@ -132,6 +144,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "memset: preenche n bytes com value (low 8 bits).",
         ts_signature: "write_bytes(dst: number, value: number, n: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "offset",
@@ -142,6 +155,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Adiciona n bytes ao ptr.",
         ts_signature: "offset(p: number, n: number): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/regex/abi.rs
+++ b/src/namespaces/regex/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Compila um pattern com flags (ex: \"i\", \"gm\"). Retorna handle ou 0 se invalido.",
         ts_signature: "compile(pattern: string, flags: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "free",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera regex compilada.",
         ts_signature: "free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "test",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True se a regex casa em qualquer posicao da string.",
         ts_signature: "test(handle: number, s: string): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "find",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Primeira ocorrencia. Retorna handle de string com o match (free pelo caller) ou 0.",
         ts_signature: "find(handle: number, s: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "find_at",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Indice (em bytes) da primeira ocorrencia, -1 se nao casa.",
         ts_signature: "find_at(handle: number, s: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "replace",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Substitui primeira ocorrencia. Retorna handle de string nova.",
         ts_signature: "replace(handle: number, s: string, replacement: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "replace_all",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Substitui todas as ocorrencias. Retorna handle de string nova.",
         ts_signature: "replace_all(handle: number, s: string, replacement: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "match_count",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de matches (overlapping=false).",
         ts_signature: "match_count(handle: number, s: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -44,6 +44,14 @@ pub mod fmt;
 pub mod crypto;
 #[path = "regex/rt.rs"]
 pub mod regex;
+#[path = "atomic/rt.rs"]
+pub mod atomic;
+#[path = "sync/rt.rs"]
+pub mod sync;
+#[path = "thread/rt.rs"]
+pub mod thread;
+#[path = "parallel/rt.rs"]
+pub mod parallel;
 #[path = "ui/rt.rs"]
 pub mod ui;
 #[path = "runtime/rt.rs"]

--- a/src/namespaces/runtime/abi.rs
+++ b/src/namespaces/runtime/abi.rs
@@ -10,6 +10,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Evaluates a TS/JS source string. Returns the program exit code.",
         ts_signature: "eval(src: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "eval_file",
@@ -20,6 +21,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Loads and evaluates a TS/JS file at the given path. Returns the program exit code.",
         ts_signature: "eval_file(path: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/string/abi.rs
+++ b/src/namespaces/string/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True when `haystack` contains `needle`.",
         ts_signature: "contains(haystack: string, needle: string): boolean",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "starts_with",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True when `s` starts with `prefix`.",
         ts_signature: "starts_with(s: string, prefix: string): boolean",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "ends_with",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "True when `s` ends with `suffix`.",
         ts_signature: "ends_with(s: string, suffix: string): boolean",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "find",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Byte index of first occurrence of `needle`, or -1 when absent.",
         ts_signature: "find(s: string, needle: string): number",
         intrinsic: None,
+        pure: true,
     },
     // ── Transform ─────────────────────────────────────────────────────
     NamespaceMember {
@@ -54,6 +58,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Uppercase copy (Unicode-aware).",
         ts_signature: "to_upper(s: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "to_lower",
@@ -64,6 +69,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Lowercase copy (Unicode-aware).",
         ts_signature: "to_lower(s: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "trim",
@@ -74,6 +80,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes ASCII + Unicode whitespace from both ends.",
         ts_signature: "trim(s: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "trim_start",
@@ -84,6 +91,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes whitespace from the start.",
         ts_signature: "trim_start(s: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "trim_end",
@@ -94,6 +102,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Removes whitespace from the end.",
         ts_signature: "trim_end(s: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "repeat",
@@ -104,6 +113,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Concatenates `s` with itself `n` times.",
         ts_signature: "repeat(s: string, n: number): string",
         intrinsic: None,
+        pure: true,
     },
     // ── Replace ───────────────────────────────────────────────────────
     NamespaceMember {
@@ -115,6 +125,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Replaces every occurrence of `from` with `to`.",
         ts_signature: "replace(s: string, from: string, to: string): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "replacen",
@@ -130,6 +141,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Replaces the first `n` occurrences of `from` with `to`.",
         ts_signature: "replacen(s: string, from: string, to: string, n: number): string",
         intrinsic: None,
+        pure: true,
     },
     // ── Split / count / indexing ──────────────────────────────────────
     NamespaceMember {
@@ -141,6 +153,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Unicode codepoint count (chars).",
         ts_signature: "char_count(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "byte_len",
@@ -151,6 +164,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Length in UTF-8 bytes.",
         ts_signature: "byte_len(s: string): number",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "char_at",
@@ -161,6 +175,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Character at Unicode index `idx` as a single-char string handle, or 0 out of range.",
         ts_signature: "char_at(s: string, idx: number): string",
         intrinsic: None,
+        pure: true,
     },
     NamespaceMember {
         name: "char_code_at",
@@ -171,6 +186,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Unicode code point at `idx`, or -1 out of range.",
         ts_signature: "char_code_at(s: string, idx: number): number",
         intrinsic: None,
+        pure: true,
     },
 ];
 

--- a/src/namespaces/sync/abi.rs
+++ b/src/namespaces/sync/abi.rs
@@ -13,6 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um Mutex protegendo um valor i64 inicializado com `initial`.",
         ts_signature: "mutex_new(initial: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mutex_lock",
@@ -23,6 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Bloqueia ate adquirir o Mutex e retorna o valor interno protegido. 0 se handle invalido.",
         ts_signature: "mutex_lock(mutex: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mutex_try_lock",
@@ -33,6 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tenta adquirir o Mutex sem bloquear. Retorna o valor interno em caso de sucesso, 0 se ja estava lockado ou handle invalido.",
         ts_signature: "mutex_try_lock(mutex: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mutex_set",
@@ -43,6 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Escreve `value` no Mutex. Caller deve ter chamado lock/try_lock antes (responsabilidade do caller).",
         ts_signature: "mutex_set(mutex: number, value: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mutex_unlock",
@@ -53,6 +57,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera o Mutex previamente adquirido por lock/try_lock. No-op se nao havia guard ativo.",
         ts_signature: "mutex_unlock(mutex: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "mutex_free",
@@ -63,6 +68,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera o Mutex e seu slot na HandleTable.",
         ts_signature: "mutex_free(mutex: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── RwLock ─────────────────────────────────────────────────────
     NamespaceMember {
@@ -74,6 +80,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um RwLock protegendo um valor i64 inicializado com `initial`.",
         ts_signature: "rwlock_new(initial: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rwlock_read",
@@ -84,6 +91,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Adquire um read guard (compartilhado) e retorna um handle de guard. Liberar via rwlock_unlock(guard). 0 se handle invalido.",
         ts_signature: "rwlock_read(rwlock: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rwlock_write",
@@ -94,6 +102,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Adquire um write guard (exclusivo) e retorna um handle de guard. Liberar via rwlock_unlock(guard). 0 se handle invalido.",
         ts_signature: "rwlock_write(rwlock: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "rwlock_unlock",
@@ -104,6 +113,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera um guard previamente adquirido via rwlock_read/rwlock_write.",
         ts_signature: "rwlock_unlock(guard: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── OnceLock ───────────────────────────────────────────────────
     NamespaceMember {
@@ -115,6 +125,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aloca um OnceLock e retorna o handle.",
         ts_signature: "once_new(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "once_call",
@@ -125,6 +136,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Executa `fn_ptr` (ponteiro para `extern \"C\" fn()`) exatamente uma vez por OnceLock. Chamadas subsequentes sao no-op.",
         ts_signature: "once_call(once: number, fn_ptr: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/sync/rt.rs
+++ b/src/namespaces/sync/rt.rs
@@ -1,0 +1,3 @@
+pub mod mutex;
+pub mod once;
+pub mod rwlock;

--- a/src/namespaces/test/abi.rs
+++ b/src/namespaces/test/abi.rs
@@ -10,6 +10,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Opens a named test suite block. Nested calls increase indent.",
         ts_signature: "suite_begin(name: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "suite_end",
@@ -20,6 +21,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Closes the innermost test suite block.",
         ts_signature: "suite_end(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "case_begin",
@@ -30,6 +32,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Starts a named test case and resets the failure flag.",
         ts_signature: "case_begin(name: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "case_end",
@@ -40,6 +43,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Ends the current case. Prints ✓ if no failures, updates counters.",
         ts_signature: "case_end(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "case_fail",
@@ -50,6 +54,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Marks current case as failed and emits message in red.",
         ts_signature: "case_fail(msg: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "case_fail_diff",
@@ -60,6 +65,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Marks current case as failed and prints an expected/received diff.",
         ts_signature: "case_fail_diff(expected: string, actual: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "print_summary",
@@ -70,6 +76,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Prints pass/fail counts. Call once at the end of the test file.",
         ts_signature: "print_summary(): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/thread/abi.rs
+++ b/src/namespaces/thread/abi.rs
@@ -12,6 +12,40 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Cria uma nova thread executando `fn_ptr(arg)`. `fn_ptr` e um ponteiro para `extern \"C\" fn(u64) -> u64`. Retorna handle do JoinHandle, 0 em falha.",
         ts_signature: "spawn(fn_ptr: number, arg: number): number",
         intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "spawn_with_ud",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_THREAD_SPAWN_WITH_UD",
+        args: &[AbiType::U64, AbiType::U64, AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Variante de `spawn` que passa um `userdata` (ex: handle de `this`) como primeiro argumento da fn. `fn_ptr` aponta para `extern \"C\" fn(u64, u64) -> u64` (ud, arg).",
+        ts_signature: "spawn_with_ud(fn_ptr: number, arg: number, userdata: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "scope",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_THREAD_SCOPE",
+        args: &[AbiType::U64],
+        returns: AbiType::Void,
+        doc: "Roda `body()` num escopo que aguarda automaticamente todas as threads spawnadas durante sua execucao. Analogo a `std::thread::scope`.",
+        ts_signature: "scope(body: () => void): void",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "scope_with_ud",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_THREAD_SCOPE_WITH_UD",
+        args: &[AbiType::U64, AbiType::U64],
+        returns: AbiType::Void,
+        doc: "Variante com userdata para `thread.scope` quando o body captura `this`.",
+        ts_signature: "scope_with_ud(body: number, userdata: number): void",
+        intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "join",
@@ -22,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Aguarda a thread terminar e retorna o valor retornado por ela. Consome o handle. 0 se handle invalido ou a thread fez panic.",
         ts_signature: "join(thread: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "detach",
@@ -32,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Libera o JoinHandle sem aguardar. A thread continua rodando ate completar.",
         ts_signature: "detach(thread: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "id",
@@ -42,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Id da thread atual (estavel por thread, atribuido na primeira chamada). Sempre != 0.",
         ts_signature: "id(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sleep_ms",
@@ -52,11 +89,12 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Pausa a thread atual por `ms` milissegundos. Valores negativos sao tratados como 0.",
         ts_signature: "sleep_ms(ms: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 
 pub const SPEC: NamespaceSpec = NamespaceSpec {
     name: "thread",
-    doc: "Primitivas de threads (spawn/join/detach/id/sleep) baseadas em std::thread.",
+    doc: "Primitivas de threads (spawn/join/detach/scope/id/sleep) baseadas em std::thread.",
     members: MEMBERS,
 };

--- a/src/namespaces/thread/join.rs
+++ b/src/namespaces/thread/join.rs
@@ -2,15 +2,11 @@
 
 use std::thread::JoinHandle;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, free_handle, shard_for_handle};
 
-/// Move o JoinHandle pra fora do slot (substituindo por Free) e libera o
-/// slot formalmente. Retorna `None` se o handle for invalido ou ja
-/// consumido.
 fn take_join_handle(handle: u64) -> Option<Box<JoinHandle<u64>>> {
     let taken: Option<Box<JoinHandle<u64>>> = {
-        let t = table();
-        let mut guard = t.lock().unwrap();
+        let mut guard = shard_for_handle(handle).lock().unwrap();
         match guard.get_mut(handle) {
             Some(entry @ Entry::JoinHandle(_)) => {
                 let prev = std::mem::replace(entry, Entry::Free);
@@ -23,8 +19,8 @@ fn take_join_handle(handle: u64) -> Option<Box<JoinHandle<u64>>> {
             _ => None,
         }
     };
-    // bump generation no slot (se ja era Free, free retorna false sem efeito)
-    table().lock().unwrap().free(handle);
+    // bump generation via free (no-op if already Free)
+    free_handle(handle);
     taken
 }
 
@@ -41,6 +37,5 @@ pub extern "C" fn __RTS_FN_NS_THREAD_JOIN(handle: u64) -> u64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_THREAD_DETACH(handle: u64) {
-    // Drop sem .join() — a thread continua rodando ate completar.
     drop(take_join_handle(handle));
 }

--- a/src/namespaces/thread/rt.rs
+++ b/src/namespaces/thread/rt.rs
@@ -1,0 +1,3 @@
+pub mod info;
+pub mod join;
+pub mod spawn;

--- a/src/namespaces/thread/spawn.rs
+++ b/src/namespaces/thread/spawn.rs
@@ -1,13 +1,30 @@
-//! thread::spawn — invoca `extern "C" fn(u64) -> u64` em nova thread.
+//! thread::spawn / thread::scope — invoca `extern "C" fn(u64) -> u64`
+//! em nova thread.
 //!
 //! O ponteiro de funcao chega como `u64` (passado pelo codegen/TS-side).
 //! Reconstruimos como `extern "C" fn(u64) -> u64` via transmute e
 //! invocamos dentro de `std::thread::spawn`. O `JoinHandle<u64>` vai pra
 //! `HandleTable` como `Entry::JoinHandle`.
 
+use std::cell::RefCell;
 use std::thread;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry};
+
+thread_local! {
+    /// Stack de scopes ativos. Cada scope acumula handles de spawns
+    /// feitos durante sua execucao. `thread.scope` empilha um novo Vec
+    /// no inicio e joina todos os handles no fim.
+    static SCOPE_STACK: RefCell<Vec<Vec<u64>>> = RefCell::new(Vec::new());
+}
+
+fn record_scoped_handle(handle: u64) {
+    SCOPE_STACK.with(|s| {
+        if let Some(top) = s.borrow_mut().last_mut() {
+            top.push(handle);
+        }
+    });
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN(fn_ptr: u64, arg: u64) -> u64 {
@@ -18,9 +35,64 @@ pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN(fn_ptr: u64, arg: u64) -> u64 {
     // funcao com assinatura `extern "C" fn(u64) -> u64`. Nao podemos
     // validar runtime — contrato com o compilador.
     let f: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    let handle = thread::spawn(move || f(arg));
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::JoinHandle(Box::new(handle)))
+    let join_handle = thread::spawn(move || f(arg));
+    let h = alloc_entry(Entry::JoinHandle(Box::new(join_handle)));
+    record_scoped_handle(h);
+    h
+}
+
+/// Variante com userdata: trampolim recebe `(ud, arg)`. Usado quando
+/// arrow capturada por `thread.spawn` referencia `this` — o lifter
+/// passa o handle do `this` como `ud`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN_WITH_UD(fn_ptr: u64, arg: u64, ud: u64) -> u64 {
+    if fn_ptr == 0 {
+        return 0;
+    }
+    // SAFETY: contrato com o codegen — `fn_ptr` aponta para
+    // `extern "C" fn(u64, u64) -> u64`.
+    let f: extern "C" fn(u64, u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let join_handle = thread::spawn(move || f(ud, arg));
+    let h = alloc_entry(Entry::JoinHandle(Box::new(join_handle)));
+    record_scoped_handle(h);
+    h
+}
+
+/// Roda `body()` num escopo que aguarda automaticamente todas as threads
+/// spawnadas durante sua execucao. Analogo a `std::thread::scope` —
+/// garante que nenhuma thread escapa do escopo.
+///
+/// Implementacao: empilha um Vec de handles thread-local antes de chamar
+/// o body; ao retornar, joina todos os handles acumulados. Spawns
+/// aninhados funcionam — cada scope guarda apenas seus proprios handles.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_THREAD_SCOPE(fn_ptr: u64) {
+    if fn_ptr == 0 {
+        return;
+    }
+    SCOPE_STACK.with(|s| s.borrow_mut().push(Vec::new()));
+    // SAFETY: callback e trampolim sintetico gerado pelo codegen com
+    // assinatura `extern "C" fn()`.
+    let f: extern "C" fn() = unsafe { std::mem::transmute(fn_ptr as usize) };
+    f();
+    let handles = SCOPE_STACK.with(|s| s.borrow_mut().pop().unwrap_or_default());
+    for h in handles {
+        super::join::__RTS_FN_NS_THREAD_JOIN(h);
+    }
+}
+
+/// Variante com userdata para `thread.scope` capturando `this`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_THREAD_SCOPE_WITH_UD(fn_ptr: u64, ud: u64) {
+    if fn_ptr == 0 {
+        return;
+    }
+    SCOPE_STACK.with(|s| s.borrow_mut().push(Vec::new()));
+    // SAFETY: `extern "C" fn(u64)`.
+    let f: extern "C" fn(u64) = unsafe { std::mem::transmute(fn_ptr as usize) };
+    f(ud);
+    let handles = SCOPE_STACK.with(|s| s.borrow_mut().pop().unwrap_or_default());
+    for h in handles {
+        super::join::__RTS_FN_NS_THREAD_JOIN(h);
+    }
 }

--- a/src/namespaces/time/abi.rs
+++ b/src/namespaces/time/abi.rs
@@ -12,6 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Monotonic milliseconds since process start.",
         ts_signature: "now_ms(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "now_ns",
@@ -22,6 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Monotonic nanoseconds since process start.",
         ts_signature: "now_ns(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "unix_ms",
@@ -32,6 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Wall-clock milliseconds since the UNIX epoch.",
         ts_signature: "unix_ms(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "unix_ns",
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Wall-clock nanoseconds since the UNIX epoch.",
         ts_signature: "unix_ns(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sleep_ms",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sleeps the current thread for `ms` milliseconds.",
         ts_signature: "sleep_ms(ms: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "sleep_ns",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sleeps the current thread for `ns` nanoseconds.",
         ts_signature: "sleep_ns(ns: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/trace/abi.rs
+++ b/src/namespaces/trace/abi.rs
@@ -10,6 +10,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Push a TS call frame onto the trace stack.",
         ts_signature: "push_frame(file: string, fn_name: string, line: number, col: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "pop_frame",
@@ -20,6 +21,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Pop the top TS call frame from the trace stack.",
         ts_signature: "pop_frame(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "capture",
@@ -30,6 +32,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Capture current trace as a GC string handle. Returns 0 if stack is empty.",
         ts_signature: "capture(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "print",
@@ -40,6 +43,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Print current trace stack to stderr.",
         ts_signature: "print(): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "depth",
@@ -50,6 +54,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns current trace stack depth.",
         ts_signature: "depth(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "free",
@@ -60,6 +65,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Free a captured trace handle.",
         ts_signature: "free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/src/namespaces/ui/abi.rs
+++ b/src/namespaces/ui/abi.rs
@@ -11,6 +11,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates the FLTK application. Call once before any widget.",
         ts_signature: "app_new(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "app_run",
@@ -21,6 +22,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Enters the FLTK event loop. Blocks until all windows are closed.",
         ts_signature: "app_run(app: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "app_free",
@@ -31,6 +33,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Frees the app handle.",
         ts_signature: "app_free(app: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Window ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -42,6 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a window (w, h, title). Returns a window handle.",
         ts_signature: "window_new(w: number, h: number, title: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_show",
@@ -52,6 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Makes the window visible.",
         ts_signature: "window_show(win: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_end",
@@ -62,6 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Ends the window widget group. Call after adding all child widgets.",
         ts_signature: "window_end(win: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_free",
@@ -72,6 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Frees the window handle.",
         ts_signature: "window_free(win: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_set_callback",
@@ -82,6 +89,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets a callback invoked when the window close button is pressed.",
         ts_signature: "window_set_callback(win: number, fn: () => void): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_set_color",
@@ -92,6 +100,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the background color of the window (r, g, b in 0–255).",
         ts_signature: "window_set_color(win: number, r: number, g: number, b: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "window_resize",
@@ -108,6 +117,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Moves and resizes the window (x, y, w, h).",
         ts_signature: "window_resize(win: number, x: number, y: number, w: number, h: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Generic widget ops ───────────────────────────────────────────────
     NamespaceMember {
@@ -119,6 +129,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the label text of any widget.",
         ts_signature: "widget_set_label(widget: number, text: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_label",
@@ -129,6 +140,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the widget label as a GC string handle.",
         ts_signature: "widget_label(widget: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_set_callback",
@@ -139,6 +151,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Registers a callback invoked when the widget is activated (click, change, etc).",
         ts_signature: "widget_set_callback(widget: number, fn: () => void): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_set_callback_with_ud",
@@ -149,6 +162,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Variante de set_callback que passa userdata (ex: handle de `this`) ao callback.",
         ts_signature: "widget_set_callback_with_ud(widget: number, fn: (this: number) => void, userdata: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_set_color",
@@ -159,6 +173,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the background color of a widget (r, g, b in 0–255).",
         ts_signature: "widget_set_color(widget: number, r: number, g: number, b: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_set_label_color",
@@ -169,6 +184,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the label text color of a widget (r, g, b in 0–255).",
         ts_signature: "widget_set_label_color(widget: number, r: number, g: number, b: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_resize",
@@ -185,6 +201,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Moves and resizes a widget (x, y, w, h).",
         ts_signature: "widget_resize(widget: number, x: number, y: number, w: number, h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_redraw",
@@ -195,6 +212,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Marks the widget as needing a redraw.",
         ts_signature: "widget_redraw(widget: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_hide",
@@ -205,6 +223,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Hides the widget.",
         ts_signature: "widget_hide(widget: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_show",
@@ -215,6 +234,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Shows the widget.",
         ts_signature: "widget_show(widget: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "widget_set_draw",
@@ -225,6 +245,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets a custom draw callback. Use draw_* functions inside to paint the widget.",
         ts_signature: "widget_set_draw(widget: number, fn: () => void): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Button ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -242,6 +263,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a push button at (x, y) with size (w, h) and label.",
         ts_signature: "button_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     // ── Frame ────────────────────────────────────────────────────────────
     NamespaceMember {
@@ -259,6 +281,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a text frame (static label) at (x, y) with size (w, h) and text.",
         ts_signature: "frame_new(x: number, y: number, w: number, h: number, text: string): number",
         intrinsic: None,
+        pure: false,
     },
     // ── CheckButton ──────────────────────────────────────────────────────
     NamespaceMember {
@@ -276,6 +299,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a checkbox widget.",
         ts_signature: "check_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "check_value",
@@ -286,6 +310,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns true if the checkbox is checked.",
         ts_signature: "check_value(handle: number): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "check_set_value",
@@ -296,6 +321,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the checked state of a checkbox.",
         ts_signature: "check_set_value(handle: number, val: boolean): void",
         intrinsic: None,
+        pure: false,
     },
     // ── RadioButton ──────────────────────────────────────────────────────
     NamespaceMember {
@@ -313,6 +339,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a radio button widget.",
         ts_signature: "radio_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "radio_value",
@@ -323,6 +350,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns true if the radio button is selected.",
         ts_signature: "radio_value(handle: number): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "radio_set_value",
@@ -333,6 +361,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the selected state of a radio button.",
         ts_signature: "radio_set_value(handle: number, val: boolean): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Input ────────────────────────────────────────────────────────────
     NamespaceMember {
@@ -350,6 +379,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a single-line text input field.",
         ts_signature: "input_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "input_value",
@@ -360,6 +390,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the current text of the input field as a GC string handle.",
         ts_signature: "input_value(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "input_set_value",
@@ -370,6 +401,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the text content of an input field.",
         ts_signature: "input_set_value(handle: number, text: string): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Output ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -387,6 +419,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a read-only output widget.",
         ts_signature: "output_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "output_set_value",
@@ -397,6 +430,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the text displayed in an output widget.",
         ts_signature: "output_set_value(handle: number, text: string): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Slider ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -414,6 +448,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a horizontal slider.",
         ts_signature: "slider_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "slider_value",
@@ -424,6 +459,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the current value of a slider.",
         ts_signature: "slider_value(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "slider_set_value",
@@ -434,6 +470,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the current value of a slider.",
         ts_signature: "slider_set_value(handle: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "slider_set_bounds",
@@ -444,6 +481,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the minimum and maximum bounds of a slider.",
         ts_signature: "slider_set_bounds(handle: number, min: number, max: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Progress ─────────────────────────────────────────────────────────
     NamespaceMember {
@@ -461,6 +499,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a progress bar widget.",
         ts_signature: "progress_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "progress_value",
@@ -471,6 +510,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the current value of a progress bar.",
         ts_signature: "progress_value(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "progress_set_value",
@@ -481,6 +521,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the current value of a progress bar.",
         ts_signature: "progress_set_value(handle: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Spinner ──────────────────────────────────────────────────────────
     NamespaceMember {
@@ -498,6 +539,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a numeric spinner widget.",
         ts_signature: "spinner_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "spinner_value",
@@ -508,6 +550,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the current numeric value of a spinner.",
         ts_signature: "spinner_value(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "spinner_set_value",
@@ -518,6 +561,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the numeric value of a spinner.",
         ts_signature: "spinner_set_value(handle: number, val: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "spinner_set_bounds",
@@ -528,6 +572,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the min/max range of a spinner.",
         ts_signature: "spinner_set_bounds(handle: number, min: number, max: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── MenuBar ──────────────────────────────────────────────────────────
     NamespaceMember {
@@ -539,6 +584,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a menu bar at (x, y) with size (w, h).",
         ts_signature: "menubar_new(x: number, y: number, w: number, h: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "menubar_add",
@@ -549,6 +595,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Adds a menu item. Path uses '/' for submenus (e.g. 'File/Open'). fn_ptr=0 for separators.",
         ts_signature: "menubar_add(handle: number, path: string, fn: () => void): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "menubar_free",
@@ -559,6 +606,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Frees a menu bar handle.",
         ts_signature: "menubar_free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── TextBuffer ───────────────────────────────────────────────────────
     NamespaceMember {
@@ -570,6 +618,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a text buffer.",
         ts_signature: "textbuf_new(): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "textbuf_set_text",
@@ -580,6 +629,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Replaces the entire text buffer contents.",
         ts_signature: "textbuf_set_text(handle: number, text: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "textbuf_text",
@@ -590,6 +640,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the text buffer contents as a GC string handle.",
         ts_signature: "textbuf_text(handle: number): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "textbuf_append",
@@ -600,6 +651,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Appends text to the end of the buffer.",
         ts_signature: "textbuf_append(handle: number, text: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "textbuf_free",
@@ -610,6 +662,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Frees the text buffer handle.",
         ts_signature: "textbuf_free(handle: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── TextDisplay ──────────────────────────────────────────────────────
     NamespaceMember {
@@ -627,6 +680,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates a read-only text display widget.",
         ts_signature: "textdisplay_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "textdisplay_set_buffer",
@@ -637,6 +691,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Associates a TextBuffer with the display.",
         ts_signature: "textdisplay_set_buffer(display: number, buf: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── TextEditor ───────────────────────────────────────────────────────
     NamespaceMember {
@@ -654,6 +709,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Creates an editable text editor widget.",
         ts_signature: "texteditor_new(x: number, y: number, w: number, h: number, label: string): number",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "texteditor_set_buffer",
@@ -664,6 +720,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Associates a TextBuffer with the editor.",
         ts_signature: "texteditor_set_buffer(editor: number, buf: number): void",
         intrinsic: None,
+        pure: false,
     },
     // ── Draw ─────────────────────────────────────────────────────────────
     NamespaceMember {
@@ -675,6 +732,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws a rectangle outline at (x, y) with size (w, h).",
         ts_signature: "draw_rect(x: number, y: number, w: number, h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "draw_rect_fill",
@@ -685,6 +743,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws a filled rectangle at (x, y) with size (w, h).",
         ts_signature: "draw_rect_fill(x: number, y: number, w: number, h: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "draw_line",
@@ -695,6 +754,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws a line from (x1, y1) to (x2, y2).",
         ts_signature: "draw_line(x1: number, y1: number, x2: number, y2: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "draw_circle",
@@ -705,6 +765,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws a circle centered at (x, y) with radius r.",
         ts_signature: "draw_circle(x: number, y: number, r: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "draw_arc",
@@ -722,6 +783,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws an arc/pie within bounding box (x, y, w, h) from angle a1 to a2 (degrees).",
         ts_signature: "draw_arc(x: number, y: number, w: number, h: number, a1: number, a2: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "draw_text",
@@ -732,6 +794,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Draws text at (x, y) using the current font and color.",
         ts_signature: "draw_text(text: string, x: number, y: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "set_draw_color",
@@ -742,6 +805,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the current drawing color (r, g, b in 0–255).",
         ts_signature: "set_draw_color(r: number, g: number, b: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "set_font",
@@ -752,6 +816,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets the current font (font_id: 0=Helvetica..14, size in pixels).",
         ts_signature: "set_font(font_id: number, size: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "set_line_style",
@@ -762,6 +827,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Sets line style (style: 0=solid,1=dash,2=dot) and width in pixels.",
         ts_signature: "set_line_style(style: number, width: number): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "measure_width",
@@ -772,6 +838,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Returns the pixel width of a string in the current font.",
         ts_signature: "measure_width(text: string): number",
         intrinsic: None,
+        pure: false,
     },
     // ── Dialog ───────────────────────────────────────────────────────────
     NamespaceMember {
@@ -783,6 +850,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Shows a blocking alert dialog with a message.",
         ts_signature: "alert(msg: string): void",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "dialog_ask",
@@ -793,6 +861,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Shows a yes/no dialog. Returns true if user clicks Yes.",
         ts_signature: "dialog_ask(msg: string): boolean",
         intrinsic: None,
+        pure: false,
     },
     NamespaceMember {
         name: "dialog_input",
@@ -803,6 +872,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Shows an input dialog (label, def). Returns GC string handle, or 0 on cancel.",
         ts_signature: "dialog_input(label: string, def: string): number",
         intrinsic: None,
+        pure: false,
     },
 ];
 

--- a/tests/parallel_map_collections.test.ts
+++ b/tests/parallel_map_collections.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "rts:test";
+import { math, parallel, collections, gc } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// 1) parallel.map result is a fully-functional Vec (uses sharded handle table).
+function cube(x: number): number {
+  return x * x * x;
+}
+const cfp = cube as unknown as number;
+const nums = [1, 2, 3, 4, 5];
+const cubed = parallel.map(nums, cfp);
+
+const cLen = gc.string_from_i64(collections.vec_len(cubed));
+print(cLen); gc.string_free(cLen); // 5
+
+const c0 = gc.string_from_i64(collections.vec_get(cubed, 0));
+print(c0); gc.string_free(c0); // 1
+
+const c2 = gc.string_from_i64(collections.vec_get(cubed, 2));
+print(c2); gc.string_free(c2); // 27
+
+const c4 = gc.string_from_i64(collections.vec_get(cubed, 4));
+print(c4); gc.string_free(c4); // 125
+
+// 2) parallel.map on a Vec created by vec_new + vec_push.
+const h = collections.vec_new();
+collections.vec_push(h, 10);
+collections.vec_push(h, 20);
+collections.vec_push(h, 30);
+
+function halve(x: number): number {
+  return x / 2;
+}
+const hfp = halve as unknown as number;
+const halved = parallel.map(h, hfp);
+
+const h0 = gc.string_from_i64(collections.vec_get(halved, 0));
+print(h0); gc.string_free(h0); // 5
+
+const h1 = gc.string_from_i64(collections.vec_get(halved, 2));
+print(h1); gc.string_free(h1); // 15
+
+// 3) parallel.reduce after parallel.map (chain of parallel ops).
+function sumTwo(acc: number, x: number): number {
+  return acc + x;
+}
+const sfp = sumTwo as unknown as number;
+const total = parallel.reduce(cubed, 0, sfp);
+const ht = gc.string_from_i64(total);
+print(ht); gc.string_free(ht); // 1+8+27+64+125 = 225
+
+// 4) parallel.map empty vec → vec_len = 0.
+const empty = collections.vec_new();
+function identity(x: number): number { return x; }
+const ifp = identity as unknown as number;
+const mapped_empty = parallel.map(empty, ifp);
+const eLen = gc.string_from_i64(collections.vec_len(mapped_empty));
+print(eLen); gc.string_free(eLen); // 0
+
+// 5) vec_set on parallel.map result.
+collections.vec_set(cubed, 0, 999);
+const after = gc.string_from_i64(collections.vec_get(cubed, 0));
+print(after); gc.string_free(after); // 999
+
+describe("fixture:parallel_map_collections", () => {
+  test("parallel.map integrates with sharded HandleTable", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "5\n1\n27\n125\n5\n15\n225\n0\n999\n"
+    );
+  });
+});

--- a/tests/parallel_purity_pass.test.ts
+++ b/tests/parallel_purity_pass.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "rts:test";
+import { math, parallel, collections, gc } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// 1) parallel.num_threads() > 0 (Rayon pool alive)
+const nt = parallel.num_threads();
+if (nt > 0) {
+  print("num-threads-ok");
+} else {
+  print("FAIL: num_threads=0");
+}
+
+// 2) Pure for...of: body only reads loop var + calls pure math fns.
+//    Purity pass should rewrite to parallel.for_each. No crash = pass.
+const angles = [0, 1, 2, 3, 4, 5, 6, 7];
+for (const x of angles) {
+  const s = math.sin(x as number);
+  const c = math.cos(s);
+}
+print("pure-forof-ok");
+
+// 3) Manual parallel.for_each with a top-level function.
+function doubleWorker(x: number): void {
+  // reads x, pure computation — just validate it runs
+  const _ = x * 2;
+}
+const dfp = doubleWorker as unknown as number;
+const nums = [10, 20, 30, 40];
+parallel.for_each(nums, dfp);
+print("manual-foreach-ok");
+
+// 4) parallel.map: results collected correctly.
+function squareFn(x: number): number {
+  return x * x;
+}
+const sfp = squareFn as unknown as number;
+const src = [1, 2, 3, 4, 5];
+const squared = parallel.map(src, sfp);
+const len = collections.vec_len(squared);
+const h = gc.string_from_i64(len);
+print(h); gc.string_free(h);   // expect 5
+
+const v0 = collections.vec_get(squared, 0);
+const hv0 = gc.string_from_i64(v0);
+print(hv0); gc.string_free(hv0); // expect 1
+
+const v4 = collections.vec_get(squared, 4);
+const hv4 = gc.string_from_i64(v4);
+print(hv4); gc.string_free(hv4); // expect 25
+
+// 5) parallel.reduce: sum of [1..5] = 15
+function addFn(acc: number, x: number): number {
+  return acc + x;
+}
+const afp = addFn as unknown as number;
+const total = parallel.reduce(src, 0, afp);
+const ht = gc.string_from_i64(total);
+print(ht); gc.string_free(ht); // expect 15
+
+// 6) Multiple pure for...of loops (each gets own __par_forof_N).
+const vals = [100, 200, 300];
+for (const v of vals) {
+  const norm = v as number / 100.0;
+  const sq = math.sqrt(norm);
+}
+for (const v of vals) {
+  const lg = math.log2(v as number);
+}
+print("multi-forof-ok");
+
+describe("fixture:parallel_purity_pass", () => {
+  test("parallel infrastructure + purity pass smoke", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "num-threads-ok\npure-forof-ok\nmanual-foreach-ok\n5\n1\n25\n15\nmulti-forof-ok\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implementa paralelismo em três camadas, conforme #231:

- **Nível 1 (silencioso):** `for...of` puro → `parallel.for_each` automático via purity pass no codegen
- **Nível 2 (explícito):** namespace `parallel` com `map`/`for_each`/`reduce`/`num_threads`
- **Nível 3 (controle total):** namespaces `thread`, `atomic`, `sync` completos

### Purity pass (Level-1)

`purity_pass` analisa estaticamente loops `for...of` top-level. Se o corpo só chama membros `pure: true` de namespaces e só referencia a variável de loop + decls internas, reescreve para `parallel.for_each(arr, __par_forof_N)` com trampolim sintético — zero mudança na API TS.

`lift_arrow_callbacks` estendido para `parallel.*`: gera trampolins `__lifted_arrow_N` com params `i64` bridging a fronteira Rayon → user fn (que pode ter params `f64`).

### HandleTable sharding

32 shards (`N_SHARDS = 32`), shard index encodado nos bits 0..4 do slot field. `alloc_entry` round-robin por thread, `shard_for_handle` O(1). Elimina serialização global de GC em contextos paralelos.

### Fix: collections::vec shard mismatch

`with_vec`/`with_vec_mut` usavam `table()` (deprecated, shard 0 only). `parallel.map` aloca o Vec resultado via `alloc_entry` (qualquer shard). Quando handle ia para shard != 0, `vec_len`/`vec_get` retornavam -1/0. Fix: migrar para `shard_for_handle(handle)`.

Issue para remover `table()` dos namespaces restantes: #232

## Test plan

- [x] `tests/parallel_purity_pass.test.ts` — smoke test completo (Level-1 + Level-2): passa solo e em suite completa
- [x] `tests/parallel_map_collections.test.ts` — `parallel.map` result interage corretamente com `collections.vec_*` (sharded handles)
- [x] `examples/parallel_purity.ts` — demo executável via `rts run`
- [x] Suite completa: 197/200 testes passando (3 falhas pré-existentes, sem regressões)
- [x] `cargo build --release` sem erros

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)