### PR TITLE
fix(codegen): cfg.server.host chained direto nao cai em URL.host fallback

### DIFF
--- a/src/codegen/lower/ctx.rs
+++ b/src/codegen/lower/ctx.rs
@@ -326,6 +326,11 @@ pub struct FnCtx<'m, 'fb> {
     /// fn user fazendo \`E.A\` retornava I64 anonimo, e \`x == E.A\` comparava
     /// como int em vez de string.
     pub global_obj_field_types: &'fb HashMap<String, HashMap<String, ValTy>>,
+    /// (#nested-chain) Tipos de fields aninhados de globais. Chave eh
+    /// (root_global, key_no_root) — analogo a local_nested_obj_field_types.
+    /// Permite `cfg.server.host` em user fn quando cfg eh global.
+    pub global_nested_obj_field_types:
+        &'fb HashMap<(String, String), HashMap<String, ValTy>>,
     /// Nome da classe atualmente sendo lowered (quando dentro de um
     /// metodo ou constructor). Usado para resolver `super`.
     pub current_class: Option<String>,
@@ -466,6 +471,10 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         classes: &'fb HashMap<String, ClassMeta>,
         global_class_ty: &'fb HashMap<String, String>,
         global_obj_field_types: &'fb HashMap<String, HashMap<String, ValTy>>,
+        global_nested_obj_field_types: &'fb HashMap<
+            (String, String),
+            HashMap<String, ValTy>,
+        >,
         fn_class_returns: &'fb HashMap<String, String>,
         node_import_map: &'fb HashMap<String, String>,
         module_scope: bool,
@@ -489,6 +498,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             local_obj_field_types: HashMap::new(),
             global_class_ty,
             global_obj_field_types,
+            global_nested_obj_field_types,
             current_class: None,
             current_is_ctor: false,
             super_already_called: false,

--- a/src/codegen/lower/expressions/members.rs
+++ b/src/codegen/lower/expressions/members.rs
@@ -715,6 +715,54 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 let n = obj_id.sym.as_str();
                 ctx.local_obj_field_types.contains_key(n)
                     || ctx.global_obj_field_types.contains_key(n)
+            } else if let Expr::Member(_) | Expr::OptChain(_) = m.obj.as_ref() {
+                // (#bug) Chained: cfg.server.host — se o root eh obj literal
+                // conhecido e o path bate em nested registrado, tratar como
+                // obj literal e ir pro map_get. Sem isso, cai no fallback
+                // de GLOBAL_CLASS_SPECS e bate em URL.host/etc, retornando lixo.
+                fn chain_root_path(e: &Expr) -> Option<(String, Vec<String>)> {
+                    match e {
+                        Expr::Ident(id) => Some((id.sym.to_string(), Vec::new())),
+                        Expr::Member(mi) => {
+                            if let MemberProp::Ident(p) = &mi.prop {
+                                let (root, mut path) = chain_root_path(&mi.obj)?;
+                                path.push(p.sym.to_string());
+                                Some((root, path))
+                            } else {
+                                None
+                            }
+                        }
+                        Expr::OptChain(o) => {
+                            if let swc_ecma_ast::OptChainBase::Member(mi) = o.base.as_ref() {
+                                if let MemberProp::Ident(p) = &mi.prop {
+                                    let (root, mut path) = chain_root_path(&mi.obj)?;
+                                    path.push(p.sym.to_string());
+                                    Some((root, path))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    }
+                }
+                if let Some((root, path)) = chain_root_path(m.obj.as_ref()) {
+                    if !path.is_empty()
+                        && (ctx.local_obj_field_types.contains_key(&root)
+                            || ctx.global_obj_field_types.contains_key(&root))
+                    {
+                        let last = path.last().unwrap().clone();
+                        let key = (root, last);
+                        ctx.local_nested_obj_field_types.contains_key(&key)
+                            || ctx.global_nested_obj_field_types.contains_key(&key)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
             } else {
                 false
             };
@@ -836,11 +884,15 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                     if let Some((root, path)) = chain_root_path(m.obj.as_ref()) {
                         if !path.is_empty() {
                             let last_key = path.last().unwrap().clone();
-                            if let Some(nested) = ctx
+                            let nkey = (root, last_key);
+                            let nested = ctx
                                 .local_nested_obj_field_types
-                                .get(&(root, last_key))
+                                .get(&nkey)
                                 .cloned()
-                            {
+                                .or_else(|| {
+                                    ctx.global_nested_obj_field_types.get(&nkey).cloned()
+                                });
+                            if let Some(nested) = nested {
                                 field_ty = nested.get(key).copied();
                             }
                         }

--- a/src/codegen/lower/func.rs
+++ b/src/codegen/lower/func.rs
@@ -6361,6 +6361,11 @@ pub fn compile_program(
     // pra string enum, Bool, etc) em vez de I64 anonimo.
     let mut global_obj_field_types: HashMap<String, HashMap<String, ValTy>> =
         HashMap::new();
+    // (#nested-chain) Tipos nested para globais — analogo ao local.
+    let mut global_nested_obj_field_types: HashMap<
+        (String, String),
+        HashMap<String, ValTy>,
+    > = HashMap::new();
     for item in &program.items {
         let Item::Statement(Statement::Raw(raw)) = item else {
             continue;
@@ -6419,6 +6424,54 @@ pub fn compile_program(
                                     swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Bool(_)) => {
                                         fts.insert(key, ValTy::Bool);
                                     }
+                                    // (#nested-chain) Object literal aninhado:
+                                    // registra sub-fields para `cfg.server.host`
+                                    // funcionar de dentro de user fn.
+                                    swc_ecma_ast::Expr::Object(sub) => {
+                                        fts.insert(key.clone(), ValTy::Handle);
+                                        let mut sub_fts: HashMap<String, ValTy> =
+                                            HashMap::new();
+                                        for sp in &sub.props {
+                                            if let swc_ecma_ast::PropOrSpread::Prop(spx) = sp {
+                                                if let swc_ecma_ast::Prop::KeyValue(skv) =
+                                                    spx.as_ref()
+                                                {
+                                                    let sk = match &skv.key {
+                                                        swc_ecma_ast::PropName::Ident(i) => {
+                                                            i.sym.as_str().to_string()
+                                                        }
+                                                        swc_ecma_ast::PropName::Str(s) => s
+                                                            .value
+                                                            .to_string_lossy()
+                                                            .to_string(),
+                                                        _ => continue,
+                                                    };
+                                                    match skv.value.as_ref() {
+                                                        swc_ecma_ast::Expr::Lit(
+                                                            swc_ecma_ast::Lit::Str(_),
+                                                        ) => {
+                                                            sub_fts.insert(sk, ValTy::Handle);
+                                                        }
+                                                        swc_ecma_ast::Expr::Lit(
+                                                            swc_ecma_ast::Lit::Num(_),
+                                                        ) => {
+                                                            sub_fts.insert(sk, ValTy::I64);
+                                                        }
+                                                        swc_ecma_ast::Expr::Lit(
+                                                            swc_ecma_ast::Lit::Bool(_),
+                                                        ) => {
+                                                            sub_fts.insert(sk, ValTy::Bool);
+                                                        }
+                                                        _ => {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        if !sub_fts.is_empty() {
+                                            global_nested_obj_field_types
+                                                .insert((name.clone(), key), sub_fts);
+                                        }
+                                    }
                                     _ => {}
                                 }
                             }
@@ -6451,6 +6504,7 @@ pub fn compile_program(
             &classes,
             &global_class_ty,
             &global_obj_field_types,
+            &global_nested_obj_field_types,
             &fn_class_returns,
             &node_import_map,
             fn_decl,
@@ -6496,6 +6550,7 @@ pub fn compile_program(
         &classes,
         &global_class_ty,
         &global_obj_field_types,
+        &global_nested_obj_field_types,
         &fn_class_returns,
         &node_import_map,
         &top_stmts,
@@ -7481,6 +7536,7 @@ fn compile_user_fn(
     classes: &HashMap<String, ClassMeta>,
     global_class_ty: &HashMap<String, String>,
     global_obj_field_types: &HashMap<String, HashMap<String, ValTy>>,
+    global_nested_obj_field_types: &HashMap<(String, String), HashMap<String, ValTy>>,
     fn_class_returns: &HashMap<String, String>,
     node_import_map: &HashMap<String, String>,
     fn_decl: &FunctionDecl,
@@ -7525,6 +7581,7 @@ fn compile_user_fn(
             classes,
             global_class_ty,
             global_obj_field_types,
+            global_nested_obj_field_types,
             fn_class_returns,
             node_import_map,
             false,
@@ -7730,6 +7787,7 @@ fn compile_main(
     classes: &HashMap<String, ClassMeta>,
     global_class_ty: &HashMap<String, String>,
     global_obj_field_types: &HashMap<String, HashMap<String, ValTy>>,
+    global_nested_obj_field_types: &HashMap<(String, String), HashMap<String, ValTy>>,
     fn_class_returns: &HashMap<String, String>,
     node_import_map: &HashMap<String, String>,
     stmts: &[&Stmt],
@@ -7762,6 +7820,7 @@ fn compile_main(
             classes,
             global_class_ty,
             global_obj_field_types,
+            global_nested_obj_field_types,
             fn_class_returns,
             node_import_map,
             true,

--- a/tests/nested_obj_chain_direct.test.ts
+++ b/tests/nested_obj_chain_direct.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "rts:test";
+
+// Acesso encadeado direto cfg.server.host (sem var intermediaria)
+// e variacoes — em var/print/concat/dentro de classe via this.
+
+const cfg = { server: { host: "localhost", port: 3000 } };
+
+const h = cfg.server.host;
+const p = cfg.server.port;
+
+const cfg2 = { a: { b: { c: "deep" } } };
+const c = cfg2.a.b.c;
+
+let captured = "";
+function print(v: string): void { captured += v + "\n"; }
+print(cfg.server.host);
+
+// Concat direto
+const concat = "host=" + cfg.server.host;
+
+// Em condicional
+let cond = "";
+if (cfg.server.host == "localhost") {
+  cond = "match";
+}
+
+// Numero direto em expressao
+const sum = cfg.server.port + 1;
+
+// Em loop
+let loopOut = "";
+for (let i = 0; i < 2; i++) {
+  loopOut += cfg.server.host;
+}
+
+// Dentro de fn
+function getHost(): string {
+  return cfg.server.host;
+}
+const fnRet = getHost();
+
+// Dentro de classe via const local da classe
+class Reader {
+  read(): string {
+    const local = { srv: { addr: "1.2.3.4" } };
+    return local.srv.addr;
+  }
+}
+const readerOut = new Reader().read();
+
+// Mix: cfg.server.host dentro de template-like concat dentro de fn
+function build(): string {
+  return cfg.server.host + ":" + cfg.server.port;
+}
+const built = build();
+
+describe("nested_obj_chain_direct", () => {
+  test("cfg.server.host direto", () => expect(h).toBe("localhost"));
+  test("cfg.server.port direto", () => expect(p).toBe(3000));
+  test("triplo aninhado a.b.c", () => expect(c).toBe("deep"));
+  test("print(cfg.server.host)", () => expect(captured).toBe("localhost\n"));
+  test("concat host=...", () => expect(concat).toBe("host=localhost"));
+  test("if condicional cfg.server.host", () => expect(cond).toBe("match"));
+  test("cfg.server.port + 1", () => expect(sum).toBe(3001));
+  test("loop 2x cfg.server.host", () => expect(loopOut).toBe("localhostlocalhost"));
+  test("fn return cfg.server.host", () => expect(fnRet).toBe("localhost"));
+  test("classe local.srv.addr", () => expect(readerOut).toBe("1.2.3.4"));
+  test("classe build host:port", () => expect(built).toBe("localhost:3000"));
+});


### PR DESCRIPTION
## Summary
- `cfg.server.host` chained direto retornava lixo porque `is_known_obj_lit` so detectava obj literal quando receiver era Ident; com Member, caia em GLOBAL_CLASS_SPECS fallback (URL.host etc.)
- Novo `global_nested_obj_field_types` em FnCtx, populado em `compile_program`, permite `cfg.server.host` em user fns quando `cfg` eh global
- Resolucao chained do `field_ty` faz fallback pra global nested

## Test plan
- [x] `tests/nested_obj_chain_direct.test.ts` (11 testes): top-level, var, print, concat, if, loop, user fn, classe com const local
- [x] Suite completa: 620/625 (vs baseline 610/618) — +10 testes, -3 falhas pre-existentes
- [ ] `this.cfg.server.host` (field de classe) fica fora — refator separado precisa registrar nested types via class meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)