### PR TITLE
fix(gc): cleanup ativo de recursos OS em free() (#279)

### DIFF
--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -126,6 +126,47 @@ pub enum Entry {
     Free,
 }
 
+/// Cleanup ativo de recursos do SO quando um Entry e' descartado (#279).
+///
+/// Nao usamos `impl Drop for Entry` para nao quebrar call sites que
+/// movem variantes via `mem::replace(entry, Entry::Free)` + pattern
+/// match (E0509). Em vez disso, esta funcao e' chamada explicitamente
+/// em `HandleTable::free` antes de substituir o slot por `Free`, e
+/// tambem percorrida no `Drop` do HandleTable inteiro.
+///
+/// Tipos cobertos:
+/// - `ProcessChild`: drop padrao nao chama wait — gera zumbi ate o pai
+///   morrer. Chamamos `try_wait` para reaproveitar o status sem
+///   bloquear; se ainda nao terminou, deixamos o SO tratar.
+/// - `TcpStream`/`TlsClient`: shutdown(Both) acorda peers em vez de
+///   esperar timeout do TCP.
+///
+/// Demais tipos (Buffer, Map, Regex, Mutex, etc) liberam memoria
+/// corretamente via Drop padrao do Box/Vec — nao precisam de logica
+/// extra aqui.
+fn cleanup_entry(entry: &mut Entry) {
+    match entry {
+        Entry::ProcessChild(child) => {
+            let _ = child.try_wait();
+        }
+        Entry::TcpStream(stream) => {
+            let _ = stream.shutdown(std::net::Shutdown::Both);
+        }
+        Entry::TlsClient(tls) => {
+            let _ = tls.tcp.shutdown(std::net::Shutdown::Both);
+        }
+        _ => {}
+    }
+}
+
+impl Drop for HandleTable {
+    fn drop(&mut self) {
+        for slot in &mut self.slots {
+            cleanup_entry(&mut slot.entry);
+        }
+    }
+}
+
 /// Storage para `Entry::RtsEventsEmitter`. Listeners agrupados por nome
 /// de evento; cada listener é um endereço de função (`func_addr` raw),
 /// chamado via transmute → `extern "C" fn`.
@@ -195,6 +236,7 @@ impl HandleTable {
         if slot.generation != expected_gen {
             return false;
         }
+        cleanup_entry(&mut slot.entry);
         slot.entry = Entry::Free;
         self.free_list.push(table_slot);
         true

--- a/tests/handle_cleanup.test.ts
+++ b/tests/handle_cleanup.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+import { gc, buffer } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// Loop de alloc + free nao deve crescer count alem de uma janela
+// pequena (handles sao reusados via free_list).
+const before = gc.live_count();
+for (let i = 0; i < 50; i = i + 1) {
+  const buf = buffer.alloc(64);
+  buffer.free(buf);
+}
+const after = gc.live_count();
+const grew = after - before;
+print(`grew_ok=${grew < 20}`);
+
+describe("handle_cleanup", () => {
+  test("free reuses slots", () => expect(__rtsCapturedOutput).toBe("grew_ok=true\n"));
+});


### PR DESCRIPTION
## Summary
- `cleanup_entry()` chamado por `HandleTable::free` antes de marcar slot como Free
- `impl Drop for HandleTable` percorre slots no shutdown
- Cobre ProcessChild (try_wait), TcpStream e TlsClient (shutdown both)

Closes #279

## Test plan
- [x] `tests/handle_cleanup.test.ts` (novo) — loop alloc+free de buffer 50× confirma slot reuse via `gc.live_count()`
- [x] `cargo test --release --lib` — 69 passed; 1 falha preexistente (`abi::tests::symbols_are_globally_unique`)

## Notas
- Nao implementamos `impl Drop for Entry` diretamente para nao quebrar 3 call sites (process/wait, thread/join, tls/client) que extraem variantes via `mem::replace + match` (E0509). Cleanup via funcao helper resolve sem mudar API.
- Tipos puramente em-memoria (Buffer, Map, Regex, Mutex, etc) ja' liberam via Drop padrao do Box/Vec — nao precisam de cleanup ativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)