### PR TITLE
fix(object): Object.keys omite slots internos de getter/setter (#110)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -464,6 +464,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
             if k.as_str() == "__proto__" {
                 continue;
             }
+            // (#110) Slots internos de getter/setter — nao expor.
+            if k.starts_with("__get_") || k.starts_with("__set_") {
+                continue;
+            }
             if is_non_enumerable(handle, k.as_str()) {
                 continue;
             }
@@ -652,6 +656,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64)
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#110) Slots internos `__get_*`/`__set_*` nao sao expostos.
+                if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
                 match parse_array_index(k) {
                     Some(n) => int_keys.push((n, k.clone())),
                     None => str_keys.push(k.clone()),
@@ -697,6 +703,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#110) Slots internos `__get_<name>`/`__set_<name>` armazenam
+                // accessor handles. Object.keys/getOwnPropertyNames JS spec nao
+                // expoe estes — RTS os usa como mecanismo interno de getter/setter.
+                if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
                 if is_non_enumerable(handle, k.as_str()) { continue; }
                 match parse_array_index(k) {
                     Some(n) => int_keys.push((n, k.clone())),


### PR DESCRIPTION
## Summary

RTS armazena getters/setters como entries especiais com chaves \`__get_<name>\`/\`__set_<name>\` no Map underlying. Object.keys, MAP_KEYS e OBJECT_OWN_PROPERTY_NAMES não devem expor estas chaves internas — só as props "públicas" aparentes para o usuário.

- Antes: \`Object.keys({get b() {return 2}, a: 1})\` -> \`["__get_b", "a"]\`
- Depois: \`["a"]\` (mais "b" quando getter dispatch resolver — escopo separado)

Cross-runtime \`110_object_getownpropertydescriptors\`: \`keys\` agora \`"a,c"\` (era \`"__get_b,a,c"\`). Falta ainda dispatch real do getter \`b\` nos descriptors.

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1216/1217 (mesma 1 flaky pré-existente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)