### PR TITLE
fix(set): Set.forEach((value, value2, set)) JS spec (#793 follow-up)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -197,17 +197,23 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FOR_EACH(handle: u64, fn_ptr: u64)
     });
     let (actual_ptr, bound): (u64, Vec<i64>) = resolved.unwrap_or((fn_ptr, Vec::new()));
     let n_bound = bound.len();
+    // (cross-runtime #793) Para Set, callback recebe (value, value, set) — key
+    // duplica como value2 (JS spec). Set storage no RTS usa Map<keyStr, 1>;
+    // o "value" da iteracao e' a key (que e' o elemento adicionado).
+    let is_set = handle_is_set_kind(handle);
     for (k, v) in pairs {
         let key_h = alloc_entry(Entry::String(k.into_bytes())) as i64;
-        // Invoca com (value, key, map_handle) prependendo bound. Limite 5 args total.
+        // Map: (value, key, map). Set: (value, value, set) — value e' o
+        // key_h (elemento original), e o segundo arg e' o mesmo key_h.
+        let (a, b) = if is_set { (key_h, key_h) } else { (v, key_h) };
         unsafe {
             use std::mem::transmute;
             match n_bound {
                 0 => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(actual_ptr)(
-                    v, key_h, handle as i64,
+                    a, b, handle as i64,
                 ),
                 1 => transmute::<u64, extern "C" fn(i64, i64, i64, i64) -> i64>(actual_ptr)(
-                    bound[0], v, key_h, handle as i64,
+                    bound[0], a, b, handle as i64,
                 ),
                 _ => 0,
             };

--- a/tests/set_foreach.test.ts
+++ b/tests/set_foreach.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const s = new Set([1, 2, 3]);
+
+const collected: string[] = [];
+s.forEach((value: number, value2: number) => {
+  collected.push(value + ":" + (value === value2));
+});
+
+print("size=" + s.size);
+print("forEach=" + collected.join(","));
+
+describe("Set.forEach((value, value2, set)) (#793 follow-up)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "size=3\n" +
+      "forEach=1:true,2:true,3:true\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Follow-up de #793 (Map.forEach): agora `Set.forEach` segue JS spec corretamente
- `MAP_FOR_EACH` detecta handle marcado como Set (via `handle_is_set_kind`) e invoca callback com `(value, value, set)` em vez de `(value, key, map)`
- Fixture `186_map_foreach` agora bate 100% com Bun/Node (5/5 linhas — `set=1,2,3` e os 3 `same=true`)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1218/1219 (mesma falha pré-existente)
- [x] Novo teste `tests/set_foreach.test.ts`