### PR TITLE
feat(codegen): __proto__ chain walk em member access (#264 PR4)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -801,6 +801,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_GET
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_SET",
             map::__RTS_FN_NS_COLLECTIONS_MAP_SET
         );

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -902,6 +902,54 @@ pub(super) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
         let inst = ctx.builder.ins().call(map_new, &[]);
         let inst_h = ctx.builder.inst_results(inst)[0];
 
+        // 1.5 (#264 PR4) Instala __proto__ chain: aloca o prototype Map
+        // de Animal e armazena em instance.__proto__ pra lookup chain
+        // walk em member access subsequentes.
+        let proto_get = ctx.get_extern(
+            "__RTS_FN_GL_FUNCTION_PROTOTYPE_GET",
+            &[cl::I64],
+            Some(cl::I64),
+        )?;
+        // Para chamar PROTOTYPE_GET precisa do Function handle — reify
+        // a partir do user fn.
+        let fn_addr = emit_user_fn_addr(ctx, &class_name)?.val;
+        let arity = ctx
+            .user_fns
+            .get(&class_name)
+            .map(|f| f.params.len() as i64)
+            .unwrap_or(0);
+        let arity_v = ctx.builder.ins().iconst(cl::I64, arity);
+        let name_tv = ctx.emit_str_handle(class_name.as_bytes())?;
+        let name_h = ctx.coerce_to_i64(name_tv).val;
+        let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+        let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+        let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+        let n_ptr = ctx.builder.inst_results(inst_p)[0];
+        let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+        let n_len = ctx.builder.inst_results(inst_l)[0];
+        let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 0);
+        let has_this_v = ctx.builder.ins().iconst(cl::I32, 0);
+        let reify_fn = ctx.get_extern(
+            "__RTS_FN_GL_FUNCTION_REIFY",
+            &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32],
+            Some(cl::I64),
+        )?;
+        let inst_r = ctx
+            .builder
+            .ins()
+            .call(reify_fn, &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v]);
+        let fn_handle = ctx.builder.inst_results(inst_r)[0];
+        let inst_proto = ctx.builder.ins().call(proto_get, &[fn_handle]);
+        let proto_h = ctx.builder.inst_results(inst_proto)[0];
+        // map_set(inst_h, "__proto__", proto_h)
+        let map_set_fn = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+            &[cl::I64, cl::I64, cl::I64, cl::I64],
+            None,
+        )?;
+        let (proto_kp, proto_kl) = ctx.emit_str_literal(b"__proto__")?;
+        ctx.builder.ins().call(map_set_fn, &[inst_h, proto_kp, proto_kl, proto_h]);
+
         // 2. Push this slot (thread-local, usado por `Expr::This` no body).
         let push_fn = ctx.get_extern(
             "__RTS_FN_RT_THIS_PUSH",

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -953,8 +953,11 @@ pub(super) fn map_get_static_typed(
     declared_ty: Option<ValTy>,
 ) -> Result<TypedVal> {
     let (kptr, klen) = ctx.emit_str_literal(key)?;
+    // (#264 PR4) Usa MAP_GET_CHAIN: busca primeiro nas own props, depois
+    // segue __proto__ chain. Para Maps sem __proto__ (classes ES6, objetos
+    // literais), o overhead eh um lookup extra que falha — sem regressao.
     let get_fn = ctx.get_extern(
-        "__RTS_FN_NS_COLLECTIONS_MAP_GET",
+        "__RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN",
         &[cl::I64, cl::I64, cl::I64],
         Some(cl::I64),
     )?;

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -101,6 +101,43 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET(
     with_map(handle, 0, |m| m.get(key).copied().unwrap_or(0))
 }
 
+/// (#264 PR4) Retorna valor de `key` seguindo cadeia `__proto__`.
+/// Se a key nao existe no map, le `__proto__` (handle de outro Map) e
+/// recursa. Retorna 0 quando atinge o fim da cadeia ou tipo invalido.
+/// Guard contra ciclos: profundidade maxima 64.
+///
+/// Codifica o estado de busca em 2 valores: -1 = nao tem proto (parar),
+/// 0 = nao tem key mas tem proto (continuar), >0 = tem key (retornar).
+/// Na pratica nao distinguimos -1 e 0 porque ambos paramos em 0 retorno.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN(
+    handle: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+) -> i64 {
+    let Some(key) = str_from_abi(key_ptr, key_len) else {
+        return 0;
+    };
+    let key_owned = key.to_string();
+    let mut current = handle;
+    let mut depth = 0u32;
+    while current != 0 && depth < 64 {
+        // 1. Tenta key no map current.
+        let found = with_map(current, 0i64, |m| m.get(&key_owned).copied().unwrap_or(0));
+        if found != 0 {
+            return found;
+        }
+        // 2. Le __proto__ pra continuar walk.
+        let next = with_map(current, 0i64, |m| m.get("__proto__").copied().unwrap_or(0));
+        if next == 0 {
+            return 0;
+        }
+        current = next as u64;
+        depth += 1;
+    }
+    0
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_SET(
     handle: u64,

--- a/tests/proto_chain_class_es6_unaffected.test.ts
+++ b/tests/proto_chain_class_es6_unaffected.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR4) Classes ES6 NAO sao afetadas pelo chain walk — Maps delas
+// nao tem __proto__ entao a busca para imediatamente apos own props.
+
+class Box {
+  width: number;
+  height: number;
+  constructor(w: number, h: number) {
+    this.width = w;
+    this.height = h;
+  }
+  area(): number {
+    return this.width * this.height;
+  }
+}
+
+const b = new Box(3, 5);
+print("w=" + b.width);
+print("h=" + b.height);
+print("area=" + b.area());
+
+// Cenario misto: classe ES6 + constructor function no mesmo programa
+function Tag(): void {}
+Tag.prototype.kind = 7 as any;
+
+const t: number = new (Tag as any)();
+const k: number = (t as any).kind;
+print("tag.kind=" + k);
+
+// Classe ES6 nao "ve" o prototype de Tag mesmo no mesmo programa
+print("box.area still=" + b.area());
+
+describe("classes ES6 nao quebram com chain walk (#264 PR4)", () => {
+  test("classe ES6 funciona normalmente; constructor fn ao lado", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "w=3\n" +
+      "h=5\n" +
+      "area=15\n" +
+      "tag.kind=7\n" +
+      "box.area still=15\n"
+    ));
+});

--- a/tests/proto_chain_method_lookup.test.ts
+++ b/tests/proto_chain_method_lookup.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR4) Member access em instance segue __proto__ chain quando
+// a key nao existe nas own props.
+
+function Animal(name: string): void {
+  collections.map_set(this as any, "id", 7);
+}
+Animal.prototype.legs = 4 as any;
+Animal.prototype.kingdom = 1 as any;  // 1 = animal
+
+const a: number = new (Animal as any)("Rex");
+
+// own prop
+const name: number = (a as any).id;
+print("id=" + name);
+
+// proto chain — legs e kingdom estao em Animal.prototype
+const legs: number = (a as any).legs;
+print("legs=" + legs);
+
+const kingdom: number = (a as any).kingdom;
+print("kingdom=" + kingdom);
+
+// missing — nem own nem proto
+const missing: number = (a as any).missing;
+print("missing=" + missing);
+
+// Outra instance: comparte mesmo prototype, suas own props sao isoladas
+const b: number = new (Animal as any)("Cat");
+collections.map_set(b, "id", 99);
+const bName: number = (b as any).id;
+const bLegs: number = (b as any).legs;
+const aName: number = (a as any).id;
+print("a.id=" + aName);
+print("b.id=" + bName);
+print("b.legs=" + bLegs);
+
+describe("proto chain lookup em instance.field (#264 PR4)", () => {
+  test("own + proto + missing + isolacao entre instances", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "id=7\n" +
+      "legs=4\n" +
+      "kingdom=1\n" +
+      "missing=0\n" +
+      "a.id=7\n" +
+      "b.id=99\n" +
+      "b.legs=4\n"
+    ));
+});

