### PR TITLE
feat(globals): new Boolean(x) boxed — fecha super #879 (2/2)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -484,6 +484,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_BOOLEAN_COERCE", __RTS_FN_GL_BOOLEAN_COERCE);
         add_fn!("__RTS_FN_GL_BOOLEAN_TO_STRING", __RTS_FN_GL_BOOLEAN_TO_STRING);
         add_fn!("__RTS_FN_GL_BOOLEAN_VALUE_OF", __RTS_FN_GL_BOOLEAN_VALUE_OF);
+        add_fn!("__RTS_FN_GL_BOOLEAN_NEW", __RTS_FN_GL_BOOLEAN_NEW);
+        add_fn!("__RTS_FN_GL_BOOLEAN_NEW_EMPTY", __RTS_FN_GL_BOOLEAN_NEW_EMPTY);
     }
 
     // (#208) encodeURIComponent / decodeURIComponent globais.

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -123,6 +123,19 @@ pub(super) fn lower_coerce_to_boolean(ctx: &mut FnCtx, call: &CallExpr) -> Resul
         if arg.spread.is_some() {
             return Ok(None);
         }
+        // (#879) `Boolean(undefined)` e `Boolean(null)` sao falsy. Em RTS,
+        // `undefined` (Ident) lower vira handle de string "undefined" (len > 0)
+        // e a coerção string_len > 0 daria true incorretamente. Detecta cedo.
+        if let swc_ecma_ast::Expr::Ident(id) = arg.expr.as_ref() {
+            if id.sym.as_str() == "undefined" && ctx.read_local("undefined").is_none() {
+                let v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I8, 0);
+                return Ok(Some(TypedVal::new(v, ValTy::Bool)));
+            }
+        }
+        if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Null(_)) = arg.expr.as_ref() {
+            let v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I8, 0);
+            return Ok(Some(TypedVal::new(v, ValTy::Bool)));
+        }
         let tv = super::lower_expr(ctx, &arg.expr)?;
         // (#550) String coerce: empty string e' falsy. Handle aponta para
         // Entry::String — usar gc.string_len(handle) > 0.

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -177,6 +177,10 @@ pub enum Entry {
     /// real do crate `sha2` — `update()` incremental, `finalize()` nao
     /// reprocessa buffer.
     Hasher(Box<HasherState>),
+    /// `new Boolean(x)` boxed primitive (#879). Wraps a primitive bool so
+    /// `typeof new Boolean(...)` returns "object" while `valueOf()` recovers
+    /// the underlying bool. `Boolean(x)` (no `new`) keeps primitive path.
+    BooleanBox(bool),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -327,6 +327,7 @@ pub extern "C" fn __RTS_FN_RT_TYPEOF_HANDLE(handle: u64) -> u64 {
         Some(Entry::Symbol { .. }) => "symbol",
         Some(Entry::Function(_)) => "function",
         Some(Entry::String(_)) => "string",
+        Some(Entry::BooleanBox(_)) => "object",
         Some(Entry::Vec(_)) | Some(Entry::Map(_)) | Some(Entry::Buffer(_))
         | Some(Entry::Json(_)) | Some(Entry::DateMs(_))
         | Some(Entry::PromiseAsync(_)) | Some(Entry::Promise(_)) => "object",

--- a/crates/rts-runtime/src/namespaces/globals/boolean/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/boolean/abi.rs
@@ -3,6 +3,29 @@
 use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
 
 pub const MEMBERS: &[NamespaceMember] = &[
+    // ── Constructors ─────────────────────────────────────────────────────
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "new Boolean(value) — boxed boolean object. typeof === 'object'.",
+        ts_signature: "new(value: any): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW_EMPTY",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "new Boolean() — boxed Boolean(false).",
+        ts_signature: "new(): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
     // ── Static / coercion ────────────────────────────────────────────────────
     NamespaceMember {
         name: "coerce",
@@ -32,8 +55,8 @@ pub const MEMBERS: &[NamespaceMember] = &[
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_BOOLEAN_VALUE_OF",
         args: &[AbiType::I64],
-        returns: AbiType::I64,
-        doc: "Returns the underlying boolean value (0 or 1).",
+        returns: AbiType::Bool,
+        doc: "Returns the underlying boolean value.",
         ts_signature: "valueOf(): boolean",
         intrinsic: None,
         pure: true,

--- a/crates/rts-runtime/src/namespaces/globals/boolean/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/boolean/rt.rs
@@ -1,5 +1,7 @@
 //! `Boolean` runtime — extern "C" implementations.
 
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
 /// Sentinel para `undefined` em RTS (NaN-tagged i64). Mantido em sync com
 /// outras coercoes do codegen: 0 = false, qualquer outro valor = true,
 /// excepto sentinel undefined.
@@ -16,17 +18,50 @@ pub extern "C" fn __RTS_FN_GL_BOOLEAN_COERCE(value: i64) -> i64 {
     }
 }
 
-/// `b.toString()` — handle de string "true" ou "false".
+/// Quando `recv` for handle de `Entry::BooleanBox`, retorna o bool boxed.
+/// Senao, fallback para interpretar `recv` como i64 primitivo (`recv != 0`).
+fn unbox_bool(recv: i64) -> bool {
+    if recv > 0 {
+        let h = recv as u64;
+        let boxed = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(b)) => Some(*b),
+            _ => None,
+        });
+        if let Some(b) = boxed {
+            return b;
+        }
+    }
+    recv != 0
+}
+
+/// `new Boolean(x)` — aloca `Entry::BooleanBox` e retorna handle. `x` ja' vem
+/// coerced (0 ou 1) pelo codegen.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW(value: i64) -> u64 {
+    let b = value != 0 && value != UNDEFINED_SENTINEL;
+    alloc_entry(Entry::BooleanBox(b))
+}
+
+/// `new Boolean()` — sem args, equivalente a `new Boolean(false)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW_EMPTY() -> u64 {
+    alloc_entry(Entry::BooleanBox(false))
+}
+
+/// `b.toString()` — handle de string "true" ou "false". Aceita tanto handle
+/// boxed (`Entry::BooleanBox`) quanto i64 primitivo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_TO_STRING(b: i64) -> u64 {
-    let s: &[u8] = if b != 0 { b"true" } else { b"false" };
+    let s: &[u8] = if unbox_bool(b) { b"true" } else { b"false" };
     crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64)
 }
 
