### PR TITLE
fix(gc): migra todos os callers de table() para shard-aware (closes #232)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -100,7 +100,8 @@
       "Bash(cargo run *)",
       "Bash(git pull *)",
       "Bash(target/debug/rts.exe test *)",
-      "Bash(git log *)"
+      "Bash(git log *)",
+      "PowerShell(Stop-Process *)"
     ]
   }
 }

--- a/src/namespaces/bigfloat/ops.rs
+++ b/src/namespaces/bigfloat/ops.rs
@@ -8,7 +8,7 @@ use super::fixed::FixedDecimal;
 // `super::super` resolves to the crate root in the standalone runtime
 // staticlib build (`rt_all.rs`) and to `namespaces` in the main `rts`
 // crate; both expose the `gc` submodule at that level.
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 // Forward-declared extern so we can intern the decimal string without
 // hard-coding the `gc::string_pool::...` path (which differs between
@@ -18,14 +18,11 @@ unsafe extern "C" {
 }
 
 fn alloc(value: FixedDecimal) -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::BigFixed(Box::new(value)))
+    alloc_entry(Entry::BigFixed(Box::new(value)))
 }
 
 fn clone_of(handle: u64) -> Option<FixedDecimal> {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::BigFixed(b)) => Some(b.as_ref().clone()),
         _ => None,
@@ -136,5 +133,5 @@ pub extern "C" fn __RTS_FN_NS_BIGFLOAT_SQRT(a: u64) -> u64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_BIGFLOAT_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }

--- a/src/namespaces/buffer/ops.rs
+++ b/src/namespaces/buffer/ops.rs
@@ -8,7 +8,7 @@
 //! representacoes nativas. Out-of-bounds retorna 0 (para reads) ou
 //! vira no-op (para writes) — sem panics no boundary C.
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 // Para o runtime staticlib, `super::super::gc` resolve para
 // `crate::gc` (sem `namespaces`). Para o crate rts principal, resolve
@@ -22,14 +22,11 @@ fn with_buffer_mut<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&mut Vec<u8>) -> R,
 {
-    // `table().lock()` returns MutexGuard of HandleTable. Mutable
-    // access ao `Entry::Buffer` interno: infelizmente o HandleTable
-    // expoe so `get(&self) -> Option<&Entry>`, nao mut — precisamos
-    // reimplementar via API publica. Na pratica, reabrimos o Mutex
-    // e chamamos `alloc` com o buffer modificado (via clone), ou
-    // exponemos `get_mut` diretamente. Escolho expor `get_mut`.
-    let t = table();
-    let mut guard = t.lock().unwrap();
+    // Roteia para o shard correto via `shard_for_handle`. Antes da
+    // migracao usavamos `table()` (shard 0 only), o que silenciosamente
+    // retornava `default` quando o buffer fora alocado em outro shard
+    // (ex: via `parallel.map`).
+    let mut guard = shard_for_handle(handle).lock().unwrap();
     if let Some(Entry::Buffer(buf)) = guard.get_mut(handle) {
         f(buf)
     } else {
@@ -41,7 +38,7 @@ fn with_buffer<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&Vec<u8>) -> R,
 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::Buffer(buf)) => f(buf),
         _ => default,
@@ -55,7 +52,7 @@ pub extern "C" fn __RTS_FN_NS_BUFFER_ALLOC(size: i64) -> u64 {
         return 0;
     }
     let buf = vec![0u8; size as usize];
-    table().lock().unwrap().alloc(Entry::Buffer(buf))
+    alloc_entry(Entry::Buffer(buf))
 }
 
 /// Alias explicito para alloc zeroed — no Rust Vec::new ja zera.
@@ -67,7 +64,7 @@ pub extern "C" fn __RTS_FN_NS_BUFFER_ALLOC_ZEROED(size: i64) -> u64 {
 /// Libera o handle. Chamadas repetidas sao no-op silencioso.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_BUFFER_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }
 
 /// Tamanho do buffer em bytes, ou -1 se handle invalido.

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
@@ -17,7 +17,7 @@ fn with_map<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&HashMap<String, i64>) -> R,
 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::Map(m)) => f(m.as_ref()),
         _ => default,
