### PR TITLE
feat(math): Math.f16round (ES2024) — fecha cross-runtime math 16/16

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -657,6 +657,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_MATH_EXPM1", basic::__RTS_FN_NS_MATH_EXPM1);
     add_fn!("__RTS_FN_NS_MATH_LOG1P", basic::__RTS_FN_NS_MATH_LOG1P);
     add_fn!("__RTS_FN_NS_MATH_FROUND", basic::__RTS_FN_NS_MATH_FROUND);
+    add_fn!("__RTS_FN_NS_MATH_F16ROUND", basic::__RTS_FN_NS_MATH_F16ROUND);
     add_fn!("__RTS_FN_NS_MATH_SINH", basic::__RTS_FN_NS_MATH_SINH);
     add_fn!("__RTS_FN_NS_MATH_COSH", basic::__RTS_FN_NS_MATH_COSH);
     add_fn!("__RTS_FN_NS_MATH_TANH", basic::__RTS_FN_NS_MATH_TANH);

--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -229,6 +229,23 @@ fn lower_typeof(ctx: &mut FnCtx, operand: &Expr) -> Result<TypedVal> {
             }
         }
     }
+    // `typeof Math.f16round` etc — namespace function members sao
+    // "function" em JS, mas o lower geral abortaria com erro.
+    if let Expr::Member(_) = operand {
+        if let Some(qualified) = crate::codegen::lower::expressions::members::qualified_member_name(operand) {
+            let target: String = if let Some(prop) = qualified.strip_prefix("Math.") {
+                format!("math.{prop}")
+            } else {
+                qualified.clone()
+            };
+            if let Some((_, member)) = crate::abi::lookup(&target) {
+                return match member.kind {
+                    crate::abi::MemberKind::Constant => ctx.emit_str_handle(b"number"),
+                    _ => ctx.emit_str_handle(b"function"),
+                };
+            }
+        }
+    }
     let tv = lower_expr(ctx, operand)?;
     // Handle pode ser string OU symbol/function/object/etc. Em vez de
     // assumir "string" estaticamente, despacha pra runtime helper que

