### PR TITLE
feat(promise): Promise.all/race/any/allSettled static methods (#779 #806)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/fetch/class_spec.rs
+++ b/crates/rts-runtime/src/namespaces/globals/fetch/class_spec.rs
@@ -168,6 +168,52 @@ pub const PROMISE_MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: false,
     },
+    // (cross-runtime #779/#806) Promise.all/race/any/allSettled — reusam
+    // as fns do namespace `promise` que ja sao expostas via SPECS.
+    NamespaceMember {
+        name: "all",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PROMISE_ALL",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Promise.all(promises) — aguarda todas; fail-fast em rejection.",
+        ts_signature: "static all<T>(values: Promise<T>[]): Promise<T[]>",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "race",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PROMISE_RACE",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Promise.race(promises) — settle com o resultado da primeira.",
+        ts_signature: "static race<T>(values: Promise<T>[]): Promise<T>",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "any",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PROMISE_ANY",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Promise.any(promises) — primeira a fulfill; reject so' se todas falharem.",
+        ts_signature: "static any<T>(values: Promise<T>[]): Promise<T>",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "allSettled",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_PROMISE_ALL_SETTLED",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Promise.allSettled(promises) — aguarda todas; sempre resolve com Vec de descriptors.",
+        ts_signature: "static allSettled<T>(values: Promise<T>[]): Promise<any[]>",
+        intrinsic: None,
+        pure: false,
+    },
 ];
 
 pub const PROMISE_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {

--- a/tests/promise_static_methods.test.ts
+++ b/tests/promise_static_methods.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+import { promise } from "rts";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// Promise.all com promises ja resolvidas (sync path).
+const p1 = Promise.resolve(10);
+const p2 = Promise.resolve(20);
+
+const allH = Promise.all([p1, p2]);
+const allWaited = promise.wait(allH as unknown as number);
+print("all_handle=" + (allWaited !== 0));
+
+// Promise.race retorna o valor da primeira.
+const raceH = Promise.race([p1, p2]);
+const raceVal = promise.wait(raceH as unknown as number);
+print("race=" + raceVal);
+
+// Promise.any tambem.
+const anyH = Promise.any([p1, p2]);
+const anyVal = promise.wait(anyH as unknown as number);
+print("any=" + anyVal);
+
+// Promise.allSettled — retorna Vec de descriptors com {status, value/reason}.
+const settledH = Promise.allSettled([p1, p2]);
+const settledHandle = promise.wait(settledH as unknown as number);
+print("settled_handle=" + (settledHandle !== 0));
+
+describe("Promise.all/race/any/allSettled static methods (#779 / #806)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "all_handle=true\n" +
+      "race=10\n" +
+      "any=10\n" +
+      "settled_handle=true\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Adiciona os 4 métodos estáticos ao `PROMISE_MEMBERS` class spec, roteando para as funções já existentes no namespace `promise` (sem mudar runtime)
- `Promise.all` / `Promise.race` / `Promise.any` / `Promise.allSettled` agora compilam (era `unknown namespace member`)
- Funciona com sync path via `promise.wait(h)`. As fixtures `167_promise_race_any` e `200_promise_allsettled` continuam crashando porque dependem de event-loop async real (`.then(val => console.log(...))` + `setTimeout`) — bloqueado em #207

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` **1223/1223** (suite 100% verde!)
- [x] Novo teste `tests/promise_static_methods.test.ts`