### PR TITLE
feat(call+url): chained method call em getter + URL decode (#746)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1513,6 +1513,59 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
             }
         }
+        // (cross-runtime #746) Chained call em obj.prop (obj nao Ident):
+        // `u.searchParams.get("q")` — m.obj eh Member. Lower o obj
+        // como expr (gera handle), depois tenta GLOBAL_CLASS_SPECS
+        // instance_method e mapeia args.
+        if let Expr::Member(m) = callee.as_ref() {
+            if matches!(m.obj.as_ref(), Expr::Member(_) | Expr::OptChain(_) | Expr::Call(_)) {
+                if let MemberProp::Ident(prop_id) = &m.prop {
+                    let prop_name = prop_id.sym.as_str();
+                    let obj_tv = lower_expr(ctx, &m.obj)?;
+                    let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                    for spec in crate::abi::GLOBAL_CLASS_SPECS {
+                        if let Some(member) = spec.instance_method(prop_name) {
+                            let sig = crate::abi::signature::lower_member(member);
+                            let f = ctx.get_extern_abi(member.symbol, &sig.params, sig.ret)?;
+                            let mut args: Vec<cranelift_codegen::ir::Value> = vec![obj_h];
+                            // Coerce args conforme assinatura (skip o `Handle` do receiver).
+                            for (i, abi_ty) in member.args.iter().skip(1).enumerate() {
+                                if let Some(arg) = call.args.get(i) {
+                                    let tv = lower_expr(ctx, &arg.expr)?;
+                                    match abi_ty {
+                                        crate::abi::AbiType::StrPtr => {
+                                            let h = ctx.coerce_to_handle(tv)?.val;
+                                            let pf = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+                                            let lf = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+                                            let ip = ctx.builder.ins().call(pf, &[h]);
+                                            let pp = ctx.builder.inst_results(ip)[0];
+                                            let il = ctx.builder.ins().call(lf, &[h]);
+                                            let ll = ctx.builder.inst_results(il)[0];
+                                            args.push(pp);
+                                            args.push(ll);
+                                        }
+                                        _ => {
+                                            let v = ctx.coerce_to_i64(tv).val;
+                                            args.push(v);
+                                        }
+                                    }
+                                }
+                            }
+                            let inst = ctx.builder.ins().call(f, &args);
+                            let v = if sig.ret.is_some() {
+                                ctx.builder.inst_results(inst)[0]
+                            } else {
+                                ctx.builder.ins().iconst(cl::I64, 0)
+                            };
+                            let ret_ty = ValTy::from_abi(member.returns);
+                            // Marca como ambiguo pra template literal funcionar.
+                            ctx.var_member_call_values.insert(v);
+                            return Ok(TypedVal::new(v, ret_ty));
+                        }
+                    }
+                }
+            }
+        }
         if let Expr::Ident(id) = callee.as_ref() {
             let name = id.sym.as_str();
             // Globais JS \`isNaN\`/\`isFinite\`/\`Number\`/\`String\`/\`Boolean\`

--- a/crates/rts-runtime/src/namespaces/globals/url/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/url/instance.rs
@@ -225,6 +225,36 @@ pub extern "C" fn __RTS_FN_GL_URL_FREE(handle: u64) {
 // (#373) URLSearchParams — backing IndexMap<String, i64> onde i64 e' handle
 // de string com value. Implementacao minimal: get/has/set/delete/toString.
 
+/// (cross-runtime #746) Percent-decode URL query component conforme
+/// WHATWG URL spec: `%XX` -> byte 0xXX; `+` -> ' '; bytes invalidos sao
+/// mantidos como-esta. Retorna lossy UTF-8.
+fn url_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'%' && i + 2 < bytes.len() {
+            let h = bytes[i + 1];
+            let l = bytes[i + 2];
+            let hv = match h { b'0'..=b'9' => Some(h - b'0'), b'a'..=b'f' => Some(h - b'a' + 10), b'A'..=b'F' => Some(h - b'A' + 10), _ => None };
+            let lv = match l { b'0'..=b'9' => Some(l - b'0'), b'a'..=b'f' => Some(l - b'a' + 10), b'A'..=b'F' => Some(l - b'A' + 10), _ => None };
+            if let (Some(hv), Some(lv)) = (hv, lv) {
+                out.push((hv << 4) | lv);
+                i += 3;
+                continue;
+            }
+        }
+        if b == b'+' {
+            out.push(b' ');
+        } else {
+            out.push(b);
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 fn parse_query(s: &str) -> indexmap::IndexMap<String, String> {
     let mut map: indexmap::IndexMap<String, String> = indexmap::IndexMap::new();
     let s = s.strip_prefix('?').unwrap_or(s);
@@ -233,9 +263,9 @@ fn parse_query(s: &str) -> indexmap::IndexMap<String, String> {
     }
     for pair in s.split('&') {
         if let Some((k, v)) = pair.split_once('=') {
-            map.insert(k.to_string(), v.to_string());
+            map.insert(url_decode(k), url_decode(v));
         } else if !pair.is_empty() {
-            map.insert(pair.to_string(), String::new());
+            map.insert(url_decode(pair), String::new());
         }
     }
     map


### PR DESCRIPTION
## Summary
Fecha #746 (107_url_edge_cases) — dois fixes:

1. `u.searchParams.get(k)` falhava com 'unsupported call expression form' (callee = Member sobre Member). Fix: fallback que lower obj como expr e tenta GLOBAL_CLASS_SPECS instance_method via assinatura ABI.
2. URL searchParams agora faz percent-decode (`%20` -> espaço, conforme WHATWG).

## Test plan
- [x] fixture 107 bate Bun/Node em todos 5 outputs
- [x] cargo --lib 12/12
- [x] rts.exe test **1222/1222**

🤖 Generated with [Claude Code](https://claude.com/claude-code)