### PR TITLE
feat(globals): Number.is* strict + Object.is -0 + global is* coerce

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -484,6 +484,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_BOOLEAN_COERCE", __RTS_FN_GL_BOOLEAN_COERCE);
         add_fn!("__RTS_FN_GL_BOOLEAN_TO_STRING", __RTS_FN_GL_BOOLEAN_TO_STRING);
         add_fn!("__RTS_FN_GL_BOOLEAN_VALUE_OF", __RTS_FN_GL_BOOLEAN_VALUE_OF);
+        add_fn!("__RTS_FN_GL_BOOLEAN_NEW", __RTS_FN_GL_BOOLEAN_NEW);
+        add_fn!("__RTS_FN_GL_BOOLEAN_NEW_EMPTY", __RTS_FN_GL_BOOLEAN_NEW_EMPTY);
     }
 
     // (#208) encodeURIComponent / decodeURIComponent globais.

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -123,6 +123,19 @@ pub(super) fn lower_coerce_to_boolean(ctx: &mut FnCtx, call: &CallExpr) -> Resul
         if arg.spread.is_some() {
             return Ok(None);
         }
+        // (#879) `Boolean(undefined)` e `Boolean(null)` sao falsy. Em RTS,
+        // `undefined` (Ident) lower vira handle de string "undefined" (len > 0)
+        // e a coerção string_len > 0 daria true incorretamente. Detecta cedo.
+        if let swc_ecma_ast::Expr::Ident(id) = arg.expr.as_ref() {
+            if id.sym.as_str() == "undefined" && ctx.read_local("undefined").is_none() {
+                let v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I8, 0);
+                return Ok(Some(TypedVal::new(v, ValTy::Bool)));
+            }
+        }
+        if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Null(_)) = arg.expr.as_ref() {
+            let v = ctx.builder.ins().iconst(cranelift_codegen::ir::types::I8, 0);
+            return Ok(Some(TypedVal::new(v, ValTy::Bool)));
+        }
         let tv = super::lower_expr(ctx, &arg.expr)?;
         // (#550) String coerce: empty string e' falsy. Handle aponta para
         // Entry::String — usar gc.string_len(handle) > 0.

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -17,7 +17,20 @@ pub(super) fn lower_coerce_is_nan(ctx: &mut FnCtx, call: &CallExpr) -> Result<Ty
         return Err(anyhow!("isNaN: spread arg not supported"));
     }
     let tv = super::lower_expr(ctx, &arg.expr)?;
-    let f = to_f64(ctx, tv);
+    // (#872/130) Global `isNaN(x)` coage para number antes de testar. String
+    // handle vai por NUMBER_FROM_STR (retorna NaN quando nao parseavel — ex:
+    // `isNaN("NaN")` → true).
+    let f = if matches!(tv.ty, ValTy::Handle) {
+        let from_str = ctx.get_extern(
+            "__RTS_FN_GL_NUMBER_FROM_STR",
+            &[cranelift_codegen::ir::types::I64],
+            Some(cranelift_codegen::ir::types::F64),
+        )?;
+        let inst = ctx.builder.ins().call(from_str, &[tv.val]);
+        ctx.builder.inst_results(inst)[0]
+    } else {
+        to_f64(ctx, tv)
+    };
     // FloatCC::Unordered nao eh suportado em alguns backends Cranelift
     // (notavelmente aarch64 — panic \"not implemented\" em
     // lower_fp_condcode). Usa NotEqual(f, f) que eh equivalente:
@@ -41,7 +54,18 @@ pub(super) fn lower_coerce_is_finite(ctx: &mut FnCtx, call: &CallExpr) -> Result
         return Err(anyhow!("isFinite: spread arg not supported"));
     }
     let tv = super::lower_expr(ctx, &arg.expr)?;
