### PR TITLE
fix(codegen): destructure alias com default (#551)

### DIFF
--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -3402,15 +3402,27 @@ fn expand_destruct_decl(
                         expand_destruct_decl(&inner_pat, Some(&access), kind, counter, out);
                     }
                     swc_ecma_ast::ObjectPatProp::KeyValue(kvp) => {
-                        // \`{ x: a }\` — alias
+                        // \`{ x: a }\` — alias; tambem \`{ x: a = default }\`
+                        // (#551) SWC representa default em KeyValue como
+                        // value=Pat::Assign{left,right=default}.
                         let key = match &kvp.key {
                             swc_ecma_ast::PropName::Ident(id) => id.sym.to_string(),
                             swc_ecma_ast::PropName::Str(s) => s.value.to_string_lossy().to_string(),
                             _ => continue,
                         };
                         consumed_keys.push(key.clone());
-                        let access = make_member_access(&tmp_name, &key);
-                        expand_destruct_decl(&kvp.value, Some(&access), kind, counter, out);
+                        let (target_pat, access) = if let Pat::Assign(ap) = kvp.value.as_ref() {
+                            let acc = make_member_access_with_default(
+                                &tmp_name,
+                                &key,
+                                ap.right.as_ref(),
+                            );
+                            (ap.left.as_ref(), acc)
+                        } else {
+                            let acc = make_member_access(&tmp_name, &key);
+                            (kvp.value.as_ref(), acc)
+                        };
+                        expand_destruct_decl(target_pat, Some(&access), kind, counter, out);
                     }
                     swc_ecma_ast::ObjectPatProp::Rest(rest) => {
                         rest_pat = Some(rest.arg.as_ref());

--- a/tests/destructure_alias_default.test.ts
+++ b/tests/destructure_alias_default.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "rts:test";
+
+// (#551) destructuring com alias + default: { key: alias = default }
+
+const { a: aa, b: bb = 88 } = { a: 1 };
+const { x: xx = 7, y: yy = 8 } = { y: 20 };
+const { p: pp = "fallback" } = {};
+const { obj: { z: zz = 5 } = { z: 0 } } = { obj: { z: 99 } };
+
+describe("destructure_alias_default", () => {
+  test("alias com default usa value (#551)", () => expect(aa).toBe(1));
+  test("alias com default missing key", () => expect(bb).toBe(88));
+  test("alias com default ambos missing", () => expect(xx).toBe(7));
+  test("alias com default um present", () => expect(yy).toBe(20));
+  test("string default", () => expect(pp).toBe("fallback"));
+  test("nested alias com default", () => expect(zz).toBe(99));
+});


### PR DESCRIPTION
Closes #551. Suite: 477/484.