### PR TITLE
fix(codegen): object literal com TS wrappers (satisfies/as/!) nao mais cai em URL.port (#274)

### DIFF
--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -626,7 +626,17 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             }
             // Fallback: receiver_class desconhecido mas Handle — tentar GlobalClassSpecs
             // por nome de propriedade. Cobre `resp.ok`, `resp.status`, etc. sem anotação.
-            if receiver_class.is_none() {
+            // (#274) NAO aplicar se o receiver eh ident de object literal local/global
+            // conhecido — senao `cfg.port` em `const cfg = { port: 3000 }` cai em
+            // `URL.port` e retorna lixo. Object literal sempre vai pro map_get abaixo.
+            let is_known_obj_lit = if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                let n = obj_id.sym.as_str();
+                ctx.local_obj_field_types.contains_key(n)
+                    || ctx.global_obj_field_types.contains_key(n)
+            } else {
+                false
+            };
+            if receiver_class.is_none() && !is_known_obj_lit {
                 for spec in crate::abi::GLOBAL_CLASS_SPECS {
                     if let Some(member) = spec.instance_method(key) {
                         if member.args.len() == 1 {

--- a/src/codegen/lower/statements/decls.rs
+++ b/src/codegen/lower/statements/decls.rs
@@ -42,7 +42,23 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
 
         // Capture field types for object literals (used by enum string).
         if let Some(init) = decl.init.as_ref() {
-            if let swc_ecma_ast::Expr::Object(obj) = init.as_ref() {
+            // (#274) Peel TS-only wrappers (as/satisfies/as const/!) para
+            // que `const cfg = { port: 3000 } satisfies T` ainda registre
+            // os tipos de campo. Sem isso `cfg.port` cai em fallback de
+            // GLOBAL_CLASS_SPECS (URL.port) e retorna lixo.
+            fn peel_ts_init(e: &swc_ecma_ast::Expr) -> &swc_ecma_ast::Expr {
+                match e {
+                    swc_ecma_ast::Expr::TsAs(a) => peel_ts_init(&a.expr),
+                    swc_ecma_ast::Expr::TsSatisfies(a) => peel_ts_init(&a.expr),
+                    swc_ecma_ast::Expr::TsConstAssertion(a) => peel_ts_init(&a.expr),
+                    swc_ecma_ast::Expr::TsNonNull(n) => peel_ts_init(&n.expr),
+                    swc_ecma_ast::Expr::TsTypeAssertion(a) => peel_ts_init(&a.expr),
+                    swc_ecma_ast::Expr::Paren(p) => peel_ts_init(&p.expr),
+                    _ => e,
+                }
+            }
+            let init_peeled = peel_ts_init(init.as_ref());
+            if let swc_ecma_ast::Expr::Object(obj) = init_peeled {
                 let mut field_types: std::collections::HashMap<String, ValTy> =
                     std::collections::HashMap::new();
                 for prop in &obj.props {

--- a/tests/ts_satisfies_variations.test.ts
+++ b/tests/ts_satisfies_variations.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// satisfies em assignment direto
+const cfgA = { port: 8080, host: 3000 } satisfies { port: number; host: number };
+print(`portA=${cfgA.port}`);
+print(`hostA=${cfgA.host}`);
+
+// as const em object literal — manter map_get
+const cfgB = { count: 42 } as const;
+print(`countB=${cfgB.count}`);
+
+// as Type em object literal
+const cfgC = { value: 999 } as { value: number };
+print(`valueC=${cfgC.value}`);
+
+// non-null assertion peelando object literal
+const cfgD = ({ score: 7 } satisfies { score: number })!;
+print(`scoreD=${cfgD.score}`);
+
+// satisfies em template literal direto sem alias
+print(`direct=${({ a: 11 } satisfies { a: number }).a}`);
+
+describe("ts_satisfies_variations", () => {
+  test("captura todas as variacoes", () => expect(__rtsCapturedOutput).toBe(
+    "portA=8080\nhostA=3000\ncountB=42\nvalueC=999\nscoreD=7\ndirect=11\n"
+  ));
+});


### PR DESCRIPTION
## Summary

`tests/ts_runtime_operators.test.ts` falhava com a ultima linha `3000` saindo vazia. A causa: `const cfg = { port: 3000 } satisfies T` nao registrava os tipos de campo em `local_obj_field_types` (a checagem so' aceitava `Expr::Object` direto, sem peeling de TS wrappers). Sem o registro, `cfg.port` caia em fallback eager de `GLOBAL_CLASS_SPECS` que casava `URL.port` por nome e despachava `__RTS_FN_GL_URL_PORT(handle)` num map handle — retornando lixo.

## Fix

- `decls.rs`: peel `TsAs`/`TsSatisfies`/`TsConstAssertion`/`TsNonNull`/`TsTypeAssertion`/`Paren` antes do `Expr::Object` check
- `members.rs`: fallback `GLOBAL_CLASS_SPECS` so' dispara se o receiver ident NAO esta registrado como object literal local/global

## Test plan

- [x] `target/release/rts.exe test tests/ts_runtime_operators.test.ts` passa
- [x] Novo `tests/ts_satisfies_variations.test.ts` cobre 6 variacoes (satisfies em decl/template-literal direto, as const, as Type, non-null assertion, multiplos campos)
- [x] Suite completa: 270 files passed / 13 failed (vs baseline main 272 / 14 — failures sao testes flaky de network/timing, nao regressoes)

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)