-    let f = to_f64(ctx, tv);
+    // (#872/130) Global `isFinite(x)` coage para number antes de testar.
+    let f = if matches!(tv.ty, ValTy::Handle) {
+        let from_str = ctx.get_extern(
+            "__RTS_FN_GL_NUMBER_FROM_STR",
+            &[cranelift_codegen::ir::types::I64],
+            Some(cranelift_codegen::ir::types::F64),
+        )?;
+        let inst = ctx.builder.ins().call(from_str, &[tv.val]);
+        ctx.builder.inst_results(inst)[0]
+    } else {
+        to_f64(ctx, tv)
+    };
     let abs_f = ctx.builder.ins().fabs(f);
     let inf = ctx.builder.ins().f64const(f64::INFINITY);
     let result = ctx.builder.ins().fcmp(FloatCC::LessThan, abs_f, inf);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -860,11 +860,34 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 //   - mesma identidade caso contrario
                 if method == "is" && call.args.len() == 2 {
                     use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-                    let a_tv = lower_expr(ctx, &call.args[0].expr)?;
-                    let b_tv = lower_expr(ctx, &call.args[1].expr)?;
-                    // Se ambos sao F64, faz bitwise comparison (cobre NaN==NaN
-                    // e 0!=-0 corretamente).
-                    if matches!(a_tv.ty, ValTy::F64) || matches!(b_tv.ty, ValTy::F64) {
+                    // (#872/134) Detecta `-N` literal ANTES de lower — em RTS
+                    // `-0` lowera para iconst 0 perdendo o sinal. Materializa
+                    // direto como f64const com sinal preservado quando arg
+                    // for `-<num_lit>`.
+                    let neg_num_lit_f64 = |e: &swc_ecma_ast::Expr| -> Option<f64> {
+                        if let swc_ecma_ast::Expr::Unary(u) = e {
+                            if u.op == swc_ecma_ast::UnaryOp::Minus {
+                                if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Num(n)) = &*u.arg {
+                                    return Some(-n.value);
+                                }
+                            }
+                        }
+                        None
+                    };
+                    let a_neg = neg_num_lit_f64(&call.args[0].expr);
+                    let b_neg = neg_num_lit_f64(&call.args[1].expr);
+                    let force_f64 = a_neg.is_some() || b_neg.is_some();
+                    let a_tv = if let Some(v) = a_neg {
+                        TypedVal::new(ctx.builder.ins().f64const(v), ValTy::F64)
+                    } else {
+                        lower_expr(ctx, &call.args[0].expr)?
+                    };
+                    let b_tv = if let Some(v) = b_neg {
+                        TypedVal::new(ctx.builder.ins().f64const(v), ValTy::F64)
+                    } else {
+                        lower_expr(ctx, &call.args[1].expr)?
+                    };
+                    if force_f64 || matches!(a_tv.ty, ValTy::F64) || matches!(b_tv.ty, ValTy::F64) {
                         let af = if matches!(a_tv.ty, ValTy::F64) {
                             a_tv.val
                         } else {

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -651,6 +651,44 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     return Ok(tv);
                 }
             }
+            // (#879/130) `Number.isFinite/isNaN/isInteger/isSafeInteger`:
+            // JS spec — NAO coage o argumento. Se tipo != number, retorna false.
+            // Distinto do global `isFinite`/`isNaN` (que coagem).
+            if matches!(
+                qualified.as_str(),
+                "Number.isFinite" | "Number.isNaN" | "Number.isInteger" | "Number.isSafeInteger"
+            ) {
+                use crate::codegen::lower::ctx::ValTy;
+                if let Some(arg) = call.args.first() {
+                    if arg.spread.is_none() {
+                        let tv = lower_expr(ctx, &arg.expr)?;
+                        if !matches!(tv.ty, ValTy::F64 | ValTy::I32 | ValTy::I64) {
+                            // Nao-numero → false. (Handle/Bool/U64/Str etc.)
+                            let v = ctx.builder.ins().iconst(cl::I64, 0);
+                            return Ok(TypedVal::new(v, ValTy::Bool));
+                        }
+                        // Number type: delega pra impl normal preservando tv.
+                        let f = match tv.ty {
+                            ValTy::F64 => tv.val,
+                            _ => {
+                                let i = ctx.coerce_to_i64(tv).val;
+                                ctx.builder.ins().fcvt_from_sint(cl::F64, i)
+                            }
+                        };
+                        let sym = match qualified.as_str() {
+                            "Number.isFinite" => "__RTS_FN_GL_NUMBER_IS_FINITE",
+                            "Number.isNaN" => "__RTS_FN_GL_NUMBER_IS_NAN",
+                            "Number.isInteger" => "__RTS_FN_GL_NUMBER_IS_INTEGER",
+                            "Number.isSafeInteger" => "__RTS_FN_GL_NUMBER_IS_SAFE_INT",
+                            _ => unreachable!(),
+                        };
+                        let fref = ctx.get_extern(sym, &[cl::F64], Some(cl::I64))?;
+                        let inst = ctx.builder.ins().call(fref, &[f]);
+                        let v = ctx.builder.inst_results(inst)[0];
+                        return Ok(TypedVal::new(v, ValTy::Bool));
+                    }
+                }
+            }
             // Date static methods (#220): Date.now() / Date.parse() via GlobalClassSpec.
             if let Some((cls, method)) = qualified.split_once('.') {
                 if let Some(spec) = crate::abi::global_class_lookup(cls) {

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -177,6 +177,10 @@ pub enum Entry {
     /// real do crate `sha2` — `update()` incremental, `finalize()` nao
     /// reprocessa buffer.
     Hasher(Box<HasherState>),
+    /// `new Boolean(x)` boxed primitive (#879). Wraps a primitive bool so
+    /// `typeof new Boolean(...)` returns "object" while `valueOf()` recovers
+    /// the underlying bool. `Boolean(x)` (no `new`) keeps primitive path.
+    BooleanBox(bool),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -327,6 +327,7 @@ pub extern "C" fn __RTS_FN_RT_TYPEOF_HANDLE(handle: u64) -> u64 {
         Some(Entry::Symbol { .. }) => "symbol",
         Some(Entry::Function(_)) => "function",
         Some(Entry::String(_)) => "string",
+        Some(Entry::BooleanBox(_)) => "object",
         Some(Entry::Vec(_)) | Some(Entry::Map(_)) | Some(Entry::Buffer(_))
         | Some(Entry::Json(_)) | Some(Entry::DateMs(_))
         | Some(Entry::PromiseAsync(_)) | Some(Entry::Promise(_)) => "object",

--- a/crates/rts-runtime/src/namespaces/globals/boolean/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/boolean/abi.rs
@@ -3,6 +3,29 @@
 use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
 
 pub const MEMBERS: &[NamespaceMember] = &[
+    // ── Constructors ─────────────────────────────────────────────────────
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "new Boolean(value) — boxed boolean object. typeof === 'object'.",
+        ts_signature: "new(value: any): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW_EMPTY",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "new Boolean() — boxed Boolean(false).",
+        ts_signature: "new(): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
     // ── Static / coercion ────────────────────────────────────────────────────
     NamespaceMember {
         name: "coerce",
@@ -32,8 +55,8 @@ pub const MEMBERS: &[NamespaceMember] = &[
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_BOOLEAN_VALUE_OF",
         args: &[AbiType::I64],
-        returns: AbiType::I64,
-        doc: "Returns the underlying boolean value (0 or 1).",
+        returns: AbiType::Bool,
+        doc: "Returns the underlying boolean value.",
         ts_signature: "valueOf(): boolean",
         intrinsic: None,
         pure: true,

--- a/crates/rts-runtime/src/namespaces/globals/boolean/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/boolean/rt.rs
@@ -1,5 +1,7 @@
 //! `Boolean` runtime — extern "C" implementations.
 
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
 /// Sentinel para `undefined` em RTS (NaN-tagged i64). Mantido em sync com
 /// outras coercoes do codegen: 0 = false, qualquer outro valor = true,
 /// excepto sentinel undefined.
@@ -16,17 +18,50 @@ pub extern "C" fn __RTS_FN_GL_BOOLEAN_COERCE(value: i64) -> i64 {
     }
 }
 
-/// `b.toString()` — handle de string "true" ou "false".
+/// Quando `recv` for handle de `Entry::BooleanBox`, retorna o bool boxed.
+/// Senao, fallback para interpretar `recv` como i64 primitivo (`recv != 0`).
+fn unbox_bool(recv: i64) -> bool {
+    if recv > 0 {
+        let h = recv as u64;
+        let boxed = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(b)) => Some(*b),
+            _ => None,
+        });
+        if let Some(b) = boxed {
+            return b;
+        }
+    }
+    recv != 0
+}
+
+/// `new Boolean(x)` — aloca `Entry::BooleanBox` e retorna handle. `x` ja' vem
+/// coerced (0 ou 1) pelo codegen.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW(value: i64) -> u64 {
+    let b = value != 0 && value != UNDEFINED_SENTINEL;
+    alloc_entry(Entry::BooleanBox(b))
+}
+
+/// `new Boolean()` — sem args, equivalente a `new Boolean(false)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW_EMPTY() -> u64 {
+    alloc_entry(Entry::BooleanBox(false))
+}
+
+/// `b.toString()` — handle de string "true" ou "false". Aceita tanto handle
+/// boxed (`Entry::BooleanBox`) quanto i64 primitivo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_TO_STRING(b: i64) -> u64 {
-    let s: &[u8] = if b != 0 { b"true" } else { b"false" };
+    let s: &[u8] = if unbox_bool(b) { b"true" } else { b"false" };
     crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64)
 }
 
