### PR TITLE
feat(nodespace): node:process pid/exit/cwd/chdir/platform/arch (#288)

### DIFF
--- a/src/nodespace/mod.rs
+++ b/src/nodespace/mod.rs
@@ -3,6 +3,7 @@ use crate::abi::AbiType;
 pub mod fs;
 pub mod os;
 pub mod path;
+pub mod process;
 
 pub struct NodespaceSpec {
     pub node_module: &'static str,
@@ -17,7 +18,7 @@ pub struct NodespaceMember {
     pub returns: AbiType,
 }
 
-pub const NODE_SPECS: &[&NodespaceSpec] = &[&fs::SPEC, &path::SPEC, &os::SPEC];
+pub const NODE_SPECS: &[&NodespaceSpec] = &[&fs::SPEC, &path::SPEC, &os::SPEC, &process::SPEC];
 
 /// Resolves a codegen-qualified name like `"node_fs.readFileSync"` to its member.
 pub(crate) fn node_lookup(qualified: &str) -> Option<&'static NodespaceMember> {

--- a/src/nodespace/process/mod.rs
+++ b/src/nodespace/process/mod.rs
@@ -1,0 +1,47 @@
+use crate::abi::AbiType;
+use super::{NodespaceMember, NodespaceSpec};
+
+pub const MEMBERS: &[NodespaceMember] = &[
+    NodespaceMember {
+        name: "exit",
+        symbol: "__RTS_FN_NS_PROCESS_EXIT",
+        args: &[AbiType::I64],
+        returns: AbiType::Void,
+    },
+    NodespaceMember {
+        name: "pid",
+        symbol: "__RTS_FN_NS_PROCESS_PID",
+        args: &[],
+        returns: AbiType::I64,
+    },
+    NodespaceMember {
+        name: "cwd",
+        symbol: "__RTS_FN_NS_ENV_CWD",
+        args: &[],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "chdir",
+        symbol: "__RTS_FN_NS_ENV_SET_CWD",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Void,
+    },
+    NodespaceMember {
+        name: "platform",
+        symbol: "__RTS_FN_NS_OS_PLATFORM",
+        args: &[],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "arch",
+        symbol: "__RTS_FN_NS_OS_ARCH",
+        args: &[],
+        returns: AbiType::Handle,
+    },
+];
+
+pub const SPEC: NodespaceSpec = NodespaceSpec {
+    node_module: "process",
+    ns_prefix: "node_process",
+    members: MEMBERS,
+};

--- a/tests/nodespace_process.test.ts
+++ b/tests/nodespace_process.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+import { pid, cwd, platform, arch } from "node:process";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+const p = pid();
+print(p > 0 ? "pid_ok" : "pid_fail");
+
+const c = cwd();
+print(c.length > 0 ? "cwd_ok" : "cwd_fail");
+
+const plat = platform();
+print(plat.length > 0 ? "platform_ok" : "platform_fail");
+
+const a = arch();
+print(a.length > 0 ? "arch_ok" : "arch_fail");
+
+describe("nodespace_process", () => {
+  test("pid/cwd/platform/arch return non-empty", () => {
+    expect(__rtsCapturedOutput).toBe("pid_ok\ncwd_ok\nplatform_ok\narch_ok\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Novo `src/nodespace/process/` mapeando `node:process` membros para símbolos existentes (process, env, os).
- Cobre: `exit`, `pid`, `cwd`, `chdir`, `platform`, `arch`.
- `path` e `os` já estavam implementados antes; gaps maiores (cpus/totalmem/freemem, parse, util.format/inspect) ficam para fase 2.

Refs #288.

## Test plan

- [x] `tests/nodespace_process.test.ts` valida pid > 0, cwd/platform/arch não-vazios.
- [x] `cargo test --release --lib` (67 unit tests) passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)