### PR TITLE
feat(cli): rts -e via stdin pipe + shebang strip (#285)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,5 +1,6 @@
 //! `rts run <input.ts>` — compile + execute via Cranelift JIT.
 
+use std::io::{IsTerminal, Read};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, anyhow};
@@ -38,14 +39,43 @@ pub fn command(input: Option<String>, options: CompileOptions) -> Result<()> {
 /// TS inline via JIT, sem precisar criar arquivo temp. Uso tipico:
 /// debug rapido de snippet, ou em pipelines/scripts shell.
 ///
+/// (#285) Quando \`source\` e' None e stdin nao e' tty, le de stdin —
+/// permite \`echo \"...\" | rts -e\` e \`cat script.ts | rts -e\`.
+///
 /// Imports relativos (\`./mod\`) nao sao resolvidos — so' builtins
 /// (\`import { io } from \"rts\"\`).
 pub fn eval_command(input: Option<String>, options: CompileOptions) -> Result<()> {
-    let source = input.ok_or_else(|| anyhow!("usage: rts eval \"<source>\" ou rts -e \"<source>\""))?;
+    let source = match input {
+        Some(s) => s,
+        None => {
+            // Tenta ler stdin. Em terminal interativo, isto bloqueia esperando
+            // input — emit usage error em vez de pendurar.
+            if is_stdin_tty() {
+                return Err(anyhow!(
+                    "usage: rts eval \"<source>\" ou rts -e \"<source>\"\n\
+                     (alternativa: 'echo ... | rts -e' para ler de stdin)"
+                ));
+            }
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("falha ao ler stdin")?;
+            if buf.trim().is_empty() {
+                return Err(anyhow!("stdin vazio"));
+            }
+            buf
+        }
+    };
+    // Shebang strip e' aplicado no parser (parse_source_with_mode) —
+    // funciona tanto para arquivos via \`rts run\` quanto pra eval/stdin.
     let (exit_code, warnings) = pipeline::run_jit_inline(&source, options)
         .with_context(|| "JIT eval falhou")?;
     for warning in &warnings {
         eprintln!("{warning}");
     }
     std::process::exit(exit_code);
+}
+
+fn is_stdin_tty() -> bool {
+    std::io::stdin().is_terminal()
 }

--- a/src/parser/parse_api.rs
+++ b/src/parser/parse_api.rs
@@ -5,8 +5,22 @@ pub fn parse_source(source: &str) -> Result<Program> {
 /// Parse sem arquivo conhecido. Registra um fonte anonimo no `SourceStore`
 /// para que diagnosticos ainda consigam renderizar snippets.
 pub fn parse_source_with_mode(source: &str, mode: FrontendMode) -> Result<Program> {
-    let file = source_store::register_anonymous("eval", source);
-    parse_source_with_file(source, mode, file)
+    let stripped = strip_shebang(source);
+    let file = source_store::register_anonymous("eval", stripped);
+    parse_source_with_file(stripped, mode, file)
+}
+
+/// Remove shebang (\`#!...\`) na primeira linha. (#285) Permite scripts
+/// executaveis com \`#!/usr/bin/env rts\` no topo. Mantem o \\n pra
+/// preservar line numbers nos diagnosticos.
+pub(crate) fn strip_shebang(source: &str) -> &str {
+    if let Some(rest) = source.strip_prefix("#!") {
+        if let Some(nl) = rest.find('\n') {
+            return &source[nl + 2..];
+        }
+        return "";
+    }
+    source
 }
 
 /// Parse com `FileId` conhecido — todos os spans do AST resultante


### PR DESCRIPTION
## Summary

- \`rts -e\` sem argumento lê de stdin quando não é tty (\`echo '...' | rts -e\`)
- Shebang \`#!/usr/bin/env rts\` no topo do .ts é ignorado pelo parser
- Detect tty via \`std::io::IsTerminal\` (Rust 1.70+, sem deps novas)

## Test plan

- [x] \`echo 'import { io } from \"rts\"; io.print(\"x\")' | rts -e\` → x
- [x] \`#!/usr/bin/env rts\nimport...\` em arquivo executa normalmente
- [x] \`rts -e\` em terminal interativo emit usage error (não pendura)
- [x] Suite full sem regressão

Closes #285 parcial (partes 1+2; multiline via \`rts -e \"...\"\` com newlines já funcionava antes)