### PR TITLE
feat(function): this binding em fn plain via thread-local slot (#449)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -159,6 +159,14 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_STACK_DEPTH", __RTS_FN_RT_STACK_DEPTH);
     }
 
+    // ── this binding slot (used by .call/.apply on plain fns) ─────────
+    {
+        use crate::namespaces::gc::this_slot::*;
+        add_fn!("__RTS_FN_RT_THIS_PUSH", __RTS_FN_RT_THIS_PUSH);
+        add_fn!("__RTS_FN_RT_THIS_POP", __RTS_FN_RT_THIS_POP);
+        add_fn!("__RTS_FN_RT_THIS_GET", __RTS_FN_RT_THIS_GET);
+    }
+
     // ── namespaces::gc ────────────────────────────────────────────────
     use crate::namespaces::gc::string_pool::*;
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/src/codegen/lower/expressions/mod.rs
+++ b/src/codegen/lower/expressions/mod.rs
@@ -43,9 +43,21 @@ pub fn lower_expr(ctx: &mut FnCtx, expr: &Expr) -> Result<TypedVal> {
         Expr::OptChain(opt) => lower_opt_chain(ctx, opt),
         Expr::SuperProp(sp) => lower_super_prop_read(ctx, sp),
         Expr::New(new_expr) => lower_new(ctx, new_expr),
-        Expr::This(_) => ctx
-            .read_local("this")
-            .ok_or_else(|| anyhow!("`this` unavailable in current context")),
+        Expr::This(_) => {
+            // Em metodo de classe (compilado com `this` como param real),
+            // ler o local. Em fn plain nao-arrow, ler do thread-local
+            // `this` slot (populado por Function.call/.apply em runtime).
+            // Em arrow plain top-level, slot retorna 0 (=undefined).
+            if let Some(v) = ctx.read_local("this") {
+                Ok(v)
+            } else {
+                let fref =
+                    ctx.get_extern("__RTS_FN_RT_THIS_GET", &[], Some(cranelift_codegen::ir::types::I64))?;
+                let inst = ctx.builder.ins().call(fref, &[]);
+                let v = ctx.builder.inst_results(inst)[0];
+                Ok(TypedVal::new(v, ValTy::I64))
+            }
+        }
         Expr::TsAs(a) => lower_expr(ctx, &a.expr),
         Expr::TsTypeAssertion(a) => lower_expr(ctx, &a.expr),
         Expr::TsConstAssertion(a) => lower_expr(ctx, &a.expr),

--- a/src/namespaces/gc/mod.rs
+++ b/src/namespaces/gc/mod.rs
@@ -16,4 +16,5 @@ pub mod promise_slot;
 pub mod stack;
 pub mod stack_map_registry;
 pub mod string_pool;
+pub mod this_slot;
 pub mod thread_registry;

--- a/src/namespaces/gc/this_slot.rs
+++ b/src/namespaces/gc/this_slot.rs
@@ -1,0 +1,35 @@
+//! Thread-local `this` binding slot for plain (non-class) user functions.
+//!
+//! Quando uma fn nao-arrow plain eh chamada via `fn.call(thisArg, ...)` ou
+//! `fn.apply(thisArg, args)`, RTS nao consegue passar `this` como param real
+//! (mudaria callconv de toda user fn). Em vez disso, a runtime de Function
+//! empilha o `thisArg` neste slot antes do invoke e desempilha depois;
+//! `Expr::This` em fn plain emite call para `__RTS_FN_RT_THIS_GET`.
+//!
+//! Stack-based para suportar nesting (`a.call(x, () => b.call(y, ...))`).
+
+use std::cell::RefCell;
+
+thread_local! {
+    static THIS_STACK: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Push thisArg ao topo da pilha. Chamado pela runtime de Function antes do invoke.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_THIS_PUSH(value: i64) {
+    THIS_STACK.with(|s| s.borrow_mut().push(value));
+}
+
+/// Pop do topo. Chamado pela runtime de Function apos o invoke retornar.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_THIS_POP() {
+    THIS_STACK.with(|s| {
+        let _ = s.borrow_mut().pop();
+    });
+}
+
+/// Le topo da pilha. `0` quando nao ha `this` corrente (fn chamada direto).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_THIS_GET() -> i64 {
+    THIS_STACK.with(|s| s.borrow().last().copied().unwrap_or(0))
+}

--- a/src/namespaces/globals/function/ops.rs
+++ b/src/namespaces/globals/function/ops.rs
@@ -318,14 +318,27 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_CALL(handle: u64, this_arg: i64, args_han
 
     // Arrow ignora thisArg (lexical this). Non-arrow com has_this_param
     // (método de classe compilado com `this` como primeiro parâmetro)
-    // recebe effective_this prepended. Plain functions não têm slot de
-    // this — não prepend.
-    if !is_arrow && has_this_param {
-        let effective_this = if has_bound_this { bound_this } else { this_arg };
+    // recebe effective_this prepended.
+    let effective_this = if has_bound_this { bound_this } else { this_arg };
+    let pushed_this_slot = if !is_arrow && has_this_param {
         all_args.insert(0, effective_this);
+        false
+    } else if !is_arrow {
+        // Plain fn (nao-classe): empilha thisArg no thread-local slot
+        // pra que `Expr::This` no body leia via __RTS_FN_RT_THIS_GET.
+        crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_PUSH(effective_this);
+        true
+    } else {
+        false
+    };
+
+    let result = unsafe { invoke_typed(fn_ptr, &all_args, &param_kinds, return_kind) };
+
+    if pushed_this_slot {
+        crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_POP();
     }
 
-    unsafe { invoke_typed(fn_ptr, &all_args, &param_kinds, return_kind) }
+    result
 }
 
 /// `fn.apply(thisArg, argsArray)`. Mesmo dispatch de call.


### PR DESCRIPTION
## Summary

Resolve #449. Implementa \`this\` em user fn nao-arrow plain via slot thread-local — sem mudar callconv de nenhuma fn existente.

## Design

\`gc::this_slot\` expoe pilha thread-local com 3 simbolos extern "C":
- \`__RTS_FN_RT_THIS_PUSH(value)\`
- \`__RTS_FN_RT_THIS_POP()\`
- \`__RTS_FN_RT_THIS_GET() -> i64\`

\`__RTS_FN_GL_FUNCTION_CALL\` empilha thisArg (aplicando bound_this de bind) antes de invocar fn plain (\`!is_arrow && !has_this_param\`), desempilha depois. Metodos de classe seguem caminho antigo (this como primeiro param).

\`Expr::This\` no codegen: tenta \`read_local("this")\` primeiro (classe); se ausente, emite call para \`__RTS_FN_RT_THIS_GET\` em vez de erro.

Stack-based suporta nesting natural: \`outer.call(5)\` chamando \`inner.call(2)\` ve this=2 dentro de inner e volta a this=5 quando inner retorna.

## Validado

\`\`\`ts
function readThis(): number { return (this as any) + 0; }
readThis.call(41 as any);              // 41
readThis.apply(99 as any, [] as any);  // 99

function outer(): number { return (this as any) * 10 + readThis.call(2 as any); }
outer.call(5 as any);                  // 52 — nesting OK
\`\`\`

## Test plan

- [x] cargo test --release --lib --test-threads=1 → 84/84
- [x] Suite TS sem regressao (335/353 passed, identico a main)
- [x] Smoke test inline (call, apply, nesting)
- [ ] Reviewer: validar comportamento com bind+call (cadeia bound_this)
- [ ] Reviewer: validar comportamento em thread.spawn (slot e thread-local — workers tem stack vazia, this=0)

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)