### PR TITLE
feat(codegen): proto methods runtime dispatch — INVOKE_AUTO + TPL_COERCE_AUTO

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -359,6 +359,11 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_FUNCTION_TO_STRING", __RTS_FN_GL_FUNCTION_TO_STRING);
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_GET", __RTS_FN_GL_FUNCTION_PROTOTYPE_GET);
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_SET", __RTS_FN_GL_FUNCTION_PROTOTYPE_SET);
+    add_fn!("__RTS_FN_RT_INVOKE_AUTO", __RTS_FN_RT_INVOKE_AUTO);
+    {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_AUTO;
+        add_fn!("__RTS_FN_RT_TPL_COERCE_AUTO", __RTS_FN_RT_TPL_COERCE_AUTO);
+    }
 
     // ── namespaces::globals::text_encoding ───────────────────────────
     use crate::namespaces::globals::text_encoding::instance::*;

--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -406,6 +406,12 @@ pub struct FnCtx<'m, 'fb> {
     /// emitir "undefined" em vez de "0" no template literal.
     pub optional_chain_values: std::collections::HashSet<cranelift_codegen::ir::Value>,
 
+    /// (#proto-method) SSA Values que sao resultado de var_member_call
+    /// (instance.method() em handle generico). Em template literal,
+    /// tentar interpretar como Handle se valor parece handle valido
+    /// (consulta entry table via runtime fn).
+    pub var_member_call_values: std::collections::HashSet<cranelift_codegen::ir::Value>,
+
     /// Dedup de data sections por conteúdo: bytes → DataId já declarado.
     /// Evita criar múltiplos .Lrts_str_N com bytes idênticos quando o mesmo
     /// literal aparece mais de uma vez (dentro ou entre funções do módulo).
@@ -474,6 +480,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             fn_ref_by_id_cache: HashMap::new(),
             fresh_handle_set: std::collections::HashSet::new(),
             optional_chain_values: std::collections::HashSet::new(),
+            var_member_call_values: std::collections::HashSet::new(),
             str_data_cache: HashMap::new(),
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),

