### PR TITLE
feat(function): reify method-via-instance with typed dispatch

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -340,6 +340,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     // ── namespaces::globals::function (#359) ──────────────────────────
     use crate::namespaces::globals::function::ops::*;
     add_fn!("__RTS_FN_GL_FUNCTION_REIFY", __RTS_FN_GL_FUNCTION_REIFY);
+    add_fn!("__RTS_FN_GL_FUNCTION_REIFY_BOUND", __RTS_FN_GL_FUNCTION_REIFY_BOUND);
+    add_fn!("__RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED", __RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED);
     add_fn!("__RTS_FN_GL_FUNCTION_NEW", __RTS_FN_GL_FUNCTION_NEW);
     add_fn!("__RTS_FN_GL_FUNCTION_CALL", __RTS_FN_GL_FUNCTION_CALL);
     add_fn!("__RTS_FN_GL_FUNCTION_APPLY", __RTS_FN_GL_FUNCTION_APPLY);

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -190,6 +190,14 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                                 }
                             }
                         }
+                        // (c) `<expr>.bind/call/apply/toString` onde <expr> não é
+                        // Ident — ex: `c.add.bind(c)`. Avalia obj e se for Handle,
+                        // despacha via FUNCTION_*.
+                        if !matches!(m.obj.as_ref(), Expr::Ident(_)) {
+                            if let Some(tv) = lower_function_handle_method(ctx, &m.obj, prop_name, call)? {
+                                return Ok(tv);
+                            }
+                        }
                     }
                 }
             }
@@ -408,7 +416,7 @@ fn lower_js_global_call(
     }
 }
 
