### PR TITLE
fix(array): sparse slot em literal usa sentinela undefined

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -73,8 +73,12 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
                 ctx.builder.ins().call(push_fn, &[handle, value]);
             }
             None => {
-                let zero = ctx.builder.ins().iconst(cl::I64, 0);
-                ctx.builder.ins().call(push_fn, &[handle, zero]);
+                // (cross-runtime #52) Sparse slot (`[1,,3]`) — JS spec
+                // distingue de slot=0 ou undefined explicito. Usa mesma
+                // sentinela `i64::MIN + 2` (undefined) que join/JSON ja'
+                // tratam como vazio. Bun/Node: join hole vira "" (igual undefined).
+                let s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+                ctx.builder.ins().call(push_fn, &[handle, s]);
             }
         }
     }


### PR DESCRIPTION
## Summary
- `[1,,3].join("|")` produzia `"1|0|3"`; agora `"1||3"` (JS spec)
- Slot vazio em array literal usa `i64::MIN+2` (mesma sentinela existente)

Melhora parcial cross-runtime #52 (resta sparse keys, filter holes em map).

## Test plan
- [x] suite TS 1195/1195
- [x] join sparse bate com Bun
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)