### PR TITLE
fix(codegen): new GlobalClass(x) preserva tipo Cranelift do constructor

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -165,21 +165,13 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
         }
         let fn_ref = ctx.get_extern_abi(ctor.symbol, &sig.params, sig.ret)?;
         let inst = ctx.builder.ins().call(fn_ref, &arg_vals);
-        let handle = ctx.builder.inst_results(inst)[0];
-        // Track local variable type for instance method dispatch
-        // Caller (lower_var_decl) will store the binding name; we store the class name
-        // via the return value annotation. Here we return a Handle tagged with class name.
-        // The caller in lower_let_decl sets local_class_ty[bind] = class_name when it sees
-        // a NewExpr whose callee is a known class. We need to ensure class_name is in
-        // local_class_ty — do so by inserting via the returned TypedVal metadata.
-        // Since we can't do it here directly (no bind name), the lower_let path handles it.
-        // But we need to mark it as a global class so lhs_static_class can find it.
-        // Store class_name in global_class_ty isn't mutable. Use local_class_ty trick:
-        // The VarDecl lowering already calls `ctx.local_class_ty.insert(bind, class_name)`
-        // when it detects a NewExpr with a known user class. We must ensure the same
-        // happens for global classes. See lower/func.rs compile_user_fn var_decl handling.
-        // For now return Handle — the VarDecl lowering will handle local_class_ty.
-        return Ok(TypedVal::new(handle, ValTy::Handle));
+        let result_val = ctx.builder.inst_results(inst)[0];
+        // (cross-runtime panic fix) Usar from_abi pra preservar tipo Cranelift
+        // do retorno do constructor. Antes assumia Handle (i64), mas Number/
+        // Boolean retornam F64/I64 inteiros — declarar como Handle causa
+        // Cranelift type mismatch panic.
+        let result_ty = ValTy::from_abi(ctor.returns);
+        return Ok(TypedVal::new(result_val, result_ty));
     }
 
     // (#218) `new Proxy(target, handler)` — aloca Entry::Proxy.

--- a/tests/new_number_no_panic.test.ts
+++ b/tests/new_number_no_panic.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// `new Number(42)` antes panicava com Cranelift type mismatch
+// porque o codegen assumia que constructor retornava Handle (i64)
+// mas Number_NEW_FROM retorna f64. Agora usamos ValTy::from_abi(returns)
+// pra preservar o tipo correto.
+const n = new Number(42);
+print("n=" + n);
+
+const z = new Number(0);
+print("z=" + z);
+
+// Verifica que tambem nao quebra outros usos comuns.
+const arr = [new Number(1), new Number(2), new Number(3)];
+print("arr_len=" + arr.length);
+
+describe("new Number(x) preserves Cranelift type (panic fix)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "n=42\n" +
+      "z=0\n" +
+      "arr_len=3\n"
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- `lower_new` para global class constructors assumia que retorno era sempre `Handle` (i64), forçando `TypedVal::new(handle, ValTy::Handle)` mesmo quando o ABI declarava `AbiType::F64` (Number) ou outros tipos
- Causava Cranelift panic *"declared type of variable doesn't match type of value"* quando `var_decl` tentava armazenar i64 em slot f64
- Fix: usar `ValTy::from_abi(ctor.returns)` pra preservar o tipo correto
- Resolve panics em fixtures que usam `new Number(x)` / `new String(x)` / `new Boolean(x)` (245, 253, 230, etc.)

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` **1226/1226** (suite 100% verde)
- [x] Novo teste `tests/new_number_no_panic.test.ts`