### PR TITLE
fix(array): new Array(N) preenche slots com undefined sentinel (#786)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -382,6 +382,44 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         }
     }
 
+    // (#786) `expr === undefined` / `expr !== undefined` quando expr eh
+    // resultado i64 (ex: `new Array(5)[0]` = sentinel i64::MIN+2).
+    // Lhs/rhs antes de lower_expr porque `undefined` ident vira string
+    // handle e a comparacao normal falha.
+    if matches!(bin.op, BinaryOp::EqEqEq | BinaryOp::NotEqEq | BinaryOp::EqEq | BinaryOp::NotEq) {
+        let is_undef_ident = |e: &Expr| matches!(e, Expr::Ident(id) if id.sym.as_str() == "undefined");
+        let lhs_undef = is_undef_ident(&bin.left) && ctx.read_local("undefined").is_none();
+        let rhs_undef = is_undef_ident(&bin.right) && ctx.read_local("undefined").is_none();
+        let other = if rhs_undef {
+            Some(&bin.left)
+        } else if lhs_undef {
+            Some(&bin.right)
+        } else {
+            None
+        };
+        if let Some(other_expr) = other {
+            let other_tv = lower_expr(ctx, other_expr)?;
+            // Caminho aplicavel quando `other` eh I64 (slot de Vec/Array) —
+            // compara com sentinel i64::MIN+2. Handles caem no path generico
+            // (string_eq) que ja' funciona para o caso de ident "undefined".
+            if matches!(other_tv.ty, ValTy::I64 | ValTy::U64) {
+                let sentinel = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+                let eq = ctx.builder.ins().icmp(
+                    cranelift_codegen::ir::condcodes::IntCC::Equal,
+                    other_tv.val,
+                    sentinel,
+                );
+                let result = if matches!(bin.op, BinaryOp::NotEqEq | BinaryOp::NotEq) {
+                    let one = ctx.builder.ins().iconst(cl::I8, 1);
+                    ctx.builder.ins().bxor(eq, one)
+                } else {
+                    eq
+                };
+                return Ok(TypedVal::new(result, ValTy::Bool));
+            }
+        }
+    }
+
     let lhs = lower_expr(ctx, &bin.left)?;
     let rhs = lower_expr(ctx, &bin.right)?;
 

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -483,12 +483,14 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SPLICE_INSERT(
     alloc_entry(Entry::Vec(Box::new(removed)))
 }
 
-/// (#780) `new Array(len)` — cria Vec preenchido com 0 (undefined em V0)
-/// Limitado ao `VEC_MAX_LEN` pra evitar OOM.
+/// (#780/#786) `new Array(len)` — cria Vec preenchido com sentinel
+/// `i64::MIN + 2` (= undefined em RTS), batendo JS spec onde slots
+/// nao inicializados sao undefined, nao 0. Limitado ao `VEC_MAX_LEN`
+/// pra evitar OOM.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_ARRAY_NEW_WITH_LENGTH(len: i64) -> u64 {
     let len = len.max(0).min(VEC_MAX_LEN as i64) as usize;
-    let v = vec![0; len];
+    let v = vec![i64::MIN + 2; len];
     alloc_entry(Entry::Vec(Box::new(v)))
 }
 

--- a/tests/array_constructor.test.ts
+++ b/tests/array_constructor.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "rts:test";
+
+// new Array(N) preenche slots com undefined sentinel (JS spec)
+const a1 = new Array(5);
+const a1_len = a1.length;
+const a1_first_undef = a1[0] === undefined;
+const a1_last_undef = a1[4] === undefined;
+// OOB read returns "" string handle (sem ser sentinel undefined) — fora
+// do escopo de #786, cobrir em follow-up.
+
+// === undefined / !== undefined em slot vazio
+const a2 = new Array(3);
+const a2_neq = a2[1] !== undefined;
+
+// Array(N) sem new
+const a3 = Array(3);
+const a3_len = a3.length;
+const a3_first_undef = a3[0] === undefined;
+
+// Multi-arg constructor preserva valores (nao zera)
+const a4 = new Array(1, 2, 3);
+const a4_values = a4.join(",");
+
+// new Array() (0 args)
+const a5 = new Array();
+const a5_len = a5.length;
+
+describe("array_constructor (#786)", () => {
+  test("new Array(5).length === 5", () => expect(a1_len).toBe(5));
+  test("new Array(5)[0] === undefined", () => expect(a1_first_undef).toBe(true));
+  test("new Array(5)[4] === undefined", () => expect(a1_last_undef).toBe(true));
+  test("slot !== undefined comparison", () => expect(a2_neq).toBe(false));
+  test("Array(3) sem new tambem zera com undefined", () => expect(a3_first_undef).toBe(true));
+  test("Array(3).length === 3", () => expect(a3_len).toBe(3));
+  test("new Array(1,2,3).join", () => expect(a4_values).toBe("1,2,3"));
+  test("new Array() vazio", () => expect(a5_len).toBe(0));
+});


### PR DESCRIPTION
## Summary
- `new Array(N)` agora preenche slots com sentinel undefined em vez de 0
- Codegen detecta `expr === undefined` quando expr eh I64/U64 e compara com o sentinel `i64::MIN + 2`, evitando que `arr[i]` (i64) seja comparado com handle de string "undefined"

Closes #786

## Test plan
- [x] Fixture `tests/cross-runtime/178_array_constructor.ts` bate Bun/Node 100%
- [x] Novo `tests/array_constructor.test.ts` (8 casos) verde
- [x] Suite TS 1195/1195 verde
- [x] `cargo test -p rts-codegen --lib` 69/69 verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)