### PR TITLE
fix(runtime): Array.filter/find/some/every aplicam JS truthy

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -158,9 +158,25 @@ pub extern "C" fn __RTS_FN_RT_TRUTHY(value: i64) -> i64 {
     if value == 0 {
         return 0;
     }
+    // Sentinela bool em slot de Vec/Map (codegen empacota false como
+    // i64::MIN, true como i64::MIN+1). Trata como JS bool.
+    if value == i64::MIN {
+        return 0;
+    }
+    if value == i64::MIN + 1 {
+        return 1;
+    }
     let h = value as u64;
     let snap = with_entry(h, |entry| match entry {
-        Some(Entry::String(b)) => Some(!b.is_empty()),
+        Some(Entry::String(b)) => {
+            // `undefined` (handle de string literal "undefined") eh falsy.
+            // String vazia tambem.
+            if b.is_empty() || b.as_slice() == b"undefined" {
+                Some(false)
+            } else {
+                Some(true)
+            }
+        }
         Some(_) => Some(true),
         None => None,
     });

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -12,6 +12,14 @@ fn snapshot_vec(handle: u64) -> Option<Vec<i64>> {
     })
 }
 
+/// JS-spec truthy do retorno de callback: chama __RTS_FN_RT_TRUTHY que
+/// trata 0/null/undefined/""/false como falsy. Sem isso, filter com
+/// `x => x` em array `[0, false, "", null]` so' descartava 0 e null
+/// (bool/string handles passavam como nao-zero).
+fn cb_truthy(v: i64) -> bool {
+    crate::namespaces::gc::string_pool::__RTS_FN_RT_TRUTHY(v) != 0
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PARALLEL_MAP(vec_handle: u64, fn_ptr: u64) -> u64 {
     let Some(items) = snapshot_vec(vec_handle) else {
@@ -91,7 +99,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FILTER(vec_handle: u64, fn_ptr: u64) -> u
         return 0;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    let result: Vec<i64> = items.into_iter().filter(|&x| f(x) != 0).collect();
+    let result: Vec<i64> = items.into_iter().filter(|&x| cb_truthy(f(x))).collect();
     alloc_entry(Entry::Vec(Box::new(result)))
 }
 
@@ -105,7 +113,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND(vec_handle: u64, fn_ptr: u64) -> i64
         return 0;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    items.into_iter().find(|&x| f(x) != 0).unwrap_or(0)
+    items.into_iter().find(|&x| cb_truthy(f(x))).unwrap_or(0)
 }
 
 /// Retorna index do primeiro elemento que satisfaz predicate, ou -1.
@@ -120,7 +128,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_INDEX(vec_handle: u64, fn_ptr: u64) 
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
     items
         .into_iter()
-        .position(|x| f(x) != 0)
+        .position(|x| cb_truthy(f(x)))
         .map(|i| i as i64)
         .unwrap_or(-1)
 }
@@ -135,7 +143,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_SOME(vec_handle: u64, fn_ptr: u64) -> i64
         return 0;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    if items.into_iter().any(|x| f(x) != 0) { 1 } else { 0 }
+    if items.into_iter().any(|x| cb_truthy(f(x))) { 1 } else { 0 }
 }
 
 /// Retorna 1 se todos os elementos satisfazem predicate, 0 caso contrario.
@@ -149,5 +157,5 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_EVERY(vec_handle: u64, fn_ptr: u64) -> i6
         return 1;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    if items.into_iter().all(|x| f(x) != 0) { 1 } else { 0 }
+    if items.into_iter().all(|x| cb_truthy(f(x))) { 1 } else { 0 }
 }


### PR DESCRIPTION
## Summary
\`arr.filter(x => x)\` em \`[0, false, \"\", null, undefined]\` deveria deixar so' elementos truthy. Antes RTS so' descartava \`0\` e \`null\` porque o callback retornava o slot raw e o filter testava \`!= 0\`, mas:
- \`false\` (sentinela \`i64::MIN\`) passava
- \`\"\"\` (handle nao-zero) passava
- \`undefined\` (handle de string \"undefined\") passava

## Fix
- \`parallel/ops.rs\`: filter/find/findIndex/some/every chamam \`cb_truthy(f(x))\` que delega para \`__RTS_FN_RT_TRUTHY\`
- \`__RTS_FN_RT_TRUTHY\` estendido:
  - sentinela bool \`i64::MIN\` -> falsy; \`i64::MIN+1\` -> truthy
  - handle de \`Entry::String\` com bytes vazios OU \"undefined\" -> falsy

## Trade-off
String literal real \`\"undefined\"\` em \`Boolean(\"undefined\")\` agora vira falsy (era truthy). Raro em codigo real; resolver direito exige sentinela distinta pra undefined.

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em 223_array_filter_truthy.ts -> IDENTICO

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)