-/// `b.valueOf()` — retorna o proprio bool.
+/// `b.valueOf()` — retorna o proprio bool. Aceita handle boxed ou primitivo.
+/// AbiType::Bool é mapeado para i64 em Cranelift (`scalar_to_cl`); retorno
+/// é 0 ou 1, e o codegen interpreta como Bool semanticamente para typeof.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_VALUE_OF(b: i64) -> i64 {
-    if b != 0 { 1 } else { 0 }
+    if unbox_bool(b) { 1 } else { 0 }
 }
 
 #[cfg(test)]

--- a/src/namespaces/gc/handles.rs
+++ b/src/namespaces/gc/handles.rs
@@ -150,6 +150,8 @@ pub enum Entry {
     WeakMap(Box<std::collections::HashMap<u64, i64>>),
     /// WeakSet (#217 v0). v0 comporta como Set forte sem coleta automatica.
     WeakSet(Box<std::collections::HashSet<u64>>),
+    /// `new Boolean(x)` boxed primitive (#879).
+    BooleanBox(bool),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,

--- a/src/namespaces/globals/boolean/abi.rs
+++ b/src/namespaces/globals/boolean/abi.rs
@@ -3,6 +3,29 @@
 use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
 
 pub const MEMBERS: &[NamespaceMember] = &[
+    // ── Constructors ─────────────────────────────────────────────────────
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "new Boolean(value) — boxed boolean object. typeof === 'object'.",
+        ts_signature: "new(value: any): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_BOOLEAN_NEW_EMPTY",
+        args: &[],
+        returns: AbiType::Handle,
+        doc: "new Boolean() — boxed Boolean(false).",
+        ts_signature: "new(): Boolean",
+        intrinsic: None,
+        pure: true,
+    },
     // ── Static / coercion ────────────────────────────────────────────────────
     NamespaceMember {
         name: "coerce",
@@ -32,8 +55,8 @@ pub const MEMBERS: &[NamespaceMember] = &[
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_BOOLEAN_VALUE_OF",
         args: &[AbiType::I64],
-        returns: AbiType::I64,
-        doc: "Returns the underlying boolean value (0 or 1).",
+        returns: AbiType::Bool,
+        doc: "Returns the underlying boolean value.",
         ts_signature: "valueOf(): boolean",
         intrinsic: None,
         pure: true,
@@ -42,6 +65,6 @@ pub const MEMBERS: &[NamespaceMember] = &[
 
 pub const BOOLEAN_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
     name: "Boolean",
-    doc: "Built-in Boolean primitive (#208 #226). Boolean(x) coerces any value to boolean.",
+    doc: "Built-in Boolean primitive (#208 #226 #879). Boolean(x) coerces; new Boolean(x) boxes.",
     members: MEMBERS,
 };

--- a/src/namespaces/globals/boolean/rt.rs
+++ b/src/namespaces/globals/boolean/rt.rs
@@ -1,5 +1,7 @@
 //! `Boolean` runtime — extern "C" implementations.
 
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
 /// Sentinel para `undefined` em RTS (NaN-tagged i64). Mantido em sync com
 /// outras coercoes do codegen: 0 = false, qualquer outro valor = true,
 /// excepto sentinel undefined.
@@ -16,17 +18,47 @@ pub extern "C" fn __RTS_FN_GL_BOOLEAN_COERCE(value: i64) -> i64 {
     }
 }
 
-/// `b.toString()` — handle de string "true" ou "false".
+/// Quando `recv` for handle de `Entry::BooleanBox`, retorna o bool boxed.
+/// Senao, fallback para interpretar `recv` como i64 primitivo (`recv != 0`).
+fn unbox_bool(recv: i64) -> bool {
+    if recv > 0 {
+        let h = recv as u64;
+        let boxed = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(b)) => Some(*b),
+            _ => None,
+        });
+        if let Some(b) = boxed {
+            return b;
+        }
+    }
+    recv != 0
+}
+
+/// `new Boolean(x)` — aloca `Entry::BooleanBox` e retorna handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW(value: i64) -> u64 {
+    let b = value != 0 && value != UNDEFINED_SENTINEL;
+    alloc_entry(Entry::BooleanBox(b))
+}
+
+/// `new Boolean()` — sem args, equivalente a `new Boolean(false)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BOOLEAN_NEW_EMPTY() -> u64 {
+    alloc_entry(Entry::BooleanBox(false))
+}
+
+/// `b.toString()` — handle de string "true" ou "false". Aceita tanto handle
+/// boxed (`Entry::BooleanBox`) quanto i64 primitivo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_TO_STRING(b: i64) -> u64 {
-    let s: &[u8] = if b != 0 { b"true" } else { b"false" };
+    let s: &[u8] = if unbox_bool(b) { b"true" } else { b"false" };
     crate::namespaces::gc::string_pool::__RTS_FN_NS_GC_STRING_NEW(s.as_ptr(), s.len() as i64)
 }
 