@@ -28,8 +28,7 @@ fn with_map_mut<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&mut HashMap<String, i64>) -> R,
 {
-    let t = table();
-    let mut guard = t.lock().unwrap();
+    let mut guard = shard_for_handle(handle).lock().unwrap();
     match guard.get_mut(handle) {
         Some(Entry::Map(m)) => f(m.as_mut()),
         _ => default,
@@ -38,15 +37,12 @@ where
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_NEW() -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::Map(Box::new(HashMap::new())))
+    alloc_entry(Entry::Map(Box::new(HashMap::new())))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }
 
 #[unsafe(no_mangle)]

--- a/src/namespaces/crypto/encode.rs
+++ b/src/namespaces/crypto/encode.rs
@@ -1,6 +1,6 @@
 //! Encoders — base64 e hex. Impl pura, sem deps.
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry};
 
 unsafe extern "C" {
     fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
@@ -56,7 +56,7 @@ pub extern "C" fn __RTS_FN_NS_CRYPTO_HEX_DECODE(ptr: *const u8, len: i64) -> u64
         out.push((h << 4) | l);
         i += 2;
     }
-    table().lock().unwrap().alloc(Entry::Buffer(out))
+    alloc_entry(Entry::Buffer(out))
 }
 
 // ── Base64 (RFC 4648, padded) ────────────────────────────────────────
@@ -139,5 +139,5 @@ pub extern "C" fn __RTS_FN_NS_CRYPTO_BASE64_DECODE(ptr: *const u8, len: i64) -> 
         }
         i += 4;
     }
-    table().lock().unwrap().alloc(Entry::Buffer(out))
+    alloc_entry(Entry::Buffer(out))
 }

--- a/src/namespaces/crypto/random.rs
+++ b/src/namespaces/crypto/random.rs
@@ -1,6 +1,6 @@
 //! CSPRNG — /dev/urandom em Unix, BCryptGenRandom em Windows.
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry};
 
 // ── Windows ──────────────────────────────────────────────────────────
 #[cfg(target_os = "windows")]
@@ -79,5 +79,5 @@ pub extern "C" fn __RTS_FN_NS_CRYPTO_RANDOM_BUFFER(len: i64) -> u64 {
     if !os_random_into(&mut buf) {
         return 0;
     }
-    table().lock().unwrap().alloc(Entry::Buffer(buf))
+    alloc_entry(Entry::Buffer(buf))
 }

--- a/src/namespaces/ffi/cstring.rs
+++ b/src/namespaces/ffi/cstring.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CString;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
@@ -21,10 +21,7 @@ pub extern "C" fn __RTS_FN_NS_FFI_CSTRING_NEW(ptr: *const u8, len: i64) -> u64 {
         return 0;
     };
     match CString::new(s) {
-        Ok(c) => table()
-            .lock()
-            .unwrap()
-            .alloc(Entry::CString(Box::new(c))),
+        Ok(c) => alloc_entry(Entry::CString(Box::new(c))),
         Err(_) => 0,
     }
 }
@@ -33,7 +30,7 @@ pub extern "C" fn __RTS_FN_NS_FFI_CSTRING_NEW(ptr: *const u8, len: i64) -> u64 {
 /// 0 se handle invalido.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_FFI_CSTRING_PTR(handle: u64) -> u64 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::CString(c)) => c.as_ptr() as u64,
         _ => 0,
@@ -43,5 +40,5 @@ pub extern "C" fn __RTS_FN_NS_FFI_CSTRING_PTR(handle: u64) -> u64 {
 /// Libera o handle (no-op se invalido).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_FFI_CSTRING_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }

--- a/src/namespaces/ffi/osstr.rs
+++ b/src/namespaces/ffi/osstr.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::OsString;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 unsafe extern "C" {
     fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64;
@@ -24,17 +24,14 @@ pub extern "C" fn __RTS_FN_NS_FFI_OSSTR_FROM_STR(ptr: *const u8, len: i64) -> u6
         return 0;
     };
     let os = OsString::from(s);
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::OsString(Box::new(os)))
+    alloc_entry(Entry::OsString(Box::new(os)))
 }
 
 /// Converte para string UTF-8 (handle gc::string). 0 se nao-UTF8 ou
 /// handle invalido.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_FFI_OSSTR_TO_STR(handle: u64) -> u64 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     let Some(Entry::OsString(os)) = guard.get(handle) else {
         return 0;
     };
