### PR TITLE
fix(nodespace fs): testes stat_helpers usam path relativo (#453)

### DIFF
--- a/tests/node_fs_size_match.test.ts
+++ b/tests/node_fs_size_match.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+import {
+  writeFileSync,
+  sizeSync,
+  rmSync,
+} from "node:fs";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #453 — sizeSync deve refletir o conteudo escrito por writeFileSync,
+// inclusive em append-style overwrites de tamanhos diferentes.
+
+const PATH = "__rts_size_match.txt";
+
+writeFileSync(PATH, "hi");
+const s1 = sizeSync(PATH);
+const h1 = gc.string_from_i64(s1);
+print(h1); gc.string_free(h1);
+
+writeFileSync(PATH, "longer-content-here");
+const s2 = sizeSync(PATH);
+const h2 = gc.string_from_i64(s2);
+print(h2); gc.string_free(h2);
+
+writeFileSync(PATH, "");
+const s3 = sizeSync(PATH);
+const h3 = gc.string_from_i64(s3);
+print(h3); gc.string_free(h3);
+
+rmSync(PATH);
+
+// sizeSync de arquivo inexistente: -1
+const s4 = sizeSync(PATH);
+const h4 = gc.string_from_i64(s4);
+print(h4); gc.string_free(h4);
+
+describe("fixture:node_fs_size_match", () => {
+  test("size after write/overwrite/empty/missing", () => {
+    expect(__rtsCapturedOutput).toBe("2\n19\n0\n-1\n");
+  });
+});

--- a/tests/node_fs_stat_helpers.test.ts
+++ b/tests/node_fs_stat_helpers.test.ts
@@ -6,6 +6,7 @@ import {
   isFileSync,
   isDirectorySync,
   sizeSync,
+  rmSync,
 } from "node:fs";
 
 let __rtsCapturedOutput: string = "";
@@ -13,27 +14,33 @@ function print(value: string): void {
   __rtsCapturedOutput += value + "\n";
 }
 
-// #287 — helpers stat-like sobre rts::fs (statSync completo retornando
-// objeto Stats fica para fase 2 quando builtin/buffer/Stats wrappers
-// estiverem prontos).
+// #287 / #453 — helpers stat-like sobre rts::fs (statSync completo
+// retornando objeto Stats fica para fase 2 quando builtin/buffer/Stats
+// wrappers estiverem prontos).
+//
+// Path relativo a cwd: portavel em Linux/macOS/Windows. Caminhos
+// hardcoded em `/tmp/...` so' funcionam em Unix; em Windows o cwd-drive
+// nao tem `/tmp` por padrao.
 
-writeFileSync("/tmp/__rts_stat_helpers.txt", "hello");
+writeFileSync("__rts_stat_helpers.txt", "hello");
 
-const ex = existsSync("/tmp/__rts_stat_helpers.txt");
+const ex = existsSync("__rts_stat_helpers.txt");
 const eh = gc.string_from_static(ex ? "exists" : "no");
 print(eh); gc.string_free(eh);
 
-const isFile = isFileSync("/tmp/__rts_stat_helpers.txt");
+const isFile = isFileSync("__rts_stat_helpers.txt");
 const fh = gc.string_from_static(isFile ? "file" : "no");
 print(fh); gc.string_free(fh);
 
-const isDir = isDirectorySync("/tmp/__rts_stat_helpers.txt");
+const isDir = isDirectorySync("__rts_stat_helpers.txt");
 const dh = gc.string_from_static(isDir ? "dir" : "notdir");
 print(dh); gc.string_free(dh);
 
-const sz = sizeSync("/tmp/__rts_stat_helpers.txt");
+const sz = sizeSync("__rts_stat_helpers.txt");
 const sh = gc.string_from_i64(sz);
 print(sh); gc.string_free(sh);
+
+rmSync("__rts_stat_helpers.txt");
 
 describe("fixture:node_fs_stat_helpers", () => {
   test("exists/isFile/isDirectory/size", () => {

--- a/tests/node_fs_write_then_exists.test.ts
+++ b/tests/node_fs_write_then_exists.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+import { gc } from "rts";
+import {
+  writeFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// #453 — writeFileSync deve ser sincrono: existsSync logo depois ve o
+// arquivo. Cobre 2 variacoes: arquivo novo e sobrescrita.
+
+const PATH = "__rts_write_exists.txt";
+
+// Variacao A: cria do zero.
+writeFileSync(PATH, "abc");
+const a = existsSync(PATH);
+const ah = gc.string_from_static(a ? "yes" : "no");
+print(ah); gc.string_free(ah);
+
+// Variacao B: sobrescreve. exists continua true.
+writeFileSync(PATH, "xyz_long_content");
+const b = existsSync(PATH);
+const bh = gc.string_from_static(b ? "yes" : "no");
+print(bh); gc.string_free(bh);
+
+// Variacao C: depois de remover, exists vira false.
+rmSync(PATH);
+const c = existsSync(PATH);
+const ch = gc.string_from_static(c ? "yes" : "no");
+print(ch); gc.string_free(ch);
+
+describe("fixture:node_fs_write_then_exists", () => {
+  test("write+exists, overwrite, remove", () => {
+    expect(__rtsCapturedOutput).toBe("yes\nyes\nno\n");
+  });
+});


### PR DESCRIPTION
## Summary

- `tests/node_fs_stat_helpers.test.ts` falhava em Windows porque o path hardcoded `/tmp/__rts_stat_helpers.txt` resolve para `<drive>:\tmp\...` no drive corrente (cwd em `E:\rts` => `E:\tmp\...`), que nao existe. `writeFileSync` retornava -1 silenciosamente; `existsSync` ficava `false` e `sizeSync` `-1`. Em Linux/macOS o teste passava porque `/tmp` sempre existe.
- Trocado para path relativo (`__rts_stat_helpers.txt`) com cleanup via `rmSync` no fim. Portavel em qualquer plataforma sem depender do filesystem do host.
- Acrescentado 2 testes nao-genericos cobrindo variacoes (`node_fs_write_then_exists`, `node_fs_size_match`) — sobrescrita, conteudo vazio, arquivo inexistente, sequencia write/exists/remove.

Closes #453

## Test plan

- [x] target/release/rts.exe test tests/node_fs_stat_helpers.test.ts verde
- [x] target/release/rts.exe test tests/node_fs_write_then_exists.test.ts verde
- [x] target/release/rts.exe test tests/node_fs_size_match.test.ts verde
- [x] Suite completa: 12 falhas (vs baseline 14 em main) — zero regressao, 2 testes a mais passando

Generated with Claude Code