### PR TITLE
fix(parser): arrow lift propaga return type da binding ann (#455)

### DIFF
--- a/src/parser/lowering_items.rs
+++ b/src/parser/lowering_items.rs
@@ -216,7 +216,18 @@ fn try_lower_fn_expr_decl(cm: &Lrc<SourceMap>, var_decl: &VarDecl, out: &mut Vec
                 pending.push(lower_function(cm, &name, &function, span));
             }
             Expr::Arrow(arrow) => {
-                let synthetic = arrow_to_function(arrow);
+                let mut synthetic = arrow_to_function(arrow);
+                // (#455) Quando a binding tem annotation `() => T` mas o arrow
+                // nao tem `: T` proprio, propaga o return type. Sem isto,
+                // codegen inferia `i64` por heuristica e `fn()` retornava 0
+                // pra arrows que retornam f64.
+                if synthetic.return_type.is_none() {
+                    if let Some(ann) = &binding.type_ann {
+                        if let Some(ret) = extract_fn_return_type_ann(&ann.type_ann) {
+                            synthetic.return_type = Some(ret);
+                        }
+                    }
+                }
                 pending.push(lower_function(cm, &name, &synthetic, arrow.span));
             }
             _ => return false,
@@ -226,6 +237,25 @@ fn try_lower_fn_expr_decl(cm: &Lrc<SourceMap>, var_decl: &VarDecl, out: &mut Vec
         out.push(Item::Function(fn_decl));
     }
     true
+}
+
+/// (#455) Extrai o return type annotation de uma TS function type
+/// (\`() => T\` ou \`(x) => T\`). Retorna `Some(Box<TsTypeAnn>)` que
+/// pode ser plugado no \`SwcFunction.return_type\` do arrow synthetic.
+fn extract_fn_return_type_ann(ts_type: &swc_ecma_ast::TsType) -> Option<Box<swc_ecma_ast::TsTypeAnn>> {
+    use swc_ecma_ast::{TsFnOrConstructorType, TsType, TsUnionOrIntersectionType};
+    match ts_type {
+        TsType::TsFnOrConstructorType(TsFnOrConstructorType::TsFnType(fn_type)) => {
+            Some(fn_type.type_ann.clone())
+        }
+        // `(() => T) | null` ou `(() => T) | undefined` — extrai o primeiro
+        // TsFnType da uniao.
+        TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(u)) => {
+            u.types.iter().find_map(|t| extract_fn_return_type_ann(t))
+        }
+        TsType::TsParenthesizedType(inner) => extract_fn_return_type_ann(&inner.type_ann),
+        _ => None,
+    }
 }
 
 /// Builds a `swc_ecma_ast::Function` from an `ArrowExpr` so it can flow

--- a/tests/arrow_var_with_type_ann.test.ts
+++ b/tests/arrow_var_with_type_ann.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#455) Antes: arrow chamada via var local com return type number retornava 0
+// porque a annotation `: () => number` na binding nao propagava para o
+// arrow lifted. Agora propaga.
+
+// 1. Annotation simples `() => number`
+const f1: () => number = () => 42;
+print("a=" + f1());
+
+// 2. Com param: `(x: number) => number`
+const f2: (x: number) => number = (x) => x * 2;
+print("b=" + f2(7));
+
+// 3. Union com null: `(() => number) | null`
+const f3: (() => number) | null = () => 99;
+print("c=" + (f3 === null ? -1 : f3()));
+
+// 4. Union dentro de paren: `((() => number)) | undefined`
+const f4: (() => number) | undefined = () => 100;
+print("d=" + (f4 === undefined ? -1 : f4()));
+
+// 5. Arrow com annotation propria continua funcionando
+const f5: () => number = (): number => 7;
+print("e=" + f5());
+
+describe("arrow via var com type ann (#455)", () => {
+  test("propaga return type da binding pro arrow lifted", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "a=42\n" +
+      "b=14\n" +
+      "c=99\n" +
+      "d=100\n" +
+      "e=7\n"
+    ));
+});


### PR DESCRIPTION
## Summary

Resolve #455. \`const fn: () => number = () => 42\` virava \`Item::Function\` com \`return_type=None\` porque a annotation estava na binding, nao no arrow. Codegen inferia i64 e \`fn()\` retornava 0.

## Fix

\`try_lower_fn_expr_decl\` agora propaga o return type via novo helper \`extract_fn_return_type_ann\`:
- TsFnType direto: extrai \`type_ann\`.
- TsUnionType: recursa no primeiro TsFnType encontrado (cobre \`(() => T) | null\`).
- TsParenthesizedType: peel.

## Test plan

- [x] tests/arrow_var_with_type_ann.test.ts (novo): 5 variacoes
- [x] tests/optional_chain_null_guard.test.ts agora verde (estava bloqueado neste bug)
- [x] 84/84 cargo test --lib --test-threads=1
- [x] Suite TS: 366→367 passed, 8→7 failed, zero regressao

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)