### PR TITLE
feat(weakmap): WeakMap/WeakSet v0 (#217)

### DIFF
--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -45,6 +45,8 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::url::class_spec::URL_CLASS_SPEC,
     &crate::namespaces::globals::function::abi::FUNCTION_CLASS_SPEC,
     &crate::namespaces::globals::symbol::SYMBOL_CLASS_SPEC,
+    &crate::namespaces::globals::weakmap::WEAKMAP_CLASS_SPEC,
+    &crate::namespaces::globals::weakset::WEAKSET_CLASS_SPEC,
 ];
 
 /// Looks up a global class spec by JS class name (e.g. `"Date"`).

--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -376,6 +376,25 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_SYMBOL_TO_STRING", __RTS_FN_GL_SYMBOL_TO_STRING);
     }
 
+    // ── namespaces::globals::weakmap (#217 v0) ───────────────────────
+    {
+        use crate::namespaces::globals::weakmap::rt::*;
+        add_fn!("__RTS_FN_GL_WEAKMAP_NEW", __RTS_FN_GL_WEAKMAP_NEW);
+        add_fn!("__RTS_FN_GL_WEAKMAP_SET", __RTS_FN_GL_WEAKMAP_SET);
+        add_fn!("__RTS_FN_GL_WEAKMAP_GET", __RTS_FN_GL_WEAKMAP_GET);
+        add_fn!("__RTS_FN_GL_WEAKMAP_HAS", __RTS_FN_GL_WEAKMAP_HAS);
+        add_fn!("__RTS_FN_GL_WEAKMAP_DELETE", __RTS_FN_GL_WEAKMAP_DELETE);
+    }
+
+    // ── namespaces::globals::weakset (#217 v0) ───────────────────────
+    {
+        use crate::namespaces::globals::weakset::rt::*;
+        add_fn!("__RTS_FN_GL_WEAKSET_NEW", __RTS_FN_GL_WEAKSET_NEW);
+        add_fn!("__RTS_FN_GL_WEAKSET_ADD", __RTS_FN_GL_WEAKSET_ADD);
+        add_fn!("__RTS_FN_GL_WEAKSET_HAS", __RTS_FN_GL_WEAKSET_HAS);
+        add_fn!("__RTS_FN_GL_WEAKSET_DELETE", __RTS_FN_GL_WEAKSET_DELETE);
+    }
+
     // ── namespaces::globals::text_encoding ───────────────────────────
     use crate::namespaces::globals::text_encoding::instance::*;
     add_fn!("__RTS_FN_GL_TEXTENC_ENCODE", __RTS_FN_GL_TEXTENC_ENCODE);

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -145,6 +145,11 @@ pub enum Entry {
     /// chamada cria handle unico — comparacao por identidade de handle.
     /// Symbol.for usa registry separado pra retornar mesmo handle.
     Symbol { description: Option<String> },
+    /// WeakMap (#217 v0). v0 comporta como Map forte sem coleta automatica
+    /// quando a key e' freed — Box<HashMap<u64,i64>> indexado por handle.
+    WeakMap(Box<std::collections::HashMap<u64, i64>>),
+    /// WeakSet (#217 v0). v0 comporta como Set forte sem coleta automatica.
+    WeakSet(Box<std::collections::HashSet<u64>>),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/src/namespaces/globals/mod.rs
+++ b/src/namespaces/globals/mod.rs
@@ -18,3 +18,5 @@ pub mod symbol;
 pub mod text_encoding;
 pub mod timers;
 pub mod url;
+pub mod weakmap;
+pub mod weakset;

--- a/src/namespaces/globals/weakmap/abi.rs
+++ b/src/namespaces/globals/weakmap/abi.rs
@@ -1,0 +1,67 @@
+//! `WeakMap` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_WEAKMAP_NEW",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Creates a new empty WeakMap.",
+        ts_signature: "new WeakMap(): WeakMap",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "set",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKMAP_SET",
+        args: &[AbiType::Handle, AbiType::Handle, AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "Sets value for key (handle). Returns the WeakMap.",
+        ts_signature: "set(key: object, value: any): WeakMap",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "get",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKMAP_GET",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Returns value for key, or 0 if absent.",
+        ts_signature: "get(key: object): any",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "has",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKMAP_HAS",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Returns 1 if key exists, 0 otherwise.",
+        ts_signature: "has(key: object): boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "delete",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKMAP_DELETE",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Removes key. Returns 1 if existed, 0 otherwise.",
+        ts_signature: "delete(key: object): boolean",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const WEAKMAP_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WeakMap",
+    doc: "Built-in WeakMap (#217 v0). Comporta como Map forte; weak semantics em PR futura.",
+    members: MEMBERS,
+};

--- a/src/namespaces/globals/weakmap/mod.rs
+++ b/src/namespaces/globals/weakmap/mod.rs
@@ -1,0 +1,10 @@
+//! `WeakMap` global class (#217 v0) — semantica forte temporaria.
+//!
+//! v0 nao implementa coleta automatica de entries quando key e' freed
+//! (faltando FinalizationRegistry / weak refs reais). Comporta como Map
+//! forte com chaves u64 (handles).
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::WEAKMAP_CLASS_SPEC;

--- a/src/namespaces/globals/weakmap/rt.rs
+++ b/src/namespaces/globals/weakmap/rt.rs
@@ -1,0 +1,89 @@
+//! `WeakMap` runtime — extern "C" implementations.
+//!
+//! v0: comporta como Map forte (sem weak references). Coleta automatica
+//! quando key e' freed fica para PR futura junto com FinalizationRegistry.
+
+use std::collections::HashMap;
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKMAP_NEW() -> u64 {
+    alloc_entry(Entry::WeakMap(Box::new(HashMap::new())))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKMAP_SET(wm: u64, key: u64, value: i64) -> u64 {
+    with_entry_mut(wm, |e| {
+        if let Some(Entry::WeakMap(map)) = e {
+            map.insert(key, value);
+        }
+    });
+    wm
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKMAP_GET(wm: u64, key: u64) -> i64 {
+    with_entry(wm, |e| match e {
+        Some(Entry::WeakMap(map)) => map.get(&key).copied().unwrap_or(0),
+        _ => 0,
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKMAP_HAS(wm: u64, key: u64) -> i64 {
+    with_entry(wm, |e| match e {
+        Some(Entry::WeakMap(map)) => i64::from(map.contains_key(&key)),
+        _ => 0,
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKMAP_DELETE(wm: u64, key: u64) -> i64 {
+    with_entry_mut(wm, |e| match e {
+        Some(Entry::WeakMap(map)) => i64::from(map.remove(&key).is_some()),
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_get_roundtrip() {
+        let wm = __RTS_FN_GL_WEAKMAP_NEW();
+        let key = 0xdead_beef;
+        assert_eq!(__RTS_FN_GL_WEAKMAP_SET(wm, key, 42), wm);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_GET(wm, key), 42);
+    }
+
+    #[test]
+    fn has_and_missing_returns_zero() {
+        let wm = __RTS_FN_GL_WEAKMAP_NEW();
+        let key = 1234;
+        assert_eq!(__RTS_FN_GL_WEAKMAP_HAS(wm, key), 0);
+        __RTS_FN_GL_WEAKMAP_SET(wm, key, 99);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_HAS(wm, key), 1);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_GET(wm, 9999), 0);
+    }
+
+    #[test]
+    fn delete_existing_and_missing() {
+        let wm = __RTS_FN_GL_WEAKMAP_NEW();
+        let key = 7;
+        __RTS_FN_GL_WEAKMAP_SET(wm, key, 100);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_DELETE(wm, key), 1);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_DELETE(wm, key), 0);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_HAS(wm, key), 0);
+    }
+
+    #[test]
+    fn overwrite_value() {
+        let wm = __RTS_FN_GL_WEAKMAP_NEW();
+        let key = 5;
+        __RTS_FN_GL_WEAKMAP_SET(wm, key, 1);
+        __RTS_FN_GL_WEAKMAP_SET(wm, key, 2);
+        assert_eq!(__RTS_FN_GL_WEAKMAP_GET(wm, key), 2);
+    }
+}

--- a/src/namespaces/globals/weakset/abi.rs
+++ b/src/namespaces/globals/weakset/abi.rs
@@ -1,0 +1,56 @@
+//! `WeakSet` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_WEAKSET_NEW",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "Creates a new empty WeakSet.",
+        ts_signature: "new WeakSet(): WeakSet",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "add",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKSET_ADD",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Adds object handle to set. Returns the WeakSet.",
+        ts_signature: "add(value: object): WeakSet",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "has",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKSET_HAS",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Returns 1 if value present, 0 otherwise.",
+        ts_signature: "has(value: object): boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "delete",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKSET_DELETE",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Removes value. Returns 1 if existed, 0 otherwise.",
+        ts_signature: "delete(value: object): boolean",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const WEAKSET_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WeakSet",
+    doc: "Built-in WeakSet (#217 v0). Comporta como Set forte; weak semantics em PR futura.",
+    members: MEMBERS,
+};

--- a/src/namespaces/globals/weakset/mod.rs
+++ b/src/namespaces/globals/weakset/mod.rs
@@ -1,0 +1,8 @@
+//! `WeakSet` global class (#217 v0) — semantica forte temporaria.
+//!
+//! v0 nao implementa coleta automatica quando elementos sao freed.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::WEAKSET_CLASS_SPEC;

--- a/src/namespaces/globals/weakset/rt.rs
+++ b/src/namespaces/globals/weakset/rt.rs
@@ -1,0 +1,70 @@
+//! `WeakSet` runtime — extern "C" implementations.
+
+use std::collections::HashSet;
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKSET_NEW() -> u64 {
+    alloc_entry(Entry::WeakSet(Box::new(HashSet::new())))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKSET_ADD(ws: u64, val: u64) -> u64 {
+    with_entry_mut(ws, |e| {
+        if let Some(Entry::WeakSet(set)) = e {
+            set.insert(val);
+        }
+    });
+    ws
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKSET_HAS(ws: u64, val: u64) -> i64 {
+    with_entry(ws, |e| match e {
+        Some(Entry::WeakSet(set)) => i64::from(set.contains(&val)),
+        _ => 0,
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKSET_DELETE(ws: u64, val: u64) -> i64 {
+    with_entry_mut(ws, |e| match e {
+        Some(Entry::WeakSet(set)) => i64::from(set.remove(&val)),
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_has() {
+        let ws = __RTS_FN_GL_WEAKSET_NEW();
+        let v = 0xcafe;
+        assert_eq!(__RTS_FN_GL_WEAKSET_HAS(ws, v), 0);
+        assert_eq!(__RTS_FN_GL_WEAKSET_ADD(ws, v), ws);
+        assert_eq!(__RTS_FN_GL_WEAKSET_HAS(ws, v), 1);
+    }
+
+    #[test]
+    fn delete_existing_and_missing() {
+        let ws = __RTS_FN_GL_WEAKSET_NEW();
+        let v = 42;
+        __RTS_FN_GL_WEAKSET_ADD(ws, v);
+        assert_eq!(__RTS_FN_GL_WEAKSET_DELETE(ws, v), 1);
+        assert_eq!(__RTS_FN_GL_WEAKSET_DELETE(ws, v), 0);
+        assert_eq!(__RTS_FN_GL_WEAKSET_HAS(ws, v), 0);
+    }
+
+    #[test]
+    fn add_idempotent() {
+        let ws = __RTS_FN_GL_WEAKSET_NEW();
+        __RTS_FN_GL_WEAKSET_ADD(ws, 1);
+        __RTS_FN_GL_WEAKSET_ADD(ws, 1);
+        assert_eq!(__RTS_FN_GL_WEAKSET_HAS(ws, 1), 1);
+        assert_eq!(__RTS_FN_GL_WEAKSET_DELETE(ws, 1), 1);
+        assert_eq!(__RTS_FN_GL_WEAKSET_HAS(ws, 1), 0);
+    }
+}

--- a/tests/weakmap_v0.test.ts
+++ b/tests/weakmap_v0.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj1 = {};
+const obj2 = {};
+const wm = new WeakMap();
+wm.set(obj1, 42);
+const v = wm.get(obj1);
+print(`${v}`);
+print(wm.has(obj1) ? "yes" : "no");
+print(wm.has(obj2) ? "yes" : "no");
+wm.delete(obj1);
+print(wm.has(obj1) ? "yes" : "no");
+
+describe("weakmap_v0", () => {
+  test("acceptance #217 v0", () => expect(out).toBe("42\nyes\nno\nno\n"));
+});

--- a/tests/weakset_v0.test.ts
+++ b/tests/weakset_v0.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj1 = {};
+const obj2 = {};
+const ws = new WeakSet();
+ws.add(obj1);
+print(ws.has(obj1) ? "yes" : "no");
+print(ws.has(obj2) ? "yes" : "no");
+ws.delete(obj1);
+print(ws.has(obj1) ? "yes" : "no");
+ws.add(obj2);
+print(ws.has(obj2) ? "yes" : "no");
+
+describe("weakset_v0", () => {
+  test("acceptance #217 v0", () => expect(out).toBe("yes\nno\nno\nyes\n"));
+});


### PR DESCRIPTION
## Summary
- Implementa WeakMap (new/set/get/has/delete) e WeakSet (new/add/has/delete) como classes globais.
- v0: comporta como Map/Set forte. Coleta automatica quando key/elemento e' freed + FinalizationRegistry ficam para PR futura.

Refs #217 #226

## Test plan
- [x] cargo build --release limpo
- [x] cargo test --release --lib 101 passed
- [x] tests/weakmap_v0.test.ts passa
- [x] tests/weakset_v0.test.ts passa
- [x] Suite TS: 405/412 passed (mesmas 7 falhas pre-existentes, zero regressao)