### PR TITLE
feat(object): propertyIsEnumerable (#788)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1082,6 +1082,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE",
+            map::__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_SET",
             map::__RTS_FN_NS_COLLECTIONS_MAP_SET
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -146,7 +146,8 @@ pub(super) fn lower_var_member_call(
     }
 
     // (#264 PR5) `obj.hasOwnProperty(key)` — verifica own props sem chain.
-    if prop == "hasOwnProperty" && call.args.len() == 1 {
+    // (cross-runtime #788) `obj.propertyIsEnumerable(key)` — own + enumerable.
+    if (prop == "hasOwnProperty" || prop == "propertyIsEnumerable") && call.args.len() == 1 {
         let key_tv = lower_expr(ctx, &call.args[0].expr)?;
         // Numero -> string handle (JS converte: `arr.hasOwnProperty(0)`
         // testa key "0"). `coerce_to_handle` ja' faz stringify de I64/F64.
@@ -157,11 +158,12 @@ pub(super) fn lower_var_member_call(
         let kptr = ctx.builder.inst_results(inst_p)[0];
         let inst_l = ctx.builder.ins().call(str_len_fn, &[key_h]);
         let klen = ctx.builder.inst_results(inst_l)[0];
-        let has_own = ctx.get_extern(
-            "__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY",
-            &[cl::I64, cl::I64, cl::I64],
-            Some(cl::I64),
-        )?;
+        let sym = if prop == "hasOwnProperty" {
+            "__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY"
+        } else {
+            "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE"
+        };
+        let has_own = ctx.get_extern(sym, &[cl::I64, cl::I64, cl::I64], Some(cl::I64))?;
         let inst = ctx.builder.ins().call(has_own, &[obj_h, kptr, klen]);
         let v = ctx.builder.inst_results(inst)[0];
         return Ok(TypedVal::new(v, ValTy::Bool));

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -171,6 +171,37 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
 }
 
+/// (cross-runtime #788) `obj.propertyIsEnumerable(key)` — true se own
+/// property + enumerable. Inherited (via __proto__) ja' retorna false
+/// porque so' checa own. Para Vec: indices = enumerable, "length" = false.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE(
+    handle: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+) -> i64 {
+    let Some(key) = str_from_abi(key_ptr, key_len) else {
+        return 0;
+    };
+    let vec_result: Option<i64> = with_entry(handle, |e| match e {
+        Some(Entry::Vec(v)) => {
+            // "length" eh own mas non-enumerable em arrays.
+            if key == "length" { Some(0) }
+            else if let Some(n) = parse_array_index(key) {
+                Some(if (n as usize) < v.len() { 1 } else { 0 })
+            } else { Some(0) }
+        }
+        _ => None,
+    });
+    if let Some(r) = vec_result { return r; }
+    // Map: own + enumerable. defineProperty com enumerable:false marca via
+    // is_non_enumerable.
+    let has_own = with_map(handle, false, |m| m.contains_key(key));
+    if !has_own { return 0; }
+    if is_non_enumerable(handle, key) { return 0; }
+    1
+}
+
 /// (#264 PR4) Retorna valor de `key` seguindo cadeia `__proto__`.
 /// Se a key nao existe no map, le `__proto__` (handle de outro Map) e
 /// recursa. Retorna 0 quando atinge o fim da cadeia ou tipo invalido.

--- a/tests/property_is_enumerable.test.ts
+++ b/tests/property_is_enumerable.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj = { a: 1, b: 2 };
+print("a=" + obj.propertyIsEnumerable("a"));
+print("b=" + obj.propertyIsEnumerable("b"));
+print("c=" + obj.propertyIsEnumerable("c"));
+
+const arr = [1, 2, 3];
+print("arr_0=" + arr.propertyIsEnumerable(0));
+print("arr_2=" + arr.propertyIsEnumerable(2));
+print("arr_99=" + arr.propertyIsEnumerable(99));
+// arrays: "length" e own mas non-enumerable
+print("arr_len=" + arr.propertyIsEnumerable("length"));
+
+describe("propertyIsEnumerable (#788)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "a=true\n" +
+      "b=true\n" +
+      "c=false\n" +
+      "arr_0=true\n" +
+      "arr_2=true\n" +
+      "arr_99=false\n" +
+      "arr_len=false\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Implementa `obj.propertyIsEnumerable(key)` (era `__RUNTIME_ERROR__`)
- Reaproveita o dispatch de `hasOwnProperty`; backing fn nova `__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE` respeita `is_non_enumerable` (definido por `Object.defineProperty(obj, k, { enumerable: false })`)
- Para `Vec`: índices em range = true, `"length"` = false (own mas non-enumerable, JS spec)
- Fixture `182_object_propertyisenumerable` agora bate com Bun/Node em todas 7 linhas

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1213/1214 (mesma falha pré-existente)
- [x] Novo teste `tests/property_is_enumerable.test.ts`