-/// `b.valueOf()` — retorna o proprio bool.
+/// `b.valueOf()` — retorna o proprio bool (i8 0/1, AbiType::Bool).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_BOOLEAN_VALUE_OF(b: i64) -> i64 {
-    if b != 0 { 1 } else { 0 }
+    if unbox_bool(b) { 1 } else { 0 }
 }
 
 #[cfg(test)]
@@ -76,5 +108,21 @@ mod tests {
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(0), 0);
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(1), 1);
         assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(42), 1);
+    }
+
+    #[test]
+    fn new_boxed_typeof_object() {
+        let h = __RTS_FN_GL_BOOLEAN_NEW(1);
+        let b = with_entry(h, |e| match e {
+            Some(Entry::BooleanBox(v)) => Some(*v),
+            _ => None,
+        });
+        assert_eq!(b, Some(true));
+    }
+
+    #[test]
+    fn unbox_value_of_after_new() {
+        let h = __RTS_FN_GL_BOOLEAN_NEW(0) as i64;
+        assert_eq!(__RTS_FN_GL_BOOLEAN_VALUE_OF(h), 0);
     }
 }

--- a/tests/boolean_class.test.ts
+++ b/tests/boolean_class.test.ts
@@ -7,8 +7,10 @@ out += (Boolean(0) ? "t" : "f") + "\n";    // f
 out += (Boolean(1) ? "t" : "f") + "\n";    // t
 out += (Boolean(42) ? "t" : "f") + "\n";   // t
 out += (Boolean(-1) ? "t" : "f") + "\n";   // t
