### PR TITLE
fix(reflect): defineProperty preserva writable/enumerable flags (#795)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1044,9 +1044,12 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         // Returna I64 (slot raw). Slots podem carregar handle
                         // de string/map ou int direto; sem analise de tipo no
                         // call site, deixamos o caller decidir via cast/use.
-                        // Combina com testes pre-existentes que usam
-                        // `Reflect.get(o,k).toString()` em ints.
-                        return lower_ns_call(ctx, "collections.map_get", call);
+                        // (#795) Marca como ambiguo pra TPL_COERCE_AUTO
+                        // resolver bool sentinels (i64::MIN/MIN+1) e string
+                        // handles em concat (`"" + Reflect.get(d, "writable")`).
+                        let tv = lower_ns_call(ctx, "collections.map_get", call)?;
+                        ctx.var_member_call_values.insert(tv.val);
+                        return Ok(tv);
                     }
                     "has" if call.args.len() == 2 => {
                         return lower_ns_call(ctx, "collections.map_has", call);

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -871,6 +871,49 @@ pub(crate) fn is_non_enumerable(handle: u64, key: &str) -> bool {
         .contains(&(handle, key.to_string()))
 }
 
+/// (cross-runtime #795) Tracking de writable=false definido via
+/// Object.defineProperty / Reflect.defineProperty. Usado pelo
+/// `Reflect.getOwnPropertyDescriptor` pra retornar writable correto.
+fn non_writable_set() -> &'static Mutex<HashSet<(u64, String)>> {
+    static S: OnceLock<Mutex<HashSet<(u64, String)>>> = OnceLock::new();
+    S.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+pub(crate) fn is_non_writable(handle: u64, key: &str) -> bool {
+    non_writable_set()
+        .lock()
+        .unwrap()
+        .contains(&(handle, key.to_string()))
+}
+
+pub(crate) fn mark_non_writable(handle: u64, key: &str) {
+    non_writable_set()
+        .lock()
+        .unwrap()
+        .insert((handle, key.to_string()));
+}
+
+pub(crate) fn unmark_non_writable(handle: u64, key: &str) {
+    non_writable_set()
+        .lock()
+        .unwrap()
+        .remove(&(handle, key.to_string()));
+}
+
+pub(crate) fn mark_non_enumerable(handle: u64, key: &str) {
+    non_enumerable_set()
+        .lock()
+        .unwrap()
+        .insert((handle, key.to_string()));
+}
+
+pub(crate) fn unmark_non_enumerable(handle: u64, key: &str) {
+    non_enumerable_set()
+        .lock()
+        .unwrap()
+        .remove(&(handle, key.to_string()));
+}
+
 /// (#208) `Object.defineProperty(obj, key, descriptor)`.
 /// Suporta `{ value: x }` e `{ enumerable: false }`. Demais
 /// (get/set/writable/configurable) caem em PR separada.

--- a/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
@@ -278,20 +278,49 @@ fn forward_define_property(target: u64, key_handle: u64, descriptor: u64) -> i64
     }) else {
         return 0;
     };
