### PR TITLE
feat(function): fn.prototype lazy alloc + GC tracing transitivo (#264 PR1)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -357,6 +357,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_FUNCTION_NAME", __RTS_FN_GL_FUNCTION_NAME);
     add_fn!("__RTS_FN_GL_FUNCTION_LENGTH", __RTS_FN_GL_FUNCTION_LENGTH);
     add_fn!("__RTS_FN_GL_FUNCTION_TO_STRING", __RTS_FN_GL_FUNCTION_TO_STRING);
+    add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_GET", __RTS_FN_GL_FUNCTION_PROTOTYPE_GET);
 
     // ── namespaces::globals::text_encoding ───────────────────────────
     use crate::namespaces::globals::text_encoding::instance::*;

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -365,6 +365,17 @@ fn lower_user_fn_getter(
             let v = ctx.builder.inst_results(inst)[0];
             Ok(TypedVal::new(v, ValTy::I64))
         }
+        "prototype" => {
+            // (#264) Lazy alloc handle de Map para o constructor.
+            let getter = ctx.get_extern(
+                "__RTS_FN_GL_FUNCTION_PROTOTYPE_GET",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(getter, &[fn_handle]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(TypedVal::new(v, ValTy::Handle))
+        }
         _ => Err(anyhow!("user_fn_getter: prop {} nao suportado", prop)),
     }
 }
@@ -482,7 +493,7 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
     if let (Expr::Ident(obj_id), MemberProp::Ident(prop)) = (m.obj.as_ref(), &m.prop) {
         let obj_name = obj_id.sym.as_str();
         let prop_name = prop.sym.as_str();
-        if matches!(prop_name, "name" | "length")
+        if matches!(prop_name, "name" | "length" | "prototype")
             && ctx.user_fns.contains_key(obj_name)
             && ctx.var_ty(obj_name).is_none()
         {

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -192,6 +192,11 @@ pub struct FunctionData {
     /// Send mas nao Sync, e Entry precisa ser Sync pra atravessar shards.
     /// Nunca destravado em runtime — overhead zero no hot path.
     pub keep_alive: Option<std::sync::Arc<std::sync::Mutex<dyn std::any::Any + Send>>>,
+    /// (#264) Handle do object usado como `fn.prototype` (constructor function).
+    /// 0 = ainda nao alocado. Lazy alloc no primeiro acesso a member `prototype`
+    /// via `__RTS_FN_GL_FUNCTION_PROTOTYPE_GET`. Eh um Map handle (collections)
+    /// onde callers fazem `fn.prototype.method = handle`.
+    pub prototype_handle: u64,
 }
 
 /// Cleanup ativo de recursos do SO quando um Entry e' descartado (#279).
@@ -223,6 +228,10 @@ fn cleanup_entry(entry: &mut Entry) {
         Entry::TlsClient(tls) => {
             let _ = tls.tcp.shutdown(std::net::Shutdown::Both);
         }
+        // Nota (#264): Entry::Function.prototype_handle nao precisa de
+        // cleanup explicito aqui — o GC scanner via mark_handle propaga
+        // marca transitiva, entao o Map prototype eh coletado no proximo
+        // sweep depois que a Function for coletada.
         _ => {}
     }
 }
@@ -430,9 +439,13 @@ impl HandleTable {
     }
 
     /// Mark a handle as reachable (GC root). No-op for invalid/freed handles.
-    pub fn mark(&mut self, handle: u64) {
-        let Some((expected_gen, _, table_slot)) = decode(handle) else { return };
-        let Some(slot) = self.slots.get_mut(table_slot as usize) else { return };
+    /// Returns Some(prototype_handle) quando a entry eh Function com prototype
+    /// alocado — caller (mark_handle global) propaga marca transitiva para
+    /// o Map de prototype, evitando que sweep colete o Map enquanto a
+    /// Function viva continua referenciando.
+    pub fn mark(&mut self, handle: u64) -> Option<u64> {
+        let Some((expected_gen, _, table_slot)) = decode(handle) else { return None };
+        let Some(slot) = self.slots.get_mut(table_slot as usize) else { return None };
         if slot.generation == expected_gen && !matches!(slot.entry, Entry::Free) {
             if super::debug::is_enabled()
                 && matches!(slot.entry, Entry::TcpListener(_) | Entry::TcpStream(_))
@@ -440,7 +453,14 @@ impl HandleTable {
                 eprintln!("[gc] MARK handle={handle:#x} slot={table_slot} kind=Tcp*");
             }
             slot.marked = true;
+            // (#264) Tracing transitivo minimo: prototype Map de Function.
+            if let Entry::Function(d) = &slot.entry {
+                if d.prototype_handle != 0 {
+                    return Some(d.prototype_handle);
+                }
+            }
         }
+        None
     }
 
     /// Sweep: free all unmarked live entries, then reset all mark bits.
@@ -571,14 +591,28 @@ pub fn alloc_entry(entry: Entry) -> u64 {
 }
 
 /// Mark a handle as reachable in the current GC cycle.
+/// Propaga marca transitivamente para handles internos relevantes
+/// (ex: Function.prototype_handle, ver #264).
 pub fn mark_handle(handle: u64) {
-    if handle == 0 {
-        return;
+    let mut worklist = vec![handle];
+    let mut depth = 0u32;
+    while let Some(h) = worklist.pop() {
+        if h == 0 {
+            continue;
+        }
+        // Guard contra ciclos pathologicos (limite generoso).
+        depth += 1;
+        if depth > 10_000 {
+            break;
+        }
+        let transitive = shard_for_handle(h)
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .mark(h);
+        if let Some(child) = transitive {
+            worklist.push(child);
+        }
     }
-    shard_for_handle(handle)
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .mark(handle);
 }
 
 /// Sweep all shards: free unmarked entries and reset mark bits.

--- a/src/namespaces/globals/function/abi.rs
+++ b/src/namespaces/globals/function/abi.rs
@@ -85,6 +85,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: true,
     },
+    NamespaceMember {
+        name: "prototype",
+        kind: MemberKind::InstanceGetter,
+        symbol: "__RTS_FN_GL_FUNCTION_PROTOTYPE_GET",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "fn.prototype — Map handle anexo a constructor function (lazy alloc).",
+        ts_signature: "prototype: any",
+        intrinsic: None,
+        pure: false,
+    },
 ];
 
 pub const FUNCTION_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {

--- a/src/namespaces/globals/function/ops.rs
+++ b/src/namespaces/globals/function/ops.rs
@@ -4,7 +4,7 @@
 //! por aridade ate 8. Funciona porque user fns com address taken usam
 //! default_call_conv (SystemV/Win64), igual extern "C" Rust.
 
-use crate::namespaces::gc::handles::{Entry, FunctionData, alloc_entry, with_entry};
+use crate::namespaces::gc::handles::{Entry, FunctionData, alloc_entry, with_entry, with_entry_mut};
 
 unsafe fn invoke_n(fn_ptr: u64, args: &[i64]) -> i64 {
     unsafe { invoke_typed(fn_ptr, args, &[], 0) }
@@ -249,6 +249,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED(
         return_kind: return_kind.clamp(0, 4) as u8,
         source: None,
         keep_alive: None,
+        prototype_handle: 0,
     })))
 }
 
