### PR TITLE
docs: atualiza CLAUDE.md e specs/INDEX com trabalho recente

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,11 +141,12 @@ Regras:
 - Cada arquivo operacional agrupa funcoes por responsabilidade (io/r-w/dir/metadata/…)
 - Nao existe `dispatch()` por namespace — cada funcao e um `#[no_mangle] extern "C"` direto
 
-Namespaces ativos (35): `io`, `fs`, `gc`, `math`, `num`, `bigfloat`, `time`, `env`,
+Namespaces ativos (36): `io`, `fs`, `gc`, `math`, `num`, `bigfloat`, `time`, `env`,
 `path`, `buffer`, `string`, `process`, `os`, `collections`, `hash`, `fmt`, `crypto`,
 `net`, `tls`, `thread`, `atomic`, `sync`, `parallel`, `mem`, `hint`, `ptr`, `ffi`,
-`regex`, `runtime`, `test`, `trace`, `ui`, `alloc`, `json`, `date`. Cobre std::* +
-paralelismo + HTTPS + UI completos + JSON + Date.
+`regex`, `runtime`, `test`, `trace`, `ui`, `alloc`, `json`, `date`, `http_server`.
+Cobre std::* + paralelismo + HTTPS + UI completos + JSON + Date + HTTP server
+nativo via actix-web.
 
 ### Namespaces existentes
 
@@ -193,9 +194,20 @@ paralelismo + HTTPS + UI completos + JSON + Date.
 - `tls/` — TLS 1.2/1.3 client via `rustls` + `webpki-roots` (Mozilla CAs
   embutidos). Wraps `TcpStream` em conexao TLS. HTTPS funciona ponta-a-
   ponta sem OpenSSL nem schannel
-- `thread/` — `std::thread` spawn/join/detach + scope auto-join +
-  sleep_ms. spawn(fp, arg) entrega arg ao worker (i64 e f64 via
-  bit-pattern preservado)
+- `thread/` — 4 mecanismos coexistindo, dev escolhe pelo workload:
+  `spawn` + `join`/`detach` (`std::thread`, JoinHandle real, ~30k spawn/s,
+  bom pra CPU-bound longo); `spawn_async_join` + `join_async` (tokio
+  `spawn_blocking`, retorna i64, ~400k spawn/s, bom pra leve/IO);
+  `spawn_async` (tokio fire-and-forget, ~400k spawn/s); `spawn_detached`
+  (pool fixo 8 workers, 5M spawn/s mas queue ilimitada — cuidado OOM).
+  Mais `scope` auto-join + `sleep_ms`. Doc-comments em
+  `src/namespaces/thread/abi.rs` tem tabela comparativa
+- `http_server/` — servidor HTTP/1.1 nativo via `actix-web` sobre
+  runtime tokio compartilhado. Bridge sync→async: `serve(addr,handler)`
+  bloqueia, cada request entra num shard map de slots, handler TS
+  chamado direto na thread async, response volta via oneshot. Suporta
+  keep-alive, pipelining, parsing correto. Pico medido 29k req/s
+  (78% do actix puro Rust)
 - `atomic/` — `std::sync::atomic`: AtomicI64 (load/store/fetch_*/cas/swap),
   AtomicBool, AtomicF64 (via AtomicU64 + bit-transmute), fences
 - `sync/` — `std::sync`: Mutex<i64>, RwLock<i64>, Once. Guards thread-
@@ -246,6 +258,40 @@ e typed arrays e follow-up.
 distribui round-robin por thread; `shard_for_handle` decodifica O(1) o
 shard de qualquer handle (encoded nos low bits). Todos os 17 namespaces
 handle-based migrados pra essa API — sem contenção em workloads paralelos.
+
+## Runtime tokio compartilhado (issue #399)
+
+`src/runtime/async_rt.rs` exporta `rt()` — `OnceLock<tokio::runtime::Runtime>`
+multi-thread global. Hooks `on_thread_start`/`on_thread_stop` registram cada
+worker no `gc/thread_registry` para o GC scanner ver handles vivos em tasks
+tokio (sem isso o sweep coletava indevidamente sob carga concorrente).
+
+Toda feature async deve reusar este runtime em vez de criar um proprio:
+
+- `http_server::serve` chama `rt().block_on(...)`
+- `thread::spawn_async*` usa `rt().handle().spawn_blocking(...)`
+- `runtime::tokio_ctx` oferece "id u64 opaco + shard map por TypeId"
+  como bridge sync↔async generico (substitui `slots()` ad-hoc do http_server)
+
+Convencao: o que cruza o JIT (extern "C") e' apenas u64 opaco. Tipos
+Rust-rich (Arc<T>, Channel, JoinHandle) ficam no shard map indexado por
+esse id.
+
+## GC stack scanner Win32
+
+`mark_stack_roots()` em `src/namespaces/gc/collector.rs` usa
+`GetCurrentThreadStackLimits` (API Win32 oficial) em vez de `gs:[0x10]`
+da TIB. O TIB.StackBase em alguns contextos retornava valor < RSP,
+deixando o scanner sem marcar nada e o sweep coletando handles vivos
+(bug encontrado em 2026-05-01 testando http_server sob carga). Mesmo
+caminho usado para varrer threads no `thread_registry` via
+`SuspendThread + GetThreadContext` + scan de registers callee-saved.
+
+## Disciplina de regressao zero
+
+Rever a `REGRA OBRIGATÓRIA: ZERO REGRESSÃO ANTES DE MERGE` no topo deste
+arquivo. Em projeto com IA acelerando velocidade, eh essa regra que
+mantem a suite confiavel ao longo de centenas de PRs.
 
 ## Capacidades de linguagem ativas (codegen)
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -15,6 +15,31 @@ arquiteturais. Para direcao de alto nivel do projeto consulte
   criterio de pureza, infra de suporte (HandleTable shard-aware,
   callconv), limitacoes.
 
