### PR TITLE
fix(array): sparse — filter/map/Object.keys pulam holes

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -74,10 +74,10 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
             }
             None => {
                 // (cross-runtime #52) Sparse slot (`[1,,3]`) — JS spec
-                // distingue de slot=0 ou undefined explicito. Usa mesma
-                // sentinela `i64::MIN + 2` (undefined) que join/JSON ja'
-                // tratam como vazio. Bun/Node: join hole vira "" (igual undefined).
-                let s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+                // distingue hole de undefined literal. Hole eh i64::MIN+4
+                // (sentinela exclusiva); Object.keys pula, join trata como
+                // empty (igual undefined).
+                let s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 4);
                 ctx.builder.ins().call(push_fn, &[handle, s]);
             }
         }

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -514,8 +514,16 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {
             out
         }
         Some(Entry::Vec(v)) => {
-            (0..v.len())
-                .map(|i| {
+            // (cross-runtime #52/#94) JS spec: Object.keys em sparse array
+            // retorna so' indices presentes. Slot `i64::MIN + 2` (undefined
+            // sentinela do codegen de array literal) representa hole.
+            // (cross-runtime #52/#94) JS spec: Object.keys em sparse array
+            // pula holes (sentinela i64::MIN+4) mas inclui `undefined` literal
+            // explicito (MIN+2).
+            v.iter()
+                .enumerate()
+                .filter(|(_, x)| **x != i64::MIN + 4)
+                .map(|(i, _)| {
                     alloc_entry(Entry::String(i.to_string().into_bytes())) as i64
                 })
                 .collect()

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -173,8 +173,8 @@ fn join_into(out: &mut Vec<u8>, elems: &[i64], sep_bytes: &[u8], depth: u32) {
             out.extend_from_slice(b"true");
             continue;
         }
-        // (cross-runtime #142) undefined/null em join viram "".
-        if *e == i64::MIN + 2 || *e == i64::MIN + 3 {
+        // (cross-runtime #142/#52) undefined/null/hole em join viram "".
+        if *e == i64::MIN + 2 || *e == i64::MIN + 3 || *e == i64::MIN + 4 {
             continue;
         }
         let h = *e as u64;

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -211,7 +211,7 @@ fn stringify_value_i64(v: i64) -> String {
     // JSON.stringify: undefined/null em array vira "null" (JS spec).
     if v == i64::MIN { return "false".to_string(); }
     if v == i64::MIN + 1 { return "true".to_string(); }
-    if v == i64::MIN + 2 || v == i64::MIN + 3 {
+    if v == i64::MIN + 2 || v == i64::MIN + 3 || v == i64::MIN + 4 {
         return "null".to_string();
     }
     let h = v as u64;

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -35,7 +35,14 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_MAP(vec_handle: u64, fn_ptr: u64) -> u64 
     // `array_methods_pass` so reescreve quando fn esta whitelisted
     // em `purity_pass` (math/string/num/etc puras).
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    let result: Vec<i64> = pool().install(|| items.par_iter().map(|&x| f(x)).collect());
+    // (cross-runtime #52) JS spec: map preserva holes (slot vazio
+    // permanece vazio no resultado, callback nao eh invocado).
+    let result: Vec<i64> = pool().install(|| {
+        items
+            .par_iter()
+            .map(|&x| if x == i64::MIN + 4 { x } else { f(x) })
+            .collect()
+    });
     alloc_entry(Entry::Vec(Box::new(result)))
 }
 
@@ -119,7 +126,12 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FILTER(vec_handle: u64, fn_ptr: u64) -> u
         return 0;
     }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    let result: Vec<i64> = items.into_iter().filter(|&x| cb_truthy(f(x))).collect();
+    // (cross-runtime #52) JS spec: filter pula holes (sparse slot ==
+    // i64::MIN + 4) sem invocar callback. Resultado sem holes.
+    let result: Vec<i64> = items
+        .into_iter()
+        .filter(|&x| x != i64::MIN + 4 && cb_truthy(f(x)))
+        .collect();
     alloc_entry(Entry::Vec(Box::new(result)))
 }
 


### PR DESCRIPTION
## Summary
- Distingue hole (i64::MIN+4) de undefined literal (MIN+2)
- filter/map/Object.keys/JSON pulam holes (JS spec)

Fixa parcialmente cross-runtime #52, #94.

## Test plan
- [x] suite TS 1195/1195
- [x] Object.keys bate com Bun
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)