### PR TITLE
fix(json): stringify omite undefined (#680/50)

### DIFF
--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -250,6 +250,10 @@ fn stringify_with_visited(
             let mut first = true;
             for (k, val) in entries {
                 if k == "__proto__" { continue; }
+                // (#110) Slots internos getter/setter — nao sao props publicas.
+                if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
+                // (#680/50) JSON spec: omite props com valor undefined em obj.
+                if is_undefined_value(val) { continue; }
                 if !first { out.push(','); }
                 first = false;
                 out.push('"');
@@ -276,7 +280,12 @@ fn stringify_with_visited(
             out.push('[');
             for (i, val) in arr.into_iter().enumerate() {
                 if i > 0 { out.push(','); }
-                out.push_str(&stringify_value_visited(val, visited, circular));
+                // (#680/50) JSON spec: undefined em array vira "null".
+                if is_undefined_value(val) {
+                    out.push_str("null");
+                } else {
+                    out.push_str(&stringify_value_visited(val, visited, circular));
+                }
                 if *circular { return None; }
             }
             out.push(']');
@@ -307,6 +316,24 @@ fn stringify_value_visited(
     }
     if *circular { return String::new(); }
     v.to_string()
+}
+
+/// (#680/50) Detecta se valor representa `undefined` em RTS:
+/// - sentinel i64::MIN+2 (undefined explicito)
+/// - sentinel i64::MIN+4 (sparse hole, comporta como undefined)
+/// - handle de Entry::String "undefined" (literal lowered)
+fn is_undefined_value(v: i64) -> bool {
+    if v == i64::MIN + 2 || v == i64::MIN + 4 {
+        return true;
+    }
+    let h = v as u64;
+    if h <= 0xFFFF_FFFF {
+        return false;
+    }
+    with_entry(h, |e| match e {
+        Some(Entry::String(b)) => b.as_slice() == b"undefined",
+        _ => false,
+    })
 }
 
 /// Helper: formata DateMs como ISO string entre aspas para JSON.


### PR DESCRIPTION
## Summary

JSON spec ECMA-262 25.5.2:
- Em objeto: props com valor \`undefined\` são omitidas.
- Em array: \`undefined\` em posição vira \`"null"\` (preserva indices).

Antes: \`payload.drop = undefined\` no obj literal lower como handle de string \`"undefined"\` — stringify renderizava como \`"undefined"\` string.

Fix: helper \`is_undefined_value()\` detecta sentinelas \`i64::MIN+2\`, \`i64::MIN+4\` (sparse hole) e handle de \`Entry::String b"undefined"\`. Aplicado em \`Snap::Map\` (skip prop) e \`Snap::Vec\` (emit \`"null"\`).

Também filtra slots internos getter/setter (\`__get_*\`/\`__set_*\`) já tratados em Object.keys.

## Cross-runtime 50_json_deep

- \`plain\` agora omite \`"drop"\`/\`"skip"\` como Bun/Node ✓
- \`list = [1,null,3]\` correto ✓
- Bool \`true\` ainda renderiza como \`1\` (vs Bun=\`true\`) — fix separado precisa sentinel bool em obj literal storage (#795 follow-up)

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1220/1221 (era 1219/1220, +1)
- [x] Mesma 1 flaky pré-existente

🤖 Generated with [Claude Code](https://claude.com/claude-code)