### PR TITLE
fix(#627): destructuring de param com string em concat

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -468,6 +468,12 @@ pub struct FnCtx<'m, 'fb> {
     /// (consulta entry table via runtime fn).
     pub var_member_call_values: std::collections::HashSet<cranelift_codegen::ir::Value>,
 
+    /// (#627) Var names cujo init veio de obj.x ambiguo (member access
+    /// sem tipo declarado). Cada read_local da var marca o Value carregado
+    /// como var_member_call_values, propagando a flag de ambiguidade
+    /// atraves da var. Sem isso, destructuring de param de fn perde info.
+    pub local_ambiguous_vars: std::collections::HashSet<String>,
+
     /// Dedup de data sections por conteúdo: bytes → DataId já declarado.
     /// Evita criar múltiplos .Lrts_str_N com bytes idênticos quando o mesmo
     /// literal aparece mais de uma vez (dentro ou entre funções do módulo).
@@ -571,6 +577,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             fresh_handle_set: std::collections::HashSet::new(),
             optional_chain_values: std::collections::HashSet::new(),
             var_member_call_values: std::collections::HashSet::new(),
+            local_ambiguous_vars: std::collections::HashSet::new(),
             str_data_cache: HashMap::new(),
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -87,6 +87,12 @@ fn lower_ident_expr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal> {
         }
     }
     if let Some(tv) = ctx.read_local(name) {
+        // (#627) Propaga ambiguidade para o Value carregado: var declarada
+        // com init de obj.x sem tipo conhecido marca cada read como
+        // var_member_call_values para que `+` use TPL_COERCE_AUTO.
+        if ctx.local_ambiguous_vars.contains(name) {
+            ctx.var_member_call_values.insert(tv.val);
+        }
         return Ok(tv);
     }
     if ctx.user_fns.contains_key(name) {

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -957,8 +957,37 @@ pub(super) fn lower_add(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result
             &[cl::I64, cl::I64],
             Some(cl::I64),
         )?;
-        let lhs_h = ctx.coerce_to_handle(lhs)?.val;
-        let rhs_h = ctx.coerce_to_handle(rhs)?.val;
+        // (#627) Operando i64 ambiguo (resultado de obj.x sem tipo declarado,
+        // member call em var, etc) usa TPL_COERCE_AUTO que detecta em runtime
+        // se eh handle de string ou i64 puro. Sem isso `"X: " + obj.x` com
+        // x: string vinda de destructuring de param emite STRING_FROM_I64
+        // (formata handle bruto como numero).
+        let lhs_ambig = matches!(lhs.ty, ValTy::I64 | ValTy::U64)
+            && ctx.var_member_call_values.contains(&lhs.val);
+        let rhs_ambig = matches!(rhs.ty, ValTy::I64 | ValTy::U64)
+            && ctx.var_member_call_values.contains(&rhs.val);
+        let lhs_h = if lhs_ambig {
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_AUTO",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[lhs.val]);
+            ctx.builder.inst_results(inst)[0]
+        } else {
+            ctx.coerce_to_handle(lhs)?.val
+        };
+        let rhs_h = if rhs_ambig {
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_AUTO",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[rhs.val]);
+            ctx.builder.inst_results(inst)[0]
+        } else {
+            ctx.coerce_to_handle(rhs)?.val
+        };
 
         // coerce_to_handle may have created new fresh handles for numeric operands.
         let lhs_free = lhs_is_fresh || (!matches!(lhs.ty, ValTy::Handle) && lhs_h != lhs.val);

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -457,6 +457,14 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             _ => init_val,
         };
 
+        // (#627) Propaga flag de ambiguidade — quando init eh resultado de
+        // obj.x sem tipo declarado, a var herda var_member_call_values para
+        // que `+` em concat use TPL_COERCE_AUTO.
+        let init_was_ambiguous = ctx.var_member_call_values.contains(&init_val);
+        if init_was_ambiguous && ann_ty.is_none() {
+            ctx.local_ambiguous_vars.insert(name.clone());
+        }
+
         if ctx.module_scope && ctx.has_global(&name) {
             ctx.write_local(&name, init_coerced)?;
         } else {

--- a/tests/edge_destr_param_string.test.ts
+++ b/tests/edge_destr_param_string.test.ts
@@ -1,0 +1,46 @@
+// Cobertura do fix #627 — destructuring de param em fn user com string
+// nao perde tipo em concat. Antes: `function f({x}: {x: string})` com
+// `return "Hi, " + x;` emitia STRING_FROM_I64(handle) -> "Hi, 281474976...".
+// Fix: var ambigua (init de obj.x sem tipo) marca local_ambiguous_vars,
+// cada read propaga var_member_call_values, lower_add usa TPL_COERCE_AUTO.
+import { describe, test, expect } from "rts:test";
+
+let __out: string = "";
+function out(s: string): void { __out += s + "\n"; }
+
+// Caso minimal
+function greet({ x }: { x: string }): string {
+  return "Hi, " + x;
+}
+
+// Caso com default + 2 fields
+function greet2({ name, greeting = "Hi" }: { name: string; greeting?: string }): string {
+  return greeting + ", " + name;
+}
+
+// Caso com numeric e string mistos
+function summarize({ name, age }: { name: string; age: number }): string {
+  return name + " (" + age + ")";
+}
+
+// Aninhado em param
+function greetNested({ user: { name } }: { user: { name: string } }): string {
+  return "Hello, " + name;
+}
+
+out(greet({ x: "Bob" }));
+out(greet2({ name: "Eve" }));
+out(greet2({ name: "Eve", greeting: "Hello" }));
+out(summarize({ name: "Carl", age: 42 }));
+out(greetNested({ user: { name: "Dora" } }));
+
+const expected =
+  "Hi, Bob\n" +
+  "Hi, Eve\n" +
+  "Hello, Eve\n" +
+  "Carl (42)\n" +
+  "Hello, Dora\n";
+
+describe("Destructuring de param com string em concat (#627)", () => {
+  test("string em concat preserva tipo", () => expect(__out).toBe(expected));
+});


### PR DESCRIPTION
## Summary
- **Bug** descoberto via probing: \`function f({x}: {x: string})\` retornando \`\"Hi, \" + x\` imprimia handle bruto formatado como número (\"Hi, 281474976710657\").
- **Causa raiz**: \`lower_params_with_destructure\` cria prologue \`const {x} = __synth_param_0\`. O \`expand_destruct_decl\` perde type info → var \`x\` fica i64 default. \`lower_add\` vê rhs=i64 e usa STRING_FROM_I64 (formata como número).
- **Fix em 3 camadas**:
  1. Novo \`ctx.local_ambiguous_vars\` rastreia vars cujo init é \`obj.x\` ambíguo.
  2. \`lower_var_decl\` marca a var quando init tem flag \`var_member_call_values\`.
  3. \`lower_ident_expr\` propaga a flag em cada read.
  4. \`lower_add\` detecta operando ambíguo e usa TPL_COERCE_AUTO (decide string vs number em runtime).
- Fixture nova \`edge_destr_param_string.test.ts\` cobrindo 5 cenários.

Closes #627

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1071/1071** (1070 + 1 fixture)