### PR TITLE
feat(nodespace): node:fs stat helpers (#287)

### DIFF
--- a/src/nodespace/fs/mod.rs
+++ b/src/nodespace/fs/mod.rs
@@ -62,6 +62,34 @@ pub const MEMBERS: &[NodespaceMember] = &[
         args: &[AbiType::StrPtr],
         returns: AbiType::Handle,
     },
+    // Stat helpers — node:fs.statSync retorna objeto Stats com varios
+    // metodos. Como nodespace e' flat, expomos cada propriedade como
+    // funcao top-level RTS-extension. O proximo PR pode adicionar
+    // wrapper TS em builtin/ que constroe um objeto Stats real.
+    NodespaceMember {
+        name: "isFileSync",
+        symbol: "__RTS_FN_NS_FS_IS_FILE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Bool,
+    },
+    NodespaceMember {
+        name: "isDirectorySync",
+        symbol: "__RTS_FN_NS_FS_IS_DIR",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Bool,
+    },
+    NodespaceMember {
+        name: "sizeSync",
+        symbol: "__RTS_FN_NS_FS_SIZE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::I64,
+    },
+    NodespaceMember {
+        name: "mtimeMsSync",
+        symbol: "__RTS_FN_NS_FS_MODIFIED_MS",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::I64,
+    },
 ];
 
 pub const SPEC: NodespaceSpec = NodespaceSpec {

--- a/tests/node_fs_stat_helpers.test.ts
+++ b/tests/node_fs_stat_helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+import {
+  writeFileSync,
+  existsSync,
+  isFileSync,
+  isDirectorySync,
+  sizeSync,
+} from "node:fs";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #287 — helpers stat-like sobre rts::fs (statSync completo retornando
+// objeto Stats fica para fase 2 quando builtin/buffer/Stats wrappers
+// estiverem prontos).
+
+writeFileSync("/tmp/__rts_stat_helpers.txt", "hello");
+
+const ex = existsSync("/tmp/__rts_stat_helpers.txt");
+const eh = gc.string_from_static(ex ? "exists" : "no");
+print(eh); gc.string_free(eh);
+
+const isFile = isFileSync("/tmp/__rts_stat_helpers.txt");
+const fh = gc.string_from_static(isFile ? "file" : "no");
+print(fh); gc.string_free(fh);
+
+const isDir = isDirectorySync("/tmp/__rts_stat_helpers.txt");
+const dh = gc.string_from_static(isDir ? "dir" : "notdir");
+print(dh); gc.string_free(dh);
+
+const sz = sizeSync("/tmp/__rts_stat_helpers.txt");
+const sh = gc.string_from_i64(sz);
+print(sh); gc.string_free(sh);
+
+describe("fixture:node_fs_stat_helpers", () => {
+  test("exists/isFile/isDirectory/size", () => {
+    expect(__rtsCapturedOutput).toBe("exists\nfile\nnotdir\n5\n");
+  });
+});


### PR DESCRIPTION
## Summary

Avanca #287 expondo helpers stat-like no `node:fs` como funcoes top-level. statSync completo (retornando objeto Stats com metodos) precisa de wrapper TS em `builtin/` que ainda nao temos.

## Mudancas

- `src/nodespace/fs/mod.rs`: 4 novos membros mapeando diretamente sobre rts::fs
  - `isFileSync` -> `__RTS_FN_NS_FS_IS_FILE`
  - `isDirectorySync` -> `__RTS_FN_NS_FS_IS_DIR`
  - `sizeSync` -> `__RTS_FN_NS_FS_SIZE`
  - `mtimeMsSync` -> `__RTS_FN_NS_FS_MODIFIED_MS`
- fixture `tests/node_fs_stat_helpers.test.ts`

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 239/249 (zero regressao)
- [x] `import { isFileSync, sizeSync } from "node:fs"` resolve
- [x] retornos batem com rts.fs equivalente

## Falta

statSync retornando objeto Stats com .isFile() e .size — fase 2 com wrapper TS em builtin/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)