### PR TITLE
fix(error): catch (e: any) reads .name/.message from ErrorObj (#745)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -307,6 +307,22 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN(
     if let Some((target, handler)) = crate::namespaces::globals::proxy::ops::resolve_proxy(handle) {
         return crate::namespaces::globals::proxy::ops::dispatch_get(target, handler, key);
     }
+    // (cross-runtime #745) Entry::ErrorObj — quando o handle e' Error e
+    // a key e' name/message/stack, retorna string handle alocado.
+    // Sem isso, `catch (e: any)` + `e.name` cai em map_get e retorna 0
+    // (renderizado como "null").
+    let err_field: Option<String> = with_entry(handle, |e| match e {
+        Some(Entry::ErrorObj { message, name, .. }) => match key {
+            "name" => Some(name.clone()),
+            "message" => Some(message.clone()),
+            // "stack" — fora de escopo (RTS nao captura stack trace string).
+            _ => None,
+        },
+        _ => None,
+    });
+    if let Some(s) = err_field {
+        return alloc_entry(Entry::String(s.into_bytes())) as i64;
+    }
     let key_owned = key.to_string();
     let mut current = handle;
     let mut depth = 0u32;

--- a/tests/error_name_in_catch.test.ts
+++ b/tests/error_name_in_catch.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+function boom() {
+  throw new Error("zap");
+}
+
+try {
+  boom();
+} catch (e: any) {
+  print("name=" + e.name);
+  print("msg=" + e.message);
+}
+
+// Mesmo padrao com TypeError
+function typeBoom() {
+  throw new TypeError("bad type");
+}
+
+try {
+  typeBoom();
+} catch (e: any) {
+  print("te_name=" + e.name);
+  print("te_msg=" + e.message);
+}
+
+describe("catch (e: any) reads .name/.message from ErrorObj (#745)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "name=Error\n" +
+      "msg=zap\n" +
+      "te_name=TypeError\n" +
+      "te_msg=bad type\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #745: quando `throw` vem de dentro de fn user e o `catch` é `(e: any)`, `e.name` retornava `null` e `e.message` falhava
- `MAP_GET_CHAIN` agora reconhece `Entry::ErrorObj` e despacha `name`/`message` como string handle alocado
- Fixture `106_error_stack_presence`: `name=Error` e `msg=zap` batem com Bun/Node (2/4 linhas — `stack=string` e `hasBoom=true` ainda divergem porque RTS não captura stack trace serializado, issue separada)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1219/1220 (mesma falha pré-existente)
- [x] Novo teste `tests/error_name_in_catch.test.ts`