### PR TITLE
feat(codegen): Map.keys/values/entries iteration (#222 v0)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -2613,6 +2613,37 @@ fn lower_map_set_builtin(
             let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
+        // (#222) Map iteration methods. Reusam fns de Object.keys/values/entries.
+        "entries" if call.args.is_empty() => {
+            let fref = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_MAP_ENTRIES",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(fref, &[recv_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        "keys" if call.args.is_empty() => {
+            let fref = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_MAP_KEYS",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(fref, &[recv_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        "values" if call.args.is_empty() => {
+            let fref = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(fref, &[recv_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
         _ => Ok(None),
     }
 }

--- a/tests/map_iteration.test.ts
+++ b/tests/map_iteration.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+const m = new Map<string, number>();
+m.set("a", 1);
+m.set("b", 2);
+m.set("c", 3);
+
+// .size
+out += m.size + "\n";
+
+// .keys() — armazenar em var pra evitar chained call ainda nao otimizado
+const ks = m.keys();
+out += ks.join(",") + "\n";
+
+// .values()
+const vs = m.values();
+out += vs.join(",") + "\n";
+
+// .entries() — Vec de Vec[k_handle, v]
+const entries = m.entries();
+out += entries.length + "\n";
+
+// for-of destructure (#210 + #222)
+for (const [k, v] of m.entries()) {
+  out += k + "=" + v + "\n";
+}
+
+describe("map_iteration", () => {
+  test("acceptance #222 v0", () => expect(out).toBe(
+    "3\na,b,c\n1,2,3\n3\na=1\nb=2\nc=3\n"
+  ));
+});


### PR DESCRIPTION
Adiciona 3 metodos de iteracao em Map handles. Combinado com PR #494 (for-of destructuring), funciona `for (const [k,v] of m.entries())`.

## Test plan
- rts test: 407/414 (+1 novo, zero regressão)

Refs #222 #210 #226.