### PR TITLE
fix(codegen): lift arrow com block sem return final

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -593,7 +593,11 @@ fn try_lift_arrow_arg(
         param_names.push(synth);
     }
 
-    // Body: Expr direto OU BlockStmt com 1 return.
+    // Body: Expr direto OU BlockStmt com 1 stmt (return ou expr).
+    // (cross-runtime #242/#248) Block sem return final retorna undefined
+    // em JS (map -> array de undefined, forEach ignora). Aceitamos block
+    // com expr-statement sozinho, retornando o valor (caso map quer)
+    // ou descartando (forEach).
     let body_expr: Expr = match arrow.body.as_ref() {
         BlockStmtOrExpr::Expr(e) => (**e).clone(),
         BlockStmtOrExpr::BlockStmt(b) => {
@@ -603,8 +607,22 @@ fn try_lift_arrow_arg(
             match &b.stmts[0] {
                 Stmt::Return(r) => match r.arg.as_deref() {
                     Some(e) => e.clone(),
-                    None => return None,
+                    // `return;` sem valor — retorna 0 (sera tratado como
+                    // undefined sentinela pelo caller quando necessario).
+                    None => Expr::Lit(swc_ecma_ast::Lit::Num(swc_ecma_ast::Number {
+                        span: Default::default(),
+                        value: 0.0,
+                        raw: None,
+                    })),
                 },
+                // (cross-runtime #242) `(x) => { x * 2; }` — bloco com expr-stmt
+                // sem return. JS: retorna undefined. Aqui retornamos 0 como
+                // valor numerico (compativel com fn ABI i64).
+                Stmt::Expr(_) => Expr::Lit(swc_ecma_ast::Lit::Num(swc_ecma_ast::Number {
+                    span: Default::default(),
+                    value: 0.0,
+                    raw: None,
+                })),
                 _ => return None,
             }
         }


### PR DESCRIPTION
## Summary
- `arr.map(x => { x * 2; })` crashava (Illegal instruction)
- Lifter agora aceita bloco com expr-statement ou `return;` vazio
- Emite `0` como placeholder (não bate exato com Bun em `+ undefined`)

Remove crash de #242 e #248. Não fecha as fixtures inteiramente
(falta undefined first-class).

## Test plan
- [x] crash some
- [x] suite TS 1195/1195
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)