### PR TITLE
feat(globals): URIError + EvalError classes (#794)

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -12,6 +12,8 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::error::abi::RANGE_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::error::abi::REF_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::error::abi::SYNTAX_ERROR_CLASS_SPEC,
+    &crate::namespaces::globals::error::abi::URI_ERROR_CLASS_SPEC,
+    &crate::namespaces::globals::error::abi::EVAL_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::events::abi::CLASS_SPEC,
     &crate::namespaces::globals::text_encoding::class_spec::TEXT_ENCODER_CLASS_SPEC,
     &crate::namespaces::globals::text_encoding::class_spec::TEXT_DECODER_CLASS_SPEC,

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -331,6 +331,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_RANGE_ERROR_NEW", __RTS_FN_GL_RANGE_ERROR_NEW);
     add_fn!("__RTS_FN_GL_REF_ERROR_NEW", __RTS_FN_GL_REF_ERROR_NEW);
     add_fn!("__RTS_FN_GL_SYNTAX_ERROR_NEW", __RTS_FN_GL_SYNTAX_ERROR_NEW);
+    add_fn!("__RTS_FN_GL_URI_ERROR_NEW", __RTS_FN_GL_URI_ERROR_NEW);
+    add_fn!("__RTS_FN_GL_EVAL_ERROR_NEW", __RTS_FN_GL_EVAL_ERROR_NEW);
     add_fn!("__RTS_FN_GL_ERROR_MESSAGE", __RTS_FN_GL_ERROR_MESSAGE);
     add_fn!("__RTS_FN_GL_ERROR_NAME", __RTS_FN_GL_ERROR_NAME);
     add_fn!("__RTS_FN_GL_ERROR_TO_STRING", __RTS_FN_GL_ERROR_TO_STRING);

--- a/crates/rts-runtime/src/namespaces/globals/error/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/abi.rs
@@ -279,3 +279,113 @@ pub const SYNTAX_ERROR_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
     doc: "Built-in SyntaxError class.",
     members: SYNTAX_ERROR_MEMBERS,
 };
+
+// ── URIError ───────────────────────────────────────────────────────────────────
+
+pub const URI_ERROR_MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_URI_ERROR_NEW",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Creates a URIError with a message string.",
+        ts_signature: "new URIError(message?: string): URIError",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "message",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_MESSAGE",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error message string.",
+        ts_signature: "message: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "name",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_NAME",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error name (\"URIError\").",
+        ts_signature: "name: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "toString",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_TO_STRING",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Returns \"URIError: <message>\".",
+        ts_signature: "toString(): string",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const URI_ERROR_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "URIError",
+    doc: "Built-in URIError class.",
+    members: URI_ERROR_MEMBERS,
+};
+
+// ── EvalError ──────────────────────────────────────────────────────────────────
+
+pub const EVAL_ERROR_MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_EVAL_ERROR_NEW",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Creates an EvalError with a message string.",
+        ts_signature: "new EvalError(message?: string): EvalError",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "message",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_MESSAGE",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error message string.",
+        ts_signature: "message: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "name",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_NAME",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error name (\"EvalError\").",
+        ts_signature: "name: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "toString",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_TO_STRING",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Returns \"EvalError: <message>\".",
+        ts_signature: "toString(): string",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const EVAL_ERROR_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "EvalError",
+    doc: "Built-in EvalError class.",
+    members: EVAL_ERROR_MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/error/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/instance.rs
@@ -87,6 +87,18 @@ pub extern "C" fn __RTS_FN_GL_SYNTAX_ERROR_NEW(ptr: i64, len: i64) -> u64 {
     alloc_error("SyntaxError", msg)
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_URI_ERROR_NEW(ptr: i64, len: i64) -> u64 {
+    let msg = unsafe { str_from_raw(ptr, len) };
+    alloc_error("URIError", msg)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_EVAL_ERROR_NEW(ptr: i64, len: i64) -> u64 {
+    let msg = unsafe { str_from_raw(ptr, len) };
+    alloc_error("EvalError", msg)
+}
+
 // ── Instance methods ──────────────────────────────────────────────────────────
 
 /// `instanceof Error` (any subtype) — handle aponta para Entry::ErrorObj.

--- a/tests/uri_eval_error.test.ts
+++ b/tests/uri_eval_error.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const u = new URIError("bad uri");
+print("uri_name=" + u.name);
+print("uri_msg=" + u.message);
+print("uri_str=" + u.toString());
+
+const e = new EvalError("eval err");
+print("eval_name=" + e.name);
+print("eval_msg=" + e.message);
+
+// Coexistencia com outros tipos
+const t = new TypeError("t");
+print("type_name=" + t.name);
+
+describe("URIError / EvalError (#794)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "uri_name=URIError\n" +
+      "uri_msg=bad uri\n" +
+      "uri_str=URIError: bad uri\n" +
+      "eval_name=EvalError\n" +
+      "eval_msg=eval err\n" +
+      "type_name=TypeError\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #794: `new URIError(msg)` e `new EvalError(msg)` agora funcionam
- Mesmo pattern de `TypeError`/`RangeError`/`ReferenceError`/`SyntaxError`: `alloc_error` com nome correspondente, members `message`/`name`/`toString`
- Registrados em `GLOBAL_CLASS_SPECS` + JIT symbol table
- Fixture `187_error_types` agora bate com Bun/Node (era `__RUNTIME_ERROR__`)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1211/1212 (mesma falha pre-existente em edge_json5)
- [x] Novo teste `tests/uri_eval_error.test.ts`