### PR TITLE
feat(codegen): Object.entries/assign/freeze/fromEntries (#208 parte 2/3)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -846,6 +846,23 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
             map::__RTS_FN_NS_COLLECTIONS_MAP_VALUES
         );
+        // (#208 / #479) Object static methods.
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_ENTRIES",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_ENTRIES
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_ASSIGN",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_ASSIGN
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_FREEZE",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_FREEZE
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES
+        );
         add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -215,6 +215,65 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
+                // (#208 / #479) Object.entries(obj).
+                if method == "entries" && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_ENTRIES",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // (#208 / #479) Object.freeze(obj) — v0 no-op, retorna handle.
+                if method == "freeze" && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_FREEZE",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // (#208 / #479) Object.fromEntries(arr).
+                if method == "fromEntries" && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // (#208 / #479) Object.assign(target, ...sources). Loop por cada source.
+                if method == "assign" && call.args.len() >= 2 {
+                    let target_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let mut acc = ctx.coerce_to_i64(target_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_ASSIGN",
+                        &[cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    for arg in &call.args[1..] {
+                        if arg.spread.is_some() {
+                            return Err(anyhow!("spread not supported in Object.assign"));
+                        }
+                        let s_tv = lower_expr(ctx, &arg.expr)?;
+                        let s = ctx.coerce_to_i64(s_tv).val;
+                        let inst = ctx.builder.ins().call(f, &[acc, s]);
+                        acc = ctx.builder.inst_results(inst)[0];
+                    }
+                    return Ok(TypedVal::new(acc, ValTy::Handle));
+                }
             }
             // Function global (#359): `<fn>.call/.apply/.bind/.toString(...)`.
             // Dois caminhos:

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -287,3 +287,149 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
         crate::namespaces::gc::handles::Entry::Vec(Box::new(vals)),
     )
 }
