### PR TITLE
feat(codegen): parseInt/parseFloat globais (#208)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -757,6 +757,45 @@ fn lower_js_global_call(
         "Number" => lower_coerce_to_number(ctx, call),
         "String" => lower_coerce_to_string(ctx, call),
         "Boolean" => lower_coerce_to_boolean(ctx, call),
+        // (#208) parseInt/parseFloat globais — alias de Number.parseInt/parseFloat.
+        // Reusa diretamente __RTS_FN_NS_FMT_PARSE_I64/F64 que ja sao
+        // chamados via Number.* ABI.
+        "parseInt" if call.args.len() == 1 && call.args[0].spread.is_none() => {
+            let arg_tv = super::lower_expr(ctx, &call.args[0].expr)?;
+            let h = ctx.coerce_to_handle(arg_tv)?.val;
+            let ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+            let len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+            let ip = ctx.builder.ins().call(ptr_fn, &[h]);
+            let p = ctx.builder.inst_results(ip)[0];
+            let il = ctx.builder.ins().call(len_fn, &[h]);
+            let l = ctx.builder.inst_results(il)[0];
+            let f = ctx.get_extern(
+                "__RTS_FN_NS_FMT_PARSE_I64",
+                &[cl::I64, cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(f, &[p, l]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::I64)))
+        }
+        "parseFloat" if call.args.len() == 1 && call.args[0].spread.is_none() => {
+            let arg_tv = super::lower_expr(ctx, &call.args[0].expr)?;
+            let h = ctx.coerce_to_handle(arg_tv)?.val;
+            let ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+            let len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+            let ip = ctx.builder.ins().call(ptr_fn, &[h]);
+            let p = ctx.builder.inst_results(ip)[0];
+            let il = ctx.builder.ins().call(len_fn, &[h]);
+            let l = ctx.builder.inst_results(il)[0];
+            let f = ctx.get_extern(
+                "__RTS_FN_NS_FMT_PARSE_F64",
+                &[cl::I64, cl::I64],
+                Some(cl::F64),
+            )?;
+            let inst = ctx.builder.ins().call(f, &[p, l]);
+            let v = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(v, ValTy::F64)))
+        }
         // getPointer(fn) — materializa o endereço de uma user fn como i64.
         // Substitui o padrão `fn as unknown as number` nos call sites.
         "getPointer" => {

--- a/tests/parseint_global.test.ts
+++ b/tests/parseint_global.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) parseInt/parseFloat globais (sem trailing chars).
+out += parseInt("100") + "\n";
+out += parseInt("-42") + "\n";
+out += parseFloat("3.14") + "\n";
+out += parseFloat("2.5") + "\n";
+
+// Number.parseInt/parseFloat (já existiam)
+out += Number.parseInt("99") + "\n";
+out += Number.parseFloat("1.5") + "\n";
+
+describe("parseint_global", () => {
+  test("parseInt/parseFloat globais (#208)", () => expect(out).toBe(
+    "100\n-42\n3.14\n2.5\n99\n1.5\n"
+  ));
+});


### PR DESCRIPTION
Adiciona dispatch de `parseInt`/`parseFloat` globais (alias de Number.parseInt/parseFloat).

## Test plan
- rts test: 424/431 (+1 novo, zero regressão)

Refs #208 #226.