### PR TITLE
fix(codegen): optional chain produz 'undefined' em template literal (#432)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -389,6 +389,11 @@ pub struct FnCtx<'m, 'fb> {
     /// Usado por lower_add para liberar operandos temporários após concat.
     pub fresh_handle_set: std::collections::HashSet<cranelift_codegen::ir::Value>,
 
+    /// (#432) SSA Values que sao resultado de optional chain (`?.`) e devem
+    /// ser tratados como `undefined` quando 0. Lido por lower_tpl para
+    /// emitir "undefined" em vez de "0" no template literal.
+    pub optional_chain_values: std::collections::HashSet<cranelift_codegen::ir::Value>,
+
     /// Dedup de data sections por conteúdo: bytes → DataId já declarado.
     /// Evita criar múltiplos .Lrts_str_N com bytes idênticos quando o mesmo
     /// literal aparece mais de uma vez (dentro ou entre funções do módulo).
@@ -456,6 +461,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             fn_ref_cache: HashMap::new(),
             fn_ref_by_id_cache: HashMap::new(),
             fresh_handle_set: std::collections::HashSet::new(),
+            optional_chain_values: std::collections::HashSet::new(),
             str_data_cache: HashMap::new(),
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),

--- a/src/codegen/lower/expressions/basics.rs
+++ b/src/codegen/lower/expressions/basics.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use cranelift_codegen::ir::{InstBuilder, types as cl};
+use cranelift_codegen::ir::{InstBuilder, condcodes::IntCC, types as cl};
 use swc_ecma_ast::{Expr, Lit, Tpl, UnaryOp};
 
 use super::lower_expr;
@@ -213,7 +213,22 @@ pub(super) fn lower_tpl(ctx: &mut FnCtx, tpl: &Tpl) -> Result<TypedVal> {
             &[cl::I64, cl::I64],
             Some(cl::I64),
         )?;
-        let rhs = ctx.coerce_to_handle(val)?.val;
+        // (#432) Se o val veio de optional chain, decide em runtime:
+        // val == 0 → handle de "undefined"; senao coerce normal.
+        let is_opt_chain = ctx.optional_chain_values.contains(&val.val);
+        let rhs = if is_opt_chain {
+            let undef_h = ctx.emit_str_handle(b"undefined")?.val;
+            let val_i64 = ctx.coerce_to_i64(val).val;
+            // val_i64 != 0 → coerce_to_handle do val original; val_i64 == 0 → undef.
+            // Para evitar emitir 2 caminhos, primeiro coerce val (preserva
+            // tipo original), depois select pelo i64 truthiness.
+            let normal_h = ctx.coerce_to_handle(val)?.val;
+            let zero = ctx.builder.ins().iconst(cl::I64, 0);
+            let is_null = ctx.builder.ins().icmp(IntCC::Equal, val_i64, zero);
+            ctx.builder.ins().select(is_null, undef_h, normal_h)
+        } else {
+            ctx.coerce_to_handle(val)?.val
+        };
         let inst = ctx.builder.ins().call(concat, &[acc.val, rhs]);
         let r = ctx.builder.inst_results(inst)[0];
         ctx.register_temp_handle(r);

--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -584,6 +584,9 @@ pub(super) fn lower_opt_chain(
 
             ctx.builder.switch_to_block(merge);
             ctx.builder.seal_block(merge);
+            // (#432) Marca o result para que lower_tpl emita "undefined"
+            // em vez de "0" quando este valor cair em template literal.
+            ctx.optional_chain_values.insert(result);
             Ok(TypedVal::new(result, access_ty))
         }
         swc_ecma_ast::OptChainBase::Call(call) => {
@@ -638,6 +641,7 @@ pub(super) fn lower_opt_chain(
 
                     ctx.builder.switch_to_block(merge);
                     ctx.builder.seal_block(merge);
+                    ctx.optional_chain_values.insert(result);
                     return Ok(TypedVal::new(result, ValTy::I64));
                 }
             }
