### PR TITLE
feat(nodespace): node:util fase 1 — wrappers sobre rts::fmt (#288)

### DIFF
--- a/src/nodespace/mod.rs
+++ b/src/nodespace/mod.rs
@@ -4,6 +4,7 @@ pub mod fs;
 pub mod os;
 pub mod path;
 pub mod process;
+pub mod util;
 
 pub struct NodespaceSpec {
     pub node_module: &'static str,
@@ -18,7 +19,13 @@ pub struct NodespaceMember {
     pub returns: AbiType,
 }
 
-pub const NODE_SPECS: &[&NodespaceSpec] = &[&fs::SPEC, &path::SPEC, &os::SPEC, &process::SPEC];
+pub const NODE_SPECS: &[&NodespaceSpec] = &[
+    &fs::SPEC,
+    &path::SPEC,
+    &os::SPEC,
+    &process::SPEC,
+    &util::SPEC,
+];
 
 /// Resolves a codegen-qualified name like `"node_fs.readFileSync"` to its member.
 pub(crate) fn node_lookup(qualified: &str) -> Option<&'static NodespaceMember> {

--- a/src/nodespace/util/mod.rs
+++ b/src/nodespace/util/mod.rs
@@ -1,0 +1,67 @@
+//! `node:util` — fase 1 (subset RTS-extensions).
+//!
+//! Node `util.format(fmt, ...args)` variadic e `util.inspect(obj)`
+//! ficam para fase 2 (variadic format string parsing + serializacao
+//! recursiva de objeto). Esta fase expoe utilities deterministicos
+//! sobre `rts::fmt` com nomes nao-conflitantes pra evitar confusao
+//! com a API node oficial:
+//!
+//! - `formatInt(n)` / `formatFloat(n)` — to-string
+//! - `formatHex/Bin/Oct(n)` — bases comuns
+//! - `parseInt/parseFloat(s)` — tolerante a whitespace e prefix
+
+use super::{NodespaceMember, NodespaceSpec};
+use crate::abi::AbiType;
+
+pub const MEMBERS: &[NodespaceMember] = &[
+    // Wrappers diretos sobre rts::fmt — convertem inteiros/floats em
+    // diferentes representacoes de string, retornando handle.
+    NodespaceMember {
+        name: "formatInt",
+        symbol: "__RTS_FN_NS_FMT_FMT_I64",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "formatFloat",
+        symbol: "__RTS_FN_NS_FMT_FMT_F64",
+        args: &[AbiType::F64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "formatHex",
+        symbol: "__RTS_FN_NS_FMT_FMT_HEX",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "formatBin",
+        symbol: "__RTS_FN_NS_FMT_FMT_BIN",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "formatOct",
+        symbol: "__RTS_FN_NS_FMT_FMT_OCT",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "parseInt",
+        symbol: "__RTS_FN_NS_FMT_PARSE_I64",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::I64,
+    },
+    NodespaceMember {
+        name: "parseFloat",
+        symbol: "__RTS_FN_NS_FMT_PARSE_F64",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::F64,
+    },
+];
+
+pub const SPEC: NodespaceSpec = NodespaceSpec {
+    node_module: "util",
+    ns_prefix: "node_util",
+    members: MEMBERS,
+};

--- a/tests/node_util_basic.test.ts
+++ b/tests/node_util_basic.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+import { formatHex, formatBin, formatOct, parseInt } from "node:util";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #288 fase 1 — node:util mapeando rts::fmt.
+
+const hex = formatHex(255);
+print(hex); gc.string_free(hex);
+
+const bin = formatBin(10);
+print(bin); gc.string_free(bin);
+
+const oct = formatOct(8);
+print(oct); gc.string_free(oct);
+
+const n = parseInt("42");
+const ns = gc.string_from_i64(n);
+print(ns); gc.string_free(ns);
+
+describe("fixture:node_util_basic", () => {
+  test("formatHex / formatBin / formatOct / parseInt", () => {
+    expect(__rtsCapturedOutput).toBe("0xff\n0b1010\n0o10\n42\n");
+  });
+});


### PR DESCRIPTION
## Summary

Fecha o ultimo gap da #288 (path/os/process ja' existiam). `node:util` exporta utilities deterministicos sobre `rts::fmt`:

- `formatInt`, `formatFloat`, `formatHex`, `formatBin`, `formatOct`
- `parseInt`, `parseFloat`

Variadic `util.format` e `util.inspect` ficam para fase 2 (variadic format string parsing e serializacao recursiva de objeto nao mapeiam 1:1 sobre rts hoje).

## Mudancas

- novo `src/nodespace/util/mod.rs` com 7 membros
- registrado em `nodespace::NODE_SPECS`
- fixture `tests/node_util_basic.test.ts`

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 238/248 (fixture nova passa, zero regressao)
- [x] `import { formatHex } from "node:util"` resolve corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)