--- a/src/codegen/lower/expressions/basics.rs
+++ b/src/codegen/lower/expressions/basics.rs
@@ -216,16 +216,25 @@ pub(super) fn lower_tpl(ctx: &mut FnCtx, tpl: &Tpl) -> Result<TypedVal> {
         // (#432) Se o val veio de optional chain, decide em runtime:
         // val == 0 → handle de "undefined"; senao coerce normal.
         let is_opt_chain = ctx.optional_chain_values.contains(&val.val);
+        // (#proto-method) Se veio de var_member_call, use coerce auto que
+        // detecta string handle em runtime.
+        let is_var_member_call = ctx.var_member_call_values.contains(&val.val);
         let rhs = if is_opt_chain {
             let undef_h = ctx.emit_str_handle(b"undefined")?.val;
             let val_i64 = ctx.coerce_to_i64(val).val;
-            // val_i64 != 0 → coerce_to_handle do val original; val_i64 == 0 → undef.
-            // Para evitar emitir 2 caminhos, primeiro coerce val (preserva
-            // tipo original), depois select pelo i64 truthiness.
             let normal_h = ctx.coerce_to_handle(val)?.val;
             let zero = ctx.builder.ins().iconst(cl::I64, 0);
             let is_null = ctx.builder.ins().icmp(IntCC::Equal, val_i64, zero);
             ctx.builder.ins().select(is_null, undef_h, normal_h)
+        } else if is_var_member_call {
+            let val_i64 = ctx.coerce_to_i64(val).val;
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_AUTO",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[val_i64]);
+            ctx.builder.inst_results(inst)[0]
         } else {
             ctx.coerce_to_handle(val)?.val
         };

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -2011,43 +2011,39 @@ fn lower_var_member_call(
         .ins()
         .trapz(callee_val, cranelift_codegen::ir::TrapCode::user(1).unwrap());
 
-    // (#261) Empilha receiver no this slot antes do call. Method
-    // shorthand em obj literal usa \`this\` via slot thread-local
-    // (PR #451). Para fns que nao usam this, push/pop sao no-op
-    // overhead.
-    let push_fn = ctx.get_extern("__RTS_FN_RT_THIS_PUSH", &[cl::I64], None)?;
-    ctx.builder.ins().call(push_fn, &[obj_h]);
-
-    // namespace fns address-taken sao SystemV/Win64 (ver
-    // user_call_conv). call_indirect tem que casar a callconv da
-    // target ou args/return chegam corrompidos.
-    let cc = ctx.module.isa().default_call_conv();
-    let mut sig = Signature::new(cc);
-    for _ in &call.args {
-        sig.params.push(AbiParam::new(cl::I64));
-    }
-    sig.returns.push(AbiParam::new(cl::I64));
-    let sig_ref = ctx.builder.import_signature(sig);
-
-    let mut args = Vec::with_capacity(call.args.len());
+    // (#proto-method) Empacota args em Vec<i64> handle e chama
+    // INVOKE_AUTO que decide entre handle Function (typed via
+    // invoke_typed com return_kind) e fn ptr raw (invoke_n i64-only).
+    // Cobre o caso de \`Animal.prototype.x = userFn\` armazenado como
+    // handle Function (PR proto-method).
+    let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+    let inst_v = ctx.builder.ins().call(vec_new, &[]);
+    let args_h = ctx.builder.inst_results(inst_v)[0];
+    let vec_push = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+        &[cl::I64, cl::I64],
+        None,
+    )?;
     for arg in &call.args {
         if arg.spread.is_some() {
             return Err(anyhow!("spread not supported in var.member call"));
         }
         let tv = lower_expr(ctx, &arg.expr)?;
-        args.push(ctx.coerce_to_i64(tv).val);
+        let v = ctx.coerce_to_i64(tv).val;
+        ctx.builder.ins().call(vec_push, &[args_h, v]);
     }
 
-    let inst = ctx.builder.ins().call_indirect(sig_ref, callee_val, &args);
-    let results = ctx.builder.inst_results(inst);
-    let v = results
-        .first()
-        .copied()
-        .unwrap_or_else(|| ctx.builder.ins().iconst(cl::I64, 0));
+    let invoke_auto = ctx.get_extern(
+        "__RTS_FN_RT_INVOKE_AUTO",
+        &[cl::I64, cl::I64, cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst = ctx.builder.ins().call(invoke_auto, &[callee_val, obj_h, args_h]);
+    let v = ctx.builder.inst_results(inst)[0];
 
-    // (#261) Pop this slot apos call.
-    let pop_fn = ctx.get_extern("__RTS_FN_RT_THIS_POP", &[], None)?;
-    ctx.builder.ins().call(pop_fn, &[]);
+    // (#proto-method) Marca o resultado para que lower_tpl use
+    // TPL_COERCE_AUTO (detecta handle de string em runtime).
+    ctx.var_member_call_values.insert(v);
 
     Ok(TypedVal::new(v, ValTy::I64))
 }

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -998,7 +998,13 @@ pub(super) fn map_get_static_typed(
         )),
         Some(ValTy::Handle) => Ok(TypedVal::new(v, ValTy::Handle)),
         Some(ValTy::Bool) => Ok(TypedVal::new(v, ValTy::Bool)),
-        _ => Ok(TypedVal::new(v, ValTy::I64)),
+        _ => {
+            // (#proto-method) Sem tipo declarado, marcar como
+            // var_member_call_values para que template literal use
+            // TPL_COERCE_AUTO (detecta string handle em runtime).
+            ctx.var_member_call_values.insert(v);
+            Ok(TypedVal::new(v, ValTy::I64))
+        }
     }
 }
 

--- a/src/codegen/lower/expressions/mod.rs
+++ b/src/codegen/lower/expressions/mod.rs
@@ -260,7 +260,98 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
             }
         }
 
