### PR TITLE
fix(ci): resolve runtime_support build + symlink_mode typo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -17,6 +18,25 @@ fn main() {
             out.display()
         )
     });
+
+    // actix-web pulls in a proc-macro chain (actix-web-codegen) that causes some
+    // shared crates (serde, serde_core, hashbrown, ...) to be compiled twice:
+    // once for the target and once for the host (proc-macro deps). Picking the
+    // newest rlib by mtime can land on the host variant, which conflicts with
+    // serde_json (target-only) and produces "multiple different versions of
+    // crate `serde_core` in the dependency graph".
+    //
+    // Anchor on a unique target-only crate (actix_web is unique because it's a
+    // direct dep used at runtime, not via proc-macro) and read its rmeta hash
+    // set. For each duplicated dep, prefer the variant whose hash is in the
+    // anchor's reference set.
+    let anchor_rlib = find_rlib_named(&deps_dir, "libactix_web-").unwrap_or_else(|| {
+        panic!(
+            "failed to locate actix_web rlib under {} (required as anchor for dep resolution)",
+            deps_dir.display()
+        )
+    });
+    let anchor_hashes = extract_referenced_hashes(&anchor_rlib);
     let fltk_rlib = find_fltk_rlib(&deps_dir).unwrap_or_else(|| {
         panic!(
             "failed to locate fltk rlib under {} (required for ui runtime symbols)",
@@ -47,48 +67,56 @@ fn main() {
             deps_dir.display()
         )
     });
-    let webpki_roots_rlib = find_rlib_named(&deps_dir, "libwebpki_roots-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate webpki_roots rlib under {} (required for tls runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let serde_json_rlib = find_rlib_named(&deps_dir, "libserde_json-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate serde_json rlib under {} (required for json runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let serde_rlib = find_rlib_named(&deps_dir, "libserde-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate serde rlib under {} (required for json runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let indexmap_rlib = find_rlib_named(&deps_dir, "libindexmap-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate indexmap rlib under {} (required for collections runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let hashbrown_rlib = find_rlib_named(&deps_dir, "libhashbrown-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate hashbrown rlib under {} (required for collections runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let equivalent_rlib = find_rlib_named(&deps_dir, "libequivalent-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate equivalent rlib under {} (required for collections runtime symbols)",
-            deps_dir.display()
-        )
-    });
-    let actix_web_rlib = find_rlib_named(&deps_dir, "libactix_web-").unwrap_or_else(|| {
-        panic!(
-            "failed to locate actix_web rlib under {} (required for http_server runtime symbols)",
-            deps_dir.display()
-        )
-    });
+    let webpki_roots_rlib = find_rlib_with_anchor(&deps_dir, "libwebpki_roots-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate webpki_roots rlib under {} (required for tls runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let serde_json_rlib = find_rlib_with_anchor(&deps_dir, "libserde_json-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate serde_json rlib under {} (required for json runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let serde_rlib = find_rlib_with_anchor(&deps_dir, "libserde-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate serde rlib under {} (required for json runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let serde_core_rlib = find_rlib_with_anchor(&deps_dir, "libserde_core-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate serde_core rlib under {} (required for json runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let indexmap_rlib = find_rlib_with_anchor(&deps_dir, "libindexmap-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate indexmap rlib under {} (required for collections runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let hashbrown_rlib = find_rlib_with_anchor(&deps_dir, "libhashbrown-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate hashbrown rlib under {} (required for collections runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let equivalent_rlib = find_rlib_with_anchor(&deps_dir, "libequivalent-", &anchor_hashes)
+        .unwrap_or_else(|| {
+            panic!(
+                "failed to locate equivalent rlib under {} (required for collections runtime symbols)",
+                deps_dir.display()
+            )
+        });
+    let actix_web_rlib = anchor_rlib.clone();
     let tokio_rlib = find_rlib_named(&deps_dir, "libtokio-").unwrap_or_else(|| {
         panic!(
             "failed to locate tokio rlib under {} (required for http_server runtime symbols)",
@@ -131,6 +159,11 @@ fn main() {
         .arg(format!("serde_json={}", serde_json_rlib.display()));
     cmd.arg("--extern")
         .arg(format!("serde={}", serde_rlib.display()));
+    // serde_core isn't used directly in our source, but we anchor its --extern
+    // so rustc resolves the trait impls (Serialize/Serializer) to the same
+    // serde_core variant that serde and serde_json were compiled against.
+    cmd.arg("--extern")
+        .arg(format!("serde_core={}", serde_core_rlib.display()));
     cmd.arg("--extern")
         .arg(format!("indexmap={}", indexmap_rlib.display()));
     cmd.arg("--extern")
@@ -274,4 +307,75 @@ fn find_rlib_named(deps_dir: &Path, prefix: &str) -> Option<PathBuf> {
         }
     }
     best.map(|(_, path)| path)
+}
+
+/// Find an rlib with a hash that appears in `allowed`, falling back to mtime
+/// when no candidate matches (single-variant deps still hit this path).
+fn find_rlib_with_anchor(
+    deps_dir: &Path,
+    prefix: &str,
+    allowed: &HashSet<String>,
+) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(deps_dir).ok()?;
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rlib") {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !file_name.starts_with(prefix) {
+            continue;
+        }
+        candidates.push(path);
+    }
+
+    // Prefer a candidate whose 16-hex hash is referenced by the anchor crate.
+    for path in &candidates {
+        if let Some(hash) = rlib_hash(path, prefix) {
+            if allowed.contains(hash) {
+                return Some(path.clone());
+            }
+        }
+    }
+
+    // Fall back to mtime when there's no anchor match (e.g. single-variant deps).
+    find_rlib_named(deps_dir, prefix)
+}
+
+fn rlib_hash<'a>(path: &'a Path, prefix: &str) -> Option<&'a str> {
+    let file_name = path.file_name()?.to_str()?;
+    let stem = file_name.strip_prefix(prefix)?.strip_suffix(".rlib")?;
+    if stem.len() == 16 && stem.bytes().all(|b| b.is_ascii_hexdigit()) {
+        Some(stem)
+    } else {
+        None
+    }
+}
+
+/// Read an rlib's bytes and collect every 16-hex-char crate hash it references
+/// (its own metadata hash plus its dependencies'). Used to anchor disambiguation
+/// when several variants of the same crate exist in the deps dir (target vs
+/// proc-macro/host build).
+fn extract_referenced_hashes(rlib_path: &Path) -> HashSet<String> {
+    let bytes = std::fs::read(rlib_path).unwrap_or_default();
+    let mut out = HashSet::new();
+    if bytes.len() < 18 {
+        return out;
+    }
+    for window in bytes.windows(17) {
+        if window[0] != b'-' {
+            continue;
+        }
+        let tail = &window[1..];
+        if !tail.iter().all(|b| b.is_ascii_hexdigit()) {
+            continue;
+        }
+        if let Ok(s) = std::str::from_utf8(tail) {
+            out.insert(s.to_string());
+        }
+    }
+    out
 }

--- a/src/registers/install.rs
+++ b/src/registers/install.rs
@@ -131,7 +131,7 @@ fn symlink_dir(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-fn install_bin(bin_dir: &Path, name: &str, target: &Path, _symlink_mode: bool) -> Result<()> {
+fn install_bin(bin_dir: &Path, name: &str, target: &Path, symlink_mode: bool) -> Result<()> {
     #[cfg(unix)]
     {
         let bin_path = bin_dir.join(name);
@@ -149,6 +149,7 @@ fn install_bin(bin_dir: &Path, name: &str, target: &Path, _symlink_mode: bool) -
     }
     #[cfg(windows)]
     {
+        let _ = symlink_mode;
         // .cmd wrapper for cmd.exe
         let cmd_path = bin_dir.join(format!("{name}.cmd"));
         let cmd_script = format!("@echo off\r\n\"{target}\" %*\r\n", target = target.display());


### PR DESCRIPTION
CI was red on all platforms after #441 due to two bugs:

1. **runtime_support staticlib failed to compile**: actix-web pulls in
   actix-web-codegen (proc-macro), which causes serde/serde_core to be
   built twice (target + host). build.rs picks rlibs by mtime, but the
   newer rlib happened to be the host (proc-macro) variant — incompatible
   with the target-only serde_json. rustc error:
   "multiple different versions of crate `serde_core` in the dependency
   graph".

   Fix: anchor on libactix_web (unique target rlib) and read its rmeta
   to extract the set of referenced crate hashes. For each duplicated dep
   (serde, serde_core, hashbrown, serde_json, indexmap, equivalent,
   webpki_roots), prefer the variant whose hash appears in the anchor's
   set. Add explicit `--extern serde_core=...` so rustc disambiguates.

2. **install.rs:138 referenced `symlink_mode` while param was named
   `_symlink_mode`**: hard compile error inside `#[cfg(unix)]` block.
   Rename param + silence unused-var warning under `#[cfg(windows)]`
   via `let _ = symlink_mode;`.

Test plan:
- [x] cargo build --release — clean
- [x] cargo test --release --lib — 84/84 passed
- [x] cargo run --release -- test — exit 0 (pre-existing failures only)