### PR TITLE
fix(array.at): valor i64 raw stringifica via TPL_COERCE_AUTO (#897)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -951,7 +951,11 @@ pub(super) fn lower_array_builtin(
             let oor = ctx.builder.ins().bor(below, above);
             let undef_h = ctx.emit_str_handle(b"undefined")?.val;
             let result = ctx.builder.ins().select(oor, undef_h, v);
-            Ok(Some(TypedVal::new(result, ValTy::Handle)))
+            // (cross-runtime #897) Valor pode ser i64 raw (numero) OU handle
+            // de string/object. Marca como var_member_call para que
+            // template literal / console.log use TPL_COERCE_AUTO em runtime.
+            ctx.var_member_call_values.insert(result);
+            Ok(Some(TypedVal::new(result, ValTy::I64)))
         }
         "join" => {
             // arr.join(sep): converte sep para string handle, chama runtime.


### PR DESCRIPTION
## Summary
- `arr.at(idx)` marcava resultado como Handle, mas valores numericos retornados sao i64 raw — `console.log("="+arr.at(2))` virava string vazia
- Fix: marcar como `var_member_call_value` e usar `ValTy::I64`, delegando para `TPL_COERCE_AUTO` em runtime

## Test plan
- [x] cross-runtime fixture `12_array_higher_order` bate Bun/Node
- [x] `cargo test --release --lib` 12/12 verde
- [x] `target/release/rts.exe test` — 1 falha pre-existente nao relacionada (edge_json5/nested obj com bool)

Fecha #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)