### PR TITLE
fix(codegen): catch (e: Error) — popular local_class_ty para global classes (#300)

### DIFF
--- a/src/codegen/lower/statements/control.rs
+++ b/src/codegen/lower/statements/control.rs
@@ -556,8 +556,25 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
                     if let Some(class_name) =
                         super::decls::class_name_from_annotation(&ann.type_ann)
                     {
-                        if ctx.classes.contains_key(&class_name) {
-                            class_for_catch = Some(class_name);
+                        // (#300) `catch (e: Error)` precisa popular
+                        // local_class_ty mesmo para global classes (Error,
+                        // TypeError, etc) — sem isso, `e.message` cai em
+                        // map_get_static em vez de __RTS_FN_GL_ERROR_MESSAGE.
+                        let is_error_class = matches!(
+                            class_name.as_str(),
+                            "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+                        );
+                        if ctx.classes.contains_key(&class_name)
+                            || crate::abi::global_class_lookup(&class_name).is_some()
+                        {
+                            class_for_catch = Some(class_name.clone());
+                        }
+                        if is_error_class {
+                            let mut ft: std::collections::HashMap<String, ValTy> =
+                                std::collections::HashMap::new();
+                            ft.insert("message".into(), ValTy::Handle);
+                            ft.insert("name".into(), ValTy::Handle);
+                            ctx.local_obj_field_types.insert(name.to_string(), ft);
                         }
                     }
                 }
@@ -573,7 +590,12 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
                             cls.as_str(),
                             "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
                         );
-                        if ctx.classes.contains_key(&cls) {
+                        // (#300) inferencia tambem aceita global classes —
+                        // sem isso `try { throw new Error(...) } catch (e) { e.message }`
+                        // (sem anotacao) caia em map_get.
+                        if ctx.classes.contains_key(&cls)
+                            || crate::abi::global_class_lookup(&cls).is_some()
+                        {
                             class_for_catch = Some(cls.clone());
                         }
                         if is_error_class {

--- a/tests/catch_error_message.test.ts
+++ b/tests/catch_error_message.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "rts:test";
+import { gc, io } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #300: catch (e: Error) deve popular local_class_ty para que e.message
+// roteie via __RTS_FN_GL_ERROR_MESSAGE em vez de map_get_static.
+// Antes: e.message retornava 0 (handle invalido).
+
+// Caso 1: anotacao explicita
+try {
+  throw new Error("explicit-anno");
+} catch (e: Error) {
+  print(e.message);
+}
+
+// Caso 2: inferencia sem anotacao (todos os throws sao new Error)
+try {
+  throw new Error("inferred");
+} catch (e) {
+  print(e.message);
+}
+
+// Caso 3: throw em fn chamada — propagacao via thread-local error
+function boom(): void {
+  throw new Error("from-fn");
+}
+try {
+  boom();
+} catch (e: Error) {
+  print(e.message);
+}
+
+// Caso 4: TypeError tambem (subclasse de Error)
+try {
+  throw new TypeError("type-err");
+} catch (e: TypeError) {
+  print(e.message);
+}
+
+describe("fixture:catch_error_message", () => {
+  test("catch (e: Error) routes e.message correctly (#300)", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "explicit-anno\ninferred\nfrom-fn\ntype-err\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Antes: \`catch (e: Error) { e.message }\` retornava 0 silenciosamente. Causa raiz: o lower de TryStmt so' populava \`local_class_ty\` para classes em \`ctx.classes\` (TS user classes), ignorando global classes (Error/TypeError/etc registradas em \`abi::global_class_lookup\`).

Sem \`local_class_ty\` populado, \`receiver_class\` resolvia para None, e \`e.message\` caia em \`map_get_static\` em vez de rotear via \`__RTS_FN_GL_ERROR_MESSAGE\`.

## Mudancas

- `src/codegen/lower/statements/control.rs`: ambos os paths de classificacao do binding de catch (anotacao explicita e inferencia) agora aceitam global classes alem de \`ctx.classes\`.
- nova fixture `tests/catch_error_message.test.ts` cobrindo:
  - anotacao explicita \`catch (e: Error)\`
  - inferencia sem anotacao
  - throw em fn chamada (propaga thread-local)
  - TypeError

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 242/252 (zero regressao)
- [x] Fixture nova passa nos 4 casos
- [x] Comportamento anterior (`map_get_static` para non-Error classes) inalterado

## Gaps remanescentes da #300 (nao escopo deste PR)

- Verifier error em \`e instanceof Error\` dentro de catch (CFG)
- e.stack ainda nao exposto
- Setjmp/longjmp real (Opcao A da issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)