-/// `b.valueOf()` — retorna o proprio bool.
+/// `b.valueOf()` — retorna o proprio bool. Aceita handle boxed ou primitivo.
+/// AbiType::Bool é mapeado para i64 em Cranelift (`scalar_to_cl`); retorno
+/// é 0 ou 1, e o codegen interpreta como Bool semanticamente para typeof.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_VALUE_OF(b: i64) -> i64 {
-    if b != 0 { 1 } else { 0 }
+    if unbox_bool(b) { 1 } else { 0 }
 }
 
 #[cfg(test)]

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -150,6 +150,8 @@ pub enum Entry {
     WeakMap(Box<std::collections::HashMap<u64, i64>>),
     /// WeakSet (#217 v0). v0 comporta como Set forte sem coleta automatica.
     WeakSet(Box<std::collections::HashSet<u64>>),
+    /// `new Boolean(x)` boxed primitive (#879).
+    BooleanBox(bool),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/src/namespaces/globals/boolean/abi.rs
+++ b/src/namespaces/globals/boolean/abi.rs
@@ -3,6 +3,29 @@
 use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
 
 pub const MEMBERS: &[NamespaceMember] = &[
+    // ── Constructors ─────────────────────────────────────────────────────
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "new Boolean(value) — boxed boolean object. typeof === 'object'.",
+        ts_signature: "new(value: any): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW_EMPTY",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "new Boolean() — boxed Boolean(false).",
+        ts_signature: "new(): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
     // ── Static / coercion ────────────────────────────────────────────────────
     NamespaceMember {
         name: "coerce",
@@ -32,8 +55,8 @@ pub const MEMBERS: &[NamespaceMember] = &[
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_BOOLEAN_VALUE_OF",
         args: &[AbiType::I64],
-        returns: AbiType::I64,
-        doc: "Returns the underlying boolean value (0 or 1).",
+        returns: AbiType::Bool,
+        doc: "Returns the underlying boolean value.",
         ts_signature: "valueOf(): boolean",
         intrinsic: None,
         pure: true,
@@ -42,6 +65,6 @@ pub const MEMBERS: &[NamespaceMember] = &[
 
 pub const BOOLEAN_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
     name: "Boolean",
-    doc: "Built-in Boolean primitive (#208 #226). Boolean(x) coerces any value to boolean.",
+    doc: "Built-in Boolean primitive (#208 #226 #879). Boolean(x) coerces; new Boolean(x) boxes.",
     members: MEMBERS,
 };

--- a/src/namespaces/globals/boolean/rt.rs
+++ b/src/namespaces/globals/boolean/rt.rs
@@ -1,5 +1,7 @@
 //! `Boolean` runtime — extern "C" implementations.
 
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
 /// Sentinel para `undefined` em RTS (NaN-tagged i64). Mantido em sync com
 /// outras coercoes do codegen: 0 = false, qualquer outro valor = true,
 /// excepto sentinel undefined.
@@ -16,17 +18,47 @@ pub extern "C" fn __RTS_FN_GL_BOOLEAN_COERCE(value: i64) -> i64 {
     }
 }
 
-/// `b.toString()` — handle de string "true" ou "false".
+/// Quando `recv` for handle de `Entry::BooleanBox`, retorna o bool boxed.
+/// Senao, fallback para interpretar `recv` como i64 primitivo (`recv != 0`).
+fn unbox_bool(recv: i64) -> bool {
+    if recv > 0 {
+        let h = recv as u64;
+        let boxed = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(b)) => Some(*b),
+            _ => None,
+        });
+        if let Some(b) = boxed {
+            return b;
+        }
+    }
+    recv != 0
+}
+
+/// `new Boolean(x)` — aloca `Entry::BooleanBox` e retorna handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW(value: i64) -> u64 {
+    let b = value != 0 && value != UNDEFINED_SENTINEL;
+    alloc_entry(Entry::BooleanBox(b))
+}
+
+/// `new Boolean()` — sem args, equivalente a `new Boolean(false)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW_EMPTY() -> u64 {
+    alloc_entry(Entry::BooleanBox(false))
+}
+
+/// `b.toString()` — handle de string "true" ou "false". Aceita tanto handle
+/// boxed (`Entry::BooleanBox`) quanto i64 primitivo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_TO_STRING(b: i64) -> u64 {
-    let s: &[u8] = if b != 0 { b"true" } else { b"false" };
+    let s: &[u8] = if unbox_bool(b) { b"true" } else { b"false" };
     crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64)
 }
 
