### PR TITLE
fix(codegen): obj?.method() — achatar duplo OptChain (#333)

### DIFF
--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -587,8 +587,64 @@ pub(super) fn lower_opt_chain(
             Ok(TypedVal::new(result, access_ty))
         }
         swc_ecma_ast::OptChainBase::Call(call) => {
-            // `callee?.(args)`: se callee for 0 (null), retorna 0 sem chamar.
-            // Caso contrario, faz call_indirect via i64 funcptr.
+            // (#333) Caso `obj?.method(args)`: o swc representa como
+            // `OptChainExpr<Call>` cujo callee e' outro `OptChainExpr<Member>`
+            // (`obj?.method`). O lower antigo recursava em ambos OptChain
+            // criando 2 niveis de blocks que nao conectavam corretamente —
+            // Verifier "invalid block reference". Achatamos pra um unico
+            // null-guard sobre `obj`: se `obj` e' null retorna 0 sem
+            // chamar, senao faz a chamada normal `obj.method(args)`.
+            if let swc_ecma_ast::Expr::OptChain(inner_opt) = call.callee.as_ref() {
+                if let swc_ecma_ast::OptChainBase::Member(inner_member) =
+                    inner_opt.base.as_ref()
+                {
+                    let obj_tv = lower_expr(ctx, &inner_member.obj)?;
+                    let obj_i64 = ctx.coerce_to_i64(obj_tv).val;
+                    let zero = ctx.builder.ins().iconst(cl::I64, 0);
+                    let is_null = ctx.builder.ins().icmp(IntCC::Equal, obj_i64, zero);
+
+                    let null_block = ctx.builder.create_block();
+                    let call_block = ctx.builder.create_block();
+                    let merge = ctx.builder.create_block();
+                    let result = ctx.builder.append_block_param(merge, cl::I64);
+
+                    ctx.builder.ins().brif(is_null, null_block, &[], call_block, &[]);
+
+                    ctx.builder.switch_to_block(null_block);
+                    ctx.builder.seal_block(null_block);
+                    let z = ctx.builder.ins().iconst(cl::I64, 0);
+                    ctx.builder.ins().jump(merge, &[z.into()]);
+
+                    ctx.builder.switch_to_block(call_block);
+                    ctx.builder.seal_block(call_block);
+                    // Constroi `obj.method(args)` sintetico (sem `?`).
+                    let synthetic_member = swc_ecma_ast::MemberExpr {
+                        span: inner_member.span,
+                        obj: inner_member.obj.clone(),
+                        prop: inner_member.prop.clone(),
+                    };
+                    let synthetic_callee =
+                        Box::new(swc_ecma_ast::Expr::Member(synthetic_member));
+                    let synthetic = CallExpr {
+                        span: call.span,
+                        ctxt: call.ctxt,
+                        callee: swc_ecma_ast::Callee::Expr(synthetic_callee),
+                        args: call.args.clone(),
+                        type_args: call.type_args.clone(),
+                    };
+                    let call_tv = super::calls::lower_call(ctx, &synthetic)?;
+                    let call_i64 = ctx.coerce_to_i64(call_tv).val;
+                    ctx.builder.ins().jump(merge, &[call_i64.into()]);
+
+                    ctx.builder.switch_to_block(merge);
+                    ctx.builder.seal_block(merge);
+                    return Ok(TypedVal::new(result, ValTy::I64));
+                }
+            }
+
+            // Caso geral: `callee?.(args)` onde callee e' uma expressao
+            // qualquer (var, member nao-optional, etc). Avalia callee, se
+            // e' null retorna 0 sem chamar.
             let callee_tv = lower_expr(ctx, &call.callee)?;
             let callee_i64 = ctx.coerce_to_i64(callee_tv).val;
             let zero = ctx.builder.ins().iconst(cl::I64, 0);

--- a/tests/optchain_call_member.test.ts
+++ b/tests/optchain_call_member.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #333: `obj?.method()` (OptChain Call em Member) disparava Verifier
+// "invalid block reference" — fix em operators.rs achata o duplo
+// guard em um null-check unico sobre obj.
+
+// Caso 1: obj null — retorna 0 sem chamar
+const deep1: any = null;
+const r1 = deep1?.getValue();
+const h1 = gc.string_from_i64(r1 === null || r1 === 0 ? 0 : 1);
+print(h1); gc.string_free(h1);
+
+// Caso 2: obj nao-null com metodo presente
+function makeObj(): any {
+  const m = new Map<string, i64>();
+  m.set("getValue", 99 as any);
+  return m;
+}
+// Em RTS, map_get em var.method() retorna funcptr — esse caso requer
+// que a chave esteja no mapa. Como nao temos closures-em-mapa direto
+// aqui, validamos so' o caminho null (caso comum em prod).
+
+describe("fixture:optchain_call_member", () => {
+  test("obj?.method() em obj null nao crasha + Verifier passes", () => {
+    expect(__rtsCapturedOutput).toBe("0\n");
+  });
+});


### PR DESCRIPTION
## Summary

\`obj?.method()\` disparava Verifier "invalid block reference" porque o swc parseia como OptChainExpr<Call> com callee = OptChainExpr<Member> (dois niveis de OptChain). O lower antigo recursava em ambos criando blocks que nao conectavam ao merge.

## Fix

Detectar `OptChainBase::Call` cujo `call.callee` e' outro `OptChainExpr<Member>` e achatar em null-guard unico sobre `obj`:
- null → retorna 0
- non-null → chama `obj.method(args)` sintetico (sem `?`)

Caso geral `callee?.(args)` (onde callee nao e' OptChain) inalterado.

## Test plan

- [x] `cargo build --release` limpo
- [x] Suite: 244/253 (vs 242/252 antes)
  - fixture nova `tests/optchain_call_member.test.ts` passa
  - `tests/optional_chain_null_guard.test.ts` voltou a passar (era falha pre-existente)
- [x] Caso original da issue compila

## Out of scope

- `tests/optional_chain_advanced.test.ts` ainda tem Verifier error em flows mais aninhados — nova issue.

Closes #333 (gap principal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)