--- a/tests/proto_chain_shared_proto.test.ts
+++ b/tests/proto_chain_shared_proto.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264 PR4) Modificar Animal.prototype apos criar instances afeta
+// todas as instances (proto eh compartilhado).
+
+function Animal(): void {}
+Animal.prototype.color = 7 as any;
+
+const a1: number = new (Animal as any)();
+const a2: number = new (Animal as any)();
+
+const c1Before: number = (a1 as any).color;
+const c2Before: number = (a2 as any).color;
+print("c1Before=" + c1Before);
+print("c2Before=" + c2Before);
+
+// Sobrescreve no proto — afeta ambas instances
+Animal.prototype.color = 99 as any;
+
+const c1After: number = (a1 as any).color;
+const c2After: number = (a2 as any).color;
+print("c1After=" + c1After);
+print("c2After=" + c2After);
+
+// Adicionar nova prop no proto eh visivel em instances ja criadas
+Animal.prototype.weight = 42 as any;
+const w1: number = (a1 as any).weight;
+const w2: number = (a2 as any).weight;
+print("w1=" + w1);
+print("w2=" + w2);
+
+// Setar prop direto na instance NAO afeta o proto
+collections.map_set(a1, "color", 1);  // own prop em a1 sobrescreve proto
+const c1Own: number = (a1 as any).color;
+const c2Still: number = (a2 as any).color;
+print("c1Own=" + c1Own);
+print("c2Still=" + c2Still);
+
+describe("proto compartilhado (#264 PR4)", () => {
+  test("mutacao no proto afeta instances; own prop sobrescreve", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "c1Before=7\n" +
+      "c2Before=7\n" +
+      "c1After=99\n" +
+      "c2After=99\n" +
+      "w1=42\n" +
+      "w2=42\n" +
+      "c1Own=1\n" +
+      "c2Still=99\n"
+    ));
+});


### PR DESCRIPTION
## Summary

PR 4 de 5 da issue #264. Member access em instance segue \`__proto__\` chain.

## Implementacao

- \`new UserFn()\` (PR3) agora instala \`__proto__\` no Map da instance
- Nova fn runtime \`__RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN\`: own → __proto__ → recursa (max 64)
- Codegen \`map_get_static_typed\` migra MAP_GET → MAP_GET_CHAIN
- Classes ES6 nao afetadas (Map sem __proto__, walk para apos 1 lookup)

## Test plan

- [x] tests/proto_chain_method_lookup.test.ts (novo)
- [x] tests/proto_chain_shared_proto.test.ts (novo)
- [x] tests/proto_chain_class_es6_unaffected.test.ts (novo)
- [x] 84/84 cargo test --lib --test-threads=1
- [x] Suite TS: 375→378 passed, 7 failed inalterado, zero regressao

## Limitacao (PR 5)

\`obj.method()\` invocado com proto method ainda nao chama com this binding correto. PR 5 fechara isso + \`hasOwnProperty\` + \`Object.create\`.

Refs #264 (PR 4 de 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)