### PR TITLE
fix(codegen): obj?.prop null guard em optional chain (#271)

### DIFF
--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -519,7 +519,35 @@ pub(super) fn lower_opt_chain(
 ) -> Result<TypedVal> {
     match opt.base.as_ref() {
         swc_ecma_ast::OptChainBase::Member(member) => {
-            super::members::lower_member_expr(ctx, member)
+            // (#271) \`obj?.prop\`: brif em obj==0; bloco null retorna 0
+            // (representa undefined em ValTy::I64); bloco non-null faz
+            // member_expr normal e converte resultado pra i64 pra unificar
+            // o merge. Same approach do OptChainBase::Call.
+            let obj_tv = lower_expr(ctx, &member.obj)?;
+            let obj_i64 = ctx.coerce_to_i64(obj_tv).val;
+            let zero = ctx.builder.ins().iconst(cl::I64, 0);
+            let is_null = ctx.builder.ins().icmp(IntCC::Equal, obj_i64, zero);
+
+            let null_block = ctx.builder.create_block();
+            let access_block = ctx.builder.create_block();
+            let merge = ctx.builder.create_block();
+            let result = ctx.builder.append_block_param(merge, cl::I64);
+            ctx.builder.ins().brif(is_null, null_block, &[], access_block, &[]);
+
+            ctx.builder.switch_to_block(null_block);
+            ctx.builder.seal_block(null_block);
+            let z = ctx.builder.ins().iconst(cl::I64, 0);
+            ctx.builder.ins().jump(merge, &[z.into()]);
+
+            ctx.builder.switch_to_block(access_block);
+            ctx.builder.seal_block(access_block);
+            let access_tv = super::members::lower_member_expr(ctx, member)?;
+            let access_i64 = ctx.coerce_to_i64(access_tv).val;
+            ctx.builder.ins().jump(merge, &[access_i64.into()]);
+
+            ctx.builder.switch_to_block(merge);
+            ctx.builder.seal_block(merge);
+            Ok(TypedVal::new(result, ValTy::I64))
         }
         swc_ecma_ast::OptChainBase::Call(call) => {
             // `callee?.(args)`: se callee for 0 (null), retorna 0 sem chamar.

--- a/tests/opt_chain_member.test.ts
+++ b/tests/opt_chain_member.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#271) \`obj?.prop\` agora null-guard: retorna 0 (representando undefined)
+// quando obj e' null/0, em vez de chamar member_expr direto.
+
+// 1. Null obj — retorna 0
+const nullObj: { a: number } | null = null;
+print(`${nullObj?.a}`);    // 0 (representa undefined)
+
+// 2. Obj normal — acessa
+const obj = { a: 42, b: 99 };
+print(`${obj?.a}`);        // 42
+print(`${obj?.b}`);        // 99
+
+// 3. Em fn user com possivel null
+function getValue(o: { x: number } | null): number {
+  const v = o?.x;
+  if (v === 0) return -1;
+  return v;
+}
+print(`${getValue({ x: 7 })}`);   // 7
+print(`${getValue(null)}`);       // -1 (v=0 vira -1)
+
+// 4. Encadeado com ternario
+const cond: boolean = true;
+const o = cond ? { val: 100 } : null;
+print(`${o?.val}`);  // 100
+
+const cond2: boolean = false;
+const o2 = cond2 ? { val: 200 } : null;
+print(`${o2?.val}`);  // 0
+
+// 5. Em classe
+class Container {
+  data: { count: number } | null = null;
+}
+const c = new Container();
+print(`${c.data?.count}`);    // 0 (data e' null)
+c.data = { count: 5 };
+print(`${c.data?.count}`);    // 5
+
+describe("opt_chain_member", () => {
+  test("null guard funcional", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "0\n" +              // 1
+      "42\n99\n" +         // 2
+      "7\n-1\n" +          // 3
+      "100\n0\n" +         // 4
+      "0\n5\n"             // 5
+    ));
+});


### PR DESCRIPTION
## Summary

\`OptChainBase::Member\` agora null-guard antes de \`lower_member_expr\`. Replica o padrão do \`OptChainBase::Call\`.

## Test plan

- [x] \`tests/opt_chain_member.test.ts\` cobre null obj, obj normal, fn user, ternário, classe field
- [x] Suite: 208 mantido sem regressão
- [x] Repro: \`null?.a\` → 0, \`{a:42}?.a\` → 42

Closes #271