### PR TITLE
fix(codegen): Verifier error em optional chain encadeada com ?.() (#481)

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -426,6 +426,12 @@ pub struct FnCtx<'m, 'fb> {
     /// Keyed por (bits, is_float, block) — per-block como str_handle_cache,
     /// para evitar usar Values de blocos não-dominadores.
     pub num_val_cache: HashMap<(u64, u8, cranelift_codegen::ir::Block), cranelift_codegen::ir::Value>,
+
+    /// Counter para gerar nomes únicos de locals temporários em
+    /// optional chain calls aninhadas (#481). Usado por
+    /// `lower_opt_chain` quando o receiver é uma expressão complexa
+    /// que não casa com Member.obj=Ident no path coberto de lower_call.
+    pub opt_chain_temp_counter: u32,
 }
 
 impl<'m, 'fb> FnCtx<'m, 'fb> {
@@ -484,7 +490,15 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             str_data_cache: HashMap::new(),
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),
+            opt_chain_temp_counter: 0,
         }
+    }
+
+    /// Próximo id único pra nome temporário em optional chain (#481).
+    pub fn next_opt_chain_temp_id(&mut self) -> u32 {
+        let id = self.opt_chain_temp_counter;
+        self.opt_chain_temp_counter += 1;
+        id
     }
 
     /// Resolve `fn_id` a um FuncRef na fn atual, cacheando.

--- a/src/codegen/lower/expressions/operators.rs
+++ b/src/codegen/lower/expressions/operators.rs
@@ -601,6 +601,14 @@ pub(super) fn lower_opt_chain(
                 if let swc_ecma_ast::OptChainBase::Member(inner_member) =
                     inner_opt.base.as_ref()
                 {
+                    // Avalia `obj` UMA VEZ. Quando `inner_member.obj` é
+                    // expressao complexa (OptChain aninhada, Call, etc),
+                    // materializa em local temp e usa Ident sintetico —
+                    // assim `lower_call` ve `Member(obj=Ident, prop=Ident)`,
+                    // forma coberta. Sem isso, lower_call retorna
+                    // "unsupported call expression form" pra `Member.obj=OptChain`,
+                    // o `?` propaga e os blocks ja criados ficam orfaos
+                    // (Verifier: "invalid block reference"). #481
                     let obj_tv = lower_expr(ctx, &inner_member.obj)?;
                     let obj_i64 = ctx.coerce_to_i64(obj_tv).val;
                     let zero = ctx.builder.ins().iconst(cl::I64, 0);
@@ -620,10 +628,32 @@ pub(super) fn lower_opt_chain(
 
                     ctx.builder.switch_to_block(call_block);
                     ctx.builder.seal_block(call_block);
+
+                    // Decide se reusa o ident original (obj simples) ou
+                    // materializa em temp. Reuso evita declare_local extra.
+                    let obj_for_synth: Box<Expr> = if matches!(
+                        inner_member.obj.as_ref(),
+                        Expr::Ident(_)
+                    ) {
+                        inner_member.obj.clone()
+                    } else {
+                        let tmp_name = format!(
+                            "__opt_recv_{}",
+                            ctx.next_opt_chain_temp_id()
+                        );
+                        ctx.declare_local(&tmp_name, ValTy::I64, obj_i64);
+                        Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                            span: Default::default(),
+                            ctxt: Default::default(),
+                            sym: tmp_name.into(),
+                            optional: false,
+                        }))
+                    };
+
                     // Constroi `obj.method(args)` sintetico (sem `?`).
                     let synthetic_member = swc_ecma_ast::MemberExpr {
                         span: inner_member.span,
-                        obj: inner_member.obj.clone(),
+                        obj: obj_for_synth,
                         prop: inner_member.prop.clone(),
                     };
                     let synthetic_callee =


### PR DESCRIPTION
## Summary

- Resolve Cranelift Verifier error `invalid block reference` em expressões como `c?.next?.()?.next?.()?.value`.
- Causa: special-case de `OptChainBase::Call` (PR #333) construia synthetic CallExpr com `Member.obj=OptChain` quando o obj era OptChain aninhada — forma não coberta por `lower_call` → `Err` propagava `?` mas blocks já criados ficavam órfãos.
- Fix: materializa o obj em local var temp `__opt_recv_N` quando não é Ident simples, usa Ident sintético no synthetic.

## Test plan

- [x] \`cargo build --release\` zero warnings de erro.
- [x] \`cargo test --release --lib\` 84/84 ok.
- [x] Repro mínimo agora compila: \`const r = c?.next?.()?.next?.()?.value;\`.
- [x] Teste full \`tests/optional_chain_advanced.test.ts\` agora **compila** (verifier OK).
- [x] Suite TS: 391/398, mesmas 7 falhas, **zero regressão**.

## Notas

O teste \`tests/optional_chain_advanced.test.ts\` continua red por **bugs separados** (não cobertos aqui):
1. Template literal sobre handle de optional chain mostra valor numérico em vez do conteúdo string.
2. \`obj?.undefined_method()\` ainda dispara \`trapz\` (SIGILL) em runtime — comportamento herdado de PR #333 onde nullguard é sobre obj, não sobre o método resolvido. Worth opening as new issue.

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)