### PR TITLE
refactor(abi): centraliza handle encoding + ENTRY_POINT (#283)

### DIFF
--- a/src/abi/handles.rs
+++ b/src/abi/handles.rs
@@ -1,0 +1,48 @@
+//! Layout do encoding de handles `u64`, compartilhado entre `gc::HandleTable`
+//! e o handle table per-thread do `ui` (#283).
+//!
+//! ```text
+//! [63..48] generation (16 bits)
+//! [47.. 5] per-shard table slot (43 bits)
+//! [ 4.. 0] shard index (5 bits, log2(N_SHARDS))
+//! ```
+//!
+//! Mudancas aqui invalidam handles ja existentes — qualquer serializacao
+//! futura (debug dump, IPC) precisa versionar o layout.
+
+/// Numero de shards lock-free do `gc::HandleTable`.
+pub const HANDLE_N_SHARDS: usize = 32;
+
+/// Bits ocupados pelo indice de shard nas posicoes baixas do handle.
+/// Sempre `log2(HANDLE_N_SHARDS)`.
+pub const HANDLE_SHARD_BITS: u32 = HANDLE_N_SHARDS.ilog2();
+
+/// Posicao do campo `generation` (16 bits) no handle `u64`.
+pub const HANDLE_GEN_SHIFT: u32 = 48;
+
+/// Mascara dos bits de slot+shard (tudo abaixo de `HANDLE_GEN_SHIFT`).
+pub const HANDLE_SLOT_MASK: u64 = (1u64 << HANDLE_GEN_SHIFT) - 1;
+
+/// Mascara do campo de shard (low bits).
+pub const HANDLE_SHARD_MASK: u64 = (HANDLE_N_SHARDS as u64) - 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shard_bits_matches_n_shards() {
+        assert_eq!(1usize << HANDLE_SHARD_BITS, HANDLE_N_SHARDS);
+    }
+
+    #[test]
+    fn slot_mask_excludes_generation() {
+        assert_eq!(HANDLE_SLOT_MASK >> HANDLE_GEN_SHIFT, 0);
+        assert_eq!(HANDLE_SLOT_MASK | (0xFFFFu64 << HANDLE_GEN_SHIFT), u64::MAX);
+    }
+
+    #[test]
+    fn shard_mask_fits_in_low_bits() {
+        assert_eq!(HANDLE_SHARD_MASK, (1u64 << HANDLE_SHARD_BITS) - 1);
+    }
+}

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -9,6 +9,7 @@
 //! legacy dispatch path; namespaces migrate one at a time.
 
 pub mod guards;
+pub mod handles;
 pub mod member;
 pub mod signature;
 pub mod symbols;

--- a/src/abi/symbols.rs
+++ b/src/abi/symbols.rs
@@ -71,6 +71,12 @@ pub fn validate_symbol(symbol: &str) -> Result<(), SymbolError> {
     Ok(())
 }
 
+/// Nome do entry point sintetico do top-level (`__RTS_MAIN`).
+///
+/// Centralizado para evitar drift entre codegen, JIT loader, eval_jit e
+/// pipeline (#283). Mudar aqui propaga pra todos os call sites.
+pub const ENTRY_POINT: &str = "__RTS_MAIN";
+
 /// Structured error produced by [`validate_symbol`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SymbolError {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -22,7 +22,7 @@ use crate::parser::span::Span;
 use super::ctx::{ClassMeta, FnCtx, GlobalVar, UserFnAbi, ValTy};
 use super::statements::lower_stmt;
 
-const RUNTIME_MAIN_SYMBOL: &str = "__RTS_MAIN";
+const RUNTIME_MAIN_SYMBOL: &str = crate::abi::symbols::ENTRY_POINT;
 
 /// Info about a user-defined function needed by callers.
 #[derive(Debug, Clone)]

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -16,13 +16,15 @@ use std::cell::Cell;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
-const GEN_SHIFT: u32 = 48;
-const SLOT_MASK: u64 = (1u64 << GEN_SHIFT) - 1;
-const SENTINEL_INVALID: u64 = 0;
+// Layout do handle (gen/slot/shard) e' compartilhado com `ui::store` via
+// `crate::abi::handles` (#283). Mudancas aqui invalidam handles existentes.
+use crate::abi::handles::{
+    HANDLE_GEN_SHIFT as GEN_SHIFT, HANDLE_N_SHARDS as N_SHARDS,
+    HANDLE_SHARD_BITS as SHARD_BITS, HANDLE_SHARD_MASK as SHARD_MASK,
+    HANDLE_SLOT_MASK as SLOT_MASK,
+};
 
-const N_SHARDS: usize = 32;
-const SHARD_BITS: u32 = 5; // log2(N_SHARDS)
-const SHARD_MASK: u64 = (N_SHARDS as u64) - 1;
+const SENTINEL_INVALID: u64 = 0;
 
 /// Value kinds stored behind a handle. Extensible as namespaces grow.
 #[derive(Debug)]

--- a/src/namespaces/rt_all.rs
+++ b/src/namespaces/rt_all.rs
@@ -72,3 +72,11 @@ pub mod namespaces {
     pub use crate::gc;
     pub use crate::trace;
 }
