### PR TITLE
fix(string): charCodeAt NaN + bracket access em string

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1169,6 +1169,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_GET
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO",
+            vec::__RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX
         );
@@ -1483,6 +1487,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_STRING_ENDS_WITH",        rt::__RTS_FN_GL_STRING_ENDS_WITH);
     add_fn!("__RTS_FN_GL_STRING_CHAR_AT",          rt::__RTS_FN_GL_STRING_CHAR_AT);
     add_fn!("__RTS_FN_GL_STRING_CHAR_CODE_AT",     rt::__RTS_FN_GL_STRING_CHAR_CODE_AT);
+    add_fn!("__RTS_FN_GL_STRING_CHAR_CODE_AT_F64", rt::__RTS_FN_GL_STRING_CHAR_CODE_AT_F64);
     add_fn!("__RTS_FN_GL_STRING_CODE_POINT_AT",    rt::__RTS_FN_GL_STRING_CODE_POINT_AT);
     add_fn!("__RTS_FN_GL_STRING_AT",               rt::__RTS_FN_GL_STRING_AT);
     add_fn!("__RTS_FN_GL_STRING_SLICE",            rt::__RTS_FN_GL_STRING_SLICE);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -146,8 +146,8 @@ pub(super) fn lower_string_builtin(
         }
         "charCodeAt" => {
             let idx = arg_i64(ctx, call, 0)?;
-            let v = call_h!("__RTS_FN_GL_STRING_CHAR_CODE_AT", &[cl::I64, cl::I64], Some(cl::I64), &[recv_h, idx]);
-            Ok(Some(TypedVal::new(v, ValTy::I64)))
+            let v = call_h!("__RTS_FN_GL_STRING_CHAR_CODE_AT_F64", &[cl::I64, cl::I64], Some(cl::F64), &[recv_h, idx]);
+            Ok(Some(TypedVal::new(v, ValTy::F64)))
         }
         "codePointAt" => {
             let idx = arg_i64(ctx, call, 0)?;

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1092,8 +1092,9 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 }
                 _ => {
                     let idx = ctx.coerce_to_i64(idx_tv).val;
+                    // INDEX_GET_AUTO roteia em runtime: Vec -> slot, String -> char-at.
                     let get_fn = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_VEC_GET",
+                        "__RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO",
                         &[cl::I64, cl::I64],
                         Some(cl::I64),
                     )?;

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -110,6 +110,39 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_GET(handle: u64, index: i64) -> i6
     with_vec(handle, 0, |v| v.get(index as usize).copied().unwrap_or(0))
 }
 
+/// `obj[i]` auto: se handle for Vec, devolve slot; se String, devolve char-at
+/// (handle de string single-char ou handle de "undefined" out-of-range — JS spec).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO(handle: u64, index: i64) -> i64 {
+    use super::super::gc::handles::with_entry;
+    enum Kind { Vec, Str(Vec<u8>), Other }
+    let kind = with_entry(handle, |e| match e {
+        Some(Entry::Vec(_)) => Kind::Vec,
+        Some(Entry::String(b)) => Kind::Str(b.clone()),
+        _ => Kind::Other,
+    });
+    match kind {
+        Kind::Vec => __RTS_FN_NS_COLLECTIONS_VEC_GET(handle, index),
+        Kind::Str(bytes) => {
+            if index < 0 {
+                return alloc_entry(Entry::String(b"undefined".to_vec())) as i64;
+            }
+            let Ok(s) = std::str::from_utf8(&bytes) else {
+                return alloc_entry(Entry::String(b"undefined".to_vec())) as i64;
+            };
+            match s.chars().nth(index as usize) {
+                Some(c) => {
+                    let mut buf = [0u8; 4];
+                    let encoded = c.encode_utf8(&mut buf).as_bytes().to_vec();
+                    alloc_entry(Entry::String(encoded)) as i64
+                }
+                None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+            }
+        }
+        Kind::Other => 0,
+    }
+}
+
 /// (cross-runtime #52) `index in arr` — true se 0 <= index < length E
 /// slot nao eh hole (sentinela i64::MIN+4). JS spec.
 #[unsafe(no_mangle)]

--- a/crates/rts-runtime/src/namespaces/globals/string/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/string/rt.rs
@@ -236,6 +236,18 @@ pub extern "C" fn __RTS_FN_GL_STRING_CHAR_CODE_AT(recv: u64, idx: i64) -> i64 {
     units.get(idx as usize).map(|&u| u as i64).unwrap_or(-1)
 }
 
+/// `str.charCodeAt(idx)` — JS spec: retorna NaN (f64) fora de range.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_STRING_CHAR_CODE_AT_F64(recv: u64, idx: i64) -> f64 {
+    let Some(s) = handle_to_str(recv) else { return f64::NAN };
+    if idx < 0 { return f64::NAN; }
+    let units: Vec<u16> = s.encode_utf16().collect();
+    match units.get(idx as usize) {
+        Some(&u) => u as f64,
+        None => f64::NAN,
+    }
+}
+
 /// `str.codePointAt(i)` — JS spec: code point que comeca no code unit
 /// `i`. Se `i` for high surrogate seguido de low, retorna o code point
 /// composto (>= 0x10000). Senao retorna o code unit em `i`. Fora de


### PR DESCRIPTION
## Summary

Dois fixes na categoria `cross-runtime [string]`:

1. **`str.charCodeAt(idx)` out-of-range agora retorna NaN** (JS spec). Antes retornava -1 (sentinel). Novo extern `__RTS_FN_GL_STRING_CHAR_CODE_AT_F64`.
2. **`s[i]` (bracket access em string)** funciona agora. `INDEX_GET_AUTO` inspeciona Entry: Vec → slot; String → char-at; outros → 0. Antes `s[0]` retornava `null`.

Parte de #860 cross-runtime [string]. Fixture `140_string_charat_charcodeat` agora difere de Node apenas no `emoji_charAt` (UTF-8 vs UTF-16 surrogate — bug arquitetural fora do escopo).

## Test plan
- [x] `cargo build --release`
- [x] `cargo test --release` 12 passed
- [x] `rts.exe test` 458 files / 1195 tests passed
- [x] `s[0]` retorna char

🤖 Generated with [Claude Code](https://claude.com/claude-code)