### PR TITLE
fix(codegen): thread.spawn(fp, f64) preserva bit pattern via bitcast

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -2769,10 +2769,31 @@ fn lower_ns_call_body(
                 // entao fcvt_to_uint_sat recupera o inteiro original.
                 // Bitcast daria o bit-pattern IEEE 754, que e' um valor
                 // completamente diferente — causaria handles invalidos.
-                // Nota: thread.spawn(fp, 3.14) nao passa float cru por
-                // U64; o worker recebe i64 e usa f64::from_bits explicitamente.
+                //
+                // Excecao (#435): `thread.spawn*(fp, arg)` — quando o
+                // worker pede `arg: number` (f64), o lifter cria
+                // trampolim com param `__rts_spawn_arg_f64` que faz
+                // bitcast i64→f64 ao receber. Nesse caso o caller deve
+                // passar os BITS do f64, nao a conversao numerica.
+                // Detectado pelo simbolo do membro (todas variantes
+                // de spawn que aceitam fn_ptr+arg).
+                let is_spawn_arg = matches!(
+                    member.symbol,
+                    "__RTS_FN_NS_THREAD_SPAWN"
+                    | "__RTS_FN_NS_THREAD_SPAWN_ASYNC"
+                    | "__RTS_FN_NS_THREAD_SPAWN_ASYNC_JOIN"
+                    | "__RTS_FN_NS_THREAD_SPAWN_DETACHED"
+                    | "__RTS_FN_NS_THREAD_SPAWN_WITH_UD"
+                ) && values.len() == 1; // segundo arg = `arg` (apos fn_ptr)
                 let tv = lower_expr(ctx, &arg.expr)?;
                 let v = match tv.ty {
+                    crate::codegen::lower::ctx::ValTy::F64 if is_spawn_arg => {
+                        ctx.builder.ins().bitcast(
+                            cl::I64,
+                            cranelift_codegen::ir::MemFlags::new(),
+                            tv.val,
+                        )
+                    }
                     crate::codegen::lower::ctx::ValTy::F64 => {
                         ctx.builder.ins().fcvt_to_uint_sat(cl::I64, tv.val)
                     }

--- a/tests/thread_arg_f64_edge.test.ts
+++ b/tests/thread_arg_f64_edge.test.ts
@@ -1,0 +1,50 @@
+// Edge cases f64 em thread.spawn(fp, N) — #435.
+// NaN, Infinity, -0.0, fracao com magnitude que cabe em i32.
+import { describe, test, expect } from "rts:test";
+import { thread, atomic } from "rts";
+
+const slot = atomic.f64_new(0.0);
+
+function workerStore(arg: number): void {
+  atomic.f64_store(slot, arg);
+}
+
+// -0.0 — bit pattern distinto de +0.0 (sign bit set). Fcvt perderia.
+atomic.f64_store(slot, 1.0);
+const fpA = getPointer(workerStore);
+const tA = thread.spawn(fpA, -0.0);
+thread.join(tA);
+const gotNegZero = atomic.f64_load(slot);
+// 1.0 / -0.0 = -Infinity ; 1.0 / +0.0 = +Infinity
+const negZeroOk = (1.0 / gotNegZero) < 0.0;
+
+// Fracao pequena com parte inteira que cabe em i32 — caso classico
+// onde fcvt_to_uint_sat truncaria pra 42, perdendo .5
+atomic.f64_store(slot, 0.0);
+const tB = thread.spawn(fpA, 42.5);
+thread.join(tB);
+const got42_5 = atomic.f64_load(slot);
+
+// Infinity — bit pattern 0x7FF0000000000000 ; fcvt_to_uint_sat saturaria
+// pra u64::MAX, perdendo a representacao IEEE.
+atomic.f64_store(slot, 0.0);
+const inf = 1.0 / 0.0;
+const tC = thread.spawn(fpA, inf);
+thread.join(tC);
+const gotInf = atomic.f64_load(slot);
+const infOk = gotInf > 1e300; // Infinity > qualquer finito
+
+describe("fixture:thread_arg_f64_edge", () => {
+  test("spawn(fp, -0.0) preserva sign bit (1/x = -Infinity)", () => {
+    expect(negZeroOk ? "1" : "0").toBe("1");
+  });
+
+  test("spawn(fp, 42.5) preserva fracao mesmo com parte inteira pequena", () => {
+    const close = got42_5 > 42.499 && got42_5 < 42.501;
+    expect(close ? "1" : "0").toBe("1");
+  });
+
+  test("spawn(fp, Infinity) preserva bit pattern de Infinity", () => {
+    expect(infOk ? "1" : "0").toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary

- Em `thread.spawn*(fp, arg)` quando o worker pede `arg: number` (f64), o lifter ja' criava um trampolim com param `__rts_spawn_arg_f64` que faz bitcast i64->f64 ao receber. Mas o **call site** em `lower_ns_call_body` (path `AbiType::U64`) chamava `fcvt_to_uint_sat` no f64 — truncando 3.14 para 3 antes mesmo de chegar na thread.
- Fix: detectar simbolos de spawn (`SPAWN`, `SPAWN_ASYNC`, `SPAWN_ASYNC_JOIN`, `SPAWN_DETACHED`, `SPAWN_WITH_UD`) e, no segundo argumento (apos `fn_ptr`), emitir `bitcast` f64->i64 dos bits IEEE 754. Worker recebe via bitcast inverso ja' existente.
- Adicionados 3 edge cases novos (`tests/thread_arg_f64_edge.test.ts`): `-0.0` (sign bit), `42.5` (fracao com parte inteira pequena), `Infinity` (bit pattern saturante).

Closes #435

## Test plan
- [x] `target/release/rts.exe test tests/thread_arg_f64.test.ts` - 3/3 passa
- [x] `target/release/rts.exe test tests/thread_arg_f64_edge.test.ts` - 3/3 passa
- [x] Suite completa: zero regressao vs main (mesmas 10 falhas pre-existentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)