### PR TITLE
feat(codegen): parseInt JS-spec — radix + tolerancia (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -725,6 +725,11 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_FMT_PARSE_I64",
             parse::__RTS_FN_NS_FMT_PARSE_I64
         );
+        // (#208) parseInt JS-spec com radix.
+        add_fn!(
+            "__RTS_FN_NS_FMT_PARSE_INT_RADIX",
+            parse::__RTS_FN_NS_FMT_PARSE_INT_RADIX
+        );
         add_fn!(
             "__RTS_FN_NS_FMT_PARSE_F64",
             parse::__RTS_FN_NS_FMT_PARSE_F64

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -757,10 +757,10 @@ fn lower_js_global_call(
         "Number" => lower_coerce_to_number(ctx, call),
         "String" => lower_coerce_to_string(ctx, call),
         "Boolean" => lower_coerce_to_boolean(ctx, call),
-        // (#208) parseInt/parseFloat globais — alias de Number.parseInt/parseFloat.
-        // Reusa diretamente __RTS_FN_NS_FMT_PARSE_I64/F64 que ja sao
-        // chamados via Number.* ABI.
-        "parseInt" if call.args.len() == 1 && call.args[0].spread.is_none() => {
+        // (#208) parseInt(s, radix?) — JS spec com radix opcional, tolerante.
+        "parseInt" if (1..=2).contains(&call.args.len())
+            && call.args.iter().all(|a| a.spread.is_none()) =>
+        {
             let arg_tv = super::lower_expr(ctx, &call.args[0].expr)?;
             let h = ctx.coerce_to_handle(arg_tv)?.val;
             let ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
@@ -769,12 +769,19 @@ fn lower_js_global_call(
             let p = ctx.builder.inst_results(ip)[0];
             let il = ctx.builder.ins().call(len_fn, &[h]);
             let l = ctx.builder.inst_results(il)[0];
+            // Radix arg ou 0 (auto-detect).
+            let radix = if call.args.len() == 2 {
+                let r_tv = super::lower_expr(ctx, &call.args[1].expr)?;
+                ctx.coerce_to_i64(r_tv).val
+            } else {
+                ctx.builder.ins().iconst(cl::I64, 0)
+            };
             let f = ctx.get_extern(
-                "__RTS_FN_NS_FMT_PARSE_I64",
-                &[cl::I64, cl::I64],
+                "__RTS_FN_NS_FMT_PARSE_INT_RADIX",
+                &[cl::I64, cl::I64, cl::I64],
                 Some(cl::I64),
             )?;
-            let inst = ctx.builder.ins().call(f, &[p, l]);
+            let inst = ctx.builder.ins().call(f, &[p, l, radix]);
             let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }

--- a/src/namespaces/fmt/parse.rs
+++ b/src/namespaces/fmt/parse.rs
@@ -28,6 +28,124 @@ pub extern "C" fn __RTS_FN_NS_FMT_PARSE_F64(ptr: *const u8, len: i64) -> f64 {
     }
 }
 
+/// (#208) `parseInt(s, radix?)` — JS spec:
+/// - Skip leading whitespace.
+/// - Optional `+`/`-` sign.
+/// - radix=0 ou ausente: detecta `0x`/`0X` (16) ou default 10.
+/// - Para no primeiro char invalido (tolerante a trailing chars).
+/// - Retorna i64::MIN sentinel em erro (codegen mapeia pra NaN).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_FMT_PARSE_INT_RADIX(
+    ptr: *const u8,
+    len: i64,
+    radix: i64,
+) -> i64 {
+    let Some(s) = str_from_abi(ptr, len) else {
+        return i64::MIN;
+    };
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    // Skip whitespace.
+    while i < bytes.len() && (bytes[i] as char).is_whitespace() {
+        i += 1;
+    }
+    if i >= bytes.len() {
+        return i64::MIN;
+    }
+    // Sign.
+    let negative = match bytes[i] {
+        b'+' => { i += 1; false }
+        b'-' => { i += 1; true }
+        _ => false,
+    };
+    if i >= bytes.len() {
+        return i64::MIN;
+    }
+    // Detect radix.
+    let mut effective_radix: u32 = if radix == 0 { 10 } else { radix as u32 };
+    if (radix == 0 || radix == 16)
+        && i + 1 < bytes.len()
+        && bytes[i] == b'0'
+        && (bytes[i + 1] == b'x' || bytes[i + 1] == b'X')
+    {
+        effective_radix = 16;
+        i += 2;
+    }
+    if !(2..=36).contains(&effective_radix) {
+        return i64::MIN;
+    }
+    // Parse chars enquanto validos no radix.
+    let mut acc: i64 = 0;
+    let mut any_digit = false;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        let Some(d) = c.to_digit(effective_radix) else {
+            break;
+        };
+        // Check overflow.
+        let Some(next) = acc.checked_mul(effective_radix as i64).and_then(|v| v.checked_add(d as i64)) else {
+            return i64::MIN;
+        };
+        acc = next;
+        any_digit = true;
+        i += 1;
+    }
+    if !any_digit {
+        return i64::MIN;
+    }
+    if negative { -acc } else { acc }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str, radix: i64) -> i64 {
+        __RTS_FN_NS_FMT_PARSE_INT_RADIX(s.as_ptr(), s.len() as i64, radix)
+    }
+
+    #[test]
+    fn radix_10_default() {
+        assert_eq!(p("100", 0), 100);
+        assert_eq!(p("100", 10), 100);
+        assert_eq!(p("-42", 0), -42);
+        assert_eq!(p("+42", 0), 42);
+    }
+
+    #[test]
+    fn radix_16_hex() {
+        assert_eq!(p("FF", 16), 255);
+        assert_eq!(p("ff", 16), 255);
+        assert_eq!(p("0xFF", 16), 255);
+        assert_eq!(p("0xff", 0), 255);
+    }
+
+    #[test]
+    fn radix_2_binary() {
+        assert_eq!(p("101", 2), 5);
+        assert_eq!(p("1111", 2), 15);
+    }
+
+    #[test]
+    fn tolerant_trailing_chars() {
+        assert_eq!(p("42abc", 10), 42);
+        assert_eq!(p("100xyz", 0), 100);
+    }
+
+    #[test]
+    fn whitespace_stripped() {
+        assert_eq!(p("  42", 0), 42);
+        assert_eq!(p("\t-7", 10), -7);
+    }
+
+    #[test]
+    fn empty_or_invalid_returns_sentinel() {
+        assert_eq!(p("", 0), i64::MIN);
+        assert_eq!(p("xyz", 10), i64::MIN);
+        assert_eq!(p("   ", 10), i64::MIN);
+    }
+}
+
 /// "true" / "false" (case-insensitive) → 1 / 0. Qualquer outra coisa
 /// retorna -1.
 #[unsafe(no_mangle)]

