### PR TITLE
ci(cross-runtime): workflow_dispatch também cria issues

### DIFF
--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -240,8 +240,8 @@ jobs:
             execSync(`git commit -m "${msg}"`);
             execSync('git push');
 
-      - name: Auto-create issues em schedule (categorizadas + dedup)
-        if: github.event_name == 'schedule' && steps.cross.outcome == 'failure'
+      - name: Auto-create issues em schedule/dispatch (categorizadas + dedup)
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.cross.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Permite disparar manualmente via gh workflow run e gerar as issues categorizadas sem esperar segunda 00:00 BRT.