### PR TITLE
feat(object): Object.getOwnPropertyDescriptor(s) (#749)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -533,6 +533,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS",
+            __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS
+        );
+        add_fn!(
             "__RTS_FN_GL_REFLECT_DEFINE_PROPERTY",
             __RTS_FN_GL_REFLECT_DEFINE_PROPERTY
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -760,6 +760,34 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
+                // (cross-runtime #749) Object.getOwnPropertyDescriptors(obj).
+                if method == "getOwnPropertyDescriptors" && call.args.len() == 1 {
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS",
+                        &[cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
+                // Object.getOwnPropertyDescriptor(obj, key) — reusa Reflect.
+                if method == "getOwnPropertyDescriptor" && call.args.len() == 2 {
+                    let obj_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                    let key_tv = lower_expr(ctx, &call.args[1].expr)?;
+                    let key_h = ctx.coerce_to_handle(key_tv)?.val;
+                    let f = ctx.get_extern(
+                        "__RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR",
+                        &[cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[obj_h, key_h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
                 let target = match method {
                     "values" => "collections.map_values",
                     "hasOwn" => "collections.map_has",

--- a/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
@@ -60,6 +60,33 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR(
     alloc_entry(Entry::Map(Box::new(desc)))
 }
 
+/// (cross-runtime #749) `Object.getOwnPropertyDescriptors(obj)` — Map
+/// onde cada key e' uma own prop e o valor e' um descriptor sintetizado
+/// {value, writable, enumerable, configurable}. Mesma sintese que
+/// Reflect.getOwnPropertyDescriptor faz por key.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS(obj: u64) -> u64 {
+    let mut out: IndexMap<String, i64> = IndexMap::new();
+    let pairs: Vec<(String, i64)> = with_entry(obj, |e| match e {
+        Some(Entry::Map(m)) => m
+            .iter()
+            .filter(|(k, _)| k.as_str() != "__proto__")
+            .map(|(k, v)| (k.clone(), *v))
+            .collect(),
+        _ => Vec::new(),
+    });
+    for (k, v) in pairs {
+        let mut desc: IndexMap<String, i64> = IndexMap::new();
+        desc.insert("value".to_string(), v);
+        desc.insert("writable".to_string(), 1);
+        desc.insert("enumerable".to_string(), 1);
+        desc.insert("configurable".to_string(), 1);
+        let desc_h = alloc_entry(Entry::Map(Box::new(desc))) as i64;
+        out.insert(k, desc_h);
+    }
+    alloc_entry(Entry::Map(Box::new(out)))
+}
+
 /// `Reflect.defineProperty(obj, key, descriptor)` — extrai
 /// `descriptor.value` e faz `obj[key] = value`. Retorna 1 (true).
 /// Ignora writable/enumerable/configurable (sempre tratado como true)

--- a/tests/object_property_descriptors.test.ts
+++ b/tests/object_property_descriptors.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj = { a: 1, b: 2 };
+const descs = Object.getOwnPropertyDescriptors(obj);
+print("keys=" + Object.keys(descs).sort().join(","));
+print("a.value=" + descs.a.value);
+
+const desc = Object.getOwnPropertyDescriptor(obj, "a");
+print("a.value2=" + desc.value);
+
+describe("Object.getOwnPropertyDescriptor(s) (#749)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "keys=a,b\n" +
+      "a.value=1\n" +
+      "a.value2=1\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- `Object.getOwnPropertyDescriptors(obj)`: retorna Map onde cada key é uma own prop e o valor é descriptor sintetizado `{value, writable:1, enumerable:1, configurable:1}`
- `Object.getOwnPropertyDescriptor(obj, key)`: reusa o impl existente de `Reflect.getOwnPropertyDescriptor`
- Fixture `110_object_getownpropertydescriptors` saiu de `__RUNTIME_ERROR__` para output parcial

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1214/1215 (mesma falha pré-existente)