### PR TITLE
feat(builtin): http package — fetch unificado HTTP/HTTPS (closes #240)

### DIFF
--- a/builtin/http/package.json
+++ b/builtin/http/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "http",
+  "version": "0.1.0",
+  "main": "src/main.ts"
+}

--- a/builtin/http/src/fetch.ts
+++ b/builtin/http/src/fetch.ts
@@ -1,0 +1,159 @@
+// fetch unificado — escolhe net (HTTP) ou tls (HTTPS) automaticamente.
+
+import { net, tls, buffer, string, thread } from "rts";
+import { ParsedUrl, parseUrl } from "./url";
+import { Response } from "./response";
+import { RequestInit, defaultInit } from "./request";
+
+const RECV_BUFFER_SIZE = 8192;
+
+export function fetch(url: string): Response {
+  return fetchWith(url, defaultInit());
+}
+
+export function fetchWith(url: string, init: RequestInit): Response {
+  const u = parseUrl(url);
+
+  const addr = u.host + ":" + (u.port as unknown as string);
+  const tcp = net.tcp_connect(addr);
+  if (tcp == 0) {
+    return new Response(0, "tcp_connect failed", "", "");
+  }
+
+  if (u.scheme == "https") {
+    return doRequestTls(tcp, u, init);
+  } else {
+    return doRequestPlain(tcp, u, init);
+  }
+}
+
+function buildRequestLine(u: ParsedUrl, init: RequestInit): string {
+  let req = "";
+  req = req + init.method + " " + u.path + " HTTP/1.1\r\n";
+  req = req + "Host: " + u.host + "\r\n";
+  req = req + "User-Agent: rts-http/0.1\r\n";
+  req = req + "Accept: */*\r\n";
+  req = req + "Connection: close\r\n";
+  if (string.byte_len(init.headers) > 0) {
+    req = req + init.headers;
+  }
+  if (string.byte_len(init.body) > 0) {
+    req = req + "Content-Length: " + (string.byte_len(init.body) as unknown as string) + "\r\n";
+  }
+  req = req + "\r\n";
+  if (string.byte_len(init.body) > 0) {
+    req = req + init.body;
+  }
+  return req;
+}
+
+function doRequestPlain(tcp: number, u: ParsedUrl, init: RequestInit): Response {
+  const req = buildRequestLine(u, init);
+  const sent = net.tcp_send(tcp, req);
+  if (sent < 0) {
+    net.tcp_close(tcp);
+    return new Response(0, "tcp_send failed", "", "");
+  }
+
+  thread.sleep_ms(300);
+
+  const buf = buffer.alloc_zeroed(RECV_BUFFER_SIZE);
+  const n = net.tcp_recv(tcp, buffer.ptr(buf), RECV_BUFFER_SIZE);
+  net.tcp_close(tcp);
+
+  if (n <= 0) {
+    buffer.free(buf);
+    return new Response(0, "tcp_recv failed", "", "");
+  }
+
+  const raw = buffer.to_string(buf);
+  buffer.free(buf);
+  return parseResponse(raw, n);
+}
+
+function doRequestTls(tcp: number, u: ParsedUrl, init: RequestInit): Response {
+  const stream = tls.client(tcp, u.host);
+  if (stream == 0) {
+    return new Response(0, "tls handshake failed", "", "");
+  }
+
+  const req = buildRequestLine(u, init);
+  const sent = tls.send(stream, req);
+  if (sent < 0) {
+    tls.close(stream);
+    return new Response(0, "tls.send failed", "", "");
+  }
+
+  thread.sleep_ms(500);
+
+  const buf = buffer.alloc_zeroed(RECV_BUFFER_SIZE);
+  const n = tls.recv(stream, buffer.ptr(buf), RECV_BUFFER_SIZE);
+  tls.close(stream);
+
+  if (n <= 0) {
+    buffer.free(buf);
+    return new Response(0, "tls.recv failed", "", "");
+  }
+
+  const raw = buffer.to_string(buf);
+  buffer.free(buf);
+  return parseResponse(raw, n);
+}
+
+function parseResponse(raw: string, totalBytes: number): Response {
+  // status line: "HTTP/1.1 NNN REASON\r\n"
+  const eol1 = string.find(raw, "\r\n");
+  if (eol1 < 0) {
+    return new Response(0, "no status line", "", "");
+  }
+  const statusLine = sliceTo(raw, eol1);
+  const sp1 = string.find(statusLine, " ");
+  const rest = sliceFrom(statusLine, sp1 + 1);
+  const sp2 = string.find(rest, " ");
+  const codeStr = sliceTo(rest, sp2);
+  const reason = sliceFrom(rest, sp2 + 1);
+  const status = parseIntStr(codeStr);
+
+  // headers
+  const sep = string.find(raw, "\r\n\r\n");
+  if (sep < 0) {
+    return new Response(status, reason, "", "");
+  }
+  const headersRaw = sliceFromTo(raw, eol1 + 2, sep);
+
+  // body
+  const bodyStart = sep + 4;
+  const body = sliceFromTo(raw, bodyStart, totalBytes);
+
+  return new Response(status, reason, headersRaw, body);
+}
+
+function parseIntStr(s: string): number {
+  let n = 0;
+  const len = string.char_count(s);
+  for (let i = 0; i < len; i = i + 1) {
+    const c = string.char_code_at(s, i);
+    if (c < 48 || c > 57) break;
+    n = n * 10 + (c - 48);
+  }
+  return n;
+}
+
+function sliceTo(s: string, end: number): string {
+  let out = "";
+  for (let i = 0; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+function sliceFrom(s: string, start: number): string {
+  let out = "";
+  const n = string.char_count(s);
+  for (let i = start; i < n; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+function sliceFromTo(s: string, start: number, end: number): string {
+  let out = "";
+  for (let i = start; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}

--- a/builtin/http/src/main.ts
+++ b/builtin/http/src/main.ts
@@ -1,0 +1,11 @@
+// http builtin — fetch unificado HTTP/HTTPS sobre net + tls.
+//
+// Uso:
+//   import { fetch } from "http";
+//   const r = fetch("https://api.github.com/users/torvalds");
+//   if (r.ok()) console.log(r.text());
+
+export { fetch, fetchWith } from "./fetch";
+export { Response } from "./response";
+export { Request, RequestInit, defaultInit } from "./request";
+export { ParsedUrl, parseUrl } from "./url";

--- a/builtin/http/src/request.ts
+++ b/builtin/http/src/request.ts
@@ -1,0 +1,30 @@
+// Request descriptor — usado pra montar a request HTTP/1.1 raw.
+
+export class Request {
+  url: string;
+  method: string;
+  headers: string;  // raw "Name: value\r\n..."
+  body: string;
+
+  constructor(url: string, method: string, headers: string, body: string) {
+    this.url = url;
+    this.method = method;
+    this.headers = headers;
+    this.body = body;
+  }
+}
+
+export class RequestInit {
+  method: string;
+  headers: string;
+  body: string;
+  constructor(method: string, headers: string, body: string) {
+    this.method = method;
+    this.headers = headers;
+    this.body = body;
+  }
+}
+
+export function defaultInit(): RequestInit {
+  return new RequestInit("GET", "", "");
+}

--- a/builtin/http/src/response.ts
+++ b/builtin/http/src/response.ts
@@ -1,0 +1,58 @@
+// Response — encapsula status code, headers, body recebido.
+
+import { string } from "rts";
+
+export class Response {
+  status: number;
+  statusText: string;
+  headersRaw: string;
+  body: string;
+
+  constructor(status: number, statusText: string, headersRaw: string, body: string) {
+    this.status = status;
+    this.statusText = statusText;
+    this.headersRaw = headersRaw;
+    this.body = body;
+  }
+
+  // Le um header pelo nome (case-insensitive). Retorna "" se nao existe.
+  header(name: string): string {
+    const lowered = string.to_lower(this.headersRaw);
+    const target = string.to_lower(name) + ":";
+    const idx = string.find(lowered, target);
+    if (idx < 0) return "";
+    // Garante que esta no inicio de linha (idx == 0 ou char anterior == \n).
+    if (idx > 0) {
+      const prev = string.char_code_at(this.headersRaw, idx - 1);
+      if (prev != 10) return "";  // \n = 10
+    }
+    // Acha o valor: depois do : ate \r ou \n
+    const valStart = idx + string.char_count(target);
+    const tail = sliceFrom(this.headersRaw, valStart);
+    const eol = string.find(tail, "\r");
+    const value = eol >= 0 ? sliceTo(tail, eol) : tail;
+    return string.trim(value);
+  }
+
+  text(): string {
+    return this.body;
+  }
+
+  // ok = status na faixa 200-299
+  ok(): boolean {
+    return this.status >= 200 && this.status < 300;
+  }
+}
+
+function sliceTo(s: string, end: number): string {
+  let out = "";
+  for (let i = 0; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+function sliceFrom(s: string, start: number): string {
+  let out = "";
+  const n = string.char_count(s);
+  for (let i = start; i < n; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}

--- a/builtin/http/src/url.ts
+++ b/builtin/http/src/url.ts
@@ -1,0 +1,76 @@
+// parseUrl — quebra "scheme://host[:port][/path]" em partes.
+//
+// Limitacoes:
+//   - sem suporte a userinfo (user:pass@host)
+//   - sem suporte a fragment (#frag)
+//   - query e mantida no path (path inclui ?...)
+
+import { string } from "rts";
+
+export class ParsedUrl {
+  scheme: string;
+  host: string;
+  port: number;
+  path: string;
+  constructor(scheme: string, host: string, port: number, path: string) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.path = path;
+  }
+}
+
+export function parseUrl(url: string): ParsedUrl {
+  // scheme
+  const sepScheme = string.find(url, "://");
+  if (sepScheme < 0) {
+    // url relativa? tratamos como http://url
+    return new ParsedUrl("http", url, 80, "/");
+  }
+  const scheme = sliceTo(url, sepScheme);
+  const rest = sliceFrom(url, sepScheme + 3);
+
+  // host[:port]/path
+  const slash = string.find(rest, "/");
+  let hostPort = rest;
+  let path = "/";
+  if (slash >= 0) {
+    hostPort = sliceTo(rest, slash);
+    path = sliceFrom(rest, slash);
+  }
+
+  let host = hostPort;
+  let port = scheme == "https" ? 443 : 80;
+  const colon = string.find(hostPort, ":");
+  if (colon >= 0) {
+    host = sliceTo(hostPort, colon);
+    const portStr = sliceFrom(hostPort, colon + 1);
+    port = parseIntStr(portStr);
+  }
+
+  return new ParsedUrl(scheme, host, port, path);
+}
+
+function sliceTo(s: string, end: number): string {
+  let out = "";
+  for (let i = 0; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+function sliceFrom(s: string, start: number): string {
+  let out = "";
+  const n = string.char_count(s);
+  for (let i = start; i < n; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+function parseIntStr(s: string): number {
+  let n = 0;
+  const len = string.char_count(s);
+  for (let i = 0; i < len; i = i + 1) {
+    const c = string.char_code_at(s, i);
+    if (c < 48 || c > 57) break;  // nao-digito interrompe
+    n = n * 10 + (c - 48);
+  }
+  return n;
+}

--- a/examples/http_unified.ts
+++ b/examples/http_unified.ts
@@ -1,0 +1,180 @@
+// Cliente HTTP/HTTPS unificado em arquivo unico.
+// Inline da logica do builtin/http/ — quando o resolver de packages
+// builtin estiver pronto, vamos usar import { fetch } from "http".
+//
+// Uso:
+//   target/release/rts.exe run examples/http_unified.ts
+
+import { net, tls, buffer, string, thread, io } from "rts";
+
+const RECV_BUFFER_SIZE = 8192;
+
+class ParsedUrl {
+  scheme: string;
+  host: string;
+  port: number;
+  path: string;
+  constructor(scheme: string, host: string, port: number, path: string) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.path = path;
+  }
+}
+
+class Response {
+  status: number;
+  statusText: string;
+  headersRaw: string;
+  body: string;
+  constructor(status: number, statusText: string, headersRaw: string, body: string) {
+    this.status = status;
+    this.statusText = statusText;
+    this.headersRaw = headersRaw;
+    this.body = body;
+  }
+  ok(): boolean { return this.status >= 200 && this.status < 300; }
+}
+
+function fetch(url: string): Response {
+  const u = parseUrl(url);
+  const addr = u.host + ":" + (u.port as unknown as string);
+  const tcp = net.tcp_connect(addr);
+  if (tcp == 0) {
+    return new Response(0, "tcp_connect failed", "", "");
+  }
+
+  if (u.scheme == "https") {
+    return doRequestTls(tcp, u);
+  } else {
+    return doRequestPlain(tcp, u);
+  }
+}
+
+function buildRequestLine(u: ParsedUrl): string {
+  let req = "";
+  req = req + "GET " + u.path + " HTTP/1.1\r\n";
+  req = req + "Host: " + u.host + "\r\n";
+  req = req + "User-Agent: rts-http/0.1\r\n";
+  req = req + "Accept: */*\r\n";
+  req = req + "Connection: close\r\n";
+  req = req + "\r\n";
+  return req;
+}
+
+function doRequestPlain(tcp: number, u: ParsedUrl): Response {
+  const req = buildRequestLine(u);
+  const sent = net.tcp_send(tcp, req);
+  if (sent < 0) { net.tcp_close(tcp); return new Response(0, "tcp_send failed", "", ""); }
+  thread.sleep_ms(300);
+  const buf = buffer.alloc_zeroed(RECV_BUFFER_SIZE);
+  const n = net.tcp_recv(tcp, buffer.ptr(buf), RECV_BUFFER_SIZE);
+  net.tcp_close(tcp);
+  if (n <= 0) { buffer.free(buf); return new Response(0, "tcp_recv failed", "", ""); }
+  const raw = buffer.to_string(buf);
+  buffer.free(buf);
+  return parseResponse(raw, n);
+}
+
+function doRequestTls(tcp: number, u: ParsedUrl): Response {
+  const stream = tls.client(tcp, u.host);
+  if (stream == 0) return new Response(0, "tls handshake failed", "", "");
+  const req = buildRequestLine(u);
+  const sent = tls.send(stream, req);
+  if (sent < 0) { tls.close(stream); return new Response(0, "tls.send failed", "", ""); }
+  thread.sleep_ms(500);
+  const buf = buffer.alloc_zeroed(RECV_BUFFER_SIZE);
+  const n = tls.recv(stream, buffer.ptr(buf), RECV_BUFFER_SIZE);
+  tls.close(stream);
+  if (n <= 0) { buffer.free(buf); return new Response(0, "tls.recv failed", "", ""); }
+  const raw = buffer.to_string(buf);
+  buffer.free(buf);
+  return parseResponse(raw, n);
+}
+
+function parseResponse(raw: string, totalBytes: number): Response {
+  const eol1 = string.find(raw, "\r\n");
+  if (eol1 < 0) return new Response(0, "no status line", "", "");
+  const statusLine = sliceTo(raw, eol1);
+  const sp1 = string.find(statusLine, " ");
+  const rest = sliceFrom(statusLine, sp1 + 1);
+  const sp2 = string.find(rest, " ");
+  const codeStr = sliceTo(rest, sp2);
+  const reason = sliceFrom(rest, sp2 + 1);
+  const status = parseIntStr(codeStr);
+  const sep = string.find(raw, "\r\n\r\n");
+  if (sep < 0) return new Response(status, reason, "", "");
+  const headersRaw = sliceFromTo(raw, eol1 + 2, sep);
+  const bodyStart = sep + 4;
+  const body = sliceFromTo(raw, bodyStart, totalBytes);
+  return new Response(status, reason, headersRaw, body);
+}
+
+function parseUrl(url: string): ParsedUrl {
+  const sepScheme = string.find(url, "://");
+  if (sepScheme < 0) return new ParsedUrl("http", url, 80, "/");
+  const scheme = sliceTo(url, sepScheme);
+  const rest = sliceFrom(url, sepScheme + 3);
+  const slash = string.find(rest, "/");
+  let hostPort = rest;
+  let path = "/";
+  if (slash >= 0) {
+    hostPort = sliceTo(rest, slash);
+    path = sliceFrom(rest, slash);
+  }
+  let host = hostPort;
+  let port = scheme == "https" ? 443 : 80;
+  const colon = string.find(hostPort, ":");
+  if (colon >= 0) {
+    host = sliceTo(hostPort, colon);
+    port = parseIntStr(sliceFrom(hostPort, colon + 1));
+  }
+  return new ParsedUrl(scheme, host, port, path);
+}
+
+function show(url: string): void {
+  io.print("");
+  io.print("→ " + url);
+  const r = fetch(url);
+  io.print("  status: " + r.status + " " + r.statusText);
+  // OBS: string.byte_len em vez de .length (strings vindas de buffer
+  // podem conter \0 e .length para na primeira ocorrencia — bug #235).
+  const bodyLen = string.byte_len(r.body);
+  io.print("  body length: " + bodyLen + " bytes");
+  if (bodyLen > 0) {
+    const previewLen = bodyLen > 200 ? 200 : bodyLen;
+    io.print("  body preview: " + sliceTo(r.body, previewLen));
+  }
+}
+
+show("http://httpforever.com/");
+show("https://api.github.com/");
+io.print("");
+io.print("✓ mesma API, dois protocolos");
+
+function parseIntStr(s: string): number {
+  let n = 0;
+  const len = string.char_count(s);
+  for (let i = 0; i < len; i = i + 1) {
+    const c = string.char_code_at(s, i);
+    if (c < 48 || c > 57) break;
+    n = n * 10 + (c - 48);
+  }
+  return n;
+}
+function sliceTo(s: string, end: number): string {
+  let out = "";
+  for (let i = 0; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+function sliceFrom(s: string, start: number): string {
+  let out = "";
+  const n = string.char_count(s);
+  for (let i = start; i < n; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+function sliceFromTo(s: string, start: number, end: number): string {
+  let out = "";
+  for (let i = start; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}

--- a/tests/http_unified.test.ts
+++ b/tests/http_unified.test.ts
@@ -1,0 +1,112 @@
+// fetch() unificado HTTP/HTTPS — mesma API resolve os dois schemes.
+import { describe, test, expect } from "rts:test";
+import { net, tls, buffer, string, thread } from "rts";
+
+// Inline da mesma logica do builtin/http (resolver de packages
+// builtin nao auto-detecta builtin/ ainda).
+
+class ParsedUrl {
+  scheme: string;
+  host: string;
+  port: number;
+  path: string;
+  constructor(scheme: string, host: string, port: number, path: string) {
+    this.scheme = scheme;
+    this.host = host;
+    this.port = port;
+    this.path = path;
+  }
+}
+
+class Response {
+  status: number;
+  body: string;
+  bodyLen: number;
+  constructor(status: number, body: string, bodyLen: number) {
+    this.status = status;
+    this.body = body;
+    this.bodyLen = bodyLen;
+  }
+}
+
+function parseUrl(url: string): ParsedUrl {
+  const sepScheme = string.find(url, "://");
+  const scheme = sliceTo(url, sepScheme);
+  const rest = sliceFrom(url, sepScheme + 3);
+  const slash = string.find(rest, "/");
+  const hostPort = slash >= 0 ? sliceTo(rest, slash) : rest;
+  const path = slash >= 0 ? sliceFrom(rest, slash) : "/";
+  return new ParsedUrl(scheme, hostPort, scheme == "https" ? 443 : 80, path);
+}
+
+function fetchUrl(url: string): Response {
+  const u = parseUrl(url);
+  const tcp = net.tcp_connect(u.host + ":" + (u.port as unknown as string));
+  if (tcp == 0) return new Response(0, "", 0);
+
+  let req = "";
+  req = req + "GET " + u.path + " HTTP/1.1\r\n";
+  req = req + "Host: " + u.host + "\r\n";
+  req = req + "User-Agent: rts-test/0.1\r\n";
+  req = req + "Connection: close\r\n\r\n";
+
+  const buf = buffer.alloc_zeroed(8192);
+  let n = 0;
+
+  if (u.scheme == "https") {
+    const stream = tls.client(tcp, u.host);
+    if (stream == 0) { buffer.free(buf); return new Response(0, "", 0); }
+    tls.send(stream, req);
+    thread.sleep_ms(500);
+    n = tls.recv(stream, buffer.ptr(buf), 8192);
+    tls.close(stream);
+  } else {
+    net.tcp_send(tcp, req);
+    thread.sleep_ms(300);
+    n = net.tcp_recv(tcp, buffer.ptr(buf), 8192);
+    net.tcp_close(tcp);
+  }
+
+  if (n <= 0) { buffer.free(buf); return new Response(0, "", 0); }
+
+  const raw = buffer.to_string(buf);
+  buffer.free(buf);
+  // status code: chars 9..12 de "HTTP/1.1 200 OK"
+  let status = 0;
+  for (let i = 9; i < 12; i = i + 1) {
+    const c = string.char_code_at(raw, i);
+    if (c < 48 || c > 57) break;
+    status = status * 10 + (c - 48);
+  }
+  const sep = string.find(raw, "\r\n\r\n");
+  if (sep < 0) return new Response(status, "", 0);
+  const bodyStart = sep + 4;
+  const bodyLen = n - bodyStart;
+  return new Response(status, "", bodyLen);
+}
+
+function sliceTo(s: string, end: number): string {
+  let out = "";
+  for (let i = 0; i < end; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+function sliceFrom(s: string, start: number): string {
+  let out = "";
+  const n = string.char_count(s);
+  for (let i = start; i < n; i = i + 1) out = out + string.char_at(s, i);
+  return out;
+}
+
+describe("fixture:http_unified", () => {
+  test("HTTP plain via fetch unificado", () => {
+    const r = fetchUrl("http://httpforever.com/");
+    expect(r.status == 200 ? "1" : "0").toBe("1");
+    expect(r.bodyLen > 100 ? "1" : "0").toBe("1");
+  });
+
+  test("HTTPS via fetch unificado (mesma fn, scheme detectado)", () => {
+    const r = fetchUrl("https://api.github.com/");
+    expect(r.status == 200 ? "1" : "0").toBe("1");
+    expect(r.bodyLen > 100 ? "1" : "0").toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary

- Novo package \`builtin/http/\` — TS puro envolvendo \`net\` + \`tls\`
- Mesma fn \`fetch(url)\` lida com \`http://\` (via \`net\`) e \`https://\` (via \`net\` + \`tls\`)
- Scheme da URL detectado automaticamente

## API

\`\`\`ts
import { fetch } from \"http\";

const r1 = fetch(\"http://httpforever.com/\");      // → net
const r2 = fetch(\"https://api.github.com/users/torvalds\");  // → net+tls

console.log(r2.status);          // 200
console.log(r2.header(\"content-type\"));  // application/json
console.log(r2.body);            // JSON real
\`\`\`

## Estrutura

\`\`\`
builtin/http/
  package.json
  src/main.ts       — exports
  src/url.ts        — parseUrl(string) → { scheme, host, port, path }
  src/request.ts    — Request, RequestInit
  src/response.ts   — Response (status, headers, body, ok())
  src/fetch.ts      — fetch(url), fetchWith(url, init)
\`\`\`

## Test plan

- [x] \`tests/http_unified.test.ts\` — 2/2 passam (HTTP plain + HTTPS via mesma API)
- [x] Demo \`examples/http_unified.ts\` recebe HTML do httpforever (5124 bytes) e JSON da GitHub API (2396 bytes)
- [x] Suite completa: lib tests passam (sem regressões)

## Limitações conhecidas (MVP)

- Single recv chunk (8 KB max body) — bug #237 (aritmética de u64 ptr) impede loop com offset
- Sync (sem Promise) — async vira na issue #207
- Sem keep-alive (\`Connection: close\` sempre)
- Sem redirects automáticos, gzip, multipart
- Resolver de \`builtin/\` ainda não auto-detecta \`import \"http\"\` — exemplos/testes usam inline (a parte do package vai pra uso futuro quando o resolver suportar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)