### PR TITLE
chore: zero warnings (cleanup imports, dead code, deprecated FLTK)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ src/                — fachada bin (re-exports), runtime_objects.rs, main.rs
 > inline+integracao+fixed-point (4.2/4.3/4.7), CSE (4.5), FMA (4.8), arr[i]=v
 > + smoke e2e (4.4/4.6). Restam escape analysis, SIMD e narrow storage real.
 > Metricas atuais: rts-mir 59/59, rts-codegen --lib mir_codegen 61/61,
-> cargo test --workspace 100/100, rts.exe test **977/977** (zero falhas).
+> cargo test --workspace 100/100, rts.exe test **1015/1015** (zero falhas).
 
 Pipeline atual (default, MIR ON):
 
@@ -180,9 +180,11 @@ Cada user fn tenta o caminho HIR→MIR→Cranelift; se bate em construct
 ainda nao modelado (member em `this`/objetos, classes, async/await,
 address-taken fns, string em params/ret de user fn), cai automaticamente
 no codegen AST sem perder semantica. 438 user fns reais da suite TS
-hoje rodam pelo MIR; suite mantem **977/977 verde** (zero falhas apos
-PRs #213, #218 (Reflect/Proxy), #261, #287, #383, #450, #573, #584,
-#592, #602, #617, #618, #619, #224, mais varios fixes de bugs).
+hoje rodam pelo MIR; suite mantem **1015/1015 verde** (zero falhas
+apos PRs #213, #218 (Reflect/Proxy), #261, #287, #289 (sha256
+streaming), #377 (timers), #383, #398 (GC transitive), #407 (globals
+roots), #450, #573, #584, #592, #602, #617, #618, #619, #224 (UI
+event loop), mais randomUUID e varios fixes de bugs).
 
 Pipeline AOT/JIT: ambos passam pelo mesmo `compile_program`; `FnCtx.module`
 e' `&mut dyn Module` para servir os dois sem duplicar codegen.
@@ -535,23 +537,28 @@ sao bem-vindos pra cobrir variacoes sem inflar o numero de arquivos.
 
 ## Status do epic #226 (paridade JS/TS)
 
-Suite TS: **977/977 (100%)**. Lotes recentes (sessao 2026-05-09) entregaram:
+Suite TS: **1015/1015 (100%)**. Lotes recentes (sessao 2026-05-09) entregaram:
 
 - **#213/#618/#619** module system completo: named/default/star imports,
   re-exports, alias `import { x as y }`, `export * as ns`, AOT module graph
 - **#218** Reflect API completa (13 metodos) + Proxy fase 1+2+3 com 13 traps
   (get/set/has/delete/apply/construct/ownKeys/getPrototypeOf/setPrototypeOf/
   defineProperty/getOwnPropertyDescriptor/isExtensible/preventExtensions)
+- **#224** ui.app_check/add_timeout/repeat_timeout/add_idle
+- **#261** computed key (`obj["x"]` e `obj[k]`) propagam field type
+- **#287** node:fs.readFileSync funcional (READ_TEXT)
+- **#289 fase SHA-256** streaming hash via `sha2` crate
+  (`createHash`/`update`/`digest`) + `randomUUID` v4
+- **#377** setTimeout/setInterval/setImmediate + clear* (cobertura formal)
 - **#383** ident desconhecido vira erro de compilacao (era warning + segfault)
+- **#398** GC scanner com transitive marking em Map/Vec/Function/Proxy
+- **#407** top-level globals registrados como GC roots (cobertura formal)
 - **#450** \`arguments.length\` em fn user nao-arrow + fix em arrow VarDecl
+- **#573** \`console.log(null)\` -> \"null\", U64 ambiguo via TPL_COERCE_AUTO
 - **#584** divisao `/` segue JS spec (sempre f64)
 - **#592** \`users[i].field\` em \`Cls[]\` propaga tipo
 - **#602** optchain 3+ niveis em obj literal
-- **#573** \`console.log(null)\` -> \"null\", U64 ambiguo via TPL_COERCE_AUTO
 - **#617** AOT classes (Function archive)
