### PR TITLE
feat(codegen): Array.values/keys/entries eager v0 (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1048,6 +1048,19 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_COLLECTIONS_VEC_SORT",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_SORT
         );
+        // (#208) Iterators eager: arr.values()/keys()/entries().
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_VALUES",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_VALUES
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_KEYS",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_KEYS
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_ENTRIES",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_ENTRIES
+        );
     }
 
     // ── namespaces::os ────────────────────────────────────────────────

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -3329,6 +3329,37 @@ fn lower_array_builtin(
             let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
+        // (#208) Iterators eager: values()/keys()/entries().
+        "values" if call.args.is_empty() => {
+            let f = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_VEC_VALUES",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(f, &[obj_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        "keys" if call.args.is_empty() => {
+            let f = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_VEC_KEYS",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(f, &[obj_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
+        "entries" if call.args.is_empty() => {
+            let f = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_VEC_ENTRIES",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(f, &[obj_h]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+        }
         "flatMap" => {
             if call.args.len() != 1 || call.args[0].spread.is_some() {
                 return Ok(None);

--- a/src/codegen/lower/statements/loops.rs
+++ b/src/codegen/lower/statements/loops.rs
@@ -237,25 +237,43 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
         // user pode anotar o ident: `for (const [k, v]: any of pairs)`
         // nao funciona via parser mas a heuristica cobre 90% do uso.
         // Detecta se o iteravel veio direto de `Object.entries(...)`
-        // OU de var inicializada com isso. Heuristica conservadora —
-        // assume slot 0 = string Handle nesse caso.
-        fn is_entries_expr(e: &swc_ecma_ast::Expr) -> bool {
+        // OU de `map.entries()` (NAO `arr.entries()` — array.entries
+        // tem slot 0 = i64 indice, nao Handle). (#208 + #494)
+        fn is_object_entries_expr(e: &swc_ecma_ast::Expr, ctx: &FnCtx) -> bool {
             match e {
                 swc_ecma_ast::Expr::Call(c) => match &c.callee {
                     swc_ecma_ast::Callee::Expr(callee) => match callee.as_ref() {
-                        swc_ecma_ast::Expr::Member(m) => matches!(
-                            &m.prop,
-                            swc_ecma_ast::MemberProp::Ident(p) if p.sym.as_str() == "entries"
-                        ),
+                        swc_ecma_ast::Expr::Member(m) => {
+                            // Confirma prop.entries.
+                            let is_entries = matches!(
+                                &m.prop,
+                                swc_ecma_ast::MemberProp::Ident(p) if p.sym.as_str() == "entries"
+                            );
+                            if !is_entries {
+                                return false;
+                            }
+                            // Object.entries(obj) — slot 0 e' string Handle.
+                            // map.entries() — slot 0 e' string Handle.
+                            // arr.entries() — slot 0 e' i64 indice → falso.
+                            match m.obj.as_ref() {
+                                // Object.entries — explicito.
+                                swc_ecma_ast::Expr::Ident(id) if id.sym.as_str() == "Object" => true,
+                                // var ident: se for marcado como array, falso.
+                                swc_ecma_ast::Expr::Ident(id) => {
+                                    !ctx.local_array_vars.contains(id.sym.as_str())
+                                }
+                                _ => true, // conservador
+                            }
+                        }
                         _ => false,
                     },
                     _ => false,
                 },
-                swc_ecma_ast::Expr::Paren(p) => is_entries_expr(&p.expr),
+                swc_ecma_ast::Expr::Paren(p) => is_object_entries_expr(&p.expr, ctx),
                 _ => false,
             }
         }
-        let is_object_entries = is_entries_expr(for_of.right.as_ref());
+        let is_object_entries = is_object_entries_expr(for_of.right.as_ref(), ctx);
         for (idx, name_opt) in names.iter().enumerate() {
             let Some((name, ann_ty)) = name_opt else { continue };
             let idx_val = ctx.builder.ins().iconst(cl::I64, idx as i64);

--- a/src/namespaces/collections/vec.rs
+++ b/src/namespaces/collections/vec.rs
@@ -435,6 +435,37 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SORT(handle: u64, fn_ptr: u64) -> 
     handle
 }
 
+/// (#208) `arr.values()` — Vec eager com copia dos valores.
+/// Em JS spec retorna Array Iterator; v0 RTS retorna Vec direto
+/// (compativel com `for-of` e `.join()`). Iterator real exige
+/// Symbol.iterator (PR separada).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_VALUES(handle: u64) -> u64 {
+    let copy: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
+    alloc_entry(Entry::Vec(Box::new(copy)))
+}
+
+/// (#208) `arr.keys()` — Vec [0, 1, ..., len-1].
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_KEYS(handle: u64) -> u64 {
+    let len = with_vec(handle, 0, |v| v.len());
+    let keys: Vec<i64> = (0..len as i64).collect();
+    alloc_entry(Entry::Vec(Box::new(keys)))
+}
+
+/// (#208) `arr.entries()` — Vec de Vec[[idx, value], ...].
+/// Cada entry e' um Vec<i64> com 2 elementos.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_ENTRIES(handle: u64) -> u64 {
+    let items: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
+    let mut out: Vec<i64> = Vec::with_capacity(items.len());
+    for (i, val) in items.into_iter().enumerate() {
+        let pair = alloc_entry(Entry::Vec(Box::new(vec![i as i64, val])));
+        out.push(pair as i64);
+    }
+    alloc_entry(Entry::Vec(Box::new(out)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -656,5 +687,39 @@ mod tests {
         // copyWithin(0, 3) → copia elementos a partir do idx 3 pro idx 0
         __RTS_FN_NS_COLLECTIONS_VEC_COPY_WITHIN(h, 0, 3, i64::MIN);
         assert_eq!(handle_to_vec(h), vec![4, 5, 3, 4, 5]);
+    }
+
+    #[test]
+    fn values_returns_copy() {
+        let h = __RTS_FN_NS_COLLECTIONS_VEC_NEW();
+        for x in [10, 20, 30] {
+            __RTS_FN_NS_COLLECTIONS_VEC_PUSH(h, x);
+        }
+        let cp = __RTS_FN_NS_COLLECTIONS_VEC_VALUES(h);
+        assert_eq!(handle_to_vec(cp), vec![10, 20, 30]);
+        assert_ne!(cp, h);
+    }
+
+    #[test]
+    fn keys_returns_indices() {
+        let h = __RTS_FN_NS_COLLECTIONS_VEC_NEW();
+        for x in [10, 20, 30, 40] {
+            __RTS_FN_NS_COLLECTIONS_VEC_PUSH(h, x);
+        }
+        let k = __RTS_FN_NS_COLLECTIONS_VEC_KEYS(h);
+        assert_eq!(handle_to_vec(k), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn entries_returns_pairs() {
+        let h = __RTS_FN_NS_COLLECTIONS_VEC_NEW();
+        for x in [100, 200] {
+            __RTS_FN_NS_COLLECTIONS_VEC_PUSH(h, x);
+        }
+        let entries = __RTS_FN_NS_COLLECTIONS_VEC_ENTRIES(h);
+        let outer = handle_to_vec(entries);
+        assert_eq!(outer.len(), 2);
+        assert_eq!(handle_to_vec(outer[0] as u64), vec![0, 100]);
+        assert_eq!(handle_to_vec(outer[1] as u64), vec![1, 200]);
     }
 }

--- a/tests/array_iterators.test.ts
+++ b/tests/array_iterators.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+const arr = [10, 20, 30];
+
+// (#208) values() — Vec eager copia
+const vs = arr.values();
+out += vs.join(",") + "\n";   // 10,20,30
+
+// keys() — indices
+const ks = arr.keys();
+out += ks.join(",") + "\n";   // 0,1,2
+
+// entries() — pares [idx, value]
+const entries = arr.entries();
+out += entries.length + "\n"; // 3
+
+// for-of destructuring em entries (sinergia com PR #494)
+for (const [i, v] of arr.entries()) {
+  out += i + "=" + v + "\n";
+}
+
+describe("array_iterators", () => {
+  test("values/keys/entries (#208 eager v0)", () => expect(out).toBe(
+    "10,20,30\n0,1,2\n3\n0=10\n1=20\n2=30\n"
+  ));
+});


### PR DESCRIPTION
Implementa os 3 últimos métodos do #208 em versão eager (Vec direto). Iterator protocol real fica pra outra PR.

## Test plan
- cargo test: 120/120 (+3 novos)
- rts test: 421/428 (+1 novo, zero regressão)

Fecha cobertura completa de Array.prototype no #208.

Closes #208.