### PR TITLE
refactor(gc): RTS_THREADS e RTS_CACHE_DIR env vars (#283 item 3)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -29,6 +29,14 @@ pub struct ObjCache {
 
 impl ObjCache {
     pub fn for_input(input: &Path) -> Self {
+        // RTS_CACHE_DIR override absoluto: util pra projetos sem
+        // node_modules/ (workspaces Rust, etc) ou pra isolar caches em CI.
+        if let Ok(custom) = std::env::var("RTS_CACHE_DIR") {
+            let p = PathBuf::from(custom);
+            if !p.as_os_str().is_empty() {
+                return Self { root: p };
+            }
+        }
         Self {
             root: find_project_root(input).join(CACHE_SUBDIR),
         }

--- a/src/namespaces/parallel/pool.rs
+++ b/src/namespaces/parallel/pool.rs
@@ -1,17 +1,29 @@
 //! Global Rayon thread pool, lazily initialised.
+//!
+//! Tamanho do pool: `RTS_THREADS` env var, ou `available_parallelism()`,
+//! ou `1` como fallback final. Antes era hardcoded `4` — arbitrario.
 
 use std::sync::OnceLock;
 
 static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
 
+fn desired_threads() -> usize {
+    if let Ok(s) = std::env::var("RTS_THREADS") {
+        if let Ok(n) = s.parse::<usize>() {
+            if n >= 1 {
+                return n;
+            }
+        }
+    }
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
 pub fn pool() -> &'static rayon::ThreadPool {
     POOL.get_or_init(|| {
         rayon::ThreadPoolBuilder::new()
-            .num_threads(
-                std::thread::available_parallelism()
-                    .map(|n| n.get())
-                    .unwrap_or(4),
-            )
+            .num_threads(desired_threads())
             .build()
             .expect("rayon pool init failed")
     })

--- a/tests/rts_threads_env.test.ts
+++ b/tests/rts_threads_env.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+import { gc, parallel } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #283 item 3: parallel.num_threads() reflete RTS_THREADS quando setado,
+// senao available_parallelism. Aqui apenas validamos que retorna >= 1.
+
+const n = parallel.num_threads();
+const valid = n >= 1;
+const h = gc.string_from_static(valid ? "ok" : "bad");
+print(h); gc.string_free(h);
+
+describe("fixture:rts_threads_env", () => {
+  test("parallel.num_threads >= 1", () => {
+    expect(__rtsCapturedOutput).toBe("ok\n");
+  });
+});


### PR DESCRIPTION
## Summary

Items 1+4 da #283 ja' fechados em PR #342. Este PR cobre item 3 (env vars).

- `RTS_THREADS=N` controla rayon thread pool
- `RTS_CACHE_DIR=/path` override absoluto do cache de objects (util pra projetos sem `node_modules/`, CI isolado, etc)

## Mudancas

- `src/namespaces/parallel/pool.rs`: `RTS_THREADS` env var, fallback `available_parallelism` → `1` (era hardcoded `4`)
- `src/cache.rs`: `ObjCache::for_input` checa `RTS_CACHE_DIR` antes do `node_modules/.rts` relativo
- nova fixture `tests/rts_threads_env.test.ts`

## Verificacao manual

```
$ RTS_THREADS=3 rts run tmp.ts → parallel.num_threads() = 3
$ RTS_THREADS=8 rts run tmp.ts → parallel.num_threads() = 8
$ RTS_CACHE_DIR=/tmp/x rts compile -p tmp.ts out → cache em /tmp/x
```

## Falta para fechar #283

- Item 2: `CompileOptions` para opt_level — follow-up.

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 236/246 (fixture nova passa, zero regressao)
- [x] RTS_THREADS=3 e =8 verificados manualmente
- [x] RTS_CACHE_DIR=/tmp/... verificado manualmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)