### PR TITLE
feat(codegen): String.matchAll (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1124,6 +1124,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     // (#208) match/search via regex.
     add_fn!("__RTS_FN_NS_STRING_MATCH", search::__RTS_FN_NS_STRING_MATCH);
     add_fn!("__RTS_FN_NS_STRING_SEARCH", search::__RTS_FN_NS_STRING_SEARCH);
+    add_fn!("__RTS_FN_NS_STRING_MATCH_ALL", search::__RTS_FN_NS_STRING_MATCH_ALL);
     add_fn!(
         "__RTS_FN_NS_STRING_TO_UPPER",
         transform::__RTS_FN_NS_STRING_TO_UPPER

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -2587,6 +2587,21 @@ fn lower_string_builtin(
             );
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
+        // (#208) `s.matchAll(pattern)` — Vec de string handles, um por match.
+        "matchAll" => {
+            let pattern = arg_handle(ctx, call, 0)?;
+            let p1 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let l1 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[recv_h]);
+            let p2 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[pattern]);
+            let l2 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[pattern]);
+            let v = call_h!(
+                "__RTS_FN_NS_STRING_MATCH_ALL",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
+                Some(cl::I64),
+                &[p1, l1, p2, l2]
+            );
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
         "localeCompare" => {
             let other = arg_handle(ctx, call, 0)?;
             let v = call_h!("__RTS_FN_GL_STRING_LOCALE_COMPARE", &[cl::I64, cl::I64], Some(cl::I64), &[recv_h, other]);

--- a/src/namespaces/globals/string/search.rs
+++ b/src/namespaces/globals/string/search.rs
@@ -108,3 +108,29 @@ pub extern "C" fn __RTS_FN_NS_STRING_SEARCH(
     };
     rx.find(s).map(|m| m.start() as i64).unwrap_or(-1)
 }
+
+/// (#208) `str.matchAll(pattern)` — retorna handle de Vec<u64> com handles
+/// de strings, um por match. Em JS retorna iterator de RegExpExecArray; em
+/// RTS v0 retorna Vec eager (cada elemento e' o conteudo do match).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_STRING_MATCH_ALL(
+    s_ptr: *const u8,
+    s_len: i64,
+    p_ptr: *const u8,
+    p_len: i64,
+) -> u64 {
+    use crate::namespaces::gc::handles::{Entry, alloc_entry};
+    let empty_vec = || alloc_entry(Entry::Vec(Box::new(Vec::new())));
+    let (Some(s), Some(p)) = (str_from_abi(s_ptr, s_len), str_from_abi(p_ptr, p_len)) else {
+        return empty_vec();
+    };
+    let Ok(rx) = regex::Regex::new(p) else {
+        return empty_vec();
+    };
+    let mut handles: Vec<i64> = Vec::new();
+    for m in rx.find_iter(s) {
+        let h = alloc_entry(Entry::String(m.as_str().as_bytes().to_vec()));
+        handles.push(h as i64);
+    }
+    alloc_entry(Entry::Vec(Box::new(handles)))
+}

--- a/tests/string_match_all.test.ts
+++ b/tests/string_match_all.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+const s = "ana banana";
+const matches = s.matchAll("an");
+out += matches.length + "\n";   // 3
+out += matches.join(",") + "\n";  // an,an,an
+
+// Sem matches — array vazio
+const empty = "xyz".matchAll("an");
+out += empty.length + "\n";    // 0
+
+// Pattern com classe
+const s2 = "Hello World";
+const ms = s2.matchAll("[Hh]");
+out += ms.length + "\n";       // 1 (so' "H")
+out += ms.join(",") + "\n";    // H
+
+describe("string_match_all", () => {
+  test("matchAll retorna Vec eager (#208)", () => expect(out).toBe(
+    "3\nan,an,an\n0\n1\nH\n"
+  ));
+});


### PR DESCRIPTION
Adiciona `s.matchAll(pattern)` que retorna Vec eager de string handles.

## Test plan
- rts test: 415/422 (+1 novo, zero regressão)

Refs #208 #226.