### PR TITLE
fix(reflect): getOwnPropertyDescriptor missing prop -> undefined (#795)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -769,6 +769,11 @@ pub(super) fn lower_opt_chain(
             ctx.builder.seal_block(access_block);
             let access_tv = super::members::lower_member_expr(ctx, &synthetic_member)?;
             let access_ty = access_tv.ty;
+            // (#795) Se o member access foi marcado como ambiguo
+            // (var_member_call_values), propaga para o block param `result`
+            // do merge — caso contrario o template literal renderiza
+            // o sentinel bool/undefined como i64 raw.
+            let access_was_ambig = ctx.var_member_call_values.contains(&access_tv.val);
             let access_val = match access_ty {
                 ValTy::F64 | ValTy::I32 => access_tv.val,
                 _ => ctx.coerce_to_i64(access_tv).val,
@@ -795,6 +800,12 @@ pub(super) fn lower_opt_chain(
             // (#432) Marca o result para que lower_tpl emita "undefined"
             // em vez de "0" quando este valor cair em template literal.
             ctx.optional_chain_values.insert(result);
+            // (#795) Propaga ambiguidade do access para o block param do merge
+            // se o lower_member_expr marcou — assim TPL_COERCE_AUTO eh chamado
+            // no template literal e detecta sentinelas (bool true/undefined).
+            if access_was_ambig {
+                ctx.var_member_call_values.insert(result);
+            }
             Ok(TypedVal::new(result, access_ty))
         }
         swc_ecma_ast::OptChainBase::Call(call) => {

--- a/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
@@ -324,7 +324,9 @@ fn forward_get_own_property_descriptor(target: u64, key_handle: u64) -> u64 {
         Some(Entry::Map(m)) => m.get(&key_str).copied(),
         _ => None,
     });
-    let Some(v) = value else { return 0 };
+    // (#795) JS spec: undefined quando prop nao existe. Handle string
+    // "undefined" — TPL_COERCE_AUTO renderiza como "undefined".
+    let Some(v) = value else { return alloc_entry(Entry::String(b"undefined".to_vec())) };
     let mut desc: indexmap::IndexMap<String, i64> = indexmap::IndexMap::new();
     desc.insert("value".to_string(), v);
     desc.insert("writable".to_string(), 1);

--- a/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
@@ -36,8 +36,11 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR(
     obj: u64,
     key_handle: u64,
 ) -> u64 {
+    // (#795) JS spec: retorna undefined quando prop nao existe. Aloca
+    // handle string "undefined" — TPL_COERCE_AUTO renderiza passthrough.
+    let alloc_undef = || alloc_entry(Entry::String(b"undefined".to_vec()));
     let Some(key_bytes_v) = key_bytes(key_handle) else {
-        return 0;
+        return alloc_undef();
     };
     let key_str = String::from_utf8_lossy(&key_bytes_v).into_owned();
 
@@ -48,7 +51,7 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR(
         _ => None,
     });
     let Some(v) = value else {
-        return 0;
+        return alloc_undef();
     };
 
     // Sintetiza { value, writable: true, enumerable: true, configurable: true }

--- a/tests/reflect_api.test.ts
+++ b/tests/reflect_api.test.ts
@@ -70,7 +70,8 @@ describe("reflect_api", () => {
     test("Reflect.getOwnPropertyDescriptor value", () => expect(descValue).toBe(1));
     test("Reflect.getOwnPropertyDescriptor writable", () =>
         expect(descWritable).toBe(1));
+    // (#795) Missing prop retorna handle de string "undefined" (ECMA spec).
     test("Reflect.getOwnPropertyDescriptor missing", () =>
-        expect(descMissing).toBe(0));
+        expect(descMissing).toBe("undefined"));
     test("Reflect.defineProperty writes value", () => expect(zv).toBe(99));
 });


### PR DESCRIPTION
## Summary

- \`Reflect.getOwnPropertyDescriptor\` agora retorna handle de string \`"undefined"\` quando prop nao existe (era handle 0 -> renderiza como \`"null"\`). Aplicado em ambos forwards (\`reflect/ops.rs\` + \`proxy/ops.rs\`).
- **Bonus**: opt-chain (\`obj?.x\`) agora propaga \`var_member_call_values\` do member access para o block-param do merge — sem isso template literal renderiza sentinelas como i64 raw em vez de delegar para \`TPL_COERCE_AUTO\`.

## Limitação conhecida

Bools no descriptor (\`writable\`/\`enumerable\`/\`configurable\`) continuam como \`1\` numérico por enquanto — mudar para sentinel \`i64::MIN+1\` (que renderiza como \`true\`) quebra vários testes que comparam via \`Reflect.get(...) === 1\`. Refator para Boolean nativo no Map (com semantic preserving \`===\`) fica como follow-up.

Cross-runtime 189: \`desc2=undefined\` agora bate Bun/Node ✓; \`writable=1\` vs \`true\` ainda diverge.

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` **1215/1216** (mesma 1 flaky pré-existente)
- [x] Manual: fixture 189 \`desc2=\` agora bate

🤖 Generated with [Claude Code](https://claude.com/claude-code)