### PR TITLE
fix(#643): logical ||/&& + ternario tratam string vazia como falsy (Bun/Node parity)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"43e56b49-68df-4ea1-b166-03441e60bad4","pid":28232,"acquiredAt":1778208265116}

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -426,6 +426,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_SPREAD_INTO_VEC", __RTS_FN_RT_SPREAD_INTO_VEC);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_TRUTHY;
+        add_fn!("__RTS_FN_RT_TRUTHY", __RTS_FN_RT_TRUTHY);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TYPEOF_HANDLE;
         add_fn!("__RTS_FN_RT_TYPEOF_HANDLE", __RTS_FN_RT_TYPEOF_HANDLE);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -770,9 +770,26 @@ pub(super) fn lower_opt_chain(
 
 pub(super) fn lower_cond(ctx: &mut FnCtx, cond: &swc_ecma_ast::CondExpr) -> Result<TypedVal> {
     let test = lower_expr(ctx, &cond.test)?;
+    let test_ty = test.ty;
     let test_i64 = ctx.coerce_to_i64(test).val;
     let zero = ctx.builder.ins().iconst(cl::I64, 0);
-    let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, test_i64, zero);
+    // (#or-empty-str) Mesma logica de truthy do logical: string vazia
+    // (handle != 0) precisa ser tratada como falsy.
+    let test_needs_truthy = matches!(test_ty, ValTy::Handle | ValTy::U64)
+        || (matches!(test_ty, ValTy::I64)
+            && ctx.var_member_call_values.contains(&test_i64));
+    let truthy_val = if test_needs_truthy {
+        let truthy_fn = ctx.get_extern(
+            "__RTS_FN_RT_TRUTHY",
+            &[cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(truthy_fn, &[test_i64]);
+        ctx.builder.inst_results(inst)[0]
+    } else {
+        test_i64
+    };
+    let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, truthy_val, zero);
 
     let then_block = ctx.builder.create_block();
     let else_block = ctx.builder.create_block();
@@ -812,11 +829,29 @@ fn lower_logical(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     let merge = ctx.builder.create_block();
     let result = ctx.builder.append_block_param(merge, cl::I64);
 
+    // (#or-empty-str) Quando lhs eh Handle/U64, usa __RTS_FN_RT_TRUTHY
+    // que reconhece string vazia como falsy (JS spec). Sem isso,
+    // `'' || 'fb'` retornava '' porque handle de "" eh != 0.
+    let lhs_needs_truthy = matches!(lhs_ty, ValTy::Handle | ValTy::U64)
+        || (matches!(lhs_ty, ValTy::I64)
+            && ctx.var_member_call_values.contains(&lhs_i64));
+    let truthy_val = if lhs_needs_truthy {
+        let truthy_fn = ctx.get_extern(
+            "__RTS_FN_RT_TRUTHY",
+            &[cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(truthy_fn, &[lhs_i64]);
+        ctx.builder.inst_results(inst)[0]
+    } else {
+        lhs_i64
+    };
+
     let rhs_ty: ValTy;
     match bin.op {
         BinaryOp::LogicalAnd => {
             let rhs_block = ctx.builder.create_block();
-            let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, lhs_i64, zero);
+            let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, truthy_val, zero);
             ctx.builder
                 .ins()
                 .brif(is_true, rhs_block, &[], merge, &[lhs_i64.into()]);
@@ -829,7 +864,7 @@ fn lower_logical(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         }
         BinaryOp::LogicalOr => {
             let rhs_block = ctx.builder.create_block();
-            let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, lhs_i64, zero);
+            let is_true = ctx.builder.ins().icmp(IntCC::NotEqual, truthy_val, zero);
             ctx.builder
                 .ins()
                 .brif(is_true, merge, &[lhs_i64.into()], rhs_block, &[]);

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -147,6 +147,30 @@ pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
     }
 }
 
+/// JS-spec truthiness para Handle ambiguo:
+/// - 0/null/undefined -> falsy (0)
+/// - Entry::String com bytes vazios -> falsy (0)
+/// - Entry::Vec/Map vazios -> truthy (objetos sao sempre truthy em JS)
+/// - Outros handles validos -> truthy (1)
+/// - Handle invalido (nao existe na tabela) e value != 0 -> truthy
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_TRUTHY(value: i64) -> i64 {
+    if value == 0 {
+        return 0;
+    }
+    let h = value as u64;
+    let snap = with_entry(h, |entry| match entry {
+        Some(Entry::String(b)) => Some(!b.is_empty()),
+        Some(_) => Some(true),
+        None => None,
+    });
+    match snap {
+        Some(true) => 1,
+        Some(false) => 0,
+        None => 1,
+    }
+}
+
 /// Spread universal: copia elementos de `src` para o Vec `dst`.
 /// Detecta tipo de Entry e itera apropriadamente:
 /// - Entry::Vec -> push de cada slot

--- a/tests/edge_cross_runtime.test.ts
+++ b/tests/edge_cross_runtime.test.ts
@@ -1,0 +1,52 @@
+// Suite de paridade cross-runtime: outputs RTS, Bun e Node devem
+// bater. Foi validado manualmente em 2026-05-10. Re-rodar quando
+// adicionar novos casos:
+//   bun tests/edge_cross_runtime.test.ts (adaptado: console.log)
+//   node tests/edge_cross_runtime.test.ts (adaptado)
+//   rts.exe test tests/edge_cross_runtime.test.ts
+import { describe, test, expect } from "rts:test";
+
+// === Logical operators com strings ===
+const lo1: string = "" || "" || "fb" || "ignored";
+const lo2: string = "first" || "second" || "third";
+const lo3: string = "" && "x" || "fallback";
+const lo4: string = "a" || "b" && "c";  // precedencia: 'a' || ('b' && 'c') = 'a'
+const lo5: string = "" || "x" && "y";   // precedencia: '' || ('x' && 'y') = 'y'
+const lo6: string = "   " || "fb";       // whitespace eh truthy
+
+// === Switch com strings ===
+function color(s: string): number {
+  switch (s) {
+    case "red": return 1;
+    case "green": return 2;
+    default: return 0;
+  }
+}
+
+function priority(s: string): string {
+  switch (s) {
+    case "high":
+    case "urgent": return "important";
+    default: return "normal";
+  }
+}
+
+// === Truthiness em ternario ===
+const empty: string = "";
+const filled: string = "value";
+const tt1: string = empty ? "yes" : "no";
+const tt2: string = filled ? "yes" : "no";
+
+describe("paridade RTS/Bun/Node — logical + switch + truthy", () => {
+  test("'' || '' || 'fb' = 'fb'", () => expect(lo1).toBe("fb"));
+  test("'first' || ... = 'first'", () => expect(lo2).toBe("first"));
+  test("'' && 'x' || 'fb' = 'fb'", () => expect(lo3).toBe("fallback"));
+  test("'a' || 'b' && 'c' = 'a'", () => expect(lo4).toBe("a"));
+  test("'' || 'x' && 'y' = 'y'", () => expect(lo5).toBe("y"));
+  test("'   ' truthy", () => expect(lo6).toBe("   "));
+  test("switch red", () => expect(color("red")).toBe(1));
+  test("switch unknown", () => expect(color("xx")).toBe(0));
+  test("switch fallthrough", () => expect(priority("urgent")).toBe("important"));
+  test("ternary empty falsy", () => expect(tt1).toBe("no"));
+  test("ternary filled truthy", () => expect(tt2).toBe("yes"));
+});

--- a/tests/edge_logical_creative.test.ts
+++ b/tests/edge_logical_creative.test.ts
@@ -1,0 +1,76 @@
+// Testes "fora da caixa" para logical operators — combinacoes inusuais,
+// chains profundas, interacao com outros features (classes, arrays,
+// JSON, ternarios).
+import { describe, test, expect } from "rts:test";
+
+// Chain longa de OR — pega primeiro truthy
+const r1: string = "" || "" || "fb" || "ignored";
+const r2: string = "first" || "second" || "third";
+const r3: string = "" || "" || "" || "" || "last";
+
+// Chain longa de AND — pega primeiro falsy ou ultimo
+const r4: string = "a" && "b" && "c";
+const r5: string = "a" && "" && "c";
+const r6: string = "" && "b" && "c";
+
+// Mix OR + AND (precedencia: && > ||)
+const r7: string = "" || "x" && "y";        // "" || ("x" && "y") = "y"
+const r8: string = "a" || "b" && "c";        // "a" || ("b" && "c") = "a"
+const r9: string = "" && "x" || "fallback"; // ("" && "x") || "fallback" = "fallback"
+
+// Em ternario — fallback "default" tem length 7 (> 5)
+function pick(s: string): string {
+  return (s || "default").length > 5 ? "long" : "short";
+}
+// "hi" || "default" -> "hi" (length 2, < 5)
+// "" || "default"   -> "default" (length 7, > 5)
+
+// String concat com OR (devia preservar o resultado correto)
+function greet(name: string): string {
+  return "Hello, " + (name || "world") + "!";
+}
+
+// Pattern de fallback com number tipado.
+// Apenas teste 0 -> fallback. Testar valor != 0 cai em bug
+// pre-existente de fcvt f64 -> i64 (number param truncate).
+
+// OR como guard de array vazio
+const arr: number[] = [];
+const fb: number[] = [1, 2, 3];
+const len: number = (arr.length && 99) || -1;
+// arr.length === 0, && curto-circuita -> 0; 0 || -1 -> -1
+
+// Truthiness de strings com whitespace
+const ws: string = "   ";
+const r10: string = ws || "fb"; // "   " eh truthy, retorna "   "
+
+// Encadeamento com null/undefined
+const maybe: any = null;
+const r11: string = maybe || "default";
+
+describe("logical operators — combinacoes criativas", () => {
+  test("|| chain pega primeiro truthy", () => expect(r1).toBe("fb"));
+  test("|| chain todos truthy pega primeiro", () => expect(r2).toBe("first"));
+  test("|| chain so' last", () => expect(r3).toBe("last"));
+  test("&& chain todos truthy pega ultimo", () => expect(r4).toBe("c"));
+  test("&& chain pega primeiro falsy", () => expect(r5).toBe(""));
+  test("&& chain primeiro falsy = ''", () => expect(r6).toBe(""));
+  test("precedencia: '' || 'x' && 'y' = 'y'", () => expect(r7).toBe("y"));
+  test("precedencia: 'a' || ... = 'a'", () => expect(r8).toBe("a"));
+  test("'' && 'x' || 'fallback' = 'fallback'", () => expect(r9).toBe("fallback"));
+  test("ternario: '' || 'default' -> 'default' (len 7 > 5 -> long)", () => expect(pick("")).toBe("long"));
+  test("ternario: 'hi' || 'default' -> 'hi' (len 2 -> short)", () => expect(pick("hi")).toBe("short"));
+  test("greet com nome vazio = world", () => expect(greet("")).toBe("Hello, world!"));
+  test("greet com nome = nome", () => expect(greet("Bob")).toBe("Hello, Bob!"));
+  test("number 0 || 99 = 99", () => {
+    const v: number = 0;
+    expect(v || 99).toBe(99);
+  });
+  test("number 7 || 99 = 7", () => {
+    const v: number = 7;
+    expect(v || 99).toBe(7);
+  });
+  test("guard array vazio cai em fallback", () => expect(len).toBe(-1));
+  test("string com whitespace eh truthy", () => expect(r10).toBe("   "));
+  test("null || default = default", () => expect(r11).toBe("default"));
+});

--- a/tests/edge_logical_string.test.ts
+++ b/tests/edge_logical_string.test.ts
@@ -1,0 +1,41 @@
+// Cobertura do fix de logical || / && com string vazia.
+// Antes: `'' || 'fb'` retornava `''` porque codegen comparava handle != 0
+// (handle de string vazia eh != 0). Fix: detecta Handle e usa
+// __RTS_FN_RT_TRUTHY que reconhece string vazia como falsy (JS spec).
+import { describe, test, expect } from "rts:test";
+
+const empty: string = "";
+const filled: string = "value";
+
+const orEmpty: string = empty || "fb";
+const orFilled: string = filled || "fb";
+const orLit1: string = "" || "fb";
+const orLit2: string = "x" || "fb";
+const andEmpty: string = empty && "x";
+const andFilled: string = filled && "x";
+
+// Combo com number tambem
+const numZero: number = 0;
+const numNonZero: number = 5;
+const orNumZero: number = numZero || -1;
+const orNumNonZero: number = numNonZero || -1;
+
+// Real-world: default value pattern
+function getName(name: string): string {
+  return name || "Anonymous";
+}
+
+describe("logical || && com string vazia (#or-empty-str)", () => {
+  test("'' || 'fb' = 'fb'", () => expect(orEmpty).toBe("fb"));
+  test("'value' || 'fb' = 'value'", () => expect(orFilled).toBe("value"));
+  test("'' || 'fb' literal = 'fb'", () => expect(orLit1).toBe("fb"));
+  test("'x' || 'fb' literal = 'x'", () => expect(orLit2).toBe("x"));
+  test("'' && 'x' = ''", () => expect(andEmpty).toBe(""));
+  test("'value' && 'x' = 'x'", () => expect(andFilled).toBe("x"));
+  // number paths (regressao guard)
+  test("0 || -1 = -1", () => expect(orNumZero).toBe(-1));
+  test("5 || -1 = 5", () => expect(orNumNonZero).toBe(5));
+  // Pattern comum
+  test("getName('') = 'Anonymous'", () => expect(getName("")).toBe("Anonymous"));
+  test("getName('Bob') = 'Bob'", () => expect(getName("Bob")).toBe("Bob"));
+});


### PR DESCRIPTION
## Summary
- **Bug**: \`\"\" || \"fb\"\` → \"\"; \`\"\" ? \"y\" : \"n\"\` → \"y\". Divergente do JS spec.
- **Cross-runtime**: Validado contra Bun 1.x e Node 22 — saídas RTS = Bun = Node em 11 casos.
- **Fix**: novo \`__RTS_FN_RT_TRUTHY\` helper. String vazia → falsy. Plugado em \`lower_logical\` (And/Or) e \`lower_cond\` (ternário).
- **Bonus**: nova regra em CLAUDE.md + .claude/rules/00-meta.md sobre guardar \`rts.prev.exe\` para diff de regressão sem rebuild.
- 39 testes novos (3 fixtures): basicos, creative chains, cross-runtime parity.

Closes #643

## Test plan
- [x] \`cargo build --release\` — ok
- [x] \`cargo test --release --workspace\` — ok
- [x] \`target/release/rts.exe test\` — **1185/1185** (1146 + 39)
- [x] Cross-check Bun + Node — outputs idênticos