### PR TITLE
fix(codegen): div/mod /0 sem trap + peephole nao-comutativo (#296)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -130,7 +130,8 @@
       "Bash(RTS_STACK_LIMIT=5 ./target/debug/rts.exe -e 'import { io } from \"rts\"; function recurse\\(n: i64\\): i64 { return recurse\\(n + 1\\); } try { recurse\\(0\\); } catch\\(e\\) { io.print\\(\"caught overflow\"\\); }')",
       "Bash(./target/debug/rts.exe -e 'import { io } from \"rts\"; function fib\\(n: i64\\): i64 { if \\(n <= 1\\) return n; return fib\\(n-1\\) + fib\\(n-2\\); } io.print\\(fib\\(10\\)\\);')",
       "Bash(./target/debug/rts.exe -e 'import { io } from \"rts\"; function count\\(n: i64\\): i64 { if \\(n <= 0\\) return 0; return count\\(n - 1\\) + 1; } let r: i64 = count\\(50\\); if \\(r == 50\\) { io.print\\(\"ok 50\"\\); }')",
-      "Bash(RTS_STACK_LIMIT=10 ./target/debug/rts.exe -e 'import { io } from \"rts\"; function recurse\\(n: i64\\): i64 { return recurse\\(n + 1\\); } recurse\\(0\\);')"
+      "Bash(RTS_STACK_LIMIT=10 ./target/debug/rts.exe -e 'import { io } from \"rts\"; function recurse\\(n: i64\\): i64 { return recurse\\(n + 1\\); } recurse\\(0\\);')",
+      "PowerShell($env:RTS_DUMP_IR=\"1\"; & target/release/rts.exe -e 'function dyn\\(x: number\\): string { const y = x; return `${100/y}`; } import { io } from \"rts\"; io.print\\(dyn\\(4\\)\\);' 2>&1 | Select-Object -First 50)"
     ]
   }
 }

--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -56,9 +56,22 @@ fn try_bin_imm(ctx: &mut FnCtx, bin: &BinExpr) -> Result<Option<TypedVal>> {
     ) {
         return Ok(None);
     }
+    // Para ops comutativas (Add, Mul, BitAnd/Or/Xor), peephole pode usar
+    // qualquer lado como imm. Para nao-comutativas (Sub, Div, Mod), so'
+    // aceita imm na direita: \`x - 5\`, \`x / 5\`, \`x % 5\` (peephole \`var op imm\`),
+    // mas NAO \`5 - x\`, \`5 / x\`, \`5 % x\` (var no lado direito quebraria
+    // a semantica — \`10 / i\` virava \`i / 10\` antes deste fix).
+    let is_commutative = matches!(
+        bin.op,
+        BinaryOp::Add
+            | BinaryOp::Mul
+            | BinaryOp::BitAnd
+            | BinaryOp::BitOr
+            | BinaryOp::BitXor
+    );
     let (var_side, imm) = match (as_int_literal(&bin.left), as_int_literal(&bin.right)) {
-        (Some(imm), None) => (&bin.right, imm),
         (None, Some(imm)) => (&bin.left, imm),
+        (Some(imm), None) if is_commutative => (&bin.right, imm),
         _ => return Ok(None),
     };
 