@@ -679,6 +683,7 @@ pub(super) fn lower_opt_chain(
 
             ctx.builder.switch_to_block(merge);
             ctx.builder.seal_block(merge);
+            ctx.optional_chain_values.insert(result);
             Ok(TypedVal::new(result, ValTy::I64))
         }
     }

--- a/tests/opt_chain_chained.test.ts
+++ b/tests/opt_chain_chained.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #432: cadeias `a?.b?.c` com qualquer link null curto-circuitam corretamente
+// porque o resultado intermediario eh 0 e o proximo `?.` testa == 0.
+
+const o1: { a: { b: { c: number } } } | null = null;
+print(`r1=${o1?.a?.b?.c}`);
+
+const o2: { a: { b: { c: number } } | null } = { a: null };
+print(`r2=${o2?.a?.b?.c}`);
+
+// Cadeia completa nao-null
+const o3 = { a: { b: { c: 99 } } };
+print(`r3=${o3?.a?.b?.c}`);
+
+describe("?. cadeia com null intermediario (#432)", () => {
+  test("curto-circuito em qualquer null da cadeia", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "r1=undefined\n" +
+      "r2=undefined\n" +
+      "r3=99\n"
+    );
+  });
+});

--- a/tests/opt_chain_method_call.test.ts
+++ b/tests/opt_chain_method_call.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #432: obj?.method() com obj null retorna undefined em template,
+// nao crash nem 0.
+
+class Greeter {
+  greet(): number { return 7; }
+}
+
+const g1: Greeter | null = null;
+print(`a=${g1?.greet()}`);
+
+const g2: Greeter | null = new Greeter();
+print(`b=${g2?.greet()}`);
+
+describe("obj?.method() com null receiver (#432)", () => {
+  test("null -> undefined; non-null -> retorno real", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "a=undefined\n" +
+      "b=7\n"
+    );
+  });
+});

--- a/tests/opt_chain_undefined_in_tpl.test.ts
+++ b/tests/opt_chain_undefined_in_tpl.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #432: ?.prop em obj null deve produzir "undefined" em template literal,
+// nao "0".
+
+const o1: { x: number } | null = null;
+print(`a=${o1?.x}`);
+
+// Mesma coisa em handle (sub-objeto null)
+const o2: { sub: { y: number } | null } = { sub: null };
+print(`b=${o2.sub?.y}`);
+
+// Optional indexing
+const arr: number[] | null = null;
+print(`c=${arr?.[0]}`);
+
+// Quando obj nao eh null, leitura normal
+const o3 = { x: 7 };
+print(`d=${o3?.x}`);
+
+describe("?. produz 'undefined' em template literal (#432)", () => {
+  test("null obj -> undefined; non-null -> valor real", () => {
+    expect(__rtsCapturedOutput).toBe(
+      "a=undefined\n" +
+      "b=undefined\n" +
+      "c=undefined\n" +
+      "d=7\n"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #432. \`obj?.prop\` em obj null antes virava \"0\" em template literal; agora vira \"undefined\".

## Implementacao

- \`FnCtx.optional_chain_values: HashSet<Value>\` marca Values retornados por \`lower_opt_chain\`.
- \`lower_tpl\` consulta o set e emite \`select(val == 0, handle(\"undefined\"), coerce_to_handle(val))\` em vez do coerce normal.

Cadeias \`a?.b?.c\` curto-circuitam: branch null mantem 0 (i64); proximo \`?.\` testa \`obj == 0\` e encadeia.

## Limitacao

\`fn?.()\` quando fn e arrow chamada via var local retorna 0 — bug separado em \`call_indirect\` (issue #455). Confirmado presente em main, nao introduzido aqui.

## Test plan

- [x] tests/opt_chain_undefined_in_tpl.test.ts (novo)
- [x] tests/opt_chain_chained.test.ts (novo): cadeia com null intermediario
- [x] tests/opt_chain_method_call.test.ts (novo): obj?.method() null receiver
- [x] 84/84 cargo test --lib --test-threads=1
- [x] Suite TS: 339->342 passed, 17 failed (inalterado), zero regressao

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)