### PR TITLE
fix(codegen): operador `in` para Vec

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1167,6 +1167,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_GET
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_SET",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_SET
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -364,6 +364,26 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         return lower_instanceof(ctx, bin);
     }
 
+    // (cross-runtime #52) `key in arr` para Vec. JS spec: index `i` esta
+    // "in" array se 0 <= i < length E slot != hole. Usa runtime helper
+    // VEC_HAS_INDEX que retorna 0/1.
+    if matches!(bin.op, BinaryOp::In) {
+        let key_tv = lower_expr(ctx, &bin.left)?;
+        let obj_tv = lower_expr(ctx, &bin.right)?;
+        if matches!(obj_tv.ty, ValTy::Handle) {
+            let idx = ctx.coerce_to_i64(key_tv).val;
+            let obj_h = obj_tv.val;
+            let fref = ctx.get_extern(
+                "__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX",
+                &[cl::I64, cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(fref, &[obj_h, idx]);
+            let v = ctx.builder.inst_results(inst)[0];
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
+    }
+
     // (#643/null-undef) `null == undefined` deve ser true em JS abstract
     // equality. Em RTS, null vira (0, Handle) e undefined vira handle
     // de string "undefined" — comparacao normal falharia. Detecta caso

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -110,6 +110,19 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_GET(handle: u64, index: i64) -> i6
     with_vec(handle, 0, |v| v.get(index as usize).copied().unwrap_or(0))
 }
 
+/// (cross-runtime #52) `index in arr` — true se 0 <= index < length E
+/// slot nao eh hole (sentinela i64::MIN+4). JS spec.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX(handle: u64, index: i64) -> i64 {
+    if index < 0 { return 0; }
+    with_vec(handle, 0, |v| {
+        match v.get(index as usize).copied() {
+            Some(slot) if slot != i64::MIN + 4 => 1,
+            _ => 0,
+        }
+    })
+}
+
 /// Escreve `value` em `index`. No-op fora do range.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SET(handle: u64, index: i64, value: i64) {


### PR DESCRIPTION
## Summary
- \`1 in arr\` para Vec retornava warning; agora retorna bool correto
- Runtime VEC_HAS_INDEX detecta hole (sentinela MIN+4)

Melhora parcial cross-runtime #52.

## Test plan
- [x] suite TS 1195/1195
- [x] manual \`1 in [1,,3]\` bate com Bun
- [x] build limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)