### PR TITLE
feat(regexp): lastIndex getter/setter + exec/g cursor (#782)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -321,6 +321,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_REGEXP_GLOBAL", __RTS_FN_GL_REGEXP_GLOBAL);
     add_fn!("__RTS_FN_GL_REGEXP_IGNORE_CASE", __RTS_FN_GL_REGEXP_IGNORE_CASE);
     add_fn!("__RTS_FN_GL_REGEXP_MULTILINE", __RTS_FN_GL_REGEXP_MULTILINE);
+    add_fn!("__RTS_FN_GL_REGEXP_LAST_INDEX_GET", __RTS_FN_GL_REGEXP_LAST_INDEX_GET);
+    add_fn!("__RTS_FN_GL_REGEXP_LAST_INDEX_SET", __RTS_FN_GL_REGEXP_LAST_INDEX_SET);
 
     // ── namespaces::globals::error (Error class family) ───────────────
     use crate::namespaces::globals::error::instance::*;

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -170,6 +170,24 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     // JS: assignment retorna o RHS.
                     return Ok(TypedVal::new(n, ValTy::I64));
                 }
+                // (#782) `re.lastIndex = N` — setter direto no Entry::Regex.
+                // Runtime ignora handles nao-Regex.
+                if prop.sym.as_str() == "lastIndex" {
+                    use cranelift_codegen::ir::types as cl;
+                    let obj_tv = lower_expr(ctx, &m.obj)?;
+                    if matches!(obj_tv.ty, ValTy::Handle) {
+                        let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                        let val_tv = lower_expr(ctx, &a.right)?;
+                        let n = ctx.coerce_to_i64(val_tv).val;
+                        let f = ctx.get_extern(
+                            "__RTS_FN_GL_REGEXP_LAST_INDEX_SET",
+                            &[cl::I64, cl::I64],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(f, &[obj_h, n]);
+                        return Ok(TypedVal::new(n, ValTy::I64));
+                    }
+                }
             }
         }
         // (#object-setter) Intercepta `obj.X = value` quando obj tem

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -36,6 +36,10 @@ pub struct RtsRegex {
     pub global: bool,
     /// Flags JS canonicas em ordem (`d g i m s u y` apenas as setadas).
     pub flags: String,
+    /// (#782) `lastIndex` JS — posicao para o proximo `exec`/`test` em
+    /// regex global/sticky. Avancado pelo `exec`/`test` em regex `g`,
+    /// resetado para 0 quando o match falha apos o final.
+    pub last_index: usize,
 }
 
 /// Value kinds stored behind a handle. Extensible as namespaces grow.

--- a/crates/rts-runtime/src/namespaces/globals/regexp/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/abi.rs
@@ -94,6 +94,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: true,
     },
     NamespaceMember {
+        name: "lastIndex",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_REGEXP_LAST_INDEX_GET",
+        args: &[AbiType::Handle],
+        returns: AbiType::I64,
+        doc: "Returns lastIndex (position for next exec/test in global regex).",
+        ts_signature: "lastIndex: number",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
         name: "multiline",
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_REGEXP_MULTILINE",

--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -3,7 +3,7 @@
 //! Constructors delegate to `__RTS_FN_NS_REGEX_COMPILE` (which accepts flags).
 //! Instance methods delegate to the existing `regex` namespace ops.
 
-use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -96,6 +96,28 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_MULTILINE(handle: u64) -> i64 {
         Some(Entry::Regex(rx)) => if rx.flags.contains('m') { 1 } else { 0 },
         _ => 0,
     })
