### PR TITLE
fix(codegen): Promise<T> annotation resolve para T (#336)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -48,6 +48,14 @@ impl ValTy {
             "string" | "str" => return ValTy::Handle,
             _ => {}
         }
+        // \`Promise<X>\` (resultado tipico de async fn): RTS nao tem
+        // Promise propria — async vira sync stripped, entao o tipo
+        // efetivo eh X. Cobre \`Promise<string>\`, \`Promise<number>\`, etc.
+        if let Some(rest) = trimmed.strip_prefix("Promise<") {
+            if let Some(inner) = rest.strip_suffix('>') {
+                return ValTy::from_annotation(inner);
+            }
+        }
         // Union types raw da source: tenta resolver para um tipo unico
         // se todos os ramos sao do mesmo. Usa parsing textual simples.
         if trimmed.contains('|') {

--- a/tests/async_try_catch_no_throw.test.ts
+++ b/tests/async_try_catch_no_throw.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+async function ok(): Promise<string> { return "ok"; }
+async function okNum(): Promise<number> { return 42; }
+
+try {
+  const r = await ok();
+  print(r);
+} catch (e) {
+  print("should not reach (string)");
+}
+
+try {
+  const n = await okNum();
+  print(`${n}`);
+} catch (e) {
+  print("should not reach (number)");
+}
+
+describe("async_try_catch_no_throw", () => {
+  test("catch nao executa quando nao ha throw", () =>
+    expect(__rtsCapturedOutput).toBe("ok\n42\n"));
+});


### PR DESCRIPTION
## Summary
\`ValTy::from_annotation(\"Promise<string>\")\` caia em fallback I64. Resultado: \`await ok()\` (com \`Promise<string>\`) escapava como i64 e o codegen emitia warning + tornava o statement subsequente unreachable, fazendo o try block aparentar ter caido em catch.

Fix: peel \`Promise<X>\` -> recurse em X.

Closes #336

## Test plan
- [x] tests/async_try_catch_no_throw.test.ts: \`await ok()\` com Promise<string> e Promise<number> imprime resultado, catch nao executa
- [x] cargo test --lib sem regressao introduzida (1 teste pre-existente falhando em main: abi::tests::symbols_are_globally_unique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)