### PR TITLE
feat(nodespace): node:crypto fase 1 — sha256 + random + base64/hex (#289)

### DIFF
--- a/src/nodespace/crypto/mod.rs
+++ b/src/nodespace/crypto/mod.rs
@@ -1,0 +1,58 @@
+//! `node:crypto` — fase 1 (mapeamento RTS-extension).
+//!
+//! Node `createHash().update().digest()` builder + `randomUUID` etc
+//! requerem state-streaming/UUID que `rts::crypto` ainda nao tem.
+//! Esta fase 1 expoe os one-shot hashes/encodings nao-conflitantes:
+//!
+//! - `sha256(s) -> hex string` (one-shot, sem update())
+//! - `randomBytesBuffer(n) -> Buffer handle`
+//! - `hexEncode/Decode(buf) -> string/buffer`
+//! - `base64Encode/Decode(buf) -> string/buffer`
+
+use super::{NodespaceMember, NodespaceSpec};
+use crate::abi::AbiType;
+
+pub const MEMBERS: &[NodespaceMember] = &[
+    NodespaceMember {
+        name: "sha256",
+        symbol: "__RTS_FN_NS_CRYPTO_SHA256_STR",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "randomBytesBuffer",
+        symbol: "__RTS_FN_NS_CRYPTO_RANDOM_BUFFER",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "hexEncode",
+        symbol: "__RTS_FN_NS_CRYPTO_HEX_ENCODE",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "hexDecode",
+        symbol: "__RTS_FN_NS_CRYPTO_HEX_DECODE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "base64Encode",
+        symbol: "__RTS_FN_NS_CRYPTO_BASE64_ENCODE",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::Handle,
+    },
+    NodespaceMember {
+        name: "base64Decode",
+        symbol: "__RTS_FN_NS_CRYPTO_BASE64_DECODE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+    },
+];
+
+pub const SPEC: NodespaceSpec = NodespaceSpec {
+    node_module: "crypto",
+    ns_prefix: "node_crypto",
+    members: MEMBERS,
+};

--- a/src/nodespace/mod.rs
+++ b/src/nodespace/mod.rs
@@ -1,5 +1,6 @@
 use crate::abi::AbiType;
 
+pub mod crypto;
 pub mod fs;
 pub mod os;
 pub mod path;
@@ -25,6 +26,7 @@ pub const NODE_SPECS: &[&NodespaceSpec] = &[
     &os::SPEC,
     &process::SPEC,
     &util::SPEC,
+    &crypto::SPEC,
 ];
 
 /// Resolves a codegen-qualified name like `"node_fs.readFileSync"` to its member.

--- a/tests/node_crypto_basic.test.ts
+++ b/tests/node_crypto_basic.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+import { sha256, randomBytesBuffer } from "node:crypto";
+import { buffer } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #289 fase 1: node:crypto.sha256/randomBytesBuffer mapeando rts::crypto.
+
+const h1 = sha256("hello");
+print(h1); gc.string_free(h1);
+
+const h2 = sha256("");
+print(h2); gc.string_free(h2);
+
+const buf = randomBytesBuffer(16);
+const len = buffer.len(buf);
+const lh = gc.string_from_i64(len);
+print(lh); gc.string_free(lh);
+buffer.free(buf);
+
+describe("fixture:node_crypto_basic", () => {
+  test("sha256 known vectors + randomBytesBuffer length", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824\n" +
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
+      "16\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Avanca #289. Expoe one-shots de node:crypto que mapeiam direto sobre `rts::crypto`:

- `sha256(s)` (one-shot, sem builder)
- `randomBytesBuffer(n)`
- `hexEncode/Decode`, `base64Encode/Decode`

## Falta para fechar #289

- `createHash().update().digest()` builder — exige API streaming nova em rts::crypto
- `randomUUID` — exige UUID generator
- Buffer wrapper — exige classe TS em builtin/

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 240/250 (zero regressao)
- [x] sha256 known vectors batem (NIST test vectors)
- [x] `randomBytesBuffer(16)` retorna Buffer com `.len() == 16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)