### PR TITLE
fix(string): charAt indexa code units UTF-16, nao code points (#762)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/string/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/string/rt.rs
@@ -216,13 +216,23 @@ pub extern "C" fn __RTS_FN_GL_STRING_ENDS_WITH_AT(recv: u64, suffix: u64, end_po
 // ── Indexing methods ───────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
+/// `str.charAt(i)` — JS spec: indexa por UTF-16 code units (nao code points).
+/// Em surrogate pair (emoji etc.), `charAt(0)` retorna o high surrogate isolado
+/// (codifica como char invalido na saida UTF-8, igual Bun/Node).
 pub extern "C" fn __RTS_FN_GL_STRING_CHAR_AT(recv: u64, idx: i64) -> u64 {
     let Some(s) = handle_to_str(recv) else { return alloc_str("") };
     if idx < 0 { return alloc_str(""); }
-    match s.chars().nth(idx as usize) {
-        Some(ch) => { let mut buf = [0u8; 4]; alloc_str(ch.encode_utf8(&mut buf)) }
-        None => alloc_str(""),
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let Some(&unit) = units.get(idx as usize) else { return alloc_str("") };
+    // Tenta decodificar como char valido (BMP nao-surrogate); surrogate isolado
+    // vira REPLACEMENT CHARACTER (U+FFFD) — bate com `console.log` de Bun/Node
+    // que mostra "�" para surrogate orfao.
+    let mut out = String::new();
+    match char::decode_utf16(std::iter::once(unit)).next() {
+        Some(Ok(ch)) => out.push(ch),
+        _ => out.push('\u{FFFD}'),
     }
+    alloc_str(&out)
 }
 
 #[unsafe(no_mangle)]

--- a/tests/string_charat_utf16.test.ts
+++ b/tests/string_charat_utf16.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const str = "hello";
+print("0=" + str.charAt(0));
+print("4=" + str.charAt(4));
+print("10=" + str.charAt(10));
+
+// Emoji fora do BMP — JS spec: charAt indexa code units UTF-16,
+// nao code points. charAt(0) de "😀" retorna o high surrogate (U+D83D)
+// isolado, que vira REPLACEMENT CHARACTER (U+FFFD = "�") na saida.
+const emoji = "😀";
+print("emoji_len=" + emoji.charCodeAt(0));
+print("emoji_isolated=" + (emoji.charAt(0) === "�"));
+
+describe("string.charAt — UTF-16 code units (#762)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "0=h\n" +
+      "4=o\n" +
+      "10=\n" +
+      "emoji_len=55357\n" +
+      "emoji_isolated=true\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #762: `"😀".charAt(0)` retornava emoji inteiro em vez do high surrogate isolado
- JS spec: `charAt` indexa por **UTF-16 code units**, nao code points. Para chars fora do BMP, `charAt(0)` retorna o high surrogate sozinho (`U+D83D`), que no console aparece como REPLACEMENT CHARACTER `�`
- Implementacao: trocar `chars().nth(i)` por `encode_utf16().collect().get(i)` + `char::decode_utf16` (surrogate orfao → U+FFFD)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1209/1210 (mesma falha pre-existente em `edge_json5`)
- [x] Fixture `140_string_charat_charcodeat` agora bate com Bun/Node