### PR TITLE
fix(codegen): mod peephole signed-correto (#297)

### DIFF
--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -194,27 +194,42 @@ fn mul_imm_peephole(
     None
 }
 
-/// `x % imm` peephole. So' otimiza POT positivo via band.
-/// AVISO: muda semantica pra x negativo (x & MASK e' positivo, x % POT
-/// preserva sinal). A maioria dos usos eh com counters >= 0. Documentar.
+/// `x % imm` peephole correto pra signed (#297).
+///
+/// Para POT positivo `n = 2^k`, `x % n` em JS preserva sinal do dividendo:
+/// `-7 % 4 = -3`, `-8 % 4 = 0`. A trick `x & (n-1)` so' funciona para
+/// `x >= 0` — para x negativo `x & MASK` retorna positivo (errado).
+///
+/// Fix correto sem perder a otimizacao em hot paths:
+///
+///     adj  = (x >> (BITS-1)) & (n-1)    // -1 todos bits se x < 0, else 0
+///     r    = (x + adj) & (n-1)          // r positivo
+///     r    = r - adj                    // ajusta sinal
+///
+/// Equivalente a `(x % n + n) & (n-1)` mas sem branch. 4 instrucoes
+/// vs srem ~20+. Cranelift egraph nao faz pra signed mod.
 fn mod_imm_peephole(
     ctx: &mut FnCtx,
     lhs: &TypedVal,
     imm: i64,
 ) -> Option<TypedVal> {
-    if imm > 0 && (imm as u64).is_power_of_two() {
-        let mask = imm - 1;
-        let v = match lhs.ty {
-            ValTy::I32 => ctx.builder.ins().band_imm(lhs.val, mask),
-            _ => {
-                let lv = ctx.coerce_to_i64(*lhs).val;
-                ctx.builder.ins().band_imm(lv, mask)
-            }
-        };
-        let ty = if matches!(lhs.ty, ValTy::I32) { ValTy::I32 } else { ValTy::I64 };
-        return Some(TypedVal::new(v, ty));
+    if !(imm > 0 && (imm as u64).is_power_of_two()) {
+        return None;
     }
-    None
+    let mask = imm - 1;
+    let (lv, ty, bits_minus_one) = match lhs.ty {
+        ValTy::I32 => (lhs.val, ValTy::I32, 31),
+        _ => (ctx.coerce_to_i64(*lhs).val, ValTy::I64, 63),
+    };
+    // adj = (x >> (BITS-1)) & mask
+    let signbits = ctx.builder.ins().sshr_imm(lv, bits_minus_one);
+    let adj = ctx.builder.ins().band_imm(signbits, mask);
+    // r = (x + adj) & mask
+    let plus = ctx.builder.ins().iadd(lv, adj);
+    let masked = ctx.builder.ins().band_imm(plus, mask);
+    // r = masked - adj
+    let r = ctx.builder.ins().isub(masked, adj);
+    Some(TypedVal::new(r, ty))
 }
 
 /// `x / imm` peephole. POT positivo vira sshr (arithmetic right shift,

--- a/tests/mod_negative.test.ts
+++ b/tests/mod_negative.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// JS preserva sinal do dividendo. RTS tinha peephole `x % 2^k -> x & MASK`
+// que ignorava o sinal — agora corrigido com adj branchless (#297).
+print(`${-7 % 4}`);
+print(`${-1 % 4}`);
+print(`${-8 % 4}`);
+print(`${7 % 4}`);
+print(`${0 % 4}`);
+print(`${-7 % 8}`);
+print(`${-15 % 16}`);
+print(`${-16 % 16}`);
+
+describe("mod_negative", () => {
+  test("preserves sign of dividend", () =>
+    expect(__rtsCapturedOutput).toBe("-3\n-1\n0\n3\n0\n-7\n-15\n0\n"));
+});


### PR DESCRIPTION
## Summary

\`x % 2^k\` peephole virava \`x & (2^k - 1)\` sem considerar sinal. \`-7 % 4\` retornava \`1\` em vez de \`-3\`.

Fix branchless mantém otimização: \`adj = (x>>BITS-1) & MASK\`, \`r = ((x+adj) & MASK) - adj\`. 4 instruções, sem srem.

## Test plan

- [x] \`tests/mod_negative.test.ts\` cobre dividendos negativos e positivos
- [x] Suite sem regressão
- [x] Repros do issue:
  - \`-7 % 4 = -3\` ✓
  - \`-1 % 4 = -1\` ✓
  - \`-8 % 4 = 0\` ✓

Closes #297