### PR TITLE
feat(reflect): Reflect API v0 (#218)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -275,6 +275,34 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     return Ok(TypedVal::new(acc, ValTy::Handle));
                 }
             }
+            // (#218) Reflect API v0: get/set/has/deleteProperty/ownKeys.
+            // Reusa as fns MAP_* (semantica identica a Object.*).
+            // Nota: ownKeys retorna sorted (mesma limitacao de Object.keys).
+            if let Some(method) = qualified.strip_prefix("Reflect.") {
+                match method {
+                    "get" if call.args.len() == 2 => {
+                        return lower_ns_call(ctx, "collections.map_get", call);
+                    }
+                    "has" if call.args.len() == 2 => {
+                        return lower_ns_call(ctx, "collections.map_has", call);
+                    }
+                    "ownKeys" if call.args.len() == 1 => {
+                        return lower_ns_call(ctx, "collections.map_keys", call);
+                    }
+                    "deleteProperty" if call.args.len() == 2 => {
+                        // map_delete retorna I64 (0/1). Reescreve como Bool.
+                        let tv = lower_ns_call(ctx, "collections.map_delete", call)?;
+                        return Ok(TypedVal::new(tv.val, ValTy::Bool));
+                    }
+                    "set" if call.args.len() == 3 => {
+                        // map_set eh Void. Faz a chamada e retorna true.
+                        let _ = lower_ns_call(ctx, "collections.map_set", call)?;
+                        let t = ctx.builder.ins().iconst(cl::I64, 1);
+                        return Ok(TypedVal::new(t, ValTy::Bool));
+                    }
+                    _ => {}
+                }
+            }
             // (#208 / #476) Array static globals: Array.isArray.
             // Array.from cobre arrayLike { length: N } — versao com mapper
             // vai em PR separada (precisa caminho de callback).

--- a/tests/reflect_v0.test.ts
+++ b/tests/reflect_v0.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj: { [k: string]: number } = { a: 1, b: 2, c: 3 };
+
+print(Reflect.get(obj, "a").toString());
+
+print(Reflect.has(obj, "a") ? "yes" : "no");
+print(Reflect.has(obj, "z") ? "yes" : "no");
+
+Reflect.set(obj, "d", 4);
+print(Reflect.get(obj, "d").toString());
+
+Reflect.deleteProperty(obj, "a");
+print(Reflect.has(obj, "a") ? "yes" : "no");
+
+const keys = Reflect.ownKeys(obj);
+print(keys.join(","));
+
+describe("reflect_v0", () => {
+  test("acceptance #218 v0", () => expect(out).toBe(
+    "1\nyes\nno\n4\nno\nb,c,d\n"
+  ));
+});


### PR DESCRIPTION
## Summary

Implementa Reflect API v0 (subset) como dispatch ad-hoc em `lower_call`, reusando as fns `__RTS_FN_NS_COLLECTIONS_MAP_*`. Semantica identica a `Object.*` para esses 5 metodos, sem novos namespaces, Entry ou fns extern.

Metodos cobertos:

- `Reflect.get(obj, key)` -> `map_get`
- `Reflect.set(obj, key, val)` -> `map_set` + retorna `true`
- `Reflect.has(obj, key)` -> `map_has` (Bool)
- `Reflect.deleteProperty(obj, key)` -> `map_delete` (Bool)
- `Reflect.ownKeys(obj)` -> `map_keys` (handle Vec)

## Skip nesta PR

- `Reflect.getPrototypeOf` / `setPrototypeOf`
- `Reflect.isExtensible` / `preventExtensions`
- `Reflect.getOwnPropertyDescriptor` / `defineProperty`
- `Reflect.ownKeys` com symbols
- **`Proxy` inteiro** — exige intercepcao em codegen (refator pesado), fica para PR separada

## Limitacao conhecida

`Reflect.ownKeys` herda a ordenacao de `Object.keys`: retorna keys ordenadas alfabeticamente (sorted), nao insertion order como o JS spec exige. Aceitavel para v0; corrigir junto com `Object.keys` em follow-up.

## Test plan

- [x] `tests/reflect_v0.test.ts` cobre os 5 metodos com acceptance #218 (output `"1\nyes\nno\n4\nno\nb,c,d\n"`)
- [x] `cargo build --release` passa sem novos warnings
- [x] Suite TS: 403 passed, 7 failed (mesmas falhas do baseline pre-PR — zero regressao)

Refs #218 #226