### PR TITLE
fix(reduceRight): result stringifica via TPL_COERCE_AUTO (#808)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1370,6 +1370,9 @@ pub(super) fn lower_array_builtin(
                 let inst = ctx.builder.ins().call(f, &[obj_h, fn_ptr]);
                 ctx.builder.inst_results(inst)[0]
             };
+            // (cross-runtime #808) Resultado pode ser handle de string OU
+            // i64 raw — marca como ambiguo pra TPL_COERCE_AUTO em runtime.
+            ctx.var_member_call_values.insert(v);
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         // (#208 ES2023) Immutable variants.


### PR DESCRIPTION
## Summary
- `arr.reduceRight(fn[, init])` marcava result como I64 sem ambiguidade — handle de string virava numero raw em template literal
- Fix: inserir Value em `var_member_call_values` (mesmo padrao de `at`, `findLast`, etc.)

## Test plan
- [x] cross-runtime fixture `202_array_reduceright` avanca de `__RUNTIME_ERROR__` para 3/4 saidas (resta `flat=null` — bug separado de `acc.concat(val)` em arrow)
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1211/1212 (1 fail pre-existente)

Fecha #808 parcialmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)