### PR TITLE
feat(number): NaN/Infinity.toFixed (#872 fixture 46)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1466,6 +1466,25 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                             );
                         }
                     }
+                    // (cross-runtime #46) `NaN.toFixed(2)` / `Infinity.toFixed(2)`
+                    // — globais f64 nao sao var, mas precisam aceitar
+                    // Number.prototype methods. Lower obj como F64 e usa
+                    // number builtin path.
+                    let global_name = obj_id.sym.as_str();
+                    if matches!(global_name, "NaN" | "Infinity") {
+                        if let MemberProp::Ident(prop) = &m.prop {
+                            let obj_tv = crate::codegen::lower::expressions::lower_expr(ctx, &m.obj)?;
+                            let recv_f = crate::codegen::lower::expressions::operators::to_f64(ctx, obj_tv);
+                            if let Some(tv) = crate::codegen::lower::expressions::calls::builtins::lower_number_builtin(
+                                ctx,
+                                prop.sym.as_str(),
+                                recv_f,
+                                call,
+                            )? {
+                                return Ok(tv);
+                            }
+                        }
+                    }
                 }
             }
             return lower_ns_call(ctx, &qualified, call);

--- a/crates/rts-runtime/src/namespaces/globals/number/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/number/rt.rs
@@ -106,6 +106,14 @@ pub extern "C" fn __RTS_FN_GL_NUMBER_VALUE_OF(v: f64) -> f64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_NUMBER_TO_FIXED(v: f64, digits: i64) -> u64 {
+    // (cross-runtime #872/46) JS spec: NaN/Infinity em toFixed retornam
+    // "NaN"/"Infinity"/"-Infinity" (Rust formataria como "inf"/"-inf").
+    if v.is_nan() {
+        return alloc_str("NaN");
+    }
+    if v.is_infinite() {
+        return alloc_str(if v > 0.0 { "Infinity" } else { "-Infinity" });
+    }
     let d = digits.clamp(0, 100) as usize;
     alloc_str(&format!("{v:.prec$}", prec = d))
 }


### PR DESCRIPTION
## Summary
- `(NaN).toFixed(2)` falhava com 'unknown namespace member NaN.toFixed' — ident NaN/Infinity nao roteado para Number.prototype methods. Fix: rotear como F64 receiver em lower_call.
- `__RTS_FN_GL_NUMBER_TO_FIXED` produzia 'inf' (Rust default) em vez de 'Infinity'. Fix: NaN/Infinity check explicito.

## Test plan
- [x] fixture 46 nao crasha, fixed_nan/fixed_inf batem JS spec
- [x] cargo --lib 12/12
- [x] rts.exe test 1224/1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)