### PR TITLE
fix(runtime): JSON.stringify aceita string como indent

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -281,6 +281,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         "__RTS_FN_NS_JSON_STRINGIFY_PRETTY",
         __RTS_FN_NS_JSON_STRINGIFY_PRETTY
     );
+    add_fn!(
+        "__RTS_FN_NS_JSON_STRINGIFY_PRETTY_STR",
+        __RTS_FN_NS_JSON_STRINGIFY_PRETTY_STR
+    );
     add_fn!("__RTS_FN_NS_JSON_FREE", __RTS_FN_NS_JSON_FREE);
     add_fn!("__RTS_FN_NS_JSON_TYPE_OF", __RTS_FN_NS_JSON_TYPE_OF);
     add_fn!("__RTS_FN_NS_JSON_AS_BOOL", __RTS_FN_NS_JSON_AS_BOOL);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -239,9 +239,21 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v_tv = lower_expr(ctx, &call.args[0].expr)?;
                     let v_h = ctx.coerce_to_i64(v_tv).val;
                     let i_tv = lower_expr(ctx, &call.args[2].expr)?;
-                    let indent = ctx.coerce_to_i64(i_tv).val;
+                    // JS spec: indent pode ser number ou string. Detecta
+                    // pelo tipo e roteia para PRETTY (i64) ou PRETTY_STR
+                    // (handle de string).
+                    let sym = if matches!(i_tv.ty, ValTy::Handle) {
+                        "__RTS_FN_NS_JSON_STRINGIFY_PRETTY_STR"
+                    } else {
+                        "__RTS_FN_NS_JSON_STRINGIFY_PRETTY"
+                    };
+                    let indent = if matches!(i_tv.ty, ValTy::Handle) {
+                        i_tv.val
+                    } else {
+                        ctx.coerce_to_i64(i_tv).val
+                    };
                     let f = ctx.get_extern(
-                        "__RTS_FN_NS_JSON_STRINGIFY_PRETTY",
+                        sym,
                         &[cl::I64, cl::I64],
                         Some(cl::I64),
                     )?;

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -261,10 +261,10 @@ pub extern "C" fn __RTS_FN_NS_JSON_STRINGIFY_TYPED(value: i64, kind: i32) -> u64
 }
 
 /// Pretty-printer recursivo para Map/Vec/String/Json com indent.
-fn stringify_pretty_inner(handle: u64, indent: usize, depth: usize) -> Option<String> {
+fn stringify_pretty_inner_str(handle: u64, indent: &str, depth: usize) -> Option<String> {
     use std::fmt::Write;
-    let pad_outer = " ".repeat(indent * depth);
-    let pad_inner = " ".repeat(indent * (depth + 1));
+    let pad_outer = indent.repeat(depth);
+    let pad_inner = indent.repeat(depth + 1);
     with_entry(handle, |e| {
         let v = e?;
         let mut out = String::new();
@@ -290,7 +290,7 @@ fn stringify_pretty_inner(handle: u64, indent: usize, depth: usize) -> Option<St
                         }
                     }
                     out.push_str("\": ");
-                    out.push_str(&stringify_pretty_value_i64(**val, indent, depth + 1));
+                    out.push_str(&stringify_pretty_value_i64_str(**val, indent, depth + 1));
                     if i + 1 < entries.len() { out.push(','); }
                     out.push('\n');
                 }
@@ -306,7 +306,7 @@ fn stringify_pretty_inner(handle: u64, indent: usize, depth: usize) -> Option<St
                 out.push_str("[\n");
                 for (i, val) in arr.iter().enumerate() {
                     out.push_str(&pad_inner);
-                    out.push_str(&stringify_pretty_value_i64(*val, indent, depth + 1));
+                    out.push_str(&stringify_pretty_value_i64_str(*val, indent, depth + 1));
                     if i + 1 < arr.len() { out.push(','); }
                     out.push('\n');
                 }
@@ -315,9 +315,8 @@ fn stringify_pretty_inner(handle: u64, indent: usize, depth: usize) -> Option<St
                 Some(out)
             }
             Entry::Json(j) => {
-                let pad = " ".repeat(indent);
                 let mut buf = Vec::with_capacity(64);
-                let formatter = serde_json::ser::PrettyFormatter::with_indent(pad.as_bytes());
+                let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
                 let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
                 serde::Serialize::serialize(j.as_ref(), &mut ser).ok()?;
                 let _ = write!(out, "{}", String::from_utf8(buf).ok()?);
@@ -328,10 +327,10 @@ fn stringify_pretty_inner(handle: u64, indent: usize, depth: usize) -> Option<St
     })
 }
 
-fn stringify_pretty_value_i64(v: i64, indent: usize, depth: usize) -> String {
+fn stringify_pretty_value_i64_str(v: i64, indent: &str, depth: usize) -> String {
     let h = v as u64;
     if h > 0xFFFF_FFFF {
-        if let Some(s) = stringify_pretty_inner(h, indent, depth) {
+        if let Some(s) = stringify_pretty_inner_str(h, indent, depth) {
             return s;
         }
     }
@@ -344,7 +343,34 @@ pub extern "C" fn __RTS_FN_NS_JSON_STRINGIFY_PRETTY(handle: u64, indent: i64) ->
     if indent == 0 {
         return __RTS_FN_NS_JSON_STRINGIFY(handle);
     }
-    if let Some(s) = stringify_pretty_inner(handle, indent, 0) {
+    let indent_str = " ".repeat(indent);
+    if let Some(s) = stringify_pretty_inner_str(handle, &indent_str, 0) {
+        return alloc_entry(Entry::String(s.into_bytes()));
+    }
+    if handle == 0 {
+        return alloc_entry(Entry::String(b"null".to_vec()));
+    }
+    alloc_entry(Entry::String(handle.to_string().into_bytes()))
+}
+
+/// `JSON.stringify(value, null, "<str>")` — indent eh string custom (ate
+/// 10 chars conforme JS spec). String vazia desativa pretty.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_JSON_STRINGIFY_PRETTY_STR(
+    handle: u64,
+    indent_h: u64,
+) -> u64 {
+    let indent_str: String = match crate::namespaces::gc::string_pool::read_string_handle(indent_h) {
+        Some(s) => {
+            // JS spec: trunca em 10 caracteres.
+            s.chars().take(10).collect()
+        }
+        None => String::new(),
+    };
+    if indent_str.is_empty() {
+        return __RTS_FN_NS_JSON_STRINGIFY(handle);
+    }
+    if let Some(s) = stringify_pretty_inner_str(handle, &indent_str, 0) {
         return alloc_entry(Entry::String(s.into_bytes()));
     }
     if handle == 0 {


### PR DESCRIPTION
Resolve cross-runtime #813 (207_json_stringify_space). `JSON.stringify(v, null, "\t")` agora respeita string como indent. Suite 1195/1195. Closes #813