### PR TITLE
fix(reflect): getOwnPropertyDescriptor bools como sentinel JS (#795/110)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
@@ -54,12 +54,15 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR(
         return alloc_undef();
     };
 
-    // Sintetiza { value, writable: true, enumerable: true, configurable: true }
+    // (#795) Sintetiza { value, writable: true, enumerable: true, configurable: true }
+    // Bools como sentinel JS (i64::MIN+1 = true) — TPL_COERCE_AUTO/JSON
+    // renderiza como "true". Slot int 1 viraria string "1".
+    let bool_true: i64 = i64::MIN + 1;
     let mut desc: IndexMap<String, i64> = IndexMap::new();
     desc.insert("value".to_string(), v);
-    desc.insert("writable".to_string(), 1);
-    desc.insert("enumerable".to_string(), 1);
-    desc.insert("configurable".to_string(), 1);
+    desc.insert("writable".to_string(), bool_true);
+    desc.insert("enumerable".to_string(), bool_true);
+    desc.insert("configurable".to_string(), bool_true);
     alloc_entry(Entry::Map(Box::new(desc)))
 }
 
@@ -78,12 +81,13 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS(obj: u64) -> u
             .collect(),
         _ => Vec::new(),
     });
+    let bool_true: i64 = i64::MIN + 1;
     for (k, v) in pairs {
         let mut desc: IndexMap<String, i64> = IndexMap::new();
         desc.insert("value".to_string(), v);
-        desc.insert("writable".to_string(), 1);
-        desc.insert("enumerable".to_string(), 1);
-        desc.insert("configurable".to_string(), 1);
+        desc.insert("writable".to_string(), bool_true);
+        desc.insert("enumerable".to_string(), bool_true);
+        desc.insert("configurable".to_string(), bool_true);
         let desc_h = alloc_entry(Entry::Map(Box::new(desc))) as i64;
         out.insert(k, desc_h);
     }


### PR DESCRIPTION
writable/enumerable/configurable agora viram sentinel JS (true/false). Suite 1227/1227.