-    let value: i64 = with_entry(descriptor, |e| match e {
-        Some(Entry::Map(m)) => m.get("value").copied().unwrap_or(0),
-        _ => 0,
+    // (cross-runtime #795) Extrai value + flags (writable/enumerable) do
+    // descriptor pra preservar via non_writable_set/non_enumerable_set.
+    // Bool sentinels: i64::MIN = false, i64::MIN+1 = true; outros valores
+    // tratados como truthy/falsy via != 0.
+    let (value, writable, enumerable) = with_entry(descriptor, |e| match e {
+        Some(Entry::Map(m)) => {
+            let v = m.get("value").copied().unwrap_or(0);
+            let w = m.get("writable").map(|x| {
+                if *x == i64::MIN { false }
+                else if *x == i64::MIN + 1 { true }
+                else { *x != 0 }
+            });
+            let en = m.get("enumerable").map(|x| {
+                if *x == i64::MIN { false }
+                else if *x == i64::MIN + 1 { true }
+                else { *x != 0 }
+            });
+            (v, w, en)
+        }
+        _ => (0, None, None),
     });
     use crate::namespaces::gc::handles::with_entry_mut;
     let key_str = String::from_utf8_lossy(&key_bytes).into_owned();
     let ok = with_entry_mut(target, |e| match e {
         Some(Entry::Map(m)) => {
-            m.insert(key_str, value);
+            m.insert(key_str.clone(), value);
             true
         }
         _ => false,
     });
-    if ok { 1 } else { 0 }
+    if !ok { return 0; }
+    // Atualiza flag tracking conforme descriptor.
+    match writable {
+        Some(false) => crate::namespaces::collections::map::mark_non_writable(target, &key_str),
+        Some(true) => crate::namespaces::collections::map::unmark_non_writable(target, &key_str),
+        None => {} // ausente — preserva estado anterior
+    }
+    match enumerable {
+        Some(false) => crate::namespaces::collections::map::mark_non_enumerable(target, &key_str),
+        Some(true) => crate::namespaces::collections::map::unmark_non_enumerable(target, &key_str),
+        None => {}
+    }
+    1
 }
 
 /// Trap `getOwnPropertyDescriptor(target, key)`. Retorna handle Map com
@@ -327,11 +356,17 @@ fn forward_get_own_property_descriptor(target: u64, key_handle: u64) -> u64 {
     // (#795) JS spec: undefined quando prop nao existe. Handle string
     // "undefined" — TPL_COERCE_AUTO renderiza como "undefined".
     let Some(v) = value else { return alloc_entry(Entry::String(b"undefined".to_vec())) };
+    // (cross-runtime #795) consulta flag tracking pra preservar
+    // writable/enumerable definidos via defineProperty.
+    let writable_bool = !crate::namespaces::collections::map::is_non_writable(target, &key_str);
+    let enumerable_bool = !crate::namespaces::collections::map::is_non_enumerable(target, &key_str);
     let mut desc: indexmap::IndexMap<String, i64> = indexmap::IndexMap::new();
     desc.insert("value".to_string(), v);
-    desc.insert("writable".to_string(), 1);
-    desc.insert("enumerable".to_string(), 1);
-    desc.insert("configurable".to_string(), 1);
+    // Bool sentinels (i64::MIN+1 = true, i64::MIN = false) pra TPL_COERCE_AUTO
+    // formatar como "true"/"false" em vez de inteiros raw.
+    desc.insert("writable".to_string(), if writable_bool { i64::MIN + 1 } else { i64::MIN });
+    desc.insert("enumerable".to_string(), if enumerable_bool { i64::MIN + 1 } else { i64::MIN });
+    desc.insert("configurable".to_string(), i64::MIN + 1);
     alloc_entry(Entry::Map(Box::new(desc)))
 }
 

--- a/tests/reflect_api.test.ts
+++ b/tests/reflect_api.test.ts
@@ -47,6 +47,10 @@ const counterIsObject = typeof counter === "object";
 const desc = Reflect.getOwnPropertyDescriptor(obj, "a");
 const descValue = Reflect.get(desc, "value");
 const descWritable = Reflect.get(desc, "writable");
+// (#795) Pre-coerce no top-level pra preservar tipo Handle do bool sentinel.
+// Closure no test() perde a marcacao var_member_call_values entre const-decl
+// e use, entao "" + descWritable dentro do arrow renderiza como i64 raw.
+const descWritableStr = "" + descWritable;
 const descMissing = Reflect.getOwnPropertyDescriptor(obj, "nope");
 
 // defineProperty: extrai value do descriptor e seta
@@ -68,8 +72,9 @@ describe("reflect_api", () => {
     test("Reflect.construct returns object", () =>
         expect(counterIsObject).toBe(true));
     test("Reflect.getOwnPropertyDescriptor value", () => expect(descValue).toBe(1));
+    // (#795) writable agora retorna bool sentinel (i64::MIN+1 = true).
     test("Reflect.getOwnPropertyDescriptor writable", () =>
-        expect(descWritable).toBe(1));
+        expect(descWritableStr).toBe("true"));
     // (#795) Missing prop retorna handle de string "undefined" (ECMA spec).
     test("Reflect.getOwnPropertyDescriptor missing", () =>
         expect(descMissing).toBe("undefined"));

--- a/tests/reflect_define_writable_flag.test.ts
+++ b/tests/reflect_define_writable_flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const obj: any = {};
+
+// defineProperty com writable:false e enumerable:true (Bun/Node JS spec)
+const success = Reflect.defineProperty(obj, "a", {
+  value: 42,
+  writable: false,
+  enumerable: true,
+});
+print("success=" + success);
+print("a=" + obj.a);
+
+const desc = Reflect.getOwnPropertyDescriptor(obj, "a");
+print("value=" + Reflect.get(desc, "value"));
+print("writable=" + Reflect.get(desc, "writable"));
+print("enumerable=" + Reflect.get(desc, "enumerable"));
+
+// defineProperty com defaults (writable:true, enumerable:true)
+const obj2: any = {};
+Reflect.defineProperty(obj2, "x", { value: 1, writable: true, enumerable: true });
+const desc2 = Reflect.getOwnPropertyDescriptor(obj2, "x");
+print("w2=" + Reflect.get(desc2, "writable"));
+
+describe("Reflect.defineProperty preserves writable/enumerable (#795)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "success=true\n" +
+      "a=42\n" +
+      "value=42\n" +
+      "writable=false\n" +
+      "enumerable=true\n" +
+      "w2=true\n"
+    )
+  );
+});

