### PR TITLE
feat(codegen): method shorthand em object literal + this binding (#261)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -1959,6 +1959,13 @@ fn lower_var_member_call(
         .ins()
         .trapz(callee_val, cranelift_codegen::ir::TrapCode::user(1).unwrap());
 
+    // (#261) Empilha receiver no this slot antes do call. Method
+    // shorthand em obj literal usa \`this\` via slot thread-local
+    // (PR #451). Para fns que nao usam this, push/pop sao no-op
+    // overhead.
+    let push_fn = ctx.get_extern("__RTS_FN_RT_THIS_PUSH", &[cl::I64], None)?;
+    ctx.builder.ins().call(push_fn, &[obj_h]);
+
     // namespace fns address-taken sao SystemV/Win64 (ver
     // user_call_conv). call_indirect tem que casar a callconv da
     // target ou args/return chegam corrompidos.
@@ -1985,6 +1992,11 @@ fn lower_var_member_call(
         .first()
         .copied()
         .unwrap_or_else(|| ctx.builder.ins().iconst(cl::I64, 0));
+
+    // (#261) Pop this slot apos call.
+    let pop_fn = ctx.get_extern("__RTS_FN_RT_THIS_POP", &[], None)?;
+    ctx.builder.ins().call(pop_fn, &[]);
+
     Ok(TypedVal::new(v, ValTy::I64))
 }
 

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -267,9 +267,37 @@ pub(super) fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -
                 }));
                 (KeySrc::Static(name), synthetic)
             }
