### PR TITLE
fix(json): stringify segue ECMA-262 OrdinaryOwnPropertyKeys ordering (#743)

### DIFF
--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -140,6 +140,33 @@ fn with_json<R>(handle: u64, default: R, f: impl FnOnce(&Value) -> R) -> R {
     }
 }
 
+/// (cross-runtime #743) ECMA-262 OrdinaryOwnPropertyKeys ordering: integer-indexed
+/// keys (canonical u32 strings) ascendentes primeiro, depois demais em ordem
+/// de insercao. Espelha o behavior de Bun/Node em Object.keys/JSON.stringify.
+fn sort_ecma_keys(entries: Vec<(String, i64)>) -> Vec<(String, i64)> {
+    fn parse_array_index(s: &str) -> Option<u32> {
+        if s.is_empty() { return None; }
+        if s.len() > 1 && s.starts_with('0') { return None; }
+        if !s.bytes().all(|b| b.is_ascii_digit()) { return None; }
+        let n: u32 = s.parse().ok()?;
+        if n == u32::MAX { return None; }
+        Some(n)
+    }
+    let mut int_keys: Vec<(u32, String, i64)> = Vec::new();
+    let mut str_keys: Vec<(String, i64)> = Vec::new();
+    for (k, v) in entries {
+        match parse_array_index(&k) {
+            Some(n) => int_keys.push((n, k, v)),
+            None => str_keys.push((k, v)),
+        }
+    }
+    int_keys.sort_by_key(|(n, _, _)| *n);
+    let mut out: Vec<(String, i64)> = Vec::with_capacity(int_keys.len() + str_keys.len());
+    for (_, k, v) in int_keys { out.push((k, v)); }
+    out.extend(str_keys);
+    out
+}
+
 /// Serializa um handle de qualquer tipo conhecido (Map/Vec/String/Json) ou
 /// devolve "" se nao reconhecido. Valores i64 dentro de Map/Vec sao tratados
 /// como numero por padrao — nao ha como saber em runtime se i64 e' handle
@@ -214,6 +241,10 @@ fn stringify_with_visited(
                 *circular = true;
                 return None;
             }
+            // (cross-runtime #743) ECMA-262 OrdinaryOwnPropertyKeys: integer-indexed
+            // keys ("0", "1", ..., max u32) ascendentes; depois string keys em
+            // ordem de insercao.
+            let entries = sort_ecma_keys(entries);
             out.push('{');
             let mut first = true;
             for (k, val) in entries {

--- a/tests/json_integer_key_ordering.test.ts
+++ b/tests/json_integer_key_ordering.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// ECMA-262 OrdinaryOwnPropertyKeys: integer keys ascendentes primeiro,
+// depois demais string keys em ordem de insercao.
+const obj: any = {};
+obj["20"] = "twenty";
+obj["3"] = "three";
+obj["aa"] = "aa";
+obj["10"] = "ten";
+obj["b"] = "b";
+
+print("json=" + JSON.stringify(obj));
+
+// Mesmo objeto com keys integer puras: ordenadas como numero.
+const ints: any = {};
+ints["100"] = 1;
+ints["2"] = 2;
+ints["50"] = 3;
+print("ints=" + JSON.stringify(ints));
+
+describe("JSON.stringify integer-key ordering (#743)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      'json={"3":"three","10":"ten","20":"twenty","aa":"aa","b":"b"}\n' +
+      'ints={"2":2,"50":3,"100":1}\n'
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #743: `JSON.stringify(obj)` agora ordena keys integer canônicas (\"0\", \"1\", ..., max u32) ascendentes antes das string keys (em ordem de insercão), seguindo ECMA-262 OrdinaryOwnPropertyKeys
- Antes: `{\"20\":...,\"3\":...,\"aa\":...,\"10\":...}` (insertion order)
- Depois: `{\"3\":...,\"10\":...,\"20\":...,\"aa\":...}` (bate com Bun/Node)
- Fixture `103_property_order_weird`: 3/4 linhas batem (a 4ª, `symbols=0` vs `1`, depende de #216)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1217/1218 (mesma falha pré-existente)
- [x] Novo teste `tests/json_integer_key_ordering.test.ts`