### PR TITLE
fix(codegen): this.name em ctor function nao interceptado por Function.name (#601)

### DIFF
--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -718,7 +718,22 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             } else {
                 false
             };
-            if receiver_class.is_none() && !is_known_obj_lit {
+            // (#601) Skip getter fallback para "name"/"length"/"prototype"
+            // quando obj nao e' Ident de user fn. Esses sao Function metadata
+            // — sem receiver_class identificavel, podem colidir com fields
+            // legitimos de instance. Mantem behavior so' para idents de user
+            // fn (Animal.name, etc.) via lower_user_fn_getter acima.
+            let is_function_meta_prop = matches!(
+                key, "name" | "length" | "prototype"
+            );
+            let obj_is_user_fn_ident = if let Expr::Ident(id) = m.obj.as_ref() {
+                ctx.user_fns.contains_key(id.sym.as_str())
+                    && ctx.var_ty(id.sym.as_str()).is_none()
+            } else {
+                false
+            };
+            let skip_function_meta = is_function_meta_prop && !obj_is_user_fn_ident;
+            if receiver_class.is_none() && !is_known_obj_lit && !skip_function_meta {
                 // (#216) Tenta instance_getter primeiro (description, source, flags, etc.)
                 for spec in crate::abi::GLOBAL_CLASS_SPECS {
                     if let Some(member) = spec.instance_getter(key) {

--- a/tests/ctor_fn_this_field.test.ts
+++ b/tests/ctor_fn_this_field.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "rts:test";
+
+// (#601) this.name em ctor function — nao deve ser interceptado por
+// Function.name getter.
+
+function Animal(n: string) {
+  (this as any).name = n;
+  (this as any).age = 5;
+}
+const a = new (Animal as any)("Rex");
+const a_name = (a as any).name;
+const a_age = (a as any).age;
+
+describe("ctor_fn_this_field", () => {
+  test("this.name = n persiste", () => expect(a_name).toBe("Rex"));
+  test("this.age = 5 persiste", () => expect(a_age).toBe(5));
+});


### PR DESCRIPTION
## Summary
- Skip do fallback de instance_getter para `name`/`length`/`prototype` quando obj nao e' Ident de user fn
- `function Animal(n) { this.name = n }` + `new Animal(...)` agora le `.name` corretamente

Closes #601

## Test plan
- [x] tests/ctor_fn_this_field.test.ts passa (2/2)
- [x] suite TS sem regressao (609/614, mesmos flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)