### PR TITLE
fix(runtime): elimina leak/segfault na test suite (vec_push limit + trap em member call)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -1508,6 +1508,15 @@ fn lower_var_member_call(
     let inst = ctx.builder.ins().call(map_get, &[obj_h, kp, kl]);
     let callee_val = ctx.builder.inst_results(inst)[0];
 
+    // Guard runtime: se obj nao for um Map (e.g. Vec sem o metodo
+    // requested como `arr.filter` antes da feature #267 estar pronta),
+    // map_get retorna 0 e o call_indirect saltaria pra endereco 0
+    // → segfault silencioso. Trap explicito da diagnostico claro em
+    // vez de access violation.
+    ctx.builder
+        .ins()
+        .trapz(callee_val, cranelift_codegen::ir::TrapCode::user(1).unwrap());
+
     // namespace fns address-taken sao SystemV/Win64 (ver
     // user_call_conv). call_indirect tem que casar a callconv da
     // target ou args/return chegam corrompidos.

--- a/src/namespaces/collections/vec.rs
+++ b/src/namespaces/collections/vec.rs
@@ -39,9 +39,28 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_LEN(handle: u64) -> i64 {
     with_vec(handle, -1, |v| v.len() as i64)
 }
 
+/// Limite duro de elementos por vec — protege contra OOM em cenarios
+/// patologicos (ex: generator infinito desugared para buffer eager,
+/// loop sem condicao de parada). 1M i64 = 8MiB por vec, suficiente
+/// pro caso real e barato comparado aos GBs que um leak descontrolado
+/// produz.
+const VEC_MAX_LEN: usize = 1_000_000;
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle: u64, value: i64) {
-    with_vec_mut(handle, (), |v| v.push(value));
+    let limit_hit = with_vec_mut(handle, false, |v| {
+        if v.len() >= VEC_MAX_LEN {
+            return true;
+        }
+        v.push(value);
+        false
+    });
+    if limit_hit {
+        eprintln!(
+            "RTS runtime: vec push exceeded limit of {VEC_MAX_LEN} elements; aborting (likely infinite generator or unbounded loop)"
+        );
+        std::process::abort();
+    }
 }
 
 /// Remove e retorna o ultimo valor, ou 0 se vazio.


### PR DESCRIPTION
## Summary
Suite (\`target/release/rts.exe test\`) parou de travar e vazar 3+ GB de RAM. Dois fixes complementares:

1. **codegen (\`calls.rs\`)** — \`lower_var_member_call\` emite \`trapz\` antes do \`call_indirect\` quando \`map_get\` retorna 0. Sem isso, \`arr.filter(arrow)\` (em handle Vec sem entry pra "filter") caia em endereco 0 → ACCESS_VIOLATION (ou salto pra lixo, que tentava alocar 128 GiB).

2. **runtime (\`vec.rs\`)** — \`VEC_PUSH\` com limite duro de 1M elementos. Generators infinitos (\`while(true) yield x\`) sao desugarized para buffer eager (\`__gen_buf\`); sem limite, \`fibonacci()\` vazava GBs em segundos. Agora: \`eprint+abort\` com mensagem clara.

## Antes / Depois
| | Antes | Depois |
|---|---|---|
| Suite completa | trava, leak 3+ GB | 240/257 files passed |
| Memoria pico | 3.4 GB+ | sem alertas > 500 MB |
| Testes ainda falham | 17 + leak | 17 com trap claro |

Os 17 testes que ainda falham (\`array_native_methods\`, \`generator_basic\`, \`async_arrow\`, etc) sao features nao-implementadas (#267, #275). Agora abortam rapido em vez de levar o sistema com eles.

## Test plan
- [x] \`target/release/rts.exe test\` termina em < 5min sem leak
- [x] Generator infinito aborta com mensagem em vez de OOM
- [x] \`cargo test --release --lib\` 70/70 (sem regressao)

🤖 Generated with [Claude Code](https://claude.com/claude-code)