-// Strings em RTS sao handles != 0 mesmo quando vazias — Boolean("") sera true (limitacao documentada).
 out += (Boolean("hello") ? "t" : "f") + "\n"; // t
+out += (Boolean("") ? "t" : "f") + "\n";   // f (#879)
+out += (Boolean(null) ? "t" : "f") + "\n"; // f (#879)
+out += (Boolean(undefined) ? "t" : "f") + "\n"; // f (#879)
 
 // toString via const (literal pode nao casar com member dispatch)
 const bt = true;
@@ -20,8 +22,21 @@ out += bf.toString() + "\n";   // false
 out += (bt.valueOf() ? "t" : "f") + "\n"; // t
 out += (bf.valueOf() ? "t" : "f") + "\n"; // f
 
+// new Boolean(x) — boxed (#879)
+let boxed = "";
+const b1 = new Boolean(true);
+const b2 = new Boolean(false);
+boxed += "valueOf_true=" + b1.valueOf() + "\n";
+boxed += "valueOf_false=" + b2.valueOf() + "\n";
+boxed += "toString_true=" + b1.toString() + "\n";
+boxed += "toString_false=" + b2.toString() + "\n";
+boxed += "typeof=" + (typeof b1) + "\n";
+
 describe("boolean_class", () => {
   test("coerce + toString + valueOf", () => expect(out).toBe(
-    "f\nt\nt\nt\nt\ntrue\nfalse\nt\nf\n"
+    "f\nt\nt\nt\nt\nf\nf\nf\ntrue\nfalse\nt\nf\n"
+  ));
+  test("new Boolean boxed (#879)", () => expect(boxed).toBe(
+    "valueOf_true=true\nvalueOf_false=false\ntoString_true=true\ntoString_false=false\ntypeof=object\n"
   ));
 });

