### PR TITLE
fix(codegen): arr[i] === undefined funciona apos length setter extend

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -422,6 +422,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_INSPECT", __RTS_FN_RT_INSPECT);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_STRICT_EQ_AMBIG;
+        add_fn!("__RTS_FN_RT_STRICT_EQ_AMBIG", __RTS_FN_RT_STRICT_EQ_AMBIG);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_UNIVERSAL_LENGTH;
         add_fn!("__RTS_FN_RT_UNIVERSAL_LENGTH", __RTS_FN_RT_UNIVERSAL_LENGTH);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -427,6 +427,32 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     // mesmo cl_type, e Handle (string) e' distinto de numericos.
     if matches!(bin.op, BinaryOp::EqEqEq | BinaryOp::NotEqEq) {
         if !same_strict_kind(lhs.ty, rhs.ty) {
+            // (#819) Se uma ponta eh I64 ambiguo (vec_get/map_get/etc),
+            // o tipo estatico nao reflete o conteudo: pode ser handle.
+            // Roteia para runtime helper que decide em runtime.
+            let lhs_ambig = matches!(lhs.ty, ValTy::I64 | ValTy::U64)
+                && ctx.var_member_call_values.contains(&lhs.val);
+            let rhs_ambig = matches!(rhs.ty, ValTy::I64 | ValTy::U64)
+                && ctx.var_member_call_values.contains(&rhs.val);
+            let other_is_handle = lhs.ty == ValTy::Handle || rhs.ty == ValTy::Handle;
+            if (lhs_ambig || rhs_ambig) && other_is_handle {
+                let lv = ctx.coerce_to_i64(lhs).val;
+                let rv = ctx.coerce_to_i64(rhs).val;
+                let fref = ctx.get_extern(
+                    "__RTS_FN_RT_STRICT_EQ_AMBIG",
+                    &[cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(fref, &[lv, rv]);
+                let eq = ctx.builder.inst_results(inst)[0];
+                let result = if matches!(bin.op, BinaryOp::NotEqEq) {
+                    let one = ctx.builder.ins().iconst(cl::I64, 1);
+                    ctx.builder.ins().bxor(eq, one)
+                } else {
+                    eq
+                };
+                return Ok(TypedVal::new(result, ValTy::Bool));
+            }
             let result = if matches!(bin.op, BinaryOp::NotEqEq) { 1 } else { 0 };
             let v = ctx.builder.ins().iconst(cl::I64, result);
             return Ok(TypedVal::new(v, ValTy::Bool));

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -81,11 +81,16 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH(handle: u64, n: i64) {
         if n < v.len() {
             v.truncate(n);
         } else if n > v.len() {
-            // JS extension: novos slots viram `undefined`. RTS slots sao
-            // i64 raw; usamos 0 como sentinela de hole. `arr[i] ===
-            // undefined` ainda diverge porque vec_get retorna I64 e
-            // codegen impoe strict-kind — tracking separado.
-            v.resize(n, 0);
+            // JS extension: novos slots viram `undefined`. Aloca um
+            // handle `Entry::String(b"undefined")` para cada novo slot,
+            // permitindo `arr[i] === undefined` retornar true via
+            // STRICT_EQ_AMBIG (codegen detecta arr[i] como I64 ambiguo
+            // e roteia para o runtime).
+            let needed = n - v.len();
+            for _ in 0..needed {
+                let h = alloc_entry(Entry::String(b"undefined".to_vec()));
+                v.push(h as i64);
+            }
         }
     });
 }

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -529,6 +529,39 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_CMP(a: u64, b: u64) -> i64 {
     })
 }
 
+/// Strict equality (===) entre dois i64 quando pelo menos um eh
+/// ambiguo (resultado de vec_get/map_get sem tipo declarado). Cada
+/// lado eh interpretado dinamicamente:
+/// - handle valido (Entry::String/Vec/Map/...) -> objeto JS
+/// - i64 fora do range de handle -> numero JS
+///
+/// Regras JS strict equality:
+/// - Mesmo tipo + mesmo valor -> 1
+/// - Tipos diferentes -> 0
+/// - Dois handles String iguais em conteudo -> 1
+/// - Dois handles do mesmo objeto (Vec/Map) -> 1 (identidade)
+/// - Numero vs handle -> 0
+///
+/// Usado quando codegen detecta uma das pontas em `var_member_call_values`
+/// e a comparacao seria short-circuit por strict-kind.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_STRICT_EQ_AMBIG(a: i64, b: i64) -> i64 {
+    // Mesmo bit pattern -> sempre igual (cobre handles identicos e
+    // numeros iguais).
+    if a == b {
+        return 1;
+    }
+    let snap_a = if a == 0 { EntrySnap::None } else { snapshot_entry(a as u64) };
+    let snap_b = if b == 0 { EntrySnap::None } else { snapshot_entry(b as u64) };
+    match (&snap_a, &snap_b) {
+        (EntrySnap::Str(sa), EntrySnap::Str(sb)) => {
+            if sa == sb { 1 } else { 0 }
+        }
+        // Tipos compostos diferentes ou um lado handle e o outro numero: 0.
+        _ => 0,
+    }
+}
+
 /// Inspect/pretty-print no estilo Node/Bun para `console.log` — arrays
 /// viram `[ 1, 2, 'a' ]`, objetos `{ k: v }`, strings TOP-LEVEL sem
 /// aspas (strings DENTRO de array/object recebem aspas simples).


### PR DESCRIPTION
## Summary
Completa o fix da fixture 214_array_length_setter. PR #830 resolvia 4/5 casos; faltava \`arr[4] === undefined\` retornar \`true\` apos \`arr.length = 5\`.

### Causa raiz
\`vec_get\` retorna \`ValTy::I64\`; \`undefined\` eh \`ValTy::Handle\`. \`same_strict_kind\` diferentes -> short-circuit \`const false\` em compile-time. Alem disso, slot novo era preenchido com \`0\` (sentinela hole).

### Fix em 3 partes
1. \`vec_set_length(extend)\` agora aloca \`Entry::String(b\"undefined\")\` por slot novo.
2. Novo extern \`__RTS_FN_RT_STRICT_EQ_AMBIG\` decide em runtime: dois handles \`Entry::String\` iguais -> 1; senao 0.
3. Codegen em \`operators.rs\`: quando uma ponta de \`===\`/\`!==\` eh \`I64\` ambiguo (vec_get/map_get marca em \`var_member_call_values\`) e a outra eh \`Handle\`, em vez de const-false roteia para \`STRICT_EQ_AMBIG\`.

## Test plan
- [x] cargo build --release limpo
- [x] cargo test --release --lib 12/12
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em \`tests/cross-runtime/214_array_length_setter.ts\` -> IDENTICO (5/5 casos)

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)