@@ -53,5 +50,5 @@ pub extern "C" fn __RTS_FN_NS_FFI_OSSTR_TO_STR(handle: u64) -> u64 {
 /// Libera o handle (no-op se invalido).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_FFI_OSSTR_FREE(handle: u64) {
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }

--- a/src/namespaces/gc/env.rs
+++ b/src/namespaces/gc/env.rs
@@ -5,7 +5,7 @@
 //! `env_get`/`env_set`. Permite capturas re-entrantes e per-iteração de
 //! loop sem o esquema promote-to-global que tem limitações estruturais.
 
-use super::handles::{table, Entry};
+use super::handles::{alloc_entry, free_handle, shard_for_handle, Entry};
 
 /// Aloca um env record com `slot_count` slots, todos inicializados em 0.
 /// Retorna o handle. `slot_count` negativo ou maior que 2^16 é tratado
@@ -16,7 +16,7 @@ pub extern "C" fn __RTS_FN_NS_GC_ENV_ALLOC(slot_count: i32) -> u64 {
         return 0;
     }
     let slots = vec![0i64; slot_count as usize];
-    table().lock().unwrap().alloc(Entry::Env(slots))
+    alloc_entry(Entry::Env(slots))
 }
 
 /// Lê o valor de um slot. Retorna 0 em caso de handle inválido ou slot
@@ -26,7 +26,7 @@ pub extern "C" fn __RTS_FN_NS_GC_ENV_GET(env: u64, slot: i32) -> i64 {
     if slot < 0 {
         return 0;
     }
-    let table = table().lock().unwrap();
+    let table = shard_for_handle(env).lock().unwrap();
     let Some(Entry::Env(slots)) = table.get(env) else {
         return 0;
     };
@@ -40,7 +40,7 @@ pub extern "C" fn __RTS_FN_NS_GC_ENV_SET(env: u64, slot: i32, value: i64) -> i64
     if slot < 0 {
         return 0;
     }
-    let mut table = table().lock().unwrap();
+    let mut table = shard_for_handle(env).lock().unwrap();
     let Some(Entry::Env(slots)) = table.get_mut(env) else {
         return 0;
     };
@@ -54,11 +54,7 @@ pub extern "C" fn __RTS_FN_NS_GC_ENV_SET(env: u64, slot: i32, value: i64) -> i64
 /// Libera o env record. Retorna 1 em sucesso, 0 se handle já era inválido.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_ENV_FREE(env: u64) -> i64 {
-    if table().lock().unwrap().free(env) {
-        1
-    } else {
-        0
-    }
+    if free_handle(env) { 1 } else { 0 }
 }
 
 #[cfg(test)]

--- a/src/namespaces/gc/error.rs
+++ b/src/namespaces/gc/error.rs
@@ -6,7 +6,7 @@
 
 use std::cell::RefCell;
 
