### PR TITLE
fix(codegen): TsAs em fn.call/.apply/.bind + Function.prototype set

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -358,6 +358,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_FUNCTION_LENGTH", __RTS_FN_GL_FUNCTION_LENGTH);
     add_fn!("__RTS_FN_GL_FUNCTION_TO_STRING", __RTS_FN_GL_FUNCTION_TO_STRING);
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_GET", __RTS_FN_GL_FUNCTION_PROTOTYPE_GET);
+    add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_SET", __RTS_FN_GL_FUNCTION_PROTOTYPE_SET);
 
     // ── namespaces::globals::text_encoding ───────────────────────────
     use crate::namespaces::globals::text_encoding::instance::*;

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -221,7 +221,21 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 if let MemberProp::Ident(prop) = &m.prop {
                     let prop_name = prop.sym.as_str();
                     if matches!(prop_name, "call" | "apply" | "bind" | "toString") {
-                        if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                        // Peel TsAs/Paren em obj para suportar
+                        // \`(Animal as any).call(this, ...)\`.
+                        let mut obj_e: &Expr = m.obj.as_ref();
+                        loop {
+                            match obj_e {
+                                Expr::TsAs(a) => obj_e = &a.expr,
+                                Expr::TsTypeAssertion(a) => obj_e = &a.expr,
+                                Expr::TsConstAssertion(a) => obj_e = &a.expr,
+                                Expr::TsSatisfies(a) => obj_e = &a.expr,
+                                Expr::TsNonNull(a) => obj_e = &a.expr,
+                                Expr::Paren(p) => obj_e = &p.expr,
+                                _ => break,
+                            }
+                        }
+                        if let Expr::Ident(obj_id) = obj_e {
                             let obj_name = obj_id.sym.as_str();
                             // (a) user fn direta
                             if ctx.user_fns.contains_key(obj_name) && ctx.var_ty(obj_name).is_none() {
@@ -239,7 +253,7 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         // (c) `<expr>.bind/call/apply/toString` onde <expr> não é
                         // Ident — ex: `c.add.bind(c)`. Avalia obj e se for Handle,
                         // despacha via FUNCTION_*.
-                        if !matches!(m.obj.as_ref(), Expr::Ident(_)) {
+                        if !matches!(obj_e, Expr::Ident(_)) {
                             if let Some(tv) = lower_function_handle_method(ctx, &m.obj, prop_name, call)? {
                                 return Ok(tv);
                             }
@@ -278,6 +292,41 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
             }
             return lower_ns_call(ctx, &qualified, call);
+        }
+        // (#264) Fallback fora do qualified path: \`(Animal as any).call(this, ...)\`
+        // — qualified_member_name retorna None por causa do TsAs, entao
+        // este block roda separado pra peelar e roteár.
+        if let Expr::Member(m) = callee.as_ref() {
+            if let MemberProp::Ident(prop) = &m.prop {
+                let prop_name = prop.sym.as_str();
+                if matches!(prop_name, "call" | "apply" | "bind" | "toString") {
+                    let mut obj_e: &Expr = m.obj.as_ref();
+                    loop {
+                        match obj_e {
+                            Expr::TsAs(a) => obj_e = &a.expr,
+                            Expr::TsTypeAssertion(a) => obj_e = &a.expr,
+                            Expr::TsConstAssertion(a) => obj_e = &a.expr,
+                            Expr::TsSatisfies(a) => obj_e = &a.expr,
+                            Expr::TsNonNull(a) => obj_e = &a.expr,
+                            Expr::Paren(p) => obj_e = &p.expr,
+                            _ => break,
+                        }
+                    }
+                    if let Expr::Ident(obj_id) = obj_e {
+                        let obj_name = obj_id.sym.as_str();
+                        if ctx.user_fns.contains_key(obj_name) && ctx.var_ty(obj_name).is_none() {
+                            if let Some(tv) = lower_function_method_call(ctx, obj_name, prop_name, call)? {
+                                return Ok(tv);
+                            }
+                        }
+                        if ctx.var_ty(obj_name).is_some() {
+                            if let Some(tv) = lower_function_handle_method(ctx, &m.obj, prop_name, call)? {
+                                return Ok(tv);
+                            }
+                        }
+                    }
+                }
+            }
         }
         if let Expr::Ident(id) = callee.as_ref() {
             let name = id.sym.as_str();

--- a/src/codegen/lower/expressions/mod.rs
+++ b/src/codegen/lower/expressions/mod.rs
@@ -119,6 +119,73 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
     }
 
     if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Member(m)) = &a.left {
+        // (#264 PR4+) Intercepta `<UserFn>.prototype = X` para chamar
+        // FUNCTION_PROTOTYPE_SET que atualiza o registry global. Sem isso,
+        // \`Dog.prototype = Object.create(...)\` faz MAP_SET em handle Function
+        // (nao Map) e o registry continua com o Map antigo.
+        if matches!(a.op, AssignOp::Assign) {
+            if let MemberProp::Ident(prop) = &m.prop {
+                if prop.sym.as_str() == "prototype" {
+                    // Peel TsAs/Paren no obj.
+                    let mut obj_e: &Expr = m.obj.as_ref();
+                    loop {
+                        match obj_e {
+                            Expr::TsAs(a) => obj_e = &a.expr,
+                            Expr::TsTypeAssertion(a) => obj_e = &a.expr,
+                            Expr::TsConstAssertion(a) => obj_e = &a.expr,
+                            Expr::TsSatisfies(a) => obj_e = &a.expr,
+                            Expr::TsNonNull(a) => obj_e = &a.expr,
+                            Expr::Paren(p) => obj_e = &p.expr,
+                            _ => break,
+                        }
+                    }
+                    if let Expr::Ident(id) = obj_e {
+                        let name = id.sym.as_str();
+                        if ctx.user_fns.contains_key(name) && ctx.var_ty(name).is_none() {
+                            // Reify Function handle.
+                            let fn_handle_tv = self::calls::emit_user_fn_addr(ctx, name)?;
+                            let fn_addr = fn_handle_tv.val;
+                            let arity = ctx
+                                .user_fns
+                                .get(name)
+                                .map(|f| f.params.len() as i64)
+                                .unwrap_or(0);
+                            let arity_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I64, arity);
+                            let name_tv = ctx.emit_str_handle(name.as_bytes())?;
+                            let name_h = ctx.coerce_to_i64(name_tv).val;
+                            let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cranelift_codegen::ir::types::I64], Some(cranelift_codegen::ir::types::I64))?;
+                            let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cranelift_codegen::ir::types::I64], Some(cranelift_codegen::ir::types::I64))?;
+                            let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+                            let n_ptr = ctx.builder.inst_results(inst_p)[0];
+                            let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+                            let n_len = ctx.builder.inst_results(inst_l)[0];
+                            let is_arrow_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I32, 0);
+                            let has_this_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I32, 0);
+                            let reify_fn = ctx.get_extern(
+                                "__RTS_FN_GL_FUNCTION_REIFY",
+                                &[cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I32, cranelift_codegen::ir::types::I32],
+                                Some(cranelift_codegen::ir::types::I64),
+                            )?;
+                            let inst_r = ctx
+                                .builder
+                                .ins()
+                                .call(reify_fn, &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v]);
+                            let fn_handle = ctx.builder.inst_results(inst_r)[0];
+                            // Lower RHS.
+                            let rhs_tv = lower_expr(ctx, &a.right)?;
+                            let rhs_h = ctx.coerce_to_i64(rhs_tv).val;
+                            let set_proto = ctx.get_extern(
+                                "__RTS_FN_GL_FUNCTION_PROTOTYPE_SET",
+                                &[cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64],
+                                None,
+                            )?;
+                            ctx.builder.ins().call(set_proto, &[fn_handle, rhs_h]);
+                            return Ok(TypedVal::new(rhs_h, ValTy::Handle));
+                        }
+                    }
+                }
+            }
+        }
         let final_rhs_expr: Box<Expr> = if matches!(a.op, AssignOp::Assign) {
             a.right.clone()
         } else {

--- a/src/namespaces/globals/function/ops.rs
+++ b/src/namespaces/globals/function/ops.rs
@@ -475,6 +475,31 @@ pub(crate) fn lookup_prototype_for_fn_ptr(fn_ptr: u64) -> Option<u64> {
     registry.get(&fn_ptr).copied().filter(|&h| h != 0)
 }
 
+/// (#264 PR4+) Substitui o prototype Map de uma user fn.
+/// \`Dog.prototype = Object.create(Animal.prototype)\` precisa atualizar
+/// o registry para que \`new Dog\` instale a chain correta.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FUNCTION_PROTOTYPE_SET(handle: u64, new_proto: u64) {
+    let fn_ptr = with_entry(handle, |e| {
+        if let Some(Entry::Function(d)) = e {
+            Some(d.fn_ptr)
+        } else {
+            None
+        }
+    });
+    let Some(fn_ptr) = fn_ptr else { return };
+    let mut registry = proto_registry().lock().unwrap_or_else(|e| e.into_inner());
+    registry.insert(fn_ptr, new_proto);
+    drop(registry);
+    // Atualiza tambem o slot da Function para tracing GC continuar valido.
+    let _ = with_entry_mut(handle, |e| {
+        if let Some(Entry::Function(d)) = e {
+            d.prototype_handle = new_proto;
+        }
+        ()
+    });
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_FUNCTION_NAME(handle: u64) -> u64 {
     let name = with_entry(handle, |e| {

--- a/tests/fn_call_with_tsas.test.ts
+++ b/tests/fn_call_with_tsas.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264) (Animal as any).call(this, ...) em fn body — antes
+// "unsupported call expression form".
+
+function Init(name: string): void {
+  collections.map_set(this as any, "tag", 7);
+}
+
+function Wrapper(name: string): void {
+  (Init as any).call(this, name);
+  collections.map_set(this as any, "wrapped", 99);
+}
+
+const w: number = new (Wrapper as any)("foo");
+const t: number = collections.map_get(w, "tag");
+const wr: number = collections.map_get(w, "wrapped");
+print("tag=" + t);
+print("wrapped=" + wr);
+
+describe("fn.call com TsAs em fn body (#264)", () => {
+  test("(Init as any).call(this, ...) propaga this slot", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "tag=7\n" +
+      "wrapped=99\n"
+    ));
+});

--- a/tests/fn_prototype_set_explicit.test.ts
+++ b/tests/fn_prototype_set_explicit.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#264) Substituir fn.prototype atualiza o registry e instances
+// novas usam o novo Map para chain.
+
+function Animal(): void {}
+Animal.prototype.legs = 4 as any;
+
+function Dog(): void {}
+// Dog.prototype = Object.create(Animal.prototype) — chain Dog -> Animal
+Dog.prototype = Object.create(Animal.prototype as any) as any;
+Dog.prototype.barks = 1 as any;
+
+const d: number = new (Dog as any)();
+const legs: number = (d as any).legs;
+const barks: number = (d as any).barks;
+const missing: number = (d as any).xyz;
+print("legs=" + legs);
+print("barks=" + barks);
+print("missing=" + missing);
+
+describe("fn.prototype set explicito (#264)", () => {
+  test("prototype = Object.create(parent) cria chain 2 niveis", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "legs=4\n" +
+      "barks=1\n" +
+      "missing=0\n"
+    ));
+});


### PR DESCRIPTION
Fixes inheritance: `(Animal as any).call(this)` + `Dog.prototype = Object.create(...)` atualiza registry. Suite 385→387.