### PR TITLE
fix(truthy): MIN+2/3/4 sentinels falsy (#861 fixture 223)

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -184,6 +184,11 @@ pub extern "C" fn __RTS_FN_RT_TRUTHY(value: i64) -> i64 {
     if value == i64::MIN + 1 {
         return 1;
     }
+    // (cross-runtime #223) Sentinelas undefined/null/hole sao falsy
+    // em JS, equivalentes ao 0 do RTS para fins de truthy check.
+    if value == i64::MIN + 2 || value == i64::MIN + 3 || value == i64::MIN + 4 {
+        return 0;
+    }
     let h = value as u64;
     let snap = with_entry(h, |entry| match entry {
         Some(Entry::String(b)) => {


### PR DESCRIPTION
## Summary
- `__RTS_FN_RT_TRUTHY` nao reconhecia sentinelas `i64::MIN+2/3/4` (undefined/null/sparse hole) como falsy — `arr.filter(x => x)` mantinha esses slots
- Fix: 3 linhas adicionando o check explicito antes do lookup de Entry

## Test plan
- [x] cross-runtime fixture `223_array_filter_truthy` bate Bun/Node (`truthy=1,2,3,4,5`)
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1214/1215 (1 fail pre-existente)

Fecha #861 / fixture 223 parcialmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)