-- **#287** node:fs.readFileSync funcional (READ_TEXT)
-- **#224** ui.app_check/add_timeout/repeat_timeout/add_idle
-- **#261** computed key (`obj["x"]` e `obj[k]`) propagam field type
 
 Issues filhas pesadas que continuam abertas (refactor necessario, fora
 de escopo de PR pequena):

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ inline + integração + fixed-point (4.2/4.3/4.7), CSE (4.5), FMA
 
 - 438 user fns reais da suite TS rodam pelo MIR
 - `cargo test --release --workspace`: **100/100** verde
-- `target/release/rts.exe test`: **977/977** (cobertura completa, zero falhas)
+- `target/release/rts.exe test`: **1015/1015** (cobertura completa, zero falhas)
 
 Variável `RTS_USE_MIR` controla o routing:
 
@@ -291,7 +291,7 @@ oportunidades de intrinsic. Ver `CLAUDE.md` § Debug do codegen.
 
 ## 🎯 Compatibilidade JS/TS
 
-Suite TS atual: **977/977 testes passando**. Cobertura ampla:
+Suite TS atual: **1015/1015 testes passando**. Cobertura ampla:
 
 - **Sintaxe core**: classes (extends/super/static/getters/setters), generics,
   destructuring (array/objeto/nested/defaults/rest/params), spread, optional
@@ -313,9 +313,16 @@ Suite TS atual: **977/977 testes passando**. Cobertura ampla:
 - **Diagnóstico**: identificadores não-resolvidos viram erro de compilação
   (não segfault)
 
+- **Timers**: `setTimeout`, `setInterval`, `setImmediate` + `clear*`
+  (via `thread::spawn` + AtomicBool de cancelamento)
+- **GC**: scanner conservativo com transitive marking em Map/Vec/Function/Proxy
+  + globals top-level registrados como roots — servidores de longa duração
+  com estado em memória são suportados
+
 Cobertura node:* parcial: `node:fs` (readFileSync/writeFileSync/exists/
-append/mkdir), `node:path/os/process/util/crypto`. Compatibilidade
-completa com Node está em #226 (epic tracking).
+append/mkdir), `node:path/os/process/util`, `node:crypto` (sha256
+streaming via `createHash`/`update`/`digest`, `randomUUID`, hex/base64).
+Compatibilidade completa com Node está em #226 (epic tracking).
 
 ---
 

--- a/crates/rts-codegen/src/codegen/lower/compile/mir_route.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/mir_route.rs
@@ -20,10 +20,10 @@ use crate::parser::ast::FunctionDecl;
 use super::super::ctx::ValTy;
 use super::program::UserFn;
 
