### PR TITLE
fix(regexp): source de empty pattern retorna "(?:)" (#877 fixture 250)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -59,6 +59,7 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
 }
 
 /// `re.source` — returns pattern string as a handle.
+/// JS spec: empty pattern returns `"(?:)"` (RegExp.prototype.source default).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_REGEXP_SOURCE(handle: u64) -> u64 {
     let source: Option<String> = with_entry(handle, |entry| match entry {
@@ -66,6 +67,7 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_SOURCE(handle: u64) -> u64 {
         _ => None,
     });
     match source {
+        Some(s) if s.is_empty() => alloc_entry(Entry::String(b"(?:)".to_vec())),
         Some(s) => alloc_entry(Entry::String(s.into_bytes())),
         None => 0,
     }

--- a/src/namespaces/globals/regexp/instance.rs
+++ b/src/namespaces/globals/regexp/instance.rs
@@ -59,6 +59,7 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
 }
 
 /// `re.source` — returns pattern string as a handle.
+/// JS spec: empty pattern returns `"(?:)"`.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_REGEXP_SOURCE(handle: u64) -> u64 {
     let source: Option<String> = with_entry(handle, |entry| match entry {
@@ -66,6 +67,7 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_SOURCE(handle: u64) -> u64 {
         _ => None,
     });
     match source {
+        Some(s) if s.is_empty() => alloc_entry(Entry::String(b"(?:)".to_vec())),
         Some(s) => alloc_entry(Entry::String(s.into_bytes())),
         None => 0,
     }

--- a/tests/regexp_source_empty.test.ts
+++ b/tests/regexp_source_empty.test.ts
@@ -1,0 +1,13 @@
+// (#877) RegExp.prototype.source — empty pattern returns "(?:)".
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+out += "abc=" + (/abc/).source + "\n";
+out += "empty=" + (new RegExp("")).source + "\n";
+out += "digits=" + (new RegExp("\\d+")).source + "\n";
+
+describe("RegExp.source empty (#877)", () => {
+  test("empty pattern returns (?:)", () => expect(out).toBe(
+    "abc=abc\nempty=(?:)\ndigits=\\d+\n"
+  ));
+});


### PR DESCRIPTION
JS spec: `new RegExp("").source === "(?:)"` para preservar invariante `new RegExp(re.source, re.flags)` equivalente. RTS retornava string vazia.

Fixture cross-runtime fechada: **250_regexp_source** (era diverge 1 linha).

461 files / 1207 tests verde, match Bun byte-a-byte.