### PR TITLE
feat(json): JSON.stringify(date) retorna ISO entre aspas (#680/292)

### DIFF
--- a/crates/rts-runtime/src/namespaces/date/ops.rs
+++ b/crates/rts-runtime/src/namespaces/date/ops.rs
@@ -22,6 +22,10 @@ fn slice_from(ptr: u64, len: i64) -> Option<&'static [u8]> {
 
 /// Converte ms-since-epoch em (year, month0, day, hour, min, sec, ms).
 /// month e 0-indexed (Jan=0). Retorna None pra valores absurdos.
+pub fn date_unpack(ts_ms: i64) -> (i64, i64, i64, i64, i64, i64, i64) {
+    unpack(ts_ms)
+}
+
 fn unpack(ts_ms: i64) -> (i64, i64, i64, i64, i64, i64, i64) {
     // Usa euclidean division pra suportar timestamps negativos (pre-1970).
     let days = ts_ms.div_euclid(MS_PER_DAY);

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -197,9 +197,20 @@ fn stringify_any_inner(handle: u64) -> Option<String> {
                 Some(out)
             }
             Entry::Json(j) => serde_json::to_string(j.as_ref()).ok(),
+            // (#680/292) JSON.stringify(date) → ISO entre aspas (toJSON spec).
+            Entry::DateMs(ms) => Some(date_iso_quoted(*ms)),
             _ => None,
         }
     })
+}
+
+/// Helper: formata DateMs como ISO string entre aspas para JSON.
+fn date_iso_quoted(ms: i64) -> String {
+    let (y, mo, d, h, mi, s, mil) = super::super::date::ops::date_unpack(ms);
+    format!(
+        "\"{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z\"",
+        y, mo + 1, d, h, mi, s, mil
+    )
 }
 
 /// Tenta interpretar um i64 dentro de Map/Vec: se o handle apontar para


### PR DESCRIPTION
## Summary

- ECMA-262 \`Date.prototype.toJSON\` retorna isoString — JSON.stringify de Date deve produzir \`\"YYYY-MM-DDTHH:MM:SS.sssZ\"\`
- \`stringify_any_inner\` agora trata \`Entry::DateMs\` retornando ISO entre aspas usando \`date::ops::date_unpack\` (exposto pub para reuso)

Cross-runtime fixture 292: \`date=\` agora bate Bun/Node. \`cls={"__rts_class":"C"}\` ainda divergente — precisa dispatch real de \`toJSON()\` para classes user (escopo maior, follow-up).

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1209/1210 (mesma 1 flaky pré-existente)
- [x] Manual fixture 292 \`date=\` bate Bun/Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)