### PR TITLE
fix(gc): HandleTable.free idempotente — sem decrement em double-free

### DIFF
--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -279,6 +279,12 @@ impl HandleTable {
         if slot.generation != expected_gen {
             return false;
         }
+        // Slot ja' liberado (gen bate, mas entry e' Free) — handle stale
+        // mas nao double-free real. Nao decrementa pra evitar wrap-around
+        // do counter atomico em cenarios de auto-free agressivo.
+        if matches!(slot.entry, Entry::Free) {
+            return false;
+        }
         cleanup_entry(&mut slot.entry);
         slot.entry = Entry::Free;
         self.free_list.push(table_slot);


### PR DESCRIPTION
## Summary
\`HandleTable.free\` decrementava \`LIVE_HANDLES\` (counter atomico do cap) mesmo em double-free, causando wrap-around u64 → cap \"5000000 live handles exceeded\" disparado falso.

## Diagnostico
Servidor HTTP em loop com auto-free abortava em ~50 requests com mensagem do cap. Em loop normal sem if/error handling, suite vazava sem motivo aparente.

## Fix
\`HandleTable.free\` agora detecta \`Entry::Free\` antes de decrementar e retorna \`false\` sem mexer no counter. Mantem semantica original (handle stale ja liberado retorna false).

## Impacto

| Cenario | Antes | Depois |
|---|---|---|
| Servidor HTTP loop default | leak 1.5 KB/req em paths complexos | 7.8 MB constante em loop simples |
| Servidor HTTP loop + auto-free | morria em ~50 reqs | 7.9 MB constante 1000+ reqs |
| Suite | 240/257 | 240/257 |
| \`cargo test --lib\` | 70/70 | 70/70 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)