### PR TITLE
fix(array): join trata undefined/null como string vazia (#142)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -40,6 +40,22 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
                     ctx.builder.ins().call(spread_fn, &[handle, src_h]);
                     continue;
                 }
+                // (cross-runtime #142) `undefined`/`null` em array literal
+                // viram sentinela. join/toString/etc espera-se que tratem
+                // como string vazia (JS spec).
+                //   MIN+2 = undefined, MIN+3 = null
+                if let Expr::Ident(id) = e.expr.as_ref() {
+                    if id.sym.as_str() == "undefined" && ctx.read_local("undefined").is_none() {
+                        let s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+                        ctx.builder.ins().call(push_fn, &[handle, s]);
+                        continue;
+                    }
+                }
+                if matches!(e.expr.as_ref(), Expr::Lit(Lit::Null(_))) {
+                    let s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 3);
+                    ctx.builder.ins().call(push_fn, &[handle, s]);
+                    continue;
+                }
                 let tv = lower_expr(ctx, &e.expr)?;
                 // Bool em array vira sentinela (i64::MIN = false, MIN+1 =
                 // true). Permite inspect_slot imprimir `true`/`false` sem

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -162,6 +162,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_JOIN(handle: u64, sep_h: u64) -> u
             out.extend_from_slice(b"true");
             continue;
         }
+        // (cross-runtime #142) JS spec: undefined/null em join viram "".
+        if *e == i64::MIN + 2 || *e == i64::MIN + 3 {
+            continue;
+        }
         let h = *e as u64;
         // Tenta como string handle primeiro.
         let as_str: Option<Vec<u8>> = with_entry(h, |entry| match entry {


### PR DESCRIPTION
## Summary
- `[1, undefined, 3].join(",")` retornava `"1,undefined,3"` em vez de `"1,,3"`
- Codegen marca undefined/null com sentinelas i64::MIN+2/+3 em array literal
- VEC_JOIN trata sentinelas como string vazia (JS spec)

Fixes cross-runtime fixture `142_array_join_edge_cases`.

## Test plan
- [x] `target/release/rts.exe run tests/cross-runtime/142_array_join_edge_cases.ts` bate com Bun
- [x] `target/release/rts.exe test` 1195/1195 passa
- [x] `cargo build --release` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)