--- a/tests/parseint_radix.test.ts
+++ b/tests/parseint_radix.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) parseInt JS-spec: radix opcional, tolerante a trailing chars.
+out += parseInt("100") + "\n";        // 100 (default 10)
+out += parseInt("100", 10) + "\n";    // 100
+out += parseInt("FF", 16) + "\n";     // 255
+out += parseInt("ff", 16) + "\n";     // 255
+out += parseInt("0xFF") + "\n";       // 255 (auto-detect 0x → 16)
+out += parseInt("101", 2) + "\n";     // 5
+out += parseInt("777", 8) + "\n";     // 511
+out += parseInt("-42") + "\n";        // -42
+out += parseInt("42abc") + "\n";      // 42 (tolerante)
+out += parseInt("  +7  ", 10) + "\n"; // 7 (whitespace)
+
+describe("parseint_radix", () => {
+  test("parseInt JS-spec com radix (#208)", () => expect(out).toBe(
+    "100\n100\n255\n255\n255\n5\n511\n-42\n42\n7\n"
+  ));
+});


### PR DESCRIPTION
parseInt agora segue spec JS: radix opcional, auto-detect 0x, tolerância a trailing chars.

## Test plan
- cargo test: 123/123 (+6 novos)
- rts test: 429/436 (+1 novo, zero regressão)

Refs #208 #226.