### PR TITLE
fix(date): Date.parse retorna NaN em falha (JS spec)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -592,6 +592,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     use crate::namespaces::date::ops::*;
     add_fn!("__RTS_FN_NS_DATE_NOW_MS", __RTS_FN_NS_DATE_NOW_MS);
     add_fn!("__RTS_FN_NS_DATE_FROM_ISO", __RTS_FN_NS_DATE_FROM_ISO);
+    add_fn!("__RTS_FN_NS_DATE_PARSE_F64", __RTS_FN_NS_DATE_PARSE_F64);
     add_fn!("__RTS_FN_NS_DATE_FROM_PARTS", __RTS_FN_NS_DATE_FROM_PARTS);
     add_fn!("__RTS_FN_NS_DATE_YEAR", __RTS_FN_NS_DATE_YEAR);
     add_fn!("__RTS_FN_NS_DATE_MONTH", __RTS_FN_NS_DATE_MONTH);

--- a/crates/rts-runtime/src/namespaces/date/ops.rs
+++ b/crates/rts-runtime/src/namespaces/date/ops.rs
@@ -93,6 +93,23 @@ pub extern "C" fn __RTS_FN_NS_DATE_FROM_ISO(ptr: u64, len: i64) -> i64 {
     parse_iso(text).unwrap_or(i64::MIN)
 }
 
+/// `Date.parse(s)` — JS spec: retorna ms desde epoch, ou NaN em falha.
+/// Diferente de `__RTS_FN_NS_DATE_FROM_ISO` (i64 + sentinel) usado pelo
+/// constructor `new Date(string)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DATE_PARSE_F64(ptr: u64, len: i64) -> f64 {
+    let Some(bytes) = slice_from(ptr, len) else {
+        return f64::NAN;
+    };
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return f64::NAN;
+    };
+    match parse_iso(text) {
+        Some(ms) => ms as f64,
+        None => f64::NAN,
+    }
+}
+
 /// Parse ISO 8601 — aceita:
 /// - YYYY-MM-DD (assume 00:00:00.000Z)
 /// - YYYY-MM-DDTHH:MM:SS (assume .000Z)

--- a/crates/rts-runtime/src/namespaces/globals/date/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/date/abi.rs
@@ -18,10 +18,10 @@ pub const MEMBERS: &[NamespaceMember] = &[
     NamespaceMember {
         name: "parse",
         kind: MemberKind::Function,
-        symbol: "__RTS_FN_NS_DATE_FROM_ISO",
+        symbol: "__RTS_FN_NS_DATE_PARSE_F64",
         args: &[AbiType::StrPtr],
-        returns: AbiType::I64,
-        doc: "Parses an ISO 8601 string to ms since epoch. Returns NaN sentinel on failure.",
+        returns: AbiType::F64,
+        doc: "Parses an ISO 8601 string to ms since epoch. Returns NaN on failure (JS spec).",
         ts_signature: "parse(dateString: string): number",
         intrinsic: None,
         pure: true,


### PR DESCRIPTION
## Summary

- `Date.parse(invalidString)` agora retorna NaN (JS spec) em vez do sentinel i64::MIN.
- Novo extern `__RTS_FN_NS_DATE_PARSE_F64` retorna f64 com NaN. Member `parse` no `GlobalClassSpec` aponta pra esse simbolo.
- Constructor `new Date(s)` continua usando `__RTS_FN_NS_DATE_FROM_ISO` (i64+sentinel).
- Fixture `174_date_parse` agora passa: `isNaN(Date.parse(\"invalid\"))` retorna `true`.

Parte de #878 (cross-runtime date). Restam #280 e #43 (bug separado de codegen, ref #674).

## Test plan
- [x] `cargo build --release`
- [x] `cargo test --release` 12 passed
- [x] `rts.exe test` 458 files / 1195 tests passed
- [x] fixture 174 RTS == Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)