### PR TITLE
fix(async): suporte multi-arg em async fn (#425)

### DIFF
--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -2076,11 +2076,9 @@ fn expand_async_functions(program: &mut Program) {
             if !f.is_async {
                 continue;
             }
-            // Suportamos so' 0 ou 1 parametro nesta primeira versao.
-            if f.parameters.len() > 1 {
-                continue;
-            }
-            let arg_name = f.parameters.first().map(|p| p.name.clone());
+            // Suporta N parametros — pack em Vec na chamada,
+            // unpack no watcher. Slot 0 = handle da Promise, 1.. = args.
+            let param_names: Vec<String> = f.parameters.iter().map(|p| p.name.clone()).collect();
             let inner_name = format!("__async_inner_{}", f.name);
             let watcher_name = format!("__async_watcher_{}", f.name);
 
@@ -2094,38 +2092,43 @@ fn expand_async_functions(program: &mut Program) {
                 is_async: false,
             }));
 
-            // 2. Watcher: extrai p e arg de uma Vec, chama inner, resolve.
-            //   const p = collections.vec_get(packed, 0);
-            //   const arg = collections.vec_get(packed, 1);  // se existir
-            //   const r = __async_inner(arg ou nada);
-            //   promise.resolve(p, r);
+            // 2. Watcher: extrai p e args do Vec, chama inner com todos
+            // os args extraidos, resolve a Promise.
+            //   const __p = collections.vec_get(__packed, 0);
+            //   const __a0 = collections.vec_get(__packed, 1);
+            //   const __a1 = collections.vec_get(__packed, 2);
+            //   ...
+            //   const __r = __async_inner(__a0, __a1, ...);
+            //   promise.resolve(__p, __r);
             //   return 0;
             let mut watcher_body: Vec<Statement> = Vec::new();
             watcher_body.push(raw_stmt(const_decl(
                 "__p",
                 ns_call("collections", "vec_get", vec![ident_expr("__packed"), num_lit(0)]),
             )));