-use super::handles::{Entry, table};
+use super::handles::{Entry, alloc_entry, free_handle};
 use super::string_pool::read_string_handle;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -30,15 +30,12 @@ fn capture_stack_handle() -> u64 {
     if text.is_empty() {
         return 0;
     }
-    table()
-        .lock()
-        .expect("handle table poisoned")
-        .alloc(Entry::String(text.into_bytes()))
+    alloc_entry(Entry::String(text.into_bytes()))
 }
 
 fn free_handle_if_any(handle: u64) {
     if handle != 0 {
-        let _ = table().lock().expect("handle table poisoned").free(handle);
+        let _ = free_handle(handle);
     }
 }
 

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -136,13 +136,6 @@ pub struct HandleTable {
 }
 
 impl HandleTable {
-    /// Legacy: allocates in shard 0. Used by callers that still go through
-    /// `table().lock().unwrap().alloc(...)`. Prefer `alloc_entry` instead.
-    #[deprecated(note = "use alloc_entry")]
-    pub fn alloc(&mut self, entry: Entry) -> u64 {
-        self.alloc_in_shard(entry, 0)
-    }
-
     /// Allocate `entry` in this shard. `shard_idx` is encoded in the low
     /// SHARD_BITS of the slot field so `shard_for_handle` can route back
     /// without extra metadata.
@@ -246,16 +239,6 @@ pub fn alloc_entry(entry: Entry) -> u64 {
 /// Frees a handle. Returns false if the handle is invalid or already freed.
 pub fn free_handle(handle: u64) -> bool {
     shard_for_handle(handle).lock().unwrap().free(handle)
-}
-
-/// Legacy single-table accessor kept for call sites that have not been
-/// migrated to the sharded API yet. Points to shard 0.
-///
-/// Deprecated: migrate callers to `alloc_entry` / `free_handle` /
-/// `shard_for_handle`. This will be removed once all namespaces are updated.
-#[deprecated(note = "use alloc_entry / free_handle / shard_for_handle")]
-pub fn table() -> &'static Mutex<HandleTable> {
-    &shards()[0]
 }
 
 #[cfg(test)]

--- a/src/namespaces/gc/instance.rs
+++ b/src/namespaces/gc/instance.rs
@@ -9,7 +9,7 @@
 //! Validacao defensiva: handle invalido ou offset fora do range retornam
 //! 0 (loads) ou 0 (stores) sem trap.
 
-use super::handles::{table, Entry, Instance};
+use super::handles::{alloc_entry, free_handle, shard_for_handle, Entry, Instance};
 
 const SENTINEL_ERR: i64 = 0;
 
@@ -25,13 +25,13 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_NEW(size: i32, class_handle: u64) -> u
         class: class_handle,
         bytes,
     };
-    table().lock().unwrap().alloc(Entry::Instance(Box::new(inst)))
+    alloc_entry(Entry::Instance(Box::new(inst)))
 }
 
 /// Retorna o class handle armazenado na instancia, ou 0 em handle invalido.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_CLASS(h: u64) -> u64 {
-    let table = table().lock().unwrap();
+    let table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get(h) else {
         return 0;
     };
@@ -41,11 +41,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_CLASS(h: u64) -> u64 {
 /// Libera a instancia. Retorna 1 em sucesso, 0 se handle ja invalido.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_FREE(h: u64) -> i64 {
-    if table().lock().unwrap().free(h) {
-        1
-    } else {
-        0
-    }
+    if free_handle(h) { 1 } else { 0 }
 }
 
 #[inline]
