### PR TITLE
feat(js): destructuring object rest (#312)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -652,6 +652,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_CLEAR
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_CLONE",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_CLONE
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT",
             map::__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT
         );

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -2333,19 +2333,24 @@ fn expand_destruct_decl(
             if let Some(init) = init {
                 out.push(make_const_decl(&tmp_name, init.clone(), kind));
             }
+            // Coleta keys explicitamente capturadas — usadas pra construir
+            // o `rest` removendo-as do clone (#312).
+            let mut consumed_keys: Vec<String> = Vec::new();
+            let mut rest_pat: Option<&Pat> = None;
             for prop in &obj.props {
                 match prop {
                     swc_ecma_ast::ObjectPatProp::Assign(ap) => {
                         // \`{ x }\` ou \`{ x = default }\`
-                        let key = ap.key.id.sym.as_str();
+                        let key = ap.key.id.sym.to_string();
+                        consumed_keys.push(key.clone());
                         let inner_pat = Pat::Ident(swc_ecma_ast::BindingIdent {
                             id: ap.key.id.clone(),
                             type_ann: None,
                         });
                         let access = if let Some(default) = ap.value.as_ref() {
-                            make_member_access_with_default(&tmp_name, key, default.as_ref())
+                            make_member_access_with_default(&tmp_name, &key, default.as_ref())
                         } else {
-                            make_member_access(&tmp_name, key)
+                            make_member_access(&tmp_name, &key)
                         };
                         expand_destruct_decl(&inner_pat, Some(&access), kind, counter, out);
                     }
@@ -2356,12 +2361,23 @@ fn expand_destruct_decl(
                             swc_ecma_ast::PropName::Str(s) => s.value.to_string_lossy().to_string(),
                             _ => continue,
                         };
+                        consumed_keys.push(key.clone());
                         let access = make_member_access(&tmp_name, &key);
                         expand_destruct_decl(&kvp.value, Some(&access), kind, counter, out);
                     }
-                    swc_ecma_ast::ObjectPatProp::Rest(_) => {
-                        // Rest em object destructuring — follow-up.
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        rest_pat = Some(rest.arg.as_ref());
                     }
+                }
+            }
+            // Object rest (#312): `const { a, b, ...rest } = obj` →
+            //   const rest = collections.map_clone(__destruct_N);
+            //   collections.map_delete(rest, "a");
+            //   collections.map_delete(rest, "b");
+            if let Some(pat) = rest_pat {
+                if let Pat::Ident(rest_id) = pat {
+                    let rest_name = rest_id.id.sym.to_string();
+                    push_object_rest_decls(&rest_name, &tmp_name, &consumed_keys, kind, out);
                 }
             }
         }
@@ -2459,6 +2475,92 @@ fn make_member_access_with_default(obj_name: &str, key: &str, default: &Expr) ->
         left: Box::new(access),
         right: Box::new(default.clone()),
     })
+}
+
+/// Empurra em `out` o desugar de object rest (#312):
+///   `const <rest_name> = collections.map_clone(<src_name>);`
+///   `collections.map_delete(<rest_name>, "<key>");` (uma por consumed_key)
+///
+/// Reusa o builtin `collections.map_clone` (registra entry novo no
+/// HandleTable com clone do IndexMap) + `map_delete` ja existente.
+fn push_object_rest_decls(
+    rest_name: &str,
+    src_name: &str,
+    consumed_keys: &[String],
+    kind: swc_ecma_ast::VarDeclKind,
+    out: &mut Vec<Statement>,
+) {
+    use swc_ecma_ast::{CallExpr, ExprOrSpread, ExprStmt, Ident, MemberExpr, Stmt};
+
+    fn ident(name: &str) -> Ident {
+        Ident {
+            span: Default::default(),
+            ctxt: Default::default(),
+            sym: name.into(),
+            optional: false,
+        }
+    }
+
+    // collections.map_clone(<src_name>)
+    let clone_call = Expr::Call(CallExpr {
+        span: Default::default(),
+        ctxt: Default::default(),
+        callee: swc_ecma_ast::Callee::Expr(Box::new(Expr::Member(MemberExpr {
+            span: Default::default(),
+            obj: Box::new(Expr::Ident(ident("collections"))),
+            prop: MemberProp::Ident(swc_ecma_ast::IdentName {
+                span: Default::default(),
+                sym: "map_clone".into(),
+            }),
+        }))),
+        args: vec![ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Ident(ident(src_name))),
+        }],
+        type_args: None,
+    });
+    out.push(make_const_decl(rest_name, clone_call, kind));
+
+    // collections.map_delete(<rest_name>, "<key>"); para cada consumed_key
+    for key in consumed_keys {
+        let delete_call = Expr::Call(CallExpr {
+            span: Default::default(),
+            ctxt: Default::default(),
+            callee: swc_ecma_ast::Callee::Expr(Box::new(Expr::Member(MemberExpr {
+                span: Default::default(),
+                obj: Box::new(Expr::Ident(ident("collections"))),
+                prop: MemberProp::Ident(swc_ecma_ast::IdentName {
+                    span: Default::default(),
+                    sym: "map_delete".into(),
+                }),
+            }))),
+            args: vec![
+                ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(Expr::Ident(ident(rest_name))),
+                },
+                ExprOrSpread {
+                    spread: None,
+                    expr: Box::new(Expr::Lit(Lit::Str(swc_ecma_ast::Str {
+                        span: Default::default(),
+                        value: key.as_str().into(),
+                        raw: None,
+                    }))),
+                },
+            ],
+            type_args: None,
+        });
+        let stmt = Stmt::Expr(ExprStmt {
+            span: Default::default(),
+            expr: Box::new(delete_call),
+        });
+        let raw = crate::parser::ast::RawStmt::new(
+            format!("collections.map_delete({rest_name}, \"{key}\");"),
+            crate::parser::span::Span::default(),
+        )
+        .with_stmt(stmt);
+        out.push(crate::parser::ast::Statement::Raw(raw));
+    }
 }
 
 /// Empurra em \`out\`:

