### PR TITLE
feat(codegen): Object.seal/isFrozen/isSealed/getPrototypeOf/defineProperty (#208 v0)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -901,6 +901,27 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_COLLECTIONS_MAP_FREEZE",
             map::__RTS_FN_NS_COLLECTIONS_MAP_FREEZE
         );
+        // (#208) Object.seal/isFrozen/isSealed/getPrototypeOf/defineProperty.
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_SEAL",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_SEAL
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_IS_FROZEN",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_IS_FROZEN
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_IS_SEALED",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_IS_SEALED
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY
+        );
         add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES",
             map::__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -237,16 +237,76 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
-                // (#208 / #479) Object.freeze(obj) — v0 no-op, retorna handle.
-                if method == "freeze" && call.args.len() == 1 {
+                // (#208 / #479) Object.freeze/seal — v0 no-op, retorna handle.
+                if (method == "freeze" || method == "seal") && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let sym = if method == "freeze" {
+                        "__RTS_FN_NS_COLLECTIONS_MAP_FREEZE"
+                    } else {
+                        "__RTS_FN_NS_COLLECTIONS_MAP_SEAL"
+                    };
+                    let f = ctx.get_extern(sym, &[cl::I64], Some(cl::I64))?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // (#208) Object.isFrozen/isSealed — v0 sempre false.
+                if (method == "isFrozen" || method == "isSealed") && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let sym = if method == "isFrozen" {
+                        "__RTS_FN_NS_COLLECTIONS_MAP_IS_FROZEN"
+                    } else {
+                        "__RTS_FN_NS_COLLECTIONS_MAP_IS_SEALED"
+                    };
+                    let f = ctx.get_extern(sym, &[cl::I64], Some(cl::I64))?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Bool));
+                }
+                // (#208) Object.getPrototypeOf(obj) — handle de __proto__ ou 0.
+                if method == "getPrototypeOf" && call.args.len() == 1 {
                     let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
                     let h = ctx.coerce_to_i64(arg_tv).val;
                     let f = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_MAP_FREEZE",
+                        "__RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO",
                         &[cl::I64],
                         Some(cl::I64),
                     )?;
                     let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // (#208) Object.defineProperty(obj, key, descriptor) — v0
+                // suporta apenas { value: x }.
+                if method == "defineProperty" && call.args.len() == 3 {
+                    let obj_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let obj = ctx.coerce_to_i64(obj_tv).val;
+                    let key_tv = lower_expr(ctx, &call.args[1].expr)?;
+                    let key_h = ctx.coerce_to_i64(key_tv).val;
+                    let desc_tv = lower_expr(ctx, &call.args[2].expr)?;
+                    let desc = ctx.coerce_to_i64(desc_tv).val;
+                    let kp_fn = ctx.get_extern(
+                        "__RTS_FN_NS_GC_STRING_PTR",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let kl_fn = ctx.get_extern(
+                        "__RTS_FN_NS_GC_STRING_LEN",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst_p = ctx.builder.ins().call(kp_fn, &[key_h]);
+                    let kp = ctx.builder.inst_results(inst_p)[0];
+                    let inst_l = ctx.builder.ins().call(kl_fn, &[key_h]);
+                    let kl = ctx.builder.inst_results(inst_l)[0];
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY",
+                        &[cl::I64, cl::I64, cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[obj, kp, kl, desc]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }

--- a/src/namespaces/collections/map.rs
+++ b/src/namespaces/collections/map.rs
@@ -338,6 +338,46 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FREEZE(handle: u64) -> u64 {
     handle
 }
 
+/// (#208) `Object.seal(obj)` — v0 no-op. JS non-strict.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_SEAL(handle: u64) -> u64 {
+    handle
+}
+
+/// (#208) `Object.isFrozen(obj)` — v0 sempre false (sem flag).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_IS_FROZEN(_handle: u64) -> i64 {
+    0
+}
+
+/// (#208) `Object.isSealed(obj)` — v0 sempre false.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_IS_SEALED(_handle: u64) -> i64 {
+    0
+}
+
+/// (#208) `Object.getPrototypeOf(obj)` — retorna handle de `__proto__` ou 0.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO(handle: u64) -> u64 {
+    let proto: i64 = with_map(handle, 0, |m| m.get("__proto__").copied().unwrap_or(0));
+    proto as u64
+}
+
+/// (#208) `Object.defineProperty(obj, key, descriptor)` — v0 simples.
+/// Suporta apenas `{ value: x }`. Demais (get/set/writable/enumerable)
+/// caem em PR separada.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY(
+    obj: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+    descriptor: u64,
+) -> u64 {
+    let value: i64 = with_map(descriptor, 0, |m| m.get("value").copied().unwrap_or(0));
+    __RTS_FN_NS_COLLECTIONS_MAP_SET(obj, key_ptr, key_len, value);
+    obj
+}
+
 /// (#208 / #479) `Object.fromEntries(arr)` — recebe Vec de pares
 /// [key_handle, value] e cria Map. Inverso de Object.entries.
 #[unsafe(no_mangle)]

--- a/tests/object_more_methods.test.ts
+++ b/tests/object_more_methods.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+const obj = { a: 1, b: 2 };
+
+// seal — v0 no-op, retorna handle
+const sealed = Object.seal(obj);
+out += ((sealed as any).a + 0) + "\n";   // 1
+
+// isFrozen / isSealed — v0 sempre false
+out += (Object.isFrozen(obj) ? "y" : "n") + "\n";  // n
+out += (Object.isSealed(obj) ? "y" : "n") + "\n";  // n
+
+// getPrototypeOf — sem __proto__ retorna 0
+const proto = { greet: 0 };  // simplified — nao testa method em proto
+const child = Object.create(proto);
+const got = Object.getPrototypeOf(child);
+out += (got !== 0 ? "has-proto" : "no-proto") + "\n";  // has-proto
+
+// defineProperty com { value: x }
+const target: { [k: string]: number } = {};
+Object.defineProperty(target, "x", { value: 42 });
+out += (target as any).x + "\n";  // 42
+
+describe("object_more_methods", () => {
+  test("seal/isFrozen/isSealed/getPrototypeOf/defineProperty (#208 v0)", () => expect(out).toBe(
+    "1\nn\nn\nhas-proto\n42\n"
+  ));
+});


### PR DESCRIPTION
5 Object static methods em versao minimal.

## Test plan
- rts test: 414/421 (+1 novo, zero regressão)

## Limitações v0
- seal/freeze são no-ops.
- defineProperty só suporta `{ value: x }`.

Refs #208 #226.