### PR TITLE
feat: JSON5 global — superset com comments, trailing commas, etc

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -69,6 +69,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     &crate::namespaces::parallel::abi::SPEC,
     &crate::namespaces::tls::abi::SPEC,
     &crate::namespaces::globals::json::abi::SPEC,
+    &crate::namespaces::globals::json5::abi::SPEC,
     &crate::namespaces::globals::console::abi::SPEC,
     &crate::namespaces::globals::timers::abi::SPEC,
     &crate::namespaces::globals::fetch::abi::SPEC,

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -271,6 +271,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     // ── namespaces::json ──────────────────────────────────────────────
     use crate::namespaces::json::ops::*;
     add_fn!("__RTS_FN_NS_JSON_PARSE", __RTS_FN_NS_JSON_PARSE);
+    add_fn!("__RTS_FN_NS_JSON_PARSE5", __RTS_FN_NS_JSON_PARSE5);
     add_fn!("__RTS_FN_NS_JSON_STRINGIFY", __RTS_FN_NS_JSON_STRINGIFY);
     add_fn!(
         "__RTS_FN_NS_JSON_STRINGIFY_TYPED",

--- a/crates/rts-runtime/Cargo.toml
+++ b/crates/rts-runtime/Cargo.toml
@@ -8,6 +8,7 @@ rts-abi = { path = "../rts-abi" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+json5 = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 rayon = "1.10"
 sha2 = "0.10"

--- a/crates/rts-runtime/src/namespaces/globals/json5/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/json5/abi.rs
@@ -1,0 +1,36 @@
+//! `JSON5` global — JSON5 superset (comments, trailing commas, unquoted
+//! keys, single-quote strings, hex, NaN/Infinity, etc.). Parse via crate
+//! `json5`; stringify reusa `JSON.stringify` (saida valida em ambos).
+
+use crate::abi::{AbiType, MemberKind, NamespaceMember, NamespaceSpec};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "parse",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_JSON_PARSE5",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::U64,
+        doc: "Parses a JSON5 string (comments, trailing commas, unquoted keys, etc.). Returns opaque handle; 0 on error.",
+        ts_signature: "parse(text: string): unknown",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "stringify",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_JSON_STRINGIFY",
+        args: &[AbiType::U64],
+        returns: AbiType::Handle,
+        doc: "Serializes a JSON5 handle to compact JSON form (subset compativel).",
+        ts_signature: "stringify(value: unknown): string",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const SPEC: NamespaceSpec = NamespaceSpec {
+    name: "JSON5",
+    doc: "Global JSON5 object — superset do JSON com comentarios, trailing commas, unquoted keys, single-quote strings, hex, NaN/Infinity.",
+    members: MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/json5/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/json5/mod.rs
@@ -1,0 +1,1 @@
+pub mod abi;

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -12,6 +12,7 @@ pub mod fetch;
 pub mod function;
 pub mod global_this;
 pub mod json;
+pub mod json5;
 pub mod performance;
 pub mod proxy;
 pub mod reflect;

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -34,6 +34,25 @@ pub extern "C" fn __RTS_FN_NS_JSON_PARSE(ptr: u64, len: i64) -> u64 {
     }
 }
 
+/// JSON5.parse — extensao do JSON com comentarios, trailing commas,
+/// keys nao-quoteadas, strings com aspas simples, hex literals, NaN/
+/// Infinity, etc. Usa o crate `json5` que serializa para
+/// `serde_json::Value`, entao a saida segue o mesmo bridge handle-table
+/// do JSON estrito (sem semantica adicional fora parse-time).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_JSON_PARSE5(ptr: u64, len: i64) -> u64 {
+    let Some(bytes) = slice_from(ptr, len) else {
+        return 0;
+    };
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return 0;
+    };
+    match json5::from_str::<Value>(text) {
+        Ok(v) => json_value_to_handle(&v),
+        Err(_) => 0,
+    }
+}
+
 /// Converte recursivamente um `serde_json::Value` em handle nativo:
 /// - Object -> Entry::Map (slots = handles ou i64 raw para scalars)
 /// - Array -> Entry::Vec (idem)

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -97,6 +97,7 @@ pub const SPECS: &[&NamespaceSpec] = &[
     // Global JS object namespaces — name matches JS global (e.g. "JSON", "console").
     // Codegen routes JSON.parse() / console.log() through these specs.
     &crate::namespaces::globals::json::abi::SPEC,
+    &crate::namespaces::globals::json5::abi::SPEC,
     &crate::namespaces::globals::console::abi::SPEC,
     &crate::namespaces::globals::timers::abi::SPEC,
     &crate::namespaces::globals::fetch::abi::SPEC,

--- a/tests/edge_json5.test.ts
+++ b/tests/edge_json5.test.ts
@@ -1,0 +1,46 @@
+// Cobertura do JSON5 — superset do JSON com comments, trailing commas,
+// unquoted keys, single quotes, hex, NaN/Infinity. Backend via crate
+// `json5` que produz serde_json::Value (mesmo bridge handle-table).
+import { describe, test, expect } from "rts:test";
+
+// Comments line + block
+const a: any = JSON5.parse(`// linha
+{ "x": 1 }`);
+const b: any = JSON5.parse(`/* bloco */ { y: 2 }`);
+
+// Unquoted keys + single quotes + trailing comma
+const c: any = JSON5.parse(`{ name: 'Alice', age: 30, }`);
+
+// Hex
+const d: any = JSON5.parse(`{ flag: 0xff }`);
+
+// Trailing comma em array
+const e: any = JSON5.parse(`[1, 2, 3,]`);
+
+// Aninhado misturando features
+const f: any = JSON5.parse(`{
+  // config
+  port: 3000,
+  hosts: ['localhost', '127.0.0.1',],
+  flags: { debug: true, },
+}`);
+
+// Stringify reusa JSON.stringify (output JSON estrito valido)
+const stringified: string = JSON5.stringify({ a: 1, b: "two" });
+
+// Erro silencioso retorna 0
+const bad: any = JSON5.parse(`{ not valid`);
+
+describe("JSON5 — superset (#json5)", () => {
+  test("line comment", () => expect(a.x).toBe(1));
+  test("block comment", () => expect(b.y).toBe(2));
+  test("unquoted key + single quote string", () => expect(c.name).toBe("Alice"));
+  test("trailing comma em obj", () => expect(c.age).toBe(30));
+  test("hex literal 0xff", () => expect(d.flag).toBe(255));
+  test("trailing comma em array", () => expect(e.length).toBe(3));
+  test("nested obj sobrevive parse", () => expect(f !== 0).toBe(true));
+  test("nested array com strings", () => expect(f.hosts.length).toBe(2));
+  test("nested obj com bool", () => expect(f.flags.debug).toBe(1));
+  test("stringify produz JSON estrito", () => expect(stringified).toBe('{"a":1,"b":"two"}'));
+  test("parse invalido retorna 0", () => expect(bad).toBe(0));
+});


### PR DESCRIPTION
## Summary
Novo global \`JSON5\` com API \`parse\` + \`stringify\`, mesma forma de \`JSON\`. Backend via crate \`json5\` (0.4).

**Features**:
- Comments line \`//\` e bloco \`/* */\`
- Trailing commas em obj/array
- Unquoted keys: \`{ x: 1 }\`
- Single-quote strings: \`{ s: 'hi' }\`
- Hex: \`0xff\` → 255
- NaN/Infinity
- Erro silencioso (handle 0)

**Por que separado de JSON**: performance (serde_json mais rápido), validação estrita em APIs externas, roundtrip JSON.parse/stringify garantido. Padrão Node usa \`JSON5.parse\` separado.

Fixture com 11 casos.

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1108/1108** (1097 + 11)