### PR TITLE
feat(js): expoe Number.MAX_SAFE_INTEGER e companhia (#305)

### DIFF
--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -274,6 +274,49 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 return Ok(tv);
             }
         }
+        // Number.* globals (#305). RTS internamente usa i64 para inteiros,
+        // entao MAX_SAFE_INTEGER ainda eh exato — mas expomos os mesmos
+        // valores que JS pra paridade (codigo que faz `< MAX_SAFE_INTEGER`
+        // pra detectar limite f64).
+        if let Some(name) = qualified.strip_prefix("Number.") {
+            use cranelift_codegen::ir::{InstBuilder, types as cl};
+            use crate::codegen::lower::ctx::ValTy;
+            match name {
+                "MAX_SAFE_INTEGER" => {
+                    let v = ctx.builder.ins().iconst(cl::I64, 9_007_199_254_740_991);
+                    return Ok(TypedVal::new(v, ValTy::I64));
+                }
+                "MIN_SAFE_INTEGER" => {
+                    let v = ctx.builder.ins().iconst(cl::I64, -9_007_199_254_740_991);
+                    return Ok(TypedVal::new(v, ValTy::I64));
+                }
+                "MAX_VALUE" => {
+                    let v = ctx.builder.ins().f64const(f64::MAX);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                "MIN_VALUE" => {
+                    let v = ctx.builder.ins().f64const(f64::MIN_POSITIVE);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                "EPSILON" => {
+                    let v = ctx.builder.ins().f64const(f64::EPSILON);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                "POSITIVE_INFINITY" => {
+                    let v = ctx.builder.ins().f64const(f64::INFINITY);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                "NEGATIVE_INFINITY" => {
+                    let v = ctx.builder.ins().f64const(f64::NEG_INFINITY);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                "NaN" => {
+                    let v = ctx.builder.ins().f64const(f64::NAN);
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
+                _ => {}
+            }
+        }
     }
 
     let receiver_class = lhs_static_class(ctx, &m.obj);

--- a/tests/number_constants.test.ts
+++ b/tests/number_constants.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+print(`${Number.MAX_SAFE_INTEGER}`);
+print(`${Number.MIN_SAFE_INTEGER}`);
+print(`${Number.POSITIVE_INFINITY}`);
+print(`${Number.NEGATIVE_INFINITY}`);
+print(`${Number.NaN}`);
+
+if (Number.MAX_SAFE_INTEGER > 0) {
+  print("positive");
+}
+
+describe("number_constants", () => {
+  test("globals_match_js", () => expect(__rtsCapturedOutput).toBe(
+    "9007199254740991\n-9007199254740991\nInfinity\n-Infinity\nNaN\npositive\n"
+  ));
+});


### PR DESCRIPTION
## Summary

- Acesso direto a Number.MAX_SAFE_INTEGER, MIN_SAFE_INTEGER, MAX_VALUE, MIN_VALUE, EPSILON, POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN sem import.
- Implementado em src/codegen/lower/expressions/members.rs apos o lookup de namespace constant — mesmo padrao de JSON.* / Date.* em calls.
- Cobre o item documentavel da issue (Opcao C). A questao maior (overflow silencioso i64 vs perda de precisao f64) fica como divergencia conhecida.

## Test plan

- [x] tests/number_constants.test.ts passa
- [x] cargo build --release sem warnings novos

🤖 Generated with [Claude Code](https://claude.com/claude-code)