### PR TITLE
fix(#638): switch com strings usa STRING_EQ

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -259,6 +259,16 @@ fn is_pure_for_select(e: &swc_ecma_ast::Expr) -> bool {
 
 pub(super) fn lower_switch_stmt(ctx: &mut FnCtx, sw: &swc_ecma_ast::SwitchStmt) -> Result<bool> {
     let discriminant = lower_expr(ctx, &sw.discriminant)?;
+    // (#sw-str) Detecta switch de string: discriminant ty Handle ou
+    // qualquer case test que seja Lit::Str — comparar handles com icmp
+    // (igualdade de bits) quebra para strings; precisa STRING_EQ.
+    let disc_is_string = matches!(discriminant.ty, crate::codegen::lower::ctx::ValTy::Handle)
+        || sw.cases.iter().any(|c| {
+            c.test.as_ref().map_or(false, |t| matches!(
+                t.as_ref(),
+                swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(_))
+            ))
+        });
     let disc_i64 = ctx.coerce_to_i64(discriminant);
     let exit = ctx.builder.create_block();
 
@@ -298,6 +308,16 @@ pub(super) fn lower_switch_stmt(ctx: &mut FnCtx, sw: &swc_ecma_ast::SwitchStmt) 
         let fallback = default_idx.map(|di| case_blocks[di]).unwrap_or(exit);
         table.emit(ctx.builder, disc_i64.val, fallback);
     } else {
+        // (#sw-str) Para switch de string, usa STRING_EQ em vez de icmp.
+        let str_eq_fn = if disc_is_string {
+            Some(ctx.get_extern(
+                "__RTS_FN_NS_GC_STRING_EQ",
+                &[cl::I64, cl::I64],
+                Some(cl::I64),
+            )?)
+        } else {
+            None
+        };
         for (pos, case_idx) in non_default_indices.iter().enumerate() {
             let test_expr = sw.cases[*case_idx]
                 .test
@@ -305,10 +325,14 @@ pub(super) fn lower_switch_stmt(ctx: &mut FnCtx, sw: &swc_ecma_ast::SwitchStmt) 
                 .expect("non-default case must have test expression");
             let test_val = lower_expr(ctx, test_expr)?;
             let test_i64 = ctx.coerce_to_i64(test_val);
-            let eq = ctx
-                .builder
-                .ins()
-                .icmp(IntCC::Equal, disc_i64.val, test_i64.val);
+            let eq = if let Some(seq) = str_eq_fn {
+                let inst = ctx.builder.ins().call(seq, &[disc_i64.val, test_i64.val]);
+                ctx.builder.inst_results(inst)[0]
+            } else {
+                ctx.builder
+                    .ins()
+                    .icmp(IntCC::Equal, disc_i64.val, test_i64.val)
+            };
 
             let false_block = if pos + 1 < non_default_indices.len() {
                 ctx.builder.create_block()

--- a/tests/edge_switch_string.test.ts
+++ b/tests/edge_switch_string.test.ts
@@ -1,0 +1,73 @@
+// Cobertura do fix de switch com strings — antes comparava handles
+// com icmp (igualdade de bits) -> sempre falso pra strings com mesmo
+// conteudo mas handles diferentes. Fix: detecta string discriminant
+// e usa STRING_EQ.
+import { describe, test, expect } from "rts:test";
+
+function color(s: string): number {
+  switch (s) {
+    case "red": return 1;
+    case "green": return 2;
+    case "blue": return 3;
+    default: return 0;
+  }
+}
+
+function priority(s: string): string {
+  switch (s) {
+    case "high":
+    case "urgent":
+      return "important";
+    case "low":
+      return "minor";
+    default:
+      return "normal";
+  }
+}
+
+// Switch numerico continua funcionando (regressao guard)
+function classify(n: number): string {
+  switch (n) {
+    case 0: return "zero";
+    case 1: return "one";
+    case 2:
+    case 3: return "two-or-three";
+    default: return "other";
+  }
+}
+
+// Fallthrough com strings
+function steps(s: string): string {
+  let r = "";
+  switch (s) {
+    case "a":
+      r = r + "a";
+      // fall through
+    case "b":
+      r = r + "b";
+      break;
+    case "c":
+      r = r + "c";
+      break;
+  }
+  return r;
+}
+
+describe("switch com strings (#sw-str)", () => {
+  test("color red", () => expect(color("red")).toBe(1));
+  test("color green", () => expect(color("green")).toBe(2));
+  test("color blue", () => expect(color("blue")).toBe(3));
+  test("color unknown -> default", () => expect(color("yellow")).toBe(0));
+  test("priority high (fallthrough case)", () => expect(priority("high")).toBe("important"));
+  test("priority urgent (fallthrough case 2)", () => expect(priority("urgent")).toBe("important"));
+  test("priority low", () => expect(priority("low")).toBe("minor"));
+  test("priority default", () => expect(priority("med")).toBe("normal"));
+  // Regressao guard — switch numerico
+  test("classify 0", () => expect(classify(0)).toBe("zero"));
+  test("classify 2 (fallthrough cases)", () => expect(classify(2)).toBe("two-or-three"));
+  test("classify default", () => expect(classify(99)).toBe("other"));
+  // Fallthrough com strings
+  test("fallthrough a -> b", () => expect(steps("a")).toBe("ab"));
+  test("fallthrough b stop", () => expect(steps("b")).toBe("b"));
+  test("fallthrough c", () => expect(steps("c")).toBe("c"));
+});


### PR DESCRIPTION
## Summary
- **Bug**: \`switch (s) { case \"red\": ... }\` sempre caía em default. Comparava handles com \`icmp(Equal)\` (igualdade de bits) — handles diferentes com mesmo conteúdo nunca igualam.
- **Fix**: detecta string discriminant e usa \`__RTS_FN_NS_GC_STRING_EQ\` no caminho de comparação pareada.
- **Switch numérico** continua via jump table (fast path preservado).
- Fixture com 14 casos: match simples, fallthrough, default, switch numérico (regression guard), fallthrough com strings.

Closes #638

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1140/1140** (1126 + 14)