-            let inner_call = if arg_name.is_some() {
+            let mut inner_args: Vec<Expr> = Vec::with_capacity(param_names.len());
+            for (idx, _) in param_names.iter().enumerate() {
+                let arg_name = format!("__a{}", idx);
                 watcher_body.push(raw_stmt(const_decl(
-                    "__a",
-                    ns_call("collections", "vec_get", vec![ident_expr("__packed"), num_lit(1)]),
+                    &arg_name,
+                    ns_call(
+                        "collections",
+                        "vec_get",
+                        vec![ident_expr("__packed"), num_lit((idx + 1) as i64)],
+                    ),
                 )));
-                Expr::Call(CallExpr {
-                    span: Default::default(),
-                    ctxt: Default::default(),
-                    callee: Callee::Expr(Box::new(ident_expr(&inner_name))),
-                    args: vec![ExprOrSpread { spread: None, expr: Box::new(ident_expr("__a")) }],
-                    type_args: None,
-                })
-            } else {
-                Expr::Call(CallExpr {
-                    span: Default::default(),
-                    ctxt: Default::default(),
-                    callee: Callee::Expr(Box::new(ident_expr(&inner_name))),
-                    args: vec![],
-                    type_args: None,
-                })
-            };
+                inner_args.push(ident_expr(&arg_name));
+            }
+            let inner_call = Expr::Call(CallExpr {
+                span: Default::default(),
+                ctxt: Default::default(),
+                callee: Callee::Expr(Box::new(ident_expr(&inner_name))),
+                args: inner_args
+                    .into_iter()
+                    .map(|e| ExprOrSpread { spread: None, expr: Box::new(e) })
+                    .collect(),
+                type_args: None,
+            });
             watcher_body.push(raw_stmt(const_decl("__r", inner_call)));
             watcher_body.push(raw_stmt(expr_stmt(ns_call(
                 "promise",
@@ -2151,12 +2154,14 @@ fn expand_async_functions(program: &mut Program) {
             }));
 
             // 3. Substitui o body de `f` por:
-            //   const p = promise.new_pending();
-            //   const args = collections.vec_new();
-            //   collections.vec_push(args, p);
-            //   [if has arg] collections.vec_push(args, arg);
-            //   thread.spawn_async(watcher_addr, args);
-            //   return p;
+            //   const __p = promise.new_pending();
+            //   const __args = collections.vec_new();
+            //   collections.vec_push(__args, __p);
+            //   collections.vec_push(__args, param_0);
+            //   collections.vec_push(__args, param_1);
+            //   ...
+            //   thread.spawn_async(watcher_addr, __args);
+            //   return __p;
             let mut new_body: Vec<Statement> = Vec::new();
             new_body.push(raw_stmt(const_decl(
                 "__p",
@@ -2171,11 +2176,11 @@ fn expand_async_functions(program: &mut Program) {
                 "vec_push",
                 vec![ident_expr("__args"), ident_expr("__p")],
             ))));
-            if let Some(ref arg) = arg_name {
+            for pname in &param_names {
                 new_body.push(raw_stmt(expr_stmt(ns_call(
                     "collections",
                     "vec_push",
-                    vec![ident_expr("__args"), ident_expr(arg)],
+                    vec![ident_expr("__args"), ident_expr(pname)],
                 ))));
             }
             new_body.push(raw_stmt(expr_stmt(ns_call(

--- a/tests/async_multi_arg.test.ts
+++ b/tests/async_multi_arg.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// Issue #425: async fn com 2+ params era silently sync.
+// Apos fix, args sao empacotados em Vec e desempacotados no watcher.
+
+// 1. Dois argumentos.
+async function add(a: i64, b: i64): i64 {
+  return a + b;
+}
+print("add(3,4)=" + (await add(3, 4)));
+print("add(100,200)=" + (await add(100, 200)));
+
+// 2. Tres argumentos.
+async function sum3(a: i64, b: i64, c: i64): i64 {
+  return a + b + c;
+}
+print("sum3=" + (await sum3(10, 20, 30)));
+
+// 3. Cinco argumentos.
+async function sum5(a: i64, b: i64, c: i64, d: i64, e: i64): i64 {
+  return a + b + c + d + e;
+}
+print("sum5=" + (await sum5(1, 2, 3, 4, 5)));
+
+// 4. Multi-arg com early return em loop (combina com #425).
+async function range(start: i64, max: i64): i64 {
+  for (let i: i64 = start; i < max; i = i + 1) {
+    if (i * i > 50) return i;
+  }
+  return -1;
+}
+print("range(0,20)=" + (await range(0, 20)));   // 8 (8*8=64>50)
+print("range(10,15)=" + (await range(10, 15))); // 10 (10*10=100>50)
+
+// 5. Args com valores grandes.
+async function mul(a: i64, b: i64): i64 {
+  return a * b;
+}
+print("mul(1000,1000)=" + (await mul(1000, 1000)));
+
+// 6. Args negativos.
+async function diff(a: i64, b: i64): i64 {
+  return a - b;
+}
+print("diff(5,10)=" + (await diff(5, 10)));    // -5
+print("diff(-3,-7)=" + (await diff(-3, -7)));  // 4
+
+describe("async fn com multiplos argumentos (#425)", () => {
+  test("matches expected stdout", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "add(3,4)=7\nadd(100,200)=300\nsum3=60\nsum5=15\nrange(0,20)=8\nrange(10,15)=10\nmul(1000,1000)=1000000\ndiff(5,10)=-5\ndiff(-3,-7)=4\n"
+    );
+  });
+});

--- a/tests/async_with_loops.test.ts
+++ b/tests/async_with_loops.test.ts
@@ -31,22 +31,18 @@ async function matrix(n: i64): i64 {
 print("matrix(5)=" + (await matrix(5)));   // 25
 print("matrix(10)=" + (await matrix(10))); // 100
 
-// 3. async fn com if dentro de loop (sem early return ou flag —
-// `let` reassignment funciona OK).
-async function countEven(n: i64): i64 {
-  let count: i64 = 0;
-  let i: i64 = 0;
-  while (i < n) {
+// 3. async fn com early return em for-loop (issue #425 fixed).
+async function firstEven(start: i64, max: i64): i64 {
+  for (let i: i64 = start; i < max; i = i + 1) {
     if (i % 2 == 0) {
-      count = count + 1;
+      return i;
     }
-    i = i + 1;
   }
-  return count;
+  return -1;
 }
 
-print("countEven(10)=" + (await countEven(10))); // 5 (0,2,4,6,8)
-print("countEven(15)=" + (await countEven(15))); // 8 (0,2,4,6,8,10,12,14)
+print("firstEven(7,20)=" + (await firstEven(7, 20)));   // 8
+print("firstEven(11,12)=" + (await firstEven(11, 12))); // -1
 
 // 4. async fn com continue.
 async function sumOdd(n: i64): i64 {
@@ -91,7 +87,7 @@ print("decrement(5)=" + (await decrement(5)));  // 5
 describe("async functions com loops e control flow", () => {
   test("matches expected stdout", () => {
     expect(__rtsCapturedOutput).toBe(
-      "sumRange(10)=55\nsumRange(100)=5050\nmatrix(5)=25\nmatrix(10)=100\ncountEven(10)=5\ncountEven(15)=8\nsumOdd(10)=25\nfindIdx(100)=10\nfindIdx(50)=8\ndecrement(5)=5\n"
+      "sumRange(10)=55\nsumRange(100)=5050\nmatrix(5)=25\nmatrix(10)=100\nfirstEven(7,20)=8\nfirstEven(11,12)=-1\nsumOdd(10)=25\nfindIdx(100)=10\nfindIdx(50)=8\ndecrement(5)=5\n"
     );
   });
 });


### PR DESCRIPTION
Closes #425.

## Diagnóstico

Pass `expand_async_functions` tinha:
\`\`\`rust
if f.parameters.len() > 1 { continue; }
\`\`\`

Async fn com 2+ params era **silently sync** — não virava Promise. `await f(a, b)` caía em `promise.wait` de handle não-Promise = 0.

O bug que parecia "early return em loop" era na verdade "fn de 2 args nunca foi async".

## Fix

Generalizei o empacotamento Vec pra N args:
- Caller: `vec_push(p)` + `vec_push(arg_i)` por param
- Watcher: `vec_get(idx)` por param + chama inner com todos desempacotados

## Validação

| Caso | Antes | Depois |
|---|---|---|
| `add(3, 4)` | 0 | 7 |
| `sum5(1,2,3,4,5)` | 0 | 15 |
| `firstEven(7, 20)` early return | 0 | 8 |
| `mul(1000, 1000)` | 0 | 1000000 |

Suite restaurada — `async_with_loops.test.ts` voltou ao pattern original (`return i` em for).

## Testes
- [x] `cargo test --release --lib` — 84 ok
- [x] 13 testes TS, todos verdes
- [x] Novo `async_multi_arg.test.ts` com 9 cenários (#425 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)