### PR TITLE
fix(array): concat variadic + valores escalares (#143)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1224,6 +1224,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_CONCAT
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_CONCAT_APPEND",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_CONCAT_APPEND
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_FILL",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_FILL
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1010,19 +1010,34 @@ pub(super) fn lower_array_builtin(
             Ok(Some(TypedVal::new(v, ValTy::Handle)))
         }
         "concat" => {
-            if call.args.len() != 1 || call.args[0].spread.is_some() {
+            if call.args.iter().any(|a| a.spread.is_some()) {
                 return Ok(None);
             }
-            let other_tv = lower_expr(ctx, &call.args[0].expr)?;
-            let other = ctx.coerce_to_i64(other_tv).val;
-            let fref = ctx.get_extern(
+            // (cross-runtime #143) JS spec: copia + variadic. Cada arg
+            // que for array faz spread; escalares viram push.
+            // Copia o receiver primeiro via CONCAT(recv, 0) (other=0 -> vazio).
+            let zero = ctx.builder.ins().iconst(cl::I64, 0);
+            let copy_fref = ctx.get_extern(
                 "__RTS_FN_NS_COLLECTIONS_VEC_CONCAT",
                 &[cl::I64, cl::I64],
                 Some(cl::I64),
             )?;
-            let inst = ctx.builder.ins().call(fref, &[obj_h, other]);
-            let v = ctx.builder.inst_results(inst)[0];
-            Ok(Some(TypedVal::new(v, ValTy::Handle)))
+            let inst = ctx.builder.ins().call(copy_fref, &[obj_h, zero]);
+            let mut acc = ctx.builder.inst_results(inst)[0];
+            if !call.args.is_empty() {
+                let append_fref = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_VEC_CONCAT_APPEND",
+                    &[cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                for a in &call.args {
+                    let tv = lower_expr(ctx, &a.expr)?;
+                    let arg_i64 = ctx.coerce_to_i64(tv).val;
+                    let inst = ctx.builder.ins().call(append_fref, &[acc, arg_i64]);
+                    acc = ctx.builder.inst_results(inst)[0];
+                }
+            }
+            Ok(Some(TypedVal::new(acc, ValTy::Handle)))
         }
         "fill" => {
             if call.args.is_empty() || call.args.iter().any(|a| a.spread.is_some()) {

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -367,6 +367,24 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_CONCAT(handle: u64, other: u64) ->
     alloc_entry(Entry::Vec(Box::new(out)))
 }
 
+/// (cross-runtime #143) Append de um arg `arr.concat(arg, ...)`. Se `arg`
+/// eh handle de Vec, faz extend; caso contrario push do escalar. JS spec:
+/// `Array.prototype.concat` so' faz spread em arrays "concat-spreadable".
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_CONCAT_APPEND(handle: u64, arg: i64) -> u64 {
+    let arg_h = arg as u64;
+    let as_vec: Option<Vec<i64>> = with_entry(arg_h, |entry| match entry {
+        Some(Entry::Vec(v)) => Some(v.iter().copied().collect()),
+        _ => None,
+    });
+    if let Some(items) = as_vec {
+        with_vec_mut(handle, (), |v| v.extend(items));
+    } else {
+        with_vec_mut(handle, (), |v| v.push(arg));
+    }
+    handle
+}
+
 /// `arr.fill(value, start, end)` — preenche range com `value` in-place.
 /// Retorna o proprio handle.
 #[unsafe(no_mangle)]


### PR DESCRIPTION
## Summary
- `[1].concat([2], [3])` retornava vazio; agora bate com JS spec
- Suporta N args, cada um spread se array ou push se escalar
- Nova fn runtime `VEC_CONCAT_APPEND` resolve tipo do arg em runtime

Fixes cross-runtime fixture `143_array_concat`.

## Test plan
- [x] `target/release/rts.exe run tests/cross-runtime/143_array_concat.ts` bate com Bun
- [x] `target/release/rts.exe test` 1195/1195
- [x] `cargo build --release` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)