### PR TITLE
feat(purity): marca num.* e mem.* como pure — pedaco (A) do #247

### DIFF
--- a/src/namespaces/mem/abi.rs
+++ b/src/namespaces/mem/abi.rs
@@ -12,7 +12,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um i64 (= 8).",
         ts_signature: "size_of_i64: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "size_of_f64",
@@ -23,7 +23,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um f64 (= 8).",
         ts_signature: "size_of_f64: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "size_of_i32",
@@ -34,7 +34,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um i32 (= 4).",
         ts_signature: "size_of_i32: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "size_of_bool",
@@ -45,7 +45,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Tamanho em bytes de um bool (= 1).",
         ts_signature: "size_of_bool: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "align_of_i64",
@@ -56,7 +56,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Alinhamento de i64 (= 8).",
         ts_signature: "align_of_i64: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "align_of_f64",
@@ -67,7 +67,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Alinhamento de f64 (= 8).",
         ts_signature: "align_of_f64: number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "swap_i64",
@@ -78,7 +78,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Retorna `b` (use idiom: `let old = mem.swap_i64(a, b)`).",
         ts_signature: "swap_i64(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "drop_handle",

--- a/src/namespaces/num/abi.rs
+++ b/src/namespaces/num/abi.rs
@@ -13,7 +13,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_add(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "checked_sub",
@@ -24,7 +24,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_sub(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "checked_mul",
@@ -35,7 +35,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b com overflow; retorna i64::MIN como sentinela em overflow.",
         ts_signature: "checked_mul(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "checked_div",
@@ -46,7 +46,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a / b; retorna i64::MIN se b == 0 ou overflow (i64::MIN / -1).",
         ts_signature: "checked_div(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     // ── saturating: clamp em i64::MIN/MAX ─────────────────────────────
     NamespaceMember {
@@ -58,7 +58,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_add(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "saturating_sub",
@@ -69,7 +69,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_sub(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "saturating_mul",
@@ -80,7 +80,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b com saturation em i64::MIN/MAX.",
         ts_signature: "saturating_mul(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     // ── wrapping: comportamento modular ───────────────────────────────
     NamespaceMember {
@@ -92,7 +92,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a + b modulo 2^64.",
         ts_signature: "wrapping_add(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "wrapping_sub",
@@ -103,7 +103,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a - b modulo 2^64.",
         ts_signature: "wrapping_sub(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "wrapping_mul",
@@ -114,7 +114,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a * b modulo 2^64.",
         ts_signature: "wrapping_mul(a: number, b: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "wrapping_neg",
@@ -125,7 +125,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "-a modulo 2^64 (i64::MIN.wrapping_neg() == i64::MIN).",
         ts_signature: "wrapping_neg(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "wrapping_shl",
@@ -136,7 +136,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a << (n & 63) — shift count masked.",
         ts_signature: "wrapping_shl(a: number, n: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "wrapping_shr",
@@ -147,7 +147,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a >> (n & 63) (arithmetic shift).",
         ts_signature: "wrapping_shr(a: number, n: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     // ── bits ──────────────────────────────────────────────────────────
     NamespaceMember {
@@ -159,7 +159,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de bits 1 em a.",
         ts_signature: "count_ones(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "count_zeros",
@@ -170,7 +170,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de bits 0 em a.",
         ts_signature: "count_zeros(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "leading_zeros",
@@ -181,7 +181,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de zeros leading em a.",
         ts_signature: "leading_zeros(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "trailing_zeros",
@@ -192,7 +192,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Numero de zeros trailing em a.",
         ts_signature: "trailing_zeros(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "rotate_left",
@@ -203,7 +203,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a rotacionado n bits para a esquerda.",
         ts_signature: "rotate_left(a: number, n: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "rotate_right",
@@ -214,7 +214,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "a rotacionado n bits para a direita.",
         ts_signature: "rotate_right(a: number, n: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "reverse_bits",
@@ -225,7 +225,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Bits invertidos (LSB->MSB).",
         ts_signature: "reverse_bits(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
     NamespaceMember {
         name: "swap_bytes",
@@ -236,7 +236,7 @@ pub const MEMBERS: &[NamespaceMember] = &[
         doc: "Bytes invertidos (endianness flip).",
         ts_signature: "swap_bytes(a: number): number",
         intrinsic: None,
-        pure: false,
+        pure: true,
     },
 ];
 

--- a/tests/parallel_purity_num_mem.test.ts
+++ b/tests/parallel_purity_num_mem.test.ts
@@ -1,0 +1,68 @@
+// Valida que num.* e mem.* (recem-marcados pure: true em #248)
+// sao reconhecidos pelo purity pass — for...of top-level com so
+// chamadas a num.* / mem.* deve ser reescrito pra parallel.for_each.
+//
+// Como nao temos API pra inspecionar o AST pos-purity-pass diretamente,
+// validamos via correctness: se rodar (paralelo ou serial) e produzir
+// o resultado correto, tudo OK. Adicionalmente, paralelizar grandes
+// arrays sem crash valida que a infra esta correta pra essas fns.
+import { describe, test, expect } from "rts:test";
+import { num, mem, atomic, gc } from "rts";
+
+describe("fixture:parallel_purity_num_mem", () => {
+  test("num.* dentro de for...of: correctness + sem crash", () => {
+    // Acumulador atomic (purity pass detecta padrao e auto-promove,
+    // ou pelo menos nao crasha quando atomic e usado).
+    const sum = atomic.i64_new(0);
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    // Body so chama num.* (todas pure agora) + atomic store.
+    // atomic.i64_fetch_add nao e pura mas e safe pra side effects
+    // controlados — purity pass pode escolher serial nesse caso.
+    for (const x of arr) {
+      const s = num.saturating_add(x, 1);  // x+1
+      const w = num.wrapping_mul(s, 2);     // (x+1)*2
+      atomic.i64_fetch_add(sum, w);
+    }
+
+    // sum esperado = sum((x+1)*2 for x in 1..10) = 2*sum(2..11) = 2*65 = 130
+    const got = atomic.i64_load(sum);
+    expect(got == 130 ? "1" : "0").toBe("1");
+  });
+
+  test("mem.size_of dentro de for...of: constantes funcionam paralelo", () => {
+    const acc = atomic.i64_new(0);
+    const arr = [1, 2, 3, 4];
+
+    for (const _ of arr) {
+      // mem.size_of_i64 e constante (= 8). Soma 4 vezes = 32.
+      atomic.i64_fetch_add(acc, mem.size_of_i64);
+    }
+
+    const got = atomic.i64_load(acc);
+    expect(got == 32 ? "1" : "0").toBe("1");
+  });
+
+  test("num.* operacoes determinísticas — multi-runs dao mesmo resultado", () => {
+    const arr = [10, 20, 30, 40, 50];
+    let total1 = 0;
+    for (const x of arr) {
+      total1 = total1 + num.checked_add(x, 5);  // x+5
+    }
+    let total2 = 0;
+    for (const x of arr) {
+      total2 = total2 + num.checked_add(x, 5);
+    }
+    // Mesmo array + mesma fn pura = mesmo resultado.
+    // Esperado: sum(x+5) = sum(15,25,35,45,55) = 175
+    expect(total1 == 175 ? "1" : "0").toBe("1");
+    expect(total1 == total2 ? "1" : "0").toBe("1");
+  });
+
+  test("num.wrapping_add comportamento esperado", () => {
+    // wrapping_add com valores moderados — valida que a fn realmente
+    // executou e retorna o valor correto.
+    const r = num.wrapping_add(100, 200);
+    expect(r == 300 ? "1" : "0").toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary

Pedaço (A) do epic #247: expande cobertura do purity pass marcando mais fns como \`pure: true\`. Aumenta 41% o conjunto de fns que o silent parallelism reconhece.

## Antes / depois

| ns | antes | depois |
|---|---|---|
| math | 30 | 30 |
| string | 16 | 16 |
| **num** | **0** | **21** |
| fmt | 10 | 10 |
| path | 8 | 8 |
| **mem** | **0** | **7** |
| hash | 4 | 4 |
| **total** | **68** | **96** |

## Marcadas (28 novas)

- **\`num\`** — todas 21 fns: \`checked_*\`, \`saturating_*\`, \`wrapping_*\`, \`count_ones/zeros\`, \`leading/trailing_zeros\`, \`rotate_*\`, \`reverse_bits\`. Todas determinísticas, sem side effect.
- **\`mem\`** — 6 \`size_of_*\`/\`align_of_*\` (constantes) + \`swap_i64\` (pura).

## Auditadas mas NÃO marcadas

- \`crypto.sha256/hex/base64\` — alocam handle (aguarda fix de sharding #232)
- \`bigfloat.*\` — todas alocam handle
- \`crypto.random_*\` — RNG state
- \`mem.drop_handle/forget_handle/replace_i64\` — mutate
- \`hint.black_box/spin_loop\` — semântica de barrier

## Impacto

Código TS comum como:

\`\`\`ts
for (const x of arr) {
  result.push(num.saturating_add(x, 1));
}
\`\`\`

Agora **paraleliza sozinho** (antes não, porque \`num.*\` não era pure).

## Test plan

- [x] \`cargo run -- test\` → 210/210 passam
- [x] \`rts.d.ts\` regenerado

Refs #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)