### PR TITLE
feat(js): Object.keys, Object.values, Object.hasOwn (#266 fase 1)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -591,6 +591,14 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_KEYS",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_KEYS
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_VALUES
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW
         );

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -125,6 +125,18 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     return lower_ns_call(ctx, target, call);
                 }
             }
+            // (#266) Object globals: Object.keys, Object.values, Object.hasOwn.
+            if let Some(method) = qualified.strip_prefix("Object.") {
+                let target = match method {
+                    "keys" => "collections.map_keys",
+                    "values" => "collections.map_values",
+                    "hasOwn" => "collections.map_has",
+                    _ => "",
+                };
+                if !target.is_empty() && lookup(target).is_some() {
+                    return lower_ns_call(ctx, target, call);
+                }
+            }
             // Fallback: ident.fn(...) onde ident e var (ex: namespace TS
             // desugared para const Foo = { ... }). Faz map_get pela key
             // e despacha via call_indirect.

--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -228,9 +228,11 @@ fn mul_imm_peephole(
 ///
 /// Fix correto sem perder a otimizacao em hot paths:
 ///
-///     adj  = (x >> (BITS-1)) & (n-1)    // -1 todos bits se x < 0, else 0
-///     r    = (x + adj) & (n-1)          // r positivo
-///     r    = r - adj                    // ajusta sinal
+/// ```text
+/// adj  = (x >> (BITS-1)) & (n-1)    // -1 todos bits se x < 0, else 0
+/// r    = (x + adj) & (n-1)          // r positivo
+/// r    = r - adj                    // ajusta sinal
+/// ```
 ///
 /// Equivalente a `(x % n + n) & (n-1)` mas sem branch. 4 instrucoes
 /// vs srem ~20+. Cranelift egraph nao faz pra signed mod.

--- a/src/namespaces/collections/abi.rs
+++ b/src/namespaces/collections/abi.rs
@@ -103,6 +103,28 @@ pub const MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: false,
     },
+    NamespaceMember {
+        name: "map_keys",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_MAP_KEYS",
+        args: &[AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Returns Vec<i64> with key handles (sorted asc). Used by Object.keys.",
+        ts_signature: "map_keys(h: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "map_values",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
+        args: &[AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Returns Vec<i64> with values (in key-sorted order). Used by Object.values.",
+        ts_signature: "map_values(h: number): number",
+        intrinsic: None,
+        pure: false,
+    },
     // ── Vec ───────────────────────────────────────────────────────────
     NamespaceMember {
         name: "vec_new",

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -132,3 +132,39 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEY_AT(handle: u64, idx: i64) -> u
         None => 0,
     }
 }
+
+/// (#266) Object.keys(obj) — retorna Vec<i64> com handles de strings dos
+/// keys. Ordem: sorted asc (mesmo criterio de KEY_AT).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
+    let keys: Vec<String> = with_map(handle, Vec::new(), |m| {
+        let mut ks: Vec<String> = m.keys().cloned().collect();
+        ks.sort();
+        ks
+    });
+    let mut vec: Vec<i64> = Vec::with_capacity(keys.len());
+    for k in keys {
+        let h = crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(
+            k.as_ptr(),
+            k.len() as i64,
+        );
+        vec.push(h as i64);
+    }
+    crate::namespaces::gc::handles::alloc_entry(
+        crate::namespaces::gc::handles::Entry::Vec(Box::new(vec)),
+    )
+}
+
+/// (#266) Object.values(obj) — retorna Vec<i64> com valores. Ordem por
+/// keys sorted asc.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
+    let vals: Vec<i64> = with_map(handle, Vec::new(), |m| {
+        let mut entries: Vec<(&String, &i64)> = m.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        entries.into_iter().map(|(_, v)| *v).collect()
+    });
+    crate::namespaces::gc::handles::alloc_entry(
+        crate::namespaces::gc::handles::Entry::Vec(Box::new(vals)),
+    )
+}

--- a/tests/object_globals.test.ts
+++ b/tests/object_globals.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#266) Object.keys, Object.values, Object.hasOwn — globais JS sobre
+// object literals (que sao Map handle no RTS).
+
+const obj = { a: 1, b: 2, c: 3 };
+
+// 1. Object.keys
+const ks = Object.keys(obj);
+print(ks.join(","));   // a,b,c (sorted)
+
+// 2. Object.values
+const vs = Object.values(obj);
+print(vs.join(","));   // 1,2,3 (in key-sorted order)
+
+// 3. Object.hasOwn
+print(`${Object.hasOwn(obj, "a")}`);   // true
+print(`${Object.hasOwn(obj, "z")}`);   // false
+
+// 4. Object.keys vazio
+const empty = {};
+print(`empty.length=${Object.keys(empty).length}`);  // 0
+
+// 5. Iterar via Object.keys + lookup — pattern comum
+const config = { host: "localhost", port: 8080, debug: 1 };
+const keys = Object.keys(config);
+print(`config has ${keys.length} keys`);  // 3
+
+describe("object_globals", () => {
+  test("Object.keys/values/hasOwn", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "a,b,c\n" +
+      "1,2,3\n" +
+      "true\nfalse\n" +
+      "empty.length=0\n" +
+      "config has 3 keys\n"
+    ));
+});


### PR DESCRIPTION
Object.keys/values mapeiam para novas runtime fns map_keys/map_values (Vec<i64> sorted). Object.hasOwn mapeado para map_has.