### PR TITLE
fix(#629): JSON.parse(...).length retorna size correto

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -417,6 +417,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_TPL_COERCE_AUTO", __RTS_FN_RT_TPL_COERCE_AUTO);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_UNIVERSAL_LENGTH;
+        add_fn!("__RTS_FN_RT_UNIVERSAL_LENGTH", __RTS_FN_RT_UNIVERSAL_LENGTH);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TYPEOF_HANDLE;
         add_fn!("__RTS_FN_RT_TYPEOF_HANDLE", __RTS_FN_RT_TYPEOF_HANDLE);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -745,20 +745,29 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
         Some("Map") | Some("Set") => None,
         other => other,
     };
-    if matches!(obj_tv.ty, ValTy::Handle) && rc_for_size.is_none() {
+    // (#json-bridge) Tambem cobre U64 (handle opaco de extern call,
+    // ex: JSON.parse) e I64+var_member_call_values — usa UNIVERSAL_LENGTH
+    // que detecta tipo de Entry em runtime. Sem isso
+    // `JSON.parse("[1,2,3]").length` caia no MAP_GET("length") -> 0.
+    let recv_is_ambiguous = matches!(obj_tv.ty, ValTy::U64)
+        || (matches!(obj_tv.ty, ValTy::I64)
+            && ctx.var_member_call_values.contains(&obj_tv.val));
+    if (matches!(obj_tv.ty, ValTy::Handle) || recv_is_ambiguous) && rc_for_size.is_none() {
         if let MemberProp::Ident(id) = &m.prop {
             let key = id.sym.as_str();
             if (key == "size" || key == "length")
                 && lhs_object_field_known(ctx, &m.obj, key).is_none()
             {
                 // gc.handle_len despacha pelo tipo do Entry — funciona
-                // para String/Map/Vec/Buffer/Env. Caller nao precisa
-                // saber se receiver eh Map vs Set vs Array.
-                let len_fn = ctx.get_extern(
-                    "__RTS_FN_NS_GC_HANDLE_LEN",
-                    &[cl::I64],
-                    Some(cl::I64),
-                )?;
+                // para String/Map/Vec/Buffer/Env. Para handle ambiguo
+                // (U64/I64 marcado), usa UNIVERSAL_LENGTH que tambem
+                // cobre Entry::Json.
+                let sym = if recv_is_ambiguous {
+                    "__RTS_FN_RT_UNIVERSAL_LENGTH"
+                } else {
+                    "__RTS_FN_NS_GC_HANDLE_LEN"
+                };
+                let len_fn = ctx.get_extern(sym, &[cl::I64], Some(cl::I64))?;
                 let inst = ctx.builder.ins().call(len_fn, &[obj_handle]);
                 let v = ctx.builder.inst_results(inst)[0];
                 return Ok(TypedVal::new(v, ValTy::I64));

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -147,6 +147,29 @@ pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
     }
 }
 
+/// `.length` universal para handles ambiguous (any/var_member_call):
+/// detecta Entry::Vec/Map/String e retorna size; retorna -1 quando
+/// handle invalido ou tipo sem length. Usado pelo codegen quando
+/// recv de `.length` tem tipo dinamico (e.g. `JSON.parse(s).length`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_UNIVERSAL_LENGTH(handle: u64) -> i64 {
+    if handle == 0 {
+        return -1;
+    }
+    with_entry(handle, |entry| match entry {
+        Some(Entry::Vec(slots)) => slots.len() as i64,
+        Some(Entry::Map(map)) => map.len() as i64,
+        Some(Entry::String(b)) => b.len() as i64,
+        Some(Entry::Json(v)) => match v.as_ref() {
+            serde_json::Value::Array(a) => a.len() as i64,
+            serde_json::Value::Object(o) => o.len() as i64,
+            serde_json::Value::String(s) => s.len() as i64,
+            _ => -1,
+        },
+        _ => -1,
+    })
+}
+
 /// Helper: nome textual do kind de Entry (para fallback `[object Kind]`).
 fn entry_kind_name(e: &Entry) -> &'static str {
     match e {

--- a/tests/edge_json_parse_length.test.ts
+++ b/tests/edge_json_parse_length.test.ts
@@ -1,0 +1,26 @@
+// Cobertura do fix do bridge JSON: `JSON.parse(...).length` antes
+// resolvia via MAP_GET("length") -> 0 -> "null" no template. Fix
+// adicionou helper UNIVERSAL_LENGTH e plugou em lower_member quando
+// receiver eh U64 (handle opaco de extern call).
+import { describe, test, expect } from "rts:test";
+
+const arr: any = JSON.parse("[10,20,30]");
+const obj: any = JSON.parse('{"name":"alice","age":30}');
+const str: any = JSON.parse('"hello"');
+
+const stArr: string = JSON.stringify([1, 2, 3]);
+const stObj: string = JSON.stringify({ a: 1, b: "hi" });
+const stEmpty: string = JSON.stringify({});
+
+describe("JSON.parse + .length / .field (#json-bridge)", () => {
+  test("parse array .length", () => expect(arr.length).toBe(3));
+  test("parse array [0]", () => expect(arr[0]).toBe(10));
+  test("parse array [1]", () => expect(arr[1]).toBe(20));
+  test("parse array [2]", () => expect(arr[2]).toBe(30));
+  test("parse object .name", () => expect(obj.name).toBe("alice"));
+  test("parse object .age", () => expect(obj.age).toBe(30));
+  test("parse string .length", () => expect(str.length).toBe(5));
+  test("stringify array", () => expect(stArr).toBe("[1,2,3]"));
+  test("stringify object", () => expect(stObj).toBe('{"a":1,"b":"hi"}'));
+  test("stringify empty obj", () => expect(stEmpty).toBe("{}"));
+});


### PR DESCRIPTION
## Summary
- \`JSON.parse(\"[1,2,3]\").length\` retornava \`null\` (caía em MAP_GET(\"length\") → 0 → TPL_COERCE_AUTO → \"null\").
- **Causa**: \`lower_member\` só acionava \`HANDLE_LEN\` quando \`obj_tv.ty == Handle\`. Resultado de \`JSON.parse\` é \`U64\` (handle opaco de extern call).
- **Fix**: novo runtime helper \`__RTS_FN_RT_UNIVERSAL_LENGTH\` que detecta Entry Vec/Map/String/Json. Plugado em \`lower_member\` para handles ambíguos (U64 ou I64+var_member_call).
- **Funciona para**: arrays, objects, strings parseadas top-level.
- Fixture cobrindo 10 casos.

Closes #629

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1081/1081** (1071 + 10 fixture)