### PR TITLE
feat(math): Math.max/min variadico (#208)

### DIFF
--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -183,6 +183,33 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             // JSON global (#215): JSON.* — spec name="JSON" is in SPECS, so
             // `lookup("JSON.parse")` resolves directly above. No fallback needed.
 
+            // (#208) Math.max/min variadico — JS spec aceita N args.
+            // ABI namespace fixou em 2 args; aqui suportamos N reduzindo
+            // pairwise.
+            if (qualified == "Math.max" || qualified == "Math.min") && call.args.len() > 2 {
+                if call.args.iter().any(|a| a.spread.is_some()) {
+                    return Err(anyhow!("spread not supported in Math.max/min"));
+                }
+                let sym = if qualified == "Math.max" {
+                    "__RTS_FN_NS_MATH_MAX_F64"
+                } else {
+                    "__RTS_FN_NS_MATH_MIN_F64"
+                };
+                let f = ctx.get_extern(sym, &[cl::F64, cl::F64], Some(cl::F64))?;
+                let mut acc: Option<cranelift_codegen::ir::Value> = None;
+                for a in &call.args {
+                    let tv = lower_expr(ctx, &a.expr)?;
+                    let val = ctx.coerce_to_f64(tv).val;
+                    acc = Some(match acc {
+                        None => val,
+                        Some(prev) => {
+                            let inst = ctx.builder.ins().call(f, &[prev, val]);
+                            ctx.builder.inst_results(inst)[0]
+                        }
+                    });
+                }
+                return Ok(TypedVal::new(acc.unwrap(), ValTy::F64));
+            }
             // (#208) String.fromCharCode/fromCodePoint variadico.
             // Default em GlobalClassSpec aceita so 1 arg; aqui suportamos N
             // chamando a fn unitaria pra cada e concatenando.

--- a/tests/math_max_min_variadic.test.ts
+++ b/tests/math_max_min_variadic.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) Math.max/min variadico — JS spec aceita N args.
+out += Math.max(1, 5, 3, 8, 2) + "\n";   // 8
+out += Math.min(1, 5, 3, 8, 2) + "\n";   // 1
+out += Math.max(1, 2) + "\n";            // 2 (2-arg ainda funciona)
+out += Math.min(1, 2) + "\n";            // 1
+out += Math.max(10, 20, 30) + "\n";      // 30
+
+describe("math_max_min_variadic", () => {
+  test("Math.max/min com N args (#208)", () => expect(out).toBe(
+    "8\n1\n2\n1\n30\n"
+  ));
+});


### PR DESCRIPTION
Aceita N args reduzindo pairwise.

## Test plan
- rts test: 449/456 (+1 novo, zero regressão)

Refs #208 #226.