### PR TITLE
feat(regexp): test() em regex /g avança lastIndex (#673/240)

### DIFF
--- a/crates/rts-runtime/src/namespaces/regex/ops.rs
+++ b/crates/rts-runtime/src/namespaces/regex/ops.rs
@@ -79,8 +79,36 @@ pub extern "C" fn __RTS_FN_NS_REGEX_FREE(handle: u64) {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_TEST(handle: u64, ptr: *const u8, len: i64) -> i64 {
-    let s = unsafe { str_from(ptr, len) };
-    with_regex(handle, 0i64, |rx| if rx.is_match(s) { 1 } else { 0 })
+    let s_full = unsafe { str_from(ptr, len) };
+    // (#673/240) JS spec: regex global usa `lastIndex` como cursor em
+    // `test`; avanca em match e reseta para 0 em miss. Regex nao-global
+    // sempre busca do 0 e nao mexe em `lastIndex`.
+    super::super::gc::handles::with_entry_mut(handle, |entry| match entry {
+        Some(super::super::gc::handles::Entry::Regex(rx)) => {
+            if rx.global {
+                let start = rx.last_index;
+                if start > s_full.len() || !s_full.is_char_boundary(start) {
+                    rx.last_index = 0;
+                    return 0;
+                }
+                match rx.regex.find(&s_full[start..]) {
+                    Some(m) => {
+                        rx.last_index = start + m.end();
+                        1
+                    }
+                    None => {
+                        rx.last_index = 0;
+                        0
+                    }
+                }
+            } else if rx.regex.is_match(s_full) {
+                1
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    })
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
## Summary

- `RegExp.prototype.test()` em regex global agora respeita `lastIndex` (avança em match, reseta em miss) — segue mesma mecânica do `exec()` do PR #934
- Aplicado em `__RTS_FN_NS_REGEX_TEST` no namespace `regex`

Fecha cross-runtime fixture `240_regexp_test_stateful`. Regex **5/10 → 6/10**.

## Test plan

- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1208/1209 (mesma 1 flaky pré-existente em `edge_json_bool_literal`)
- [x] Fixture 240 bate byte-a-byte com Bun/Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)