### PR TITLE
docs: atualiza CLAUDE.md/rules + spec do epic #226

### DIFF
--- a/.claude/rules/03-features.md
+++ b/.claude/rules/03-features.md
@@ -20,6 +20,27 @@
 - async/await com pipeline Promise-centric (ver secao abaixo).
 - Function class — `.call/.apply/.bind/.toString` + `.name/.length`
   + `new Function("body")` via eval em runtime.
+- Destructuring (#210): array/objeto, defaults, rest, aninhado,
+  em params de fn/arrow, em for-of, em catch, alias `{a: b}`.
+- Builtins JS expandidos (epic #226 em progresso): Array
+  (indexOf/lastIndexOf/includes com fromIndex, reverse, shift/
+  unshift, slice, concat, fill, flat/flatMap, splice, findLast/
+  findLastIndex, reduceRight, copyWithin, sort com strings,
+  values/keys/entries, toSorted/toReversed/toSpliced/with,
+  Array.from(length) e Array.from(arr)); Object (entries, assign,
+  freeze, fromEntries, seal, isFrozen, isSealed, getPrototypeOf,
+  defineProperty); Math (sign, hypot, expm1, log1p, fround,
+  sinh/cosh/tanh/asinh/acosh/atanh, imul, clz32 + SQRT2/SQRT1_2/
+  LN2/LN10/LOG2E/LOG10E); String (split com limit, startsWith/
+  endsWith com offset, match/search/matchAll via regex); Symbol
+  (Symbol/Symbol.for/keyFor/description + well-known iterator/
+  asyncIterator/hasInstance/toPrimitive/toStringTag); URL/
+  URLSearchParams completos; Date setters (setFullYear/Month/Date/
+  Hours/Minutes/Seconds + UTC variants), getTimezoneOffset,
+  toUTCString/toDateString/toJSON/toLocaleString/toTimeString;
+  TextEncoder/TextDecoder; encodeURIComponent/decodeURIComponent;
+  WeakMap/WeakSet (semantica strong por enquanto, #217); Boolean
+  class com toString/valueOf; parseInt com radix.
 
 ## Silent parallelism (Level-1)
 

--- a/.claude/rules/04-workflow.md
+++ b/.claude/rules/04-workflow.md
@@ -200,3 +200,25 @@ Suite completa:
 ```bash
 powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
 ```
+
+## Status do epic #226 (paridade JS/TS)
+
+Suite TS (`target/release/rts.exe test`): **457/464** (98.5% em
+2026-05-03). Lote recente de PRs (#483-#547) fechou ~10 issues
+filhas (#208, #210, #220, #221, #371-#375, #434) cobrindo ~60
+APIs JS faltantes — ver `03-features.md` para a lista por categoria.
+
+Issues pesadas ainda abertas e fora de escopo de PR pequena
+(manter abertas, requerem refactor):
+
+- **#195** mutable closures — env-record refactor; bloqueado por
+  #90 (block params).
+- **#207** event loop async/await real — refactor de Promise.
+- **#213** module exports — resolver refactor.
+- **#216** Symbol como chave computada — side-channel HashMap.
+- **#217** WeakMap/WeakSet semantica fraca real + FinalizationRegistry.
+- **#218** Proxy — interceptacao em codegen.
+- **#222** Map/Set Symbol.iterator real (hoje so' stub).
+- **#223** dynamic import.
+- **#211** generators / **#219** BigInt / **#225** Intl —
+  candidate-discard.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,15 @@ src/namespaces/globals/<class>/
   `isFinite`/`parseInt`/`parseFloat`/`encodeURIComponent`/`decodeURIComponent`
 - `text_encoding/` — `TextEncoder`/`TextDecoder` (UTF-8)
 - `url/` — `URL`: href/protocol/host/pathname/search/hash/searchParams
+  + `URLSearchParams`: get/set/has/delete/append/getAll/keys/values/
+  entries/toString
+- `symbol/` — `Symbol`: `Symbol(desc)`, `Symbol.for(key)`, `keyFor`,
+  `description`, `toString`; well-known: `iterator`, `asyncIterator`,
+  `hasInstance`, `toPrimitive`, `toStringTag`
+- `weakmap/`, `weakset/` — stubs com semantica strong (refs fortes
+  no HandleTable). Issue #217 rastreia FinalizationRegistry e weak
+  refs reais
+- `boolean/` — `Boolean`: `toString`, `valueOf`, coercao `Boolean(x)`
 
 ## Silent parallelism (Level-1)
 
@@ -486,6 +495,24 @@ Os testes vivem em `tests/*.test.ts` (formato `rts:test`). Reaproveite
 o template padrao: `__rtsCapturedOutput`, `print()` shim, `describe()`
 com 1 ou mais `test()`/`expect().toBe()`. Multiplos `test()` por arquivo
 sao bem-vindos pra cobrir variacoes sem inflar o numero de arquivos.
+
+## Status do epic #226 (paridade JS/TS)
+
+Suite TS: **457/464** (98.5% em 2026-05-03). Lote recente de PRs
+(#483-#547) cobriu ~60 APIs JS faltantes em Array/Object/Math/String/
+Symbol/URL/Date/Boolean/parseInt e adicionou destructuring completo
+(#210). Issues filhas pesadas que continuam abertas (refactor
+necessario, fora de escopo de PR pequena):
+
+- **#195** mutable closures (env-record refactor; bloqueado por #90)
+- **#207** event loop async/await real
+- **#213** module exports
+- **#216** Symbol como chave computada
+- **#217** WeakMap/WeakSet semantica fraca + FinalizationRegistry
+- **#218** Proxy
+- **#222** Map/Set Symbol.iterator real
+- **#223** dynamic import
+- **#211/#219/#225** generators / BigInt / Intl (candidate-discard)
 
 ## Como testar
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -14,6 +14,10 @@ arquiteturais. Para direcao de alto nivel do projeto consulte
   reescreve transparentemente para `parallel.*`. Pipeline dos 3 passes,
   criterio de pureza, infra de suporte (HandleTable shard-aware,
   callconv), limitacoes.
+- [Epic #226 — paridade JS/TS](js-parity-epic-226.md) — Lote PRs
+  #483-#547: ~60 APIs JS adicionadas (Array/Object/Math/String/Symbol/
+  URL/Date/Boolean/parseInt/destructuring), bugs corrigidos no caminho,
+  tabela de issues abertas pesadas. Suite: 457/464 (98.5%).
 - [async / Promise / Function](async-promise-function.md) — Subsistema
   unificado de async/await, Promise<T>, e Function class. Pipeline do
   desugar `expand_async_functions` (`async fn` → `promise.create`),

--- a/docs/specs/js-parity-epic-226.md
+++ b/docs/specs/js-parity-epic-226.md
@@ -1,0 +1,83 @@
+# Epic #226 — Paridade JS/TS
+
+Status em 2026-05-03. Suite TS: **457/464** (98.5%).
+
+## Lote concluido (PRs #483-#547)
+
+Aproximadamente 60 APIs JS adicionadas/corrigidas, ~10 issues
+filhas fechadas (#208, #210, #220, #221, #371-#375, #434).
+Categorias:
+
+### Array
+indexOf/lastIndexOf/includes com fromIndex; reverse; shift/unshift;
+slice; concat; fill; flat; flatMap; splice; findLast/findLastIndex;
+reduceRight; copyWithin; sort com deteccao de strings; values/keys/
+entries; toSorted/toReversed/toSpliced/with; Array.from(length) e
+Array.from(arr).
+
+### Object
+entries; assign; freeze; fromEntries; seal; isFrozen; isSealed;
+getPrototypeOf; defineProperty. keys/values/entries excluem
+`__proto__`.
+
+### Math
+sign; hypot; expm1; log1p; fround; sinh/cosh/tanh/asinh/acosh/
+atanh; imul; clz32. Constantes SQRT2/SQRT1_2/LN2/LN10/LOG2E/
+LOG10E. Aliases abs/min/max/log/random.
+
+### String
+split com limit; startsWith/endsWith com offset; match/search/
+matchAll via backend regex.
+
+### Symbol
+Novo namespace `globals/symbol/`. Symbol(desc), Symbol.for(key),
+keyFor, description, toString. Well-known: iterator,
+asyncIterator, hasInstance, toPrimitive, toStringTag.
+
+### URL
+URLSearchParams completo (get/set/has/delete/append/getAll/keys/
+values/entries/toString) + URL.searchParams getter.
+
+### Date
+setFullYear/Month/Date/Hours/Minutes/Seconds + variantes UTC;
+getTimezoneOffset; toUTCString/toDateString/toJSON/toLocaleString/
+toTimeString.
+
+### Outros
+TextEncoder/TextDecoder (fix critico de OOM 2.4TB em PR #485 —
+GlobalClassSpec apontava para fns sem self param);
+encodeURIComponent/decodeURIComponent; WeakMap/WeakSet (semantica
+strong por enquanto, #217 rastreia weak real); Boolean class
+(toString/valueOf); parseInt(s, radix) com semantica JS-spec.
+
+### Destructuring (#210)
+Array/objeto, defaults, rest, aninhado, em params de fn/arrow,
+em for-of, em catch, alias `{a: b}`.
+
+## Bugs descobertos e corrigidos no caminho
+
+- Verifier error block6 invalid reference em optional chain `?.()`
+  (#481): obj de Member.obj=OptChain materializado em local var temp.
+- Boolean(NaN) retornando true: trocado FloatCC::NotEqual
+  (Unordered) por OrderedNotEqual.
+- Filter/find/etc retornando lixo: caia em string_builtin antes de
+  array_builtin — corrigido com `local_array_vars` em FnCtx.
+- Object.keys retornando `__proto__`: explicit skip em map iteration.
+
+## Issues abertas pesadas (fora de escopo de PR pequena)
+
+| # | Tema | Bloqueio |
+|---|---|---|
+| #195 | Mutable closures | Env-record refactor; depende de #90 |
+| #207 | Event loop async/await real | Promise refactor |
+| #213 | Module exports | Resolver refactor |
+| #216 | Symbol como chave computada | Side-channel HashMap por objeto |
+| #217 | WeakMap/WeakSet weak real + FinalizationRegistry | GC refactor |
+| #218 | Proxy | Codegen interception |
+| #222 | Map/Set Symbol.iterator real | Hoje so' stub |
+| #223 | Dynamic import | Module resolver async |
+| #211/#219/#225 | Generators / BigInt / Intl | Candidate-discard |
+
+## Restantes na suite (7 fails)
+
+Convertidos em issues filhas durante o epic — ver tracker.


### PR DESCRIPTION
## Summary
- CLAUDE.md root e .claude/rules/{03,04} refletem builtins JS adicionados no lote #483-#547 (~60 APIs)
- Novo spec docs/specs/js-parity-epic-226.md documenta lote completo + bugs descobertos + tabela de issues pesadas abertas
- Mantem #195/#207/#213/#216/#217/#218/#222/#223 explicitamente abertas (refactor necessario, fora de PR pequena)

Suite: 457/464 (98.5%). Sem mudanca de codigo.

## Test plan
- [x] docs only, no code changes