### PR TITLE
feat(console): stub methods (table/group/count/time/etc.)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -899,6 +899,13 @@ pub(super) fn lower_console_call(
         }
         // (#686) dir(obj) — alias de console.log com 1 arg + INSPECT.
         "dir" => "__RTS_FN_NS_IO_PRINT",
+        // (cross-runtime #311/#310) Console methods nao implementados —
+        // tratados como noop ou alias de log/error pra evitar
+        // 'unknown namespace member'. table/group/groupEnd/groupCollapsed/
+        // count/countReset/trace/time*/clear/profile/profileEnd/timeStamp.
+        "table" | "group" | "groupCollapsed" | "groupEnd" |
+        "count" | "countReset" | "trace" | "time" | "timeEnd" | "timeLog" |
+        "clear" | "profile" | "profileEnd" | "timeStamp" => "__RTS_FN_NS_IO_PRINT",
         _ => return Ok(None),
     };
 

--- a/tests/console_stub_methods.test.ts
+++ b/tests/console_stub_methods.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// Esses metodos antes davam 'unknown namespace member'. Agora sao
+// tratados como alias de io.print (stub) — output nao bate 100% com
+// Bun/Node mas pelo menos compila e nao crasha.
+console.table([1, 2]);
+console.group("g");
+console.groupEnd();
+console.count("c");
+console.time("t");
+console.timeEnd("t");
+console.trace();
+console.clear();
+
+print("ok");
+
+describe("console stub methods (#310/#311)", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe("ok\n")
+  );
+});


### PR DESCRIPTION
Adiciona stubs (alias io.print) pros metodos console nao implementados. Suite 1232/1232 verde.