### PR TITLE
ci: build artifacts versionados + release automatico

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -7,8 +7,26 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: write  # criar release em push para main
+
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - name: Compute version
+        id: compute
+        run: |
+          # v0.0-<UTC timestamp YYYYMMDDHHMM>. Compartilhado entre os 3 jobs
+          # de build para que os artifacts saiam com o mesmo nome de versao.
+          VERSION="v0.0-$(date -u +%Y%m%d%H%M)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed VERSION=$VERSION"
+
   build:
+    needs: version
     strategy:
       fail-fast: false
       matrix:
@@ -39,37 +57,76 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build release
+        env:
+          RTS_BUILD_VERSION: ${{ needs.version.outputs.version }}
         run: cargo build --release
 
       - name: Smoke test — rts run (JIT)
         run: target/release/rts run bench/pi_machin.ts
         shell: bash
 
-      #- name: Smoke test — rts compile (AOT)
-      #  run: |
-      #    if [ "$RUNNER_OS" = "Windows" ]; then
-      #      RTS=target/release/rts.exe
-      #      OUT=smoke_pi.exe
-      #    else
-      #      RTS=target/release/rts
-      #      OUT=smoke_pi
-      #    fi
-      #    $RTS compile bench/pi_machin.ts smoke_pi
-      #    ./$OUT
-      #  shell: bash
+      - name: Rename artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/release/rts.exe "dist/rts-${{ needs.version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}.exe"
+
+      - name: Rename artifact (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/release/rts "dist/rts-${{ needs.version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}"
 
       - name: Upload artifact (Windows)
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: rts-${{ runner.os }}-${{ runner.arch }}
-          path: target/release/rts.exe
+          name: rts-${{ needs.version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+          path: dist/*.exe
           if-no-files-found: error
 
       - name: Upload artifact (Unix)
         if: runner.os != 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: rts-${{ runner.os }}-${{ runner.arch }}
-          path: target/release/rts
+          name: rts-${{ needs.version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+          path: dist/rts-*
           if-no-files-found: error
+
+  release:
+    # So' cria release em push para main (nao em PRs nem dispatch).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List artifacts
+        run: find artifacts -type f | sort
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.version.outputs.version }}
+          name: ${{ needs.version.outputs.version }}
+          body: |
+            Build automatico de `main` em ${{ needs.version.outputs.version }}.
+
+            Commit: ${{ github.sha }}
+
+            Binarios:
+            - Linux x64
+            - Windows x64
+            - macOS ARM64
+          files: artifacts/**/*
+          fail_on_unmatched_files: true
+          generate_release_notes: false
+          make_latest: true


### PR DESCRIPTION
Cada push em main passa a gerar release `v0.0-<UTC timestamp>` com os 3 binarios versionados (Linux/Windows/macOS-ARM64). PR/dispatch continuam gerando so' artifacts.