### PR TITLE
fix(array): findLast retorna undefined em miss (#260)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1324,6 +1324,13 @@ pub(super) fn lower_array_builtin(
             let f = ctx.get_extern(sym, &[cl::I64, cl::I64], Some(cl::I64))?;
             let inst = ctx.builder.ins().call(f, &[obj_h, fn_ptr]);
             let v = ctx.builder.inst_results(inst)[0];
+            // (cross-runtime #260) findLast pode retornar elemento OU
+            // sentinela MIN+2 (undefined). Marca I64 ambiguo via
+            // var_member_call_values — operadores de concat usam TPL_COERCE
+            // pra resolver sentinela/handle/i64. findLastIndex sempre i64.
+            if method == "findLast" {
+                ctx.var_member_call_values.insert(v);
+            }
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "reduceRight" => {

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -256,7 +256,8 @@ fn lift_arrows_in_expr(
                         "map" | "forEach" => Some((0, 1, 1)),
                         "reduce" if call.args.len() == 1 => Some((0, 1, 2)),
                         "reduce" => Some((0, 2, 2)),
-                        "filter" | "find" | "findIndex" | "some" | "every" => {
+                        "filter" | "find" | "findIndex" | "some" | "every"
+                        | "findLast" | "findLastIndex" => {
                             Some((0, 1, 1))
                         }
                         _ if is_array_from && call.args.len() == 2 => {
@@ -342,6 +343,7 @@ fn lift_arrows_in_expr(
                                     let is_bool_cb = matches!(
                                         method,
                                         "filter" | "find" | "findIndex" | "some" | "every"
+                                        | "findLast" | "findLastIndex"
                                     );
                                     let body_expr: Expr = if is_bool_cb {
                                         // `cb(p) ? 1 : 0` — boolean -> int explicit.

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -552,13 +552,15 @@ pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_VEC(src: u64, fn_ptr: u64) -> u64 {
     alloc_entry(Entry::Vec(Box::new(out)))
 }
 
-/// (#208) `arr.findLast(fn)` — ultimo elemento que satisfaz, ou 0.
+/// (#208) `arr.findLast(fn)` — ultimo elemento que satisfaz, ou undefined.
+/// (cross-runtime #260) Miss retorna sentinela MIN+2 (undefined); codegen
+/// marca como Handle pra TPL_COERCE_AUTO resolver via tabela de sentinelas.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_FIND_LAST(handle: u64, fn_ptr: u64) -> i64 {
     let items: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
-    if fn_ptr == 0 { return 0; }
+    if fn_ptr == 0 { return i64::MIN + 2; }
     let f: extern "C" fn(i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    items.into_iter().rev().find(|&x| f(x) != 0).unwrap_or(0)
+    items.into_iter().rev().find(|&x| f(x) != 0).unwrap_or(i64::MIN + 2)
 }
 
 /// (#208) `arr.findLastIndex(fn)` — index do ultimo match, ou -1.

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -132,6 +132,18 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64(value: i64) -> u64 {
 /// - Handle invalido / nao-handle: trata o valor como i64 raw
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
+    // (cross-runtime sentinelas) Array literal sentinelas viram strings:
+    //   MIN     = false, MIN+1 = true, MIN+2 = undefined, MIN+3 = null,
+    //   MIN+4   = sparse hole (renderiza vazio em join, mas como
+    //   "undefined" quando coergido isoladamente, ex: forOf var).
+    if value == i64::MIN { return alloc_entry(Entry::String(b"false".to_vec())); }
+    if value == i64::MIN + 1 { return alloc_entry(Entry::String(b"true".to_vec())); }
+    if value == i64::MIN + 2 || value == i64::MIN + 4 {
+        return alloc_entry(Entry::String(b"undefined".to_vec()));
+    }
+    if value == i64::MIN + 3 {
+        return alloc_entry(Entry::String(b"null".to_vec()));
+    }
     // (#573) value=0 com tipo Handle representa `null` em RTS (e
     // tambem o sentinel de handle invalido). Em JS, console.log(null)
     // -> "null", consistente com Array.prototype.join e String(null).


### PR DESCRIPTION
## Summary
- TPL_COERCE_AUTO trata 4 sentinelas (false/true/undefined/null) + hole
- findLast retorna sentinela `MIN+2` em miss (era 0)
- Codegen marca findLast como I64 ambíguo → força coerção runtime
- Lifter agora aceita arrow inline para findLast/findLastIndex

Fecha cross-runtime #260.

## Test plan
- [x] suite TS 1195/1195
- [x] #260 bate com Bun
- [x] array_more_methods (user fn ident) continua passando
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)