### PR TITLE
feat(object): Object.prototype.isPrototypeOf (#772)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1122,6 +1122,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_IS_PROTOTYPE_OF",
+            map::__RTS_FN_GL_OBJECT_IS_PROTOTYPE_OF
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_SET",
             map::__RTS_FN_NS_COLLECTIONS_MAP_SET
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -145,6 +145,21 @@ pub(super) fn lower_var_member_call(
         }
     }
 
+    // (cross-runtime #772) `obj.isPrototypeOf(other)` — walk __proto__
+    // de `other` procurando `obj`. Retorna true se obj aparece na cadeia.
+    if prop == "isPrototypeOf" && call.args.len() == 1 {
+        let other_tv = lower_expr(ctx, &call.args[0].expr)?;
+        let other_h = ctx.coerce_to_i64(other_tv).val;
+        let f = ctx.get_extern(
+            "__RTS_FN_GL_OBJECT_IS_PROTOTYPE_OF",
+            &[cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(f, &[obj_h, other_h]);
+        let v = ctx.builder.inst_results(inst)[0];
+        return Ok(TypedVal::new(v, ValTy::Bool));
+    }
+
     // (#264 PR5) `obj.hasOwnProperty(key)` — verifica own props sem chain.
     // (cross-runtime #788) `obj.propertyIsEnumerable(key)` — own + enumerable.
     if (prop == "hasOwnProperty" || prop == "propertyIsEnumerable") && call.args.len() == 1 {

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -280,6 +280,26 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_FOR_EACH(handle: u64, fn_ptr: u64)
     }
 }
 
+/// (cross-runtime #772) `obj.isPrototypeOf(other)` — walk `other.__proto__`
+/// chain procurando `obj`. Retorna 1 se obj aparece na cadeia, 0 caso
+/// contrario. Guard contra ciclos: profundidade maxima 64.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_IS_PROTOTYPE_OF(obj: u64, other: u64) -> i64 {
+    if obj == 0 || other == 0 { return 0; }
+    let mut current = with_map(other, 0u64, |m| {
+        m.get("__proto__").copied().unwrap_or(0) as u64
+    });
+    let mut depth = 0u32;
+    while current != 0 && depth < 64 {
+        if current == obj { return 1; }
+        current = with_map(current, 0u64, |m| {
+            m.get("__proto__").copied().unwrap_or(0) as u64
+        });
+        depth += 1;
+    }
+    0
+}
+
 /// (cross-runtime #788) `obj.propertyIsEnumerable(key)` — true se own
 /// property + enumerable. Inherited (via __proto__) ja' retorna false
 /// porque so' checa own. Para Vec: indices = enumerable, "length" = false.

--- a/tests/object_is_prototype_of.test.ts
+++ b/tests/object_is_prototype_of.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+const parent: any = { x: 1 };
+const child: any = Object.create(parent);
+
+print("parent_of_child=" + parent.isPrototypeOf(child));
+print("child_of_parent=" + child.isPrototypeOf(parent));
+
+// Nested chain: parent <- mid <- child
+const mid: any = Object.create(parent);
+const grandchild: any = Object.create(mid);
+print("parent_of_grandchild=" + parent.isPrototypeOf(grandchild));
+print("mid_of_grandchild=" + mid.isPrototypeOf(grandchild));
+
+// Unrelated objects
+const other: any = { y: 2 };
+print("other_of_child=" + other.isPrototypeOf(child));
+
+describe("Object.prototype.isPrototypeOf (#772)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "parent_of_child=true\n" +
+      "child_of_parent=false\n" +
+      "parent_of_grandchild=true\n" +
+      "mid_of_grandchild=true\n" +
+      "other_of_child=false\n"
+    )
+  );
+});


### PR DESCRIPTION
obj.isPrototypeOf(other) walk other.__proto__ chain. Fixture 247_object_isprototypeof: 2/5 linhas batem (as outras dependem de Object/Array.prototype standalone). Suite 1225 (4 pre-existentes).