### PR TITLE
feat(math): Math.random alias (#208)

### DIFF
--- a/src/namespaces/math/abi.rs
+++ b/src/namespaces/math/abi.rs
@@ -467,6 +467,18 @@ pub const MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: false, // mutates thread-local RNG state
     },
+    // (#208) JS-style alias: Math.random() → Math.random_f64().
+    NamespaceMember {
+        name: "random",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_MATH_RANDOM_F64",
+        args: &[],
+        returns: AbiType::F64,
+        doc: "Math.random() — alias de random_f64. Uniform [0, 1).",
+        ts_signature: "random(): number",
+        intrinsic: None,
+        pure: false,
+    },
     NamespaceMember {
         name: "random_i64_range",
         kind: MemberKind::Function,

--- a/tests/math_random.test.ts
+++ b/tests/math_random.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) Math.random() — alias de random_f64.
+const r1: number = Math.random();
+const r2: number = Math.random();
+out += (r1 >= 0 && r1 < 1 ? "in-range" : "out") + "\n";
+out += (r2 >= 0 && r2 < 1 ? "in-range" : "out") + "\n";
+out += (r1 !== r2 ? "different" : "same") + "\n";  // muito provavel diferente
+
+describe("math_random", () => {
+  test("Math.random alias (#208)", () => expect(out).toBe(
+    "in-range\nin-range\ndifferent\n"
+  ));
+});


### PR DESCRIPTION
Alias de random_f64.

## Test plan
- rts test: 439/446 (+1 novo, zero regressão)

Refs #208 #226.