### PR TITLE
fix(coalesce): nullish ?? reconhece undefined/null/hole sentinels (#902)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"43e56b49-68df-4ea1-b166-03441e60bad4","pid":28232,"acquiredAt":1778208265116}
+{"sessionId":"97ddab68-9f86-4762-aa31-6ffc97329be0","pid":4380,"acquiredAt":1778773297665}

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1060,7 +1060,19 @@ fn lower_logical(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         }
         BinaryOp::NullishCoalescing => {
             let rhs_block = ctx.builder.create_block();
-            let is_null = ctx.builder.ins().icmp(IntCC::Equal, lhs_i64, zero);
+            // (cross-runtime #902) Nullish em RTS: 0 (null classico),
+            // i64::MIN+2 (undefined), i64::MIN+3 (null sentinela),
+            // i64::MIN+4 (sparse hole — comporta como undefined).
+            let is_zero = ctx.builder.ins().icmp(IntCC::Equal, lhs_i64, zero);
+            let undef_s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+            let null_s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 3);
+            let hole_s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 4);
+            let is_undef = ctx.builder.ins().icmp(IntCC::Equal, lhs_i64, undef_s);
+            let is_null_s = ctx.builder.ins().icmp(IntCC::Equal, lhs_i64, null_s);
+            let is_hole = ctx.builder.ins().icmp(IntCC::Equal, lhs_i64, hole_s);
+            let a = ctx.builder.ins().bor(is_zero, is_undef);
+            let b = ctx.builder.ins().bor(is_null_s, is_hole);
+            let is_null = ctx.builder.ins().bor(a, b);
             ctx.builder
                 .ins()
                 .brif(is_null, rhs_block, &[], merge, &[lhs_i64.into()]);


### PR DESCRIPTION
## Summary
- `NullishCoalescing` comparava apenas `lhs == 0`, ignorando sentinelas RTS (`i64::MIN+2` undefined, `MIN+3` null, `MIN+4` sparse hole)
- Resultado: destructuring com defaults em arrays esparsos (`const [a, b = 20] = [1, ,]`) retornava o sentinela em vez de aplicar default
- Fix: expandir `is_null` pra cobrir os 4 valores nullish

## Test plan
- [x] cross-runtime fixture `104_destructuring_edge_cases` bate Bun/Node
- [x] `cargo test --release --lib` 12/12 verde
- [x] `target/release/rts.exe test` 1209/1209 verde (463 files)

Fecha #902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)