### PR TITLE
feat(math): Math.log alias de ln (#208)

### DIFF
--- a/src/namespaces/math/abi.rs
+++ b/src/namespaces/math/abi.rs
@@ -107,6 +107,18 @@ pub const MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: true,
     },
+    // (#208) JS-style: Math.log(x) = ln(x) (natural log).
+    NamespaceMember {
+        name: "log",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_MATH_LN",
+        args: &[AbiType::F64],
+        returns: AbiType::F64,
+        doc: "Math.log(x) — natural log (alias de ln).",
+        ts_signature: "log(x: number): number",
+        intrinsic: None,
+        pure: true,
+    },
     NamespaceMember {
         name: "log2",
         kind: MemberKind::Function,

--- a/tests/math_log_alias.test.ts
+++ b/tests/math_log_alias.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) Math.log = ln (natural log) — JS spec.
+out += Math.log(Math.E) + "\n";   // 1
+out += Math.log(1) + "\n";        // 0
+
+// log2 e log10 ja existiam.
+out += Math.log2(8) + "\n";       // 3
+out += Math.log10(1000) + "\n";   // 3
+
+describe("math_log_alias", () => {
+  test("Math.log alias de ln (#208)", () => expect(out).toBe(
+    "1\n0\n3\n3\n"
+  ));
+});


### PR DESCRIPTION
JS spec: Math.log e' natural log (= ln em RTS).

## Test plan
- rts test: 440/447 (+1 novo, zero regressão)

Refs #208 #226.