### PR TITLE
feat(codegen): Array.lastIndexOf(needle, fromIndex) (#208)

### DIFF
--- a/src/codegen/jit.rs
+++ b/src/codegen/jit.rs
@@ -1036,6 +1036,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_INDEX_OF_FROM
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF_FROM",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF_FROM
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF
         );

--- a/src/codegen/lower/expressions/calls.rs
+++ b/src/codegen/lower/expressions/calls.rs
@@ -3362,12 +3362,17 @@ fn lower_array_builtin(
             }
             let needle_tv = lower_expr(ctx, &call.args[0].expr)?;
             let needle = ctx.coerce_to_i64(needle_tv).val;
-            // (#208) indexOf(needle, fromIndex) — variant 2-arg.
-            if method == "indexOf" && call.args.len() == 2 {
+            // (#208) indexOf/lastIndexOf(needle, fromIndex) — variant 2-arg.
+            if (method == "indexOf" || method == "lastIndexOf") && call.args.len() == 2 {
                 let from_tv = lower_expr(ctx, &call.args[1].expr)?;
                 let from = ctx.coerce_to_i64(from_tv).val;
+                let sym = if method == "indexOf" {
+                    "__RTS_FN_NS_COLLECTIONS_VEC_INDEX_OF_FROM"
+                } else {
+                    "__RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF_FROM"
+                };
                 let fref = ctx.get_extern(
-                    "__RTS_FN_NS_COLLECTIONS_VEC_INDEX_OF_FROM",
+                    sym,
                     &[cl::I64, cl::I64, cl::I64],
                     Some(cl::I64),
                 )?;

--- a/src/namespaces/collections/vec.rs
+++ b/src/namespaces/collections/vec.rs
@@ -180,6 +180,28 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF(handle: u64, needle:
     })
 }
 
+/// (#208) `arr.lastIndexOf(needle, fromIndex)` — busca de tras pra frente,
+/// comecando em `from` (inclusive). Negativo = relativo ao fim.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_LAST_INDEX_OF_FROM(
+    handle: u64,
+    needle: i64,
+    from: i64,
+) -> i64 {
+    with_vec(handle, -1, |v| {
+        let len = v.len() as i64;
+        let end = if from < 0 { (len + from).max(-1) + 1 } else { (from + 1).min(len) } as usize;
+        if end == 0 {
+            return -1;
+        }
+        v[..end]
+            .iter()
+            .rposition(|x| *x == needle)
+            .map(|i| i as i64)
+            .unwrap_or(-1)
+    })
+}
+
 /// `arr.includes(needle)` → 1 ou 0.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_INCLUDES(handle: u64, needle: i64) -> i64 {

--- a/tests/array_lastindexof_fromindex.test.ts
+++ b/tests/array_lastindexof_fromindex.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+
+// (#208) Array.lastIndexOf(needle, fromIndex)
+const a = [1, 2, 3, 2, 1];
+out += a.lastIndexOf(2) + "\n";       // 3
+out += a.lastIndexOf(2, 2) + "\n";    // 1
+out += a.lastIndexOf(1, 0) + "\n";    // 0
+
+describe("array_lastindexof_fromindex", () => {
+  test("lastIndexOf 2-arg (#208)", () => expect(out).toBe(
+    "3\n1\n0\n"
+  ));
+});


### PR DESCRIPTION
Adiciona segundo arg fromIndex em lastIndexOf.

## Test plan
- rts test: 452/459 (+1 novo, zero regressão)

Refs #208 #226.