-            Prop::Method(_) | Prop::Getter(_) | Prop::Setter(_) | Prop::Assign(_) => {
+            // (#261) Method shorthand: \`{ greet() { ... } }\` desugara
+            // pra \`{ greet: function() { ... } }\`. \`this\` no body usa
+            // slot thread-local (PR #451), populado pelo call site
+            // que faz THIS_PUSH antes do invoke (\`obj.greet()\`).
+            Prop::Method(method) => {
+                let name = match &method.key {
+                    PropName::Ident(id) => id.sym.as_str().to_string(),
+                    PropName::Str(s) => s.value.to_string_lossy().to_string(),
+                    PropName::Num(n) => n.value.to_string(),
+                    PropName::Computed(c) => {
+                        if let Expr::Lit(swc_ecma_ast::Lit::Str(s)) = c.expr.as_ref() {
+                            s.value.to_string_lossy().to_string()
+                        } else {
+                            return Err(anyhow!(
+                                "computed key dynamic em method shorthand ainda nao suportado"
+                            ));
+                        }
+                    }
+                    PropName::BigInt(_) => {
+                        return Err(anyhow!("bigint key em method nao suportado"));
+                    }
+                };
+                let fn_expr = swc_ecma_ast::FnExpr {
+                    ident: None,
+                    function: method.function.clone(),
+                };
+                (KeySrc::Static(name), Box::new(Expr::Fn(fn_expr)))
+            }
+            Prop::Getter(_) | Prop::Setter(_) | Prop::Assign(_) => {
                 return Err(anyhow!(
-                    "method/get/set/assign em object literal nao suportado (MVP)"
+                    "get/set/assign em object literal nao suportado (MVP)"
                 ));
             }
         };

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -2140,6 +2140,246 @@ fn expand_async_functions(program: &mut Program) {
 /// (try_lower_fn_expr_decl); este pass cobre o que sobrou. Nao tenta
 /// resolver capturas de escopo — se o body referenciar variaveis
 /// fora dele, falha em codegen como ident undefined.
+/// (#261) Desugara \`{ method() { body } }\` em \`{ method: function() { body } }\`
+/// antes do hoist_fn_expressions. Permite que methods em object literal sejam
+/// hoisted como user fns top-level e despachados como handles.
+/// \`this\` no body funciona via thread-local slot (PR #451) — o call site
+/// \`obj.method()\` empilha obj antes do invoke.
+fn desugar_object_methods(program: &mut Program) {
+    use swc_ecma_ast::{Prop, PropOrSpread};
+
+    fn visit_expr(expr: &mut Expr) {
+        match expr {
+            Expr::Object(obj) => {
+                for prop in obj.props.iter_mut() {
+                    if let PropOrSpread::Prop(p) = prop {
+                        // Visita sub-exprs em KeyValue antes de tentar desugar.
+                        if let Prop::KeyValue(kv) = p.as_mut() {
+                            visit_expr(kv.value.as_mut());
+                            continue;
+                        }
+                        // Desugar Method para KeyValue + Fn.
+                        if matches!(p.as_ref(), Prop::Method(_)) {
+                            let owned = std::mem::replace(
+                                p.as_mut(),
+                                Prop::KeyValue(swc_ecma_ast::KeyValueProp {
+                                    key: swc_ecma_ast::PropName::Ident(
+                                        swc_ecma_ast::IdentName::new("__placeholder".into(), Default::default()),
+                                    ),
+                                    value: Box::new(Expr::Invalid(swc_ecma_ast::Invalid {
+                                        span: Default::default(),
+                                    })),
+                                }),
+                            );
+                            if let Prop::Method(method) = owned {
+                                let mut function = method.function;
+                                if let Some(body) = function.body.as_mut() {
+                                    for stmt in body.stmts.iter_mut() {
+                                        visit_stmt(stmt);
+                                    }
+                                }
+                                let fn_expr = swc_ecma_ast::FnExpr {
+                                    ident: None,
+                                    function,
+                                };
+                                **p = Prop::KeyValue(swc_ecma_ast::KeyValueProp {
+                                    key: method.key,
+                                    value: Box::new(Expr::Fn(fn_expr)),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Expr::Array(arr) => {
+                for elem in arr.elems.iter_mut().flatten() {
+                    visit_expr(elem.expr.as_mut());
+                }
+            }
+            Expr::Call(c) => {
+                if let swc_ecma_ast::Callee::Expr(callee) = &mut c.callee {
+                    visit_expr(callee.as_mut());
+                }
+                for arg in c.args.iter_mut() {
+                    visit_expr(arg.expr.as_mut());
+                }
+            }
+            Expr::New(n) => {
+                visit_expr(n.callee.as_mut());
+                if let Some(args) = n.args.as_mut() {
+                    for arg in args.iter_mut() {
+                        visit_expr(arg.expr.as_mut());
+                    }
+                }
+            }
+            Expr::Bin(b) => {
+                visit_expr(b.left.as_mut());
+                visit_expr(b.right.as_mut());
+            }
+            Expr::Assign(a) => visit_expr(a.right.as_mut()),
+            Expr::Cond(c) => {
+                visit_expr(c.test.as_mut());
+                visit_expr(c.cons.as_mut());
+                visit_expr(c.alt.as_mut());
+            }
+            Expr::Member(m) => visit_expr(m.obj.as_mut()),
+            Expr::Paren(p) => visit_expr(p.expr.as_mut()),
+            Expr::TsAs(a) => visit_expr(a.expr.as_mut()),
+            Expr::TsTypeAssertion(a) => visit_expr(a.expr.as_mut()),
+            Expr::TsConstAssertion(a) => visit_expr(a.expr.as_mut()),
+            Expr::TsSatisfies(a) => visit_expr(a.expr.as_mut()),
+            Expr::TsNonNull(n) => visit_expr(n.expr.as_mut()),
+            Expr::Await(a) => visit_expr(a.arg.as_mut()),
+            Expr::Tpl(t) => {
+                for e in t.exprs.iter_mut() {
+                    visit_expr(e.as_mut());
+                }
+            }
+            Expr::Unary(u) => visit_expr(u.arg.as_mut()),
+            Expr::Update(u) => visit_expr(u.arg.as_mut()),
+            Expr::Seq(s) => {
+                for e in s.exprs.iter_mut() {
+                    visit_expr(e.as_mut());
+                }
+            }
+            Expr::Fn(f) => {
+                if let Some(body) = f.function.body.as_mut() {
+                    for stmt in body.stmts.iter_mut() {
+                        visit_stmt(stmt);
+                    }
+                }
+            }
+            Expr::Arrow(arrow) => match arrow.body.as_mut() {
+                swc_ecma_ast::BlockStmtOrExpr::BlockStmt(b) => {
+                    for stmt in b.stmts.iter_mut() {
+                        visit_stmt(stmt);
+                    }
+                }
+                swc_ecma_ast::BlockStmtOrExpr::Expr(e) => visit_expr(e.as_mut()),
+            },
+            _ => {}
+        }
+    }
+
+    fn visit_stmt(stmt: &mut Stmt) {
+        match stmt {
+            Stmt::Expr(e) => visit_expr(e.expr.as_mut()),
+            Stmt::Decl(swc_ecma_ast::Decl::Var(v)) => {
+                for d in v.decls.iter_mut() {
+                    if let Some(init) = &mut d.init {
+                        visit_expr(init.as_mut());
+                    }
+                }
+            }
+            Stmt::Return(r) => {
+                if let Some(arg) = &mut r.arg {
+                    visit_expr(arg.as_mut());
+                }
+            }
+            Stmt::If(i) => {
+                visit_expr(i.test.as_mut());
+                visit_stmt(i.cons.as_mut());
+                if let Some(alt) = &mut i.alt {
+                    visit_stmt(alt.as_mut());
+                }
+            }
+            Stmt::Block(b) => {
+                for s in b.stmts.iter_mut() {
+                    visit_stmt(s);
+                }
+            }
+            Stmt::While(w) => {
+                visit_expr(w.test.as_mut());
+                visit_stmt(w.body.as_mut());
+            }
+            Stmt::DoWhile(w) => {
+                visit_expr(w.test.as_mut());
+                visit_stmt(w.body.as_mut());
+            }
+            Stmt::For(f) => {
+                if let Some(init) = &mut f.init {
+                    match init {
+                        swc_ecma_ast::VarDeclOrExpr::VarDecl(v) => {
+                            for d in v.decls.iter_mut() {
+                                if let Some(i) = &mut d.init {
+                                    visit_expr(i.as_mut());
+                                }
+                            }
+                        }
+                        swc_ecma_ast::VarDeclOrExpr::Expr(e) => visit_expr(e.as_mut()),
+                    }
+                }
+                if let Some(t) = &mut f.test {
+                    visit_expr(t.as_mut());
+                }
+                if let Some(u) = &mut f.update {
+                    visit_expr(u.as_mut());
+                }
+                visit_stmt(f.body.as_mut());
+            }
+            Stmt::ForOf(f) => {
+                visit_expr(f.right.as_mut());
+                visit_stmt(f.body.as_mut());
+            }
+            Stmt::ForIn(f) => {
+                visit_expr(f.right.as_mut());
+                visit_stmt(f.body.as_mut());
+            }
+            Stmt::Throw(t) => visit_expr(t.arg.as_mut()),
+            Stmt::Try(t) => {
+                for s in t.block.stmts.iter_mut() {
+                    visit_stmt(s);
+                }
+                if let Some(handler) = &mut t.handler {
+                    for s in handler.body.stmts.iter_mut() {
+                        visit_stmt(s);
+                    }
+                }
+                if let Some(finalizer) = &mut t.finalizer {
+                    for s in finalizer.stmts.iter_mut() {
+                        visit_stmt(s);
+                    }
+                }
+            }
+            Stmt::Switch(s) => {
+                visit_expr(s.discriminant.as_mut());
+                for case in s.cases.iter_mut() {
+                    if let Some(test) = &mut case.test {
+                        visit_expr(test.as_mut());
+                    }
+                    for stmt in case.cons.iter_mut() {
+                        visit_stmt(stmt);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for item in program.items.iter_mut() {
+        match item {
+            crate::parser::ast::Item::Function(fdecl) => {
+                for stmt in fdecl.body.iter_mut() {
+                    if let crate::parser::ast::Statement::Raw(raw) = stmt {
+                        if let Some(s) = raw.stmt.as_mut() {
+                            visit_stmt(s);
+                        }
+                    }
+                }
+            }
+            crate::parser::ast::Item::Class(_) => {}
+            crate::parser::ast::Item::Statement(stmt) => {
+                if let crate::parser::ast::Statement::Raw(raw) = stmt {
+                    if let Some(s) = raw.stmt.as_mut() {
+                        visit_stmt(s);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 fn hoist_fn_expressions(program: &mut Program) {
     use swc_ecma_ast::{ArrowExpr, BlockStmtOrExpr};
 
@@ -5339,6 +5579,7 @@ pub fn compile_program(
     let mut par_fn_names = reduce_pass(program);
     par_fn_names.extend(purity_pass(program));
     let lifted_needs_c_callconv = lift_arrow_callbacks(program);
+    desugar_object_methods(program);
     hoist_fn_expressions(program);
     expand_destructuring(program);
     expand_default_args(program);

--- a/tests/object_method_nested_call.test.ts
+++ b/tests/object_method_nested_call.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#261) Method de um obj chamando method de outro obj.
+// THIS_PUSH eh stack-based — nesting nao quebra.
+
+const inner: any = {
+  marker: 99,
+  read(): number {
+    return collections.map_get((this as any), "marker");
+  },
+};
+
+const outer: any = {
+  marker: 7,
+  combo(): number {
+    const myMarker: number = collections.map_get((this as any), "marker");
+    const innerMarker: number = inner.read();
+    return myMarker * 100 + innerMarker;
+  },
+};
+
+const r: number = outer.combo();
+print("r=" + r);  // 7*100 + 99 = 799
+
+// Confirma que outer ainda eh ele mesmo apos call retornar
+const m: number = collections.map_get((outer as any), "marker");
+print("m=" + m);
+
+describe("method nested call (#261)", () => {
+  test("stack this slot preserva receiver apos nested invoke", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "r=799\n" +
+      "m=7\n"
+    ));
+});

--- a/tests/object_method_shorthand_basic.test.ts
+++ b/tests/object_method_shorthand_basic.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#261) Method shorthand em object literal eh desugared para
+// FnExpr e hoisted. Chamada via obj.method() roteada por
+// MAP_GET_CHAIN + call_indirect.
+
+const o: any = {
+  greet(): number { return 42; },
+  add(a: number, b: number): number { return a + b; },
+};
+
+const r1: number = o.greet();
+const r2: number = o.add(3, 4);
+print("greet=" + r1);
+print("add=" + r2);
+
+describe("method shorthand basico (#261)", () => {
+  test("greet sem args; add com args", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "greet=42\n" +
+      "add=7\n"
+    ));
+});

--- a/tests/object_method_this_binding.test.ts
+++ b/tests/object_method_this_binding.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#261) `this` dentro de method shorthand referencia o object
+// receiver via thread-local slot. Cada call empilha o receiver.
+
+const counter: any = {
+  v: 0,
+  inc(): number {
+    const t: number = (this as any);
+    const cur: number = collections.map_get(t, "v");
+    collections.map_set(t, "v", cur + 1);
+    return cur + 1;
+  },
+};
+
+const r1: number = counter.inc();
+const r2: number = counter.inc();
+const r3: number = counter.inc();
+print("r1=" + r1);
+print("r2=" + r2);
+print("r3=" + r3);
+
+// Diferentes objetos isolam estado
+const counter2: any = {
+  v: 100,
+  inc(): number {
+    const t: number = (this as any);
+    const cur: number = collections.map_get(t, "v");
+    collections.map_set(t, "v", cur + 1);
+    return cur + 1;
+  },
+};
+
+const a: number = counter2.inc();
+const b: number = counter.inc();
+print("a=" + a);
+print("b=" + b);
+
+describe("method shorthand this binding (#261)", () => {
+  test("this referencia receiver, estado isolado entre objs", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "r1=1\n" +
+      "r2=2\n" +
+      "r3=3\n" +
+      "a=101\n" +
+      "b=4\n"
+    ));
+});


### PR DESCRIPTION
## Summary

\`{ method() { body } }\` em object literais. Desugar pre-pass converte \`Prop::Method\` em \`Prop::KeyValue\` com \`Expr::Fn\` antes do hoist. \`this\` via thread-local slot empilhado pelo call site.

## Test plan

- [x] tests/object_method_shorthand_basic.test.ts
- [x] tests/object_method_this_binding.test.ts (counter state, isolacao)
- [x] tests/object_method_nested_call.test.ts (stack slot)
- [x] Suite TS 380→383 passed, 8 failed inalterado

Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)