### PR TITLE
fix(codegen): arity check em map/set builtin (#311 6/6)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -1680,6 +1680,20 @@ fn lower_map_set_builtin(
         Ok((p, l))
     }
 
+    // Arity check: a heuristica so' deve disparar quando o nº de args
+    // bate com a assinatura JS de Map/Set. Sem isso, qualquer obj literal
+    // com chave `add`/`set`/`get`/`has`/`delete` que carregue uma fn de
+    // user com aridade diferente cai aqui e retorna lixo (#311). Caller
+    // recebe None e tenta o path generico de map_get + call_indirect.
+    let arity = call.args.len();
+    let expected_arity = match method {
+        "set" => 2, // Map.set(key, value)
+        "add" | "delete" | "has" | "get" => 1,
+        _ => usize::MAX, // outros metodos nao tem checagem aqui
+    };
+    if expected_arity != usize::MAX && arity != expected_arity {
+        return Ok(None);
+    }
     match method {
         "set" => {
             // Map.set(key, value) — value pode ser handle ou number.


### PR DESCRIPTION
## Summary
- \`lower_map_set_builtin\` agora valida aridade (set=2, add/get/has/delete=1) antes de rotear
- Mismatch retorna None — caller cai no path generico de map_get + call_indirect
- \`tests/function_expression.test.ts\` passa 6/6

## Repro pre-fix
\`\`\`ts
const math = { add: function(a,b){ return a+b }, mul: function(a,b){ return a*b } };
math.add(2, 3);  // retornava lixo (interpretava \`2\` como string ptr/len de chave)
math.mul(4, 5);  // funcionava (mul nao e' nome de metodo Set/Map)
\`\`\`

Closes #311 (case 6/6)

## Test plan
- [x] \`tests/function_expression.test.ts\` passa
- [x] Suite completa: 235 passed (era 231) / 14 failed (era 15) — sem regressao
- [x] Map/Set tests (\`map_set_native\`, \`object_computed_methods\`) mantem mesmo status pre-fix (eram falhas pre-existentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)