### PR TITLE
fix(gc): elimina Box::leak em codegen (#276)

### DIFF
--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -57,7 +57,7 @@ pub fn compile_program_to_object(
 }
 
 fn collect_used_namespaces(
-    extern_cache: &HashMap<&'static str, cranelift_module::FuncId>,
+    extern_cache: &HashMap<String, cranelift_module::FuncId>,
 ) -> HashSet<String> {
     extern_cache
         .keys()

--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -253,7 +253,7 @@ pub struct ClassMeta {
 pub struct FnCtx<'m, 'fb> {
     pub builder: &'fb mut FunctionBuilder<'m>,
     pub module: &'m mut dyn Module,
-    pub extern_cache: &'fb mut HashMap<&'static str, cranelift_module::FuncId>,
+    pub extern_cache: &'fb mut HashMap<String, cranelift_module::FuncId>,
     pub data_counter: &'fb mut u32,
 
     /// Stack of scopes. The first entry is the function scope (where `var`
@@ -386,7 +386,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
     pub fn new(
         builder: &'fb mut FunctionBuilder<'m>,
         module: &'m mut dyn Module,
-        extern_cache: &'fb mut HashMap<&'static str, cranelift_module::FuncId>,
+        extern_cache: &'fb mut HashMap<String, cranelift_module::FuncId>,
         data_counter: &'fb mut u32,
         globals: &'fb HashMap<String, GlobalVar>,
         user_fns: &'fb HashMap<String, UserFnAbi>,
@@ -682,7 +682,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
                 .module
                 .declare_function(symbol, Linkage::Import, &sig)
                 .map_err(|e| anyhow!("failed to declare extern {symbol}: {e}"))?;
-            self.extern_cache.insert(symbol, id);
+            self.extern_cache.insert(symbol.to_string(), id);
         }
         let id = *self.extern_cache.get(symbol).expect("extern declared");
         let fref = self.module.declare_func_in_func(id, self.builder.func);

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -579,10 +579,10 @@ fn emit_named_method_call(
         .get(fn_name)
         .ok_or_else(|| anyhow!("user fn `{fn_name}` nao registrada"))?
         .clone();
-    let mangled: &'static str = Box::leak(format!("__user_{fn_name}").into_boxed_str());
+    let mangled: String = format!("__user_{fn_name}");
     let fn_id = *ctx
         .extern_cache
-        .get(mangled)
+        .get(mangled.as_str())
         .ok_or_else(|| anyhow!("mangled `{mangled}` nao registrado"))?;
     let fref = ctx.fref_for_id(fn_id);
 
@@ -819,10 +819,10 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
             .get(&init_fn_name)
             .ok_or_else(|| anyhow!("init de classe `{init_owner}` nao registrado"))?
             .clone();
-        let mangled: &'static str = Box::leak(format!("__user_{init_fn_name}").into_boxed_str());
+        let mangled: String = format!("__user_{init_fn_name}");
         let fn_id = *ctx
             .extern_cache
-            .get(mangled)
+            .get(mangled.as_str())
             .ok_or_else(|| anyhow!("init mangled `{mangled}` faltando"))?;
         let fref = ctx.fref_for_id(fn_id);
 
@@ -893,10 +893,10 @@ fn lower_super_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         .get(&init_fn_name)
         .ok_or_else(|| anyhow!("super init de `{init_owner}` nao registrado"))?
         .clone();
-    let mangled: &'static str = Box::leak(format!("__user_{init_fn_name}").into_boxed_str());
+    let mangled: String = format!("__user_{init_fn_name}");
     let fn_id = *ctx
         .extern_cache
-        .get(mangled)
+        .get(mangled.as_str())
         .ok_or_else(|| anyhow!("super init mangled `{mangled}` faltando"))?;
     let fref = ctx.fref_for_id(fn_id);
 
@@ -1198,10 +1198,10 @@ fn emit_method_call(
         .get(&fn_name)
         .ok_or_else(|| anyhow!("metodo `{owner}.{method_name}` nao registrado"))?
         .clone();
-    let mangled: &'static str = Box::leak(format!("__user_{fn_name}").into_boxed_str());
+    let mangled: String = format!("__user_{fn_name}");
     let fn_id = *ctx
         .extern_cache
-        .get(mangled)
+        .get(mangled.as_str())
         .ok_or_else(|| anyhow!("metodo mangled `{mangled}` faltando"))?;
     let fref = ctx.fref_for_id(fn_id);
 
@@ -1320,10 +1320,10 @@ pub(super) fn emit_user_fn_addr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal>
     // User fns cujo endereço é tomado são declaradas com C callconv
     // (ver `address_taken_fns` em compile_program / #206) — seguro para
     // `thread.spawn` e FFI.
-    let mangled: &'static str = Box::leak(format!("__user_{name}").into_boxed_str());
+    let mangled: String = format!("__user_{name}");
     let func_id = *ctx
         .extern_cache
-        .get(mangled)
+        .get(mangled.as_str())
         .ok_or_else(|| anyhow!("user function `{name}` has no cached id"))?;
     let fref = ctx.fref_for_id(func_id);
     let ptr_ty = ctx.module.isa().pointer_type();
@@ -1971,7 +1971,7 @@ fn emit_constant_load(ctx: &mut FnCtx, member: &crate::abi::NamespaceMember) -> 
             .module
             .declare_function(member.symbol, Linkage::Import, &sig)
             .map_err(|e| anyhow!("failed to declare {}: {e}", member.symbol))?;
-        ctx.extern_cache.insert(member.symbol, id);
+        ctx.extern_cache.insert(member.symbol.to_string(), id);
         id
     };
     let fref = ctx.fref_for_id(func_id);
@@ -2190,7 +2190,7 @@ fn lower_ns_call_body(
             .module
             .declare_function(member.symbol, Linkage::Import, &sig)
             .map_err(|e| anyhow!("failed to declare {}: {e}", member.symbol))?;
-        ctx.extern_cache.insert(member.symbol, id);
+        ctx.extern_cache.insert(member.symbol.to_string(), id);
         id
     } else {
         *ctx.extern_cache.get(member.symbol).unwrap()
@@ -2318,7 +2318,7 @@ fn lower_node_ns_call(ctx: &mut FnCtx, qualified: &str, call: &CallExpr) -> Resu
             .module
             .declare_function(member.symbol, Linkage::Import, &sig)
             .map_err(|e| anyhow!("failed to declare {}: {e}", member.symbol))?;
-        ctx.extern_cache.insert(member.symbol, id);
+        ctx.extern_cache.insert(member.symbol.to_string(), id);
         id
     } else {
         *ctx.extern_cache.get(member.symbol).unwrap()
@@ -2467,11 +2467,11 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
         .ok_or_else(|| anyhow!("call to undeclared user function `{name}`"))?
         .clone();
 
-    let mangled: &'static str = Box::leak(format!("__user_{name}").into_boxed_str());
-    if !ctx.extern_cache.contains_key(mangled) {
+    let mangled: String = format!("__user_{name}");
+    if !ctx.extern_cache.contains_key(mangled.as_str()) {
         return Err(anyhow!("call to undeclared user function `{name}`"));
     }
-    let func_id = *ctx.extern_cache.get(mangled).unwrap();
+    let func_id = *ctx.extern_cache.get(mangled.as_str()).unwrap();
     let fref = ctx.fref_for_id(func_id);
 
     if call.args.len() != abi.params.len() {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -4719,7 +4719,7 @@ fn make_slot_assign(slot_name: &str) -> Statement {
 pub fn compile_program(
     program: &mut Program,
     module: &mut dyn Module,
-    extern_cache: &mut HashMap<&'static str, cranelift_module::FuncId>,
+    extern_cache: &mut HashMap<String, cranelift_module::FuncId>,
     data_counter: &mut u32,
 ) -> Result<Vec<String>> {
     expand_static_fields(program);
@@ -4868,8 +4868,8 @@ pub fn compile_program(
     for fn_decl in &fn_decls {
         let address_taken = address_taken_fns.contains(&fn_decl.name);
         let info = declare_user_fn(module, fn_decl, address_taken)?;
-        let mangled: &'static str = Box::leak(format!("__user_{}", fn_decl.name).into_boxed_str());
-        extern_cache.insert(mangled, info.id);
+        let mangled: String = format!("__user_{}", fn_decl.name);
+        extern_cache.insert(mangled.clone(), info.id);
         user_fns.insert(fn_decl.name.clone(), info);
     }
 
@@ -5904,7 +5904,7 @@ fn fn_signature(fn_decl: &FunctionDecl) -> (Vec<ValTy>, Option<ValTy>) {
 
 fn compile_user_fn(
     module: &mut dyn Module,
-    extern_cache: &mut HashMap<&'static str, cranelift_module::FuncId>,
+    extern_cache: &mut HashMap<String, cranelift_module::FuncId>,
     data_counter: &mut u32,
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,
@@ -6096,7 +6096,7 @@ fn compile_user_fn(
 
 fn compile_main(
     module: &mut dyn Module,
-    extern_cache: &mut HashMap<&'static str, cranelift_module::FuncId>,
+    extern_cache: &mut HashMap<String, cranelift_module::FuncId>,
     data_counter: &mut u32,
     globals: &HashMap<String, GlobalVar>,
     user_fns: &HashMap<String, UserFnAbi>,


### PR DESCRIPTION
## Summary
- Troca `HashMap<&'static str, FuncId>` por `HashMap<String, FuncId>` em `extern_cache`
- Remove 7 sites de `Box::leak(format!("__user_{...}").into_boxed_str())`
- Mangled names agora vivem dentro do cache e somem quando o JITModule e' dropado

Closes #276

## Test plan
- [x] `cargo test --release --lib` — 69 passed; 1 falha preexistente (`abi::tests::symbols_are_globally_unique`)
- [x] Smoke em fixtures de classe (que usam mangled `__user_<method>`): class_basic, class_extras, class_inheritance, class_flat_dispatch — todos passam
- [x] `tests/destructuring_params.test.ts`, `tests/handle_cleanup.test.ts` continuam verdes

## Notas
- Lookups continuam zero-alloc via `HashMap::get(&str)` (`Borrow<str>`)
- Custo extra: uma alocacao por simbolo unico ao popular o cache (antes ja' havia `format!` + `Box::leak`, agora so' `format!` + `clone`)
- Liberacao real do leak depende tambem de #277 (mem::forget no JITModule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)