### PR TITLE
fix(thread): valida que arg passing funciona (closes #245)

### DIFF
--- a/tests/thread_arg_passing.test.ts
+++ b/tests/thread_arg_passing.test.ts
@@ -1,0 +1,54 @@
+// thread.spawn(fp, arg) entrega o arg ao worker. Foi quebrado por
+// callconv mismatch (#206) e call_indirect Tail vs SystemV (#242).
+// Apos os fixes, arg passing e robusto em varios cenarios.
+import { describe, test, expect } from "rts:test";
+import { thread, atomic } from "rts";
+
+const sumI64 = atomic.i64_new(0);
+function workerI64(arg: i64): void {
+  atomic.i64_fetch_add(sumI64, arg);
+}
+
+function spawnAndJoinHelper(value: i64): void {
+  const fp = workerI64 as unknown as number;
+  const t = thread.spawn(fp, value);
+  thread.join(t);
+}
+
+describe("fixture:thread_arg_passing", () => {
+  test("spawn(fp, N) entrega N ao worker(arg: i64)", () => {
+    atomic.i64_store(sumI64, 0);
+    const fp = workerI64 as unknown as number;
+    const t = thread.spawn(fp, 42);
+    thread.join(t);
+    const got = atomic.i64_load(sumI64);
+    expect(got == 42 ? "1" : "0").toBe("1");
+  });
+
+  // OBS: spawn(fp, 3.14) com worker(arg: number) ainda nao funciona
+  // — o trampolim recebe __rts_spawn_arg: i64 e a coerção integer→f64
+  // perde o bit-pattern. Workaround: passar como int e dividir.
+  // Bug separado do callconv original.
+
+  test("multiplos spawns paralelos com args diferentes", () => {
+    atomic.i64_store(sumI64, 0);
+    const fp = workerI64 as unknown as number;
+    const t1 = thread.spawn(fp, 10);
+    const t2 = thread.spawn(fp, 20);
+    const t3 = thread.spawn(fp, 30);
+    const t4 = thread.spawn(fp, 40);
+    thread.join(t1);
+    thread.join(t2);
+    thread.join(t3);
+    thread.join(t4);
+    const got = atomic.i64_load(sumI64);
+    expect(got == 100 ? "1" : "0").toBe("1");
+  });
+
+  test("spawn dentro de fn helper (nao top-level) — caso #206 historico", () => {
+    atomic.i64_store(sumI64, 0);
+    spawnAndJoinHelper(99);
+    const got = atomic.i64_load(sumI64);
+    expect(got == 99 ? "1" : "0").toBe("1");
+  });
+});

--- a/tests/thread_basic.test.ts
+++ b/tests/thread_basic.test.ts
@@ -6,14 +6,13 @@ function print(value: string): void {
   __rtsCapturedOutput += value + "\n";
 }
 
-// Counter compartilhado: a worker incrementa quando roda. Como o arg
-// passado pra spawn nao chega de forma confiavel ao user fn (CallConv
-// mismatch entre Tail dos user fns e extern "C" da spawn), o worker
-// trabalha apenas via globais. spawn/join validam o lifecycle do handle.
+// Counter compartilhado: a worker incrementa pelo valor que vem como
+// argumento. Apos #206 (callconv) + #242 (call_indirect match), o
+// arg de thread.spawn(fp, N) chega corretamente ao worker.
 const counter = atomic.i64_new(0);
 
-function worker(): void {
-  atomic.i64_fetch_add(counter, 1);
+function worker(delta: i64): void {
+  atomic.i64_fetch_add(counter, delta);
 }
 
 // 1) thread.id da thread atual != 0 e estavel
@@ -34,9 +33,9 @@ if (id1 == id2) {
 thread.sleep_ms(1);
 print("sleep-ok");
 
-// 3) spawn retorna handle != 0
+// 3) spawn(fp, 7) retorna handle != 0 — arg 7 deve chegar ao worker
 const fp = worker as unknown as number;
-const t = thread.spawn(fp, 0);
+const t = thread.spawn(fp, 7);
 if (t == 0) {
   print("FAIL: thread.spawn retornou 0");
 } else {
@@ -47,12 +46,13 @@ if (t == 0) {
 thread.join(t);
 print("join-ok");
 
-// 5) Apos join, counter deve ter sido incrementado pelo worker
+// 5) Apos join, counter deve ter sido incrementado pelo worker em 7
 const v = atomic.i64_load(counter);
 const hv = gc.string_from_i64(v);
-print(hv); gc.string_free(hv); // 1
+print(hv); gc.string_free(hv); // 7
 
-// 6) detach smoke — spawn + detach nao bloqueiam
+// 6) detach smoke — spawn + detach nao bloqueiam. Passa 0 pra nao
+//    perturbar counter (race com 5 acima ja medido).
 const t2 = thread.spawn(fp, 0);
 if (t2 == 0) {
   print("FAIL: spawn 2 retornou 0");
@@ -65,7 +65,7 @@ print("detach-ok");
 describe("fixture:thread_basic", () => {
   test("matches expected stdout", () => {
     expect(__rtsCapturedOutput).toBe(
-      "id-ok\nid-stable\nsleep-ok\nspawn-ok\njoin-ok\n1\nspawn2-ok\ndetach-ok\n"
+      "id-ok\nid-stable\nsleep-ok\nspawn-ok\njoin-ok\n7\nspawn2-ok\ndetach-ok\n"
     );
   });
 });


### PR DESCRIPTION
## Summary

#245 reportava que \`thread.spawn(fp, N)\` não entregava \`N\` ao worker. Investigando, descobri que o bug **já está resolvido** pelo combo dos fixes anteriores:

- **#206**: user fns address-taken declaradas com SystemV/Win64 + trampolim threadea \`__rts_spawn_arg\`
- **#242**: \`lower_indirect_call\` usa \`default_call_conv()\` pra casar a callconv

O comentário em \`tests/thread_basic.test.ts\` (que documentava o bug) ficou desatualizado. Esta PR apenas valida e documenta:

## Test plan

- [x] \`spawn(fp, 42)\` com \`worker(arg: i64)\` → arg=42 chega ✓
- [x] 4 spawns paralelos com args diferentes (sum 10+20+30+40=100) ✓
- [x] spawn dentro de fn helper (caso #206 histórico) → arg chega ✓
- [x] suite completa: 210/210 passa

## Mudanças

- \`tests/thread_basic.test.ts\`: comment obsoleto removido; worker recebe \`delta\` e é chamado com 7 (não 0)
- \`tests/thread_arg_passing.test.ts\`: NOVO arquivo cobrindo 3 cenários

## Limitação remanescente (não coberta — bug separado)

\`spawn(fp, 3.14)\` com \`worker(arg: number)\` ainda não funciona — o trampolim recebe \`__rts_spawn_arg: i64\` e a coerção integer→f64 perde o bit-pattern. Workaround atual: passar i64 e dividir. Vai virar issue separada se necessário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)