### PR TITLE
fix(textencoding): TextEncoder/Decoder instance methods (#374)

### DIFF
--- a/src/namespaces/globals/text_encoding/class_spec.rs
+++ b/src/namespaces/globals/text_encoding/class_spec.rs
@@ -15,7 +15,7 @@ pub const TEXT_ENCODER_MEMBERS: &[NamespaceMember] = &[
     NamespaceMember {
         name: "encode",
         kind: MemberKind::InstanceMethod,
-        symbol: "__RTS_FN_GL_TEXTENC_ENCODE",
+        symbol: "__RTS_FN_GL_TEXTENC_ENCODE_INSTANCE",
         args: &[AbiType::Handle, AbiType::StrPtr],
         returns: AbiType::Handle,
         doc: "encoder.encode(text) — UTF-8 bytes como Buffer handle.",
@@ -46,7 +46,7 @@ pub const TEXT_DECODER_MEMBERS: &[NamespaceMember] = &[
     NamespaceMember {
         name: "decode",
         kind: MemberKind::InstanceMethod,
-        symbol: "__RTS_FN_GL_TEXTENC_DECODE",
+        symbol: "__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE",
         args: &[AbiType::Handle, AbiType::Handle],
         returns: AbiType::Handle,
         doc: "decoder.decode(buf) — Buffer handle para string handle.",

--- a/src/namespaces/globals/text_encoding/instance.rs
+++ b/src/namespaces/globals/text_encoding/instance.rs
@@ -153,6 +153,7 @@ pub extern "C" fn __RTS_FN_GL_TEXTDEC_NEW() -> u64 {
 }
 
 // Instance method variants: (self_handle, ptr, len) — self ignored.
+// Usados pelos GlobalClassSpec (encode/decode em receiver this).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_TEXTENC_ENCODE_INSTANCE(
     _self_h: u64,

--- a/tests/text_encoding_class.test.ts
+++ b/tests/text_encoding_class.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#374) TextEncoder/TextDecoder roundtrip
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const round = dec.decode(enc.encode("hello"));
+out += round + "\n";    // hello
+
+const round2 = dec.decode(enc.encode("rts works"));
+out += round2 + "\n";   // rts works
+
+describe("text_encoding_class", () => {
+  test("encode/decode roundtrip (#374)", () => expect(out).toBe(
+    "hello\nrts works\n"
+  ));
+});


### PR DESCRIPTION
Fix bug crítico de OOM em `new TextEncoder().encode("hello")` — symbol pointing errado.

## Test plan
- rts test: 416/423 (+1 novo, zero regressão)

Closes #374.