+
+/// (#208 / #479) `Object.entries(obj)` — retorna Vec de Vec [key_handle, value].
+/// Cada par e' um Vec<i64> com 2 elementos: handle de string da key, e o
+/// valor i64. Ordem: keys sorted asc.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(handle: u64) -> u64 {
+    let pairs: Vec<(String, i64)> = with_map(handle, Vec::new(), |m| {
+        let mut entries: Vec<(String, i64)> = m.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    });
+    let mut outer: Vec<i64> = Vec::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        let key_h = crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(
+            k.as_ptr(),
+            k.len() as i64,
+        );
+        let inner = crate::namespaces::gc::handles::alloc_entry(
+            crate::namespaces::gc::handles::Entry::Vec(Box::new(vec![key_h as i64, v])),
+        );
+        outer.push(inner as i64);
+    }
+    crate::namespaces::gc::handles::alloc_entry(
+        crate::namespaces::gc::handles::Entry::Vec(Box::new(outer)),
+    )
+}
+
+/// (#208 / #479) `Object.assign(target, source)` — copia own props de source
+/// pra target. Retorna handle do target. Versao com multiplos sources e'
+/// chamada repetidamente pelo codegen.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ASSIGN(target: u64, source: u64) -> u64 {
+    let pairs: Vec<(String, i64)> = with_map(source, Vec::new(), |m| {
+        m.iter().map(|(k, v)| (k.clone(), *v)).collect()
+    });
+    with_map_mut(target, (), |m| {
+        for (k, v) in pairs {
+            m.insert(k, v);
+        }
+    });
+    target
+}
+
+/// (#208 / #479) `Object.freeze(obj)` — v0 sem flag de frozen no Entry.
+/// Retorna o proprio handle. Mutacoes subsequentes nao sao bloqueadas
+/// (JS non-strict mode behavior). Issue separada cobrira freeze real.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FREEZE(handle: u64) -> u64 {
+    handle
+}
+
+/// (#208 / #479) `Object.fromEntries(arr)` — recebe Vec de pares
+/// [key_handle, value] e cria Map. Inverso de Object.entries.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES(arr: u64) -> u64 {
+    use crate::namespaces::gc::handles::{Entry, with_entry};
+    let pair_handles: Vec<i64> = with_entry(arr, |entry| match entry {
+        Some(Entry::Vec(v)) => v.as_ref().clone(),
+        _ => Vec::new(),
+    });
+    let m = alloc_entry(Entry::Map(Box::new(IndexMap::new())));
+    for ph in pair_handles {
+        let pair_h = ph as u64;
+        let kv: Option<(String, i64)> = with_entry(pair_h, |entry| match entry {
+            Some(Entry::Vec(pair)) if pair.len() >= 2 => {
+                let key_h = pair[0] as u64;
+                let key_str: Option<String> = with_entry(key_h, |ke| match ke {
+                    Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                    _ => None,
+                });
+                key_str.map(|k| (k, pair[1]))
+            }
+            _ => None,
+        });
+        if let Some((k, v)) = kv {
+            with_map_mut(m, (), |mm| {
+                mm.insert(k, v);
+            });
+        }
+    }
+    m
+}
+
+#[cfg(test)]
+mod object_tests {
+    use super::*;
+    use crate::namespaces::gc::handles::{Entry, with_entry};
+
+    fn read_str(h: u64) -> Option<String> {
+        with_entry(h, |e| match e {
+            Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            _ => None,
+        })
+    }
+
+    fn read_vec(h: u64) -> Vec<i64> {
+        with_entry(h, |e| match e {
+            Some(Entry::Vec(v)) => v.as_ref().clone(),
+            _ => Vec::new(),
+        })
+    }
+
+    fn map_with(pairs: &[(&str, i64)]) -> u64 {
+        let h = __RTS_FN_NS_COLLECTIONS_MAP_NEW();
+        for (k, v) in pairs {
+            with_map_mut(h, (), |m| {
+                m.insert((*k).to_string(), *v);
+            });
+        }
+        h
+    }
+
+    #[test]
+    fn entries_returns_pairs_sorted() {
+        let m = map_with(&[("b", 2), ("a", 1), ("c", 3)]);
+        let entries = __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(m);
+        let outer = read_vec(entries);
+        assert_eq!(outer.len(), 3);
+        let p0 = read_vec(outer[0] as u64);
+        assert_eq!(read_str(p0[0] as u64).unwrap(), "a");
+        assert_eq!(p0[1], 1);
+    }
+
+    #[test]
+    fn assign_copies_source_to_target() {
+        let target = map_with(&[("x", 1)]);
+        let source = map_with(&[("y", 2), ("z", 3)]);
+        let result = __RTS_FN_NS_COLLECTIONS_MAP_ASSIGN(target, source);
+        assert_eq!(result, target);
+        assert_eq!(__RTS_FN_NS_COLLECTIONS_MAP_LEN(target), 3);
+    }
+
+    #[test]
+    fn from_entries_roundtrip() {
+        let m = map_with(&[("a", 1), ("b", 2)]);
+        let entries = __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(m);
+        let back = __RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES(entries);
+        assert_eq!(__RTS_FN_NS_COLLECTIONS_MAP_LEN(back), 2);
+    }
+
+    #[test]
+    fn freeze_returns_same_handle() {
+        let m = map_with(&[("a", 1)]);
+        assert_eq!(__RTS_FN_NS_COLLECTIONS_MAP_FREEZE(m), m);
+    }
+}

--- a/tests/object_static_methods.test.ts
+++ b/tests/object_static_methods.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj = { a: 1, b: 2, c: 3 };
+
+// Object.entries — pares ordenados
+const entries = Object.entries(obj);
+print(`${entries.length}`);
+
+// Object.assign
+const target = { x: 1 };
+Object.assign(target, { y: 2 }, { z: 3 });
+print(`${(target as any).x} ${(target as any).y} ${(target as any).z}`);
+
+// Object.freeze — v0 retorna mesmo handle (no-op)
+const frozen = Object.freeze({ n: 42 });
+print(`${(frozen as any).n}`);
+
+// Object.fromEntries roundtrip
+const back = Object.fromEntries(entries);
+print(`${(back as any).a} ${(back as any).b} ${(back as any).c}`);
+
+describe("object_static_methods", () => {
+  test("all", () => expect(out).toBe(
+    "3\n1 2 3\n42\n1 2 3\n"
+  ));
+});


### PR DESCRIPTION
## Summary

Implementa 4 métodos estáticos faltantes de \`Object\`:
- \`Object.entries(obj)\` — array de pares [key, value]
- \`Object.assign(target, ...sources)\` — merge
- \`Object.freeze(obj)\` — v0 no-op (retorna handle); freeze real fica pra PR separada com flag no Entry
- \`Object.fromEntries(arr)\` — inverso de entries

\`Object.keys/values/hasOwn/create\` já existiam.

## Test plan

- [x] cargo test: 88/88 (4 novos).
- [x] rts test: 392/399 (mesmas 7 falhas, +1 pelo novo teste).
- [x] Zero regressão.
- [x] \`tests/object_static_methods.test.ts\` cobre os 4.

Refs #208 (Tier 1, parte 2 de 3).
Refs #479.
Refs #226 (epic JS/TS parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)