### PR TITLE
fix(codegen): new Error() sem args nao engole stmt seguinte (#452)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -754,15 +754,20 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
                 }
             } else {
                 spec.constructor_for_arity(n_args)
+                    // Fallback: nenhum ctor com aridade exata. Pega o primeiro com
+                    // aridade >= n_args para preencher os faltantes com defaults
+                    // (e.g. `new Error()` resolve no ctor StrPtr passando ptr=0,
+                    // len=0 que `str_from_raw` trata como String::new()).
+                    .or_else(|| spec.constructors().find(|m| m.args.len() >= n_args))
             }
         }.ok_or_else(|| anyhow!("`new {}`: no constructor with {n_args} args", class_name))?;
         let sig = crate::abi::signature::lower_member(ctor);
         let mut arg_vals = Vec::new();
-        if let Some(args) = &new_expr.args {
-            for (idx, arg) in args.iter().enumerate() {
-                let expected = ctor.args[idx];
+        let provided_args = new_expr.args.as_deref().unwrap_or(&[]);
+        for (idx, expected) in ctor.args.iter().enumerate() {
+            if let Some(arg) = provided_args.get(idx) {
                 let tv = lower_expr(ctx, &arg.expr)?;
-                if expected == AbiType::StrPtr {
+                if *expected == AbiType::StrPtr {
                     // expand handle to (ptr, len)
                     let ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
                     let len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
@@ -776,6 +781,14 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
                 } else {
                     arg_vals.push(ctx.coerce_to_i64(tv).val);
                 }
+            } else if *expected == AbiType::StrPtr {
+                // Arg omitido: passa (ptr=0, len=0) — runtime trata como string vazia.
+                let zero = ctx.builder.ins().iconst(cl::I64, 0);
+                arg_vals.push(zero);
+                arg_vals.push(zero);
+            } else {
+                let zero = ctx.builder.ins().iconst(cl::I64, 0);
+                arg_vals.push(zero);
             }
         }
         let fn_ref = ctx.get_extern(ctor.symbol, &sig.params, sig.ret)?;

--- a/tests/error_empty_string.test.ts
+++ b/tests/error_empty_string.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #452: tambem cobrir new Error("") com literal vazio explicito
+// (caminho diferente: passa handle de string vazia em vez de omitir arg).
+
+const e1 = new Error("");
+print(`m1=[${e1.message}]`);
+
+// Em try/catch
+try {
+  throw new Error("");
+} catch (e) {
+  print(`m2=[${(e as Error).message}]`);
+}
+
+// Em fn user
+function fail(): void {
+  throw new TypeError("");
+}
+try {
+  fail();
+} catch (e) {
+  print(`m3=[${(e as TypeError).message}]`);
+  print(`n3=${(e as TypeError).name}`);
+}
+
+describe("error com message vazia explicita (#452)", () => {
+  test("new Error('') / throw new Error('') / TypeError('')", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "m1=[]\n" +
+      "m2=[]\n" +
+      "m3=[]\nn3=TypeError\n"
+    );
+  });
+});

--- a/tests/error_no_args.test.ts
+++ b/tests/error_no_args.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #452: ctor de Error/TypeError/etc com 0 args precisa retornar
+// instancia com message="" em vez de "absorver" a stmt seguinte.
+
+const e = new Error();
+print(`a=[${e.message}]`);
+
+const t = new TypeError();
+print(`b=[${t.message}]`);
+print(`bn=${t.name}`);
+
+const r = new RangeError();
+print(`c=[${r.message}]`);
+print(`cn=${r.name}`);
+
+const ref = new ReferenceError();
+print(`d=[${ref.message}]`);
+print(`dn=${ref.name}`);
+
+const syn = new SyntaxError();
+print(`e=[${syn.message}]`);
+print(`en=${syn.name}`);
+
+describe("error sem args (#452)", () => {
+  test("Error() => message vazia, name preservado", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "a=[]\n" +
+      "b=[]\nbn=TypeError\n" +
+      "c=[]\ncn=RangeError\n" +
+      "d=[]\ndn=ReferenceError\n" +
+      "e=[]\nen=SyntaxError\n"
+    );
+  });
+});

--- a/tests/error_no_args_chain.test.ts
+++ b/tests/error_no_args_chain.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #452: garantir que stmts apos `new Error()` sem args nao sao
+// "engolidas" (regressao original: linha sumia inteira).
+
+const before = "x";
+const e = new Error();
+const after = "y";
+
+print(before);
+print(`mid=[${e.message}]`);
+print(after);
+
+// Mesma verificacao em loop (cada iter cria um Error novo)
+for (let i = 0; i < 3; i++) {
+  const ei = new Error();
+  print(`it${i}=[${ei.message}]`);
+}
+
+// Conditional: ramo com new Error() nao deve perder stmt subsequente
+let cond = true;
+if (cond) {
+  const e2 = new Error();
+  print(`cond=[${e2.message}]`);
+  print("post-cond");
+}
+
+describe("ctor sem args nao engole stmt seguinte (#452)", () => {
+  test("sequencias antes/depois preservadas", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "x\n" +
+      "mid=[]\n" +
+      "y\n" +
+      "it0=[]\n" +
+      "it1=[]\n" +
+      "it2=[]\n" +
+      "cond=[]\n" +
+      "post-cond\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #452. \`new Error()\` (sem args) fazia o codegen falhar silenciosamente porque o ctor registrado em GLOBAL_CLASS_SPECS exige 1 arg StrPtr e o lookup por aridade exata nao encontrava match. Resultado: a stmt seguinte sumia do output.

## Fix em \`lower_new\` (calls.rs)

1. Lookup de ctor: quando nao ha aridade exata, fallback procura primeiro ctor com \`args.len() >= n_args\`.
2. Iteracao agora sobre \`ctor.args\` (nao sobre args providos). Args omitidos sao preenchidos com:
   - \`StrPtr\` → \`ptr=0, len=0\` (runtime \`str_from_raw\` ja trata como String::new())
   - outros → \`0\`

Vale para todas as Error subclasses + qualquer outro GlobalClassSpec.

## Test plan

- [x] tests/error_class.test.ts verde (antes: linha \`empty=\` sumia)
- [x] tests/error_no_args.test.ts (novo): cobre Error/TypeError/RangeError/ReferenceError/SyntaxError sem args
- [x] tests/error_empty_string.test.ts (novo): cobre \`new Error("")\` com literal explicito
- [x] tests/error_no_args_chain.test.ts (novo): garante stmts antes/depois (loop, if, sequencia) preservadas
- [x] 84/84 cargo test --lib --test-threads=1
- [x] Suite TS: 337→340 passed, 16 failed (era 17), zero regressao

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)