### PR TITLE
fix(gc): globals top-level com Handle agora sao roots GC (#407, fecha #409)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -64,6 +64,25 @@ pub fn compile_program_to_jit(program: &mut Program) -> Result<(JITModule, Vec<S
         }
     }
 
+    // Resolve DataIds das globals com Handle pra enderecos reais
+    // (issue #407, epic #419). Sem isso o sweep coleta handles vivos
+    // armazenados em globals top-level.
+    {
+        use crate::namespaces::gc::global_roots;
+        use cranelift_module::DataId;
+        let pending = global_roots::drain_pending_data_ids();
+        let mut total = 0usize;
+        for raw_id in pending {
+            let data_id = DataId::from_u32(raw_id);
+            let (ptr, _size) = module.get_finalized_data(data_id);
+            global_roots::add(ptr as usize);
+            total += 1;
+        }
+        if std::env::var("RTS_GC_DEBUG").is_ok() {
+            eprintln!("[gc] registered {total} global roots (handle-typed top-level vars)");
+        }
+    }
+
     Ok((module, warnings))
 }
 

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -5250,6 +5250,24 @@ fn collect_module_globals(
                 .define_data(data_id, &desc)
                 .with_context(|| format!("failed to define module global `{name}`"))?;
 
+            // Issue #407 / epic #419 — globals com tipo Handle precisam
+            // ser tratadas como roots GC, senao o sweep coleta o handle
+            // armazenado. Registra o DataId pra `jit.rs` resolver pra
+            // endereco real apos `finalize_definitions`.
+            //
+            // U64 e Bool nao sao tratados como handle por padrao; so'
+            // Handle explicito. Outros tipos podem armazenar bits
+            // arbitrarios (ptr, valor numerico) mas a regra do
+            // scanner conservativo (gen != 0) ja' filtra falsos
+            // positivos.
+            if matches!(ty, ValTy::Handle) {
+                use cranelift_module::DataId;
+                let _ = DataId::from_u32; // garante o tipo
+                crate::namespaces::gc::global_roots::push_pending_data_id(
+                    data_id.as_u32(),
+                );
+            }
+
             globals.insert(name, GlobalVar { data_id, ty });
         }
     }

--- a/src/namespaces/gc/collector.rs
+++ b/src/namespaces/gc/collector.rs
@@ -80,10 +80,43 @@ unsafe fn mark_stack_roots() {
         //    eram swept e segfault sob carga (>16 conn http_server).
         #[cfg(target_os = "windows")]
         unsafe { mark_other_threads_windows(); }
+
+        // 3. Globals top-level com handles (issue #407, epic #419).
+        //    Codegen registra cada `let buffer = ...` de top-level
+        //    cujo `ValTy::Handle` apos `finalize_definitions()`. Sem
+        //    isso o sweep coleta handles vivos armazenados em globals.
+        unsafe { mark_global_roots(); }
     }
 
     #[cfg(not(target_arch = "x86_64"))]
     let _ = ();
