### PR TITLE
fix(console): coercao auto i64/f64/bool em console.log (#380)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -42,6 +42,10 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
             }
             if let Some(qualified) = qualified_member_name(callee) {
+                // Console builtin precisa preceder o lookup (#380).
+                if let Some(tv) = lower_console_call(ctx, &qualified, call)? {
+                    return Ok(tv);
+                }
                 if lookup(&qualified).is_some() {
                     return lower_ns_call(ctx, &qualified, call);
                 }
@@ -88,6 +92,15 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             }
         }
         if let Some(qualified) = qualified_member_name(callee) {
+            // Console builtin (#221, #380): console.log/info/debug → io.print,
+            // console.error/warn → io.eprint. Args concatenados separados
+            // por espaco. PRECISA vir antes do `lookup` generico porque
+            // console.* tambem esta listado em SPECS (com aridade fixa
+            // `StrPtr`) so' pra type-check / `rts apis` — passar 42 ali
+            // dispararia "StrPtr argument must be a string value".
+            if let Some(tv) = lower_console_call(ctx, &qualified, call)? {
+                return Ok(tv);
+            }
             if lookup(&qualified).is_some() {
                 return lower_ns_call(ctx, &qualified, call);
             }
@@ -101,14 +114,6 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         }
                     }
                 }
-            }
-            // Console builtin (#221): console.log/info/debug → io.print,
-            // console.error/warn → io.eprint. Args concatenados separados
-            // por espaco. Implementado em codegen direto pra evitar
-            // dependencia em pacote builtin/console que precisaria ser
-            // auto-importado.
-            if let Some(tv) = lower_console_call(ctx, &qualified, call)? {
-                return Ok(tv);
             }
             // JSON global (#215): JSON.* — spec name="JSON" is in SPECS, so
             // `lookup("JSON.parse")` resolves directly above. No fallback needed.

--- a/tests/console_log_types.test.ts
+++ b/tests/console_log_types.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// console.log com varios tipos — coercao automatica via coerce_to_handle.
+// Como nao temos como interceptar console.log no test runner, validamos
+// via wrapper de print.
+function logLike(...args: any[]): string {
+  // Nao temos spread/rest em var-args ainda; abaixo replico o behavior
+  // manualmente.
+  return "";
+}
+
+// Smoke test: chamamos console.log direto e verificamos que nao crasha
+// nem dispara warnings.
+console.log(42);
+console.log(3.14);
+console.log("hi");
+console.log("x", 42);
+console.log(true, false);
+console.log(1, "two", 3.5);
+print("ok");
+
+describe("console_log_types", () => {
+  test("mixed types do not crash", () =>
+    expect(__rtsCapturedOutput).toBe("ok\n"));
+});


### PR DESCRIPTION
## Summary
- \`lower_console_call\` agora vem antes do \`lookup\` generico em ambos os sites (calls.rs L44 e L90)
- Coercao automatica de i64/f64/bool em \`console.log\` etc via \`coerce_to_handle\` existente

Closes #380

## Repro pre-fix
\`\`\`ts
console.log(42);   // \"StrPtr argument must be a string value\"
console.log(3.14); // idem
\`\`\`

## Causa
\`console.log\` foi listado em SPECS com aridade fixa StrPtr so' pra type-check / \`rts apis\`. O comentario do abi.rs diz que codegen continua special-casing — mas o ramo de \`lookup\` resolvia antes.

## Test plan
- [x] \`tests/console_log_types.test.ts\` (novo) — mix livre de tipos
- [x] Suite: 237 passed (era 236) / 17 failed (era 18) — sem regressao

🤖 Generated with [Claude Code](https://claude.com/claude-code)