--- a/src/namespaces/collections/abi.rs
+++ b/src/namespaces/collections/abi.rs
@@ -93,6 +93,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: false,
     },
     NamespaceMember {
+        name: "map_clone",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_MAP_CLONE",
+        args: &[AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Returns a shallow copy of the map (new handle).",
+        ts_signature: "map_clone(h: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
         name: "map_key_at",
         kind: MemberKind::Function,
         symbol: "__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT",

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -137,6 +137,20 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_CLEAR(handle: u64) {
     with_map_mut(handle, (), |m| m.clear());
 }
 
+/// Shallow clone do map — aloca novo handle com mesmas (key, value) pairs.
+/// Usado pelo desugar de `const { a, ...rest } = obj` (#312): rest e'
+/// inicializado como clone, e em seguida o codegen emite map_delete para
+/// cada key explicita.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_CLONE(handle: u64) -> u64 {
+    let cloned: Option<IndexMap<String, i64>> =
+        with_map(handle, None, |m| Some(m.clone()));
+    match cloned {
+        Some(m) => alloc_entry(Entry::Map(Box::new(m))),
+        None => 0,
+    }
+}
+
 /// Retorna a key na posição `idx` na ordem de enumeração definida pelo JS:
 /// 1. integer-indexed keys (string que parseia para u32 sem leading zero,
 ///    exceto "0") em ordem numérica ascendente;

--- a/tests/destructuring_object.test.ts
+++ b/tests/destructuring_object.test.ts
@@ -21,9 +21,10 @@ print(`${m} ${n}`);
 const { outer: { inner } } = { outer: { inner: 99 } };
 print(`${inner}`);
 
-// Rest in object destructuring
+// Rest in object destructuring (#312)
 const { p, ...remaining } = { p: 1, q: 2, r: 3 };
 print(`${p}`);
+print(`${remaining.q} ${remaining.r}`);
 
 // In function parameter — tipos numericos (string em parametro destructured
 // depende de fix preexistente em concatenacao de template com handle).
@@ -33,5 +34,5 @@ function addPair({ left, right }: { left: number; right: number }): void {
 addPair({ left: 30, right: 12 });
 
 describe("destructuring_object", () => {
-  test("basic", () => expect(__rtsCapturedOutput).toBe("10 20\n42\n1 10\n99\n1\n42\n"));
+  test("basic", () => expect(__rtsCapturedOutput).toBe("10 20\n42\n1 10\n99\n1\n2 3\n42\n"));
 });


### PR DESCRIPTION
## Summary
- Novo builtin \`collections.map_clone(h)\` (shallow copy do IndexMap)
- \`expand_destruct_decl\` em \`Pat::Object\` agora gera para Rest: clone do tmp + map_delete por key consumida
- \`rest.b\` etc funcionam direto via member access existente

Closes #312 (object rest — array rest+defaults ja estavam em PR #341)

## Repro pre-fix
\`\`\`ts
const { a, ...rest } = { a: 1, b: 2, c: 3 };
// rest era undefined → \"undefined variable rest\"
\`\`\`

## Test plan
- [x] \`tests/destructuring_object.test.ts\` estendido com checagem de \`rest.q rest.r\`
- [x] Suite completa: 237 passed (era 235) / 14 failed (sem regressao)

🤖 Generated with [Claude Code](https://claude.com/claude-code)