### PR TITLE
fix(runtime): hasOwnProperty funciona em arrays

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -133,7 +133,9 @@ pub(super) fn lower_var_member_call(
     // (#264 PR5) `obj.hasOwnProperty(key)` — verifica own props sem chain.
     if prop == "hasOwnProperty" && call.args.len() == 1 {
         let key_tv = lower_expr(ctx, &call.args[0].expr)?;
-        let key_h = ctx.coerce_to_i64(key_tv).val;
+        // Numero -> string handle (JS converte: `arr.hasOwnProperty(0)`
+        // testa key "0"). `coerce_to_handle` ja' faz stringify de I64/F64.
+        let key_h = ctx.coerce_to_handle(key_tv)?.val;
         let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
         let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
         let inst_p = ctx.builder.ins().call(str_ptr_fn, &[key_h]);

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -151,6 +151,23 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
     let Some(key) = str_from_abi(key_ptr, key_len) else {
         return 0;
     };
+    // Arrays (Vec): "length" eh own; chaves de indice (parsam como
+    // uint32) sao own quando < length. Demais nao.
+    let vec_result: Option<i64> = with_entry(handle, |e| match e {
+        Some(Entry::Vec(v)) => {
+            if key == "length" {
+                Some(1)
+            } else if let Some(n) = parse_array_index(key) {
+                Some(if (n as usize) < v.len() { 1 } else { 0 })
+            } else {
+                Some(0)
+            }
+        }
+        _ => None,
+    });
+    if let Some(r) = vec_result {
+        return r;
+    }
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
 }
 


### PR DESCRIPTION
## Summary
\`arr.hasOwnProperty(0)\` / \`arr.hasOwnProperty(\"length\")\` retornava \`false\`. Causas:
1. \`__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY\` so' inspecionava \`Entry::Map\`. Para \`Entry::Vec\` retornava 0.
2. Codegen em \`indirect.rs\` coergia arg como i64 e passava como ptr/len — \`hasOwnProperty(0)\` (number) precisa stringify.

## Fix
- \`map.rs\`: \`HAS_OWN_PROPERTY\` agora detecta \`Entry::Vec\`. \`\"length\"\` -> own, indices uint32 < len -> own, resto -> nao
- \`indirect.rs\`: usa \`coerce_to_handle\` (stringify de Number/Bool) em vez de \`coerce_to_i64\`

## Test plan
- [x] cargo build --release limpo
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em 227_object_hasownproperty.ts -> IDENTICO

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)