### PR TITLE
fix(array): reduce sem initial value (numéricos) (#254 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1810,6 +1810,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             parallel_ops::__RTS_FN_NS_PARALLEL_REDUCE
         );
         add_fn!(
+            "__RTS_FN_NS_PARALLEL_REDUCE_NO_INIT",
+            parallel_ops::__RTS_FN_NS_PARALLEL_REDUCE_NO_INIT
+        );
+        add_fn!(
             "__RTS_FN_NS_PARALLEL_NUM_THREADS",
             parallel_ops::__RTS_FN_NS_PARALLEL_NUM_THREADS
         );

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -254,6 +254,7 @@ fn lift_arrows_in_expr(
                     let lift_info: Option<(usize, usize, usize)> = match method {
                         // (arg_idx_to_lift, n_args, arrow_arity)
                         "map" | "forEach" => Some((0, 1, 1)),
+                        "reduce" if call.args.len() == 1 => Some((0, 1, 2)),
                         "reduce" => Some((0, 2, 2)),
                         "filter" | "find" | "findIndex" | "some" | "every" => {
                             Some((0, 1, 1))
@@ -877,6 +878,8 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                         "map" if call.args.len() == 1 && arg0_is_user_fn => Some("map"),
                         "forEach" if call.args.len() == 1 && arg0_is_user_fn => Some("for_each"),
                         "reduce" if call.args.len() == 2 && arg0_is_user_fn => Some("reduce"),
+                        // (cross-runtime #254) reduce sem initial value.
+                        "reduce" if call.args.len() == 1 && arg0_is_user_fn => Some("reduce_no_init"),
                         "filter" if call.args.len() == 1 && arg0_is_user_fn => Some("filter"),
                         "find" if call.args.len() == 1 && arg0_is_user_fn => Some("find"),
                         "findIndex" if call.args.len() == 1 && arg0_is_user_fn => {
@@ -898,6 +901,7 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                                 swc_ecma_ast::ExprOrSpread { spread: None, expr: fn_arg },
                             ]
                         } else {
+                            // reduce_no_init / map / forEach / etc: (arr, fn)
                             vec![
                                 swc_ecma_ast::ExprOrSpread { spread: None, expr: Box::new(arr_expr) },
                                 swc_ecma_ast::ExprOrSpread { spread: None, expr: fn_arg },

--- a/crates/rts-runtime/src/namespaces/parallel/abi.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/abi.rs
@@ -26,6 +26,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: false,
     },
     NamespaceMember {
+        name: "reduce_no_init",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PARALLEL_REDUCE_NO_INIT",
+        args: &[AbiType::Handle, AbiType::U64],
+        returns: AbiType::I64,
+        doc: "(cross-runtime #254) reduce sem initial value. Sequencial.",
+        ts_signature: "reduce_no_init(vec_handle: number, fn_ptr: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
         name: "reduce",
         kind: MemberKind::Function,
         symbol: "__RTS_FN_NS_PARALLEL_REDUCE",

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -56,6 +56,26 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FOR_EACH(vec_handle: u64, fn_ptr: u64) {
     items.iter().for_each(|&x| f(x));
 }
 
+/// (cross-runtime #254) `arr.reduce(fn)` sem initial value. JS spec:
+/// primeiro elemento vira acc, loop comeca do index 1. Array vazio
+/// joga TypeError; aqui retornamos 0 (caller pode adicionar guard se
+/// quiser distinguir). Sequencial — sem identity, paralelizar exige
+/// fn associativa garantida.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_REDUCE_NO_INIT(
+    vec_handle: u64,
+    fn_ptr: u64,
+) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 0; };
+    if fn_ptr == 0 || items.is_empty() { return 0; }
+    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let mut acc = items[0];
+    for &x in &items[1..] {
+        acc = f(acc, x);
+    }
+    acc
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PARALLEL_REDUCE(
     vec_handle: u64,


### PR DESCRIPTION
## Summary
- `arr.reduce(fn)` falhava em compile (\"undefined variable\")
- Adiciona `parallel.reduce_no_init` runtime + lifter aceita reduce 1-arg
- Numéricos OK; string concat ainda vaza handle (follow-up)

## Test plan
- [x] 3/4 sub-casos de #254 passam
- [x] suite TS 1195/1195
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)