### PR TITLE
feat(object): bool em obj literal vira sentinel JS (#680/50)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -292,7 +292,16 @@ pub(super) fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -
         };
 
         let value_tv = lower_expr(ctx, &value_expr)?;
-        let value_i64 = ctx.coerce_to_i64(value_tv).val;
+        // (#680/50) Bool em obj literal vira sentinel (i64::MIN = false,
+        // i64::MIN+1 = true). Permite JSON.stringify/console.log
+        // distinguir bool de int 0/1, e iterar com tipo correto.
+        let value_i64 = if matches!(value_tv.ty, ValTy::Bool) {
+            let b = ctx.coerce_to_i64(value_tv).val;
+            let min = ctx.builder.ins().iconst(cl::I64, i64::MIN);
+            ctx.builder.ins().iadd(min, b)
+        } else {
+            ctx.coerce_to_i64(value_tv).val
+        };
         match key_src {
             KeySrc::Static(s) => {
                 let (kptr, klen) = ctx.emit_str_literal(s.as_bytes())?;

--- a/tests/proxy_phase3.test.ts
+++ b/tests/proxy_phase3.test.ts
@@ -59,7 +59,8 @@ const p7: any = new Proxy(t7, {
 });
 const desc7 = Reflect.getOwnPropertyDescriptor(p7, "x");
 const desc7Value: i64 = Reflect.get(desc7, "value");
-const desc7Writable: i64 = Reflect.get(desc7, "writable");
+// (#680/50) Bool em obj literal vira sentinel — comparacao via String().
+const desc7Writable = String(Reflect.get(desc7, "writable"));
 
 // 8. getOwnPropertyDescriptor forward — sintetiza do target
 const t8: any = { z: 50 };
@@ -123,7 +124,7 @@ describe("proxy_phase3", () => {
     test("getOwnDesc trap returns custom value", () =>
         expect(desc7Value).toBe(42));
     test("getOwnDesc trap returns custom writable", () =>
-        expect(desc7Writable).toBe(true));
+        expect(desc7Writable).toBe("true"));
     test("getOwnDesc forward synthesizes from target", () =>
         expect(desc8Value).toBe(50));
     test("getOwnDesc forward missing has no value", () =>


### PR DESCRIPTION
JSON.stringify({a:true}) agora retorna {"a":true} (era {"a":1}). Lower_object_lit converte ValTy::Bool em sentinel i64::MIN+b. Suite 1227/1227.