### PR TITLE
feat(bigint): BigInt.asIntN / asUintN stubs (#742)

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -24,6 +24,7 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::function::abi::FUNCTION_CLASS_SPEC,
     &crate::namespaces::globals::symbol::SYMBOL_CLASS_SPEC,
     &crate::namespaces::globals::boolean::BOOLEAN_CLASS_SPEC,
+    &crate::namespaces::globals::bigint::BIGINT_CLASS_SPEC,
     &crate::namespaces::globals::weakmap::WEAKMAP_CLASS_SPEC,
     &crate::namespaces::globals::weakset::WEAKSET_CLASS_SPEC,
     &crate::namespaces::globals::weakref::WEAKREF_CLASS_SPEC,

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -499,6 +499,13 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_BOOLEAN_NEW_EMPTY", __RTS_FN_GL_BOOLEAN_NEW_EMPTY);
     }
 
+    // (cross-runtime #742) BigInt.asIntN / asUintN helpers staticos.
+    {
+        use crate::namespaces::globals::bigint::rt::*;
+        add_fn!("__RTS_FN_GL_BIGINT_AS_INT_N", __RTS_FN_GL_BIGINT_AS_INT_N);
+        add_fn!("__RTS_FN_GL_BIGINT_AS_UINT_N", __RTS_FN_GL_BIGINT_AS_UINT_N);
+    }
+
     // (#208) encodeURIComponent / decodeURIComponent globais.
     {
         use crate::namespaces::globals::global_this::rt::*;

--- a/crates/rts-runtime/src/namespaces/globals/bigint/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/bigint/abi.rs
@@ -1,0 +1,34 @@
+//! `BigInt.asIntN` / `BigInt.asUintN` — ABI declarativa.
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+pub const MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "asIntN",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_GL_BIGINT_AS_INT_N",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::I64,
+        doc: "BigInt.asIntN(bits, n) — n modulo 2^bits, interpretado como signed.",
+        ts_signature: "static asIntN(bits: number, n: bigint): bigint",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "asUintN",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_GL_BIGINT_AS_UINT_N",
+        args: &[AbiType::I64, AbiType::I64],
+        returns: AbiType::I64,
+        doc: "BigInt.asUintN(bits, n) — n modulo 2^bits, sem signo.",
+        ts_signature: "static asUintN(bits: number, n: bigint): bigint",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const BIGINT_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "BigInt",
+    doc: "BigInt namespace (helpers staticos asIntN/asUintN). RTS trata BigInt como i64.",
+    members: MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/bigint/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/bigint/mod.rs
@@ -1,0 +1,10 @@
+//! `BigInt` global class — stub minimal (cross-runtime #742).
+//!
+//! RTS nao tem BigInt real (issue #219), tratamos como i64. Essa class
+//! expoe os helpers staticos `asIntN(bits, n)` / `asUintN(bits, n)`
+//! que sao usados em testes cross-runtime.
+
+pub mod abi;
+pub mod rt;
+
+pub use abi::BIGINT_CLASS_SPEC;

--- a/crates/rts-runtime/src/namespaces/globals/bigint/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/bigint/rt.rs
@@ -1,0 +1,57 @@
+//! BigInt asIntN/asUintN — modular reduction em i64.
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BIGINT_AS_INT_N(bits: i64, n: i64) -> i64 {
+    // JS spec: result is n mod 2^bits, interpreted as signed (range [-2^(bits-1), 2^(bits-1) - 1]).
+    if bits <= 0 { return 0; }
+    if bits >= 64 { return n; }
+    let bits = bits as u32;
+    let modulus = 1i128 << bits;
+    let half = 1i128 << (bits - 1);
+    let mut r = (n as i128) % modulus;
+    if r < 0 { r += modulus; }
+    // Range adjust: se r >= 2^(bits-1), subtract modulus pra ficar signed.
+    if r >= half { r -= modulus; }
+    r as i64
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BIGINT_AS_UINT_N(bits: i64, n: i64) -> i64 {
+    // JS spec: result is n mod 2^bits (unsigned). Resultado e' positivo.
+    if bits <= 0 { return 0; }
+    if bits >= 64 {
+        // Para bits == 64, retorna n unsigned interpretado, mas como i64
+        // mantemos o bit pattern.
+        return n;
+    }
+    let bits = bits as u32;
+    let modulus = 1i128 << bits;
+    let mut r = (n as i128) % modulus;
+    if r < 0 { r += modulus; }
+    r as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_int_n_8_255() {
+        assert_eq!(__RTS_FN_GL_BIGINT_AS_INT_N(8, 255), -1);
+    }
+
+    #[test]
+    fn as_uint_n_8_neg1() {
+        assert_eq!(__RTS_FN_GL_BIGINT_AS_UINT_N(8, -1), 255);
+    }
+
+    #[test]
+    fn as_int_n_16_65535() {
+        assert_eq!(__RTS_FN_GL_BIGINT_AS_INT_N(16, 65535), -1);
+    }
+
+    #[test]
+    fn as_uint_n_16_65536() {
+        assert_eq!(__RTS_FN_GL_BIGINT_AS_UINT_N(16, 65536), 0);
+    }
+}

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -2,6 +2,7 @@
 //! + JSON, Date, console, globalThis, RegExp, Error family, timers, fetch,
 //! TextEncoder/Decoder, atob/btoa, structuredClone, URL, performance.
 
+pub mod bigint;
 pub mod boolean;
 pub mod console;
 pub mod date;

--- a/tests/bigint_asintn.test.ts
+++ b/tests/bigint_asintn.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// BigInt.asIntN — wrap signed em N bits.
+print("i8_255=" + BigInt.asIntN(8, 255n));     // -1
+print("i8_128=" + BigInt.asIntN(8, 128n));     // -128
+print("i8_127=" + BigInt.asIntN(8, 127n));     // 127
+print("i16_neg=" + BigInt.asIntN(16, 65535n)); // -1
+
+// BigInt.asUintN — wrap unsigned em N bits.
+print("u8_neg1=" + BigInt.asUintN(8, -1n));    // 255
+print("u8_256=" + BigInt.asUintN(8, 256n));    // 0
+print("u16_65536=" + BigInt.asUintN(16, 65536n)); // 0
+
+describe("BigInt.asIntN / asUintN (#742)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "i8_255=-1\n" +
+      "i8_128=-128\n" +
+      "i8_127=127\n" +
+      "i16_neg=-1\n" +
+      "u8_neg1=255\n" +
+      "u8_256=0\n" +
+      "u16_65536=0\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- Adiciona namespace `globals/bigint` com class spec minimal: `BigInt.asIntN(bits, n)` e `BigInt.asUintN(bits, n)`
- Impl em i128 intermediário faz a redução modular correta no range signed/unsigned
- Fixture `102_bigint_ops`: 7/8 linhas batem (`div=5.666...` ainda diverge porque RTS faz float div, BigInt em JS usa int div — issue de follow-up)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1224/1224 (100% verde)
- [x] Novo teste `tests/bigint_asintn.test.ts`