-fn resolve_method_owner(ctx: &FnCtx, class: &str, method: &str) -> Option<String> {
+pub(super) fn resolve_method_owner(ctx: &FnCtx, class: &str, method: &str) -> Option<String> {
     let mut cur = class.to_string();
     loop {
         let meta = ctx.classes.get(&cur)?;
@@ -2404,6 +2412,15 @@ fn lower_array_builtin(
 
 fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &CallExpr) -> Result<TypedVal> {
     let callee = lower_expr(ctx, callee_expr)?;
+
+    // Quando callee é Handle (var que recebeu fn handle de bind/REIFY/
+    // new Function), despacha via __RTS_FN_GL_FUNCTION_CALL — esse path
+    // entende bound_args, has_this_param, is_arrow, etc. Caso contrário
+    // trata como fn pointer raw (call_indirect direto).
+    if matches!(callee.ty, ValTy::Handle) {
+        return emit_function_handle_indirect_call(ctx, callee.val, call);
+    }
+
     let callee_val = ctx.coerce_to_i64(callee).val;
 
     // User fns address-taken (apply(double, ...), thread.spawn) sao
@@ -2435,6 +2452,73 @@ fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &CallExpr) -> 
         .copied()
         .unwrap_or_else(|| ctx.builder.ins().iconst(cl::I64, 0));
     Ok(TypedVal::new(v, ValTy::I64))
+}
+
+/// Despacha chamada via handle Function (bind/REIFY/new Function) através
+/// de __RTS_FN_GL_FUNCTION_CALL. Empacota args em Vec collections.
+fn emit_function_handle_indirect_call(
+    ctx: &mut FnCtx,
+    handle_val: cranelift_codegen::ir::Value,
+    call: &CallExpr,
+) -> Result<TypedVal> {
+    // Empacota args em Vec<i64>.
+    let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+    let inst_v = ctx.builder.ins().call(vec_new, &[]);
+    let args_handle = ctx.builder.inst_results(inst_v)[0];
+    let vec_push = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+        &[cl::I64, cl::I64],
+        None,
+    )?;
+    for a in &call.args {
+        if a.spread.is_some() {
+            return Err(anyhow!("spread em call de handle Function nao suportado"));
+        }
+        let tv = lower_expr(ctx, &a.expr)?;
+        // Args numéricos são empacotados como `f64::to_bits` (i64) para
+        // preservar precisão na travessia do Vec<i64>. O invoke_typed em
+        // runtime usa `f64::from_bits` quando param_kinds[i]=1 (F64).
+        // Handles/Bool ficam como i64 puro (param_kinds[i]=0).
+        let v = match tv.ty {
+            ValTy::F64 => ctx.builder.ins().bitcast(
+                cl::I64,
+                cranelift_codegen::ir::MemFlags::new(),
+                tv.val,
+            ),
+            ValTy::I32 | ValTy::I64 => {
+                // Literal int em TS é `number` (F64). Promove e empacota
+                // como bits para que invoke_typed leia f64 corretamente.
+                let as_f = ctx.coerce_to_f64(tv).val;
+                ctx.builder.ins().bitcast(
+                    cl::I64,
+                    cranelift_codegen::ir::MemFlags::new(),
+                    as_f,
+                )
+            }
+            ValTy::Bool | ValTy::Handle | ValTy::U64 => ctx.coerce_to_i64(tv).val,
+        };
+        ctx.builder.ins().call(vec_push, &[args_handle, v]);
+    }
+    // thisArg = 0 (chamada direta, sem this); FUNCTION_CALL respeita
+    // bound_this/has_this_param se setados em bind().
+    let this_zero = ctx.builder.ins().iconst(cl::I64, 0);
+    let call_fn = ctx.get_extern(
+        "__RTS_FN_GL_FUNCTION_CALL",
+        &[cl::I64, cl::I64, cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst_c = ctx.builder.ins().call(call_fn, &[handle_val, this_zero, args_handle]);
+    let v_i64 = ctx.builder.inst_results(inst_c)[0];
+    // FUNCTION_CALL retorna i64 contendo bits f64 quando o método tem
+    // return_kind=1 (F64). Para métodos number (caso comum em RTS), bitcast
+    // para F64. Métodos void/i64 têm bits 0 — `to_bits` de 0.0 = 0, então
+    // F64 wraps continua semanticamente correto.
+    let v_f64 = ctx.builder.ins().bitcast(
+        cl::F64,
+        cranelift_codegen::ir::MemFlags::new(),
+        v_i64,
+    );
+    Ok(TypedVal::new(v_f64, ValTy::F64))
 }
 
 fn emit_constant_load(ctx: &mut FnCtx, member: &crate::abi::NamespaceMember) -> Result<TypedVal> {

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -4,7 +4,10 @@ use swc_ecma_ast::{Expr, Lit, MemberProp};
 
 use crate::abi::lookup;
 
-use super::calls::{AccessorKind, emit_namespace_constant, emit_virtual_accessor_dispatch, fn_name_has_this_param};
+use super::calls::{
+    AccessorKind, emit_namespace_constant, emit_user_fn_addr,
+    emit_virtual_accessor_dispatch, fn_name_has_this_param, resolve_method_owner,
+};
 use super::lower_expr;
 use crate::codegen::lower::ctx::{FieldSlot, FnCtx, TypedVal, ValTy, is_class_flat_enabled};
 
@@ -316,7 +319,6 @@ fn lower_user_fn_getter(
     prop: &str,
 ) -> Result<TypedVal> {
     use crate::codegen::lower::ctx::ValTy;
-    use super::calls::emit_user_fn_addr;
 
     let fn_ptr = emit_user_fn_addr(ctx, fn_name)?.val;
     let arity = ctx
@@ -364,6 +366,96 @@ fn lower_user_fn_getter(
             Ok(TypedVal::new(v, ValTy::I64))
         }
         _ => Err(anyhow!("user_fn_getter: prop {} nao suportado", prop)),
+    }
+}
+
+/// Reifica método de instância em handle Function pré-bindado.
+/// Usado quando codegen vê `obj.method` em posição de valor (não chamada
+/// direta): emite REIFY com has_this_param=true + BIND com receiver como this.
+fn emit_method_reify(
+    ctx: &mut FnCtx,
+    receiver_expr: &Expr,
+    fn_name: &str,
+    method_name: &str,
+) -> Result<TypedVal> {
+    let fn_ptr = emit_user_fn_addr(ctx, fn_name)?.val;
+    let arity = ctx
+        .user_fns
+        .get(fn_name)
+        .map(|f| f.params.len() as i64)
+        .unwrap_or(0);
+    let name_tv = ctx.emit_str_handle(method_name.as_bytes())?;
+    let name_h = ctx.coerce_to_i64(name_tv).val;
+    let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+    let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+    let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+    let n_ptr = ctx.builder.inst_results(inst_p)[0];
+    let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+    let n_len = ctx.builder.inst_results(inst_l)[0];
+
+    let arity_v = ctx.builder.ins().iconst(cl::I64, arity);
+    let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let has_this_v = ctx.builder.ins().iconst(cl::I32, 1);
+    // Avalia receiver e usa diretamente como bound_this no REIFY_BOUND_TYPED.
+    let recv_tv = lower_expr(ctx, receiver_expr)?;
+    let recv_i64 = ctx.coerce_to_i64(recv_tv).val;
+    let has_bound_v = ctx.builder.ins().iconst(cl::I32, 1);
+
+    // Coleta param_kinds + return_kind para invoke_typed dispatchar com
+    // signature correta (number → f64, etc).
+    let (param_kinds_bytes, return_kind_v): (Vec<u8>, i32) = {
+        let info = ctx.user_fns.get(fn_name);
+        let pks: Vec<u8> = info
+            .map(|f| f.params.iter().map(|t| val_ty_to_kind(*t)).collect())
+            .unwrap_or_default();
+        let rk: i32 = info
+            .and_then(|f| f.ret)
+            .map(|t| val_ty_to_kind(t) as i32)
+            .unwrap_or(4); // void = 4
+        (pks, rk)
+    };
+    let pk_ptr_v: cranelift_codegen::ir::Value;
+    let pk_len_v: cranelift_codegen::ir::Value;
+    if param_kinds_bytes.is_empty() {
+        pk_ptr_v = ctx.builder.ins().iconst(cl::I64, 0);
+        pk_len_v = ctx.builder.ins().iconst(cl::I64, 0);
+    } else {
+        let tv = ctx.emit_str_handle(&param_kinds_bytes)?;
+        let h = ctx.coerce_to_i64(tv).val;
+        let p = ctx.builder.ins().call(str_ptr_fn, &[h]);
+        let l = ctx.builder.ins().call(str_len_fn, &[h]);
+        pk_ptr_v = ctx.builder.inst_results(p)[0];
+        pk_len_v = ctx.builder.inst_results(l)[0];
+    }
+    let rk_v = ctx.builder.ins().iconst(cl::I32, return_kind_v as i64);
+
+    let reify_fn = ctx.get_extern(
+        "__RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED",
+        &[
+            cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32, cl::I64, cl::I32,
+            cl::I64, cl::I64, cl::I32,
+        ],
+        Some(cl::I64),
+    )?;
+    let inst_r = ctx.builder.ins().call(
+        reify_fn,
+        &[
+            fn_ptr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v,
+            recv_i64, has_bound_v, pk_ptr_v, pk_len_v, rk_v,
+        ],
+    );
+    let fn_handle = ctx.builder.inst_results(inst_r)[0];
+    Ok(TypedVal::new(fn_handle, ValTy::Handle))
+}
+
+fn val_ty_to_kind(ty: ValTy) -> u8 {
+    match ty {
+        ValTy::I64 => 0,
+        ValTy::F64 => 1,
+        ValTy::Bool => 2,
+        ValTy::I32 => 3,
+        ValTy::Handle => 0, // Handle e' u64 → cabe em i64 raw
+        ValTy::U64 => 0,
     }
 }
 
@@ -426,6 +518,17 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                     let inst = ctx.builder.ins().call(fn_ref, &[recv_i64]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::from_abi(member.returns)));
+                }
+            }
+            // Reificação de método de instância (#359): `c.method` em
+            // posição de valor (não callee direto) → handle Function com
+            // bound_this = c. Habilita `c.method.bind(c)`, `c.method.call(c, ...)`,
+            // passar como callback. Método precisa estar em address_taken_fns
+            // (callconv C) — métodos de classe são marcados em compile_program.
+            if let Some(owner) = resolve_method_owner(ctx, cls, prop_name) {
+                let fn_name_str = format!("__class_{owner}_{prop_name}");
+                if ctx.user_fns.contains_key(&fn_name_str) {
+                    return emit_method_reify(ctx, &m.obj, &fn_name_str, prop_name);
                 }
             }
         }
