### PR TITLE
fix(ci): adiciona deps do build.rs em [build-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,18 @@ actix-web = { version = "4", default-features = false, features = ["macros"] }
 actix-rt = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 
+[build-dependencies]
+fltk = { version = "1", features = ["fltk-bundled"] }
+regex = "1"
+rayon = "1.10"
+rustls = { version = "0.23", default-features = false, features = ["std", "ring", "tls12"] }
+webpki-roots = "0.26"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+indexmap = "2.14.0"
+actix-web = { version = "4", default-features = false, features = ["macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+
 [profile.release]
 opt-level = "z"
 lto = true


### PR DESCRIPTION
## Summary
- CI em debug ainda quebrava em runner fresh apos PR #445: `failed to locate actix_web rlib under target/debug/deps`
- Causa: build.rs procura rlibs em `target/<profile>/deps/` mas, em debug fresh, Cargo paraleliza a compilacao das deps normais com o build.rs — as rlibs ainda nao existem quando o script roda
- PR #445 endureceu o lookup mas nao mudou o ordering — o problema persiste
- Fix: declarar `fltk`, `regex`, `rayon`, `rustls`, `webpki-roots`, `serde`, `serde_json`, `indexmap`, `actix-web`, `tokio` em `[build-dependencies]` — Cargo entao garante que estejam compiladas antes do build script

## Test plan
- [x] `rm -rf target/debug && cargo build` passa fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)