### PR TITLE
fix(runtime): implementa Array.length setter (truncate/extend)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1139,6 +1139,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_POP
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_GET",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_GET
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -151,6 +151,27 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
     }
 
     if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Member(m)) = &a.left {
+        // `arr.length = N` — JS spec: trunca/extende o array.
+        // Detecta via prop name; runtime decide se eh Vec mesmo.
+        if matches!(a.op, AssignOp::Assign) {
+            if let MemberProp::Ident(prop) = &m.prop {
+                if prop.sym.as_str() == "length" {
+                    use cranelift_codegen::ir::types as cl;
+                    let obj_tv = lower_expr(ctx, &m.obj)?;
+                    let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                    let val_tv = lower_expr(ctx, &a.right)?;
+                    let n = ctx.coerce_to_i64(val_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH",
+                        &[cl::I64, cl::I64],
+                        None,
+                    )?;
+                    ctx.builder.ins().call(f, &[obj_h, n]);
+                    // JS: assignment retorna o RHS.
+                    return Ok(TypedVal::new(n, ValTy::I64));
+                }
+            }
+        }
         // (#object-setter) Intercepta `obj.X = value` quando obj tem
         // setter `__set_X`. Chama o setter via INVOKE_AUTO em vez do
         // MAP_SET direto. Detecta em runtime via map_get(__set_X).

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -67,6 +67,29 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_POP(handle: u64) -> i64 {
     with_vec_mut(handle, 0, |v| v.pop().unwrap_or(0))
 }
 
+/// `arr.length = n` — JS spec: trunca se n < length, extende com
+/// undefined (slot 0) se n > length, no-op se n == length.
+/// n negativo gera RangeError em JS; aqui silently no-op (RTS nao
+/// tem throw real; alternativa seria abort).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH(handle: u64, n: i64) {
+    if n < 0 {
+        return;
+    }
+    let n = n as usize;
+    with_vec_mut(handle, (), |v| {
+        if n < v.len() {
+            v.truncate(n);
+        } else if n > v.len() {
+            // JS extension: novos slots viram `undefined`. RTS slots sao
+            // i64 raw; usamos 0 como sentinela de hole. `arr[i] ===
+            // undefined` ainda diverge porque vec_get retorna I64 e
+            // codegen impoe strict-kind — tracking separado.
+            v.resize(n, 0);
+        }
+    });
+}
+
 /// Valor em `index`, ou 0 fora do range.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_GET(handle: u64, index: i64) -> i64 {


### PR DESCRIPTION
## Summary
\`arr.length = N\` agora trunca/extende o Vec subjacente conforme JS spec. Antes era no-op silencioso.

- \`__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH\` em runtime: truncate ou resize(n, 0)
- \`lower_assign_expr\` intercepta \`MemberProp::Ident(\"length\")\` antes do caminho generico de setter
- Registrado no JIT

## Antes vs depois (fixture 214)

\`\`\`
                 antes              agora            esperado
truncated=       1,2,3,4,5          1,2,3        ✓   1,2,3
new_length=      5                  3            ✓   3
cleared=         5                  0            ✓   0
empty=           1,2,3,4,5          (vazio)      ✓   (vazio)
undef=           false              false        ✗   true   ← separado
\`\`\`

## Limitacao

\`arr[i] === undefined\` em slot extendido continua false. Causa: \`vec_get\` retorna I64 sentinela 0; \`undefined\` eh Handle de string; strict-kind check em \`operators.rs\` reporta tipos diferentes -> const false. Resolver isso exige refator (tipagem dinamica de slot ou marcacao runtime). Fica como follow-up, fora de escopo deste PR.

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] 4 de 5 divergencias da fixture 214 corrigidas

Refs #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)