### PR TITLE
feat(object): propertyIsEnumerable v0 (#788)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1082,6 +1082,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE",
+            map::__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_SET",
             map::__RTS_FN_NS_COLLECTIONS_MAP_SET
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -145,6 +145,31 @@ pub(super) fn lower_var_member_call(
         }
     }
 
+    // (cross-runtime #788) `obj.propertyIsEnumerable(key)` — v0 retorna
+    // true se key e' own prop e nao foi marcada como nao-enumerable via
+    // defineProperty. Implementacao minimal: equivalente a hasOwnProperty
+    // (defineProperty com enumerable:false ainda nao e' rastreado).
+    // Para arrays, `length` deve retornar false; numeric keys retornam
+    // true se em range. Bate Bun/Node nos casos basicos.
+    if prop == "propertyIsEnumerable" && call.args.len() == 1 {
+        let key_tv = lower_expr(ctx, &call.args[0].expr)?;
+        let key_h = ctx.coerce_to_handle(key_tv)?.val;
+        let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+        let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+        let inst_p = ctx.builder.ins().call(str_ptr_fn, &[key_h]);
+        let kptr = ctx.builder.inst_results(inst_p)[0];
+        let inst_l = ctx.builder.ins().call(str_len_fn, &[key_h]);
+        let klen = ctx.builder.inst_results(inst_l)[0];
+        let f = ctx.get_extern(
+            "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE",
+            &[cl::I64, cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(f, &[obj_h, kptr, klen]);
+        let v = ctx.builder.inst_results(inst)[0];
+        return Ok(TypedVal::new(v, ValTy::Bool));
+    }
+
     // (#264 PR5) `obj.hasOwnProperty(key)` — verifica own props sem chain.
     if prop == "hasOwnProperty" && call.args.len() == 1 {
         let key_tv = lower_expr(ctx, &call.args[0].expr)?;

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -171,6 +171,38 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
 }
 
+/// (cross-runtime #788) `obj.propertyIsEnumerable(key)` — similar a
+/// hasOwnProperty, mas `length` em arrays retorna false (non-enumerable
+/// por spec) e keys herdadas via __proto__ retornam false. v0 nao
+/// rastreia o flag `enumerable` de defineProperty.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE(
+    handle: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+) -> i64 {
+    let Some(key) = str_from_abi(key_ptr, key_len) else {
+        return 0;
+    };
+    let vec_result: Option<i64> = with_entry(handle, |e| match e {
+        Some(Entry::Vec(v)) => {
+            if key == "length" {
+                Some(0)
+            } else if let Some(n) = parse_array_index(key) {
+                Some(if (n as usize) < v.len() { 1 } else { 0 })
+            } else {
+                Some(0)
+            }
+        }
+        _ => None,
+    });
+    if let Some(r) = vec_result {
+        return r;
+    }
+    // Own props apenas — nao segue __proto__.
+    with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
+}
+
 /// (#264 PR4) Retorna valor de `key` seguindo cadeia `__proto__`.
 /// Se a key nao existe no map, le `__proto__` (handle de outro Map) e
 /// recursa. Retorna 0 quando atinge o fim da cadeia ou tipo invalido.


### PR DESCRIPTION
## Summary
- Novo método `obj.propertyIsEnumerable(key)` no codegen (path `obj.X(args)` em `indirect.rs`) + runtime fn `__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE` em `collections/map.rs`
- Para arrays: `length` retorna false (non-enumerable), indices validos retornam true
- Para maps: contém key -> true; nao segue __proto__

## Test plan
- [x] cross-runtime fixture `182_object_propertyisenumerable` 6/7 (resta `hidden=false` pos-defineProperty enumerable:false — v0 limitation)
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1213/1214 (1 fail pre-existente)

Fecha #788 parcialmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)