+
+// Shim para `crate::abi::handles` (#283) — handle layout compartilhado entre
+// gc e ui. Inclui o mesmo arquivo que o main crate (`src/abi/handles.rs`).
+#[path = "../abi/handles.rs"]
+pub mod __abi_handles;
+pub mod abi {
+    pub use super::__abi_handles as handles;
+}

--- a/src/namespaces/runtime/eval_jit.rs
+++ b/src/namespaces/runtime/eval_jit.rs
@@ -41,6 +41,10 @@ fn run_source(src: &str) -> anyhow::Result<i32> {
     let mut program = crate::parser::parse_source_with_mode(src, FrontendMode::Native)?;
     let (module, _warnings) = crate::codegen::compile_program_to_jit(&mut program)?;
 
+    // Mantido hardcoded: este arquivo eh compilado tanto como parte do main
+    // crate quanto como parte de `runtime_support` (rt_all.rs), e a constante
+    // `crate::abi::symbols::ENTRY_POINT` so existe no main crate. Se mudar la,
+    // mudar aqui tambem.
     let name = "__RTS_MAIN";
     let main_id = match module.get_name(name) {
         Some(cranelift_module::FuncOrDataId::Func(id)) => id,

--- a/src/namespaces/ui/store.rs
+++ b/src/namespaces/ui/store.rs
@@ -11,8 +11,8 @@ use fltk::{
     text, valuator, window,
 };
 
-const GEN_SHIFT: u32 = 48;
-const SLOT_MASK: u64 = (1u64 << GEN_SHIFT) - 1;
+// Compartilhado com `gc::HandleTable` via `crate::abi::handles` (#283).
+use crate::abi::handles::{HANDLE_GEN_SHIFT as GEN_SHIFT, HANDLE_SLOT_MASK as SLOT_MASK};
 
 pub enum UiEntry {
     App,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -136,7 +136,7 @@ pub fn run_jit_with_imports(input: &Path, options: CompileOptions) -> Result<(i3
         crate::codegen::compile_program_to_jit(&mut program).context("JIT compile failed")?;
 
     use cranelift_module::Module;
-    let name = "__RTS_MAIN";
+    let name = crate::abi::symbols::ENTRY_POINT;
     let main_id = match module.get_name(name) {
         Some(cranelift_module::FuncOrDataId::Func(id)) => id,
         _ => anyhow::bail!("JIT: `{name}` not found in module"),
@@ -174,9 +174,10 @@ pub fn run_jit_inline(source: &str, options: CompileOptions) -> Result<(i32, Vec
     let (module, warnings) =
         crate::codegen::compile_program_to_jit(&mut program).context("JIT compile failed")?;
     use cranelift_module::Module;
-    let main_id = match module.get_name("__RTS_MAIN") {
+    let entry = crate::abi::symbols::ENTRY_POINT;
+    let main_id = match module.get_name(entry) {
         Some(cranelift_module::FuncOrDataId::Func(id)) => id,
-        _ => anyhow::bail!("JIT: `__RTS_MAIN` not found in module"),
+        _ => anyhow::bail!("JIT: `{entry}` not found in module"),
     };
     let main_ptr = module.get_finalized_function(main_id);
     let main_fn: extern "C" fn() -> i32 = unsafe { std::mem::transmute(main_ptr) };
@@ -202,7 +203,7 @@ pub fn run_jit(input: &Path, options: CompileOptions) -> Result<(i32, Vec<String
     // Resolve `__RTS_MAIN`. The codegen pipeline always emits it with
     // Linkage::Local + platform default call conv (`int __RTS_MAIN(void)`).
     use cranelift_module::Module;
-    let name = "__RTS_MAIN";
+    let name = crate::abi::symbols::ENTRY_POINT;
     let main_id = match module.get_name(name) {
         Some(cranelift_module::FuncOrDataId::Func(id)) => id,
         _ => anyhow::bail!("JIT: `{name}` not found in module"),


### PR DESCRIPTION
## Summary

- Cria `src/abi/handles.rs` como fonte unica do layout do handle u64 (HANDLE_N_SHARDS / HANDLE_SHARD_BITS / HANDLE_GEN_SHIFT / HANDLE_SLOT_MASK / HANDLE_SHARD_MASK).
- gc/handles.rs e ui/store.rs deixam de duplicar GEN_SHIFT/SLOT_MASK e importam do abi. rt_all.rs expoe o mesmo arquivo via #[path] pro runtime_support standalone.
- Adiciona `crate::abi::symbols::ENTRY_POINT` (= `"__RTS_MAIN"`) e troca os call sites em pipeline.rs e codegen/lower/func.rs.

Resolve os itens 1 e 4 do plano da issue. Itens 2 (CompileOptions opt_level) e 3 (env vars RTS_THREADS/RTS_CACHE_DIR) ficam para follow-up.

## Test plan

- [x] cargo build --release
- [x] cargo test --release --lib (70 passed)
- [x] target/release/rts.exe -e 'console.log(1+2)' -> 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)