### PR TITLE
feat(syntax): BigInt literals (Nn) tratados como i64 (#751)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -65,6 +65,16 @@ pub(super) fn lower_lit(ctx: &mut FnCtx, lit: &Lit) -> Result<TypedVal> {
             let tv = ctx.emit_str_handle(s.value.as_bytes())?;
             Ok(TypedVal::new(tv.val, ValTy::Handle))
         }
+        // (cross-runtime #751) BigInt literals (1234n) — RTS nao tem BigInt
+        // real, mas tratamos como i64 quando o valor cabe (perde precisao
+        // acima de 2^63, mas suficiente pra fixtures com valores pequenos
+        // como `1_234_567_890n`).
+        Lit::BigInt(b) => {
+            let s = b.value.to_string();
+            // Parse decimal string como i64 (saturate em overflow).
+            let v: i64 = s.parse().unwrap_or(i64::MAX);
+            Ok(TypedVal::new(ctx.builder.ins().iconst(cl::I64, v), ValTy::I64))
+        }
         Lit::Regex(r) => {
             // /pattern/flags  →  regex.compile(pattern, flags)
             let pat_bytes = r.exp.as_bytes();

--- a/tests/bigint_literal_as_i64.test.ts
+++ b/tests/bigint_literal_as_i64.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// BigInt literals — RTS aceita mas trata como i64 (perde precisao acima de 2^63).
+const small = 100n;
+print("small=" + small);
+
+const billion = 1_000_000_000n;
+print("billion=" + billion);
+
+// Com underscores
+const big = 1_234_567_890n;
+print("big=" + big);
+
+describe("BigInt literals as i64 (#751)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "small=100\n" +
+      "billion=1000000000\n" +
+      "big=1234567890\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Fix #751: BigInt literals (`1_234_567_890n`) agora compilam em vez de gerar `undefined variable`
- RTS não tem BigInt real (issue #219 candidate-discard), mas tratamos `Nn` como i64 truncado (parse decimal → `iconst.i64`)
- Limitação: valores acima de 2^63 saturam em `i64::MAX`. Para fixtures comuns (até ~9.2 quintilhões) bate com Bun/Node
- Fixture `118_numeric_separators`: 5/5 linhas batem

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1221/1222 (mesma falha pré-existente)
- [x] Novo teste `tests/bigint_literal_as_i64.test.ts`