@@ -743,26 +756,81 @@ fn lower_mul(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> 
 }
 
 fn lower_div(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {
+    // (#296) sdiv crasha em divisor 0. Solucao: int/int onde o divisor e'
+    // literal nao-zero mantem sdiv (caminho rapido); caso contrario emite
+    // guard inline que retorna i64. Em divisor 0, retorna 0 como sentinel
+    // — nao e' Infinity exato mas evita trap. Float div ja' e' IEEE-754,
+    // f.div_zero retorna Inf/-Inf/NaN naturalmente.
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
-    let val = match ty {
-        ValTy::F64 => ctx.builder.ins().fdiv(lv, rv),
-        _ => ctx.builder.ins().sdiv(lv, rv),
-    };
+    if matches!(ty, ValTy::F64) {
+        return Ok(TypedVal::new(ctx.builder.ins().fdiv(lv, rv), ty));
+    }
+    let val = lower_idiv_safe(ctx, lv, rv, ty);
     Ok(TypedVal::new(val, ty))
 }
 
 fn lower_mod(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
-    let val = match ty {
-        ValTy::F64 => {
-            let div = ctx.builder.ins().fdiv(lv, rv);
-            let trunc = ctx.builder.ins().trunc(div);
-            let mul = ctx.builder.ins().fmul(trunc, rv);
-            ctx.builder.ins().fsub(lv, mul)
-        }
-        _ => ctx.builder.ins().srem(lv, rv),
-    };
+    if matches!(ty, ValTy::F64) {
+        let div = ctx.builder.ins().fdiv(lv, rv);
+        let trunc = ctx.builder.ins().trunc(div);
+        let mul = ctx.builder.ins().fmul(trunc, rv);
+        return Ok(TypedVal::new(ctx.builder.ins().fsub(lv, mul), ty));
+    }
+    let val = lower_imod_safe(ctx, lv, rv, ty);
     Ok(TypedVal::new(val, ty))
+}
+
+/// Emite sdiv com guard pra divisor 0. (#296) Em divisor 0 retorna 0.
+/// Estrategia branchless: bor(rv, is_zero_flag) garante divisor != 0;
+/// em divisor 0, divide por 1 (mascara is_zero=1 entra no rv). Depois
+/// AND com !is_zero zera o resultado quando original era 0.
+/// Sem branches, sem select — IR mais previsivel pra Cranelift.
+/// Emite sdiv com guard branchless pra divisor 0. (#296) Em divisor 0
+/// retorna 0 (sentinel). Estrategia: `safe_rv = rv | is_zero` evita o
+/// trap, depois `result & (is_zero - 1)` mascara para 0 no caso original 0.
+fn lower_idiv_safe(
+    ctx: &mut FnCtx,
+    lv: cranelift_codegen::ir::Value,
+    rv: cranelift_codegen::ir::Value,
+    ty: ValTy,
+) -> cranelift_codegen::ir::Value {
+    let cl_ty = if matches!(ty, ValTy::I32) { cl::I32 } else { cl::I64 };
+    let zero = ctx.builder.ins().iconst(cl_ty, 0);
+    let is_zero_b = ctx.builder.ins().icmp(IntCC::Equal, rv, zero);
+    let bool_ty = ctx.builder.func.dfg.value_type(is_zero_b);
+    let is_zero = if bool_ty == cl_ty {
+        is_zero_b
+    } else {
+        ctx.builder.ins().uextend(cl_ty, is_zero_b)
+    };
+    let safe_rv = ctx.builder.ins().bor(rv, is_zero);
+    let q = ctx.builder.ins().sdiv(lv, safe_rv);
+    let one = ctx.builder.ins().iconst(cl_ty, 1);
+    let mask = ctx.builder.ins().isub(is_zero, one);
+    ctx.builder.ins().band(q, mask)
+}
+
+fn lower_imod_safe(
+    ctx: &mut FnCtx,
+    lv: cranelift_codegen::ir::Value,
+    rv: cranelift_codegen::ir::Value,
+    ty: ValTy,
+) -> cranelift_codegen::ir::Value {
+    let cl_ty = if matches!(ty, ValTy::I32) { cl::I32 } else { cl::I64 };
+    let zero = ctx.builder.ins().iconst(cl_ty, 0);
+    let is_zero_b = ctx.builder.ins().icmp(IntCC::Equal, rv, zero);
+    let bool_ty = ctx.builder.func.dfg.value_type(is_zero_b);
+    let is_zero = if bool_ty == cl_ty {
+        is_zero_b
+    } else {
+        ctx.builder.ins().uextend(cl_ty, is_zero_b)
+    };
+    let safe_rv = ctx.builder.ins().bor(rv, is_zero);
+    let r = ctx.builder.ins().srem(lv, safe_rv);
+    let one = ctx.builder.ins().iconst(cl_ty, 1);
+    let mask = ctx.builder.ins().isub(is_zero, one);
+    ctx.builder.ins().band(r, mask)
 }
 
 fn lower_icmp(ctx: &mut FnCtx, cc: IntCC, lhs: TypedVal, rhs: TypedVal) -> TypedVal {

--- a/src/namespaces/gc/string_pool.rs
+++ b/src/namespaces/gc/string_pool.rs
@@ -89,9 +89,16 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64(value: i64) -> u64 {
 }
 
 /// Converts an `f64` to its decimal string representation and returns a handle.
+/// Match JS Number.prototype.toString: NaN/Infinity formatados como
+/// "NaN"/"Infinity"/"-Infinity"; finitos sem fracao formatados como i64
+/// (sem `.0`); finitos com fracao via Display do Rust.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_F64(value: f64) -> u64 {
-    let s = if value.fract() == 0.0 && value.is_finite() {
+    let s = if value.is_nan() {
+        "NaN".to_string()
+    } else if value.is_infinite() {
+        if value > 0.0 { "Infinity".to_string() } else { "-Infinity".to_string() }
+    } else if value.fract() == 0.0 && value.abs() < 1e16 {
         format!("{}", value as i64)
     } else {
         format!("{value}")

--- a/tests/div_mod_zero.test.ts
+++ b/tests/div_mod_zero.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#296) RTS antes crashava com 'Illegal instruction' em x/0 e x%0 com
+// inteiros. Agora emite guard inline em sdiv/srem que retorna sentinel 0
+// em divisor 0 — nao bate JS (que retorna Infinity/NaN) mas evita trap.
+//
+// Float continua IEEE-754 (Infinity/NaN naturais).
+
+// 1. Casos do issue — int (sentinel 0) e float (Infinity/NaN)
+print(`${5 / 0}`);          // 0    (int/0 sentinel)
+print(`${5.0 / 0.0}`);      // Infinity (float/0 IEEE)
+print(`${-5.0 / 0.0}`);     // -Infinity
+print(`${0.0 / 0.0}`);      // NaN
+print(`${5 % 0}`);          // 0    (int sentinel)
+print(`${5.0 % 0.0}`);      // NaN
+
+// 2. Caminho normal preservado (sem trap penalty)
+print(`${10 / 2}`);   // 5
+print(`${10 % 3}`);   // 1
+print(`${-7 % 3}`);   // -1 (sinal preservado, fix #297)
+
+// 3. Combinado com guard ternario — evita o sentinel 0
+const a: number = 0;
+print(`${a !== 0 ? 100 / a : "guarded"}`);  // guarded
+print(`${a === 0 ? "skip" : 100 / a}`);     // skip
+
+// 4. Em loop — counter sempre nao-zero. Inteiros literais (10) e
+// counter int (i: I32) fazem int div: 10/1+10/2+10/3+10/4+10/5
+// = 10+5+3+2+2 = 22 (sem fracao).
+let total: number = 0;
+for (let i = 1; i <= 5; i++) {
+  total = total + (10 / i);
+}
+print(`${total}`);  // 22
+
+// 5. Fn user com div em path sem guard explicito (number = f64, IEEE)
+function divUnsafe(a: number, b: number): number {
+  return a / b;
+}
+print(`${divUnsafe(10, 2)}`);  // 5
+print(`${divUnsafe(10, 0)}`);  // Infinity (f64 IEEE)
+
+// 6. Classe com static method usando div
+class Calculator {
+  static safeDiv(a: number, b: number): number {
+    if (b === 0) return -1;
+    return a / b;
+  }
+}
+print(`${Calculator.safeDiv(20, 4)}`);  // 5
+print(`${Calculator.safeDiv(20, 0)}`);  // -1
+
+// 7. Try/catch — div/0 nao throw em JS, nem em RTS agora
+try {
+  const x = 1 / 0;
+  print(`tried: ${x}`);    // tried: 0 (sentinel)
+} catch (e) {
+  print("nao deveria throw");
+}
+
+// 8. Modulo em counter de loop — caso comum
+let evens = 0;
+for (let i = 1; i <= 10; i++) {
+  if (i % 2 === 0) evens = evens + 1;
+}
+print(`${evens}`);  // 5
+
+// 9. Mod por zero em runtime variable (number = f64)
+function modBy(n: number, k: number): number {
+  return n % k;
+}
+print(`${modBy(7, 3)}`);  // 1
+print(`${modBy(7, 0)}`);  // NaN (f64 IEEE)
+
+describe("div_mod_zero", () => {
+  test("no trap, sentinel 0 in int /0, IEEE in float /0", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "0\nInfinity\n-Infinity\nNaN\n0\nNaN\n" +    // 1
+      "5\n1\n-1\n" +                                // 2
+      "guarded\nskip\n" +                           // 3
+      "22\n" +                                      // 4
+      "5\nInfinity\n" +                             // 5
+      "5\n-1\n" +                                   // 6
+      "tried: 0\n" +                                // 7
+      "5\n" +                                       // 8
+      "1\nNaN\n"                                    // 9
+    ));
+});


### PR DESCRIPTION
## Summary

- Inteiro \`x/0\` e \`x%0\` retornam sentinel \`0\` em vez de trapar (\"Illegal instruction\")
- Guard branchless: \`bor(rv, is_zero)\` evita trap, \`band(q, is_zero-1)\` mascara para 0
- Bug peephole pré-existente descoberto: \`10 / i\` virava \`i / 10\` (try_bin_imm invertia lhs/rhs em ops não-comutativas). Fix com flag \`is_commutative\`.

## Test plan

- [x] \`tests/div_mod_zero.test.ts\` — 9 cenários (basico, ternário, loop, fn user, classe, try/catch, runtime variable)
- [x] Suite full sem regressão (204 fixtures verdes)
- [x] Repros do issue:
  - \`5/0\` int → 0 (sentinel, sem trap) ✓
  - \`5.0/0.0\` → Infinity ✓
  - \`-5.0/0.0\` → -Infinity ✓
  - \`0.0/0.0\` → NaN ✓
- [x] Bug peephole \`10/3\` agora retorna 3 (era 0)

Closes #296