### PR TITLE
fix(runtime): String.indexOf/lastIndexOf respeitam fromIndex

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1429,6 +1429,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_STRING_FROM_CODE_POINT",  rt::__RTS_FN_GL_STRING_FROM_CODE_POINT);
     add_fn!("__RTS_FN_GL_STRING_INDEX_OF",         rt::__RTS_FN_GL_STRING_INDEX_OF);
     add_fn!("__RTS_FN_GL_STRING_LAST_INDEX_OF",    rt::__RTS_FN_GL_STRING_LAST_INDEX_OF);
+    add_fn!("__RTS_FN_GL_STRING_INDEX_OF_FROM",    rt::__RTS_FN_GL_STRING_INDEX_OF_FROM);
+    add_fn!("__RTS_FN_GL_STRING_LAST_INDEX_OF_FROM", rt::__RTS_FN_GL_STRING_LAST_INDEX_OF_FROM);
     add_fn!("__RTS_FN_GL_STRING_INCLUDES",         rt::__RTS_FN_GL_STRING_INCLUDES);
     add_fn!("__RTS_FN_GL_STRING_STARTS_WITH",      rt::__RTS_FN_GL_STRING_STARTS_WITH);
     add_fn!("__RTS_FN_GL_STRING_ENDS_WITH",        rt::__RTS_FN_GL_STRING_ENDS_WITH);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -56,11 +56,31 @@ pub(super) fn lower_string_builtin(
         // ── search ──────────────────────────────────────────────────────
         "indexOf" => {
             let needle = arg_handle(ctx, call, 0)?;
+            if call.args.len() >= 2 {
+                let from = arg_i64(ctx, call, 1)?;
+                let v = call_h!(
+                    "__RTS_FN_GL_STRING_INDEX_OF_FROM",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                    &[recv_h, needle, from]
+                );
+                return Ok(Some(TypedVal::new(v, ValTy::I64)));
+            }
             let v = call_h!("__RTS_FN_GL_STRING_INDEX_OF", &[cl::I64, cl::I64], Some(cl::I64), &[recv_h, needle]);
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "lastIndexOf" => {
             let needle = arg_handle(ctx, call, 0)?;
+            if call.args.len() >= 2 {
+                let from = arg_i64(ctx, call, 1)?;
+                let v = call_h!(
+                    "__RTS_FN_GL_STRING_LAST_INDEX_OF_FROM",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                    &[recv_h, needle, from]
+                );
+                return Ok(Some(TypedVal::new(v, ValTy::I64)));
+            }
             let v = call_h!("__RTS_FN_GL_STRING_LAST_INDEX_OF", &[cl::I64, cl::I64], Some(cl::I64), &[recv_h, needle]);
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }

--- a/crates/rts-runtime/src/namespaces/globals/string/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/string/rt.rs
@@ -72,6 +72,73 @@ pub extern "C" fn __RTS_FN_GL_STRING_LAST_INDEX_OF(recv: u64, needle: u64) -> i6
     }
 }
 
+/// `str.indexOf(needle, fromIndex)` — semantica JS:
+/// - fromIndex clamped a [0, s.len()]
+/// - needle vazio: retorna min(fromIndex, s.len())
+/// - resto: busca a partir de fromIndex em chars Unicode
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_STRING_INDEX_OF_FROM(recv: u64, needle: u64, from: i64) -> i64 {
+    let Some(s) = handle_to_str(recv) else { return -1; };
+    let Some(n) = handle_to_str(needle) else { return -1; };
+    let len = s.chars().count() as i64;
+    let from_clamped = from.max(0).min(len);
+    if n.is_empty() {
+        return from_clamped;
+    }
+    // Converte fromIndex (em chars) pra byte offset.
+    let byte_start = s
+        .char_indices()
+        .nth(from_clamped as usize)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    // Busca no slice apos byte_start; resultado precisa virar char index global.
+    let slice = &s[byte_start..];
+    match slice.find(n) {
+        Some(byte_off) => {
+            // Conta chars desde o inicio ate byte_start + byte_off.
+            let abs_byte = byte_start + byte_off;
+            s[..abs_byte].chars().count() as i64
+        }
+        None => -1,
+    }
+}
+
+/// `str.lastIndexOf(needle, fromIndex)` — semantica JS:
+/// - fromIndex clamped a [0, s.len()]; NaN ou ausente = length
+/// - needle vazio: retorna min(fromIndex, s.len())
+/// - busca a ultima ocorrencia cujo INICIO seja <= fromIndex
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_STRING_LAST_INDEX_OF_FROM(recv: u64, needle: u64, from: i64) -> i64 {
+    let Some(s) = handle_to_str(recv) else { return -1; };
+    let Some(n) = handle_to_str(needle) else { return -1; };
+    let len = s.chars().count() as i64;
+    let from_clamped = from.max(0).min(len);
+    if n.is_empty() {
+        return from_clamped;
+    }
+    let limit_byte = s
+        .char_indices()
+        .nth(from_clamped as usize)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    // Encontra ultima posicao de byte tal que o match comece em <= limit_byte.
+    let mut best: Option<usize> = None;
+    let mut search_from = 0usize;
+    while let Some(rel) = s[search_from..].find(n) {
+        let abs = search_from + rel;
+        if abs > limit_byte {
+            break;
+        }
+        best = Some(abs);
+        // Avanca pelo menos 1 byte pra evitar loop em casos degenerados.
+        search_from = abs + n.len().max(1);
+    }
+    match best {
+        Some(byte_pos) => s[..byte_pos].chars().count() as i64,
+        None => -1,
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_STRING_INCLUDES(recv: u64, needle: u64) -> i64 {
     match (handle_to_str(recv), handle_to_str(needle)) {


### PR DESCRIPTION
## Summary
- Adiciona overloads 3-ary \`__RTS_FN_GL_STRING_INDEX_OF_FROM\` e \`__RTS_FN_GL_STRING_LAST_INDEX_OF_FROM\` em \`globals/string/rt.rs\`, com clamp \`[0, length]\` e tratamento especial para \`needle === \"\"\` (retorna \`min(from, length)\`).
- Codegen ramifica para os novos symbols quando \`call.args.len() >= 2\` em \`indexOf\`/\`lastIndexOf\`.
- Indexacao em chars Unicode, consistente com semantica JS de String.

## Antes vs depois (fixture 212)

\`\`\`
"hello".indexOf("", 2)       antes 0   agora 2   ✓
"hello".indexOf("", 10)      antes 0   agora 5   ✓
"hello".lastIndexOf("", 2)   antes 5   agora 2   ✓
\`\`\`

Output bate exato com Bun/Node.

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em \`tests/cross-runtime/212_string_indexof_empty.ts\` -> IDENTICO

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)