-        let rhs = lower_expr(ctx, &final_rhs_expr)?;
+        // (#264 PR5+) Quando o RHS eh ident de user fn E o LHS eh
+        // \`<UserFn>.prototype.X\` (member chain de prototype), reify
+        // o ident em handle Function antes do MAP_SET. Isso permite
+        // que call sites futuros (\`instance.X(...)\`) usem
+        // FUNCTION_CALL com return_kind correto.
+        let reify_rhs = matches!(a.op, AssignOp::Assign)
+            && {
+                // Detecta lhs: <UserFn>.prototype.X
+                if let MemberProp::Ident(_) = &m.prop {
+                    if let Expr::Member(inner) = m.obj.as_ref() {
+                        if let MemberProp::Ident(p) = &inner.prop {
+                            if p.sym.as_str() == "prototype" {
+                                let mut o: &Expr = inner.obj.as_ref();
+                                loop {
+                                    match o {
+                                        Expr::TsAs(a) => o = &a.expr,
+                                        Expr::Paren(p) => o = &p.expr,
+                                        _ => break,
+                                    }
+                                }
+                                if let Expr::Ident(id) = o {
+                                    let n = id.sym.as_str();
+                                    ctx.user_fns.contains_key(n) && ctx.var_ty(n).is_none()
+                                } else { false }
+                            } else { false }
+                        } else { false }
+                    } else { false }
+                } else { false }
+            }
+            && {
+                // RHS eh ident de user fn? Peel TsAs.
+                let mut e: &Expr = final_rhs_expr.as_ref();
+                loop {
+                    match e {
+                        Expr::TsAs(a) => e = &a.expr,
+                        Expr::Paren(p) => e = &p.expr,
+                        _ => break,
+                    }
+                }
+                if let Expr::Ident(id) = e {
+                    let n = id.sym.as_str();
+                    ctx.user_fns.contains_key(n) && ctx.var_ty(n).is_none()
+                } else { false }
+            };
+
+        let rhs = if reify_rhs {
+            // Extrai o nome da user fn (peel TsAs).
+            let mut e: &Expr = final_rhs_expr.as_ref();
+            loop {
+                match e {
+                    Expr::TsAs(a) => e = &a.expr,
+                    Expr::Paren(p) => e = &p.expr,
+                    _ => break,
+                }
+            }
+            let fn_name = if let Expr::Ident(id) = e {
+                id.sym.as_str().to_string()
+            } else {
+                unreachable!()
+            };
+            // Reify em handle Function.
+            let fn_addr = self::calls::emit_user_fn_addr(ctx, &fn_name)?.val;
+            let arity = ctx
+                .user_fns
+                .get(&fn_name)
+                .map(|f| f.params.len() as i64)
+                .unwrap_or(0);
+            let arity_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I64, arity);
+            let name_tv = ctx.emit_str_handle(fn_name.as_bytes())?;
+            let name_h = ctx.coerce_to_i64(name_tv).val;
+            let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cranelift_codegen::ir::types::I64], Some(cranelift_codegen::ir::types::I64))?;
+            let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cranelift_codegen::ir::types::I64], Some(cranelift_codegen::ir::types::I64))?;
+            let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+            let n_ptr = ctx.builder.inst_results(inst_p)[0];
+            let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+            let n_len = ctx.builder.inst_results(inst_l)[0];
+            let is_arrow_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I32, 0);
+            let has_this_v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I32, 0);
+            let reify_fn = ctx.get_extern(
+                "__RTS_FN_GL_FUNCTION_REIFY",
+                &[cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I64, cranelift_codegen::ir::types::I32, cranelift_codegen::ir::types::I32],
+                Some(cranelift_codegen::ir::types::I64),
+            )?;
+            let inst_r = ctx
+                .builder
+                .ins()
+                .call(reify_fn, &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v]);
+            let v = ctx.builder.inst_results(inst_r)[0];
+            TypedVal::new(v, ValTy::Handle)
+        } else {
+            lower_expr(ctx, &final_rhs_expr)?
+        };
 
         // Dual-path #147 passo 7: escrita tipada em campo flat. Preserva
         // o tipo do RHS para coercao no slot exato (i32/f64/i64/handle).

--- a/src/namespaces/gc/string_pool.rs
+++ b/src/namespaces/gc/string_pool.rs
@@ -63,6 +63,22 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64(value: i64) -> u64 {
     alloc_entry(Entry::String(value.to_string().into_bytes()))
 }
 