+}
+
+#[cfg(target_arch = "x86_64")]
+unsafe fn mark_global_roots() {
+    let mut total = 0usize;
+    let mut marked = 0usize;
+    super::global_roots::for_each(|addr| {
+        total += 1;
+        // SAFETY: codegen so' registra enderecos de data symbols
+        // alocados via `module.declare_data` + `define_data`. O simbolo
+        // vive enquanto o JITModule existe — o que cobre toda a vida
+        // do processo no caminho `rts run`.
+        let candidate = unsafe { *(addr as *const u64) };
+        if candidate != 0 {
+            let generation = (candidate >> crate::abi::handles::HANDLE_GEN_SHIFT) & 0xFFFF;
+            if generation != 0 {
+                mark_handle(candidate);
+                marked += 1;
+            }
+        }
+    });
+    if super::debug::is_enabled() {
+        eprintln!(
+            "[gc]   mark_global_roots globals={} marks={}",
+            total, marked
+        );
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/namespaces/gc/global_roots.rs
+++ b/src/namespaces/gc/global_roots.rs
@@ -1,0 +1,125 @@
+//! Registry de globals top-level com handles para o GC marcar como roots.
+//!
+//! Issue #407 — globals declarados via `let buffer = "..."` no top-level
+//! são alocadas como data symbols (8 bytes) em `compile_program`. O
+//! handle armazenado nessa global não está em nenhuma stack — o
+//! `mark_stack_roots()` conservativo não enxerga, e o sweep eventualmente
+//! coleta o handle ativo.
+//!
+//! Solução: codegen registra cada global de tipo `Handle` aqui após
+//! `module.finalize_definitions()` (quando o endereço real do data symbol
+//! é conhecido). O GC, no `mark_stack_roots()`, lê cada endereço como
+//! `*const u64` e marca o handle.
+//!
+//! Thread-safety: registry é populado uma vez no startup, depois só leitura.
+//! `RwLock` cobre a fase de bootstrap; reads no GC são paralelas.
+
+use std::sync::RwLock;
+use std::sync::OnceLock;
+
+fn registry() -> &'static RwLock<Vec<usize>> {
+    static R: OnceLock<RwLock<Vec<usize>>> = OnceLock::new();
+    R.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Adiciona um endereço ao registry. `addr` deve apontar para um
+/// `u64` que armazena um handle GC. Tipicamente chamado pelo
+/// codegen JIT após `finalize_definitions()` para cada data symbol
+/// de global com `ValTy::Handle`.
+pub fn add(addr: usize) {
+    if addr == 0 {
+        return;
+    }
+    let mut guard = registry().write().unwrap_or_else(|e| e.into_inner());
+    if !guard.contains(&addr) {
+        guard.push(addr);
+    }
+}
+
+/// Itera sobre os endereços registrados. O GC chama no `mark_stack_roots`
+/// e lê cada endereço como ponteiro pra u64, marca o handle.
+pub fn for_each<F: FnMut(usize)>(mut f: F) {
+    let guard = registry().read().unwrap_or_else(|e| e.into_inner());
+    for addr in guard.iter() {
+        f(*addr);
+    }
+}
+
+/// Remove um endereço (útil em hot-reload onde o módulo JIT é recompilado).
+pub fn remove(addr: usize) {
+    let mut guard = registry().write().unwrap_or_else(|e| e.into_inner());
+    guard.retain(|a| *a != addr);
+}
+
+/// Limpa todo o registry. Útil pra testes / hot-reload completo.
+pub fn clear() {
+    let mut guard = registry().write().unwrap_or_else(|e| e.into_inner());
+    guard.clear();
+}
+
+/// Total de globals registradas. Diagnóstico.
+pub fn len() -> usize {
+    registry().read().unwrap_or_else(|e| e.into_inner()).len()
+}
+
+// ─── Registry de DataIds pendentes (compile-time) ────────────────────────
+//
+// Codegen acumula DataIds de globals com tipo Handle durante
+// `compile_program`. Apos `finalize_definitions`, `jit.rs` chama
+// `drain_pending_data_ids()` e resolve cada DataId pra endereco real
+// via `module.get_finalized_data()`, registrando via `add(addr)`.
+
+use std::sync::Mutex;
+
+fn pending() -> &'static Mutex<Vec<u32>> {
+    static P: OnceLock<Mutex<Vec<u32>>> = OnceLock::new();
+    P.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Codegen chama isto durante `compile_program` para cada global de
+/// tipo Handle declarada. Argumento e' o `DataId.as_u32()` —
+/// resolveremos pra endereco apos finalize_definitions.
+pub fn push_pending_data_id(data_id_raw: u32) {
+    pending().lock().unwrap_or_else(|e| e.into_inner()).push(data_id_raw);
+}
+
+/// JIT chama isto apos `finalize_definitions`. Devolve a lista
+/// acumulada e limpa.
+pub fn drain_pending_data_ids() -> Vec<u32> {
+    let mut guard = pending().lock().unwrap_or_else(|e| e.into_inner());
+    std::mem::take(&mut *guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_iterate() {
+        clear();
+        add(0x1000);
+        add(0x2000);
+        add(0x1000); // duplicada — ignora
+        let mut count = 0;
+        for_each(|_| count += 1);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn remove_works() {
+        clear();
+        add(0x3000);
+        add(0x4000);
+        remove(0x3000);
+        let mut found = Vec::new();
+        for_each(|a| found.push(a));
+        assert_eq!(found, vec![0x4000]);
+    }
+
+    #[test]
+    fn zero_addr_ignored() {
+        clear();
+        add(0);
+        assert_eq!(len(), 0);
+    }
+}

--- a/src/namespaces/gc/mod.rs
+++ b/src/namespaces/gc/mod.rs
@@ -9,6 +9,7 @@ pub mod collector;
 pub mod debug;
 pub mod env;
 pub mod error;
+pub mod global_roots;
 pub mod handles;
 pub mod instance;
 pub mod stack;


### PR DESCRIPTION
## Summary

Adiciona registry de globals top-level com `ValTy::Handle` que o `mark_stack_roots()` consulta antes do sweep. Sem isso, handles em `let buffer = "..."` eram coletados (scanner conservativo só varre stacks).

## Mudanças
- `src/namespaces/gc/global_roots.rs` (novo) — registry 2-fase
- `src/codegen/lower/func.rs` — `collect_module_globals` registra DataId quando `ValTy::Handle`
- `src/codegen/jit.rs` — após `finalize_definitions`, resolve DataId → endereço, registra
- `src/namespaces/gc/collector.rs` — `mark_stack_roots` chama `mark_global_roots`

## Validação

### `examples/http_chat.ts` (caso real do bug original)
- Antes: mensagens sumiam após ~minutos (buffer global zerava)
- Depois: 500 msgs em rajada → 20284 bytes preservados, RAM 17.9 MB estável
- Log mostra `registered 2 global roots (handle-typed top-level vars)`

### `bench/events_crossover.ts` (issue #409)
Causa-raiz era o `counter` atomic global ser coletado entre threads tokio. Antes vs depois:

| Custo listener | Antes | Depois |
|---|---|---|
| 4.7µs | async 1× | async 1× ✓ |
| 17.7µs | **TIMEOUT** | async ganha **2×** ⭐ |
| 98.6µs | **TIMEOUT** | async ganha **4×** ⭐ |
| 64 × 4.7µs | **TIMEOUT** | funciona ✓ |

**emit_async agora funciona** em todos os cenários onde antes travava.

## Test plan
- [x] `cargo test --release --lib` — 80 ok (77 anteriores + 3 novos)
- [x] http_chat com 500 msgs sob carga, GC ON, sem perda
- [x] events_crossover bench, listeners pesados sem timeout

Closes #409. Parte da epic #419 (completar GC roots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)