### PR TITLE
feat(codegen): new UserFn(args) cria Map+this binding (#264 PR3)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -711,7 +711,20 @@ fn collect_method_overrides(ctx: &FnCtx, base: &str, method: &str) -> Vec<(Strin
 }
 
 pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Result<TypedVal> {
-    let class_name = match new_expr.callee.as_ref() {
+    // (#264) Peel TsAs/Paren etc para suportar `new (Animal as any)(...)`.
+    let mut callee_expr: &Expr = new_expr.callee.as_ref();
+    loop {
+        match callee_expr {
+            Expr::TsAs(a) => callee_expr = &a.expr,
+            Expr::TsTypeAssertion(a) => callee_expr = &a.expr,
+            Expr::TsConstAssertion(a) => callee_expr = &a.expr,
+            Expr::TsSatisfies(a) => callee_expr = &a.expr,
+            Expr::TsNonNull(a) => callee_expr = &a.expr,
+            Expr::Paren(p) => callee_expr = &p.expr,
+            _ => break,
+        }
+    }
+    let class_name = match callee_expr {
         Expr::Ident(id) => id.sym.as_str().to_string(),
         _ => {
             return Err(anyhow!(
@@ -871,6 +884,55 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
         ctx.builder.ins().call(set_fn, &[h, msg_kp, msg_kl, msg_handle]);
 
         return Ok(TypedVal::new(h, ValTy::Handle));
+    }
+
+    // (#264 PR3) Constructor function: `new Animal(name)` quando Animal eh
+    // user fn nao-classe. Aloca Map (instance), empilha como `this` no slot
+    // thread-local, chama Animal(args), desempilha. Retorna o Map handle.
+    //
+    // Limitacao desta PR: nao instala __proto__ chain — `instance.method()`
+    // ainda nao acha methods em Animal.prototype.method (PR 4 cobre).
+    // Mas `this.field = v` no body do constructor ja persiste no Map
+    // (assignment usa MAP_SET sobre o handle do `this`).
+    if !ctx.classes.contains_key(&class_name)
+        && ctx.user_fns.contains_key(&class_name)
+    {
+        // 1. Aloca Map vazio (instance).
+        let map_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_MAP_NEW", &[], Some(cl::I64))?;
+        let inst = ctx.builder.ins().call(map_new, &[]);
+        let inst_h = ctx.builder.inst_results(inst)[0];
+
+        // 2. Push this slot (thread-local, usado por `Expr::This` no body).
+        let push_fn = ctx.get_extern(
+            "__RTS_FN_RT_THIS_PUSH",
+            &[cl::I64],
+            None,
+        )?;
+        ctx.builder.ins().call(push_fn, &[inst_h]);
+
+        // 3. Chama a user fn como call direto. Args sao os do new_expr.
+        // Reusa o caminho de chamada normal sintetizando um CallExpr.
+        let synthetic_callee = Box::new(Expr::Ident(swc_ecma_ast::Ident::new(
+            class_name.as_str().into(),
+            new_expr.span,
+            new_expr.ctxt,
+        )));
+        let synthetic_args = new_expr.args.clone().unwrap_or_default();
+        let synthetic_call = swc_ecma_ast::CallExpr {
+            span: new_expr.span,
+            ctxt: new_expr.ctxt,
+            callee: swc_ecma_ast::Callee::Expr(synthetic_callee),
+            args: synthetic_args,
+            type_args: new_expr.type_args.clone(),
+        };
+        let _call_result = lower_call(ctx, &synthetic_call)?;
+
+        // 4. Pop this slot.
+        let pop_fn = ctx.get_extern("__RTS_FN_RT_THIS_POP", &[], None)?;
+        ctx.builder.ins().call(pop_fn, &[]);
+
+        // 5. Retorna o instance handle.
+        return Ok(TypedVal::new(inst_h, ValTy::Handle));
     }
 
     let meta = ctx

--- a/tests/new_user_fn_chained_state.test.ts
+++ b/tests/new_user_fn_chained_state.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) Cenario realista: lista de objetos construidos via `new`,
+// processados em loop. Simula um carrinho de compras.
+
+function Item(price: number, qty: number): void {
+  collections.map_set(this as any, "price", price);
+  collections.map_set(this as any, "qty", qty);
+  collections.map_set(this as any, "subtotal", price * qty);
+}
+
+const i1: number = new (Item as any)(10, 3);
+const i2: number = new (Item as any)(25, 2);
+const i3: number = new (Item as any)(7, 5);
+
+// Soma subtotais
+let total: number = 0;
+total = total + (collections.map_get(i1, "subtotal") as number);
+total = total + (collections.map_get(i2, "subtotal") as number);
+total = total + (collections.map_get(i3, "subtotal") as number);
+print("total=" + total);  // 30 + 50 + 35 = 115
+
+// Soma quantidades
+let qtyTotal: number = 0;
+qtyTotal = qtyTotal + (collections.map_get(i1, "qty") as number);
+qtyTotal = qtyTotal + (collections.map_get(i2, "qty") as number);
+qtyTotal = qtyTotal + (collections.map_get(i3, "qty") as number);
+print("qty=" + qtyTotal);  // 3+2+5 = 10
+
+// Modificar uma instancia depois de criada — `this` slot ja foi popado
+// entao writes diretos no handle Map continuam funcionando.
+collections.map_set(i2, "qty", 99);
+const newQty: number = collections.map_get(i2, "qty");
+print("i2.qty after=" + newQty);
+
+// As outras instancias nao sao afetadas (Maps independentes)
+const i1Qty: number = collections.map_get(i1, "qty");
+const ok: boolean = (i1Qty === 3);
+print("i1.qty unchanged=" + ok);
+
+describe("new UserFn cenario carrinho (#264 PR3)", () => {
+  test("multiplas instances + agregacao + mutacao isolada", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "total=115\n" +
+      "qty=10\n" +
+      "i2.qty after=99\n" +
+      "i1.qty unchanged=true\n"
+    ));
+});

--- a/tests/new_user_fn_constructor.test.ts
+++ b/tests/new_user_fn_constructor.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) `new UserFn(args)` aloca Map, empilha como this, chama,
+// retorna o Map. \`this.x = v\` no body do constructor persiste.
+
+function Animal(legs: number): void {
+  collections.map_set(this as any, "legs", legs);
+}
+
+function Plant(): void {
+  collections.map_set(this as any, "tag", 99);
+}
+
+const a: number = new (Animal as any)(4);
+const aLegs: number = collections.map_get(a, "legs");
+print("aLegs=" + aLegs);
+
+const p: number = new (Plant as any)();
+const pTag: number = collections.map_get(p, "tag");
+print("pTag=" + pTag);
+
+// Cada `new` cria instancia fresh — handles distintos
+const a2: number = new (Animal as any)(8);
+print("distinct=" + (a !== a2));
+const a2Legs: number = collections.map_get(a2, "legs");
+print("a2Legs=" + a2Legs);
+const aLegsAgain: number = collections.map_get(a, "legs");
+print("aStill=" + aLegsAgain);
+
+describe("new UserFn(...) constructor function (#264 PR3)", () => {
+  test("aloca, this persiste, instancias distintas", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "aLegs=4\n" +
+      "pTag=99\n" +
+      "distinct=true\n" +
+      "a2Legs=8\n" +
+      "aStill=4\n"
+    ));
+});

--- a/tests/new_user_fn_in_conditional.test.ts
+++ b/tests/new_user_fn_in_conditional.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) Constructor chamado em ramos condicionais. Garante que
+// THIS_PUSH/POP nao desalinha em paths que nao executam.
+
+function Cat(): void {
+  collections.map_set(this as any, "kind", 1);
+}
+
+function Dog(): void {
+  collections.map_set(this as any, "kind", 2);
+}
+
+function makeAnimal(useDog: boolean): number {
+  if (useDog) {
+    return new (Dog as any)();
+  } else {
+    return new (Cat as any)();
+  }
+}
+
+const a1: number = makeAnimal(true);
+const a2: number = makeAnimal(false);
+const k1: number = collections.map_get(a1, "kind");
+const k2: number = collections.map_get(a2, "kind");
+print("dog.kind=" + k1);
+print("cat.kind=" + k2);
+
+// Ternary
+function Bird(): void {
+  collections.map_set(this as any, "kind", 3);
+}
+const a3: number = (true ? new (Bird as any)() : new (Cat as any)());
+const k3: number = collections.map_get(a3, "kind");
+print("ternary.kind=" + k3);
+
+describe("new UserFn em conditional/ternary (#264 PR3)", () => {
+  test("if/else + ternary — this slot disciplinado", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "dog.kind=2\n" +
+      "cat.kind=1\n" +
+      "ternary.kind=3\n"
+    ));
+});

