### PR TITLE
fix(collections): arr.length=N extende com sentinel undefined (#861 fixture 214)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -87,15 +87,14 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH(handle: u64, n: i64) {
         if n < v.len() {
             v.truncate(n);
         } else if n > v.len() {
-            // JS extension: novos slots viram `undefined`. Aloca um
-            // handle `Entry::String(b"undefined")` para cada novo slot,
-            // permitindo `arr[i] === undefined` retornar true via
-            // STRICT_EQ_AMBIG (codegen detecta arr[i] como I64 ambiguo
-            // e roteia para o runtime).
+            // JS extension: novos slots viram `undefined`. Usa sentinel
+            // i64::MIN+2 (reconhecido pelo codegen em `=== undefined`)
+            // em vez de handle de string "undefined" — handle nao casa
+            // com sentinel e arr[i] === undefined retornaria false
+            // (#861 fixture 214).
             let needed = n - v.len();
             for _ in 0..needed {
-                let h = alloc_entry(Entry::String(b"undefined".to_vec()));
-                v.push(h as i64);
+                v.push(i64::MIN + 2);
             }
         }
     });

--- a/tests/array_length_setter_undefined.test.ts
+++ b/tests/array_length_setter_undefined.test.ts
@@ -1,0 +1,20 @@
+// (#861/214) arr.length = N (N > length) extende com sentinel undefined,
+// nao com handle de string "undefined". Permite arr[i] === undefined ser true.
+import { describe, test, expect } from "rts:test";
+
+let out = "";
+const arr = [1, 2, 3];
+arr.length = 5;
+out += "len=" + arr.length + "\n";
+out += "extended=" + (arr[3] === undefined) + "\n";
+out += "extended2=" + (arr[4] === undefined) + "\n";
+
+arr.length = 2;
+out += "truncated=" + arr.join(",") + "\n";
+out += "trunc_len=" + arr.length + "\n";
+
+describe("Array length setter undefined sentinel (#861)", () => {
+  test("extend fills with undefined sentinel", () => expect(out).toBe(
+    "len=5\nextended=true\nextended2=true\ntruncated=1,2\ntrunc_len=2\n"
+  ));
+});


### PR DESCRIPTION
VEC_SET_LENGTH alocava `Entry::String("undefined")` por slot, mas o codegen compara `=== undefined` contra sentinel `i64::MIN+2`. Troca para usar o sentinel direto — evita alocações desnecessárias e `arr[i] === undefined` retorna true.

Fixture cross-runtime fechada: **214_array_length_setter**.

462 files / 1208 tests verde.