### PR TITLE
fix(ci): adiciona deps do build.rs em [build-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,15 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 
 [build-dependencies]
 fltk = { version = "1", features = ["fltk-bundled"] }
+regex = "1"
+rayon = "1.10"
+rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
+webpki-roots = "0.26"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+indexmap = "2.14.0"
+actix-web = { version = "4", default-features = false, features = ["macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
## Summary
- CI em debug (`cargo run -- test`) quebrava com `failed to locate actix_web rlib under target/debug/deps`
- build.rs procura rlibs em `target/<profile>/deps/` mas, em debug, ele roda em paralelo com a compilacao das deps normais — Cargo nao garante que estejam prontas
- Fix: declarar `actix-web`, `regex`, `rayon`, `rustls`, `webpki-roots`, `serde`, `serde_json`, `indexmap`, `tokio` em `[build-dependencies]` (mesma solucao ja em uso pra `fltk`), forcando Cargo a materializar as rlibs antes do build script

## Test plan
- [x] `cargo build` em debug passa
- [x] `cargo run -- test` mesmo numero de falhas que baseline (pre-existentes, nao relacionadas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)