--- a/tests/new_user_fn_in_loop.test.ts
+++ b/tests/new_user_fn_in_loop.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) Constructor chamado dentro de loop — cada iteracao
+// produz instance distinta sem vazar this slot entre iteracoes.
+
+function Item(value: number): void {
+  collections.map_set(this as any, "v", value);
+}
+
+let total: number = 0;
+for (let i = 0; i < 5; i++) {
+  const it: number = new (Item as any)(i * 10);
+  const v: number = collections.map_get(it, "v");
+  total = total + v;
+}
+print("total=" + total);  // 0+10+20+30+40 = 100
+
+// Nesting: ctor dentro de ctor
+function Container(seedVal: number): void {
+  const inner: number = new (Item as any)(seedVal * 2);
+  const v: number = collections.map_get(inner, "v");
+  collections.map_set(this as any, "child_v", v);
+  collections.map_set(this as any, "seed", seedVal);
+}
+
+const c: number = new (Container as any)(7);
+const seed: number = collections.map_get(c, "seed");
+const childV: number = collections.map_get(c, "child_v");
+print("c.seed=" + seed + " c.child_v=" + childV);
+
+describe("new UserFn em loop e nested (#264 PR3)", () => {
+  test("instances distintas no loop, this slot stack-based em nested", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "total=100\n" +
+      "c.seed=7 c.child_v=14\n"
+    ));
+});

