### PR TITLE
fix(array): push variadic (#150)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -759,11 +759,7 @@ pub(super) fn lower_array_builtin(
 ) -> Result<Option<TypedVal>> {
     match method {
         "push" => {
-            if call.args.len() != 1 {
-                return Ok(None);
-            }
-            let arg = &call.args[0];
-            if arg.spread.is_some() {
+            if call.args.is_empty() || call.args.iter().any(|a| a.spread.is_some()) {
                 return Ok(None);
             }
             let push_fn = ctx.get_extern(
@@ -771,9 +767,13 @@ pub(super) fn lower_array_builtin(
                 &[cl::I64, cl::I64],
                 None,
             )?;
-            let tv = lower_expr(ctx, &arg.expr)?;
-            let v = ctx.coerce_to_i64(tv).val;
-            ctx.builder.ins().call(push_fn, &[obj_h, v]);
+            // (cross-runtime #150) JS: push aceita N args, todos sao
+            // pushed em ordem.
+            for arg in &call.args {
+                let tv = lower_expr(ctx, &arg.expr)?;
+                let v = ctx.coerce_to_i64(tv).val;
+                ctx.builder.ins().call(push_fn, &[obj_h, v]);
+            }
             // JS: push retorna novo length.
             let len_fn = ctx.get_extern(
                 "__RTS_FN_NS_COLLECTIONS_VEC_LEN",


### PR DESCRIPTION
## Summary
- `arr.push(5, 6)` rejeitava args > 1 e crashava (Illegal instruction)
- Codegen agora aceita N args, push em ordem

Fixes cross-runtime fixture `150_array_push_pop_shift_unshift`.

## Test plan
- [x] fixture bate com Bun
- [x] suite TS 1195/1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)