### PR TITLE
fix(codegen): for-in ordem JS — int keys ascendentes + strings em ordem de inserção (#308)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,12 +1090,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1788,6 +1788,7 @@ dependencies = [
  "flate2",
  "fltk",
  "gc-arena",
+ "indexmap",
  "indicatif",
  "notify",
  "object 0.39.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ fltk = { version = "1", features = ["fltk-bundled"] }
 regex = "1"
 rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
 webpki-roots = "0.26"
+indexmap = "2.14.0"
 
 [build-dependencies]
 fltk = { version = "1", features = ["fltk-bundled"] }

--- a/build.rs
+++ b/build.rs
@@ -65,6 +65,24 @@ fn main() {
             deps_dir.display()
         )
     });
+    let indexmap_rlib = find_rlib_named(&deps_dir, "libindexmap-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate indexmap rlib under {} (required for collections runtime symbols)",
+            deps_dir.display()
+        )
+    });
+    let hashbrown_rlib = find_rlib_named(&deps_dir, "libhashbrown-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate hashbrown rlib under {} (required for collections runtime symbols)",
+            deps_dir.display()
+        )
+    });
+    let equivalent_rlib = find_rlib_named(&deps_dir, "libequivalent-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate equivalent rlib under {} (required for collections runtime symbols)",
+            deps_dir.display()
+        )
+    });
 
     let mut cmd = Command::new(&rustc);
     cmd.args([
@@ -102,6 +120,12 @@ fn main() {
         .arg(format!("serde_json={}", serde_json_rlib.display()));
     cmd.arg("--extern")
         .arg(format!("serde={}", serde_rlib.display()));
+    cmd.arg("--extern")
+        .arg(format!("indexmap={}", indexmap_rlib.display()));
+    cmd.arg("--extern")
+        .arg(format!("hashbrown={}", hashbrown_rlib.display()));
+    cmd.arg("--extern")
+        .arg(format!("equivalent={}", equivalent_rlib.display()));
 
     let status = cmd
         .status()

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -1,8 +1,35 @@
-//! HashMap<String, i64> — mapa de chave string para valor i64.
+//! IndexMap<String, i64> — mapa de chave string para valor i64.
+//!
+//! Usa `indexmap::IndexMap` para preservar ordem de inserção, necessário
+//! para implementar a ordem de enumeração de propriedades do JS:
+//! - integer-indexed keys (`"0"`, `"1"`, `"2"`, ...) em ordem numérica
+//!   ascendente;
+//! - demais string keys em ordem de inserção.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use super::super::gc::handles::{Entry, alloc_entry, free_handle, shard_for_handle};
+
+/// Reconhece "array index" no sentido do ECMA-262: string que representa
+/// um u32 canônico (sem leading zeros exceto "0"; máximo 2^32 - 2).
+/// Retorna o valor numérico para ordenação. Strings como "01", "+1", "1.0",
+/// " 1" não são consideradas índices.
+fn parse_array_index(s: &str) -> Option<u32> {
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() > 1 && s.starts_with('0') {
+        return None;
+    }
+    if !s.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: u32 = s.parse().ok()?;
+    if n == u32::MAX {
+        return None;
+    }
+    Some(n)
+}
 
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
@@ -15,7 +42,7 @@ fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
 
 fn with_map<F, R>(handle: u64, default: R, f: F) -> R
 where
-    F: FnOnce(&HashMap<String, i64>) -> R,
+    F: FnOnce(&IndexMap<String, i64>) -> R,
 {
     let guard = shard_for_handle(handle).lock().unwrap();
     match guard.get(handle) {
@@ -26,7 +53,7 @@ where
 
 fn with_map_mut<F, R>(handle: u64, default: R, f: F) -> R
 where
-    F: FnOnce(&mut HashMap<String, i64>) -> R,
+    F: FnOnce(&mut IndexMap<String, i64>) -> R,
 {
     let mut guard = shard_for_handle(handle).lock().unwrap();
     match guard.get_mut(handle) {
@@ -37,7 +64,7 @@ where
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_NEW() -> u64 {
-    alloc_entry(Entry::Map(Box::new(HashMap::new())))
+    alloc_entry(Entry::Map(Box::new(IndexMap::new())))
 }
 
 #[unsafe(no_mangle)]
@@ -102,7 +129,7 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_DELETE(
     let Some(key) = str_from_abi(key_ptr, key_len) else {
         return 0;
     };
-    with_map_mut(handle, 0, |m| if m.remove(key).is_some() { 1 } else { 0 })
+    with_map_mut(handle, 0, |m| if m.shift_remove(key).is_some() { 1 } else { 0 })
 }
 
 #[unsafe(no_mangle)]
@@ -110,19 +137,33 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_CLEAR(handle: u64) {
     with_map_mut(handle, (), |m| m.clear());
 }
 
-/// Retorna a key na posição `idx` (em ordem de iteração estável dentro
-/// de uma chamada). Usado por for-in. Coleta keys em snapshot Vec
-/// ordenado pra garantir ordem reproduzível em runs distintos. Retorna
-/// handle de string ou 0 se idx fora de range.
+/// Retorna a key na posição `idx` na ordem de enumeração definida pelo JS:
+/// 1. integer-indexed keys (string que parseia para u32 sem leading zero,
+///    exceto "0") em ordem numérica ascendente;
+/// 2. demais string keys em ordem de inserção (preservada pelo IndexMap).
+///
+/// Usado por for-in. Retorna handle de string ou 0 se idx fora de range.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEY_AT(handle: u64, idx: i64) -> u64 {
     if idx < 0 {
         return 0;
     }
     let key_opt: Option<String> = with_map(handle, None, |m| {
-        let mut keys: Vec<&String> = m.keys().collect();
-        keys.sort();
-        keys.get(idx as usize).map(|s| (*s).clone())
+        let mut int_keys: Vec<(u32, &String)> = Vec::new();
+        let mut str_keys: Vec<&String> = Vec::new();
+        for k in m.keys() {
+            match parse_array_index(k) {
+                Some(n) => int_keys.push((n, k)),
+                None => str_keys.push(k),
+            }
+        }
+        int_keys.sort_by_key(|(n, _)| *n);
+        let i = idx as usize;
+        if i < int_keys.len() {
+            Some(int_keys[i].1.clone())
+        } else {
+            str_keys.get(i - int_keys.len()).map(|s| (*s).clone())
+        }
     });
     match key_opt {
         Some(s) => crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -41,9 +41,12 @@ pub enum Entry {
     /// Child process handle owned via std::process::Child — usado pelo
     /// namespace `process` para spawn/wait/kill.
     ProcessChild(Box<std::process::Child>),
-    /// HashMap<String, i64> — namespace `collections` (map_*).
+    /// IndexMap<String, i64> — namespace `collections` (map_*).
     /// Valor i64 cobre inteiros, handles, e bool (0/1).
-    Map(Box<std::collections::HashMap<String, i64>>),
+    /// IndexMap preserva ordem de inserção (necessário para ordem de
+    /// enumeração JS: integer keys ascendentes + string keys em ordem de
+    /// inserção). Ver `MAP_KEY_AT` para a lógica de ordenação.
+    Map(Box<indexmap::IndexMap<String, i64>>),
     /// Vec<i64> — namespace `collections` (vec_*).
     Vec(Box<Vec<i64>>),
     /// Regex compilada — namespace `regex`.

--- a/tests/for_in_basic.test.ts
+++ b/tests/for_in_basic.test.ts
@@ -16,6 +16,6 @@ for (const key in obj) {
 
 describe("fixture:for_in_basic", () => {
   test("matches expected stdout", () => {
-    expect(__rtsCapturedOutput).toBe("bar\nbaz\nfoo\n");
+    expect(__rtsCapturedOutput).toBe("foo\nbar\nbaz\n");
   });
 });

--- a/tests/for_in_enumeration_order.test.ts
+++ b/tests/for_in_enumeration_order.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// JS: integer-indexed keys ascendentes, depois string keys em ordem de inserção.
+const obj: any = {};
+obj["b"] = 1;
+obj["2"] = 2;
+obj["a"] = 3;
+obj["0"] = 4;
+obj["1"] = 5;
+obj["c"] = 6;
+
+let order = "";
+for (const k in obj) {
+  order += k + ",";
+}
+print(order);
+
+describe("for_in_enumeration_order", () => {
+  test("integers first ascending then strings in insertion order", () => {
+    expect(__rtsCapturedOutput).toBe("0,1,2,b,a,c,\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Substitui `HashMap` por `indexmap::IndexMap` em `collections.map_*` para preservar ordem de inserção.
- Reescreve `__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT` pra implementar a ordem ECMA-262: integer-indexed keys ascendentes primeiro, depois string keys em ordem de inserção.
- Atualiza `build.rs` pra propagar `--extern indexmap/hashbrown/equivalent` ao staticlib `runtime_support`.

Fixes #308.

## Test plan

- [x] Nova fixture `tests/for_in_enumeration_order.test.ts` cobre keys mistas (string + integer string).
- [x] `tests/for_in_basic.test.ts` atualizada — antes esperava ordem alfabética (workaround), agora reflete ordem de inserção real.
- [x] `cargo test --release --tests` passa (67 unit tests).
- [x] Sweep de 230 `tests/*.test.ts` (excluindo `array_native_methods`, `object_builtins`, `object_computed_methods` — falhas pré-existentes não relacionadas) passa sem regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)