### PR TITLE
feat(globals): encodeURI / decodeURI (#775)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -500,6 +500,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         use crate::namespaces::globals::global_this::rt::*;
         add_fn!("__RTS_FN_GL_ENCODE_URI_COMPONENT", __RTS_FN_GL_ENCODE_URI_COMPONENT);
         add_fn!("__RTS_FN_GL_DECODE_URI_COMPONENT", __RTS_FN_GL_DECODE_URI_COMPONENT);
+        add_fn!("__RTS_FN_GL_ENCODE_URI", __RTS_FN_GL_ENCODE_URI);
+        add_fn!("__RTS_FN_GL_DECODE_URI", __RTS_FN_GL_DECODE_URI);
     }
 
     // ── namespaces::globals::weakmap (#217 v0) ───────────────────────

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1676,7 +1676,8 @@ fn lower_js_global_call(
             Ok(Some(TypedVal::new(v, ValTy::F64)))
         }
         // (#208) encodeURIComponent / decodeURIComponent globais.
-        "encodeURIComponent" | "decodeURIComponent"
+        // (#775) encodeURI / decodeURI globais (preservam reserved chars).
+        "encodeURIComponent" | "decodeURIComponent" | "encodeURI" | "decodeURI"
             if call.args.len() == 1 && call.args[0].spread.is_none() =>
         {
             let arg_tv = super::lower_expr(ctx, &call.args[0].expr)?;
@@ -1687,10 +1688,12 @@ fn lower_js_global_call(
             let p = ctx.builder.inst_results(ip)[0];
             let il = ctx.builder.ins().call(len_fn, &[h]);
             let l = ctx.builder.inst_results(il)[0];
-            let sym = if name == "encodeURIComponent" {
-                "__RTS_FN_GL_ENCODE_URI_COMPONENT"
-            } else {
-                "__RTS_FN_GL_DECODE_URI_COMPONENT"
+            let sym = match name {
+                "encodeURIComponent" => "__RTS_FN_GL_ENCODE_URI_COMPONENT",
+                "decodeURIComponent" => "__RTS_FN_GL_DECODE_URI_COMPONENT",
+                "encodeURI" => "__RTS_FN_GL_ENCODE_URI",
+                "decodeURI" => "__RTS_FN_GL_DECODE_URI",
+                _ => unreachable!(),
             };
             let f = ctx.get_extern(sym, &[cl::I64, cl::I64], Some(cl::I64))?;
             let inst = ctx.builder.ins().call(f, &[p, l]);

--- a/crates/rts-runtime/src/namespaces/globals/global_this/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/global_this/rt.rs
@@ -22,6 +22,57 @@ fn is_uri_component_safe(b: u8) -> bool {
     )
 }
 
+/// JS encodeURI: preserva URI reserved chars + URI-component-safe.
+/// Reserved: ; / ? : @ & = + $ , #
+fn is_uri_safe(b: u8) -> bool {
+    is_uri_component_safe(b)
+        || matches!(b, b';' | b'/' | b'?' | b':' | b'@' | b'&' | b'=' | b'+' | b'$' | b',' | b'#')
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ENCODE_URI(ptr: i64, len: i64) -> u64 {
+    let s = str_from_parts(ptr, len);
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        if is_uri_safe(b) {
+            out.push(b);
+        } else {
+            out.push(b'%');
+            out.extend_from_slice(format!("{:02X}", b).as_bytes());
+        }
+    }
+    alloc_entry(Entry::String(out))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_DECODE_URI(ptr: i64, len: i64) -> u64 {
+    // decodeURI preserva reserved chars escapados (%2F nao vira /).
+    // Reserved set: ; / ? : @ & = + $ , #
+    let s = str_from_parts(ptr, len);
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                let b = (h * 16 + l) as u8;
+                if matches!(b, b';' | b'/' | b'?' | b':' | b'@' | b'&' | b'=' | b'+' | b'$' | b',' | b'#') {
+                    out.extend_from_slice(&bytes[i..i + 3]);
+                } else {
+                    out.push(b);
+                }
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    alloc_entry(Entry::String(out))
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_ENCODE_URI_COMPONENT(ptr: i64, len: i64) -> u64 {
     let s = str_from_parts(ptr, len);

--- a/tests/encode_uri.test.ts
+++ b/tests/encode_uri.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const url = "https://example.com/path with spaces";
+print("enc=" + encodeURI(url));
+print("dec=" + decodeURI(encodeURI(url)));
+
+// reserved chars preservados por encodeURI
+print("slash_uri=" + encodeURI("a/b"));
+print("amp_uri=" + encodeURI("a&b"));
+
+// encodeURIComponent escapa tudo
+print("slash_comp=" + encodeURIComponent("/"));
+print("amp_comp=" + encodeURIComponent("&"));
+
+// decodeURI preserva %2F (reserved)
+print("dec_reserved=" + decodeURI("a%2Fb"));
+// decodeURIComponent decodifica tudo
+print("dec_comp=" + decodeURIComponent("a%2Fb"));
+
+describe("encodeURI / decodeURI (#775)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "enc=https://example.com/path%20with%20spaces\n" +
+      "dec=https://example.com/path with spaces\n" +
+      "slash_uri=a/b\n" +
+      "amp_uri=a&b\n" +
+      "slash_comp=%2F\n" +
+      "amp_comp=%26\n" +
+      "dec_reserved=a%2Fb\n" +
+      "dec_comp=a/b\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #775: `encodeURI`/`decodeURI` retornavam `__RUNTIME_ERROR__` (não existiam — só `encodeURIComponent`/`decodeURIComponent`)
- `encodeURI` preserva reserved chars URI (`; / ? : @ & = + \$ , #`) além do conjunto URI-component-safe
- `decodeURI` preserva escapes de reserved chars (não decodifica `%2F` para `/`)
- Fixture `158_encodeuri_decodeuri` agora bate com Bun/Node

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1210/1211 (mesma falha pré-existente em edge_json5)
- [x] Novo teste `tests/encode_uri.test.ts`