+/// (#proto-method) Coerce inteligente para template literal:
+/// se \`value\` (i64) eh handle valido para Entry::String, retorna o
+/// proprio handle. Senao, formata como integer (\`STRING_FROM_I64\`).
+/// Usado pra \`${expr}\` quando \`expr\` veio de var_member_call cujo
+/// retorno tem tipo dinamico.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
+    let h = value as u64;
+    let is_string = with_entry(h, |e| matches!(e, Some(Entry::String(_))));
+    if is_string {
+        h
+    } else {
+        alloc_entry(Entry::String(value.to_string().into_bytes()))
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_F64(value: f64) -> u64 {
     let s = if value.is_nan() {

--- a/src/namespaces/globals/function/ops.rs
+++ b/src/namespaces/globals/function/ops.rs
@@ -475,6 +475,51 @@ pub(crate) fn lookup_prototype_for_fn_ptr(fn_ptr: u64) -> Option<u64> {
     registry.get(&fn_ptr).copied().filter(|&h| h != 0)
 }
 
+/// (#proto-method) Auto-dispatch: se \`callee\` eh handle Function valido,
+/// chama via invoke_typed (com return_kind correto). Senao trata como
+/// fn_ptr cru e faz invoke_n (todos i64). Usado por
+/// \`lower_var_member_call\` quando member access em handle pode resolver
+/// para fn ptr OU para handle Function (depende se foi REIFY-ed).
+///
+/// `this_arg` so eh empilhado quando callee eh Function handle (caminho
+/// classes). Args vem de Vec<i64> handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_INVOKE_AUTO(
+    callee: i64,
+    this_arg: i64,
+    args_handle: u64,
+) -> i64 {
+    // Tenta como handle Function primeiro.
+    if let Some((fn_ptr, bound_args, has_bound_this, bound_this, is_arrow, has_this_param, param_kinds, return_kind)) =
+        read_function_data(callee as u64)
+    {
+        let mut all_args = bound_args;
+        all_args.extend(read_args_vec(args_handle));
+        let pushed_this = if !is_arrow && has_this_param {
+            let effective = if has_bound_this { bound_this } else { this_arg };
+            all_args.insert(0, effective);
+            false
+        } else if !is_arrow {
+            let effective = if has_bound_this { bound_this } else { this_arg };
+            crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_PUSH(effective);
+            true
+        } else {
+            false
+        };
+        let r = unsafe { invoke_typed(fn_ptr, &all_args, &param_kinds, return_kind) };
+        if pushed_this {
+            crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_POP();
+        }
+        return r;
+    }
+    // Fn ptr raw — invoke_n com args vec.
+    let args_v = read_args_vec(args_handle);
+    crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_PUSH(this_arg);
+    let r = unsafe { invoke_n(callee as u64, &args_v) };
+    crate::namespaces::gc::this_slot::__RTS_FN_RT_THIS_POP();
+    r
+}
+
 /// (#264 PR4+) Substitui o prototype Map de uma user fn.
 /// \`Dog.prototype = Object.create(Animal.prototype)\` precisa atualizar
 /// o registry para que \`new Dog\` instale a chain correta.

--- a/tests/proto_method_int_return.test.ts
+++ b/tests/proto_method_int_return.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#proto-method) Method que retorna int continua formatando como int
+// (TPL_COERCE_AUTO detecta valor que NAO eh handle Entry::String).
+
+function Counter(): void {}
+Counter.prototype.value = function(): number { return 42; };
+Counter.prototype.times2 = function(): number { return 100; };
+
+const c: number = new (Counter as any)();
+print(`${(c as any).value()}`);
+print(`${(c as any).times2()}`);
+
+describe("proto method retorna int (#proto-method)", () => {
+  test("ints nao sao confundidos com handles", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "42\n" +
+      "100\n"
+    ));
+});

--- a/tests/proto_method_string_return.test.ts
+++ b/tests/proto_method_string_return.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+import { collections } from "rts";
+
+let __rtsCapturedOutput: string = "";
+function print(value: string): void {
+  __rtsCapturedOutput += value + "\n";
+}
+
+// (#proto-method) Method em fn.prototype que retorna string handle
+// agora aparece corretamente em template literal via TPL_COERCE_AUTO.
+
+function Box(): void {
+  collections.map_set(this as any, "n", 7);
+}
+Box.prototype.greet = function(): string { return "hello"; };
+Box.prototype.farewell = function(): string { return "bye"; };
+
+const b: number = new (Box as any)();
+print(`${(b as any).greet()}`);
+print(`${(b as any).farewell()}`);
+
+describe("proto method retorna string em template (#proto-method)", () => {
+  test("INVOKE_AUTO + TPL_COERCE_AUTO mostra handle como string", () =>
+    expect(__rtsCapturedOutput).toBe(
+      "hello\n" +
+      "bye\n"
+    ));
+});


### PR DESCRIPTION
INVOKE_AUTO + TPL_COERCE_AUTO + REIFY auto. Permite proto methods que retornam string aparecerem corretamente em template literals.