### PR TITLE
feat(types): mapear `: number` para F64 (#323)

### DIFF
--- a/src/codegen/lower/expressions/mod.rs
+++ b/src/codegen/lower/expressions/mod.rs
@@ -315,6 +315,7 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
         let coerced = match ctx.var_ty(&name) {
             Some(ValTy::I32) => ctx.coerce_to_i32(rhs_val),
             Some(ValTy::I64) => ctx.coerce_to_i64(rhs_val),
+            Some(ValTy::F64) => ctx.coerce_to_f64(rhs_val),
             Some(ValTy::Handle) => ctx.coerce_to_handle(rhs_val)?,
             _ => rhs_val,
         };

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -5541,7 +5541,7 @@ fn ts_type_to_val_ty(ty: &TsType) -> Option<ValTy> {
 
     if let TsType::TsKeywordType(kw) = ty {
         return Some(match kw.kind {
-            TsKeywordTypeKind::TsNumberKeyword => ValTy::I32,
+            TsKeywordTypeKind::TsNumberKeyword => ValTy::F64,
             TsKeywordTypeKind::TsBooleanKeyword => ValTy::Bool,
             TsKeywordTypeKind::TsStringKeyword => ValTy::Handle,
             TsKeywordTypeKind::TsVoidKeyword => ValTy::I64,

--- a/src/codegen/lower/statements/decls.rs
+++ b/src/codegen/lower/statements/decls.rs
@@ -157,6 +157,7 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         let init_coerced = match ty {
             ValTy::I32 => ctx.coerce_to_i32(TypedVal::new(init_val, inferred_ty)).val,
             ValTy::I64 => ctx.coerce_to_i64(TypedVal::new(init_val, inferred_ty)).val,
+            ValTy::F64 => ctx.coerce_to_f64(TypedVal::new(init_val, inferred_ty)).val,
             _ => init_val,
         };
 
@@ -175,7 +176,7 @@ pub(super) fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {
     use swc_ecma_ast::{TsKeywordTypeKind, TsLit, TsLitType, TsType, TsUnionOrIntersectionType};
     if let TsType::TsKeywordType(kw) = ty {
         return Some(match kw.kind {
-            TsKeywordTypeKind::TsNumberKeyword => ValTy::I32,
+            TsKeywordTypeKind::TsNumberKeyword => ValTy::F64,
             TsKeywordTypeKind::TsBooleanKeyword => ValTy::Bool,
             TsKeywordTypeKind::TsStringKeyword => ValTy::Handle,
             TsKeywordTypeKind::TsVoidKeyword => ValTy::I64,

--- a/tests/number_is_f64.test.ts
+++ b/tests/number_is_f64.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "rts:test";
+import { io, gc } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #323: `: number` deve mapear para F64 (alinhar com JS).
+// Antes: divisao integer (sentinel 0) e perda de fracao.
+
+const x: number = 1.0;
+const y: number = 0.0;
+const z: number = x / y;
+
+if (z > 1e300) {
+  const h = gc.string_from_static("Infinity");
+  print(h); gc.string_free(h);
+} else {
+  const h = gc.string_from_static("not-infinity");
+  print(h); gc.string_free(h);
+}
+
+const a: number = 7;
+const b: number = 2;
+const c: number = a / b;
+if (c > 3.4 && c < 3.6) {
+  const h = gc.string_from_static("3.5");
+  print(h); gc.string_free(h);
+} else {
+  const h = gc.string_from_static("wrong");
+  print(h); gc.string_free(h);
+}
+
+let acc: number = 0;
+acc = acc + 1.5;
+acc = acc + 2.5;
+if (acc > 3.9 && acc < 4.1) {
+  const h = gc.string_from_static("4");
+  print(h); gc.string_free(h);
+}
+
+describe("fixture:number_is_f64", () => {
+  test("number type is f64 with correct semantics", () => {
+    expect(__rtsCapturedOutput).toBe("Infinity\n3.5\n4\n");
+  });
+});


### PR DESCRIPTION
## Summary

- `: number` agora mapeia para `ValTy::F64` (alinhado com JS — `number` e' f64 IEEE-754)
- Antes: `1.0 / 0.0 === 0` (sentinel int), wraparound, perda de fracao
- Agora: `1.0 / 0.0 === Infinity`, `7/2 === 3.5`

## Mudancas

- `TsNumberKeyword` → `ValTy::F64` em `decls.rs:178` e `func.rs:5544`
- coercao F64 no init de var/let/const em `decls.rs` (antes so' I32/I64)
- coercao F64 no reassign em `expressions/mod.rs` (antes: panic Cranelift `declared type doesn't match` quando atribuia int a var declarada `: number`)
- nova fixture `tests/number_is_f64.test.ts` cobrindo Infinity, divisao fracionaria e reassign acumulando float

## Compat

Quem realmente precisa de int deve declarar `: i32` (ja funciona). Static fields, params e returns nao foram tocados — escopo focado em var declarations.

## Resultados

- Baseline: 230 pass / 11 fail (todas pre-existentes — segfault em #314, optchain #333, etc)
- Apos mudanca: 230 pass / 11 fail (zero regressao)
- Issue #323 repro funciona: `Infinity` em vez de `0`

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite full sem regressao
- [x] Fixture nova `number_is_f64.test.ts` passa
- [x] Repro original da issue retorna Infinity

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)