### PR TITLE
fix(array): reduceRight sem initial (numéricos) (#202 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1274,6 +1274,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT_NO_INIT",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT_NO_INIT
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_FLAT_MAP",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_FLAT_MAP
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1327,7 +1327,8 @@ pub(super) fn lower_array_builtin(
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "reduceRight" => {
-            if call.args.len() != 2 || call.args.iter().any(|a| a.spread.is_some()) {
+            // (cross-runtime #202) reduceRight aceita (fn) ou (fn, init).
+            if !matches!(call.args.len(), 1 | 2) || call.args.iter().any(|a| a.spread.is_some()) {
                 return Ok(None);
             }
             let fn_ptr = match call.args[0].expr.as_ref() {
@@ -1342,15 +1343,25 @@ pub(super) fn lower_array_builtin(
                 }
                 _ => return Ok(None),
             };
-            let init_tv = lower_expr(ctx, &call.args[1].expr)?;
-            let init = ctx.coerce_to_i64(init_tv).val;
-            let f = ctx.get_extern(
-                "__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT",
-                &[cl::I64, cl::I64, cl::I64],
-                Some(cl::I64),
-            )?;
-            let inst = ctx.builder.ins().call(f, &[obj_h, init, fn_ptr]);
-            let v = ctx.builder.inst_results(inst)[0];
+            let v = if call.args.len() == 2 {
+                let init_tv = lower_expr(ctx, &call.args[1].expr)?;
+                let init = ctx.coerce_to_i64(init_tv).val;
+                let f = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(f, &[obj_h, init, fn_ptr]);
+                ctx.builder.inst_results(inst)[0]
+            } else {
+                let f = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT_NO_INIT",
+                    &[cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(f, &[obj_h, fn_ptr]);
+                ctx.builder.inst_results(inst)[0]
+            };
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         // (#208 ES2023) Immutable variants.

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -590,6 +590,24 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT(
     items.into_iter().rev().fold(init, |a, b| f(a, b))
 }
 
+/// (cross-runtime #202) `arr.reduceRight(fn)` sem initial value. JS spec:
+/// ultimo elemento vira acc, loop comeca do penultimo indo pra esquerda.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT_NO_INIT(
+    handle: u64,
+    fn_ptr: u64,
+) -> i64 {
+    let items: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
+    if fn_ptr == 0 || items.is_empty() { return 0; }
+    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let mut iter = items.into_iter().rev();
+    let mut acc = iter.next().unwrap();
+    for x in iter {
+        acc = f(acc, x);
+    }
+    acc
+}
+
 /// (#208) `arr.flatMap(fn)` — map + flat depth=1.
 /// Cada elemento de `fn(x)` deve ser handle de Vec; senao adiciona o
 /// proprio valor.


### PR DESCRIPTION
## Summary
- \`arr.reduceRight(fn)\` (1-arg) caía em fallback com lixo como init
- Novo \`VEC_REDUCE_RIGHT_NO_INIT\` runtime + codegen aceita 1-arg
- Espelha PR #899 (reduce_no_init)

Casos numéricos passam; string concat/nested array ainda vazam handle.

## Test plan
- [x] suite TS 1195/1195
- [x] reduceRight numérico sem initial OK
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)