### PR TITLE
fix(#634): array spread universal — string [..."abc"] retorna chars

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -422,6 +422,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_UNIVERSAL_LENGTH", __RTS_FN_RT_UNIVERSAL_LENGTH);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_SPREAD_INTO_VEC;
+        add_fn!("__RTS_FN_RT_SPREAD_INTO_VEC", __RTS_FN_RT_SPREAD_INTO_VEC);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TYPEOF_HANDLE;
         add_fn!("__RTS_FN_RT_TYPEOF_HANDLE", __RTS_FN_RT_TYPEOF_HANDLE);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -27,14 +27,17 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
         match elem {
             Some(e) => {
                 if e.spread.is_some() {
-                    // #209: array spread — copia cada elemento da fonte
-                    // pro array destino. Fonte deve ser handle Vec
-                    // (qualquer expressao que avalie pra um). v0 nao
-                    // suporta spread de Set/Map nem iteradores nativos
-                    // — caller passa array.
+                    // (#209/spread) Spread universal — runtime helper
+                    // detecta Vec/String/Map e itera. Antes so' funcionava
+                    // pra Vec; `[..."abc"]` retornava vazio.
                     let src_tv = lower_expr(ctx, &e.expr)?;
                     let src_h = ctx.coerce_to_i64(src_tv).val;
-                    emit_vec_extend(ctx, handle, src_h, push_fn)?;
+                    let spread_fn = ctx.get_extern(
+                        "__RTS_FN_RT_SPREAD_INTO_VEC",
+                        &[cl::I64, cl::I64],
+                        None,
+                    )?;
+                    ctx.builder.ins().call(spread_fn, &[handle, src_h]);
                     continue;
                 }
                 let tv = lower_expr(ctx, &e.expr)?;
@@ -136,61 +139,6 @@ fn emit_map_extend(
     // map_set(dst, kp, kl, value)
     ctx.builder.ins().call(set_fn, &[dst, kp, kl, value]);
 
-    let one = ctx.builder.ins().iconst(cl::I64, 1);
-    let next_i = ctx.builder.ins().iadd(i, one);
-    ctx.builder.ins().jump(loop_block, &[next_i.into()]);
-
-    ctx.builder.seal_block(loop_block);
-    ctx.builder.switch_to_block(exit_block);
-    ctx.builder.seal_block(exit_block);
-    Ok(())
-}
-
-/// Para cada elemento `i` em [0, len(src)), faz dst.push(src[i]).
-/// Emite um loop em IR usando block params.
-fn emit_vec_extend(
-    ctx: &mut FnCtx,
-    dst: cranelift_codegen::ir::Value,
-    src: cranelift_codegen::ir::Value,
-    push_fn: cranelift_codegen::ir::FuncRef,
-) -> Result<()> {
-    use cranelift_codegen::ir::condcodes::IntCC;
-
-    let len_fn = ctx.get_extern(
-        "__RTS_FN_NS_COLLECTIONS_VEC_LEN",
-        &[cl::I64],
-        Some(cl::I64),
-    )?;
-    let get_fn = ctx.get_extern(
-        "__RTS_FN_NS_COLLECTIONS_VEC_GET",
-        &[cl::I64, cl::I64],
-        Some(cl::I64),
-    )?;
-
-    let len_inst = ctx.builder.ins().call(len_fn, &[src]);
-    let len = ctx.builder.inst_results(len_inst)[0];
-
-    // Loop classico: i = 0; while (i < len) { push(get(src, i)); i++; }
-    let loop_block = ctx.builder.create_block();
-    let body_block = ctx.builder.create_block();
-    let exit_block = ctx.builder.create_block();
-    ctx.builder.append_block_param(loop_block, cl::I64);
-
-    let zero = ctx.builder.ins().iconst(cl::I64, 0);
-    ctx.builder.ins().jump(loop_block, &[zero.into()]);
-
-    ctx.builder.switch_to_block(loop_block);
-    let i = ctx.builder.block_params(loop_block)[0];
-    let cond = ctx.builder.ins().icmp(IntCC::SignedLessThan, i, len);
-    ctx.builder
-        .ins()
-        .brif(cond, body_block, &[], exit_block, &[]);
-
-    ctx.builder.switch_to_block(body_block);
-    ctx.builder.seal_block(body_block);
-    let elem_inst = ctx.builder.ins().call(get_fn, &[src, i]);
-    let elem = ctx.builder.inst_results(elem_inst)[0];
-    ctx.builder.ins().call(push_fn, &[dst, elem]);
     let one = ctx.builder.ins().iconst(cl::I64, 1);
     let next_i = ctx.builder.ins().iadd(i, one);
     ctx.builder.ins().jump(loop_block, &[next_i.into()]);

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -1,6 +1,6 @@
 //! String-producing ABI for the GC namespace.
 
-use super::handles::{Entry, alloc_entry, free_handle, with_entry, with_two_entries};
+use super::handles::{Entry, alloc_entry, free_handle, with_entry, with_entry_mut, with_two_entries};
 
 /// Reads a string handle into an owned Rust `String`.
 pub fn read_string_handle(handle: u64) -> Option<String> {
@@ -145,6 +145,64 @@ pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
             alloc_entry(Entry::String(bytes))
         }
     }
+}
+
+/// Spread universal: copia elementos de `src` para o Vec `dst`.
+/// Detecta tipo de Entry e itera apropriadamente:
+/// - Entry::Vec -> push de cada slot
+/// - Entry::String -> push de cada char (handle de string char)
+/// - Entry::Map -> push de cada value (ordem do IndexMap)
+/// - outros -> no-op
+///
+/// Usado por `[...x]` no codegen quando `x` pode ser string/array.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_SPREAD_INTO_VEC(dst: u64, src: u64) {
+    if dst == 0 || src == 0 {
+        return;
+    }
+    enum Snap {
+        Vec(Vec<i64>),
+        Str(Vec<u8>),
+        Map(Vec<i64>),
+        Empty,
+    }
+    let snap = with_entry(src, |entry| match entry {
+        Some(Entry::Vec(slots)) => Snap::Vec(slots.as_ref().clone()),
+        Some(Entry::String(b)) => Snap::Str(b.clone()),
+        Some(Entry::Map(m)) => Snap::Map(m.values().copied().collect()),
+        _ => Snap::Empty,
+    });
+    match snap {
+        Snap::Vec(items) => {
+            for v in items {
+                push_vec_slot(dst, v);
+            }
+        }
+        Snap::Str(bytes) => {
+            // Iter por chars Unicode (string spread JS itera codepoints).
+            let s = String::from_utf8_lossy(&bytes);
+            for ch in s.chars() {
+                let mut buf = [0u8; 4];
+                let ch_bytes = ch.encode_utf8(&mut buf).as_bytes().to_vec();
+                let h = alloc_entry(Entry::String(ch_bytes));
+                push_vec_slot(dst, h as i64);
+            }
+        }
+        Snap::Map(vals) => {
+            for v in vals {
+                push_vec_slot(dst, v);
+            }
+        }
+        Snap::Empty => {}
+    }
+}
+
+fn push_vec_slot(dst: u64, value: i64) {
+    with_entry_mut(dst, |entry| {
+        if let Some(Entry::Vec(slots)) = entry {
+            slots.push(value);
+        }
+    });
 }
 
 /// `.length` universal para handles ambiguous (any/var_member_call):

--- a/tests/edge_spread_universal.test.ts
+++ b/tests/edge_spread_universal.test.ts
@@ -1,0 +1,37 @@
+// Cobertura do spread universal — `[...iter]` agora aceita Vec/String/Map
+// via runtime helper SPREAD_INTO_VEC. Antes so' Vec funcionava (chamava
+// VEC_LEN/VEC_GET, retornava len=-1 em string -> array vazio).
+import { describe, test, expect } from "rts:test";
+
+// Array spread (caso original que ja funcionava)
+const a1: number[] = [1, 2, 3];
+const a2: number[] = [...a1, 4, 5];
+const a3: number[] = [0, ...a1, 99];
+const a4: number[] = [...a1];
+
+// String spread (NOVO — antes retornava vazio)
+const s1: string[] = [..."abc"] as any;
+const s2: string[] = [..."hello"] as any;
+const s3: string[] = [..."" as string] as any;
+
+// Spread em call args
+function sum3(a: number, b: number, c: number): number { return a + b + c; }
+const args = [10, 20, 30];
+const r = sum3(...args);
+
+// Object spread (caso original)
+const o1 = { x: 1, y: 2 };
+const o2 = { ...o1, z: 3 };
+const o3 = { ...o1, x: 99 };
+
+describe("Spread universal — Vec/String em [...x] (#spread)", () => {
+  test("array spread tail", () => expect(a2.length).toBe(5));
+  test("array spread mid", () => expect(a3.length).toBe(5));
+  test("array spread copy", () => expect(a4.length).toBe(3));
+  test("string spread chars", () => expect(s1.length).toBe(3));
+  test("string spread longer", () => expect(s2.length).toBe(5));
+  test("string spread empty", () => expect(s3.length).toBe(0));
+  test("call args spread", () => expect(r).toBe(60));
+  test("object spread", () => expect(o2.z).toBe(3));
+  test("object spread override", () => expect(o3.x).toBe(99));
+});


### PR DESCRIPTION
## Summary
- **Bug**: \`[...\"abc\"]\` retornava array vazio (era esperado [\"a\",\"b\",\"c\"]).
- **Causa**: \`emit_vec_extend\` assumia src como Vec; usava VEC_LEN/VEC_GET. String → VEC_LEN=-1 → loop pula.
- **Fix**: novo runtime helper \`__RTS_FN_RT_SPREAD_INTO_VEC\` detecta tipo (Vec/String/Map) em runtime. String itera chars Unicode.
- Bônus: spread de Map também funciona agora (itera values).
- Codegen \`emit_vec_extend\` deletada (substituída pelo helper genérico).

Closes #634

## Test plan
- [x] \`cargo build --release\` — 0 warnings
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1117/1117** (1108 + 9 fixture)