### PR TITLE
fix(gc): string_from_i64_raw para num.checked_*/saturating_* (#raw-int)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -194,6 +194,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         __RTS_FN_NS_GC_STRING_FROM_I64
     );
     add_fn!(
+        "__RTS_FN_NS_GC_STRING_FROM_I64_RAW",
+        __RTS_FN_NS_GC_STRING_FROM_I64_RAW
+    );
+    add_fn!(
         "__RTS_FN_NS_GC_STRING_FROM_F64",
         __RTS_FN_NS_GC_STRING_FROM_F64
     );

--- a/crates/rts-runtime/src/namespaces/gc/abi.rs
+++ b/crates/rts-runtime/src/namespaces/gc/abi.rs
@@ -18,6 +18,17 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: false,
     },
     NamespaceMember {
+        name: "string_from_i64_raw",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_GC_STRING_FROM_I64_RAW",
+        args: &[AbiType::I64],
+        returns: AbiType::Handle,
+        doc: "Like string_from_i64, but never substitutes JS sentinel values (i64::MIN -> 'false' etc). Use for raw int formatting (num.checked_*).",
+        ts_signature: "string_from_i64_raw(value: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    NamespaceMember {
         name: "string_from_f64",
         kind: MemberKind::Function,
         symbol: "__RTS_FN_NS_GC_STRING_FROM_F64",

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -130,6 +130,14 @@ pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64(value: i64) -> u64 {
     alloc_entry(Entry::String(value.to_string().into_bytes()))
 }
 
+/// (#raw-int) gc.string_from_i64_raw — formata int como decimal sem
+/// interceptar sentinelas. Usado por num.checked_*/saturating_* etc.
+/// onde i64::MIN representa overflow real, nao sentinel "false".
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_I64_RAW(value: i64) -> u64 {
+    alloc_entry(Entry::String(value.to_string().into_bytes()))
+}
+
 /// (#proto-method) Coerce inteligente para template literal:
 /// se \`value\` (i64) eh handle valido para Entry::String, retorna o
 /// proprio handle. Senao, formata como integer (\`STRING_FROM_I64\`).

--- a/tests/num_bits.test.ts
+++ b/tests/num_bits.test.ts
@@ -10,23 +10,23 @@ function print(value: string): void {
 
 // 0xFF = 8 ones
 const a = num.count_ones(255);
-const h1 = gc.string_from_i64(a); print(h1); gc.string_free(h1);
+const h1 = gc.string_from_i64_raw(a); print(h1); gc.string_free(h1);
 
 // 1 << 0 = 1: 63 leading zeros (i64).
 const b = num.leading_zeros(1);
-const h2 = gc.string_from_i64(b); print(h2); gc.string_free(h2);
+const h2 = gc.string_from_i64_raw(b); print(h2); gc.string_free(h2);
 
 // 8: 3 trailing zeros.
 const c = num.trailing_zeros(8);
-const h3 = gc.string_from_i64(c); print(h3); gc.string_free(h3);
+const h3 = gc.string_from_i64_raw(c); print(h3); gc.string_free(h3);
 
 // rotate_left(1, 4) = 16
 const d = num.rotate_left(1, 4);
-const h4 = gc.string_from_i64(d); print(h4); gc.string_free(h4);
+const h4 = gc.string_from_i64_raw(d); print(h4); gc.string_free(h4);
 
 // swap_bytes(0x12) = 0x1200000000000000 (signed: negativo grande)
 const e = num.swap_bytes(0x12);
-const h5 = gc.string_from_i64(e); print(h5); gc.string_free(h5);
+const h5 = gc.string_from_i64_raw(e); print(h5); gc.string_free(h5);
 
 describe("fixture:num_bits", () => {
   test("matches expected stdout", () => {

--- a/tests/num_checked.test.ts
+++ b/tests/num_checked.test.ts
@@ -9,16 +9,16 @@ function print(value: string): void {
 // num.checked_*: aritmetica que sinaliza overflow via i64::MIN.
 
 const a = num.checked_add(100, 200);
-const h1 = gc.string_from_i64(a); print(h1); gc.string_free(h1);
+const h1 = gc.string_from_i64_raw(a); print(h1); gc.string_free(h1);
 
 const b = num.checked_div(100, 0);
-const h2 = gc.string_from_i64(b); print(h2); gc.string_free(h2);
+const h2 = gc.string_from_i64_raw(b); print(h2); gc.string_free(h2);
 
 const c = num.checked_sub(50, 30);
-const h3 = gc.string_from_i64(c); print(h3); gc.string_free(h3);
+const h3 = gc.string_from_i64_raw(c); print(h3); gc.string_free(h3);
 
 const d = num.checked_mul(7, 6);
-const h4 = gc.string_from_i64(d); print(h4); gc.string_free(h4);
+const h4 = gc.string_from_i64_raw(d); print(h4); gc.string_free(h4);
 
 describe("fixture:num_checked", () => {
   test("matches expected stdout", () => {

--- a/tests/num_saturating.test.ts
+++ b/tests/num_saturating.test.ts
@@ -10,13 +10,13 @@ function print(value: string): void {
 
 // 9_000_000_000_000_000_000 + 9_000_000_000_000_000_000 saturaria.
 const a = num.saturating_add(9000000000000000000, 9000000000000000000);
-const h1 = gc.string_from_i64(a); print(h1); gc.string_free(h1);
+const h1 = gc.string_from_i64_raw(a); print(h1); gc.string_free(h1);
 
 const b = num.saturating_sub(-9000000000000000000, 9000000000000000000);
-const h2 = gc.string_from_i64(b); print(h2); gc.string_free(h2);
+const h2 = gc.string_from_i64_raw(b); print(h2); gc.string_free(h2);
 
 const c = num.saturating_mul(3, 7);
-const h3 = gc.string_from_i64(c); print(h3); gc.string_free(h3);
+const h3 = gc.string_from_i64_raw(c); print(h3); gc.string_free(h3);
 
 describe("fixture:num_saturating", () => {
   test("matches expected stdout", () => {

--- a/tests/num_wrapping.test.ts
+++ b/tests/num_wrapping.test.ts
@@ -10,20 +10,20 @@ function print(value: string): void {
 
 // MAX + 1 -> MIN (modular wrap).
 const a = num.wrapping_add(9223372036854775807, 1);
-const h1 = gc.string_from_i64(a); print(h1); gc.string_free(h1);
+const h1 = gc.string_from_i64_raw(a); print(h1); gc.string_free(h1);
 
 // 0 - 1 -> -1
 const b = num.wrapping_sub(0, 1);
-const h2 = gc.string_from_i64(b); print(h2); gc.string_free(h2);
+const h2 = gc.string_from_i64_raw(b); print(h2); gc.string_free(h2);
 
 const c = num.wrapping_neg(42);
-const h3 = gc.string_from_i64(c); print(h3); gc.string_free(h3);
+const h3 = gc.string_from_i64_raw(c); print(h3); gc.string_free(h3);
 
 const d = num.wrapping_shl(1, 4);
-const h4 = gc.string_from_i64(d); print(h4); gc.string_free(h4);
+const h4 = gc.string_from_i64_raw(d); print(h4); gc.string_free(h4);
 
 const e = num.wrapping_shr(256, 4);
-const h5 = gc.string_from_i64(e); print(h5); gc.string_free(h5);
+const h5 = gc.string_from_i64_raw(e); print(h5); gc.string_free(h5);
 
 describe("fixture:num_wrapping", () => {
   test("matches expected stdout", () => {


### PR DESCRIPTION
string_from_i64() trata sentinelas JS para uso em tpl, mas num.checked_add(MAX,1) retorna i64::MIN como overflow real - novo string_from_i64_raw nao interpreta sentinelas. Suite 1228/1229.