### PR TITLE
feat(codegen): NaN, Infinity, undefined globais (#298 parcial)

### DIFF
--- a/src/codegen/lower/expressions/basics.rs
+++ b/src/codegen/lower/expressions/basics.rs
@@ -136,16 +136,32 @@ pub(super) fn lower_unary(ctx: &mut FnCtx, u: &swc_ecma_ast::UnaryExpr) -> Resul
 fn lower_typeof(ctx: &mut FnCtx, operand: &Expr) -> Result<TypedVal> {
     // `typeof undeclaredVar` em JS retorna "undefined" sem erro — fast
     // path para nao tentar resolver o ident e disparar undefined-var.
+    // Excluimos NaN/Infinity (que sao globais resolvidos em
+    // lower_ident_expr): \`typeof NaN\` em JS e' "number".
     if let Expr::Ident(id) = operand {
         let name = id.sym.as_str();
-        if ctx.read_local(name).is_none() && !ctx.user_fns.contains_key(name) {
+        let is_js_global = matches!(name, "NaN" | "Infinity" | "undefined");
+        if !is_js_global
+            && ctx.read_local(name).is_none()
+            && !ctx.user_fns.contains_key(name)
+        {
             return ctx.emit_str_handle(b"undefined");
         }
     }
     let tv = lower_expr(ctx, operand)?;
     let ty_str = match tv.ty {
         ValTy::Bool => "boolean",
-        ValTy::Handle => "string",
+        ValTy::Handle => {
+            // \`undefined\` global vira string handle "undefined". Caso
+            // especifico — distinguir typeof "x" (string normal) de
+            // typeof undefined (undefined) exige checagem do ident.
+            if let Expr::Ident(id) = operand {
+                if id.sym.as_ref() == "undefined" {
+                    return ctx.emit_str_handle(b"undefined");
+                }
+            }
+            "string"
+        }
         ValTy::F64 | ValTy::I32 | ValTy::I64 | ValTy::U64 => "number",
     };
     ctx.emit_str_handle(ty_str.as_bytes())

--- a/src/codegen/lower/expressions/mod.rs
+++ b/src/codegen/lower/expressions/mod.rs
@@ -70,6 +70,31 @@ fn lower_ident_expr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal> {
     if ctx.user_fns.contains_key(name) {
         return emit_user_fn_addr(ctx, name);
     }
+    // (#298) Globais JS NaN/Infinity/undefined. NaN e Infinity sao
+    // f64 IEEE; \`undefined\` em RTS nao tem representacao distinta de
+    // 0/null entao mapeamos para 0 (caller que comparar com === detecta
+    // tipo via context). Cobre uso comum em template/aritmetica.
+    use cranelift_codegen::ir::{InstBuilder, types as cl};
+    use crate::codegen::lower::ctx::ValTy;
+    match name {
+        "NaN" => {
+            let v = ctx.builder.ins().f64const(f64::NAN);
+            return Ok(TypedVal::new(v, ValTy::F64));
+        }
+        "Infinity" => {
+            let v = ctx.builder.ins().f64const(f64::INFINITY);
+            return Ok(TypedVal::new(v, ValTy::F64));
+        }
+        "undefined" => {
+            // Usado em \`x === undefined\`, \`x ?? def\`, \`${undefined}\`.
+            // Sentinel 0 cobre as 3 — strict check distingue tipo via
+            // operador, e template literal converte i64 0 para "0".
+            // Pra alinhar com JS \`${undefined}\` -> "undefined", emitimos
+            // string handle "undefined" direto.
+            return ctx.emit_str_handle(b"undefined");
+        }
+        _ => {}
+    }
     Err(anyhow!("undefined variable `{name}`"))
 }
 

--- a/tests/nan_infinity.test.ts
+++ b/tests/nan_infinity.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#298) Globais JS NaN, Infinity, undefined antes davam undefined-var.
+
+// 1. Stringificacao em template
+print(`${NaN}`);          // NaN
+print(`${Infinity}`);     // Infinity
+print(`${-Infinity}`);    // -Infinity
+print(`${undefined}`);    // undefined
+
+// 2. typeof
+print(`${typeof NaN}`);        // number
+print(`${typeof Infinity}`);   // number
+print(`${typeof undefined}`);  // undefined
+print(`${typeof 5}`);          // number
+print(`${typeof "x"}`);        // string
+
+// 3. NaN === NaN sempre false (regra JS)
+print(`${NaN === NaN}`);   // false
+print(`${NaN !== NaN}`);   // true
+print(`${NaN == NaN}`);    // false
+
+// 4. Infinity comparisons
+print(`${Infinity > 1e308}`);     // true
+print(`${-Infinity < -1e308}`);   // true
+print(`${Infinity === Infinity}`); // true
+
+// 5. Aritmetica f64 IEEE — via vars pra evitar peephole de literais.
+// Anotacao \`: f64\` explicita pra f64; \`number\` em var decl tem bug
+// separado que faz tipo virar int (a investigar).
+const one: f64 = 1.0;
+const minus_one: f64 = -1.0;
+const zero: f64 = 0.0;
+print(`${one / zero}`);     // Infinity
+print(`${minus_one / zero}`); // -Infinity
+print(`${zero / zero}`);    // NaN
+print(`${Infinity - Infinity}`);  // NaN
+print(`${Infinity + 1}`);          // Infinity
+
+// 6. Em fn user
+function safeDiv(a: number, b: number): number {
+  return a / b;  // se b=0, retorna +/- Infinity
+}
+print(`${safeDiv(10, 0)}`);     // Infinity
+print(`${safeDiv(-10, 0)}`);    // -Infinity
+
+// 7. Em conditional — NaN === NaN sempre false, branch alt
+const x: f64 = NaN;
+const tag: string = (x === x) ? "ordered" : "NaN";
+print(tag);  // NaN
+
+// 8. NaN no Math
+import { math } from "rts";
+print(`${math.sqrt(-1)}`);  // NaN
+
+describe("nan_infinity", () => {
+  test("globals + IEEE-754 propagation", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "NaN\nInfinity\n-Infinity\nundefined\n" +     // 1
+      "number\nnumber\nundefined\nnumber\nstring\n" + // 2
+      "false\ntrue\nfalse\n" +                       // 3
+      "true\ntrue\ntrue\n" +                         // 4
+      "Infinity\n-Infinity\nNaN\nNaN\nInfinity\n" +  // 5
+      "Infinity\n-Infinity\n" +                      // 6
+      "NaN\n" +                                      // 7
+      "NaN\n"                                        // 8
+    ));
+});


### PR DESCRIPTION
## Summary

\`NaN\`, \`Infinity\`, \`undefined\` agora são resolvidos como globais JS em vez de \"undefined variable\".

- \`NaN\` → f64::NAN
- \`Infinity\` → f64::INFINITY
- \`undefined\` → string handle \"undefined\"
- \`typeof NaN\`/\`typeof Infinity\` → \"number\" ✓
- \`typeof undefined\` → \"undefined\" ✓

## Test plan

- [x] \`tests/nan_infinity.test.ts\` — 8 grupos (stringification, typeof, NaN!==NaN, Infinity, IEEE arith, fn user, conditional, math.sqrt)
- [x] Suite: 205 → 206

## Pendente do issue (próxima fase)

- \`isNaN\`/\`isFinite\` helpers
- NaN propagation em + - * (qualquer arith com NaN → NaN)
- Bug separado descoberto: var decl \`: number\` quebra div f64; \`: f64\` funciona

Closes #298 parcial