### PR TITLE
feat(nodespace): node:fs.readdirSync via fs.readdir (#287)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -254,6 +254,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     );
     add_fn!("__RTS_FN_NS_FS_RENAME", ops::__RTS_FN_NS_FS_RENAME);
     add_fn!("__RTS_FN_NS_FS_COPY", ops::__RTS_FN_NS_FS_COPY);
+    add_fn!("__RTS_FN_NS_FS_READDIR", dir::__RTS_FN_NS_FS_READDIR);
 
     // ── namespaces::math ──────────────────────────────────────────────
     use crate::namespaces::math::*;

--- a/src/namespaces/fs/abi.rs
+++ b/src/namespaces/fs/abi.rs
@@ -169,6 +169,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: false,
     },
     NamespaceMember {
+        name: "readdir",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_FS_READDIR",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Lê o conteúdo do diretório e retorna handle de Vec<string-handle> com os nomes (file_name, sem path). Retorna 0 em erro.",
+        ts_signature: "readdir(path: string): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
         name: "copy",
         kind: MemberKind::Function,
         symbol: "__RTS_FN_NS_FS_COPY",

--- a/src/namespaces/fs/dir.rs
+++ b/src/namespaces/fs/dir.rs
@@ -1,6 +1,8 @@
-//! Directory creation and removal. Wraps `std::fs` directory ops.
+//! Directory creation, removal, and enumeration. Wraps `std::fs` directory ops.
 
 use super::common::path_from_abi;
+use crate::namespaces::gc::handles::{Entry, alloc_entry};
+use crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW;
 
 /// Creates the directory at `path`. Fails if the parent is missing.
 /// Returns `0` on success, `-1` on error.
@@ -56,4 +58,28 @@ pub extern "C" fn __RTS_FN_NS_FS_REMOVE_DIR_ALL(path_ptr: *const u8, path_len: i
         Ok(()) => 0,
         Err(_) => -1,
     }
+}
+
+/// Lê o conteúdo do diretório em `path` e retorna um handle de
+/// `Vec<i64>` contendo handles de string para cada nome de entrada
+/// (apenas o `file_name`, sem o caminho completo, igual a
+/// `node:fs.readdirSync`). Entradas com nomes não-UTF-8 são ignoradas.
+/// Retorna `0` em qualquer erro de I/O.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_FS_READDIR(path_ptr: *const u8, path_len: i64) -> u64 {
+    let Some(path) = (unsafe { path_from_abi(path_ptr, path_len) }) else {
+        return 0;
+    };
+    let Ok(iter) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    let mut entries: Vec<i64> = Vec::new();
+    for entry in iter.flatten() {
+        let name = entry.file_name();
+        if let Some(s) = name.to_str() {
+            let h = __RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64);
+            entries.push(h as i64);
+        }
+    }
+    alloc_entry(Entry::Vec(Box::new(entries)))
 }

--- a/src/nodespace/fs/mod.rs
+++ b/src/nodespace/fs/mod.rs
@@ -56,6 +56,12 @@ pub const MEMBERS: &[NodespaceMember] = &[
         args: &[AbiType::StrPtr, AbiType::StrPtr],
         returns: AbiType::Void,
     },
+    NodespaceMember {
+        name: "readdirSync",
+        symbol: "__RTS_FN_NS_FS_READDIR",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+    },
 ];
 
 pub const SPEC: NodespaceSpec = NodespaceSpec {

--- a/tests/nodespace_fs_readdir.test.ts
+++ b/tests/nodespace_fs_readdir.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "rts:test";
+import { writeFileSync, readdirSync, mkdirSync, rmSync } from "node:fs";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+const dir = "tmp_readdir_test_287";
+mkdirSync(dir);
+writeFileSync(dir + "/a.txt", "1");
+writeFileSync(dir + "/b.txt", "2");
+
+const entries = readdirSync(dir);
+print(`len=${entries.length}`);
+
+rmSync(dir + "/a.txt");
+rmSync(dir + "/b.txt");
+
+describe("nodespace_fs_readdir", () => {
+  test("readdirSync returns entry names", () => {
+    expect(__rtsCapturedOutput).toBe("len=2\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Novo símbolo `__RTS_FN_NS_FS_READDIR(path) -> u64` em `namespaces/fs/dir.rs`: retorna handle de `Vec<i64>` com handles de string dos `file_name` das entradas (sem path), igual a `node:fs.readdirSync`. Erro de I/O → handle 0; entradas não-UTF-8 são ignoradas.
- Registrado em `abi/fs` (`fs.readdir`), `nodespace/fs` (`readdirSync`) e `codegen/jit.rs`.

statSync fica como follow-up — exige construir objeto com múltiplos campos (size/mtimeMs/isFile/isDirectory), o que vai além do mapeamento símbolo→símbolo do nodespace atual.

Refs #287.

## Test plan

- [x] `tests/nodespace_fs_readdir.test.ts` — cria dir + 2 arquivos, lê via `readdirSync`, valida `length`.
- [x] `cargo test --release --lib` (67 unit tests) passa.
- [x] Sweep dos `tests/{fs_*,nodespace_*,for_in*}.test.ts` (5 tests) passa sem regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)