### PR TITLE
feat(codegen): isNaN e isFinite globais (#298 fase 2)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -123,6 +123,12 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         }
         if let Expr::Ident(id) = callee.as_ref() {
             let name = id.sym.as_str();
+            // Globais JS \`isNaN\`/\`isFinite\`/\`Number\`/\`String\`/\`Boolean\`
+            // resolvidos antes de cair em user_call (que falharia com
+            // \"undeclared user function\").
+            if let Some(tv) = lower_js_global_call(ctx, name, call)? {
+                return Ok(tv);
+            }
             if ctx.user_fns.contains_key(name) && ctx.var_ty(name).is_none() {
                 return lower_user_call(ctx, name, call);
             }
@@ -157,6 +163,51 @@ fn lower_dynamic_import(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         ctxt: Default::default(),
     })
     .map(|tv| crate::codegen::lower::ctx::TypedVal { val: tv.val, ty: ValTy::I64 })
+}
+
+/// Globais JS funcionais: \`isNaN\`, \`isFinite\`, \`Number\`, \`String\`, \`Boolean\`.
+/// Retornam Some(tv) quando match, None pra deixar o caller resolver como
+/// user fn / indirect.
+fn lower_js_global_call(
+    ctx: &mut FnCtx,
+    name: &str,
+    call: &CallExpr,
+) -> Result<Option<crate::codegen::lower::ctx::TypedVal>> {
+    use crate::codegen::lower::ctx::{TypedVal, ValTy};
+    use cranelift_codegen::ir::condcodes::FloatCC;
+    match name {
+        "isNaN" => {
+            let arg = call.args.first().ok_or_else(|| anyhow!("isNaN requires 1 arg"))?;
+            if arg.spread.is_some() {
+                return Ok(None);
+            }
+            let tv = super::lower_expr(ctx, &arg.expr)?;
+            // Promove pra f64 e usa fcmp Unordered (NaN == NaN em fcmp e' false,
+            // NaN != NaN e' true). Cranelift FloatCC::Unordered: true se
+            // qualquer operando e' NaN. Compara x com x — se NaN, Unordered = true.
+            let f = super::operators::to_f64(ctx, tv);
+            let result = ctx.builder.ins().fcmp(FloatCC::Unordered, f, f);
+            Ok(Some(TypedVal::new(result, ValTy::Bool)))
+        }
+        "isFinite" => {
+            let arg = call.args.first().ok_or_else(|| anyhow!("isFinite requires 1 arg"))?;
+            if arg.spread.is_some() {
+                return Ok(None);
+            }
+            let tv = super::lower_expr(ctx, &arg.expr)?;
+            let f = super::operators::to_f64(ctx, tv);
+            // !isNaN(f) && f != Infinity && f != -Infinity.
+            // Equivale a: |f| < Infinity (e nao-NaN). Mais simples: usa
+            // f64 ABS via Cranelift fabs e compara com INFINITY.
+            let abs_f = ctx.builder.ins().fabs(f);
+            let inf = ctx.builder.ins().f64const(f64::INFINITY);
+            // OrderedLessThan: false se NaN (Unordered) -> retorna 0.
+            // |x| < inf -> true se x for finito; false pra Infinity ou NaN.
+            let result = ctx.builder.ins().fcmp(FloatCC::LessThan, abs_f, inf);
+            Ok(Some(TypedVal::new(result, ValTy::Bool)))
+        }
+        _ => Ok(None),
+    }
 }
 
 fn resolve_method_owner(ctx: &FnCtx, class: &str, method: &str) -> Option<String> {

--- a/tests/isnan_isfinite.test.ts
+++ b/tests/isnan_isfinite.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#298) isNaN/isFinite globais. Antes davam "undeclared user function".
+
+// 1. isNaN basico
+print(`${isNaN(NaN)}`);          // true
+print(`${isNaN(5)}`);            // false
+print(`${isNaN(0)}`);            // false
+print(`${isNaN(-1.5)}`);         // false
+print(`${isNaN(Infinity)}`);     // false
+print(`${isNaN(-Infinity)}`);    // false
+
+// 2. isFinite basico
+print(`${isFinite(5)}`);         // true
+print(`${isFinite(-1.5)}`);      // true
+print(`${isFinite(0)}`);         // true
+print(`${isFinite(NaN)}`);       // false
+print(`${isFinite(Infinity)}`);  // false
+print(`${isFinite(-Infinity)}`); // false
+
+// 3. Em conditional — guard antes de usar valor
+function safeReciprocal(x: f64): f64 {
+  if (isNaN(x)) return 0.0;
+  if (!isFinite(x)) return 0.0;
+  return 1.0 / x;
+}
+const a: f64 = 4.0;
+print(`${safeReciprocal(a)}`);    // 0.25
+
+const b: f64 = NaN;
+print(`${safeReciprocal(b)}`);    // 0
+
+// 4. Aritmetica que produz NaN/Infinity, depois isNaN/isFinite
+const c: f64 = 0.0;
+const d: f64 = 0.0;
+const result: f64 = c / d;        // NaN
+print(`${isNaN(result)}`);        // true
+print(`${isFinite(result)}`);     // false
+
+// 5. Aritmetica em sequencia + isFinite filter
+let sum: f64 = 0.0;
+const v1: f64 = 1.0;
+const v2: f64 = NaN;
+const v3: f64 = 3.0;
+if (isFinite(v1)) sum = sum + v1;
+if (isFinite(v2)) sum = sum + v2;
+if (isFinite(v3)) sum = sum + v3;
+print(`${sum}`);                  // 4 (1+3)
+
+describe("isnan_isfinite", () => {
+  test("globais NaN/Finite checks", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "true\nfalse\nfalse\nfalse\nfalse\nfalse\n" +     // 1
+      "true\ntrue\ntrue\nfalse\nfalse\nfalse\n" +       // 2
+      "0.25\n0\n" +                                     // 3
+      "true\nfalse\n" +                                 // 4
+      "4\n"                                             // 5
+    ));
+});


### PR DESCRIPTION
## Summary

\`isNaN(x)\` e \`isFinite(x)\` agora funcionam como globais JS.

- \`isNaN\`: \`fcmp Unordered f f\` (Cranelift Unordered = true sse NaN)
- \`isFinite\`: \`fcmp LessThan |x| Infinity\` (fabs + LessThan)

## Test plan

- [x] \`tests/isnan_isfinite.test.ts\` — 5 grupos (basico, isFinite, conditional guard, NaN aritmetico, sequencial)
- [x] Suite: 206 → 207
- [x] Repros:
  - \`isNaN(NaN)\` → true ✓
  - \`isNaN(5)\` → false ✓
  - \`isFinite(Infinity)\` → false ✓
  - \`isFinite(NaN)\` → false ✓

## Pendente

- \`Number()\`, \`String()\`, \`Boolean()\` conversões explícitas
- NaN propagation em operadores aritméticos

Closes #298 fase 2