### PR TITLE
feat(class): rejeita super() multiplo no mesmo constructor (#303 parte 1)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -286,6 +286,10 @@ pub struct FnCtx<'m, 'fb> {
     /// True quando a função atual é um constructor de classe
     /// (`__class_C__init`). Usado pra permitir assign em readonly fields.
     pub current_is_ctor: bool,
+    /// (#303) True quando \`super(...)\` ja foi chamado neste constructor.
+    /// JS lanca ReferenceError no segundo super(). Reseta a cada
+    /// constructor lowered.
+    pub super_already_called: bool,
     /// True when lowering top-level statements in `main`.
     pub module_scope: bool,
     /// Declared return type of the surrounding function, used to coerce
@@ -390,6 +394,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             global_class_ty,
             current_class: None,
             current_is_ctor: false,
+            super_already_called: false,
             module_scope,
             return_ty: None,
             in_tail_position: false,

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -639,6 +639,14 @@ fn lower_super_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         .and_then(|m| m.super_class.clone())
         .ok_or_else(|| anyhow!("`super(...)` em classe sem extends"))?;
 
+    // (#303) JS: \`Super constructor may only be called once\`. Detect
+    // estatico via flag aqui ja' produzia falso positivo em branches
+    // \`if/else\` mutualmente exclusivos. Flag agora rastreia mas nao
+    // bloqueia automaticamente — caller de detect com scan AST especifico
+    // deve invalidar o caso linear (super; super no mesmo block).
+    // Nao implementado completamente; placeholder pra fase futura.
+    ctx.super_already_called = true;
+
     let Some(init_owner) = resolve_init_owner(ctx, &parent) else {
         for a in &call.args {
             if a.spread.is_some() {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -5281,6 +5281,10 @@ fn compile_user_fn(
             .as_ref()
             .map(|c| fn_decl.name == class_init_name(c))
             .unwrap_or(false);
+        // Reset por fn — \`super_already_called\` rastreia chamadas dentro
+        // do constructor corrente. Sem reset, multiplos constructors no
+        // mesmo programa compartilhariam a flag.
+        fn_ctx.super_already_called = false;
         // Em metodos/constructors, o param `this` e instancia da classe
         // dona — populamos local_class_ty pra que `this.field`/dispatch
         // tipicos funcionem (e overload em `this.x + ...`).
@@ -5624,6 +5628,25 @@ fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
         match member {
             ClassMember::Constructor(ctor) => {
                 has_constructor = true;
+                // (#303 parte 1) Detecta \`super(...); super(...)\` em
+                // sequencia direta (mesmo bloco/escopo top-level do
+                // constructor body). JS proibe — segundo super lanca
+                // ReferenceError. So' rejeita o caso linear obvio; em
+                // branches if/else mutuamente exclusivos (super em cons
+                // E em alt), passa silenciosamente — runtime check seria
+                // a fase 2 dessa issue.
+                if count_super_calls_in_top_level(&ctor.body) > 1 {
+                    // SyntaxError-like: rejeita o programa em compile time.
+                    // Usar eprintln + std::process::exit(1) imita o caminho
+                    // de erros existentes em outras validacoes (abstract,
+                    // visibility). Sem Result aqui pra nao espalhar
+                    // mudanca de tipo em todo synthesize_class_fns caller.
+                    eprintln!(
+                        "error: ReferenceError: super constructor may only be called once (em `{}`)",
+                        class.name
+                    );
+                    std::process::exit(1);
+                }
                 for p in &ctor.parameters {
                     if let Some(ann) = p.type_annotation.as_deref() {
                         field_types
@@ -5841,6 +5864,26 @@ fn make_field_init_stmt(
 /// - Se `has_super` e o primeiro statement do user é `super(...)`,
 ///   coloca os initializers logo depois.
 /// - Caso contrário, prepende.
+/// (#303 parte 1) Conta \`super(...)\` no nivel top-level do body de um
+/// constructor, sem descer em if/else/loops/blocks. Detect de duplicacao
+/// linear evita o caso degenerate \`super(); super();\`.
+fn count_super_calls_in_top_level(body: &[Statement]) -> usize {
+    use swc_ecma_ast::{Callee, Expr, Stmt};
+    let mut count = 0usize;
+    for stmt in body {
+        let Statement::Raw(raw) = stmt;
+        let Some(s) = raw.stmt.as_ref() else { continue };
+        if let Stmt::Expr(e) = s {
+            if let Expr::Call(c) = e.expr.as_ref() {
+                if matches!(c.callee, Callee::Super(_)) {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
 fn weave_initializers(
     user_body: &[Statement],
     init_stmts: &[Statement],

--- a/tests/super_call_once.test.ts
+++ b/tests/super_call_once.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#303 parte 1) JS proibe \`super(...)\` mais de uma vez no mesmo
+// constructor. Antes RTS chamava o construtor pai duas vezes,
+// silenciosamente sobrescrevendo state. Agora rejeita em compile-time.
+
+class Animal {
+  name: string = "";
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+// 1. super uma vez — caso normal
+class Dog extends Animal {
+  breed: string;
+  constructor(name: string, breed: string) {
+    super(name);
+    this.breed = breed;
+  }
+}
+
+const d = new Dog("Rex", "Husky");
+print(`${d.name}/${d.breed}`);  // Rex/Husky
+
+// 2. super em branch — ainda passa pq codegen so detecta seq direta
+class Cat extends Animal {
+  constructor(name: string) {
+    if (name === "") {
+      super("default");
+    } else {
+      super(name);
+    }
+  }
+}
+const c = new Cat("Mia");
+print(c.name);  // Mia
+
+// 3. Super seguido de outras ops — OK
+class Pet extends Animal {
+  age: number;
+  constructor(name: string, age: number) {
+    super(name);
+    this.age = age;
+    print(`init pet`);
+  }
+}
+const p = new Pet("Bibi", 5);
+print(`${p.name}/${p.age}`);  // Bibi/5
+
+describe("super_call_once", () => {
+  test("super legal flows OK", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "Rex/Husky\n" +
+      "Mia\n" +
+      "init pet\n" +
+      "Bibi/5\n"
+    ));
+});


### PR DESCRIPTION
## Summary

\`super(...)\` chamado 2+ vezes no mesmo constructor agora emite ReferenceError em compile time. Antes RTS chamava o pai 2x sobrescrevendo state.

Detect estático: conta \`super()\` no top-level do body sem descer em if/else (branches mutuamente exclusivos passam — runtime check é fase 2).

## Test plan

- [x] \`tests/super_call_once.test.ts\` — super 1x normal, super em if/else, super + outras ops
- [x] Suite: 207 → 208
- [x] Repro: \`class B extends A { constructor() { super(1); super(2); } }\` → error

## Pendente

- Constructor return value (parte 2 do issue)
- \`new.target\` (parte 3)
- Runtime check para super() em loops/condicionais

Closes #303 parte 1