### PR TITLE
fix(codegen): == coerce, === strict (#306)

### DIFF
--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -365,6 +365,69 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         return Ok(TypedVal::new(result, ValTy::Bool));
     }
 
+    // === / !== com tipos diferentes em compile-time → const false/true.
+    // (#306) JS strict equality nao coerce; `0 === false` deve ser false.
+    // Bool e' detectavel separado de I64/F64 em ValTy mesmo backed por
+    // mesmo cl_type, e Handle (string) e' distinto de numericos.
+    if matches!(bin.op, BinaryOp::EqEqEq | BinaryOp::NotEqEq) {
+        if !same_strict_kind(lhs.ty, rhs.ty) {
+            let result = if matches!(bin.op, BinaryOp::NotEqEq) { 1 } else { 0 };
+            let v = ctx.builder.ins().iconst(cl::I64, result);
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
+    }
+
+    // == / != com Bool ↔ numerico: coerce ambos para numerico e comparar.
+    // (#306) JS abstract equality: `0 == false` e' true via Number(false)=0.
+    // Mesmo tratamento para I64<->F64<->I32 (promove pra F64 via promote_numeric
+    // que ja' roda abaixo). Mas distincao Bool e' importante: sem este branch,
+    // `0 === false` (mesmo backing i64) cairia em strict-eq numerico true.
+    if matches!(bin.op, BinaryOp::EqEq | BinaryOp::NotEq)
+        && (lhs.ty == ValTy::Bool || rhs.ty == ValTy::Bool)
+        && lhs.ty != ValTy::Handle
+        && rhs.ty != ValTy::Handle
+    {
+        // Promote ambos para i64 e comparar.
+        let lv = ctx.coerce_to_i64(lhs).val;
+        let rv = ctx.coerce_to_i64(rhs).val;
+        let cc = if matches!(bin.op, BinaryOp::EqEq) {
+            IntCC::Equal
+        } else {
+            IntCC::NotEqual
+        };
+        let result = ctx.builder.ins().icmp(cc, lv, rv);
+        return Ok(TypedVal::new(result, ValTy::Bool));
+    }
+
+    // == entre Handle (string) e numerico: parse a string como numero
+    // e compara. Conservador — sem fast path para casos comuns.
+    if matches!(bin.op, BinaryOp::EqEq | BinaryOp::NotEq)
+        && ((lhs.ty == ValTy::Handle && rhs.ty != ValTy::Handle)
+            || (rhs.ty == ValTy::Handle && lhs.ty != ValTy::Handle))
+    {
+        // Converte o numerico em string handle e compara conteudo.
+        // JS: `"1" == 1` -> ToNumber("1") == 1 -> 1 == 1 -> true.
+        // Implementacao: stringify ambos e usa STRING_EQ. Funciona pq
+        // STRING_FROM_I64/F64 emite a representacao decimal canonica que
+        // bate com a string parseavel original (`"1" -> 1 -> "1"`).
+        let lhs_h = ctx.coerce_to_handle(lhs)?.val;
+        let rhs_h = ctx.coerce_to_handle(rhs)?.val;
+        let fref = ctx.get_extern(
+            "__RTS_FN_NS_GC_STRING_EQ",
+            &[cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(fref, &[lhs_h, rhs_h]);
+        let eq = ctx.builder.inst_results(inst)[0];
+        let result = if matches!(bin.op, BinaryOp::NotEq) {
+            let one = ctx.builder.ins().iconst(cl::I64, 1);
+            ctx.builder.ins().bxor(eq, one)
+        } else {
+            eq
+        };
+        return Ok(TypedVal::new(result, ValTy::Bool));
+    }
+
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
     // Reaproveita os valores ja promovidos pra comparacoes —
     // antes lower_icmp recebia lhs/rhs originais e fazia coerce_to_i64
@@ -720,6 +783,19 @@ fn ident_name(expr: &Expr) -> Option<&str> {
     } else {
         None
     }
+}
+
+/// Strict equality (===) considera tipos como JS: Bool, Number (I32/I64/F64
+/// unificados), String (Handle). U64 trata como numerico.
+fn same_strict_kind(a: ValTy, b: ValTy) -> bool {
+    fn kind(t: ValTy) -> u8 {
+        match t {
+            ValTy::Bool => 0,
+            ValTy::Handle => 1,
+            ValTy::I32 | ValTy::I64 | ValTy::F64 | ValTy::U64 => 2,
+        }
+    }
+    kind(a) == kind(b)
 }
 
 /// `lhs instanceof RhsClass`. RHS deve ser um Ident referenciando uma

--- a/tests/loose_equality.test.ts
+++ b/tests/loose_equality.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// === sem coercion: tipos diferentes -> false
+print(`${0 === false}`);
+print(`${1 === true}`);
+print(`${"1" === 1}`);
+print(`${0 === 0}`);
+print(`${true === true}`);
+
+// == com coercion: bool <-> number
+print(`${0 == false}`);
+print(`${1 == true}`);
+print(`${0 == true}`);
+
+// == com coercion: string <-> number
+print(`${"1" == 1}`);
+print(`${"42" == 42}`);
+print(`${"x" == 1}`);
+
+describe("loose_equality", () => {
+  test("=== strict, == coerces", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "false\nfalse\nfalse\ntrue\ntrue\ntrue\ntrue\nfalse\ntrue\ntrue\nfalse\n"
+    ));
+});


### PR DESCRIPTION
## Summary

- \`===\` com tipos diferentes em compile-time → false direto, sem coercion
- \`==\` Bool ↔ Number → promove ambos pra i64 e icmp (\`0==false\` true)
- \`==\` Handle ↔ Number → stringify ambos via STRING_FROM_I64/F64 e compara conteúdo (\`\"1\"==1\` true)

Fixture novo \`tests/loose_equality.test.ts\` cobre os casos JS canônicos.

## Test plan

- [x] \`tests/loose_equality.test.ts\` passa
- [x] Suite full sem regressão (fixtures vermelhos em batch já falhavam pre-fix, verificado via git stash)
- [x] Repros do issue:
  - \`0 === false\` → false ✓
  - \`0 == false\` → true ✓
  - \`\"1\" == 1\` → true ✓
  - \`\"1\" === 1\` → false ✓

Closes #306