-/// Thread-local cache de MirFuncs ja lowered nesta passada de
-/// `compile_program`. Permite inline aplicar quando o callee foi
-/// declarado antes do caller no source. Limpado pelo `compile_program`
-/// no inicio de cada nova chamada via `clear_mir_cache_for_program`.
+// Thread-local cache de MirFuncs ja lowered nesta passada de
+// compile_program. Permite inline aplicar quando o callee foi
+// declarado antes do caller no source. Limpado por
+// clear_mir_cache_for_program no inicio de cada nova chamada.
 thread_local! {
     static MIR_CACHE: std::cell::RefCell<HashMap<String, rts_mir::ir::MirFunc>>
         = std::cell::RefCell::new(HashMap::new());

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{Result, anyhow};
 use cranelift_codegen::ir::{AbiParam, InstBuilder, Signature, types as cl};
-use cranelift_module::{Linkage, Module};
+use cranelift_module::Module;
 use swc_ecma_ast::{CallExpr, Expr};
 
 use crate::codegen::lower::ctx::{FnCtx, TypedVal, ValTy};

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -7,19 +7,19 @@ mod ns_call;
 mod super_calls;
 
 use self::indirect::{
-    emit_function_handle_indirect_call, lower_indirect_call, lower_var_member_call,
+    lower_indirect_call, lower_var_member_call,
 };
-use self::new_expr::{lower_function_handle_method, lower_function_method_call, lower_new_function};
+use self::new_expr::{lower_function_handle_method, lower_function_method_call};
 
 pub(super) use self::new_expr::lower_new;
 
 use self::builtins::{
-    lower_array_builtin, lower_console_call, lower_map_set_builtin, lower_number_builtin,
+    lower_array_builtin, lower_console_call, lower_number_builtin,
     lower_string_builtin,
 };
 use self::ns_call::{
-    emit_constant_load, lower_global_instance_call, lower_intrinsic, lower_node_ns_call,
-    lower_ns_call, lower_ns_call_body, lower_ns_call_member,
+    lower_global_instance_call, lower_node_ns_call,
+    lower_ns_call, lower_ns_call_member,
 };
 use self::super_calls::{lower_super_call, lower_super_method_call};
 
@@ -27,14 +27,13 @@ pub(super) use self::ns_call::emit_namespace_constant;
 pub(super) use self::super_calls::{lower_super_prop_assign, lower_super_prop_read};
 
 pub(super) use class_dispatch::{
-    AccessorKind, emit_method_call, emit_named_method_call, emit_virtual_accessor_dispatch,
-    fn_name_has_this_param, lower_class_method_call_with_recv, resolve_getter_owner,
-    resolve_init_owner, resolve_method_owner, resolve_setter_owner,
+    AccessorKind, emit_virtual_accessor_dispatch,
+    fn_name_has_this_param, lower_class_method_call_with_recv, resolve_method_owner, resolve_setter_owner,
 };
 
 use anyhow::{Result, anyhow};
-use cranelift_codegen::ir::{AbiParam, InstBuilder, Signature, types as cl};
-use cranelift_module::{Linkage, Module};
+use cranelift_codegen::ir::{InstBuilder, types as cl};
+use cranelift_module::Module;
 use swc_ecma_ast::{CallExpr, Callee, Expr, MemberProp};
 
 use self::coerce::{
@@ -43,19 +42,15 @@ use self::coerce::{
 };
 
 use crate::abi::lookup;
-use crate::abi::signature::lower_member;
-use crate::abi::types::AbiType;
 
 use super::lower_expr;
 use super::members::{
-    emit_class_tag_read, field_type_in_hierarchy, lhs_static_class, map_get_static_typed,
-    qualified_member_name, validate_visibility,
+    lhs_static_class,
+    qualified_member_name,
 };
 use super::operators::to_f64;
 use crate::codegen::lower::ctx::{FnCtx, TypedVal, ValTy};
-use crate::codegen::lower::compile::class::{
-    class_getter_name, class_setter_name, class_static_method_name,
-};
+use crate::codegen::lower::compile::class::class_static_method_name;
 
 pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
     if matches!(&call.callee, Callee::Super(_)) {

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -5,13 +5,10 @@
 //!   chamadas em handles `Function` reificados (.call/.apply/.bind/etc).
 
 use anyhow::{Result, anyhow};
-use cranelift_codegen::ir::{AbiParam, InstBuilder, Signature, types as cl};
-use cranelift_module::{Linkage, Module};
-use swc_ecma_ast::{CallExpr, Expr, MemberProp};
+use cranelift_codegen::ir::{InstBuilder, types as cl};
+use swc_ecma_ast::{CallExpr, Expr};
 
-use crate::abi::lookup;
 use crate::abi::types::AbiType;
-use crate::codegen::lower::compile::class::class_init_name;
 use crate::codegen::lower::ctx::{FnCtx, TypedVal, ValTy};
 use super::super::lower_expr;
 use super::super::operators::to_f64;

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
@@ -22,7 +22,6 @@ use crate::abi::types::AbiType;
 use crate::codegen::lower::ctx::{FnCtx, TypedVal, ValTy};
 use super::super::lower_expr;
 use super::super::operators::to_f64;
-use super::emit_user_fn_addr;
 
 pub(super) fn emit_constant_load(ctx: &mut FnCtx, member: &crate::abi::NamespaceMember) -> Result<TypedVal> {
     use crate::abi::signature::scalar_to_cl;

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1314,14 +1314,6 @@ pub(crate) fn emit_class_tag_read(
     Ok(ctx.builder.inst_results(inst)[0])
 }
 
-pub(super) fn map_get_static(
-    ctx: &mut FnCtx,
-    obj_handle: cranelift_codegen::ir::Value,
-    key: &[u8],
-) -> Result<TypedVal> {
-    map_get_static_typed(ctx, obj_handle, key, None)
-}
-
 pub(super) fn map_get_static_typed(
     ctx: &mut FnCtx,
     obj_handle: cranelift_codegen::ir::Value,

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1045,34 +1045,6 @@ fn lower_mod(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> 
 
 /// Emite sdiv com guard pra divisor 0. (#296) Em divisor 0 retorna 0.
 /// Estrategia branchless: bor(rv, is_zero_flag) garante divisor != 0;
-/// em divisor 0, divide por 1 (mascara is_zero=1 entra no rv). Depois
-/// AND com !is_zero zera o resultado quando original era 0.
-/// Sem branches, sem select — IR mais previsivel pra Cranelift.
-/// Emite sdiv com guard branchless pra divisor 0. (#296) Em divisor 0
-/// retorna 0 (sentinel). Estrategia: `safe_rv = rv | is_zero` evita o
-/// trap, depois `result & (is_zero - 1)` mascara para 0 no caso original 0.
-fn lower_idiv_safe(
-    ctx: &mut FnCtx,
-    lv: cranelift_codegen::ir::Value,
-    rv: cranelift_codegen::ir::Value,
-    ty: ValTy,
-) -> cranelift_codegen::ir::Value {
-    let cl_ty = if matches!(ty, ValTy::I32) { cl::I32 } else { cl::I64 };
-    let zero = ctx.builder.ins().iconst(cl_ty, 0);
-    let is_zero_b = ctx.builder.ins().icmp(IntCC::Equal, rv, zero);
-    let bool_ty = ctx.builder.func.dfg.value_type(is_zero_b);
-    let is_zero = if bool_ty == cl_ty {
-        is_zero_b
-    } else {
-        ctx.builder.ins().uextend(cl_ty, is_zero_b)
-    };
-    let safe_rv = ctx.builder.ins().bor(rv, is_zero);
-    let q = ctx.builder.ins().sdiv(lv, safe_rv);
-    let one = ctx.builder.ins().iconst(cl_ty, 1);
-    let mask = ctx.builder.ins().isub(is_zero, one);
-    ctx.builder.ins().band(q, mask)
-}
-
 fn lower_imod_safe(
     ctx: &mut FnCtx,
     lv: cranelift_codegen::ir::Value,

--- a/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
@@ -270,7 +270,7 @@ pub extern "C" fn __RTS_FN_GL_PROMISE_FINALLY(promise_h: u64, fp: u64) -> u64 {
 /// recebe o valor inline.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_PROMISE_RESOLVE(value: u64) -> i64 {
-    use crate::namespaces::gc::handles::with_entry as _;
+    
     let kind = with_entry(value, |entry| match entry {
         Some(Entry::Promise(v)) => Some(*v),
         Some(Entry::PromiseAsync(_)) => Some(i64::MIN), // sentinela: ja e' Promise

--- a/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
@@ -23,7 +23,7 @@ fn key_bytes(handle: u64) -> Option<Vec<u8>> {
     })
 }
 
-/// Helper: aloca string handle a partir de bytes UTF-8 estaticos.
+#[cfg(test)]
 fn alloc_str(s: &str) -> u64 {
     alloc_entry(Entry::String(s.as_bytes().to_vec()))
 }

--- a/crates/rts-runtime/src/namespaces/ui/app.rs
+++ b/crates/rts-runtime/src/namespaces/ui/app.rs
@@ -67,7 +67,7 @@ pub extern "C" fn __RTS_FN_NS_UI_APP_ADD_TIMEOUT(tm_secs: f64, cb: i64) {
     if cb == 0 {
         return;
     }
-    app::add_timeout(tm_secs, move || {
+    app::add_timeout3(tm_secs, move |_| {
         invoke_no_args(cb);
     });
 }
@@ -84,7 +84,7 @@ pub extern "C" fn __RTS_FN_NS_UI_APP_REPEAT_TIMEOUT(tm_secs: f64, cb: i64) {
 }
 
 fn schedule_repeat(tm_secs: f64, cb: i64) {
-    app::add_timeout(tm_secs, move || {
+    app::add_timeout3(tm_secs, move |_| {
         invoke_no_args(cb);
         // Auto-reagenda. Em FLTK puro o user chama repeat_timeout no body
         // do callback — aqui fazemos transparente.
@@ -99,7 +99,7 @@ pub extern "C" fn __RTS_FN_NS_UI_APP_ADD_IDLE(cb: i64) {
     if cb == 0 {
         return;
     }
-    app::add_idle(move || {
+    app::add_idle3(move |_| {
         invoke_no_args(cb);
     });
 }

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -51,14 +51,6 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::weakset::WEAKSET_CLASS_SPEC,
 ];
 
-/// Looks up a global class spec by JS class name (e.g. `"Date"`).
-pub(crate) fn global_class_lookup(name: &str) -> Option<&'static GlobalClassSpec> {
-    GLOBAL_CLASS_SPECS
-        .iter()
-        .copied()
-        .find(|s| s.name == name)
-}
-
 /// Global registry of namespaces exposed through the new ABI.
 ///
 /// Each migrated namespace appends its `SPEC` here. Codegen consults this
@@ -114,21 +106,3 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::events::abi::SPEC,
 ];
 
-/// Locates a member by its fully qualified name (e.g. `"io.print"`).
-///
-/// **Trust boundary (#204)**: este lookup eh `pub(crate)` por design.
-/// Todos os call sites estao em `src/codegen/lower/` — sao alimentados
-/// por strings derivadas de AST nodes static (Member expressions),
-/// nunca de input arbitrario do usuario em runtime. Se um caminho
-/// futuro (`runtime.eval_file`, reflection API) precisar resolver
-/// nomes em runtime, deve usar uma allowlist explicita em vez de
-/// expor este lookup.
-///
-/// Auditoria de uso: `grep -rn "abi::lookup" src/` deve retornar
-/// apenas codegen, nunca runtime/* ou cli/*.
-pub(crate) fn lookup(qualified: &str) -> Option<(&'static NamespaceSpec, &'static NamespaceMember)> {
-    let (ns_name, fn_name) = qualified.split_once('.')?;
-    let spec = SPECS.iter().copied().find(|spec| spec.name == ns_name)?;
-    let member = spec.members.iter().find(|m| m.name == fn_name)?;
-    Some((spec, member))
-}

--- a/src/nodespace/mod.rs
+++ b/src/nodespace/mod.rs
@@ -29,17 +29,6 @@ pub const NODE_SPECS: &[&NodespaceSpec] = &[
     &crypto::SPEC,
 ];
 
-/// Resolves a codegen-qualified name like `"node_fs.readFileSync"` to its member.
-pub(crate) fn node_lookup(qualified: &str) -> Option<&'static NodespaceMember> {
-    let (ns_prefix, fn_name) = qualified.split_once('.')?;
-    let module_name = ns_prefix.strip_prefix("node_")?;
-    let spec = NODE_SPECS
-        .iter()
-        .copied()
-        .find(|s| s.node_module == module_name)?;
-    spec.members.iter().find(|m| m.name == fn_name)
-}
-
 /// Maps a `node:` import specifier to its codegen ns_prefix.
 /// e.g. `"node:fs"` → `"node_fs"`
 pub fn ns_prefix_for(specifier: &str) -> Option<&'static str> {


### PR DESCRIPTION
## Summary
- `cargo fix` removeu 18 unused imports em `rts-codegen`
- `alloc_str` (reflect/ops.rs) marcada `#[cfg(test)]`
- doc comment órfão antes de `thread_local!` em `mir_route.rs` vira `//`
- deletadas funções dead da fachada: `lookup`, `global_class_lookup` (`src/abi/mod.rs`), `node_lookup` (`src/nodespace/mod.rs`)
- deletadas em `rts-codegen`: `map_get_static`, `lower_idiv_safe`
- FLTK `add_timeout`/`add_idle` (deprecated) → `add_timeout3`/`add_idle3` (assinatura recebe Handle)
- atualiza `CLAUDE.md`/`README.md`: 977/977 → 1015/1015

Antes: 29 warnings. Depois: **0**.

## Test plan
- [x] `cargo build --release` — 0 warnings
- [x] `cargo test --release --lib` — 12/12
- [x] `target/release/rts.exe test` — 1015/1015