### PR TITLE
fix(codegen): Boolean(NaN) === false (#208)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -4430,8 +4430,12 @@ fn lower_coerce_to_boolean(ctx: &mut FnCtx, call: &CallExpr) -> Result<Option<Ty
         }
         let tv = super::lower_expr(ctx, &arg.expr)?;
         if matches!(tv.ty, ValTy::F64) {
+            // (#208 fix): NaN deve ser falsy. fcmp NotEqual retorna false
+            // pra NaN (NaN != X e' Unordered, nao true). Use OrderedNotEqual
+            // que e' false quando NaN — exatamente o comportamento desejado.
+            // Em Cranelift: OrderedNotEqual = "ordered AND not equal".
             let zero = ctx.builder.ins().f64const(0.0);
-            let ne_zero = ctx.builder.ins().fcmp(FloatCC::NotEqual, tv.val, zero);
+            let ne_zero = ctx.builder.ins().fcmp(FloatCC::OrderedNotEqual, tv.val, zero);
             return Ok(Some(TypedVal::new(ne_zero, ValTy::Bool)));
         }
         let v = ctx.coerce_to_i64(tv).val;

--- a/tests/boolean_nan.test.ts
+++ b/tests/boolean_nan.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208 fix): Boolean(NaN) deve ser false (NaN e' falsy em JS).
+out += (Boolean(0) ? "y" : "n") + "\n";       // n
+out += (Boolean(1) ? "y" : "n") + "\n";       // y
+out += (Boolean(NaN) ? "y" : "n") + "\n";     // n (era y antes do fix)
+out += (Boolean(-0) ? "y" : "n") + "\n";      // n
+out += (Boolean(Infinity) ? "y" : "n") + "\n";// y
+out += (Boolean(3.14) ? "y" : "n") + "\n";    // y
+
+describe("boolean_nan", () => {
+  test("Boolean(NaN) === false (#208 fix)", () => expect(out).toBe(
+    "n\ny\nn\nn\ny\ny\n"
+  ));
+});


### PR DESCRIPTION
Fix bug Boolean(NaN). Usa OrderedNotEqual em vez de NotEqual.

## Test plan
- rts test: 446/453 (+1 novo, zero regressão)

Refs #208 #226.