-/// `b.valueOf()` — retorna o proprio bool.
+/// `b.valueOf()` — retorna o proprio bool (i8 0/1, AbiType::Bool).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_VALUE_OF(b: i64) -> i64 {
-    if b != 0 { 1 } else { 0 }
+    if unbox_bool(b) { 1 } else { 0 }
 }
 
 #[cfg(test)]
@@ -76,5 +108,21 @@ mod tests {
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(0), 0);
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(1), 1);
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(42), 1);
+    }
+
+    #[test]
+    fn new_boxed_typeof_object() {
+        let h = __RTS_FN_GL_BOOLEAN_NEW(1);
+        let b = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(v)) => Some(*v),
+            _ => None,
+        });
+        assert_eq!(b, Some(true));
+    }
+
+    #[test]
+    fn unbox_value_of_after_new() {
+        let h = __RTS_FN_GL_BOOLEAN_NEW(0) as i64;
+        assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(h), 0);
     }
 }

--- a/tests/boolean_class.test.ts
+++ b/tests/boolean_class.test.ts
@@ -7,8 +7,10 @@ out += (Boolean(0) ? "t" : "f") + "\n";    // f
 out += (Boolean(1) ? "t" : "f") + "\n";    // t
 out += (Boolean(42) ? "t" : "f") + "\n";   // t
 out += (Boolean(-1) ? "t" : "f") + "\n";   // t
