### PR TITLE
fix(codegen): Math.min/max com 1 arg retorna o proprio valor

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -527,7 +527,12 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             }
             // (#208) Math.max/min variadico — JS spec aceita N args.
             // ABI namespace fixou em 2 args; aqui suportamos N reduzindo
-            // pairwise.
+            // pairwise. Caso 1 arg: retorna `Number(arg)` (sem call).
+            if (qualified == "Math.max" || qualified == "Math.min") && call.args.len() == 1 {
+                let tv = lower_expr(ctx, &call.args[0].expr)?;
+                let v = ctx.coerce_to_f64(tv).val;
+                return Ok(TypedVal::new(v, ValTy::F64));
+            }
             if (qualified == "Math.max" || qualified == "Math.min") && call.args.len() > 2 {
                 if call.args.iter().any(|a| a.spread.is_some()) {
                     return Err(anyhow!("spread not supported in Math.max/min"));


### PR DESCRIPTION
## Summary
\`Math.min(1)\` / \`Math.max(1)\` caiam no caminho do ABI fixo (2 args), gerando \`codegen warning: missing arg 1\` e resultado errado. JS spec: chamada com 1 arg retorna \`Number(arg)\`.

Special-case adicionado em \`calls/mod.rs\` ao lado dos ja existentes (0 args -> Infinity/-Infinity; > 2 args -> pairwise).

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em \`tests/cross-runtime/213_math_min_max_empty.ts\` -> IDENTICO

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)