### PR TITLE
test(async): cobertura TS para Promise + async function (#412/#413)

### DIFF
--- a/tests/async_function.test.ts
+++ b/tests/async_function.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+import { promise } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// async fn sem args — retorna Promise pendente que resolve com 42.
+async function getAnswer(): i64 {
+  return 42;
+}
+
+const p1 = getAnswer();
+print("getAnswer.wait=" + promise.wait(p1));
+
+// async fn com 1 arg.
+async function double(x: i64): i64 {
+  return x * 2;
+}
+
+const p2 = double(21);
+print("double(21).wait=" + promise.wait(p2));
+
+// async fn que devolve handle (string) — funciona porque internamente
+// e' i64. Caller interpreta.
+async function makeNumber(): i64 {
+  return 99;
+}
+
+const p3 = makeNumber();
+print("makeNumber.wait=" + promise.wait(p3));
+
+describe("async function codegen (issue #413, F2)", () => {
+  test("matches expected stdout", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "getAnswer.wait=42\ndouble(21).wait=42\nmakeNumber.wait=99\n"
+    );
+  });
+});

--- a/tests/promise_basic.test.ts
+++ b/tests/promise_basic.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+import { promise } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// Promise.resolve atalho — nasce ja' fulfilled.
+const p1 = promise.new_resolved(42);
+print("state=" + promise.state(p1));   // 1 (fulfilled)
+print("wait=" + promise.wait(p1));     // 42
+
+// Promise.reject atalho.
+const p2 = promise.new_rejected(7);
+print("state=" + promise.state(p2));   // 2 (rejected)
+print("try_value=" + promise.try_value(p2)); // 7
+
+// Idempotencia: segundo resolve eh no-op.
+const p3 = promise.new_pending();
+print("primeiro_resolve=" + promise.resolve(p3, 1));  // 1
+print("segundo_resolve=" + promise.resolve(p3, 2));   // 0
+print("valor_final=" + promise.wait(p3));             // 1
+
+// reject apos resolve tambem eh no-op (state ja' settled).
+const p4 = promise.new_pending();
+promise.resolve(p4, 100);
+print("reject_apos_resolve=" + promise.reject(p4, 999));  // 0
+print("valor_p4=" + promise.wait(p4));                    // 100
+
+// state de handle invalido.
+print("state_invalido=" + promise.state(0));  // -1
+
+describe("promise primitive (issue #412)", () => {
+  test("matches expected stdout", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "state=1\nwait=42\nstate=2\ntry_value=7\nprimeiro_resolve=1\nsegundo_resolve=0\nvalor_final=1\nreject_apos_resolve=0\nvalor_p4=100\nstate_invalido=-1\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adiciona cobertura de teste TS que faltou nos PRs anteriores (#421 F1, #422 F2). Os testes Rust (`promise_slot::tests`, 4 testes) cobrem state machine; estes cobrem o caminho end-to-end TS → codegen → runtime.

## Mudanças

- `tests/promise_basic.test.ts` — Promise primitive (F1)
- `tests/async_function.test.ts` — async function codegen (F2)

## Cobertura

**promise_basic** valida via `import { promise } from "rts"`:
- `new_resolved` / `new_rejected` (state correto)
- `resolve` / `reject` idempotentes (segundo settle = no-op)
- `state` de handle inválido = -1
- `try_value` devolve valor settled

**async_function** valida codegen do `async function`:
- async sem args
- async com 1 arg i64
- async retornando primitivo

## Test plan
- [x] `cargo test --release --lib` — 84 ok
- [x] `target/release/rts.exe test tests/promise_basic.test.ts` — 1/1 passa
- [x] `target/release/rts.exe test tests/async_function.test.ts` — 1/1 passa

## Continuação

Branch fica viva pra próximo dev rever / continuar. Próximo passo natural é F3 #414 (codegen `await expr` → `promise.wait`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)