+## Subsistemas recentes (2026-05)
+
+Documentacao primaria fica nos doc-comments dos arquivos Rust. Resumo:
+
+- **HTTP server nativo** — `src/namespaces/http_server/`. Servidor
+  HTTP/1.1 via actix-web. Bridge sync→async com shard map de slots +
+  oneshot channel. Pico medido 29k req/s (78% do actix puro). API:
+  `serve(addr, handler)`, `req_method/path/body`, `respond`. PR #400.
+- **Runtime tokio compartilhado** — `src/runtime/async_rt.rs` +
+  `src/runtime/tokio_ctx.rs`. `OnceLock<Runtime>` global com hooks
+  `on_thread_start/stop` que registram workers no `gc/thread_registry`.
+  `tokio_ctx` oferece "id u64 opaco + shard map por TypeId" generico
+  para qualquer feature async. PR #401, issue #399.
+- **GC mark+sweep com stack maps Cranelift** — `src/codegen/jit.rs` +
+  `src/namespaces/gc/collector.rs`. Stack scanner usa
+  `GetCurrentThreadStackLimits` (Win32 oficial — `gs:[0x10]` retornava
+  StackBase < RSP em alguns contextos, bug fix em PR #400). Scan
+  multi-thread via `SuspendThread + GetThreadContext` + registers
+  callee-saved. Issue #397.
+- **4 tipos de spawn coexistindo** — `src/namespaces/thread/abi.rs` tem
+  tabela comparativa: `spawn` (std::thread, 30k/s), `spawn_async`
+  (tokio, 400k/s), `spawn_async_join` + `join_async` (tokio com
+  retorno, 400k/s), `spawn_detached` (pool fixo, 5M/s mas queue
+  ilimitada). PRs #401-#403.
+
 ## Historico / pendente de reescrita
 
 Os documentos abaixo descrevem versoes anteriores do runtime e ainda nao
@@ -35,9 +60,18 @@ historica; nao os tome como guia para novo codigo.
 
 Itens acompanhados em `NEXT_STEPS.md` / `ROAD_MAP.md`:
 
-- GC deterministico (gc-arena) nos pontos de quiescencia documentados em
-  `CLAUDE.md`.
+- **gc-arena ainda nao integrado** — issue #393. Apesar do
+  `gc-arena = "0.5"` no Cargo.toml e referencias em comentarios, a
+  `HandleTable` atual e' slotmap+Mutex sharded com mark+sweep proprio
+  via stack maps Cranelift. `collect_debt`/`finish_cycle` redirecionam
+  para esse mark+sweep, nao para gc-arena. Migracao real exige refator
+  grande (todas as 25+ variantes de `Entry` precisam derivar `Collect`
+  + `Mutation<'gc>` token cruzando JIT, incompativel com ABI atual).
 - Semantica de modulos top-level.
 - Pipeline sem stubs de funcao.
 - Link fallback multi-objeto.
-- Promises sem vazamento.
+- Promises sem vazamento (Promise atual e' sincrona resolvida na hora
+  — pre-async/await real).
+- async/await real no codegen (continuation-passing transform). Sem
+  isso a Promise atual quebra na primeira vez que codigo TS faz `await`
+  de algo que precisa pausar de verdade.


### PR DESCRIPTION
## Summary

Atualiza CLAUDE.md e `docs/specs/INDEX.md` refletindo as mudanças recentes (PRs #400-#404):

### CLAUDE.md
- Namespaces ativos: 35 → 36 (`http_server`)
- Reescreve entrada do `thread/` com as 4 variantes (`spawn`, `spawn_async`, `spawn_async_join`, `spawn_detached`) e seus spawn rates
- Adiciona entrada `http_server/` (actix-web, 29k req/s, bridge sync→async)
- Nova seção "Runtime tokio compartilhado" (async_rt + tokio_ctx)
- Nova seção "GC stack scanner Win32" (fix `GetCurrentThreadStackLimits`, scan multi-thread)

### docs/specs/INDEX.md
- Nova seção "Subsistemas recentes (2026-05)" cross-referenciando PRs/issues
- Atualiza pendências: gc-arena ainda não integrado de fato (#393), async/await real continua pendente

Sem mudança de código. Tests: 77 ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)