### PR TITLE
feat(globals): URL.canParse(href, base?) + static method overload by arity (#746)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -608,6 +608,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     // ── namespaces::globals::url ──────────────────────────────────────
     use crate::namespaces::globals::url::instance::*;
     add_fn!("__RTS_FN_GL_URL_NEW", __RTS_FN_GL_URL_NEW);
+    add_fn!("__RTS_FN_GL_URL_CAN_PARSE", __RTS_FN_GL_URL_CAN_PARSE);
+    add_fn!("__RTS_FN_GL_URL_CAN_PARSE_BASE", __RTS_FN_GL_URL_CAN_PARSE_BASE);
     add_fn!("__RTS_FN_GL_URL_HREF", __RTS_FN_GL_URL_HREF);
     add_fn!("__RTS_FN_GL_URL_PROTOCOL", __RTS_FN_GL_URL_PROTOCOL);
     add_fn!("__RTS_FN_GL_URL_HOST", __RTS_FN_GL_URL_HOST);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -715,6 +715,27 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             // Date static methods (#220): Date.now() / Date.parse() via GlobalClassSpec.
             if let Some((cls, method)) = qualified.split_once('.') {
                 if let Some(spec) = crate::abi::global_class_lookup(cls) {
+                    // (cross-runtime #746) Multiplos static members com mesmo
+                    // nome (overloads por arity TS): prefere o que combina.
+                    // Cada AbiType::StrPtr conta como 1 arg TS (expandida em
+                    // 2 slots na ABI Cranelift).
+                    let n_args = call.args.len();
+                    fn ts_arity(args: &[crate::abi::types::AbiType]) -> usize {
+                        args.len()
+                    }
+                    let arity_match = spec.members.iter().find(|m| {
+                        if m.name != method { return false; }
+                        if !matches!(m.kind,
+                            crate::abi::member::MemberKind::Function
+                            | crate::abi::member::MemberKind::Constant
+                            | crate::abi::member::MemberKind::StaticMethod) {
+                            return false;
+                        }
+                        ts_arity(m.args) == n_args
+                    });
+                    if let Some(member) = arity_match {
+                        return lower_ns_call_member(ctx, member, call);
+                    }
                     if let Some(member) = spec.static_member(method) {
                         return lower_ns_call_member(ctx, member, call);
                     }

--- a/crates/rts-runtime/src/namespaces/globals/url/class_spec.rs
+++ b/crates/rts-runtime/src/namespaces/globals/url/class_spec.rs
@@ -156,6 +156,29 @@ pub const URL_MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: false,
     },
+    // (cross-runtime #746) URL.canParse(href, base?) — true se o URL parsa.
+    NamespaceMember {
+        name: "canParse",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_GL_URL_CAN_PARSE",
+        args: &[AbiType::StrPtr],
+        returns: AbiType::Bool,
+        doc: "URL.canParse(href) — true se o URL parsa, false caso contrario.",
+        ts_signature: "static canParse(href: string): boolean",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
+        name: "canParse",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_GL_URL_CAN_PARSE_BASE",
+        args: &[AbiType::StrPtr, AbiType::StrPtr],
+        returns: AbiType::Bool,
+        doc: "URL.canParse(href, base) — true se href resolve em relacao a base.",
+        ts_signature: "static canParse(href: string, base: string): boolean",
+        intrinsic: None,
+        pure: true,
+    },
 ];
 
 pub const URL_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {

--- a/crates/rts-runtime/src/namespaces/globals/url/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/url/instance.rs
@@ -129,6 +129,37 @@ fn str_from_parts(ptr: i64, len: i64) -> &'static str {
     }
 }
 
+/// (cross-runtime #746) URL.canParse(href) — true se o URL parsa.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_URL_CAN_PARSE(ptr: i64, len: i64) -> i64 {
+    let raw = str_from_parts(ptr, len);
+    if ParsedUrl::parse(raw).is_some() { 1 } else { 0 }
+}
+
+/// URL.canParse(href, base) — true se href resolve relativo a base.
+/// Implementacao minima: tenta parse(href); se falhar, tenta concatenar
+/// com base + "/" + href; retorna true se algum parsa.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_URL_CAN_PARSE_BASE(
+    href_ptr: i64, href_len: i64,
+    base_ptr: i64, base_len: i64,
+) -> i64 {
+    let href = str_from_parts(href_ptr, href_len);
+    let base = str_from_parts(base_ptr, base_len);
+    // Tenta parse direto primeiro (href ja absoluto).
+    if ParsedUrl::parse(href).is_some() { return 1; }
+    // base precisa parsar.
+    let Some(base_url) = ParsedUrl::parse(base) else { return 0 };
+    // Resolve href relativo a base. Para "/x" + "https://example.com",
+    // retorna "https://example.com/x". Para path complexo, usa join naive.
+    let combined = if href.starts_with('/') {
+        format!("{}://{}{}", base_url.protocol.trim_end_matches(':'), base_url.host(), href)
+    } else {
+        format!("{}://{}/{}", base_url.protocol.trim_end_matches(':'), base_url.host(), href)
+    };
+    if ParsedUrl::parse(&combined).is_some() { 1 } else { 0 }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_URL_NEW(ptr: i64, len: i64) -> u64 {
     let raw = str_from_parts(ptr, len);

--- a/tests/url_canparse.test.ts
+++ b/tests/url_canparse.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+print("abs=" + URL.canParse("https://example.com/x"));
+print("rel=" + URL.canParse("/x", "https://example.com"));
+print("ftp=" + URL.canParse("ftp://files.example.com/a"));
+// Sem scheme://: nao parsa
+print("noscheme=" + URL.canParse("just a string"));
+
+describe("URL.canParse (#746)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "abs=true\n" +
+      "rel=true\n" +
+      "ftp=true\n" +
+      "noscheme=false\n"
+    )
+  );
+});


### PR DESCRIPTION
URL.canParse(href) e URL.canParse(href, base). Fix em codegen pra dispatch de static methods com overload por arity (antes pegava sempre o primeiro). Suite 1225 OK (4 falhas pre-existentes em fixtures que printam i64::MIN literal — bool sentinel).