-// Strings em RTS sao handles != 0 mesmo quando vazias — Boolean("") sera true (limitacao documentada).
 out += (Boolean("hello") ? "t" : "f") + "\n"; // t
+out += (Boolean("") ? "t" : "f") + "\n";   // f (#879)
+out += (Boolean(null) ? "t" : "f") + "\n"; // f (#879)
+out += (Boolean(undefined) ? "t" : "f") + "\n"; // f (#879)
 
 // toString via const (literal pode nao casar com member dispatch)
 const bt = true;
@@ -20,8 +22,21 @@ out += bf.toString() + "\n";   // false
 out += (bt.valueOf() ? "t" : "f") + "\n"; // t
 out += (bf.valueOf() ? "t" : "f") + "\n"; // f
 
+// new Boolean(x) — boxed (#879)
+let boxed = "";
+const b1 = new Boolean(true);
+const b2 = new Boolean(false);
+boxed += "valueOf_true=" + b1.valueOf() + "\n";
+boxed += "valueOf_false=" + b2.valueOf() + "\n";
+boxed += "toString_true=" + b1.toString() + "\n";
+boxed += "toString_false=" + b2.toString() + "\n";
+boxed += "typeof=" + (typeof b1) + "\n";
+
 describe("boolean_class", () => {
   test("coerce + toString + valueOf", () => expect(out).toBe(
-    "f\nt\nt\nt\nt\ntrue\nfalse\nt\nf\n"
+    "f\nt\nt\nt\nt\nf\nf\nf\ntrue\nfalse\nt\nf\n"
+  ));
+  test("new Boolean boxed (#879)", () => expect(boxed).toBe(
+    "valueOf_true=true\nvalueOf_false=false\ntoString_true=true\ntoString_false=false\ntypeof=object\n"
   ));
 });


### PR DESCRIPTION
## Summary

- Adiciona `Entry::BooleanBox(bool)` no GC + constructors `__RTS_FN_GL_BOOLEAN_NEW{,_EMPTY}` registrados na ABI + JIT
- `b.valueOf()` / `b.toString()` ganham `unbox_bool` que extrai do BooleanBox quando recv é handle; fallback para primitivo i64
- `TYPEOF_HANDLE` retorna \`\"object\"\` para BooleanBox (typeof spec correto)
- Codegen: `Boolean(undefined)` e `Boolean(null)` viram fast-path falsy (antes caíam em `string_len(\"undefined\") > 0 = true`)
- Sync entre `crates/rts-runtime` e `src/` (regra de duplicação atual)

## Fixtures fechadas (cross-runtime [boolean] 0/2 → 2/2 — fecha super #879)

- `175_boolean_constructor`
- `246_boolean_valueof`

## Test plan
- [x] cargo test --release --lib (12 pass)
- [x] cargo test --release --workspace (1 falha pre-existente: \`map::entries_returns_pairs_sorted\`, sem relação)
- [x] target/release/rts.exe test → 458 files / 1196 tests verde (1196 = 1195 + novo \`boolean_class\`)
- [x] target/release/rts.exe run tests/cross-runtime/175_boolean_constructor.ts → match Bun/Node
- [x] target/release/rts.exe run tests/cross-runtime/246_boolean_valueof.ts → match Bun/Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)