### PR TITLE
feat(globals): AggregateError class (#748)

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -14,6 +14,7 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::error::abi::SYNTAX_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::error::abi::URI_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::error::abi::EVAL_ERROR_CLASS_SPEC,
+    &crate::namespaces::globals::error::abi::AGGREGATE_ERROR_CLASS_SPEC,
     &crate::namespaces::globals::events::abi::CLASS_SPEC,
     &crate::namespaces::globals::text_encoding::class_spec::TEXT_ENCODER_CLASS_SPEC,
     &crate::namespaces::globals::text_encoding::class_spec::TEXT_DECODER_CLASS_SPEC,

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -333,6 +333,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_SYNTAX_ERROR_NEW", __RTS_FN_GL_SYNTAX_ERROR_NEW);
     add_fn!("__RTS_FN_GL_URI_ERROR_NEW", __RTS_FN_GL_URI_ERROR_NEW);
     add_fn!("__RTS_FN_GL_EVAL_ERROR_NEW", __RTS_FN_GL_EVAL_ERROR_NEW);
+    add_fn!("__RTS_FN_GL_AGGREGATE_ERROR_NEW", __RTS_FN_GL_AGGREGATE_ERROR_NEW);
+    add_fn!("__RTS_FN_GL_AGGREGATE_ERROR_ERRORS", __RTS_FN_GL_AGGREGATE_ERROR_ERRORS);
     add_fn!("__RTS_FN_GL_ERROR_MESSAGE", __RTS_FN_GL_ERROR_MESSAGE);
     add_fn!("__RTS_FN_GL_ERROR_NAME", __RTS_FN_GL_ERROR_NAME);
     add_fn!("__RTS_FN_GL_ERROR_TO_STRING", __RTS_FN_GL_ERROR_TO_STRING);

--- a/crates/rts-runtime/src/namespaces/globals/error/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/abi.rs
@@ -466,3 +466,69 @@ pub const EVAL_ERROR_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
     doc: "Built-in EvalError class.",
     members: EVAL_ERROR_MEMBERS,
 };
+
+// ── AggregateError ────────────────────────────────────────────────────────────
+
+pub const AGGREGATE_ERROR_MEMBERS: &[NamespaceMember] = &[
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol: "__RTS_FN_GL_AGGREGATE_ERROR_NEW",
+        args: &[AbiType::Handle, AbiType::StrPtr],
+        returns: AbiType::Handle,
+        doc: "Creates an AggregateError com array de errors e message opcional.",
+        ts_signature: "new AggregateError(errors: any[], message?: string): AggregateError",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
+        name: "message",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_MESSAGE",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error message string.",
+        ts_signature: "message: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "name",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_NAME",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "The error name (\"AggregateError\").",
+        ts_signature: "name: string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "toString",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_ERROR_TO_STRING",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Returns \"AggregateError: <message>\".",
+        ts_signature: "toString(): string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "errors",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_AGGREGATE_ERROR_ERRORS",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Vec<i64> handle dos errors passados no construtor.",
+        ts_signature: "errors: any[]",
+        intrinsic: None,
+        pure: true,
+    },
+];
+
+pub const AGGREGATE_ERROR_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "AggregateError",
+    doc: "Built-in AggregateError class (ES2021).",
+    members: AGGREGATE_ERROR_MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/error/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/error/instance.rs
@@ -121,6 +121,25 @@ pub extern "C" fn __RTS_FN_GL_EVAL_ERROR_NEW(ptr: i64, len: i64, options: u64) -
     alloc_error_with_cause("EvalError", msg, extract_cause(options))
 }
 
+/// (cross-runtime #748) `new AggregateError(errors, message?)` — errors
+/// e' handle de Vec<i64> contendo os erros aggregados. Armazenamos o
+/// handle de errors no slot `cause` da ErrorObj (single i64 disponivel
+/// sem refactor de Entry); `.errors` lê esse slot.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_AGGREGATE_ERROR_NEW(errors: u64, ptr: i64, len: i64) -> u64 {
+    let msg = unsafe { str_from_raw(ptr, len) };
+    alloc_error_with_cause("AggregateError", msg, errors)
+}
+
+/// `agg.errors` — retorna o handle do Vec passado no construtor.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_AGGREGATE_ERROR_ERRORS(handle: u64) -> u64 {
+    with_entry(handle, |entry| match entry {
+        Some(Entry::ErrorObj { cause, .. }) => *cause,
+        _ => 0,
+    })
+}
+
 // ── Instance methods ──────────────────────────────────────────────────────────
 
 /// `instanceof Error` (any subtype) — handle aponta para Entry::ErrorObj

--- a/tests/aggregate_error.test.ts
+++ b/tests/aggregate_error.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const errs = [new Error("a"), new Error("b")];
+const agg = new AggregateError(errs, "multiple");
+
+print("name=" + agg.name);
+print("msg=" + agg.message);
+print("len=" + agg.errors.length);
+
+// Mensagem opcional ausente
+const agg2 = new AggregateError([new Error("only")]);
+print("name2=" + agg2.name);
+print("len2=" + agg2.errors.length);
+
+describe("AggregateError (#748)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "name=AggregateError\n" +
+      "msg=multiple\n" +
+      "len=2\n" +
+      "name2=AggregateError\n" +
+      "len2=1\n"
+    )
+  );
+});


### PR DESCRIPTION
Adiciona new AggregateError(errors, message?) seguindo ES2021. .errors retorna handle Vec dos errors. Fixture 278_aggregate_error sai de RUNTIME_ERROR para 3/4 linhas (items=a|b ainda diverge — issue separada). Suite 1227/1227 verde.