### PR TITLE
feat(codegen): String.match e String.search via regex backend (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1054,6 +1054,9 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         search::__RTS_FN_NS_STRING_ENDS_WITH
     );
     add_fn!("__RTS_FN_NS_STRING_FIND", search::__RTS_FN_NS_STRING_FIND);
+    // (#208) match/search via regex.
+    add_fn!("__RTS_FN_NS_STRING_MATCH", search::__RTS_FN_NS_STRING_MATCH);
+    add_fn!("__RTS_FN_NS_STRING_SEARCH", search::__RTS_FN_NS_STRING_SEARCH);
     add_fn!(
         "__RTS_FN_NS_STRING_TO_UPPER",
         transform::__RTS_FN_NS_STRING_TO_UPPER

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -354,10 +354,20 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                                     return Ok(tv);
                                 }
                             }
-                            // (b) var handle (de bind ou new Function)
-                            if ctx.var_ty(obj_name).is_some() {
-                                if let Some(tv) = lower_function_handle_method(ctx, &m.obj, prop_name, call)? {
-                                    return Ok(tv);
+                            // (b) var handle (de bind ou new Function) — pula
+                            // primitivos (Bool/F64/I32) pra deixar dispatch
+                            // correto cair em lower_var_member_call.
+                            if let Some(var_ty) = ctx.var_ty(obj_name) {
+                                let is_primitive = matches!(
+                                    var_ty,
+                                    crate::codegen::lower::ctx::ValTy::Bool
+                                        | crate::codegen::lower::ctx::ValTy::F64
+                                        | crate::codegen::lower::ctx::ValTy::I32
+                                );
+                                if !is_primitive {
+                                    if let Some(tv) = lower_function_handle_method(ctx, &m.obj, prop_name, call)? {
+                                        return Ok(tv);
+                                    }
                                 }
                             }
                         }
@@ -2360,6 +2370,37 @@ fn lower_string_builtin(
             let sep = arg_handle(ctx, call, 0)?;
             let v = call_h!("__RTS_FN_GL_STRING_SPLIT", &[cl::I64, cl::I64], Some(cl::I64), &[recv_h, sep]);
             Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        // (#208) `s.match(pattern)` — primeiro match, retorna string handle ou 0.
+        "match" => {
+            let pattern = arg_handle(ctx, call, 0)?;
+            // Converte recv_h e pattern de handle pra (ptr, len).
+            let p1 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let l1 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let p2 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[pattern]);
+            let l2 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[pattern]);
+            let v = call_h!(
+                "__RTS_FN_NS_STRING_MATCH",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
+                Some(cl::I64),
+                &[p1, l1, p2, l2]
+            );
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        // (#208) `s.search(pattern)` — index do primeiro match, ou -1.
+        "search" => {
+            let pattern = arg_handle(ctx, call, 0)?;
+            let p1 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let l1 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let p2 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[pattern]);
+            let l2 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[pattern]);
+            let v = call_h!(
+                "__RTS_FN_NS_STRING_SEARCH",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
+                Some(cl::I64),
+                &[p1, l1, p2, l2]
+            );
+            Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "localeCompare" => {
             let other = arg_handle(ctx, call, 0)?;

--- a/src/namespaces/globals/string/search.rs
+++ b/src/namespaces/globals/string/search.rs
@@ -68,3 +68,43 @@ pub extern "C" fn __RTS_FN_NS_STRING_FIND(
         _ => -1,
     }
 }
+
+/// (#208) `str.match(pattern)` — primeiro match, retorna handle de string
+/// com o conteudo encontrado, ou 0 se nao acha. Pattern e' string regex.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_STRING_MATCH(
+    s_ptr: *const u8,
+    s_len: i64,
+    p_ptr: *const u8,
+    p_len: i64,
+) -> u64 {
+    use crate::namespaces::gc::handles::{Entry, alloc_entry};
+    let (Some(s), Some(p)) = (str_from_abi(s_ptr, s_len), str_from_abi(p_ptr, p_len)) else {
+        return 0;
+    };
+    let Ok(rx) = regex::Regex::new(p) else {
+        return 0;
+    };
+    match rx.find(s) {
+        Some(m) => alloc_entry(Entry::String(m.as_str().as_bytes().to_vec())),
+        None => 0,
+    }
+}
+
+/// (#208) `str.search(pattern)` — index do primeiro match, ou -1.
+/// Pattern e' string regex.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_STRING_SEARCH(
+    s_ptr: *const u8,
+    s_len: i64,
+    p_ptr: *const u8,
+    p_len: i64,
+) -> i64 {
+    let (Some(s), Some(p)) = (str_from_abi(s_ptr, s_len), str_from_abi(p_ptr, p_len)) else {
+        return -1;
+    };
+    let Ok(rx) = regex::Regex::new(p) else {
+        return -1;
+    };
+    rx.find(s).map(|m| m.start() as i64).unwrap_or(-1)
+}

--- a/tests/string_match_search.test.ts
+++ b/tests/string_match_search.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// match e search via regex backend.
+// (#208) Patterns com `\d`/`\s` ficam pra futura PR — bug separado
+// no parser de string literals onde `"\d"` perde o backslash.
+
+const s = "Hello World";
+
+// search: index do primeiro match (literal e classes simples funcionam)
+out += s.search("World") + "\n";          // 6
+out += s.search("xyz") + "\n";            // -1
+out += s.search("[Hh]ello") + "\n";       // 0
+
+// match: retorna substring encontrado como handle de string.
+// concat com "" forca conversao + comparacao de bytes via string concat.
+const m1 = s.match("World");
+out += (m1 + "") + "\n";                  // World
+
+const m2 = s.match("xyz");
+// nao acha → 0; concat com "" via STRING_CONCAT trata 0 como vazio
+out += "after-noMatch\n";
+
+describe("string_match_search", () => {
+  test("match + search via regex (subset sem escape backslash)", () => expect(out).toBe(
+    "6\n-1\n0\nWorld\nafter-noMatch\n"
+  ));
+});


### PR DESCRIPTION
Adiciona `s.match(pattern)` e `s.search(pattern)` que reusam o regex crate.

## Test plan
- cargo test: 108/108
- rts test: 408/415 (+1 novo, zero regressão)

## Limitação conhecida
Patterns com `\d`/`\s` não funcionam — bug pré-existente no parser de string literals do RTS. Patterns literais e classes (`[abc]`) funcionam.

Refs #208 #226.