### PR TITLE
fix(codegen): -0 literal preserva sinal IEEE 754 (#872)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -137,6 +137,18 @@ pub(super) fn lower_unary(ctx: &mut FnCtx, u: &swc_ecma_ast::UnaryExpr) -> Resul
         ));
     }
 
+    // (#872) JS `-0` precisa preservar o sinal — IEEE 754 distingue +0 e -0,
+    // mas `ineg(iconst 0) = 0` perde isso. Quando o operando eh literal
+    // `Num(0)` que viraria I32/I64, emite f64const(-0.0) direto.
+    if matches!(u.op, UnaryOp::Minus) {
+        if let Expr::Lit(Lit::Num(n)) = u.arg.as_ref() {
+            if n.value == 0.0 {
+                let v = ctx.builder.ins().f64const(-0.0_f64);
+                return Ok(TypedVal::new(v, ValTy::F64));
+            }
+        }
+    }
+
     let operand = lower_expr(ctx, &u.arg)?;
     match u.op {
         UnaryOp::Minus => match operand.ty {


### PR DESCRIPTION
## Summary

- JS spec distingue +0 de -0 (IEEE 754), mas RTS lowerava \`-0\` como \`ineg(iconst.i32 0) = 0\` perdendo o sinal
- Fix em \`lower_unary\`: \`UnaryOp::Minus\` aplicado a literal \`Num(0)\` agora emite \`f64const(-0.0)\` direto
- \`1/-0\` agora retorna \`-Infinity\`, \`Object.is(-0, 0)\` retorna \`false\`, \`Object.is(-0, -0)\` retorna \`true\`

Cross-runtime fixture 95_nan_negative_zero ainda diverge em `map`/`set` (Map/Set NaN/-0 keys), escopo separado.

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1208/1209 (mesma 1 flaky pré-existente)
- [x] \`1/-0\` agora \`-Infinity\`
- [x] \`Object.is(-0, 0) === false\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)