### PR TITLE
feat(gc-weak): WeakRef + FinalizationRegistry stubs (#685)

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -26,6 +26,8 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::boolean::BOOLEAN_CLASS_SPEC,
     &crate::namespaces::globals::weakmap::WEAKMAP_CLASS_SPEC,
     &crate::namespaces::globals::weakset::WEAKSET_CLASS_SPEC,
+    &crate::namespaces::globals::weakref::WEAKREF_CLASS_SPEC,
+    &crate::namespaces::globals::finalization_registry::FINALIZATION_REGISTRY_CLASS_SPEC,
 ];
 
 pub fn global_class_lookup(name: &str) -> Option<&'static GlobalClassSpec> {

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -525,6 +525,21 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_WEAKSET_DELETE", __RTS_FN_GL_WEAKSET_DELETE);
     }
 
+    // ── namespaces::globals::weakref (#685 v0) ────────────────────────
+    {
+        use crate::namespaces::globals::weakref::rt::*;
+        add_fn!("__RTS_FN_GL_WEAKREF_NEW", __RTS_FN_GL_WEAKREF_NEW);
+        add_fn!("__RTS_FN_GL_WEAKREF_DEREF", __RTS_FN_GL_WEAKREF_DEREF);
+    }
+
+    // ── namespaces::globals::finalization_registry (#685 v0) ──────────
+    {
+        use crate::namespaces::globals::finalization_registry::rt::*;
+        add_fn!("__RTS_FN_GL_FINREG_NEW", __RTS_FN_GL_FINREG_NEW);
+        add_fn!("__RTS_FN_GL_FINREG_REGISTER", __RTS_FN_GL_FINREG_REGISTER);
+        add_fn!("__RTS_FN_GL_FINREG_UNREGISTER", __RTS_FN_GL_FINREG_UNREGISTER);
+    }
+
     // ── namespaces::globals::reflect (#218) ──────────────────────────
     {
         use crate::namespaces::globals::reflect::ops::*;

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -173,6 +173,12 @@ pub enum Entry {
     WeakMap(Box<std::collections::HashMap<u64, i64>>),
     /// WeakSet (#217 v0). v0 comporta como Set forte sem coleta automatica.
     WeakSet(Box<std::collections::HashSet<u64>>),
+    /// WeakRef (#685 v0). Armazena handle do target (strong ref por enquanto).
+    /// `deref()` retorna o handle armazenado.
+    WeakRef(u64),
+    /// FinalizationRegistry (#685 v0). Stub — armazena callback handle e lista
+    /// (target, heldValue) sem nunca disparar callback (sem GC weak real).
+    FinalizationRegistry { callback: u64, entries: Vec<(u64, i64)> },
     /// Proxy (#218). `target` e' o objeto subjacente, `handler` e' um Map
     /// com traps `get`, `set`, `has`, `deleteProperty` (handles de Function
     /// reificadas). Quando ausente, MAP_GET_CHAIN/MAP_SET/etc fazem fallback

--- a/crates/rts-runtime/src/namespaces/globals/finalization_registry/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/finalization_registry/abi.rs
@@ -1,0 +1,45 @@
+//! `FinalizationRegistry` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_FINREG_NEW",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Creates a new FinalizationRegistry with cleanup callback.",
+        ts_signature: "new FinalizationRegistry(callback: (heldValue: any) => void): FinalizationRegistry",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "register",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_FINREG_REGISTER",
+        args: &[AbiType::Handle, AbiType::Handle, AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Registers target for cleanup with held value. v0: noop (sem weak ref real).",
+        ts_signature: "register(target: object, heldValue: any, unregisterToken?: object): void",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "unregister",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_FINREG_UNREGISTER",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::Bool,
+        doc: "Unregisters target. v0: sempre retorna false (nada registrado).",
+        ts_signature: "unregister(unregisterToken: object): boolean",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const FINALIZATION_REGISTRY_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "FinalizationRegistry",
+    doc: "Built-in FinalizationRegistry (#685 v0). Stub — register/unregister sao noops; callback nunca dispara.",
+    members: MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/finalization_registry/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/finalization_registry/mod.rs
@@ -1,0 +1,10 @@
+//! `FinalizationRegistry` global class (#685 v0) — stub sem GC weak real.
+//!
+//! v0: register/unregister sao noops. Callback nunca dispara — RTS nao tem
+//! weak ref real ainda. Cobre a shape API exigida por libs que checam
+//! disponibilidade.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::FINALIZATION_REGISTRY_CLASS_SPEC;

--- a/crates/rts-runtime/src/namespaces/globals/finalization_registry/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/finalization_registry/rt.rs
@@ -1,0 +1,59 @@
+//! `FinalizationRegistry` runtime — extern "C" implementations.
+//!
+//! v0: armazena callback + entries mas nunca dispara cleanup. Callback
+//! real exigiria GC weak ref (#393).
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_NEW(callback: u64) -> u64 {
+    alloc_entry(Entry::FinalizationRegistry {
+        callback,
+        entries: Vec::new(),
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_REGISTER(reg: u64, target: u64, held: i64) {
+    with_entry_mut(reg, |e| {
+        if let Some(Entry::FinalizationRegistry { entries, .. }) = e {
+            entries.push((target, held));
+        }
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_UNREGISTER(reg: u64, token: u64) -> i64 {
+    with_entry_mut(reg, |e| {
+        if let Some(Entry::FinalizationRegistry { entries, .. }) = e {
+            let before = entries.len();
+            entries.retain(|(t, _)| *t != token);
+            return i64::from(entries.len() != before);
+        }
+        0
+    })
+}
+
+// callback field intentionally unused for now — silence dead_code.
+#[allow(dead_code)]
+fn _touch_callback(reg: u64) -> u64 {
+    with_entry(reg, |e| match e {
+        Some(Entry::FinalizationRegistry { callback, .. }) => *callback,
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_unregister_roundtrip() {
+        let cb = alloc_entry(Entry::String(b"cb".to_vec()));
+        let reg = __RTS_FN_GL_FINREG_NEW(cb);
+        let target = 0xdeadbeef;
+        __RTS_FN_GL_FINREG_REGISTER(reg, target, 7);
+        assert_eq!(__RTS_FN_GL_FINREG_UNREGISTER(reg, target), 1);
+        assert_eq!(__RTS_FN_GL_FINREG_UNREGISTER(reg, target), 0);
+    }
+}

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -23,4 +23,6 @@ pub mod text_encoding;
 pub mod timers;
 pub mod url;
 pub mod weakmap;
+pub mod weakref;
 pub mod weakset;
+pub mod finalization_registry;

--- a/crates/rts-runtime/src/namespaces/globals/weakref/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/weakref/abi.rs
@@ -1,0 +1,34 @@
+//! `WeakRef` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_WEAKREF_NEW",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Creates a new WeakRef wrapping target.",
+        ts_signature: "new WeakRef(target: object): WeakRef",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "deref",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKREF_DEREF",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Returns the target object (or undefined if collected). v0 sempre retorna target.",
+        ts_signature: "deref(): object | undefined",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const WEAKREF_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WeakRef",
+    doc: "Built-in WeakRef (#685 v0). Strong reference; weak semantics em PR futura.",
+    members: MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/weakref/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/weakref/mod.rs
@@ -1,0 +1,9 @@
+//! `WeakRef` global class (#685 v0) — semantica strong temporaria.
+//!
+//! v0: armazena referencia forte ao target. `deref()` retorna o target
+//! enquanto vivo. Coleta automatica fica para PR futura.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::WEAKREF_CLASS_SPEC;

--- a/crates/rts-runtime/src/namespaces/globals/weakref/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/weakref/rt.rs
@@ -1,0 +1,31 @@
+//! `WeakRef` runtime — extern "C" implementations.
+//!
+//! v0: armazena strong reference. `deref()` retorna o target enquanto
+//! o handle for valido. Coleta automatica fica para PR futura.
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKREF_NEW(target: u64) -> u64 {
+    alloc_entry(Entry::WeakRef(target))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKREF_DEREF(wr: u64) -> u64 {
+    with_entry(wr, |e| match e {
+        Some(Entry::WeakRef(target)) => *target,
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deref_returns_target() {
+        let target = alloc_entry(Entry::String(b"hello".to_vec()));
+        let wr = __RTS_FN_GL_WEAKREF_NEW(target);
+        assert_eq!(__RTS_FN_GL_WEAKREF_DEREF(wr), target);
+    }
+}

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -49,6 +49,8 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::boolean::BOOLEAN_CLASS_SPEC,
     &crate::namespaces::globals::weakmap::WEAKMAP_CLASS_SPEC,
     &crate::namespaces::globals::weakset::WEAKSET_CLASS_SPEC,
+    &crate::namespaces::globals::weakref::WEAKREF_CLASS_SPEC,
+    &crate::namespaces::globals::finalization_registry::FINALIZATION_REGISTRY_CLASS_SPEC,
 ];
 
 /// Global registry of namespaces exposed through the new ABI.

--- a/src/namespaces/globals/finalization_registry/abi.rs
+++ b/src/namespaces/globals/finalization_registry/abi.rs
@@ -1,0 +1,45 @@
+//! `FinalizationRegistry` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_FINREG_NEW",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Creates a new FinalizationRegistry with cleanup callback.",
+        ts_signature: "new FinalizationRegistry(callback: (heldValue: any) => void): FinalizationRegistry",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "register",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_FINREG_REGISTER",
+        args: &[AbiType::Handle, AbiType::Handle, AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Registers target for cleanup with held value. v0: noop (sem weak ref real).",
+        ts_signature: "register(target: object, heldValue: any, unregisterToken?: object): void",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "unregister",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_FINREG_UNREGISTER",
+        args: &[AbiType::Handle, AbiType::Handle],
+        returns: AbiType::Bool,
+        doc: "Unregisters target. v0: sempre retorna false (nada registrado).",
+        ts_signature: "unregister(unregisterToken: object): boolean",
+        intrinsic: None,
+        pure: false,
+    },
+];
+
+pub const FINALIZATION_REGISTRY_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "FinalizationRegistry",
+    doc: "Built-in FinalizationRegistry (#685 v0). Stub — register/unregister sao noops; callback nunca dispara.",
+    members: MEMBERS,
+};

--- a/src/namespaces/globals/finalization_registry/mod.rs
+++ b/src/namespaces/globals/finalization_registry/mod.rs
@@ -1,0 +1,10 @@
+//! `FinalizationRegistry` global class (#685 v0) — stub sem GC weak real.
+//!
+//! v0: register/unregister sao noops. Callback nunca dispara — RTS nao tem
+//! weak ref real ainda. Cobre a shape API exigida por libs que checam
+//! disponibilidade.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::FINALIZATION_REGISTRY_CLASS_SPEC;

--- a/src/namespaces/globals/finalization_registry/rt.rs
+++ b/src/namespaces/globals/finalization_registry/rt.rs
@@ -1,0 +1,59 @@
+//! `FinalizationRegistry` runtime — extern "C" implementations.
+//!
+//! v0: armazena callback + entries mas nunca dispara cleanup. Callback
+//! real exigiria GC weak ref (#393).
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_NEW(callback: u64) -> u64 {
+    alloc_entry(Entry::FinalizationRegistry {
+        callback,
+        entries: Vec::new(),
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_REGISTER(reg: u64, target: u64, held: i64) {
+    with_entry_mut(reg, |e| {
+        if let Some(Entry::FinalizationRegistry { entries, .. }) = e {
+            entries.push((target, held));
+        }
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_FINREG_UNREGISTER(reg: u64, token: u64) -> i64 {
+    with_entry_mut(reg, |e| {
+        if let Some(Entry::FinalizationRegistry { entries, .. }) = e {
+            let before = entries.len();
+            entries.retain(|(t, _)| *t != token);
+            return i64::from(entries.len() != before);
+        }
+        0
+    })
+}
+
+// callback field intentionally unused for now — silence dead_code.
+#[allow(dead_code)]
+fn _touch_callback(reg: u64) -> u64 {
+    with_entry(reg, |e| match e {
+        Some(Entry::FinalizationRegistry { callback, .. }) => *callback,
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_unregister_roundtrip() {
+        let cb = alloc_entry(Entry::String(b"cb".to_vec()));
+        let reg = __RTS_FN_GL_FINREG_NEW(cb);
+        let target = 0xdeadbeef;
+        __RTS_FN_GL_FINREG_REGISTER(reg, target, 7);
+        assert_eq!(__RTS_FN_GL_FINREG_UNREGISTER(reg, target), 1);
+        assert_eq!(__RTS_FN_GL_FINREG_UNREGISTER(reg, target), 0);
+    }
+}

--- a/src/namespaces/globals/mod.rs
+++ b/src/namespaces/globals/mod.rs
@@ -20,4 +20,6 @@ pub mod text_encoding;
 pub mod timers;
 pub mod url;
 pub mod weakmap;
+pub mod weakref;
 pub mod weakset;
+pub mod finalization_registry;

--- a/src/namespaces/globals/weakref/abi.rs
+++ b/src/namespaces/globals/weakref/abi.rs
@@ -1,0 +1,34 @@
+//! `WeakRef` global class — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_WEAKREF_NEW",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Creates a new WeakRef wrapping target.",
+        ts_signature: "new WeakRef(target: object): WeakRef",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "deref",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_WEAKREF_DEREF",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Returns the target object (or undefined if collected). v0 sempre retorna target.",
+        ts_signature: "deref(): object | undefined",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const WEAKREF_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WeakRef",
+    doc: "Built-in WeakRef (#685 v0). Strong reference; weak semantics em PR futura.",
+    members: MEMBERS,
+};

--- a/src/namespaces/globals/weakref/mod.rs
+++ b/src/namespaces/globals/weakref/mod.rs
@@ -1,0 +1,9 @@
+//! `WeakRef` global class (#685 v0) — semantica strong temporaria.
+//!
+//! v0: armazena referencia forte ao target. `deref()` retorna o target
+//! enquanto vivo. Coleta automatica fica para PR futura.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::WEAKREF_CLASS_SPEC;

--- a/src/namespaces/globals/weakref/rt.rs
+++ b/src/namespaces/globals/weakref/rt.rs
@@ -1,0 +1,31 @@
+//! `WeakRef` runtime — extern "C" implementations.
+//!
+//! v0: armazena strong reference. `deref()` retorna o target enquanto
+//! o handle for valido. Coleta automatica fica para PR futura.
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKREF_NEW(target: u64) -> u64 {
+    alloc_entry(Entry::WeakRef(target))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WEAKREF_DEREF(wr: u64) -> u64 {
+    with_entry(wr, |e| match e {
+        Some(Entry::WeakRef(target)) => *target,
+        _ => 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deref_returns_target() {
+        let target = alloc_entry(Entry::String(b"hello".to_vec()));
+        let wr = __RTS_FN_GL_WEAKREF_NEW(target);
+        assert_eq!(__RTS_FN_GL_WEAKREF_DEREF(wr), target);
+    }
+}


### PR DESCRIPTION
## Summary

Adiciona duas classes globais como stubs (sem GC weak real ainda):

**WeakRef:**
- \`new WeakRef(target)\` -> \`Entry::WeakRef(target)\`
- \`wr.deref()\` -> retorna target (strong-ref por enquanto)

**FinalizationRegistry:**
- \`new FinalizationRegistry(callback)\` -> \`Entry::FinalizationRegistry { callback, entries }\`
- \`fr.register(target, heldValue, ?token)\` -> push no entries
- \`fr.unregister(token)\` -> retorna bool

v0 stubs porque RTS não tem GC weak real ainda — callback nunca dispara, deref sempre retorna target. Cobre shape API exigida por libs que checam disponibilidade.

## Status cross-runtime

- ✅ \`307_weakref_shape\`: bate Bun/Node (\`type=function\`, \`deref=object\`)
- ❌ \`308_finalization_registry_shape\`: ainda diverge em \`typeof fr.register=number\` (Bun/Node=function) — precisa method dispatch em \`typeof\`

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1216/1217 (mesma 1 flaky pré-existente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)