### PR TITLE
feat(object): Object.getOwnPropertyNames (#789)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1118,6 +1118,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES",
+            map::__RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
             map::__RTS_FN_NS_COLLECTIONS_MAP_VALUES
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -745,6 +745,21 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
+                // (cross-runtime #789) Object.getOwnPropertyNames — inclui
+                // non-enumerable (diferenca para keys). Para arrays inclui
+                // "length" como own property name.
+                if method == "getOwnPropertyNames" && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
                 let target = match method {
                     "values" => "collections.map_values",
                     "hasOwn" => "collections.map_has",

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -534,6 +534,46 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ASSIGN(target: u64, source: u64) -
     target
 }
 
+/// Object.getOwnPropertyNames — inclui keys non-enumerable (diferenca para keys).
+/// Para Vec: ["0","1",...,"length"]. Para Map: todas as keys exceto __proto__.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64) -> u64 {
+    let result: Vec<i64> = with_entry(handle, |e| match e {
+        Some(Entry::Map(m)) => {
+            let mut int_keys: Vec<(u32, String)> = Vec::new();
+            let mut str_keys: Vec<String> = Vec::new();
+            for k in m.keys() {
+                if k.as_str() == "__proto__" { continue; }
+                match parse_array_index(k) {
+                    Some(n) => int_keys.push((n, k.clone())),
+                    None => str_keys.push(k.clone()),
+                }
+            }
+            int_keys.sort_by_key(|(n, _)| *n);
+            let mut out: Vec<i64> = Vec::with_capacity(int_keys.len() + str_keys.len());
+            for (_, k) in int_keys {
+                out.push(alloc_entry(Entry::String(k.into_bytes())) as i64);
+            }
+            for k in str_keys {
+                out.push(alloc_entry(Entry::String(k.into_bytes())) as i64);
+            }
+            out
+        }
+        Some(Entry::Vec(v)) => {
+            // JS spec: arrays incluem "length" como own property name nao-enumerable.
+            let mut out: Vec<i64> = v.iter()
+                .enumerate()
+                .filter(|(_, x)| **x != i64::MIN + 4)
+                .map(|(i, _)| alloc_entry(Entry::String(i.to_string().into_bytes())) as i64)
+                .collect();
+            out.push(alloc_entry(Entry::String(b"length".to_vec())) as i64);
+            out
+        }
+        _ => Vec::new(),
+    });
+    alloc_entry(Entry::Vec(Box::new(result)))
+}
+
 /// Object.keys auto: se handle e' Map retorna keys; se Vec retorna ["0","1",...].
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {

--- a/tests/object_get_own_property_names.test.ts
+++ b/tests/object_get_own_property_names.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj = { a: 1, b: 2 };
+print("obj=" + Object.getOwnPropertyNames(obj).sort().join(","));
+
+const arr = [1, 2, 3];
+print("arr=" + Object.getOwnPropertyNames(arr).sort().join(","));
+
+const empty = {};
+print("empty=" + Object.getOwnPropertyNames(empty).join(","));
+
+describe("Object.getOwnPropertyNames (#789)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "obj=a,b\n" +
+      "arr=0,1,2,length\n" +
+      "empty=\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Implementa `Object.getOwnPropertyNames(obj)` (era `__RUNTIME_ERROR__`)
- Para objetos comuns retorna todas as keys (inclui non-enumerable, diferente de `Object.keys`)
- Para arrays inclui `"length"` como own property name (JS spec)
- Fixture `183_object_getownpropertynames`: 3/4 linhas batem com Bun/Node (a linha `str=` continua divergente porque `new String("hi")` não cria wrapper de string — assunto separado)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1212/1213 (mesma falha pré-existente)
- [x] Novo teste `tests/object_get_own_property_names.test.ts`