--- a/tests/number_static_strict.test.ts
+++ b/tests/number_static_strict.test.ts
@@ -1,0 +1,29 @@
+// #872 fix: Number.isFinite/isNaN/isInteger/isSafeInteger NAO coagem
+// (retornam false para non-number); global isNaN/isFinite coagem string.
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+out += "n_isFinite_str=" + Number.isFinite("5") + "\n";       // false
+out += "n_isNaN_str=" + Number.isNaN("NaN") + "\n";           // false
+out += "n_isInt_str=" + Number.isInteger("5") + "\n";         // false
+out += "n_isSafe_str=" + Number.isSafeInteger("5") + "\n";    // false
+out += "n_isFinite_5=" + Number.isFinite(5) + "\n";           // true
+out += "n_isNaN_NaN=" + Number.isNaN(NaN) + "\n";             // true
+out += "n_isInt_5=" + Number.isInteger(5) + "\n";             // true
+out += "n_isSafe_5=" + Number.isSafeInteger(5) + "\n";        // true
+
+let g = "";
+g += "g_isNaN_str=" + isNaN("NaN") + "\n";       // true (coage "NaN" → NaN)
+g += "g_isNaN_5=" + isNaN("5") + "\n";           // false (coage "5" → 5)
+g += "g_isFinite_str=" + isFinite("5") + "\n";   // true (coage)
+g += "g_isFinite_bad=" + isFinite("abc") + "\n"; // false (NaN)
+
+describe("Number.is* strict + global is* coerce (#872)", () => {
+  test("Number.is* sem coercao", () => expect(out).toBe(
+    "n_isFinite_str=false\nn_isNaN_str=false\nn_isInt_str=false\nn_isSafe_str=false\n" +
+    "n_isFinite_5=true\nn_isNaN_NaN=true\nn_isInt_5=true\nn_isSafe_5=true\n"
+  ));
+  test("global is* com coercao", () => expect(g).toBe(
+    "g_isNaN_str=true\ng_isNaN_5=false\ng_isFinite_str=true\ng_isFinite_bad=false\n"
+  ));
+});

--- a/tests/object_is_neg_zero.test.ts
+++ b/tests/object_is_neg_zero.test.ts
@@ -1,0 +1,16 @@
+// Object.is distingue 0 e -0 (#872 fixture 134).
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+out += "is_0_neg0=" + Object.is(0, -0) + "\n";   // false
+out += "eq_0_neg0=" + (0 === -0) + "\n";          // true (=== nao distingue)
+out += "is_NaN_NaN=" + Object.is(NaN, NaN) + "\n"; // true
+out += "eq_NaN_NaN=" + (NaN === NaN) + "\n";       // false
+out += "is_5_5=" + Object.is(5, 5) + "\n";         // true
+out += "is_5_str=" + Object.is(5, "5") + "\n";     // false
+
+describe("Object.is -0/0 distinction (#872)", () => {
+  test("egal semantics", () => expect(out).toBe(
+    "is_0_neg0=false\neq_0_neg0=true\nis_NaN_NaN=true\neq_NaN_NaN=false\nis_5_5=true\nis_5_str=false\n"
+  ));
+});


### PR DESCRIPTION
Fix fixtures cross-runtime 130/131/134 (super #872 numeric). Number.is* nao coage (false para non-number); global is* coage via NUMBER_FROM_STR; Object.is(0,-0) distingue via -<num_lit> path. 459 files / 1198 tests verde.