### PR TITLE
test(performance): acceptance #371

### DIFF
--- a/tests/performance_api.test.ts
+++ b/tests/performance_api.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#371) performance.now() — monotonic ms
+const a = performance.now();
+const b = performance.now();
+out += (b >= a ? "monotonic" : "broken") + "\n";
+
+// performance.timeOrigin — recente epoch
+out += (performance.timeOrigin > 1700000000000 ? "origin-ok" : "origin-bad") + "\n";
+
+describe("performance_api", () => {
+  test("now + timeOrigin (#371)", () => expect(out).toBe(
+    "monotonic\norigin-ok\n"
+  ));
+});


### PR DESCRIPTION
performance.now/timeOrigin já existiam. Test acceptance.

Closes #371.