### PR TITLE
refactor(codegen): RTS_OPT_LEVEL env var (#283 item 2 — fecha #283)

### DIFF
--- a/src/codegen/emit.rs
+++ b/src/codegen/emit.rs
@@ -84,7 +84,7 @@ fn build_module() -> Result<ObjectModule> {
     // Speed: inlining and LICM help hot loops like bench/monte_carlo_pi;
     // impact on non-loop code is negligible.
     flag_builder
-        .set("opt_level", "speed")
+        .set("opt_level", crate::compile_options::opt_level())
         .map_err(|e| anyhow!("cranelift flag error: {e}"))?;
     // Egraph e alias analysis sao default-on em Cranelift recente mas
     // a explicitacao garante CSE/constant fold/LICM agressivo.

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -42,7 +42,7 @@ fn build_jit_module() -> Result<JITModule> {
         .set("is_pic", "false")
         .map_err(|e| anyhow!("cranelift flag error: {e}"))?;
     flag_builder
-        .set("opt_level", "speed")
+        .set("opt_level", crate::compile_options::opt_level())
         .map_err(|e| anyhow!("cranelift flag error: {e}"))?;
     let _ = flag_builder.set("use_egraphs", "true");
     let _ = flag_builder.set("enable_alias_analysis", "true");

--- a/src/compile_options.rs
+++ b/src/compile_options.rs
@@ -145,3 +145,16 @@ impl Default for CompileOptions {
         }
     }
 }
+
+/// Le `RTS_OPT_LEVEL` e devolve um valor aceito por Cranelift.
+/// Aceita: `none` | `speed` | `speed_and_size`. Default `speed`.
+/// `none` reduz tempo de compilacao em troca de codigo mais lento — util
+/// pra debug rapido de codegen e iteracoes em testes.
+pub fn opt_level() -> &'static str {
+    match std::env::var("RTS_OPT_LEVEL").as_deref() {
+        Ok("none") => "none",
+        Ok("speed_and_size") => "speed_and_size",
+        Ok("speed") => "speed",
+        _ => "speed",
+    }
+}


### PR DESCRIPTION
## Summary

Ultimo item de #283. `RTS_OPT_LEVEL` agora controla `opt_level` Cranelift em ambos `rts run` (JIT) e `rts compile` (AOT).

## Mudancas

- `src/compile_options.rs`: nova fn `opt_level()` que le `RTS_OPT_LEVEL`
- `src/codegen/jit.rs` e `src/codegen/emit.rs`: usam `opt_level()`

## Verificacao

```
$ time RTS_OPT_LEVEL=speed rts run trivial.ts → ~300ms
$ time RTS_OPT_LEVEL=none  rts run trivial.ts → ~42ms (~7x mais rapido)
```

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 237/247 (zero regressao)
- [x] `RTS_OPT_LEVEL=none` reduz tempo de compilacao
- [x] Default (sem env) continua `speed`
- [x] Valor invalido cai em `speed` (default)

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)