### PR TITLE
fix(#636): class X extends Error preserva message via super(msg)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/super_calls.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/super_calls.rs
@@ -37,11 +37,47 @@ pub(super) fn lower_super_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<Typed
     ctx.super_already_called = true;
 
     let Some(init_owner) = resolve_init_owner(ctx, &parent) else {
-        for a in &call.args {
-            if a.spread.is_some() {
-                return Err(anyhow!("spread em super(...) nao suportado"));
+        // (#err-extends) Caso especial: parent eh Error class global. Em vez
+        // de descartar args, armazena message+name no map de `this` para que
+        // `e.message`/`e.name` funcionem em subclasse de Error.
+        let is_error_parent = matches!(
+            parent.as_str(),
+            "Error" | "TypeError" | "RangeError" | "ReferenceError" | "SyntaxError"
+        );
+        if is_error_parent && !call.args.is_empty() {
+            let msg_tv = lower_expr(ctx, &call.args[0].expr)?;
+            let msg_h = ctx.coerce_to_handle(msg_tv)?.val;
+            let this_val = ctx
+                .read_local("this")
+                .ok_or_else(|| anyhow!("`this` indisponivel em super(...)"))?;
+            let this_h = ctx.coerce_to_i64(this_val).val;
+            // map.set(this, "message", msg_h)
+            let set_fn = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
+                None,
+            )?;
+            let (kptr, klen) = ctx.emit_str_literal(b"message")?;
+            ctx.builder.ins().call(set_fn, &[this_h, kptr, klen, msg_h]);
+            // Tambem armazena "name" = parent (Error/TypeError/etc.) caso
+            // nao seja sobrescrito pelo body do constructor.
+            let name_tv = ctx.emit_str_handle(parent.as_bytes())?;
+            let (nkptr, nklen) = ctx.emit_str_literal(b"name")?;
+            ctx.builder.ins().call(set_fn, &[this_h, nkptr, nklen, name_tv.val]);
+            // Avalia args restantes pra side effects (raro em super de Error).
+            for a in call.args.iter().skip(1) {
+                if a.spread.is_some() {
+                    return Err(anyhow!("spread em super(...) nao suportado"));
+                }
+                let _ = lower_expr(ctx, &a.expr)?;
             }
-            let _ = lower_expr(ctx, &a.expr)?;
+        } else {
+            for a in &call.args {
+                if a.spread.is_some() {
+                    return Err(anyhow!("spread em super(...) nao suportado"));
+                }
+                let _ = lower_expr(ctx, &a.expr)?;
+            }
         }
         return Ok(TypedVal::new(
             ctx.builder.ins().iconst(cl::I64, 0),

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -672,7 +672,27 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
     let coerced = match ctx.var_ty(&name) {
         Some(ValTy::I32) => ctx.coerce_to_i32(rhs_val),
         Some(ValTy::I64) => ctx.coerce_to_i64(rhs_val),
-        Some(ValTy::Handle) => ctx.coerce_to_handle(rhs_val)?,
+        Some(ValTy::Handle) => {
+            // (#err-extends/627) Quando rhs eh I64 ambiguo (resultado de
+            // obj.x sem tipo) e var declarada como string (Handle), usa
+            // TPL_COERCE_AUTO em vez de STRING_FROM_I64 (que formata
+            // handle bruto como numero).
+            if matches!(rhs_val.ty, ValTy::I64 | ValTy::U64)
+                && ctx.var_member_call_values.contains(&rhs_val.val)
+            {
+                use cranelift_codegen::ir::types as cl;
+                let coerce_fn = ctx.get_extern(
+                    "__RTS_FN_RT_TPL_COERCE_AUTO",
+                    &[cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(coerce_fn, &[rhs_val.val]);
+                let v = ctx.builder.inst_results(inst)[0];
+                TypedVal::new(v, ValTy::Handle)
+            } else {
+                ctx.coerce_to_handle(rhs_val)?
+            }
+        }
         _ => rhs_val,
     };
     ctx.write_local(&name, coerced.val)?;

--- a/crates/rts-runtime/src/namespaces/globals/error/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/instance.rs
@@ -24,12 +24,29 @@ fn alloc_error(name: &str, message: String) -> u64 {
 }
 
 fn get_field(handle: u64, field: &str) -> String {
-    with_entry(handle, |entry| match entry {
-        Some(Entry::ErrorObj { message, name }) => match field {
+    // Tenta primeiro Entry::ErrorObj (caso comum: new Error("msg"))
+    let direct = with_entry(handle, |entry| match entry {
+        Some(Entry::ErrorObj { message, name }) => Some(match field {
             "message" => message.clone(),
             "name" => name.clone(),
             _ => String::new(),
-        },
+        }),
+        _ => None,
+    });
+    if let Some(s) = direct {
+        return s;
+    }
+    // Fallback: Entry::Map com keys "message"/"name" — usado quando
+    // user class extends Error e super(msg) armazena no Map.
+    let slot_handle: u64 = with_entry(handle, |entry| match entry {
+        Some(Entry::Map(m)) => m.get(field).copied().unwrap_or(0) as u64,
+        _ => 0,
+    });
+    if slot_handle == 0 {
+        return String::new();
+    }
+    with_entry(slot_handle, |entry| match entry {
+        Some(Entry::String(b)) => String::from_utf8_lossy(b).into_owned(),
         _ => String::new(),
     })
 }

--- a/tests/edge_error_extends.test.ts
+++ b/tests/edge_error_extends.test.ts
@@ -1,0 +1,63 @@
+// Cobertura do fix de `class X extends Error` — super(msg) agora
+// armazena message+name no map de this. Antes: super para Error class
+// caia em fallback que descartava args -> e.message="" -> "null" no template.
+import { describe, test, expect } from "rts:test";
+
+class A extends Error {
+  constructor(m: string) { super(m); }
+}
+
+class B extends Error {
+  constructor(public code: number, m: string) {
+    super(m);
+    this.name = "B";
+  }
+}
+
+class CustomTypeError extends TypeError {
+  constructor(m: string) { super(m); }
+}
+
+const a = new A("hello");
+const b = new B(42, "with code");
+const c = new CustomTypeError("type oops");
+
+let caughtMsg = "";
+let caughtCode = 0;
+let caughtName = "";
+
+try {
+  throw new A("inside try");
+} catch (e: any) {
+  caughtMsg = e.message;
+}
+
+try {
+  throw new B(99, "rich");
+} catch (e: any) {
+  caughtCode = e.code;
+  caughtName = e.name;
+}
+
+let chained = "";
+try {
+  try {
+    throw new TypeError("inner");
+  } catch (e: any) {
+    throw new RangeError("re: " + e.message);
+  }
+} catch (e: any) {
+  chained = e.message;
+}
+
+describe("class extends Error — super propaga message (#err-extends)", () => {
+  test("A.message", () => expect(a.message).toBe("hello"));
+  test("B.message", () => expect(b.message).toBe("with code"));
+  test("B.code (custom field)", () => expect(b.code).toBe(42));
+  test("B.name override", () => expect(b.name).toBe("B"));
+  test("CustomTypeError.message", () => expect(c.message).toBe("type oops"));
+  test("caught A.message", () => expect(caughtMsg).toBe("inside try"));
+  test("caught B.code", () => expect(caughtCode).toBe(99));
+  test("caught B.name", () => expect(caughtName).toBe("B"));
+  test("chained throw rethrow", () => expect(chained).toBe("re: inner"));
+});


### PR DESCRIPTION
## Summary
- **Bug**: \`class A extends Error { constructor(m) { super(m); } }\` → \`a.message\` retornava \"null\". Afetava todas as variantes (TypeError, RangeError, etc.) subclasseadas.
- **Causa**: super para Error class caía em fallback que descartava args. \`this\` ficava Map vazio; \`e.message\` despachava para Entry::ErrorObj que não existia.
- **Fix em 3 camadas**:
  1. \`lower_super_call\` detecta parent Error e armazena message+name no Map de \`this\`.
  2. \`get_field\` em runtime aceita Entry::Map como fallback (lê \"message\"/\"name\").
  3. \`lower_assign_expr\` para var Handle com rhs ambíguo usa TPL_COERCE_AUTO.
- Fixture com 9 casos.

Closes #636

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1126/1126** (1117 + 9 fixture)