--- a/crates/rts-runtime/src/namespaces/math/abi.rs
+++ b/crates/rts-runtime/src/namespaces/math/abi.rs
@@ -199,6 +199,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: true,
     },
     NamespaceMember {
+        name: "f16round",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_MATH_F16ROUND",
+        args: &[AbiType::F64],
+        returns: AbiType::F64,
+        doc: "Arredonda para IEEE 754 binary16 (half) e volta para f64.",
+        ts_signature: "f16round(x: number): number",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
         name: "sinh",
         kind: MemberKind::Function,
         symbol: "__RTS_FN_NS_MATH_SINH",

--- a/crates/rts-runtime/src/namespaces/math/basic.rs
+++ b/crates/rts-runtime/src/namespaces/math/basic.rs
@@ -107,6 +107,103 @@ pub extern "C" fn __RTS_FN_NS_MATH_FROUND(x: f64) -> f64 {
     x as f32 as f64
 }
 
+/// `Math.f16round(x)` — arredonda para IEEE 754 binary16 (half) e volta para f64.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_MATH_F16ROUND(x: f64) -> f64 {
+    f16_from_f64(x)
+}
+
+fn f16_from_f64(x: f64) -> f64 {
+    if x.is_nan() {
+        return f64::NAN;
+    }
+    if x == 0.0 {
+        return x;
+    }
+    if !x.is_finite() {
+        return x;
+    }
+    let f = x as f32;
+    let bits = f.to_bits();
+    let sign = ((bits >> 31) & 0x1) as u16;
+    let exp = ((bits >> 23) & 0xff) as i32;
+    let mant = bits & 0x7f_ffff;
+
+    let half_bits: u16 = if exp == 0xff {
+        let m16 = if mant != 0 { 0x200 | ((mant >> 13) as u16) } else { 0 };
+        (sign << 15) | (0x1f << 10) | m16
+    } else {
+        let new_exp = exp - 127 + 15;
+        if new_exp >= 0x1f {
+            (sign << 15) | (0x1f << 10)
+        } else if new_exp <= 0 {
+            if new_exp < -10 {
+                sign << 15
+            } else {
+                let m = mant | 0x80_0000;
+                let shift = (14 - new_exp) as u32;
+                let round_bit = 1u32 << (shift - 1);
+                let sticky_mask = round_bit - 1;
+                let sticky = (m & sticky_mask) != 0;
+                let mut q = m >> shift;
+                let r = (m >> (shift - 1)) & 1;
+                if r == 1 && (sticky || (q & 1) == 1) {
+                    q += 1;
+                }
+                (sign << 15) | (q as u16)
+            }
+        } else {
+            let round_bit = 1u32 << 12;
+            let sticky_mask = round_bit - 1;
+            let sticky = (mant & sticky_mask) != 0;
+            let mut q = mant >> 13;
+            let r = (mant >> 12) & 1;
+            if r == 1 && (sticky || (q & 1) == 1) {
+                q += 1;
+            }
+            let mut e = new_exp as u32;
+            if q == 0x400 {
+                q = 0;
+                e += 1;
+            }
+            if e >= 0x1f {
+                (sign << 15) | (0x1f << 10)
+            } else {
+                (sign << 15) | ((e as u16) << 10) | (q as u16)
+            }
+        }
+    };
+
+    half_to_f64(half_bits)
+}
+
+fn half_to_f64(h: u16) -> f64 {
+    let sign = ((h >> 15) & 0x1) as u32;
+    let exp = ((h >> 10) & 0x1f) as u32;
+    let mant = (h & 0x3ff) as u32;
+    let bits32: u32 = if exp == 0 {
+        if mant == 0 {
+            sign << 31
+        } else {
+            let mut m = mant;
+            let mut e: i32 = -14;
+            while (m & 0x400) == 0 {
+                m <<= 1;
+                e -= 1;
+            }
+            m &= 0x3ff;
+            let new_exp = (e + 127) as u32;
+            (sign << 31) | (new_exp << 23) | (m << 13)
+        }
+    } else if exp == 0x1f {
+        (sign << 31) | (0xff << 23) | (mant << 13)
+    } else {
+        let new_exp = exp + (127 - 15);
+        (sign << 31) | (new_exp << 23) | (mant << 13)
+    };
+    f32::from_bits(bits32) as f64
+}
+
 /// (#208) `Math.sinh/cosh/tanh` — funcoes hiperbolicas.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_MATH_SINH(x: f64) -> f64 { x.sinh() }

--- a/tests/cross-runtime/284_math_f16round.ts
+++ b/tests/cross-runtime/284_math_f16round.ts
@@ -1,10 +1,14 @@
-// Cross-runtime: Math.f16round with local fallback when absent.
-const f16 = Math.f16round ?? ((x: number) => {
+// Cross-runtime: Math.f16round (ES2024 spec).
+// Engines sem suporte caem no fallback via if (typeof ...).
+function f16(x: number): number {
+  if (typeof Math.f16round === "function") {
+    return Math.f16round(x);
+  }
   if (Number.isNaN(x) || !Number.isFinite(x) || x === 0) return x;
   if (x === 1.337) return 1.3369140625;
   if (x === 0.1) return 0.0999755859375;
   return Math.fround(x);
-});
+}
 console.log("a=" + String(f16(1.337)));
 console.log("b=" + String(f16(0.1)));
 console.log("c=" + String(f16(NaN)));


### PR DESCRIPTION
## Summary

- Implementa `Math.f16round` (ES2024) — arredonda para IEEE 754 binary16 com round-half-to-even, lida com subnormals/inf/nan.
- `typeof Math.member` agora resolve em compile-time para `"function"`/`"number"` (permite fallback `typeof x === "function" ? ... : ...` em engines sem suporte).
- Fixture `284_math_f16round` valida paridade RTS vs Node 22.

Fecha o último item de `cross-runtime [math]` — categoria vai a 16/16 (100%).

## Test plan
- [x] `cargo build --release` zero warnings
- [x] `cargo test --release` 12 passed, 0 failed
- [x] `target/release/rts.exe test` 1195 passed, 0 failed (458 files)
- [x] `rts run 284_math_f16round.ts` saída byte-a-byte igual a Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)