@@ -301,6 +302,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_NEW(params_handle: u64, body_handle: u64)
         return_kind: 0,
         source: Some(format!("function anonymous({}) {{\n{}\n}}", params_str, body_str).into_boxed_str()),
         keep_alive: Some(compiled.keep_alive),
+        prototype_handle: 0,
     })))
 }
 
@@ -402,7 +404,50 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_BIND(handle: u64, this_arg: i64, args_han
         return_kind,
         source,
         keep_alive,
+        prototype_handle: 0,
     })))
+}
+
+/// (#264) Lazy-aloca e retorna o handle de `fn.prototype`.
+/// Constructor functions usam isto pra anexar metodos compartilhados.
+/// Primeiro acesso aloca um Map vazio; chamadas subsequentes retornam o mesmo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FUNCTION_PROTOTYPE_GET(handle: u64) -> u64 {
+    // Tenta ler primeiro (caminho rapido — ja alocado).
+    let existing = with_entry(handle, |e| {
+        if let Some(Entry::Function(d)) = e {
+            Some(d.prototype_handle)
+        } else {
+            None
+        }
+    });
+    match existing {
+        Some(h) if h != 0 => return h,
+        Some(_) => {}  // existe a Function mas prototype eh 0 — alocar
+        None => return 0, // handle invalido ou nao e' Function
+    }
+    // Aloca novo Map vazio. Map handle precisa ser alocado FORA do
+    // with_entry_mut porque alloc_entry pode chamar shard locks.
+    let new_proto = crate::namespaces::collections::map::__RTS_FN_NS_COLLECTIONS_MAP_NEW();
+    // Atualiza o slot. Outra thread podera ter alocado entre a leitura e o
+    // write — nesse caso descarta o nosso (race benigna; libera o duplicado).
+    let final_h = with_entry_mut(handle, |e| {
+        if let Some(Entry::Function(d)) = e {
+            if d.prototype_handle != 0 {
+                d.prototype_handle
+            } else {
+                d.prototype_handle = new_proto;
+                new_proto
+            }
+        } else {
+            0
+        }
+    });
+    if final_h != new_proto {
+        // outra thread venceu — libera nosso
+        let _ = crate::namespaces::gc::handles::free_handle(new_proto);
+    }
+    final_h
 }
 
 #[unsafe(no_mangle)]

