### PR TITLE
feat(globals): URL.searchParams getter (#373)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -433,6 +433,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_URL_HASH", __RTS_FN_GL_URL_HASH);
     add_fn!("__RTS_FN_GL_URL_ORIGIN", __RTS_FN_GL_URL_ORIGIN);
     add_fn!("__RTS_FN_GL_URL_FREE", __RTS_FN_GL_URL_FREE);
+    add_fn!("__RTS_FN_GL_URL_SEARCH_PARAMS", __RTS_FN_GL_URL_SEARCH_PARAMS);
     // (#373) URLSearchParams.
     add_fn!("__RTS_FN_GL_USP_NEW", __RTS_FN_GL_USP_NEW);
     add_fn!("__RTS_FN_GL_USP_GET", __RTS_FN_GL_USP_GET);

--- a/src/namespaces/globals/url/class_spec.rs
+++ b/src/namespaces/globals/url/class_spec.rs
@@ -122,6 +122,18 @@ pub const URL_MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: true,
     },
+    // (#373) url.searchParams — constroi URLSearchParams a partir de search.
+    NamespaceMember {
+        name: "searchParams",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_URL_SEARCH_PARAMS",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "url.searchParams — URLSearchParams parseada do search query.",
+        ts_signature: "readonly searchParams: URLSearchParams",
+        intrinsic: None,
+        pure: false,
+    },
 ];
 
 pub const URL_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {

--- a/src/namespaces/globals/url/instance.rs
+++ b/src/namespaces/globals/url/instance.rs
@@ -136,6 +136,19 @@ pub extern "C" fn __RTS_FN_GL_URL_HASH(h: u64) -> u64     { url_field(h, 7) }
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_URL_ORIGIN(h: u64) -> u64   { url_field(h, 8) }
 
+/// (#373) `url.searchParams` — constroi URLSearchParams a partir do
+/// `search` da URL. Cada chamada cria novo handle (sem cache vinculado).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_URL_SEARCH_PARAMS(handle: u64) -> u64 {
+    let search_h = url_field(handle, 6);
+    let search: String = with_entry(search_h, |e| match e {
+        Some(Entry::String(b)) => String::from_utf8_lossy(b).into_owned(),
+        _ => String::new(),
+    });
+    // O search inclui o '?' inicial; parse_query strip-prefix
+    alloc_search_params(parse_query(&search))
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_URL_FREE(handle: u64) {
     // Collect inner string handles outside any with_entry closure to avoid

--- a/tests/url_search_params_getter.test.ts
+++ b/tests/url_search_params_getter.test.ts
@@ -1,0 +1,18 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#373) url.searchParams getter — liga URL e URLSearchParams.
+// Anotacao explicita preserva tipo.
+const u = new URL("https://example.com/path?a=1&b=2&c=3");
+const sp: URLSearchParams = u.searchParams;
+
+out += sp.get("a") + "\n";
+out += sp.get("b") + "\n";
+out += (sp.has("a") ? "y" : "n") + "\n";
+
+describe("url_search_params_getter", () => {
+  test("url.searchParams (#373)", () => expect(out).toBe(
+    "1\n2\ny\n"
+  ));
+});


### PR DESCRIPTION
Adiciona url.searchParams que liga URL e URLSearchParams.

## Test plan
- rts test: 426/433 (+1 novo, zero regressão)

## Nota
User precisa anotar tipo `const sp: URLSearchParams = ...` pra preservar tipo (limitação do dispatch atual).

Refs #373 #226.