+}
+
+/// (#782) `re.lastIndex` — getter retorna posicao do proximo `exec`/`test`
+/// em regex global (ou 0 em regex nao-global).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_REGEXP_LAST_INDEX_GET(handle: u64) -> i64 {
+    with_entry(handle, |entry| match entry {
+        Some(Entry::Regex(rx)) => rx.last_index as i64,
+        _ => 0,
+    })
+}
+
+/// (#782) `re.lastIndex = N` — setter direto. JS spec aceita qualquer
+/// numero; clamps para >= 0 e armazena como usize.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_REGEXP_LAST_INDEX_SET(handle: u64, n: i64) {
+    let v = if n < 0 { 0 } else { n as usize };
+    with_entry_mut(handle, |entry| {
+        if let Some(Entry::Regex(rx)) = entry {
+            rx.last_index = v;
+        }
+    });
 }
 
 /// `re.source` — returns pattern string as a handle.

--- a/crates/rts-runtime/src/namespaces/regex/ops.rs
+++ b/crates/rts-runtime/src/namespaces/regex/ops.rs
@@ -67,7 +67,7 @@ pub extern "C" fn __RTS_FN_NS_REGEX_COMPILE(
         }
     }
     match builder.build() {
-        Ok(rx) => alloc_entry(Entry::Regex(Box::new(crate::namespaces::gc::handles::RtsRegex { regex: rx, global, flags: canon }))),
+        Ok(rx) => alloc_entry(Entry::Regex(Box::new(crate::namespaces::gc::handles::RtsRegex { regex: rx, global, flags: canon, last_index: 0 }))),
         Err(_) => 0,
     }
 }
@@ -85,9 +85,42 @@ pub extern "C" fn __RTS_FN_NS_REGEX_TEST(handle: u64, ptr: *const u8, len: i64) 
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_FIND(handle: u64, ptr: *const u8, len: i64) -> u64 {
-    let s = unsafe { str_from(ptr, len) };
-    let bytes = with_regex(handle, None, |rx| {
-        rx.find(s).map(|m| m.as_str().as_bytes().to_vec())
+    let s_full = unsafe { str_from(ptr, len) };
+    // (#782) JS spec: regex global usa `lastIndex` como cursor; avanca em
+    // match e reseta para 0 em miss ou quando passa do fim. Regex
+    // nao-global ignora `lastIndex` e sempre comeca do 0.
+    let bytes = super::super::gc::handles::with_entry_mut(handle, |entry| {
+        match entry {
+            Some(super::super::gc::handles::Entry::Regex(rx)) => {
+                if rx.global {
+                    let start = rx.last_index;
+                    if start > s_full.len() {
+                        rx.last_index = 0;
+                        return None;
+                    }
+                    // Find a partir de byte offset; precisa que start esteja
+                    // em fronteira UTF-8 (caso contrario reset).
+                    if !s_full.is_char_boundary(start) {
+                        rx.last_index = 0;
+                        return None;
+                    }
+                    match rx.regex.find(&s_full[start..]) {
+                        Some(m) => {
+                            let abs_end = start + m.end();
+                            rx.last_index = abs_end;
+                            Some(m.as_str().as_bytes().to_vec())
+                        }
+                        None => {
+                            rx.last_index = 0;
+                            None
+                        }
+                    }
+                } else {
+                    rx.regex.find(s_full).map(|m| m.as_str().as_bytes().to_vec())
+                }
+            }
+            _ => None,
+        }
     });
     match bytes {
         Some(b) => alloc_string(b),


### PR DESCRIPTION
## Summary

- Adiciona `RtsRegex.last_index` para armazenar o cursor JS de regex global
- `exec`/`find` em regex `/.../g` agora consome `lastIndex`, avança até `m.end()`, e reseta para 0 quando o match falha (spec ECMA-262)
- Expõe `re.lastIndex` como getter (`InstanceMethod` 1-arg) e setter (`re.lastIndex = N` interceptado em `lower_assign_expr`)

Fecha cross-runtime fixture `171_regexp_lastindex` — saída agora bate com Bun/Node byte-a-byte. Categoria regex passa de **4/10 → 5/10**.

## Test plan

- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12 verde
- [x] `target/release/rts.exe test` 1208/1209 (mesma 1 flaky pré-existente em `edge_json_bool_literal` que falha tanto no main quanto na branch)
- [x] Fixture 171 produz mesma saída do Bun/Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)