@@ -62,7 +58,7 @@ fn check_range(len: usize, offset: i32, slot: usize) -> Option<usize> {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_I64(h: u64, offset: i32) -> i64 {
-    let table = table().lock().unwrap();
+    let table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get(h) else {
         return 0;
     };
@@ -76,7 +72,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_I64(h: u64, offset: i32) -> i64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_STORE_I64(h: u64, offset: i32, value: i64) -> i64 {
-    let mut table = table().lock().unwrap();
+    let mut table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get_mut(h) else {
         return SENTINEL_ERR;
     };
@@ -89,7 +85,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_STORE_I64(h: u64, offset: i32, value: 
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_I32(h: u64, offset: i32) -> i32 {
-    let table = table().lock().unwrap();
+    let table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get(h) else {
         return 0;
     };
@@ -103,7 +99,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_I32(h: u64, offset: i32) -> i32 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_STORE_I32(h: u64, offset: i32, value: i32) -> i64 {
-    let mut table = table().lock().unwrap();
+    let mut table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get_mut(h) else {
         return SENTINEL_ERR;
     };
@@ -116,7 +112,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_STORE_I32(h: u64, offset: i32, value: 
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_F64(h: u64, offset: i32) -> f64 {
-    let table = table().lock().unwrap();
+    let table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get(h) else {
         return 0.0;
     };
@@ -130,7 +126,7 @@ pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_LOAD_F64(h: u64, offset: i32) -> f64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_INSTANCE_STORE_F64(h: u64, offset: i32, value: f64) -> i64 {
-    let mut table = table().lock().unwrap();
+    let mut table = shard_for_handle(h).lock().unwrap();
     let Some(Entry::Instance(inst)) = table.get_mut(h) else {
         return SENTINEL_ERR;
     };

--- a/src/namespaces/gc/string_pool.rs
+++ b/src/namespaces/gc/string_pool.rs
@@ -5,12 +5,12 @@
 //! buffer. The pointer remains valid as long as the handle is live; callers
 //! must copy before freeing.
 
-use super::handles::{Entry, table};
+use super::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 /// Reads a string handle into an owned Rust `String`.
 /// Returns `None` for invalid/non-string handles.
 pub fn read_string_handle(handle: u64) -> Option<String> {
-    let t = table().lock().expect("handle table poisoned");
+    let t = shard_for_handle(handle).lock().expect("handle table poisoned");
     match t.get(handle) {
         Some(Entry::String(bytes)) => Some(String::from_utf8_lossy(bytes).into_owned()),
         _ => None,
@@ -30,15 +30,14 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_NEW(ptr: *const u8, len: i64) -> u64 {
     }
     // SAFETY: caller contract guarantees `ptr` covers `len` live bytes.
     let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
-    let mut t = table().lock().expect("handle table poisoned");
-    t.alloc(Entry::String(slice.to_vec()))
+    alloc_entry(Entry::String(slice.to_vec()))
 }
 
 /// Returns the byte length of the string behind `handle`, or `-1` if the
 /// handle is invalid or has been freed.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_LEN(handle: u64) -> i64 {
-    let t = table().lock().expect("handle table poisoned");
+    let t = shard_for_handle(handle).lock().expect("handle table poisoned");
     match t.get(handle) {
         Some(Entry::String(bytes)) => bytes.len() as i64,
         _ => -1,
@@ -52,7 +51,7 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_LEN(handle: u64) -> i64 {
 /// Readers must not exceed `LEN` bytes from the returned pointer.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_PTR(handle: u64) -> *const u8 {
-    let t = table().lock().expect("handle table poisoned");
+    let t = shard_for_handle(handle).lock().expect("handle table poisoned");
     match t.get(handle) {
         Some(Entry::String(bytes)) => bytes.as_ptr(),
         _ => std::ptr::null(),
@@ -63,16 +62,14 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_PTR(handle: u64) -> *const u8 {
 /// success, `0` if the handle was already invalid.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_FREE(handle: u64) -> i64 {
-    let mut t = table().lock().expect("handle table poisoned");
-    if t.free(handle) { 1 } else { 0 }
+    if free_handle(handle) { 1 } else { 0 }
 }
 
 /// Converts an `i64` to its decimal string representation and returns a handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64(value: i64) -> u64 {
     let s = value.to_string();
-    let mut t = table().lock().expect("handle table poisoned");
-    t.alloc(Entry::String(s.into_bytes()))
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 /// Converts an `f64` to its decimal string representation and returns a handle.
@@ -83,32 +80,32 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_F64(value: f64) -> u64 {
     } else {
         format!("{value}")
     };
-    let mut t = table().lock().expect("handle table poisoned");
-    t.alloc(Entry::String(s.into_bytes()))
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 /// Concatenates two string handles and returns a new handle.
 /// Handles invalidos sao tratados como string vazia — match ergonomia
 /// JS de `${undefined}` (que vira "undefined") e evita propagar handle
 /// 0 que silenciaria o resto do template.
+///
+/// `a` e `b` podem viver em shards diferentes — clonamos cada um sob
+/// seu lock proprio antes de alocar o resultado.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_CONCAT(a: u64, b: u64) -> u64 {
     let mut bytes = {
-        let t = table().lock().expect("handle table poisoned");
+        let t = shard_for_handle(a).lock().expect("handle table poisoned");
         match t.get(a) {
             Some(Entry::String(s)) => s.clone(),
             _ => Vec::new(),
         }
     };
     {
-        let t = table().lock().expect("handle table poisoned");
-        match t.get(b) {
-            Some(Entry::String(s)) => bytes.extend_from_slice(s),
-            _ => {}
+        let t = shard_for_handle(b).lock().expect("handle table poisoned");
+        if let Some(Entry::String(s)) = t.get(b) {
+            bytes.extend_from_slice(s);
         }
     }
-    let mut t = table().lock().expect("handle table poisoned");
-    t.alloc(Entry::String(bytes))
+    alloc_entry(Entry::String(bytes))
 }
 
 /// Promotes a static string slice (ptr, len) to a GC handle.
@@ -121,19 +118,27 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_STATIC(ptr: *const u8, len: i64) ->
 /// Compares dois string handles por conteudo (memcmp). Retorna 1 se
 /// os bytes forem iguais, 0 caso contrario. Handles invalidos so sao
 /// iguais entre si quando ambos forem 0.
+///
+/// Como `a` e `b` podem viver em shards diferentes, cada lookup ocorre
+/// sob seu shard proprio. Clonamos `sa` pra liberar o primeiro lock
+/// antes de pegar o segundo (evita deadlock se mesma thread tentar dois
+/// locks nos diferentes shards na ordem oposta em outra chamada).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_EQ(a: u64, b: u64) -> i64 {
     if a == b {
         return 1;
     }
-    let t = table().lock().expect("handle table poisoned");
-    let sa = match t.get(a) {
-        Some(Entry::String(s)) => s,
-        _ => return 0,
+    let sa: Vec<u8> = {
+        let t = shard_for_handle(a).lock().expect("handle table poisoned");
+        match t.get(a) {
+            Some(Entry::String(s)) => s.clone(),
+            _ => return 0,
+        }
     };
+    let t = shard_for_handle(b).lock().expect("handle table poisoned");
     let sb = match t.get(b) {
         Some(Entry::String(s)) => s,
         _ => return 0,
     };
-    if sa == sb { 1 } else { 0 }
+    if sa == *sb { 1 } else { 0 }
 }

--- a/src/namespaces/mem/ops.rs
+++ b/src/namespaces/mem/ops.rs
@@ -43,7 +43,7 @@ pub extern "C" fn __RTS_FN_NS_MEM_SWAP_I64(_a: i64, b: i64) -> i64 {
 /// Forca free de um handle GC (string, vec, map, regex, ...).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_MEM_DROP_HANDLE(handle: u64) {
-    let _ = super::super::gc::handles::table().lock().unwrap().free(handle);
+    let _ = super::super::gc::handles::free_handle(handle);
 }
 
 /// Esquece handle (no-op em GC slab — vaza ate program exit).

--- a/src/namespaces/process/spawn.rs
+++ b/src/namespaces/process/spawn.rs
@@ -6,7 +6,7 @@
 
 use std::process::{Child, Command, Stdio};
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
@@ -42,10 +42,7 @@ pub extern "C" fn __RTS_FN_NS_PROCESS_SPAWN(
         .stderr(Stdio::inherit());
 
     match command.spawn() {
-        Ok(child) => table()
-            .lock()
-            .unwrap()
-            .alloc(Entry::ProcessChild(Box::new(child))),
+        Ok(child) => alloc_entry(Entry::ProcessChild(Box::new(child))),
         Err(_) => 0,
     }
 }
@@ -56,8 +53,7 @@ pub extern "C" fn __RTS_FN_NS_PROCESS_SPAWN(
 pub extern "C" fn __RTS_FN_NS_PROCESS_WAIT(handle: u64) -> i32 {
     // Take: move o Child pra fora do Entry, substitui por Free.
     let child: Option<Box<Child>> = {
-        let t = table();
-        let mut guard = t.lock().unwrap();
+        let mut guard = shard_for_handle(handle).lock().unwrap();
         match guard.get_mut(handle) {
             Some(entry @ Entry::ProcessChild(_)) => {
                 let taken = std::mem::replace(entry, Entry::Free);
@@ -71,7 +67,7 @@ pub extern "C" fn __RTS_FN_NS_PROCESS_WAIT(handle: u64) -> i32 {
         }
     };
     // free formal do slot (bump generation)
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
     let Some(mut child) = child else {
         return -1;
     };
@@ -85,8 +81,7 @@ pub extern "C" fn __RTS_FN_NS_PROCESS_WAIT(handle: u64) -> i32 {
 /// sucesso, -1 em erro.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PROCESS_KILL(handle: u64) -> i64 {
-    let t = table();
-    let mut guard = t.lock().unwrap();
+    let mut guard = shard_for_handle(handle).lock().unwrap();
     match guard.get_mut(handle) {
         Some(Entry::ProcessChild(c)) => match c.kill() {
             Ok(_) => 0,

--- a/src/namespaces/regex/ops.rs
+++ b/src/namespaces/regex/ops.rs
@@ -1,6 +1,6 @@
 //! Regex runtime operations — backend `regex` crate.
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 use regex::{Regex, RegexBuilder};
 
 unsafe fn slice_from(ptr: *const u8, len: i64) -> &'static [u8] {
@@ -16,14 +16,14 @@ unsafe fn str_from(ptr: *const u8, len: i64) -> &'static str {
 }
 
 fn alloc_string(bytes: Vec<u8>) -> u64 {
-    table().lock().unwrap().alloc(Entry::String(bytes))
+    alloc_entry(Entry::String(bytes))
 }
 
 fn with_regex<F, R>(handle: u64, default: R, f: F) -> R
 where
     F: FnOnce(&Regex) -> R,
 {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     if let Some(Entry::Regex(rx)) = guard.get(handle) {
         f(rx)
     } else {
@@ -63,14 +63,14 @@ pub extern "C" fn __RTS_FN_NS_REGEX_COMPILE(
         }
     }
     match builder.build() {
-        Ok(rx) => table().lock().unwrap().alloc(Entry::Regex(Box::new(rx))),
+        Ok(rx) => alloc_entry(Entry::Regex(Box::new(rx))),
         Err(_) => 0,
     }
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_FREE(handle: u64) {
-    let _ = table().lock().unwrap().free(handle);
+    let _ = free_handle(handle);
 }
 
 #[unsafe(no_mangle)]

--- a/src/namespaces/sync/mutex.rs
+++ b/src/namespaces/sync/mutex.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard};
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
 
 thread_local! {
     /// Guarda ativos por handle de mutex, para esta thread.
@@ -23,17 +23,14 @@ thread_local! {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_SYNC_MUTEX_NEW(initial: i64) -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::SyncMutex(Box::new(Mutex::new(initial))))
+    alloc_entry(Entry::SyncMutex(Box::new(Mutex::new(initial))))
 }
 
 /// Helper: obtem ponteiro estavel para o `Mutex<i64>` referenciado pelo
 /// handle. Retorna `None` se o handle for invalido. O ponteiro e valido
 /// enquanto o slot na HandleTable nao for liberado.
 fn mutex_ptr(handle: u64) -> Option<*const Mutex<i64>> {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::SyncMutex(m)) => Some(m.as_ref() as *const Mutex<i64>),
         _ => None,
@@ -97,5 +94,5 @@ pub extern "C" fn __RTS_FN_NS_SYNC_MUTEX_FREE(handle: u64) {
     GUARDS.with(|cell| {
         cell.borrow_mut().remove(&handle);
     });
-    table().lock().unwrap().free(handle);
+    free_handle(handle);
 }

--- a/src/namespaces/sync/once.rs
+++ b/src/namespaces/sync/once.rs
@@ -7,14 +7,11 @@
 
 use std::sync::Once;
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_SYNC_ONCE_NEW() -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::SyncOnce(Box::new(Once::new())))
+    alloc_entry(Entry::SyncOnce(Box::new(Once::new())))
 }
 
 #[unsafe(no_mangle)]
@@ -24,7 +21,7 @@ pub extern "C" fn __RTS_FN_NS_SYNC_ONCE_CALL(handle: u64, fn_ptr: i64) {
     }
     // Obtem ponteiro estavel para o Once dentro do Box.
     let once_ptr: *const Once = {
-        let guard = table().lock().unwrap();
+        let guard = shard_for_handle(handle).lock().unwrap();
         match guard.get(handle) {
             Some(Entry::SyncOnce(o)) => o.as_ref() as *const Once,
             _ => return,

--- a/src/namespaces/sync/rwlock.rs
+++ b/src/namespaces/sync/rwlock.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, shard_for_handle};
 
 /// Os campos parecem "dead" para o compilador, mas existem pelo seu
 /// efeito Drop: liberar o lock subjacente ao serem removidos do mapa.
@@ -31,14 +31,11 @@ fn next_guard_id() -> u64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_SYNC_RWLOCK_NEW(initial: i64) -> u64 {
-    table()
-        .lock()
-        .unwrap()
-        .alloc(Entry::SyncRwLock(Box::new(RwLock::new(initial))))
+    alloc_entry(Entry::SyncRwLock(Box::new(RwLock::new(initial))))
 }
 
 fn rwlock_ptr(handle: u64) -> Option<*const RwLock<i64>> {
-    let guard = table().lock().unwrap();
+    let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
         Some(Entry::SyncRwLock(r)) => Some(r.as_ref() as *const RwLock<i64>),
         _ => None,

--- a/src/namespaces/trace/ops.rs
+++ b/src/namespaces/trace/ops.rs
@@ -1,5 +1,5 @@
 use super::frame_stack;
-use super::super::gc::handles::{Entry, table};
+use super::super::gc::handles::{Entry, alloc_entry, free_handle};
 
 unsafe fn str_from_raw(ptr: *const u8, len: usize) -> String {
     let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
@@ -36,7 +36,7 @@ pub extern "C" fn __RTS_FN_NS_TRACE_CAPTURE() -> u64 {
     if s.is_empty() {
         return 0;
     }
-    table().lock().unwrap().alloc(Entry::String(s.into_bytes()))
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 /// Print current trace stack to stderr.
@@ -60,5 +60,5 @@ pub extern "C" fn __RTS_FN_NS_TRACE_DEPTH() -> i64 {
 /// Free a GC handle returned by `trace.capture()`.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_TRACE_FREE(handle: u64) {
-    let _ = table().lock().unwrap().free(handle);
+    let _ = free_handle(handle);
 }


### PR DESCRIPTION
## Summary

Pedaço (F) do epic #247 — completa a migração shard-aware iniciada em #231.

Migra os 17 arquivos restantes que usavam o legacy \`table()\` (shard 0 only) para \`alloc_entry\`/\`free_handle\`/\`shard_for_handle\`. Remove \`pub fn table()\` e \`HandleTable::alloc\` deprecated.

## Por que importa

Antes: handles alocados em shard != 0 (via \`parallel.map\` ou \`alloc_entry\` direto) ficavam **invisíveis** pros namespaces que ainda usavam \`table()\`. Retornavam defaults silenciosamente.

Como exemplo concreto, o bug já documentado em \`collections::vec.rs\` (corrigido em \`e8e0e2e\`) era exatamente isso. Esta PR previne futuros bugs do mesmo tipo nos outros 17 namespaces.

## Migrados

- \`gc/{string_pool,instance,env,error}\` — base do sistema
- \`collections/map\`
- \`buffer/ops\`, \`bigfloat/ops\`
- \`crypto/{encode,random}\`
- \`ffi/{cstring,osstr}\`
- \`regex/ops\`
- \`sync/{mutex,once,rwlock}\`
- \`process/spawn\` (incluindo \`wait\` com \`get_mut + take\` pattern)
- \`trace/ops\`, \`mem/ops\`

## Notas de cuidado

- **\`gc::string_pool::CONCAT\` e \`EQ\`** leem 2 handles que podem viver em shards diferentes. \`CONCAT\` clona a primeira sob seu lock, depois pega o segundo. \`EQ\` também clona a primeira pra evitar segurar 2 locks na mesma thread (potencial deadlock se ordem variasse).
- **\`process::wait\`** usa \`get_mut + std::mem::replace\` pra mover o Child pra fora do slot — mantida lógica original, só trocando forma de obter o lock.

## Test plan

- [x] \`cargo build --release\` → 0 errors, 1 warning (era 103)
- [x] \`target/release/rts.exe test\` → 214/214 passa
- [x] \`cargo run -- test\` (debug) → 214/214 passa
- [x] \`grep -rn "table()" src/namespaces/\` → 0 matches

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)