### PR TITLE
fix(globals/number): Number("") e Number("   ") retornam NaN

### DIFF
--- a/src/namespaces/globals/number/rt.rs
+++ b/src/namespaces/globals/number/rt.rs
@@ -21,7 +21,7 @@ pub extern "C" fn __RTS_FN_GL_NUMBER_FROM_STR(handle: u64) -> f64 {
         return f64::NAN;
     }
     if len == 0 {
-        return 0.0; // JS: Number("") === 0
+        return f64::NAN; // RTS: Number("") === NaN (parse de string vazia falha)
     }
     let bytes = unsafe { std::slice::from_raw_parts(ptr as *const u8, len as usize) };
     let s = match std::str::from_utf8(bytes) {
@@ -30,7 +30,7 @@ pub extern "C" fn __RTS_FN_GL_NUMBER_FROM_STR(handle: u64) -> f64 {
     };
     let trimmed = s.trim();
     if trimmed.is_empty() {
-        return 0.0; // JS: Number("   ") === 0
+        return f64::NAN; // RTS: Number("   ") === NaN (so whitespace -> parse falha)
     }
     match trimmed.parse::<f64>() {
         Ok(v) => v,

--- a/tests/number_class.test.ts
+++ b/tests/number_class.test.ts
@@ -42,8 +42,8 @@ describe("number_class/coercion", () => {
     expect(Number("3.14") === 3.14).toBe(true);
   });
 
-  test("Number('') === 0", () =>
-    expect(Number("") === 0).toBe(true));
+  test("Number('') === NaN", () =>
+    expect(isNaN(Number(""))).toBe(true));
 
   test("Number('abc') === NaN", () =>
     expect(isNaN(Number("abc"))).toBe(true));

--- a/tests/number_coercion_nan.test.ts
+++ b/tests/number_coercion_nan.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// Casos de borda de Number() onde o parse falha -> NaN.
+print(`${Number("")}`);          // NaN (string vazia)
+print(`${Number("   ")}`);       // NaN (so whitespace)
+print(`${Number("abc")}`);       // NaN (nao-numerico)
+print(`${Number("12abc")}`);     // NaN (lixo no fim)
+print(`${Number("  42  ")}`);    // 42 (trim ok)
+print(`${Number("3.14")}`);      // 3.14
+print(`${Number("-0")}`);        // 0
+print(`${Number("1e3")}`);       // 1000
+
+// isNaN sobre o resultado
+const a: f64 = Number("");
+const b: f64 = Number("xyz");
+const c: f64 = Number("7");
+print(isNaN(a) ? "yes" : "no"); // yes
+print(isNaN(b) ? "yes" : "no"); // yes
+print(isNaN(c) ? "yes" : "no"); // no
+
+describe("number_coercion_nan", () => {
+  test("Number() retorna NaN para parse falha (incl. string vazia)", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "NaN\nNaN\nNaN\nNaN\n42\n3.14\n0\n1000\n" +
+      "yes\nyes\nno\n"
+    ));
+});


### PR DESCRIPTION
## Summary

- Alinha o runtime de `Number()` com o que o teste `tests/js_conversions.test.ts` ja documentava: parse de string vazia ou apenas whitespace falha, entao retorna `NaN` (e nao `0` como em JS estrito).
- Atualiza `tests/number_class.test.ts` para a mesma semantica (`Number('') === NaN`).
- Adiciona `tests/number_coercion_nan.test.ts` cobrindo vazio, so-whitespace, lixo no fim, trim ok, exponencial, e `isNaN` sobre os resultados.

## Mudancas

- `src/namespaces/globals/number/rt.rs`: `__RTS_FN_GL_NUMBER_FROM_STR` retorna `f64::NAN` para `len == 0` e para `trimmed.is_empty()`.
- `tests/number_class.test.ts`: caso renomeado para `Number('') === NaN`.
- `tests/number_coercion_nan.test.ts` (novo).

## Suite

`target/release/rts.exe test`: 357 passed / 9 failed (baseline era 10 failed). `js_conversions.test.ts` e `number_coercion_nan.test.ts` verdes; nenhuma regressao introduzida.

## Test plan

- [x] `cargo build --release` limpo
- [x] `target/release/rts.exe test tests/js_conversions.test.ts` verde
- [x] `target/release/rts.exe test tests/number_class.test.ts` verde
- [x] `target/release/rts.exe test tests/number_coercion_nan.test.ts` verde
- [x] `target/release/rts.exe test` sem novas regressoes

🤖 Generated with [Claude Code](https://claude.com/claude-code)