### PR TITLE
test(diag): cobre fix incremental de #383 (no-crash)

### DIFF
--- a/tests/undefined_ident_warn.test.ts
+++ b/tests/undefined_ident_warn.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#383) Antes: ident global desconhecida causava segfault.
+// Agora: codegen emite warning + chamada e' no-op (sem crash).
+
+unknownGlobalXYZ123();  // no-op + warning, sem crash
+
+out = "survived";
+
+describe("undefined_ident_warn", () => {
+  test("ident global desconhecida nao crasha (#383)", () =>
+    expect(out).toBe("survived"));
+});


### PR DESCRIPTION
Test que cobre o subset 'no-crash' de #383. Erro de compilação real (em vez de warning) fica em PR separada.

Refs #383.