### PR TITLE
fix(codegen): preservar ordem AST em string+number concat (#299)

### DIFF
--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -77,6 +77,19 @@ fn try_bin_imm(ctx: &mut FnCtx, bin: &BinExpr) -> Result<Option<TypedVal>> {
 
     let lhs = lower_expr(ctx, var_side)?;
 
+    // (#299) Peephole de Add inverteu lhs/rhs quando literal estava na
+    // esquerda. Pra Number e' OK (3+5=5+3) mas Add com Handle vira
+    // string concat e a ordem importa (\`3+\"5\"=\"35\"\`, \`\"5\"+3=\"53\"\`).
+    // Quando o var_side e' Handle e o literal estava do outro lado,
+    // a inversao quebra a semantica — abort do peephole, deixa o fluxo
+    // principal lower_bin emitir concat na ordem do AST.
+    if matches!(bin.op, BinaryOp::Add)
+        && matches!(lhs.ty, ValTy::Handle)
+        && matches!(as_int_literal(&bin.left), Some(_))
+    {
+        return Ok(None);
+    }
+
     // Peepholes so' aplicam quando lhs eh inteiro. F64 *2 nao pode
     // virar shift; f64 %4 nao pode virar band. Sem essa guarda o
     // peephole quebrava \`5.5 % 4\` (vinha 1 em vez de 1.5) e

--- a/tests/string_number_concat.test.ts
+++ b/tests/string_number_concat.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#299) String + Number e' concat na ordem do AST. Bug previo: peephole
+// de Add invertia lhs/rhs quando literal numerico estava a esquerda,
+// produzindo \`3 + "5" = "53"\` em vez de \`"35"\`.
+
+// 1. Casos basicos do issue
+print(`${"5" + 3}`);     // "53"
+print(`${3 + "5"}`);     // "35"
+print(`${"abc" + 5}`);   // "abc5"
+print(`${5 + "abc"}`);   // "5abc"
+
+// 2. String + string nao afetado
+print(`${"a" + "b"}`);   // "ab"
+print(`${"" + "x"}`);    // "x"
+
+// 3. Number + number ainda funciona normalmente
+print(`${1 + 2}`);       // 3
+print(`${10 + 5}`);      // 15
+
+// 4. Encadeamento — JS avalia left-to-right
+print(`${1 + 2 + "3"}`);    // "33" (1+2=3 numero, depois 3+"3"="33")
+print(`${"1" + 2 + 3}`);    // "123" (concat preserva: "12" depois "123")
+print(`${1 + "2" + 3}`);    // "123" (1+"2"="12" depois +"3"="123")
+
+// 5. Em fn user
+function concat(a: number, b: string): string {
+  return a + b;
+}
+print(concat(7, "x"));      // "7x"
+print(`${42 + "test"}`);    // "42test"
+
+// 6. Em template — multiplas expressoes
+const n: number = 5;
+const s: string = "items";
+print(`have ${n} ${s}, total: ${n + " " + s}`);  // "have 5 items, total: 5 items"
+
+// 7. Compound assign
+let acc: string = "";
+acc += 1;
+acc += 2;
+acc += "x";
+print(acc);   // "12x"
+
+// 8. Em conditional (ternario com string concat)
+const flag: boolean = true;
+const r: string = flag ? 1 + "x" : "none";
+print(r);   // "1x"
+
+// 9. Negativos preservam ordem
+print(`${-3 + "z"}`);   // "-3z"
+print(`${"z" + -3}`);   // "z-3"
+
+describe("string_number_concat", () => {
+  test("ordem do AST preservada em concat", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "53\n35\nabc5\n5abc\n" +              // 1
+      "ab\nx\n" +                           // 2
+      "3\n15\n" +                           // 3
+      "33\n123\n123\n" +                    // 4
+      "7x\n42test\n" +                      // 5
+      "have 5 items, total: 5 items\n" +    // 6
+      "12x\n" +                             // 7
+      "1x\n" +                              // 8
+      "-3z\nz-3\n"                          // 9
+    ));
+});


### PR DESCRIPTION
## Summary

\`3 + \"5\"\` retornava \`\"53\"\` em vez de \`\"35\"\`. Peephole de Add invertia lhs/rhs em ops comutativas, mas concat de string preserva ordem visual.

Fix: quando var_side resolve a Handle e o literal estava na esquerda, abort do peephole. CONCAT emitido na ordem do source.

## Test plan

- [x] \`tests/string_number_concat.test.ts\` — 9 grupos (basico, encadeamento, fn user, template, compound assign, ternario, negativos)
- [x] Suite: 204 → 205 fixtures verdes
- [x] Repros do issue:
  - \`3 + \"5\" = \"35\"\` ✓
  - \`\"5\" + 3 = \"53\"\` ✓
  - \`1 + 2 + \"3\" = \"33\"\` (avaliado left-to-right) ✓

Closes #299