### PR TITLE
feat(js): hoisting de function expressions arbitrarias (#260, #311)

### DIFF
--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -1670,6 +1670,442 @@ fn rewrite_static_in_expr(e: &mut Expr, map: &HashMap<String, HashMap<String, St
     }
 }
 
+/// Hoist de Expr::Fn / Expr::Arrow em posicoes arbitrarias (call args,
+/// IIFE, valor em object literal, etc) para Item::Function sintetico
+/// no topo do programa, substituindo a expressao por Expr::Ident.
+///
+/// Top-level \`const x = function() {}\` ja foi convertido pelo parser
+/// (try_lower_fn_expr_decl); este pass cobre o que sobrou. Nao tenta
+/// resolver capturas de escopo — se o body referenciar variaveis
+/// fora dele, falha em codegen como ident undefined.
+fn hoist_fn_expressions(program: &mut Program) {
+    use swc_ecma_ast::{ArrowExpr, BlockStmtOrExpr};
+
+    let mut counter: u32 = 0;
+    let mut new_fns: Vec<Item> = Vec::new();
+
+    fn fresh_ident(name: &str) -> Expr {
+        Expr::Ident(swc_ecma_ast::Ident {
+            span: Default::default(),
+            ctxt: Default::default(),
+            sym: name.into(),
+            optional: false,
+        })
+    }
+
+    fn pat_to_param_name(p: &Pat) -> Option<String> {
+        if let Pat::Ident(b) = p {
+            Some(b.id.sym.to_string())
+        } else {
+            None
+        }
+    }
+
+    fn body_has_return_value(stmts: &[Stmt]) -> bool {
+        for s in stmts {
+            if has_return_value_stmt(s) {
+                return true;
+            }
+        }
+        false
+    }
+    fn has_return_value_stmt(s: &Stmt) -> bool {
+        match s {
+            Stmt::Return(r) => r.arg.is_some(),
+            Stmt::Block(b) => body_has_return_value(&b.stmts),
+            Stmt::If(i) => {
+                has_return_value_stmt(&i.cons)
+                    || i.alt.as_deref().map_or(false, has_return_value_stmt)
+            }
+            Stmt::While(w) => has_return_value_stmt(&w.body),
+            Stmt::DoWhile(w) => has_return_value_stmt(&w.body),
+            Stmt::For(f) => has_return_value_stmt(&f.body),
+            Stmt::ForOf(f) => has_return_value_stmt(&f.body),
+            Stmt::ForIn(f) => has_return_value_stmt(&f.body),
+            Stmt::Try(t) => {
+                body_has_return_value(&t.block.stmts)
+                    || t.handler
+                        .as_ref()
+                        .map_or(false, |h| body_has_return_value(&h.body.stmts))
+                    || t.finalizer
+                        .as_ref()
+                        .map_or(false, |f| body_has_return_value(&f.stmts))
+            }
+            _ => false,
+        }
+    }
+
+    fn build_fn_decl(
+        name: &str,
+        params: &[swc_ecma_ast::Param],
+        body_stmts: Vec<Stmt>,
+    ) -> FunctionDecl {
+        let parameters = params
+            .iter()
+            .filter_map(|p| pat_to_param_name(&p.pat))
+            .map(|n| Parameter {
+                name: n,
+                type_annotation: None,
+                modifiers: MemberModifiers::default(),
+                variadic: false,
+                default: None,
+                span: Span::default(),
+            })
+            .collect();
+        // Heuristica: se body tem \`return <expr>\`, declaramos retorno
+        // i64. Sem isso, declare_user_fn vira void e o codegen descarta
+        // o valor retornado, quebrando \`apply(fn, x)\` e IIFE com retorno.
+        let return_type = if body_has_return_value(&body_stmts) {
+            Some("i64".to_string())
+        } else {
+            None
+        };
+        let body: Vec<Statement> = body_stmts
+            .into_iter()
+            .map(|s| {
+                Statement::Raw(
+                    RawStmt::new("<hoisted-fn>".to_string(), Span::default()).with_stmt(s),
+                )
+            })
+            .collect();
+        FunctionDecl {
+            name: name.to_string(),
+            parameters,
+            return_type,
+            body,
+            span: Span::default(),
+        }
+    }
+
+    fn arrow_body_stmts(arrow: &ArrowExpr) -> Vec<Stmt> {
+        match arrow.body.as_ref() {
+            BlockStmtOrExpr::BlockStmt(b) => b.stmts.clone(),
+            BlockStmtOrExpr::Expr(e) => vec![Stmt::Return(swc_ecma_ast::ReturnStmt {
+                span: arrow.span,
+                arg: Some(e.clone()),
+            })],
+        }
+    }
+
+    fn arrow_params(arrow: &ArrowExpr) -> Vec<swc_ecma_ast::Param> {
+        arrow
+            .params
+            .iter()
+            .map(|pat| swc_ecma_ast::Param {
+                span: Default::default(),
+                decorators: Vec::new(),
+                pat: pat.clone(),
+            })
+            .collect()
+    }
+
+    fn visit_expr(expr: &mut Expr, counter: &mut u32, new_fns: &mut Vec<Item>) {
+        // Pre-order: primeiro visitamos sub-exprs (para que Fn/Arrow
+        // aninhadas tambem sejam hoisted) e depois substituimos a
+        // raiz se for Fn/Arrow.
+        descend_expr(expr, counter, new_fns);
+
+        // Peel \`(expr)\` wrappers — IIFE \`(function(){...})(...)\` apos
+        // hoist vira \`(__hoisted_fn_N)(...)\` e o codegen so' reconhece
+        // Expr::Ident como callee direto.
+        loop {
+            let take = matches!(expr, Expr::Paren(_));
+            if !take {
+                break;
+            }
+            if let Expr::Paren(p) = std::mem::replace(
+                expr,
+                Expr::Invalid(swc_ecma_ast::Invalid {
+                    span: Default::default(),
+                }),
+            ) {
+                *expr = *p.expr;
+            }
+        }
+
+        let replace = match expr {
+            Expr::Fn(_) | Expr::Arrow(_) => true,
+            _ => false,
+        };
+        if !replace {
+            return;
+        }
+
+        let owned = std::mem::replace(
+            expr,
+            Expr::Invalid(swc_ecma_ast::Invalid {
+                span: Default::default(),
+            }),
+        );
+        let name = format!("__hoisted_fn_{}", *counter);
+        *counter += 1;
+
+        let fn_decl = match owned {
+            Expr::Fn(fn_expr) => {
+                let func = &fn_expr.function;
+                let body = func.body.as_ref().map(|b| b.stmts.clone()).unwrap_or_default();
+                build_fn_decl(&name, &func.params, body)
+            }
+            Expr::Arrow(arrow) => {
+                let params = arrow_params(&arrow);
+                let body = arrow_body_stmts(&arrow);
+                build_fn_decl(&name, &params, body)
+            }
+            _ => unreachable!(),
+        };
+        new_fns.push(Item::Function(fn_decl));
+        *expr = fresh_ident(&name);
+    }
+
+    fn descend_expr(expr: &mut Expr, counter: &mut u32, new_fns: &mut Vec<Item>) {
+        match expr {
+            Expr::Call(c) => {
+                if let Callee::Expr(callee) = &mut c.callee {
+                    visit_expr(callee.as_mut(), counter, new_fns);
+                }
+                for arg in c.args.iter_mut() {
+                    visit_expr(arg.expr.as_mut(), counter, new_fns);
+                }
+            }
+            Expr::New(n) => {
+                visit_expr(n.callee.as_mut(), counter, new_fns);
+                if let Some(args) = n.args.as_mut() {
+                    for arg in args.iter_mut() {
+                        visit_expr(arg.expr.as_mut(), counter, new_fns);
+                    }
+                }
+            }
+            Expr::Bin(b) => {
+                visit_expr(b.left.as_mut(), counter, new_fns);
+                visit_expr(b.right.as_mut(), counter, new_fns);
+            }
+            Expr::Assign(a) => {
+                visit_expr(a.right.as_mut(), counter, new_fns);
+            }
+            Expr::Unary(u) => visit_expr(u.arg.as_mut(), counter, new_fns),
+            Expr::Update(u) => visit_expr(u.arg.as_mut(), counter, new_fns),
+            Expr::Cond(c) => {
+                visit_expr(c.test.as_mut(), counter, new_fns);
+                visit_expr(c.cons.as_mut(), counter, new_fns);
+                visit_expr(c.alt.as_mut(), counter, new_fns);
+            }
+            Expr::Seq(s) => {
+                for e in s.exprs.iter_mut() {
+                    visit_expr(e.as_mut(), counter, new_fns);
+                }
+            }
+            Expr::Member(m) => {
+                visit_expr(m.obj.as_mut(), counter, new_fns);
+                if let MemberProp::Computed(c) = &mut m.prop {
+                    visit_expr(c.expr.as_mut(), counter, new_fns);
+                }
+            }
+            Expr::OptChain(o) => {
+                use swc_ecma_ast::OptChainBase;
+                match o.base.as_mut() {
+                    OptChainBase::Member(m) => {
+                        visit_expr(m.obj.as_mut(), counter, new_fns);
+                    }
+                    OptChainBase::Call(c) => {
+                        visit_expr(c.callee.as_mut(), counter, new_fns);
+                        for arg in c.args.iter_mut() {
+                            visit_expr(arg.expr.as_mut(), counter, new_fns);
+                        }
+                    }
+                }
+            }
+            Expr::Array(arr) => {
+                for elem in arr.elems.iter_mut().flatten() {
+                    visit_expr(elem.expr.as_mut(), counter, new_fns);
+                }
+            }
+            Expr::Object(obj) => {
+                for prop in obj.props.iter_mut() {
+                    if let swc_ecma_ast::PropOrSpread::Prop(p) = prop {
+                        if let swc_ecma_ast::Prop::KeyValue(kv) = p.as_mut() {
+                            visit_expr(kv.value.as_mut(), counter, new_fns);
+                        }
+                    }
+                }
+            }
+            Expr::Tpl(t) => {
+                for e in t.exprs.iter_mut() {
+                    visit_expr(e.as_mut(), counter, new_fns);
+                }
+            }
+            Expr::Paren(p) => visit_expr(p.expr.as_mut(), counter, new_fns),
+            Expr::TsAs(a) => visit_expr(a.expr.as_mut(), counter, new_fns),
+            Expr::TsTypeAssertion(a) => visit_expr(a.expr.as_mut(), counter, new_fns),
+            Expr::TsConstAssertion(a) => visit_expr(a.expr.as_mut(), counter, new_fns),
+            Expr::TsSatisfies(a) => visit_expr(a.expr.as_mut(), counter, new_fns),
+            Expr::TsNonNull(n) => visit_expr(n.expr.as_mut(), counter, new_fns),
+            Expr::Await(a) => visit_expr(a.arg.as_mut(), counter, new_fns),
+            Expr::Yield(y) => {
+                if let Some(e) = y.arg.as_mut() {
+                    visit_expr(e.as_mut(), counter, new_fns);
+                }
+            }
+            // Fn/Arrow: nao descer dentro do body — body sera tratado
+            // quando o pass rodar de novo recursivamente nos new_fns.
+            // Aqui apenas paramos. Se body tiver mais lambdas, elas
+            // sao hoisted no proximo loop fixed-point.
+            _ => {}
+        }
+    }
+
+    fn visit_stmt(stmt: &mut Stmt, counter: &mut u32, new_fns: &mut Vec<Item>) {
+        match stmt {
+            Stmt::Expr(e) => visit_expr(e.expr.as_mut(), counter, new_fns),
+            Stmt::Return(r) => {
+                if let Some(e) = r.arg.as_mut() {
+                    visit_expr(e.as_mut(), counter, new_fns);
+                }
+            }
+            Stmt::Decl(Decl::Var(vd)) => {
+                for d in vd.decls.iter_mut() {
+                    if let Some(init) = d.init.as_mut() {
+                        visit_expr(init.as_mut(), counter, new_fns);
+                    }
+                }
+            }
+            Stmt::Block(b) => {
+                for s in b.stmts.iter_mut() {
+                    visit_stmt(s, counter, new_fns);
+                }
+            }
+            Stmt::If(i) => {
+                visit_expr(i.test.as_mut(), counter, new_fns);
+                visit_stmt(i.cons.as_mut(), counter, new_fns);
+                if let Some(alt) = i.alt.as_mut() {
+                    visit_stmt(alt.as_mut(), counter, new_fns);
+                }
+            }
+            Stmt::While(w) => {
+                visit_expr(w.test.as_mut(), counter, new_fns);
+                visit_stmt(w.body.as_mut(), counter, new_fns);
+            }
+            Stmt::DoWhile(d) => {
+                visit_expr(d.test.as_mut(), counter, new_fns);
+                visit_stmt(d.body.as_mut(), counter, new_fns);
+            }
+            Stmt::For(f) => {
+                if let Some(init) = f.init.as_mut() {
+                    if let swc_ecma_ast::VarDeclOrExpr::Expr(e) = init {
+                        visit_expr(e.as_mut(), counter, new_fns);
+                    }
+                    if let swc_ecma_ast::VarDeclOrExpr::VarDecl(vd) = init {
+                        for d in vd.decls.iter_mut() {
+                            if let Some(init) = d.init.as_mut() {
+                                visit_expr(init.as_mut(), counter, new_fns);
+                            }
+                        }
+                    }
+                }
+                if let Some(t) = f.test.as_mut() {
+                    visit_expr(t.as_mut(), counter, new_fns);
+                }
+                if let Some(u) = f.update.as_mut() {
+                    visit_expr(u.as_mut(), counter, new_fns);
+                }
+                visit_stmt(f.body.as_mut(), counter, new_fns);
+            }
+            Stmt::ForOf(f) => {
+                visit_expr(f.right.as_mut(), counter, new_fns);
+                visit_stmt(f.body.as_mut(), counter, new_fns);
+            }
+            Stmt::ForIn(f) => {
+                visit_expr(f.right.as_mut(), counter, new_fns);
+                visit_stmt(f.body.as_mut(), counter, new_fns);
+            }
+            Stmt::Switch(s) => {
+                visit_expr(s.discriminant.as_mut(), counter, new_fns);
+                for c in s.cases.iter_mut() {
+                    if let Some(t) = c.test.as_mut() {
+                        visit_expr(t.as_mut(), counter, new_fns);
+                    }
+                    for s in c.cons.iter_mut() {
+                        visit_stmt(s, counter, new_fns);
+                    }
+                }
+            }
+            Stmt::Throw(t) => visit_expr(t.arg.as_mut(), counter, new_fns),
+            Stmt::Try(t) => {
+                for s in t.block.stmts.iter_mut() {
+                    visit_stmt(s, counter, new_fns);
+                }
+                if let Some(handler) = t.handler.as_mut() {
+                    for s in handler.body.stmts.iter_mut() {
+                        visit_stmt(s, counter, new_fns);
+                    }
+                }
+                if let Some(finalizer) = t.finalizer.as_mut() {
+                    for s in finalizer.stmts.iter_mut() {
+                        visit_stmt(s, counter, new_fns);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Iterate ate fixed-point: visitar items, hoistar, e depois
+    // re-visitar new_fns (que podem conter outras Fn/Arrow aninhadas).
+    let mut to_visit_items: Vec<&mut Item> = program.items.iter_mut().collect();
+    for item in to_visit_items.drain(..) {
+        match item {
+            Item::Function(f) => {
+                for s in f.body.iter_mut() {
+                    let Statement::Raw(raw) = s;
+                    if let Some(stmt) = raw.stmt.as_mut() {
+                        visit_stmt(stmt, &mut counter, &mut new_fns);
+                    }
+                }
+            }
+            Item::Statement(Statement::Raw(raw)) => {
+                if let Some(stmt) = raw.stmt.as_mut() {
+                    visit_stmt(stmt, &mut counter, &mut new_fns);
+                }
+            }
+            Item::Class(class) => {
+                for member in class.members.iter_mut() {
+                    let body = match member {
+                        ClassMember::Method(m) => &mut m.body,
+                        ClassMember::Constructor(c) => &mut c.body,
+                        _ => continue,
+                    };
+                    for s in body.iter_mut() {
+                        let Statement::Raw(raw) = s;
+                        if let Some(stmt) = raw.stmt.as_mut() {
+                            visit_stmt(stmt, &mut counter, &mut new_fns);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Process new_fns recursivamente (lambdas dentro de lambdas).
+    let mut work = std::mem::take(&mut new_fns);
+    let mut acc: Vec<Item> = Vec::new();
+    while let Some(item) = work.pop() {
+        if let Item::Function(mut f) = item {
+            for s in f.body.iter_mut() {
+                let Statement::Raw(raw) = s;
+                if let Some(stmt) = raw.stmt.as_mut() {
+                    let mut local_new: Vec<Item> = Vec::new();
+                    visit_stmt(stmt, &mut counter, &mut local_new);
+                    work.extend(local_new);
+                }
+            }
+            acc.push(Item::Function(f));
+        } else {
+            acc.push(item);
+        }
+    }
+    program.items.extend(acc);
+}
+
 fn expand_destructuring(program: &mut Program) {
     // Counter global para gerar nomes de temporários únicos.
     let mut counter: u32 = 0;
@@ -4291,6 +4727,7 @@ pub fn compile_program(
     let mut par_fn_names = reduce_pass(program);
     par_fn_names.extend(purity_pass(program));
     let lifted_needs_c_callconv = lift_arrow_callbacks(program);
+    hoist_fn_expressions(program);
     expand_destructuring(program);
     expand_default_args(program);
     // Spread antes de rest: spread aplaina array literal nos call sites


### PR DESCRIPTION
## Summary
Pass novo \`hoist_fn_expressions\` antes de \`expand_destructuring\`. Percorre o programa todo (top-level, bodies de fn/method/constructor) e substitui \`Expr::Fn\` / \`Expr::Arrow\` em posicoes arbitrarias por \`Item::Function\` sintetico (\`__hoisted_fn_N\`) + \`Expr::Ident\`.

Cobre patterns que antes falhavam:
- \`arr.map(function(x){ return x*2 })\` (function como call arg)
- \`(function(){ return 42 })()\` (IIFE)
- \`const r = (function(a,b){ return a+b })(3,4)\`
- arrows aninhadas dentro do body de outra fn/arrow

Inclui peel de \`Expr::Paren\` ao redor de \`Ident\` apos hoist (IIFE \`(__hoisted_fn_N)(...)\` precisa de callee = Ident direto). Inferencia de return type: se o body tem \`return <expr>\` declara \`i64\`, senao \`void\`.

## Limitacoes (declaradas no commit)
- Sem captura de escopo (closures completas — refs #229).
- Object literal value: hoisting funciona, mas chamada \`obj.method(...)\` em runtime ainda falha por bug separado de \`lower_var_member_call\` com user fn (call_indirect retorna 0).
- 5/6 cases de \`tests/function_expression.test.ts\` passam.

Refs #260 #311

## Test plan
- [x] tests/function_expression.test.ts: 5/6 cases passam
- [x] \`cargo test --release --lib\` sem regressao introduzida (1 teste pre-existente falhando em main: \`abi::tests::symbols_are_globally_unique\`, nao relacionado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)