### PR TITLE
fix(runtime): Array.shift/pop em vazio retorna undefined

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -782,7 +782,9 @@ pub(super) fn lower_array_builtin(
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "pop" => {
-            // JS: retorna o ultimo elemento (ou undefined). v0 retorna 0 quando vazio.
+            // JS: retorna ultimo elemento ou `undefined`. Runtime aloca
+            // handle "undefined" em vazio. Marca como ambiguo para que
+            // template literal/console formate corretamente.
             let pop_fn = ctx.get_extern(
                 "__RTS_FN_NS_COLLECTIONS_VEC_POP",
                 &[cl::I64],
@@ -790,6 +792,7 @@ pub(super) fn lower_array_builtin(
             )?;
             let inst = ctx.builder.ins().call(pop_fn, &[obj_h]);
             let v = ctx.builder.inst_results(inst)[0];
+            ctx.var_member_call_values.insert(v);
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "length" | "size" => {
@@ -939,6 +942,8 @@ pub(super) fn lower_array_builtin(
             )?;
             let inst = ctx.builder.ins().call(fref, &[obj_h]);
             let v = ctx.builder.inst_results(inst)[0];
+            // Mesma marca de POP (handle "undefined" em vazio).
+            ctx.var_member_call_values.insert(v);
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "unshift" => {

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -61,10 +61,16 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle: u64, value: i64) {
     }
 }
 
-/// Remove e retorna o ultimo valor, ou 0 se vazio.
+/// Remove e retorna o ultimo valor. JS spec: undefined se vazio.
+/// Retorna handle de Entry::String("undefined") em vez de 0 — codegen
+/// marca o resultado como ambiguo para template literal formatar.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_POP(handle: u64) -> i64 {
-    with_vec_mut(handle, 0, |v| v.pop().unwrap_or(0))
+    let popped: Option<i64> = with_vec_mut(handle, None, |v| v.pop());
+    match popped {
+        Some(v) => v,
+        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+    }
 }
 
 /// `arr.length = n` — JS spec: trunca se n < length, extende com
@@ -303,10 +309,17 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_REVERSE(handle: u64) -> u64 {
     handle
 }
 
-/// `arr.shift()` — remove e retorna primeiro elemento, ou 0 se vazio.
+/// `arr.shift()` — remove e retorna primeiro elemento. JS spec:
+/// undefined se vazio. Mesmo padrao de POP (handle "undefined").
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SHIFT(handle: u64) -> i64 {
-    with_vec_mut(handle, 0, |v| if v.is_empty() { 0 } else { v.remove(0) })
+    let first: Option<i64> = with_vec_mut(handle, None, |v| {
+        if v.is_empty() { None } else { Some(v.remove(0)) }
+    });
+    match first {
+        Some(v) => v,
+        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+    }
 }
 
 /// `arr.unshift(v)` — insere no começo. Retorna novo length.
@@ -832,7 +845,11 @@ mod tests {
         assert_eq!(handle_to_vec(h), vec![2, 3]);
         assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), 2);
         assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), 3);
-        assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), 0); // vazio
+        // Vazio: retorna handle de string "undefined" (nao 0). JS spec.
+        let undef_h = __RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h);
+        assert_ne!(undef_h, 0);
+        let s = crate::namespaces::gc::string_pool::read_string_handle(undef_h as u64);
+        assert_eq!(s.as_deref(), Some("undefined"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
JS spec: \`[].shift()\` e \`[].pop()\` retornam \`undefined\`. RTS retornava \`0\` -> stringificava \"0\".

## Fix
- \`vec.rs\`: \`VEC_POP\`/\`VEC_SHIFT\` alocam handle \`Entry::String(b\"undefined\")\` quando vazio
- \`builtins.rs\`: marca resultados em \`var_member_call_values\` para template literal/console formatar via \`TPL_COERCE_AUTO\`/\`INSPECT\`
- Atualiza teste \`shift_unshift_roundtrip\` que assertava 0 em vazio

## Test plan
- [x] cargo build --release limpo
- [x] cargo test --release --lib 12/12
- [x] target/release/rts.exe test 1195/1195
- [x] diff RTS vs Node em 211_array_shift_empty.ts -> IDENTICO

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)