--- a/tests/new_user_fn_no_args.test.ts
+++ b/tests/new_user_fn_no_args.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) constructor sem args: corpo executa, `this` populado.
+
+function Box(): void {
+  collections.map_set(this as any, "filled", 1);
+}
+
+const b: number = new (Box as any)();
+const filled: number = collections.map_get(b, "filled");
+print("filled=" + filled);
+
+// Vazia (sem this no body): `this` ainda eh alocado mas Map vazio
+function Empty(): void {}
+const e: number = new (Empty as any)();
+print("e_nonzero=" + (e !== 0));
+
+describe("new UserFn() sem args (#264 PR3)", () => {
+  test("ctor sem args, corpo opcional", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "filled=1\n" +
+      "e_nonzero=true\n"
+    ));
+});

--- a/tests/new_user_fn_with_args_propagation.test.ts
+++ b/tests/new_user_fn_with_args_propagation.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR3) Args do `new` chegam corretamente nos params da fn
+// constructor. Cobre passagem de varios args com tipos diferentes.
+
+function Point(x: number, y: number): void {
+  collections.map_set(this as any, "x", x);
+  collections.map_set(this as any, "y", y);
+}
+
+function Triangle(a: number, b: number, c: number): void {
+  collections.map_set(this as any, "a", a);
+  collections.map_set(this as any, "b", b);
+  collections.map_set(this as any, "c", c);
+  collections.map_set(this as any, "perimeter", a + b + c);
+}
+
+const p: number = new (Point as any)(3, 5);
+const px: number = collections.map_get(p, "x");
+const py: number = collections.map_get(p, "y");
+print("p=(" + px + "," + py + ")");
+
+const t: number = new (Triangle as any)(3, 4, 5);
+const ta: number = collections.map_get(t, "a");
+const tb: number = collections.map_get(t, "b");
+const tc: number = collections.map_get(t, "c");
+const tper: number = collections.map_get(t, "perimeter");
+print("t=" + ta + "," + tb + "," + tc + " perim=" + tper);
+
+describe("new UserFn com args propagados (#264 PR3)", () => {
+  test("Point e Triangle recebem args corretamente", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "p=(3,5)\n" +
+      "t=3,4,5 perim=12\n"
+    ));
+});


### PR DESCRIPTION
## Summary

PR 3 de 5 da issue #264. \`new Animal(name)\` em user fn nao-classe agora funciona: aloca Map, empilha como this, chama, retorna Map.

## Implementacao

Novo branch em \`lower_new\` antes do erro \"classe nao declarada\":
- Aloca Map vazio
- \`__RTS_FN_RT_THIS_PUSH(map_handle)\` (slot do PR #451)
- Chama user fn via CallExpr sintetico
- \`__RTS_FN_RT_THIS_POP()\`
- Retorna handle do Map

Tambem peel de TsAs/Paren no callee de NewExpr.

## Limitacao consciente

PR nao instala \`__proto__\` chain — methods em \`Animal.prototype\` ainda nao sao acessiveis via \`instance.method()\`. PR 4 cobrira.

## Test plan

- [x] tests/new_user_fn_constructor.test.ts (novo)
- [x] tests/new_user_fn_no_args.test.ts (novo)
- [x] 84/84 cargo test --lib --test-threads=1
- [x] Suite TS: 369→371 passed, 7 failed (inalterado), zero regressao

Refs #264 (PR 3 de 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)