### PR TITLE
fix(codegen): chain de array methods (arr.map(fn).join) nao crasha mais

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -413,6 +413,14 @@ fn lift_arrows_in_expr(
         for a in &mut call.args {
             lift_arrows_in_expr(&mut a.expr, user_fn_names, new_fns, counter);
         }
+        // (#821 follow-up) Recursa no obj do callee tambem para suportar
+        // chains como `arr.map(x => x.id).join(",")`. Sem isso, o arrow
+        // inline em `.map` ficava sem lift e o `.join` em chain crashava.
+        if let Callee::Expr(callee) = &mut call.callee {
+            if let Expr::Member(m) = callee.as_mut() {
+                lift_arrows_in_expr(&mut m.obj, user_fn_names, new_fns, counter);
+            }
+        }
         return;
     }
     // (#593) Descer em Tpl/Bin/Cond/Paren/Unary para que arrows em
@@ -886,6 +894,13 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
         }
         for a in &mut call.args {
             rewrite_array_methods_in_expr(&mut a.expr, user_fn_names);
+        }
+        // (#821 follow-up) Recursa no obj do callee para chains
+        // (`arr.map(fn).join(...)`).
+        if let Callee::Expr(callee) = &mut call.callee {
+            if let Expr::Member(m) = callee.as_mut() {
+                rewrite_array_methods_in_expr(&mut m.obj, user_fn_names);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
\`arr.map(x => x.id).join(\",\")\` causava SIGILL.

### Causa
1. \`lift_inline_arrows_in_array_methods\` so' recursava em \`call.args\`, nao em \`callee.m.obj\` — arrow inline em \`.map\` ficava sem lift
2. \`array_methods_pass\` mesmo problema — \`arr.map(arrow)\` em chain nao era reescrito pra \`parallel.map\`
3. Sem lift, codegen caia no caminho \`Expr::Call obj\` (mod.rs:405) que faz \`MAP_GET + trapz\`. Como o resultado de \`arr.map(fn)\` nao eh Map, MAP_GET retornava 0 e \`trapz\` disparava SIGILL.

### Fix
Ambos os passes agora recursam em \`callee.m.obj\` quando o callee eh Member com Call aninhado. Cobre niveis arbitrarios de chain.

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em \`tests/cross-runtime/217_array_sort_stability.ts\` -> IDENTICO

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)