### PR TITLE
feat(error): e.stack retorna stack real do throw (#745 fase 2)

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/error.rs
+++ b/crates/rts-runtime/src/namespaces/gc/error.rs
@@ -62,11 +62,36 @@ pub extern "C" fn __RTS_FN_RT_ERROR_GET_STACK() -> u64 {
     ERROR_SLOT.with(|slot| slot.borrow().stack)
 }
 
+/// (#745) Mapa thread-local handle->stack_text. Antes de CLEAR liberar
+/// o stack handle pendente, copiamos o conteudo aqui para que
+/// `e.stack` possa ler dentro do catch body.
+thread_local! {
+    static ERR_STACKS: std::cell::RefCell<std::collections::HashMap<u64, String>>
+        = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+pub fn stack_for_handle(handle: u64) -> Option<String> {
+    ERR_STACKS.with(|m| m.borrow().get(&handle).cloned())
+}
+
 /// Clears pending runtime error and releases captured stack handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_RT_ERROR_CLEAR() {
     ERROR_SLOT.with(|slot| {
         let mut slot = slot.borrow_mut();
+        // (#745) Salva stack para ler dentro do catch body — RTS_FN_GL_ERROR_STACK
+        // consulta ERR_STACKS por handle do thrown value.
+        let msg = slot.message;
+        let stk = slot.stack;
+        if msg != 0 && stk != 0 {
+            let text = with_entry(stk, |e| match e {
+                Some(Entry::String(b)) => String::from_utf8_lossy(b).into_owned(),
+                _ => String::new(),
+            });
+            if !text.is_empty() {
+                ERR_STACKS.with(|m| m.borrow_mut().insert(msg, text));
+            }
+        }
         free_handle_if_any(slot.stack);
         slot.message = 0;
         slot.stack = 0;

--- a/crates/rts-runtime/src/namespaces/globals/error/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/instance.rs
@@ -158,18 +158,26 @@ pub extern "C" fn __RTS_FN_GL_ERROR_NAME(handle: u64) -> u64 {
     alloc_str(get_field(handle, "name"))
 }
 
-/// (#745) `e.stack` — JS spec: string. RTS nao tem stack capture real
-/// ainda; retorna "<name>: <msg>" como base mínima para `typeof e.stack
-/// === "string"` ser verdadeiro e `.includes("functionName")` poder ser
-/// avaliado (ainda retornara false sem stack real).
+/// (#745) `e.stack` — JS spec: string com call stack. RTS captura stack
+/// no momento de ERROR_SET via trace::frame_stack — se houver stack
+/// pendente, prefixa header "<name>: <msg>" + frames. Caso contrario,
+/// retorna apenas o header (typeof string ainda eh true).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_ERROR_STACK(handle: u64) -> u64 {
     let name = get_field(handle, "name");
     let msg = get_field(handle, "message");
-    let s = if msg.is_empty() {
+    let header = if msg.is_empty() {
         name
     } else {
         format!("{name}: {msg}")
+    };
+    // (#745) Stack salvo pelo ERROR_CLEAR (ver gc/error.rs ERR_STACKS).
+    let stack_text: String = crate::namespaces::gc::error::stack_for_handle(handle)
+        .unwrap_or_default();
+    let s = if stack_text.is_empty() {
+        header
+    } else {
+        format!("{header}\n{stack_text}")
     };
     alloc_str(s)
 }


### PR DESCRIPTION
## Summary

Em \`throw\`, o codegen já chamava \`push_frame\` antes do \`ERROR_SET\`, fazendo o \`trace::frame_stack\` capturar a fn ativa. \`ERROR_SET\` salvava o stack em \`SLOT.stack\`, mas \`ERROR_CLEAR\` (chamado antes do catch body) liberava o handle e zerava o slot — então \`e.stack\` dentro do catch não via nada.

Fix: \`ERR_STACKS\` thread-local (\`HashMap<u64, String>\`) preserva stack_text indexado pelo handle do thrown value. \`ERROR_CLEAR\` copia text antes de liberar. \`ERROR_STACK\` consulta \`ERR_STACKS\` por handle.

Resultado:
\`\`\`js
try { boom() } catch(e) { console.log(e.stack) }
// "Error: zap\n      at boom (<file>)"
\`\`\`

## Status cross-runtime 106

\`hasBoom\` ainda false porque \`String(e.stack).includes("boom")\` retorna false em RTS — bug separado de \`String()\` coerce que perde handle. Com var intermediária funciona:
\`\`\`js
const s = e.stack; s.includes("boom"); // true
\`\`\`

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1219/1220 (mesma 1 flaky pré-existente)
- [x] Manual: \`e.stack\` agora exibe \`"Error: zap\n      at boom (<file>)"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)