### PR TITLE
feat(js): builtin Error classes (#214)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -631,6 +631,54 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
         }
     }
 
+    // (#214) Error / TypeError / RangeError / ReferenceError / SyntaxError —
+    // builtin error classes JS. Implementados como Map handle com keys
+    // \`message\` (string) e \`name\` (string). Permite \`throw new Error(\"x\")\`,
+    // \`(e as Error).message\`, comparacoes etc.
+    let is_error_class = matches!(
+        class_name.as_str(),
+        "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+    );
+    if is_error_class && !ctx.classes.contains_key(&class_name) {
+        let new_fn = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_MAP_NEW", &[], Some(cl::I64))?;
+        let inst = ctx.builder.ins().call(new_fn, &[]);
+        let h = ctx.builder.inst_results(inst)[0];
+
+        let set_fn = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+            &[cl::I64, cl::I64, cl::I64, cl::I64],
+            None,
+        )?;
+
+        // Set name = "Error" / "TypeError" / etc.
+        let (name_kp, name_kl) = ctx.emit_str_literal(b"name")?;
+        let (cls_ptr, cls_len) = ctx.emit_str_literal(class_name.as_bytes())?;
+        let from_static = ctx.get_extern(
+            "__RTS_FN_NS_GC_STRING_FROM_STATIC",
+            &[cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(from_static, &[cls_ptr, cls_len]);
+        let name_handle = ctx.builder.inst_results(inst)[0];
+        ctx.builder.ins().call(set_fn, &[h, name_kp, name_kl, name_handle]);
+
+        // Set message = primeiro argumento (string) ou "" se sem args.
+        let msg_handle = if let Some(arg) = new_expr.args.as_ref().and_then(|args| args.first()) {
+            if arg.spread.is_none() {
+                let tv = super::lower_expr(ctx, &arg.expr)?;
+                ctx.coerce_to_handle(tv)?.val
+            } else {
+                ctx.emit_str_handle(b"")?.val
+            }
+        } else {
+            ctx.emit_str_handle(b"")?.val
+        };
+        let (msg_kp, msg_kl) = ctx.emit_str_literal(b"message")?;
+        ctx.builder.ins().call(set_fn, &[h, msg_kp, msg_kl, msg_handle]);
+
+        return Ok(TypedVal::new(h, ValTy::Handle));
+    }
+
     let meta = ctx
         .classes
         .get(&class_name)

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -349,6 +349,19 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             let mut field_ty = receiver_class
                 .as_deref()
                 .and_then(|c| field_type_in_hierarchy(ctx, c, key));
+            // (#214) \`(e as Error).message\` ou \`obj_typed_as_Error.message\`:
+            // receiver_class detecta builtin error class e expoe
+            // \`message\`/\`name\` como Handle.
+            if field_ty.is_none() && (key == "message" || key == "name") {
+                if let Some(cls) = receiver_class.as_deref() {
+                    if matches!(
+                        cls,
+                        "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+                    ) {
+                        field_ty = Some(ValTy::Handle);
+                    }
+                }
+            }
             // Fallback: tipo de campo registrado em var local (object literal).
             if field_ty.is_none() {
                 if let Expr::Ident(obj_id) = m.obj.as_ref() {

--- a/src/codegen/lower/statements/control.rs
+++ b/src/codegen/lower/statements/control.rs
@@ -569,8 +569,19 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
                 if class_for_catch.is_none() {
                     let inferred = infer_throw_class(&t.block.stmts);
                     if let Some(cls) = inferred {
+                        let is_error_class = matches!(
+                            cls.as_str(),
+                            "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+                        );
                         if ctx.classes.contains_key(&cls) {
-                            class_for_catch = Some(cls);
+                            class_for_catch = Some(cls.clone());
+                        }
+                        if is_error_class {
+                            let mut ft: std::collections::HashMap<String, ValTy> =
+                                std::collections::HashMap::new();
+                            ft.insert("message".into(), ValTy::Handle);
+                            ft.insert("name".into(), ValTy::Handle);
+                            ctx.local_obj_field_types.insert(name.to_string(), ft);
                         }
                     }
                 }

--- a/src/codegen/lower/statements/decls.rs
+++ b/src/codegen/lower/statements/decls.rs
@@ -94,8 +94,22 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                 if let swc_ecma_ast::Expr::New(ne) = init.as_ref() {
                     if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
                         let cn = cid.sym.as_str().to_string();
+                        // (#214) Error builtin classes: registra field
+                        // types pra que \`e.message\`/\`e.name\` retorne
+                        // Handle em vez de I64 anonimo.
+                        let is_error_class = matches!(
+                            cn.as_str(),
+                            "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+                        );
                         if ctx.classes.contains_key(&cn) {
-                            ctx.local_class_ty.insert(name.clone(), cn);
+                            ctx.local_class_ty.insert(name.clone(), cn.clone());
+                        }
+                        if is_error_class {
+                            let mut ft: std::collections::HashMap<String, ValTy> =
+                                std::collections::HashMap::new();
+                            ft.insert("message".into(), ValTy::Handle);
+                            ft.insert("name".into(), ValTy::Handle);
+                            ctx.local_obj_field_types.insert(name.clone(), ft);
                         }
                     }
                 }

--- a/tests/error_class.test.ts
+++ b/tests/error_class.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#214) Error / TypeError / RangeError / ReferenceError / SyntaxError
+// como builtin classes JS. Mapped pra Map handle com keys
+// \`message\` e \`name\`.
+
+// 1. new Error
+const e = new Error("oops");
+print(e.message);          // oops
+print(e.name);             // Error
+
+// 2. TypeError
+const t = new TypeError("bad arg");
+print(t.message);          // bad arg
+print(t.name);             // TypeError
+
+// 3. Em throw + catch (e tem tipo Error inferido pelo throw class)
+try {
+  throw new RangeError("range");
+} catch (e) {
+  print((e as RangeError).message);  // range
+  print((e as RangeError).name);     // RangeError
+}
+
+// 4. Mensagem vazia (no args)
+const e2 = new Error();
+print(`empty=${e2.message}`);  // empty=
+
+// 5. Em fn user
+function fail(reason: string): void {
+  throw new Error(reason);
+}
+
+try {
+  fail("from fn");
+} catch (e) {
+  print(`caught: ${(e as Error).message}`);  // caught: from fn
+}
+
+describe("error_class", () => {
+  test("Error builtin com message/name", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "oops\nError\n" +              // 1
+      "bad arg\nTypeError\n" +       // 2
+      "range\nRangeError\n" +        // 3
+      "empty=\n" +                   // 4
+      "caught: from fn\n"            // 5
+    ));
+});


### PR DESCRIPTION
Error/TypeError/RangeError/ReferenceError/SyntaxError como builtins. Map handle com message/name. Funciona em `new`, throw+catch, e `(e as Error).message` cast.