--- a/tests/reflect_edge_cases.test.ts
+++ b/tests/reflect_edge_cases.test.ts
@@ -103,6 +103,8 @@ const obj3 = { zero: 0 };
 const desc0 = Reflect.getOwnPropertyDescriptor(obj3, "zero");
 const desc0Value = Reflect.get(desc0, "value");
 const desc0Configurable = Reflect.get(desc0, "configurable");
+// (#795) Pre-coerce no top-level (vide tests/reflect_api.test.ts).
+const desc0ConfigurableStr = "" + desc0Configurable;
 
 // 16. Reflect.set retorno e' sempre true (v0)
 const setRetObj: any = {};
@@ -163,7 +165,7 @@ describe("reflect_edge_cases", () => {
     test("defineProperty overwrites", () => expect(dp2x).toBe(99));
     // 15. descriptor
     test("descriptor value=0 preserved", () => expect(desc0Value).toBe(0));
-    test("descriptor configurable=true", () => expect(desc0Configurable).toBe(1));
+    test("descriptor configurable=true", () => expect(desc0ConfigurableStr).toBe("true"));
     // 16. set return
     test("Reflect.set returns true", () => expect(setRet).toBe(true));
     // 17. delete return

--- a/tests/reflect_with_classes.test.ts
+++ b/tests/reflect_with_classes.test.ts
@@ -80,8 +80,11 @@ class Holder {
 const h = new Holder();
 const hDesc = Reflect.getOwnPropertyDescriptor(h, "v");
 const hDescValue: i64 = Reflect.get(hDesc, "value");
-const hDescConfig: i64 = Reflect.get(hDesc, "configurable");
-const hDescEnum: i64 = Reflect.get(hDesc, "enumerable");
+const hDescConfig = Reflect.get(hDesc, "configurable");
+const hDescEnum = Reflect.get(hDesc, "enumerable");
+// (#795) Pre-coerce no top-level pra preservar tipo Handle do bool sentinel.
+const hDescConfigStr = "" + hDescConfig;
+const hDescEnumStr = "" + hDescEnum;
 
 // 8. Reflect.has antes/depois de defineProperty
 const lazy: any = {};
@@ -152,8 +155,8 @@ describe("reflect_with_classes", () => {
     test("apply pow(10,0)", () => expect(pow10).toBe(1));
     // 7
     test("class field descriptor value", () => expect(hDescValue).toBe(7));
-    test("class field descriptor configurable", () => expect(hDescConfig).toBe(1));
-    test("class field descriptor enumerable", () => expect(hDescEnum).toBe(1));
+    test("class field descriptor configurable", () => expect(hDescConfigStr).toBe("true"));
+    test("class field descriptor enumerable", () => expect(hDescEnumStr).toBe("true"));
     // 8
     test("has before defineProperty", () => expect(beforeDef).toBe(false));
     test("has after defineProperty", () => expect(afterDef).toBe(true));


### PR DESCRIPTION
## Summary
- `forward_define_property` extrai `writable`/`enumerable` do descriptor e marca em `non_writable_set`/`non_enumerable_set` globais
- `forward_get_own_property_descriptor` consulta esses sets e retorna bool sentinels (`i64::MIN+1` = true, `i64::MIN` = false) — `TPL_COERCE_AUTO` formata como `"true"`/`"false"`
- `Reflect.get` marca retorno como ambíguo (`var_member_call_values`) pra que `"" + Reflect.get(d, "writable")` em top-level use `TPL_COERCE_AUTO` em vez de `string_from_i64` do bool sentinel raw
- Fixture `189_reflect_defineproperty`: **6/6 linhas batem** com Bun/Node (era 3/6 com `writable=1`, `enumerable=1`, `desc2=null`)
- Tests pré-existentes atualizados pra esperar `"true"`/`"false"` via concat string em top-level (closure em `test()` perde marcação `var_member_call_values`)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1220/1221 (mesma falha pré-existente)
- [x] Novo teste `tests/reflect_define_writable_flag.test.ts`