--- a/tests/fn_prototype_distinct.test.ts
+++ b/tests/fn_prototype_distinct.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR1) Cada user fn tem seu proprio prototype Map distinto.
+
+function Animal(): void {}
+function Plant(): void {}
+
+const a: number = Animal.prototype as any;
+const p: number = Plant.prototype as any;
+
+print("distinct=" + (a !== p));
+print("a_nonzero=" + (a !== 0));
+print("p_nonzero=" + (p !== 0));
+
+describe("prototype distinto por fn (#264 PR1)", () => {
+  test("Animal.prototype != Plant.prototype, ambos non-zero", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "distinct=true\n" +
+      "a_nonzero=true\n" +
+      "p_nonzero=true\n"
+    ));
+});

--- a/tests/fn_prototype_lazy.test.ts
+++ b/tests/fn_prototype_lazy.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR1) fn.prototype eh lazy-alocado como Map handle.
+// Acessos repetidos retornam handle nao-zero.
+
+function Animal(): void {}
+
+const p1: number = Animal.prototype as any;
+
+print("p1_nonzero=" + (p1 !== 0));
+
+describe("fn.prototype lazy alloc (#264 PR1)", () => {
+  test("retorna handle nao-zero", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "p1_nonzero=true\n"
+    ));
+});


### PR DESCRIPTION
## Summary

Primeiro de 5 PRs para resolver #264 (prototype chain). Estabelece a fundacao: constructor functions ganham \`fn.prototype\` Map handle lazy-alocado.

## Mudancas

- \`FunctionData.prototype_handle: u64\` (default 0).
- \`__RTS_FN_GL_FUNCTION_PROTOTYPE_GET\`: extern \"C\" lazy-aloca Map no primeiro acesso, race-safe via \`with_entry_mut\`.
- ABI registra \`prototype\` como \`InstanceGetter\`; codegen \`lower_user_fn_getter\` reconhece junto com \`name\`/\`length\`.
- **GC tracing transitivo**: \`mark\` retorna handle filho; \`mark_handle\` global usa worklist iterativo. Quando marca Function com prototype, marca o Map tambem — evita sweep coletar o Map enquanto Function viva.

## Sim, eh gerido pelo GC

Resposta direta a pergunta levantada: o Map alocado eh tracked. Quando a Function morre, o Map prototype morre no proximo ciclo (sem cleanup explicito; GC sweep faz isso naturalmente).

## Test plan

- tests/fn_prototype_lazy.test.ts (novo)
- tests/fn_prototype_distinct.test.ts (novo)
- 84/84 cargo test --lib --test-threads=1
- Suite TS: 364→366 passed, 8 failed inalterado, zero regressao

## Limitacoes (proximos PRs)

- PR 2: \`Animal.prototype.method = fn\` (assignment em member chain)
- PR 3: \`new Animal(name)\` em user fn nao-classe
- PR 4: \`Object.create\` + chain walk em member read
- PR 5: \`hasOwnProperty\`, \`instanceof\`

Refs #264 (PR 1 de 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)