### PR TITLE
fix(runtime): Array.find sem match retorna undefined

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
@@ -308,6 +308,12 @@ pub(super) fn lower_ns_call_body(
     let inst = ctx.builder.ins().call(fref, &values);
     if lowered.ret.is_some() {
         let v = ctx.builder.inst_results(inst)[0];
+        // `parallel.find` retorna I64 mas o slot pode ser handle de
+        // "undefined" quando nao acha. Marca como ambiguo para que
+        // template literal/console use TPL_COERCE_AUTO/INSPECT.
+        if member.symbol == "__RTS_FN_NS_PARALLEL_FIND" {
+            ctx.var_member_call_values.insert(v);
+        }
         Ok(TypedVal::new(v, ValTy::from_abi(member.returns)))
     } else {
         Ok(TypedVal::new(

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -113,7 +113,16 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND(vec_handle: u64, fn_ptr: u64) -> i64
         return 0;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    items.into_iter().find(|&x| cb_truthy(f(x))).unwrap_or(0)
+    match items.into_iter().find(|&x| cb_truthy(f(x))) {
+        Some(v) => v,
+        None => {
+            // JS spec: find sem match retorna `undefined`. Aloca handle
+            // de string "undefined" — codegen marca .find(...) como
+            // ambiguo (var_member_call_values), template literal/console
+            // formata corretamente via TPL_COERCE_AUTO/INSPECT.
+            alloc_entry(Entry::String(b"undefined".to_vec())) as i64
+        }
+    }
 }
 
 /// Retorna index do primeiro elemento que satisfaz predicate, ou -1.


### PR DESCRIPTION
## Summary
JS spec: \`arr.find(pred)\` retorna \`undefined\` quando nenhum elemento satisfaz o predicate. RTS retornava \`0\` (i64) que virava \"0\" em template literal.

## Fix
- \`parallel/ops.rs::__RTS_FN_NS_PARALLEL_FIND\`: ao inves de \`unwrap_or(0)\`, aloca handle \`Entry::String(b\"undefined\")\` quando find nao acha
- \`ns_call.rs\` marca o retorno de \`PARALLEL_FIND\` em \`var_member_call_values\` para que template literal/console use \`TPL_COERCE_AUTO\`/\`INSPECT\` e formate como \"undefined\"

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em 226_array_find_undefined.ts -> IDENTICO

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)