### PR TITLE
fix(array): arr.at() retorna i64 cru em vez de Handle (#897)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -943,15 +943,16 @@ pub(super) fn lower_array_builtin(
             )?;
             let inst = ctx.builder.ins().call(get_fn, &[obj_h, final_idx]);
             let v = ctx.builder.inst_results(inst)[0];
-            // (cross-runtime #259) OOR (idx<0 ou idx>=len apos ajuste) retorna
-            // undefined; senao retorna o valor. Marca como Handle pra TPL_COERCE
-            // resolver string handle / decimal.
+            // (cross-runtime #897) OOR (idx<0 ou idx>=len apos ajuste) retorna
+            // undefined sentinel; senao retorna o valor cru (i64). Marca como
+            // ambiguo via var_member_call_values pra TPL_COERCE_AUTO formatar.
             let below = ctx.builder.ins().icmp(IntCC::SignedLessThan, final_idx, zero);
             let above = ctx.builder.ins().icmp(IntCC::SignedGreaterThanOrEqual, final_idx, len);
             let oor = ctx.builder.ins().bor(below, above);
             let undef_h = ctx.emit_str_handle(b"undefined")?.val;
             let result = ctx.builder.ins().select(oor, undef_h, v);
-            Ok(Some(TypedVal::new(result, ValTy::Handle)))
+            ctx.var_member_call_values.insert(result);
+            Ok(Some(TypedVal::new(result, ValTy::I64)))
         }
         "join" => {
             // arr.join(sep): converte sep para string handle, chama runtime.

--- a/tests/array_at.test.ts
+++ b/tests/array_at.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const values = [5, 12, 8, 130, 44];
+print("at_neg2=" + values.at(-2));
+print("at_0=" + values.at(0));
+print("at_last=" + values.at(4));
+print("at_neg1=" + values.at(-1));
+print("at_oor_pos=" + values.at(99));
+print("at_oor_neg=" + values.at(-99));
+
+// Em loop / condicional
+let acc = 0;
+for (let i = 0; i < values.length; i++) {
+  acc += values.at(i) as number;
+}
+print("sum=" + acc);
+
+// Array de strings — ainda deve formatar corretamente
+const tags = ["a", "b", "c"];
+print("tag_neg=" + tags.at(-1));
+print("tag_0=" + tags.at(0));
+
+describe("array.at — negative + OOR", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "at_neg2=130\n" +
+      "at_0=5\n" +
+      "at_last=44\n" +
+      "at_neg1=44\n" +
+      "at_oor_pos=undefined\n" +
+      "at_oor_neg=undefined\n" +
+      "sum=199\n" +
+      "tag_neg=c\n" +
+      "tag_0=a\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #897 (cross-runtime divergence em `12_array_higher_order`)
- `arr.at(i)` estava marcando resultado como `ValTy::Handle`, fazendo o template literal interpretar o `i64` (ex: `130`) como handle string e gerar vazio
- Mesmo pattern de `pop()`: retorna `ValTy::I64` + `var_member_call_values.insert` pra `TPL_COERCE_AUTO` formatar corretamente
- Antes: `values.at(-2)` → `""`; Depois: `130` (bate com Bun/Node)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1209/1210 (1 falha pré-existente em `edge_json5`, não regressão)
- [x] Novo teste `tests/array_at.test.ts` cobrindo neg / OOR / loop / array de strings