### PR TITLE
feat(codegen): Array.from({length}) e Array.from(vec) (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -974,6 +974,15 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_COLLECTIONS_VEC_SPLICE_REMOVE",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_SPLICE_REMOVE
         );
+        // (#208) Array.from variants.
+        add_fn!(
+            "__RTS_FN_GL_ARRAY_FROM_LENGTH",
+            vec::__RTS_FN_GL_ARRAY_FROM_LENGTH
+        );
+        add_fn!(
+            "__RTS_FN_GL_ARRAY_FROM_VEC",
+            vec::__RTS_FN_GL_ARRAY_FROM_VEC
+        );
     }
 
     // ── namespaces::os ────────────────────────────────────────────────

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -303,15 +303,11 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     _ => {}
                 }
             }
-            // (#208 / #476) Array static globals: Array.isArray.
-            // Array.from cobre arrayLike { length: N } — versao com mapper
-            // vai em PR separada (precisa caminho de callback).
+            // (#208 / #476) Array static globals: isArray, from.
             if let Some(method) = qualified.strip_prefix("Array.") {
                 if method == "isArray" && call.args.len() == 1
                     && call.args[0].spread.is_none()
                 {
-                    // arr.isArray(x): true se x e' handle valido cujo Entry::Vec.
-                    // Reusa __RTS_FN_NS_GC_IS_VEC se existir, senao via tag.
                     let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
                     let arg_h = ctx.coerce_to_i64(arg_tv).val;
                     let is_vec_fn = ctx.get_extern(
@@ -322,6 +318,83 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let inst = ctx.builder.ins().call(is_vec_fn, &[arg_h]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Bool));
+                }
+                // (#208) Array.from(arrayLike, mapper?). Aceita 2 formas:
+                //   1. Array.from({length: N}, fn?) — gera Vec [fn(0,0), fn(1,1), ...]
+                //      Detecta object literal com unica key "length".
+                //   2. Array.from(vecHandle, fn?) — converte/mapeia Vec existente.
+                // mapper e' Ident de user fn (lift de arrow inline fica em
+                // PR separada — usuario pode definir `function f(_, i)` antes).
+                if method == "from" && (call.args.len() == 1 || call.args.len() == 2) {
+                    let first = &call.args[0];
+                    if first.spread.is_some() {
+                        return Err(anyhow!("spread not supported in Array.from"));
+                    }
+                    // Resolve mapper fn_ptr (0 se ausente).
+                    let fn_ptr = if call.args.len() == 2 {
+                        let arg = &call.args[1];
+                        if arg.spread.is_some() {
+                            return Err(anyhow!("spread not supported in Array.from"));
+                        }
+                        match arg.expr.as_ref() {
+                            Expr::Ident(id) => {
+                                let fn_name = id.sym.as_str().to_string();
+                                if ctx.user_fns.contains_key(&fn_name)
+                                    && ctx.var_ty(&fn_name).is_none()
+                                {
+                                    let tv = emit_user_fn_addr(ctx, &fn_name)?;
+                                    ctx.coerce_to_i64(tv).val
+                                } else {
+                                    ctx.builder.ins().iconst(cl::I64, 0)
+                                }
+                            }
+                            _ => ctx.builder.ins().iconst(cl::I64, 0),
+                        }
+                    } else {
+                        ctx.builder.ins().iconst(cl::I64, 0)
+                    };
+                    // Detecta `{length: N}` literal.
+                    if let Expr::Object(obj_lit) = first.expr.as_ref() {
+                        let mut length_lit: Option<i64> = None;
+                        for prop in &obj_lit.props {
+                            if let swc_ecma_ast::PropOrSpread::Prop(p) = prop {
+                                if let swc_ecma_ast::Prop::KeyValue(kv) = p.as_ref() {
+                                    let key = match &kv.key {
+                                        swc_ecma_ast::PropName::Ident(i) => Some(i.sym.as_str().to_string()),
+                                        swc_ecma_ast::PropName::Str(s) => Some(s.value.to_string_lossy().to_string()),
+                                        _ => None,
+                                    };
+                                    if key.as_deref() == Some("length") {
+                                        if let Expr::Lit(swc_ecma_ast::Lit::Num(n)) = kv.value.as_ref() {
+                                            length_lit = Some(n.value as i64);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(n_lit) = length_lit {
+                            let n = ctx.builder.ins().iconst(cl::I64, n_lit);
+                            let f = ctx.get_extern(
+                                "__RTS_FN_GL_ARRAY_FROM_LENGTH",
+                                &[cl::I64, cl::I64],
+                                Some(cl::I64),
+                            )?;
+                            let inst = ctx.builder.ins().call(f, &[n, fn_ptr]);
+                            let v = ctx.builder.inst_results(inst)[0];
+                            return Ok(TypedVal::new(v, ValTy::Handle));
+                        }
+                    }
+                    // Fallback: src e' Vec handle.
+                    let src_tv = lower_expr(ctx, &first.expr)?;
+                    let src = ctx.coerce_to_i64(src_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_GL_ARRAY_FROM_VEC",
+                        &[cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[src, fn_ptr]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
                 }
             }
             // Function global (#359): `<fn>.call/.apply/.bind/.toString(...)`.

--- a/src/namespaces/collections/vec.rs
+++ b/src/namespaces/collections/vec.rs
@@ -278,6 +278,50 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SPLICE_REMOVE(
     alloc_entry(Entry::Vec(Box::new(removed)))
 }
 
+/// (#208) `Array.from({length: n}, fn?)` — gera Vec [fn(0), fn(1), ...].
+/// Se fn_ptr == 0, gera [0, 1, ..., n-1] (sem mapeamento).
+/// fn_ptr e' `extern "C" fn(item: i64, idx: i64) -> i64`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_LENGTH(n: i64, fn_ptr: u64) -> u64 {
+    if n < 0 || n > VEC_MAX_LEN as i64 {
+        return alloc_entry(Entry::Vec(Box::new(Vec::new())));
+    }
+    let n = n as usize;
+    let mut out: Vec<i64> = Vec::with_capacity(n);
+    if fn_ptr == 0 {
+        for i in 0..n {
+            out.push(i as i64);
+        }
+    } else {
+        // SAFETY: fn_ptr e' `extern "C" fn(i64, i64) -> i64`.
+        // Em JS Array.from(arrayLike, mapFn) chama mapFn(undefined, idx)
+        // pra cada slot vazio. Aqui passamos (idx, idx) pra simplificar
+        // — mapper tipico em RTS recebe `(_, i) => ...` e usa so' i.
+        let f: extern "C" fn(i64, i64) -> i64 =
+            unsafe { std::mem::transmute(fn_ptr as usize) };
+        for i in 0..n {
+            out.push(f(i as i64, i as i64));
+        }
+    }
+    alloc_entry(Entry::Vec(Box::new(out)))
+}
+
+/// (#208) `Array.from(vecHandle, fn?)` — converte Vec existente, opcionalmente
+/// mapeando cada elemento. Sem fn, retorna copia rasa.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_VEC(src: u64, fn_ptr: u64) -> u64 {
+    let src_items: Vec<i64> = with_vec(src, Vec::new(), |v| v.clone());
+    if fn_ptr == 0 {
+        return alloc_entry(Entry::Vec(Box::new(src_items)));
+    }
+    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let mut out: Vec<i64> = Vec::with_capacity(src_items.len());
+    for (i, item) in src_items.into_iter().enumerate() {
+        out.push(f(item, i as i64));
+    }
+    alloc_entry(Entry::Vec(Box::new(out)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,5 +432,33 @@ mod tests {
         let removed = __RTS_FN_NS_COLLECTIONS_VEC_SPLICE_REMOVE(h, 1, 2);
         assert_eq!(handle_to_vec(removed), vec![2, 3]);
         assert_eq!(handle_to_vec(h), vec![1, 4, 5]);
+    }
+
+    #[test]
+    fn array_from_length_no_fn() {
+        let h = __RTS_FN_GL_ARRAY_FROM_LENGTH(4, 0);
+        assert_eq!(handle_to_vec(h), vec![0, 1, 2, 3]);
+    }
+
+    extern "C" fn triple(_item: i64, idx: i64) -> i64 {
+        idx * 3
+    }
+
+    #[test]
+    fn array_from_length_with_fn() {
+        let fp = triple as *const () as u64;
+        let h = __RTS_FN_GL_ARRAY_FROM_LENGTH(4, fp);
+        assert_eq!(handle_to_vec(h), vec![0, 3, 6, 9]);
+    }
+
+    #[test]
+    fn array_from_vec_no_fn() {
+        let src = __RTS_FN_NS_COLLECTIONS_VEC_NEW();
+        for x in [10, 20, 30] {
+            __RTS_FN_NS_COLLECTIONS_VEC_PUSH(src, x);
+        }
+        let cp = __RTS_FN_GL_ARRAY_FROM_VEC(src, 0);
+        assert_eq!(handle_to_vec(cp), vec![10, 20, 30]);
+        assert_ne!(cp, src);
     }
 }

--- a/tests/array_from.test.ts
+++ b/tests/array_from.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+let out = "";
+
+// Array.from({length: N}) sem mapper
+const a = Array.from({ length: 4 });
+out += a.join(",") + "\n";   // 0,1,2,3
+
+// Array.from(vec) — copia
+const src = [10, 20, 30];
+const cp: number[] = Array.from(src);
+out += cp.join(",") + "\n";  // 10,20,30
+
+// (#208) Array.from com mapper user fn que retorna i64 — typed annotation
+// pra match com extern "C" fn(i64, i64) -> i64. Mapper recebe (item, index).
+// Mapper com tipo `number` (f64) ainda nao funciona — fica em outra PR.
+
+describe("array_from", () => {
+  test("Array.from sem mapper (#208)", () => expect(out).toBe(
+    "0,1,2,3\n10,20,30\n"
+  ));
+});


### PR DESCRIPTION
Implementa Array.from minimal: `{length: N}` e copia de Vec.

## Test plan
- rts test: 410/417 (+1 novo, zero regressão)

## Limitação
Mapper com tipo `number` (f64) ainda não funciona — exige transmute apropriado, fica em PR separada.

Refs #208 #226.