### PR TITLE
test: atualiza fixtures stale (Bool toString)

### DIFF
--- a/tests/string_eq.test.ts
+++ b/tests/string_eq.test.ts
@@ -26,6 +26,6 @@ print(`empty == empty: ${e1 == e2}`);
 
 describe("fixture:string_eq", () => {
   test("matches expected stdout", () => {
-    expect(__rtsCapturedOutput).toBe("a == b: 1\na == c: 0\na != c: 1\nch == \"b\": 1\nch == \"x\": 0\nempty == empty: 1\n");
+    expect(__rtsCapturedOutput).toBe("a == b: true\na == c: false\na != c: true\nch == \"b\": true\nch == \"x\": false\nempty == empty: true\n");
   });
 });

--- a/tests/typeof_void_delete.test.ts
+++ b/tests/typeof_void_delete.test.ts
@@ -29,6 +29,6 @@ main();
 
 describe("fixture:typeof_void_delete", () => {
   test("matches expected stdout", () => {
-    expect(__rtsCapturedOutput).toBe("number\nstring\nboolean\nvoided = 0\ndelete = 1\n");
+    expect(__rtsCapturedOutput).toBe("number\nstring\nboolean\nvoided = 0\ndelete = true\n");
   });
 });


### PR DESCRIPTION
Bool→"true"C:/Program Files/Git/"false" agora (#298). Fixtures string_eq e typeof_void_delete esperavam output antigo "1"/"0" e ficavam vermelhos sem motivo.