@@ -957,6 +1060,20 @@ fn class_name_from_ts_type(ty: &swc_ecma_ast::TsType) -> Option<String> {
     None
 }
 
+fn resolve_method_owner_local(ctx: &FnCtx, class: &str, method: &str) -> Option<String> {
+    let mut cur = class.to_string();
+    loop {
+        let meta = ctx.classes.get(&cur)?;
+        if meta.methods.iter().any(|m| m == method) {
+            return Some(cur);
+        }
+        match &meta.super_class {
+            Some(parent) => cur = parent.clone(),
+            None => return None,
+        }
+    }
+}
+
 pub(super) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
     match expr {
         Expr::This(_) => ctx.current_class.clone(),
@@ -987,7 +1104,15 @@ pub(super) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
                 MemberProp::PrivateName(pn) => pn.name.as_ref(),
                 MemberProp::Computed(_) => return None,
             };
-            field_class_in_hierarchy(ctx, &owner, prop)
+            if let Some(c) = field_class_in_hierarchy(ctx, &owner, prop) {
+                return Some(c);
+            }
+            // Method reified como Function handle (#359). Permite que
+            // `c.add.bind(c)` resolva o callee como Function class.
+            if resolve_method_owner_local(ctx, &owner, prop).is_some() {
+                return Some("Function".to_string());
+            }
+            None
         }
         Expr::Call(call) => {
             if let swc_ecma_ast::Callee::Expr(callee) = &call.callee {

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -5440,6 +5440,17 @@ pub fn compile_program(
     // Funções sintéticas do purity_pass (Level-1 parallel ForOf).
     address_taken_fns.extend(par_fn_names.iter().cloned());
 
+    // Métodos de classe (`__class_<C>_<m>`, exceto `__init`) são marcados
+    // como address-taken para permitir reificação via `obj.method` (Function
+    // class #359). Custo: perda de TCO em métodos. Benefício: `c.add.bind(c)`
+    // funciona como handle Function de primeira classe.
+    for fn_decl in &fn_decls {
+        let n = &fn_decl.name;
+        if n.starts_with("__class_") && !n.ends_with("__init") && !n.contains("_static_") {
+            address_taken_fns.insert(n.clone());
+        }
+    }
+
     // Phase 1: declare all user functions so forward calls resolve.
     let mut user_fns: HashMap<String, UserFn> = HashMap::new();
     for fn_decl in &fn_decls {
@@ -6072,6 +6083,17 @@ fn infer_expr_ty(expr: Option<&Expr>) -> ValTy {
             if let swc_ecma_ast::Callee::Expr(callee) = &c.callee {
                 if let Some(ty) = infer_abi_member_ty(callee) {
                     return ty;
+                }
+                // Function global #359: `<expr>.bind/call/apply/toString`
+                // retornam handle Function (Handle). Sem isso o global
+                // recebe storage I64 e `f(...)` cai em lower_user_call
+                // em vez de indirect via FUNCTION_CALL.
+                if let Expr::Member(m) = callee.as_ref() {
+                    if let swc_ecma_ast::MemberProp::Ident(p) = &m.prop {
+                        if matches!(p.sym.as_ref(), "bind" | "toString") {
+                            return ValTy::Handle;
+                        }
+                    }
                 }
             }
             ValTy::I64

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -180,6 +180,12 @@ pub struct FunctionData {
     /// (método de classe não-estático). CALL/APPLY prepend effective_this
     /// antes de invoke_n quando este flag está ativo.
     pub has_this_param: bool,
+    /// Tipos ABI dos parâmetros (codificação: 0=i64, 1=f64, 2=bool, 3=i32).
+    /// Vazio = assume todos i64. Usado por invoke_n para coerção correta
+    /// quando método tem `number` (f64) ou outros tipos não-i64.
+    pub param_kinds: Vec<u8>,
+    /// Tipo ABI do retorno: 0=i64, 1=f64, 2=bool, 3=i32, 4=void. 0 default.
+    pub return_kind: u8,
     pub source: Option<Box<str>>,
     /// Mantem viva a JITModule de origem se a fn veio de `new Function`
     /// (compilada em runtime). Mutex existe so' por Sync — JITModule e'

--- a/src/namespaces/globals/function/ops.rs
+++ b/src/namespaces/globals/function/ops.rs
@@ -7,6 +7,87 @@
 use crate::namespaces::gc::handles::{Entry, FunctionData, alloc_entry, with_entry};
 
 unsafe fn invoke_n(fn_ptr: u64, args: &[i64]) -> i64 {
+    unsafe { invoke_typed(fn_ptr, args, &[], 0) }
+}
+
+/// Despacha por signature heterogênea. `param_kinds[i]` codifica:
+/// 0=i64, 1=f64, 2=bool, 3=i32. `return_kind` idem (4=void → retorna 0).
+/// Args entram como `i64` (representação carregada pelo handle Function);
+/// se o tipo for f64/i32/bool, faz transmute/cast no boundary.
+///
+/// Suporta combinações comuns para métodos de classe RTS:
+/// `(i64, ...mixed) -> mixed`. Assume primeiro param i64 (this) quando
+/// has_this_param dispara em CALL.
+unsafe fn invoke_typed(
+    fn_ptr: u64,
+    args: &[i64],
+    param_kinds: &[u8],
+    return_kind: u8,
+) -> i64 {
+    use std::mem::transmute;
+    // Quando param_kinds é vazio, todos os args são i64 (caminho rápido).
+    if param_kinds.is_empty() && return_kind == 0 {
+        return unsafe { invoke_all_i64(fn_ptr, args) };
+    }
+    // Caminho tipado: aridade ate 4 + (this i64) — cobre métodos de classe
+    // RTS comuns. Aumentar conforme necessário.
+    // Convenção: param_kinds[i] descreve args[i] (this incluso se for o caso).
+    let n = args.len();
+    // Coerções por param.
+    let a0_i64 = args.first().copied().unwrap_or(0);
+    let a1_i64 = args.get(1).copied().unwrap_or(0);
+    let a2_i64 = args.get(2).copied().unwrap_or(0);
+    let a3_i64 = args.get(3).copied().unwrap_or(0);
+    let a4_i64 = args.get(4).copied().unwrap_or(0);
+
+    let a0_f64 = i64_to_f64(a0_i64);
+    let a1_f64 = i64_to_f64(a1_i64);
+    let a2_f64 = i64_to_f64(a2_i64);
+    let a3_f64 = i64_to_f64(a3_i64);
+    let _a4_f64 = i64_to_f64(a4_i64);
+
+    let pk0 = param_kinds.first().copied().unwrap_or(0);
+    let pk1 = param_kinds.get(1).copied().unwrap_or(0);
+    let pk2 = param_kinds.get(2).copied().unwrap_or(0);
+    let pk3 = param_kinds.get(3).copied().unwrap_or(0);
+    let pk4 = param_kinds.get(4).copied().unwrap_or(0);
+
+    // Encode a tupla (n, pk0, pk1, ..., return_kind) num discriminador.
+    // Hot path: this (i64) + 1-3 args mistos + retorno mixed.
+    unsafe {
+        match (n, pk0, pk1, pk2, return_kind) {
+            // 0 args, retorno mixed
+            (0, _, _, _, 0) => transmute::<u64, extern "C" fn() -> i64>(fn_ptr)(),
+            (0, _, _, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn() -> f64>(fn_ptr)()),
+            // 1 arg
+            (1, 0, _, _, 0) => transmute::<u64, extern "C" fn(i64) -> i64>(fn_ptr)(a0_i64),
+            (1, 0, _, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn(i64) -> f64>(fn_ptr)(a0_i64)),
+            (1, 1, _, _, 0) => transmute::<u64, extern "C" fn(f64) -> i64>(fn_ptr)(a0_f64),
+            (1, 1, _, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn(f64) -> f64>(fn_ptr)(a0_f64)),
+            // 2 args (this i64 + 1 outro)
+            (2, 0, 0, _, 0) => transmute::<u64, extern "C" fn(i64, i64) -> i64>(fn_ptr)(a0_i64, a1_i64),
+            (2, 0, 0, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn(i64, i64) -> f64>(fn_ptr)(a0_i64, a1_i64)),
+            (2, 0, 1, _, 0) => transmute::<u64, extern "C" fn(i64, f64) -> i64>(fn_ptr)(a0_i64, a1_f64),
+            (2, 0, 1, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn(i64, f64) -> f64>(fn_ptr)(a0_i64, a1_f64)),
+            (2, 1, 1, _, 1) => f64_to_i64(transmute::<u64, extern "C" fn(f64, f64) -> f64>(fn_ptr)(a0_f64, a1_f64)),
+            // 3 args (this + 2 outros)
+            (3, 0, 0, 0, 0) => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(fn_ptr)(a0_i64, a1_i64, a2_i64),
+            (3, 0, 1, 1, 1) => f64_to_i64(transmute::<u64, extern "C" fn(i64, f64, f64) -> f64>(fn_ptr)(a0_i64, a1_f64, a2_f64)),
+            (3, 0, 0, 1, 0) => transmute::<u64, extern "C" fn(i64, i64, f64) -> i64>(fn_ptr)(a0_i64, a1_i64, a2_f64),
+            (3, 0, 1, 0, 0) => transmute::<u64, extern "C" fn(i64, f64, i64) -> i64>(fn_ptr)(a0_i64, a1_f64, a2_i64),
+            (3, 0, 1, 1, 0) => transmute::<u64, extern "C" fn(i64, f64, f64) -> i64>(fn_ptr)(a0_i64, a1_f64, a2_f64),
+            // 4 args (this + 3 outros) — só combinações importantes
+            (4, 0, 1, 1, 1) => f64_to_i64(transmute::<u64, extern "C" fn(i64, f64, f64, f64) -> f64>(fn_ptr)(a0_i64, a1_f64, a2_f64, a3_f64)),
+            // Fallback: tudo i64 (perda de precisão se f64 esperado).
+            _ => {
+                let _ = (pk3, pk4, a3_i64, a4_i64);
+                invoke_all_i64(fn_ptr, args)
+            }
+        }
+    }
+}
+
+unsafe fn invoke_all_i64(fn_ptr: u64, args: &[i64]) -> i64 {
     use std::mem::transmute;
     unsafe {
         match args.len() {
@@ -41,7 +122,17 @@ unsafe fn invoke_n(fn_ptr: u64, args: &[i64]) -> i64 {
     }
 }
 
-fn read_function_data(handle: u64) -> Option<(u64, Vec<i64>, bool, i64, bool, bool)> {
+#[inline]
+fn i64_to_f64(v: i64) -> f64 {
+    f64::from_bits(v as u64)
+}
+
+#[inline]
+fn f64_to_i64(v: f64) -> i64 {
+    v.to_bits() as i64
+}
+
+fn read_function_data(handle: u64) -> Option<(u64, Vec<i64>, bool, i64, bool, bool, Vec<u8>, u8)> {
     with_entry(handle, |entry| {
         if let Some(Entry::Function(data)) = entry {
             Some((
@@ -51,6 +142,8 @@ fn read_function_data(handle: u64) -> Option<(u64, Vec<i64>, bool, i64, bool, bo
                 data.bound_this,
                 data.is_arrow,
                 data.has_this_param,
+                data.param_kinds.clone(),
+                data.return_kind,
             ))
         } else {
             None
@@ -83,6 +176,50 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_REIFY(
     is_arrow: i32,
     has_this_param: i32,
 ) -> u64 {
+    __RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED(
+        fn_ptr, arity, name_ptr, name_len, is_arrow, has_this_param, 0, 0, 0, 0, 0,
+    )
+}
+
+/// REIFY com bound_this. Usado para reificação de método de instância:
+/// `c.add` em posição de valor → handle Function pré-bindado em `c`.
+/// Quando `bind_this != 0`, o handle resultante tem `has_bound_this=true`
+/// e `bound_this=bind_this`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FUNCTION_REIFY_BOUND(
+    fn_ptr: u64,
+    arity: i64,
+    name_ptr: i64,
+    name_len: i64,
+    is_arrow: i32,
+    has_this_param: i32,
+    bound_this: i64,
+    has_bound_this: i32,
+) -> u64 {
+    __RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED(
+        fn_ptr, arity, name_ptr, name_len, is_arrow, has_this_param,
+        bound_this, has_bound_this, 0, 0, 0,
+    )
+}
+
+/// REIFY_BOUND com signature ABI (`param_kinds_ptr/len`, `return_kind`).
+/// Usado para reificação de método de classe com tipos não-i64.
+/// `param_kinds` codifica cada param: 0=i64, 1=f64, 2=bool, 3=i32 (este
+/// codifica o param já incluindo `this` quando aplicável).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED(
+    fn_ptr: u64,
+    arity: i64,
+    name_ptr: i64,
+    name_len: i64,
+    is_arrow: i32,
+    has_this_param: i32,
+    bound_this: i64,
+    has_bound_this: i32,
+    param_kinds_ptr: i64,
+    param_kinds_len: i64,
+    return_kind: i32,
+) -> u64 {
     let name = if name_ptr != 0 && name_len > 0 {
         unsafe {
             let bytes = std::slice::from_raw_parts(name_ptr as *const u8, name_len as usize);
@@ -91,15 +228,25 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_REIFY(
     } else {
         "anonymous".to_owned()
     };
+    let param_kinds = if param_kinds_ptr != 0 && param_kinds_len > 0 {
+        unsafe {
+            std::slice::from_raw_parts(param_kinds_ptr as *const u8, param_kinds_len as usize)
+                .to_vec()
+        }
+    } else {
+        Vec::new()
+    };
     alloc_entry(Entry::Function(Box::new(FunctionData {
         fn_ptr,
         arity: arity.clamp(0, 255) as u8,
         name: name.into_boxed_str(),
-        bound_this: 0,
-        has_bound_this: false,
+        bound_this,
+        has_bound_this: has_bound_this != 0,
         bound_args: Vec::new(),
         is_arrow: is_arrow != 0,
         has_this_param: has_this_param != 0,
+        param_kinds,
+        return_kind: return_kind.clamp(0, 4) as u8,
         source: None,
         keep_alive: None,
     })))
@@ -150,6 +297,8 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_NEW(params_handle: u64, body_handle: u64)
         bound_args: Vec::new(),
         is_arrow: false,
         has_this_param: false,
+        param_kinds: Vec::new(),
+        return_kind: 0,
         source: Some(format!("function anonymous({}) {{\n{}\n}}", params_str, body_str).into_boxed_str()),
         keep_alive: Some(compiled.keep_alive),
     })))
@@ -158,7 +307,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_NEW(params_handle: u64, body_handle: u64)
 /// `fn.call(thisArg, argsVec)`. Args vem como Vec handle (codegen empacota).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_FUNCTION_CALL(handle: u64, this_arg: i64, args_handle: u64) -> i64 {
-    let (fn_ptr, bound_args, has_bound_this, bound_this, is_arrow, has_this_param) =
+    let (fn_ptr, bound_args, has_bound_this, bound_this, is_arrow, has_this_param, param_kinds, return_kind) =
         match read_function_data(handle) {
             Some(d) => d,
             None => return 0,
@@ -176,7 +325,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_CALL(handle: u64, this_arg: i64, args_han
         all_args.insert(0, effective_this);
     }
 
-    unsafe { invoke_n(fn_ptr, &all_args) }
+    unsafe { invoke_typed(fn_ptr, &all_args, &param_kinds, return_kind) }
 }
 
 /// `fn.apply(thisArg, argsArray)`. Mesmo dispatch de call.
@@ -201,6 +350,8 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_BIND(handle: u64, this_arg: i64, args_han
                 d.bound_args.clone(),
                 d.is_arrow,
                 d.has_this_param,
+                d.param_kinds.clone(),
+                d.return_kind,
                 d.source.clone(),
                 d.keep_alive.clone(),
                 d.has_bound_this,
@@ -210,7 +361,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_BIND(handle: u64, this_arg: i64, args_han
             None
         }
     });
-    let Some((fn_ptr, arity, name, mut bound_args, is_arrow, has_this_param, source, keep_alive, had_bound_this, prev_bound_this)) =
+    let Some((fn_ptr, arity, name, mut bound_args, is_arrow, has_this_param, param_kinds, return_kind, source, keep_alive, had_bound_this, prev_bound_this)) =
         original
     else {
         return 0;
@@ -234,6 +385,8 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_BIND(handle: u64, this_arg: i64, args_han
         bound_args,
         is_arrow,
         has_this_param,
+        param_kinds,
+        return_kind,
         source,
         keep_alive,
     })))


### PR DESCRIPTION
## Summary
- Habilita `c.add.bind(c)`, `c.add.call(c, ...)` e passar método como callback (issue #359 follow-up)
- Novo `REIFY_BOUND_TYPED` armazena `param_kinds`/`return_kind` em `FunctionData`; `invoke_typed` despacha com signature correta — antes `invoke_n` assumia `(i64...) -> i64` e métodos com `number` retornavam lixo
- `c.add` em posição de valor → emite handle Function pré-bindado em `c`

## Test plan
- [x] `cargo build --release` sem erros
- [x] `cargo test --release --lib` — 84/84 verdes
- [x] `target/release/rts.exe test tests/function_global.test.ts` — passa
- [x] `target/release/rts.exe test tests/first_class_functions.test.ts` — passa
- [x] `target/release/rts.exe test tests/arrow_functions.test.ts` — passa
- [x] Repro manual `c.add.bind(c)(5)` retorna 5 (era 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)