### PR TITLE
fix(codegen): (c as Counter).method() nao crasha mais (regressao do PR5)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -30,32 +30,35 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         }
         // (#264 PR5) Fast path: `(var as any).method(...)` — TsAs/Paren etc
         // antes do member. Peel e despacha como var.method().
+        // (#fix) NAO sequestra quando \`lhs_static_class\` resolve via TsAs
+        // para uma classe — esse caso deve ir pelo caminho de class method
+        // (lower_class_method_call_with_recv) via lhs_static_class.
         if let Expr::Member(m) = callee.as_ref() {
-            let mut obj_e: &Expr = m.obj.as_ref();
-            loop {
-                match obj_e {
-                    Expr::TsAs(a) => obj_e = &a.expr,
-                    Expr::TsTypeAssertion(a) => obj_e = &a.expr,
-                    Expr::TsConstAssertion(a) => obj_e = &a.expr,
-                    Expr::TsSatisfies(a) => obj_e = &a.expr,
-                    Expr::TsNonNull(a) => obj_e = &a.expr,
-                    Expr::Paren(p) => obj_e = &p.expr,
-                    _ => break,
+            let class_via_assertion = lhs_static_class(ctx, &m.obj);
+            if class_via_assertion.is_none() {
+                let mut obj_e: &Expr = m.obj.as_ref();
+                loop {
+                    match obj_e {
+                        Expr::TsAs(a) => obj_e = &a.expr,
+                        Expr::TsTypeAssertion(a) => obj_e = &a.expr,
+                        Expr::TsConstAssertion(a) => obj_e = &a.expr,
+                        Expr::TsSatisfies(a) => obj_e = &a.expr,
+                        Expr::TsNonNull(a) => obj_e = &a.expr,
+                        Expr::Paren(p) => obj_e = &p.expr,
+                        _ => break,
+                    }
                 }
-            }
-            // Se peel produziu um Ident e o obj original NAO era Ident,
-            // re-rola como var.member chamando lower_var_member_call diretamente.
-            // (Para Ident puro, deixa fluir pelo caminho existente.)
-            if !matches!(m.obj.as_ref(), Expr::Ident(_)) {
-                if let Expr::Ident(obj_id) = obj_e {
-                    if ctx.var_ty(obj_id.sym.as_str()).is_some() {
-                        if let MemberProp::Ident(prop) = &m.prop {
-                            return lower_var_member_call(
-                                ctx,
-                                obj_id.sym.as_str(),
-                                prop.sym.as_str(),
-                                call,
-                            );
+                if !matches!(m.obj.as_ref(), Expr::Ident(_)) {
+                    if let Expr::Ident(obj_id) = obj_e {
+                        if ctx.var_ty(obj_id.sym.as_str()).is_some() {
+                            if let MemberProp::Ident(prop) = &m.prop {
+                                return lower_var_member_call(
+                                    ctx,
+                                    obj_id.sym.as_str(),
+                                    prop.sym.as_str(),
+                                    call,
+                                );
+                            }
                         }
                     }
                 }

--- a/tests/type_assertion_class_method.test.ts
+++ b/tests/type_assertion_class_method.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#fix) `(c as Counter).bump()` antes crashava com SIGILL porque o
+// fast path do PR5 (#264) sequestrava todos TsAs.method() para
+// var_member_call generico, ignorando que a annotation resolvia
+// para classe registrada.
+
+class Counter {
+  n: number = 0;
+  bump(): number {
+    this.n = this.n + 1;
+    return this.n;
+  }
+  reset(): void {
+    this.n = 0;
+  }
+}
+
+const c = new Counter();
+const v1: number = (c as Counter).bump();
+const v2: number = (c as Counter).bump();
+const v3: number = ((c as Counter) as Counter).bump();
+print("v1=" + v1);
+print("v2=" + v2);
+print("v3=" + v3);
+
+(c as Counter).reset();
+const v4: number = (c as Counter).bump();
+print("v4=" + v4);
+
+describe("(receiver as Class).method() (#fix)", () => {
+  test("class method routing preservado com TsAs", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "v1=1\n" +
+      "v2=2\n" +
+      "v3=3\n" +
+      "v4=1\n"
+    ));
+});


### PR DESCRIPTION
Fast path TsAs.method do PR5 ignorava annotation de classe. Fix: lhs_static_class first.