### PR TITLE
fix(#625): Bool em string concat — fix de free prematuro

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -1085,10 +1085,25 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             ValTy::Bool => {
                 // Bool em string vira "true"/"false" (semantica JS), nao
                 // "1"/"0". Sem isso `${x instanceof C}` saia como `1`.
-                let true_h = self.emit_str_handle(b"true")?;
-                let false_h = self.emit_str_handle(b"false")?;
+                //
+                // Usa __RTS_FN_GL_BOOLEAN_TO_STRING para evitar bug de
+                // ordering de free: quando os 2 handles "true"/"false" eram
+                // alocados separadamente e selecionados, o handle nao
+                // selecionado ficava em str_handle_cache para reuso na
+                // proxima expressao bool, mas o selecionado era freed via
+                // register_temp_handle. Em segunda print, select pegava
+                // handle ja freed -> string vazia. (#XXX)
                 let cond = self.coerce_to_i64(tv).val;
-                let val = self.builder.ins().select(cond, true_h.val, false_h.val);
+                let fref = self.get_extern(
+                    "__RTS_FN_GL_BOOLEAN_TO_STRING",
+                    &[cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = self.builder.ins().call(fref, &[cond]);
+                let val = self.builder.inst_results(inst)[0];
+                self.declare_gc_handle(val);
+                self.fresh_handle_set.insert(val);
+                self.register_temp_handle(val);
                 Ok(TypedVal::new(val, ValTy::Handle))
             }
             ValTy::I64 | ValTy::I32

--- a/tests/edge_bool_concat.test.ts
+++ b/tests/edge_bool_concat.test.ts
@@ -1,0 +1,43 @@
+// Cobertura do fix de Bool em string concat / template literal.
+// Bug raiz: emit_str_handle alocava 2 handles "true"/"false" + select,
+// mas o handle selecionado era freed apos a expressao via
+// register_temp_handle. Em segunda expressao, select pegava handle ja
+// liberado -> string vazia.
+// Fix: usa __RTS_FN_GL_BOOLEAN_TO_STRING (single call) ao inves de
+// double-alloc + select.
+import { describe, test, expect } from "rts:test";
+
+let __out: string = "";
+function out(s: string): void { __out += s + "\n"; }
+
+const t: boolean = true;
+const f: boolean = false;
+
+// Cenario que reproduzia o bug: bool var seguido de bool literal.
+out("t=" + t);
+out("f=" + f);
+out("plain false: " + false);
+out("plain true: " + true);
+
+// Combinacoes que retornam bool e devem stringify corretamente.
+const arr = [1, 2, 3];
+const isArr: boolean = Array.isArray(arr);
+const everyPos: boolean = arr.every((n: number) => n > 0);
+const everyNeg: boolean = arr.every((n: number) => n < 0);
+const someBig: boolean = arr.some((n: number) => n > 10);
+out("isArray=" + isArr);
+out("every>0=" + everyPos);
+out("every<0=" + everyNeg);
+out("some>10=" + someBig);
+
+// Multiplas Bool concat na mesma expressao.
+out("multi: " + t + "/" + f + "/" + true + "/" + false);
+
+const expected =
+  "t=true\nf=false\nplain false: false\nplain true: true\n" +
+  "isArray=true\nevery>0=true\nevery<0=false\nsome>10=false\n" +
+  "multi: true/false/true/false\n";
+
+describe("Bool em string concat — sem free prematuro", () => {
+  test("bool var + literal nao perde handle", () => expect(__out).toBe(expected));
+});


### PR DESCRIPTION
## Summary
- **Bug**: \`io.print(\"x: \" + false)\` após \`io.print(\"y: \" + boolVar)\` imprimia \`\"x: \"\` (vazio). Mesmo padrão afetava \`Array.isArray\`, \`arr.every/some\` em string concat.
- **Causa**: \`coerce_to_handle\` para \`Bool\` alocava 2 handles \"true\"/\"false\" + select. Cache de \`str_handle_cache\` reutilizava SSA Value entre expressões, mas \`register_temp_handle\` marcava o selecionado para free. Segunda expressão pegava handle freed → string vazia.
- **Fix**: usa \`__RTS_FN_GL_BOOLEAN_TO_STRING\` (single extern), que aloca handle fresh por expressão via string_pool — sem reuso problemático.
- Fixture nova \`edge_bool_concat.test.ts\` cobrindo o cenário reproduzido.

Closes #625

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1070/1070** (1069 + 1 fixture)