### PR TITLE
fix(abi): aceitar scope GL no validator + permitir aliases de simbolo

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -135,7 +135,19 @@
       "Bash(grep \"src\\\\\\\\\")",
       "Bash(target/release/rts.exe eval *)",
       "Bash(target/release/rts.exe ir *)",
-      "Bash(bun *)"
+      "Bash(bun *)",
+      "Bash(grep \"tests\\\\\\\\\\\\\\\\\")",
+      "Bash(grep -oE \"tests[\\\\\\\\\\\\\\\\/][a-z_0-9]+\\\\.test\\\\.ts\")",
+      "Bash(grep -E \"tests[\\\\\\\\\\\\\\\\/].*\\\\.test\\\\.ts\" \"/c/Users/Marcos/AppData/Local/Temp/claude/C--Users-Marcos-Desktop-SERVICO-ESCRAVO-rts1/c633b635-772d-42bd-b028-ff02934e7e98/tasks/b9msgrzyd.output\")",
+      "Bash(echo \"exit=$?\")",
+      "Bash(taskkill //F //IM rts.exe)",
+      "Bash(tasklist //FI \"IMAGENAME eq rts.exe\")",
+      "Bash(grep -nE \"tests[\\\\\\\\\\\\\\\\/].*\\\\.test\\\\.ts|crashed|Files |Tests \" /tmp/rts-test-full.log)",
+      "Bash(awk '/\\\\.test\\\\.ts/ { last=$0 } /crashed/ { print last; print $0 }' /tmp/rts-test-full.log)",
+      "Bash(awk '/\\\\.test\\\\.ts/ { last=$0 } /crashed|test failed/ { if \\(last\\) print last; last=\"\" }' /tmp/rts-test-full.log)",
+      "Bash(grep -oE \"tests\\\\\\\\\\\\\\\\[a-z_0-9]+\\\\.test\\\\.ts\")",
+      "Bash(sed -E 's/\\\\x1b\\\\[[0-9;]*m//g' /tmp/rts-test-full.log)",
+      "Bash(awk '/\\\\.test\\\\.ts$/ { last=$0 } /crashed|test failed|✗ 1 test/ { if \\(last != \"\"\\) { print last; last=\"\" } }' /tmp/rts-clean.log)"
     ]
   }
 }

--- a/src/abi/symbols.rs
+++ b/src/abi/symbols.rs
@@ -7,7 +7,8 @@
 //! ```
 //!
 //! where `KIND` is one of `FN`, `CONST`, `TYPE`, `SCOPE` is one of `NS`,
-//! `GC`, `ABI`, and both `NS` and `NAME` are uppercase ASCII with digits and
+//! `GC`, `ABI`, `GL` (global JS objects/classes), and both `NS` and `NAME`
+//! are uppercase ASCII with digits and
 //! underscores. The convention is enforced at startup by
 //! [`validate_symbol`]; malformed entries in `SPECS` cause immediate panic
 //! during tests and in debug builds.
@@ -53,7 +54,7 @@ pub fn validate_symbol(symbol: &str) -> Result<(), SymbolError> {
     let rest = parts.next().ok_or(SymbolError::MissingScope)?;
     let mut parts = rest.splitn(2, '_');
     let scope = parts.next().ok_or(SymbolError::MissingScope)?;
-    if !matches!(scope, "NS" | "GC" | "ABI") {
+    if !matches!(scope, "NS" | "GC" | "ABI" | "GL") {
         return Err(SymbolError::InvalidScope);
     }
 

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -29,15 +29,27 @@ fn every_symbol_is_canonical() {
 
 #[test]
 fn symbols_are_globally_unique() {
-    let mut seen: HashSet<&'static str> = HashSet::new();
+    // Mesmo simbolo so' eh permitido quando duas specs declaram um alias
+    // (assinatura identica). Ex: `JSON.parse` (global) e `json.parse`
+    // (namespace) compartilham `__RTS_FN_NS_JSON_PARSE`. Colisao com
+    // assinaturas divergentes continua sendo erro.
+    use std::collections::HashMap;
+    let mut seen: HashMap<&'static str, (&'static str, &'static [AbiType], AbiType)> =
+        HashMap::new();
     for spec in SPECS {
         for member in spec.members {
-            assert!(
-                seen.insert(member.symbol),
-                "duplicate symbol {} found in namespace {}",
-                member.symbol,
-                spec.name
-            );
+            let sig = (spec.name, member.args, member.returns);
+            if let Some(prev) = seen.get(member.symbol) {
+                assert!(
+                    prev.1 == sig.1 && prev.2 == sig.2,
+                    "symbol {} shared between {} and {} with diverging signatures",
+                    member.symbol,
+                    prev.0,
+                    spec.name
+                );
+            } else {
+                seen.insert(member.symbol, sig);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `validate_symbol` agora aceita `GL` (global JS classes/objects) no campo SCOPE.
- `symbols_are_globally_unique` agora permite simbolos compartilhados entre specs quando assinatura bate (aliases reais como `JSON.parse` ↔ `json.parse`).

## Why
PRs recentes (`text_encoding`, `timers`, `performance`, `url`, `fetch`, `globals/json`) adicionaram simbolos `__RTS_FN_GL_*` e o alias `JSON.parse → __RTS_FN_NS_JSON_PARSE`, quebrando `cargo test --release --lib`.

## Test plan
- [x] `cargo test --release --lib abi::` → 18/18 passa
- [x] `cargo test --release --lib` completo → 70/70 passa (era 68/70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)