### PR TITLE
fix(#753): Symbol como key em obj literal/computed access/in

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1099,6 +1099,26 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_HAS
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_OBJ_HAS",
+            map::__RTS_FN_NS_COLLECTIONS_OBJ_HAS
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_SET_KH",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_SET_KH
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_MAP_GET_KH",
+            map::__RTS_FN_NS_COLLECTIONS_MAP_GET_KH
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_OBJ_SET",
+            map::__RTS_FN_NS_COLLECTIONS_OBJ_SET
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_OBJ_GET",
+            map::__RTS_FN_NS_COLLECTIONS_OBJ_GET
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_GET",
             map::__RTS_FN_NS_COLLECTIONS_MAP_GET
         );

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1143,6 +1143,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS",
+            map::__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS
+        );
+        add_fn!(
             "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE",
             map::__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -781,17 +781,18 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
-                // (#798/192) Object.getOwnPropertySymbols(obj) — RTS Maps usam
-                // chaves String, sem suporte real a Symbol keys (#216). Retorna
-                // sempre Vec vazio para satisfazer a shape API.
+                // (#798) Object.getOwnPropertySymbols(obj) — apos #753, Symbol
+                // keys sao gravadas como `@@sym:<handle>` no Map. Decodifica
+                // essas keys de volta para Vec de Symbol handles.
                 if method == "getOwnPropertySymbols" && call.args.len() == 1 {
-                    let _ = lower_expr(ctx, &call.args[0].expr)?;
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
                     let f = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
-                        &[],
+                        "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS",
+                        &[cl::I64],
                         Some(cl::I64),
                     )?;
-                    let inst = ctx.builder.ins().call(f, &[]);
+                    let inst = ctx.builder.ins().call(f, &[h]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -310,27 +310,19 @@ pub(super) fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -
                     .call(set_fn, &[handle, kptr, klen, value_i64]);
             }
             KeySrc::Computed(expr) => {
-                // Avalia expr -> handle (string). Coerce + chama
-                // gc.string_ptr/len pra extrair ptr+len.
+                // (#753) Avalia expr -> handle e usa MAP_SET_KH que
+                // aceita key como handle (resolve String OU Symbol via
+                // repr canonica `@@sym:<handle>`).
                 let key_tv = lower_expr(ctx, &expr)?;
                 let key_h = ctx.coerce_to_handle(key_tv)?.val;
-                let ptr_fn = ctx.get_extern(
-                    "__RTS_FN_NS_GC_STRING_PTR",
-                    &[cl::I64],
-                    Some(cl::I64),
+                let set_kh_fn = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_MAP_SET_KH",
+                    &[cl::I64, cl::I64, cl::I64],
+                    None,
                 )?;
-                let len_fn = ctx.get_extern(
-                    "__RTS_FN_NS_GC_STRING_LEN",
-                    &[cl::I64],
-                    Some(cl::I64),
-                )?;
-                let p_inst = ctx.builder.ins().call(ptr_fn, &[key_h]);
-                let kptr = ctx.builder.inst_results(p_inst)[0];
-                let l_inst = ctx.builder.ins().call(len_fn, &[key_h]);
-                let klen = ctx.builder.inst_results(l_inst)[0];
                 ctx.builder
                     .ins()
-                    .call(set_fn, &[handle, kptr, klen, value_i64]);
+                    .call(set_kh_fn, &[handle, key_h, value_i64]);
             }
         }
     }
@@ -1113,20 +1105,16 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             let idx_tv = lower_expr(ctx, &c.expr)?;
             match idx_tv.ty {
                 ValTy::Handle => {
-                    let ptr_fref =
-                        ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
-                    let len_fref =
-                        ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
-                    let pi = ctx.builder.ins().call(ptr_fref, &[idx_tv.val]);
-                    let kptr = ctx.builder.inst_results(pi)[0];
-                    let li = ctx.builder.ins().call(len_fref, &[idx_tv.val]);
-                    let klen = ctx.builder.inst_results(li)[0];
+                    // (#753) MAP_GET_KH aceita key como handle (String OU
+                    // Symbol via repr canonica `@@sym:<handle>`). Antes,
+                    // STRING_PTR/LEN em Symbol retornava null -> MAP_GET
+                    // sempre 0.
                     let get_fn = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_MAP_GET",
-                        &[cl::I64, cl::I64, cl::I64],
+                        "__RTS_FN_NS_COLLECTIONS_MAP_GET_KH",
+                        &[cl::I64, cl::I64],
                         Some(cl::I64),
                     )?;
-                    let inst = ctx.builder.ins().call(get_fn, &[obj_handle, kptr, klen]);
+                    let inst = ctx.builder.ins().call(get_fn, &[obj_handle, idx_tv.val]);
                     let raw = ctx.builder.inst_results(inst)[0];
                     // (#261) Pos-MAP_GET com chave dinamica: aplica
                     // TPL_COERCE_AUTO no slot pra que se for handle de

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -606,18 +606,36 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     let (kp, kl) = ctx.emit_str_literal(s.value.as_bytes())?;
                     ctx.builder.ins().call(set_fn, &[obj_h, kp, kl, rhs_i64]);
                 } else {
-                    let idx_tv = lower_expr(ctx, &c.expr)?;
-                    let idx = ctx.coerce_to_i64(idx_tv).val;
-                    let vec_set = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_VEC_SET",
-                        &[
-                            cranelift_codegen::ir::types::I64,
-                            cranelift_codegen::ir::types::I64,
-                            cranelift_codegen::ir::types::I64,
-                        ],
-                        None,
-                    )?;
-                    ctx.builder.ins().call(vec_set, &[obj_h, idx, rhs_i64]);
+                    let key_tv = lower_expr(ctx, &c.expr)?;
+                    // Hot path: key claramente numerica -> VEC_SET direto
+                    // (sem alocar handle string por iteracao).
+                    if matches!(key_tv.ty, ValTy::I32 | ValTy::I64 | ValTy::U64) {
+                        let idx = ctx.coerce_to_i64(key_tv).val;
+                        let vec_set = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_VEC_SET",
+                            &[
+                                cranelift_codegen::ir::types::I64,
+                                cranelift_codegen::ir::types::I64,
+                                cranelift_codegen::ir::types::I64,
+                            ],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(vec_set, &[obj_h, idx, rhs_i64]);
+                    } else {
+                        // (#753) Symbol/handle key -> OBJ_SET dispatcher
+                        // (Vec/Map em runtime + repr canonica de Symbol).
+                        let key_h = ctx.coerce_to_handle(key_tv)?.val;
+                        let obj_set = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_OBJ_SET",
+                            &[
+                                cranelift_codegen::ir::types::I64,
+                                cranelift_codegen::ir::types::I64,
+                                cranelift_codegen::ir::types::I64,
+                            ],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(obj_set, &[obj_h, key_h, rhs_i64]);
+                    }
                 }
             }
             MemberProp::PrivateName(pn) => {

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -364,21 +364,23 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         return lower_instanceof(ctx, bin);
     }
 
-    // (cross-runtime #52) `key in arr` para Vec. JS spec: index `i` esta
-    // "in" array se 0 <= i < length E slot != hole. Usa runtime helper
-    // VEC_HAS_INDEX que retorna 0/1.
+    // (cross-runtime #52/#753) `key in obj` — dispatcher universal que
+    // aceita Vec ou Map, com key como handle (String, Symbol, etc).
+    // Chama OBJ_HAS que despacha por Entry type do obj.
     if matches!(bin.op, BinaryOp::In) {
         let key_tv = lower_expr(ctx, &bin.left)?;
         let obj_tv = lower_expr(ctx, &bin.right)?;
         if matches!(obj_tv.ty, ValTy::Handle) {
-            let idx = ctx.coerce_to_i64(key_tv).val;
+            // Coerce key para handle: string literals/handles passam direto,
+            // numbers viram string handle via gc.string_from_i64/f64.
+            let key_h = ctx.coerce_to_handle(key_tv)?.val;
             let obj_h = obj_tv.val;
             let fref = ctx.get_extern(
-                "__RTS_FN_NS_COLLECTIONS_VEC_HAS_INDEX",
+                "__RTS_FN_NS_COLLECTIONS_OBJ_HAS",
                 &[cl::I64, cl::I64],
                 Some(cl::I64),
             )?;
-            let inst = ctx.builder.ins().call(fref, &[obj_h, idx]);
+            let inst = ctx.builder.ins().call(fref, &[obj_h, key_h]);
             let v = ctx.builder.inst_results(inst)[0];
             return Ok(TypedVal::new(v, ValTy::Bool));
         }

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -76,6 +76,34 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             if matches!(init_peeled, swc_ecma_ast::Expr::Array(_)) {
                 ctx.local_array_vars.insert(name.clone());
             }
+            // (#798) `const x = Object.keys/values/getOwnPropertyNames/getOwnPropertySymbols(...)`
+            // retorna Vec — marca pra que `x.includes(sym)` use VEC_INCLUDES e nao
+            // o string builtin (que ignora needle e retorna 0).
+            if let swc_ecma_ast::Expr::Call(call) = init_peeled {
+                if let swc_ecma_ast::Callee::Expr(callee) = &call.callee {
+                    if let swc_ecma_ast::Expr::Member(m) = callee.as_ref() {
+                        let is_object_recv = matches!(
+                            m.obj.as_ref(),
+                            swc_ecma_ast::Expr::Ident(id) if id.sym.as_str() == "Object"
+                        );
+                        let prop_name: Option<&str> = match &m.prop {
+                            swc_ecma_ast::MemberProp::Ident(id) => Some(id.sym.as_str()),
+                            _ => None,
+                        };
+                        if is_object_recv {
+                            if let Some(p) = prop_name {
+                                if matches!(
+                                    p,
+                                    "keys" | "values" | "entries"
+                                    | "getOwnPropertyNames" | "getOwnPropertySymbols"
+                                ) {
+                                    ctx.local_array_vars.insert(name.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             // (#592) Array de object literals — extrai field types do
             // primeiro elemento (heuristica: arrays homogeneos).
             if let swc_ecma_ast::Expr::Array(arr) = init_peeled {

--- a/crates/rts-runtime/src/namespaces/collections/abi.rs
+++ b/crates/rts-runtime/src/namespaces/collections/abi.rs
@@ -92,6 +92,68 @@ pub const MEMBERS: &[NamespaceMember] = &[
         intrinsic: None,
         pure: false,
     },
+    // (cross-runtime #753) Dispatcher universal pra `key in obj` —
+    // aceita key como handle (String/Symbol/etc) e obj como Vec ou Map.
+    NamespaceMember {
+        name: "obj_has",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_OBJ_HAS",
+        args: &[AbiType::U64, AbiType::U64],
+        returns: AbiType::Bool,
+        doc: "True when `key_h` is an own property of `obj_h` (Vec or Map). Accepts Symbol keys.",
+        ts_signature: "obj_has(obj_h: number, key_h: number): boolean",
+        intrinsic: None,
+        pure: false,
+    },
+    // (cross-runtime #753) MAP_SET aceitando key como handle (Symbol
+    // canonical encoded como `@@sym:<handle>`).
+    NamespaceMember {
+        name: "map_set_kh",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_MAP_SET_KH",
+        args: &[AbiType::U64, AbiType::U64, AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Inserts/overwrites value for key handle (String or Symbol).",
+        ts_signature: "map_set_kh(obj_h: number, key_h: number, value: number): void",
+        intrinsic: None,
+        pure: false,
+    },
+    // (cross-runtime #753) Dispatcher universal pra `obj[key] = value`.
+    NamespaceMember {
+        name: "obj_set",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_OBJ_SET",
+        args: &[AbiType::U64, AbiType::U64, AbiType::I64],
+        returns: AbiType::Void,
+        doc: "Sets obj[key]=value, dispatching on Vec vs Map. Accepts Symbol keys.",
+        ts_signature: "obj_set(obj_h: number, key_h: number, value: number): void",
+        intrinsic: None,
+        pure: false,
+    },
+    // (cross-runtime #753) Dispatcher universal pra `obj[key]`.
+    NamespaceMember {
+        name: "obj_get",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_OBJ_GET",
+        args: &[AbiType::U64, AbiType::U64],
+        returns: AbiType::I64,
+        doc: "Reads obj[key], dispatching on Vec vs Map. Accepts Symbol keys.",
+        ts_signature: "obj_get(obj_h: number, key_h: number): number",
+        intrinsic: None,
+        pure: false,
+    },
+    // (cross-runtime #753) MAP_GET aceitando key como handle.
+    NamespaceMember {
+        name: "map_get_kh",
+        kind: MemberKind::Function,
+        symbol: "__RTS_FN_NS_COLLECTIONS_MAP_GET_KH",
+        args: &[AbiType::U64, AbiType::U64],
+        returns: AbiType::I64,
+        doc: "Returns value for key handle, or 0 if absent.",
+        ts_signature: "map_get_kh(obj_h: number, key_h: number): number",
+        intrinsic: None,
+        pure: false,
+    },
     NamespaceMember {
         name: "map_clone",
         kind: MemberKind::Function,

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -31,6 +31,19 @@ fn parse_array_index(s: &str) -> Option<u32> {
     Some(n)
 }
 
+/// (#798) Keys com prefixo `@@sym:` sao a repr canonica de Symbol entries
+/// (escrita pelo codegen via OBJ_SET/MAP_SET_KH). NAO sao expostas em
+/// Object.keys/getOwnPropertyNames/values/entries — JS spec separa
+/// string-keyed (Object.keys) de symbol-keyed (getOwnPropertySymbols).
+fn is_symbol_key(k: &str) -> bool {
+    k.starts_with("@@sym:")
+}
+
+/// (#798) Decodifica `@@sym:<handle>` -> handle do Entry::Symbol.
+fn decode_symbol_key(k: &str) -> Option<u64> {
+    k.strip_prefix("@@sym:").and_then(|s| s.parse::<u64>().ok())
+}
+
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
         return None;
@@ -195,6 +208,19 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
         return r;
     }
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
+}
+
+/// (cross-runtime #798) `Object.getOwnPropertySymbols(obj)` — retorna
+/// Vec<i64> com handles de Symbol entries (keys `@@sym:<handle>`).
+/// Ordem: insercao no IndexMap.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS(handle: u64) -> u64 {
+    let syms: Vec<i64> = with_map(handle, Vec::new(), |m| {
+        m.keys()
+            .filter_map(|k| decode_symbol_key(k).map(|h| h as i64))
+            .collect()
+    });
+    alloc_entry(Entry::Vec(Box::new(syms)))
 }
 
 /// (cross-runtime #753) Resolve um handle de "chave qualquer" para a
@@ -664,6 +690,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
             if k.starts_with("__get_") || k.starts_with("__set_") {
                 continue;
             }
+            // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+            if is_symbol_key(k.as_str()) {
+                continue;
+            }
             if is_non_enumerable(handle, k.as_str()) {
                 continue;
             }
@@ -700,6 +730,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
         let mut str_entries: Vec<i64> = Vec::new();
         for (k, v) in m.iter() {
             if k.as_str() == "__proto__" { continue; }
+            // (#798) Symbol keys nao aparecem em Object.keys/values/entries/
+            // getOwnPropertyNames — JS spec.
+            if is_symbol_key(k.as_str()) { continue; }
             if is_non_enumerable(handle, k.as_str()) { continue; }
             match parse_array_index(k) {
                 Some(n) => int_entries.push((n, *v)),
@@ -732,6 +765,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(handle: u64) -> u64 {
         let mut str_entries: Vec<(String, i64)> = Vec::new();
         for (k, v) in m.iter() {
             if k.as_str() == "__proto__" { continue; }
+            // (#798) Symbol keys nao aparecem em Object.keys/values/entries/
+            // getOwnPropertyNames — JS spec.
+            if is_symbol_key(k.as_str()) { continue; }
             if is_non_enumerable(handle, k.as_str()) { continue; }
             match parse_array_index(k) {
                 Some(n) => int_entries.push((n, k.clone(), *v)),
@@ -852,6 +888,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64)
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+                if is_symbol_key(k.as_str()) { continue; }
                 // (#110) Slots internos `__get_*`/`__set_*` nao sao expostos.
                 if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
                 match parse_array_index(k) {
@@ -899,6 +937,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+                if is_symbol_key(k.as_str()) { continue; }
                 // (#110) Slots internos `__get_<name>`/`__set_<name>` armazenam
                 // accessor handles. Object.keys/getOwnPropertyNames JS spec nao
                 // expoe estes — RTS os usa como mecanismo interno de getter/setter.

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -197,6 +197,134 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
 }
 
+/// (cross-runtime #753) Resolve um handle de "chave qualquer" para a
+/// representacao canonica em string usada no IndexMap.
+///
+/// - `Entry::String(bytes)` -> string UTF-8 direta.
+/// - `Entry::Symbol`        -> "@@sym:<handle>" (unico por symbol, sticky).
+/// - outros types           -> None (caller decide).
+fn key_handle_to_string(key_h: u64) -> Option<String> {
+    with_entry(key_h, |e| match e {
+        Some(Entry::String(bytes)) => Some(String::from_utf8_lossy(bytes).into_owned()),
+        Some(Entry::Symbol { .. }) => Some(format!("@@sym:{key_h}")),
+        _ => None,
+    })
+}
+
+/// (cross-runtime #753) `key in obj` generico — dispatch baseado em
+/// Entry type do obj. Aceita key como handle (String, Symbol, etc).
+/// Retorna 1/0.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_HAS(obj_h: u64, key_h: u64) -> i64 {
+    let key = match key_handle_to_string(key_h) {
+        Some(s) => s,
+        None => return 0,
+    };
+    // Vec: index `i` esta "in" array se 0 <= i < length E slot != hole.
+    let vec_result: Option<i64> = with_entry(obj_h, |e| match e {
+        Some(Entry::Vec(v)) => {
+            if let Some(n) = parse_array_index(&key) {
+                let slot = v.get(n as usize).copied();
+                Some(match slot {
+                    Some(s) if s != i64::MIN + 4 => 1,
+                    _ => 0,
+                })
+            } else if key == "length" {
+                Some(1)
+            } else {
+                Some(0)
+            }
+        }
+        _ => None,
+    });
+    if let Some(r) = vec_result {
+        return r;
+    }
+    with_map(obj_h, 0, |m| if m.contains_key(&key) { 1 } else { 0 })
+}
+
+/// (cross-runtime #753) `MAP_SET` aceitando key como handle (resolve
+/// Symbol via repr canonica `@@sym:<handle>`). Para String key normal,
+/// equivalente a MAP_SET.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_SET_KH(obj_h: u64, key_h: u64, value: i64) {
+    let Some(key) = key_handle_to_string(key_h) else {
+        return;
+    };
+    with_map_mut(obj_h, (), |m| {
+        m.insert(key, value);
+    });
+}
+
+/// (cross-runtime #753) `MAP_GET` aceitando key como handle. Retorna
+/// 0 se ausente (use OBJ_HAS pra distinguir).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_KH(obj_h: u64, key_h: u64) -> i64 {
+    let Some(key) = key_handle_to_string(key_h) else {
+        return 0;
+    };
+    with_map(obj_h, 0, |m| m.get(&key).copied().unwrap_or(0))
+}
+
+/// (cross-runtime #753) Dispatcher universal pra `obj[key] = value`:
+/// Vec   -> parse key como uint32 e VEC_SET (extending com holes se preciso).
+/// Map   -> MAP_SET_KH (resolve Symbol via repr canonica).
+/// outros-> noop.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_SET(obj_h: u64, key_h: u64, value: i64) {
+    // Vec path: tenta parse de array index a partir da key.
+    let is_vec = with_entry(obj_h, |e| matches!(e, Some(Entry::Vec(_))));
+    if is_vec {
+        if let Some(key) = key_handle_to_string(key_h) {
+            if let Some(n) = parse_array_index(&key) {
+                with_entry_mut(obj_h, |e| {
+                    if let Some(Entry::Vec(v)) = e {
+                        let idx = n as usize;
+                        if idx >= v.len() {
+                            v.resize(idx + 1, i64::MIN + 4);
+                        }
+                        v[idx] = value;
+                    }
+                });
+            }
+        }
+        return;
+    }
+    // Map path (ou other -> noop).
+    if let Some(key) = key_handle_to_string(key_h) {
+        with_map_mut(obj_h, (), |m| {
+            m.insert(key, value);
+        });
+    }
+}
+
+/// (cross-runtime #753) Dispatcher universal pra `obj[key]`:
+/// Vec   -> parse key como uint32 e VEC_GET. "length" retorna len.
+/// Map   -> MAP_GET_KH.
+/// outros-> 0.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_GET(obj_h: u64, key_h: u64) -> i64 {
+    let Some(key) = key_handle_to_string(key_h) else {
+        return 0;
+    };
+    let vec_result: Option<i64> = with_entry(obj_h, |e| match e {
+        Some(Entry::Vec(v)) => {
+            if key == "length" {
+                Some(v.len() as i64)
+            } else if let Some(n) = parse_array_index(&key) {
+                Some(v.get(n as usize).copied().unwrap_or(i64::MIN + 2))
+            } else {
+                Some(0)
+            }
+        }
+        _ => None,
+    });
+    if let Some(r) = vec_result {
+        return r;
+    }
+    with_map(obj_h, 0, |m| m.get(&key).copied().unwrap_or(0))
+}
+
 /// (cross-runtime #793) `map.forEach((value, key, map) => ...)`.
 /// JS spec: callback recebe (value, key, map). RTS aceita callback ate 3 args;
 /// se aridade for menor, args extras sao ignorados (transmute pra arity certa).

--- a/tests/object_own_property_symbols.test.ts
+++ b/tests/object_own_property_symbols.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+// (#798) Object.getOwnPropertySymbols deve retornar handles de Symbol
+// gravados como computed keys; Object.keys / getOwnPropertyNames devem
+// filtrar essas entries `@@sym:<handle>` da repr interna.
+
+const sym1 = Symbol("a");
+const sym2 = Symbol("b");
+const obj: any = {
+  normal: 1,
+  [sym1]: "value1",
+  [sym2]: "value2",
+};
+
+const symbols: any = Object.getOwnPropertySymbols(obj);
+const count = symbols.length;
+const has1 = symbols.includes(sym1);
+const has2 = symbols.includes(sym2);
+const keysJoined = Object.keys(obj).join(",");
+const namesJoined = Object.getOwnPropertyNames(obj).join(",");
+
+describe("Object.getOwnPropertySymbols (#798)", () => {
+  test("count == 2", () => expect(count).toBe(2));
+  test("includes sym1", () => expect(has1).toBe(true));
+  test("includes sym2", () => expect(has2).toBe(true));
+  test("Object.keys nao vaza @@sym:", () => expect(keysJoined).toBe("normal"));
+  test("Object.getOwnPropertyNames nao vaza @@sym:", () =>
+    expect(namesJoined).toBe("normal"));
+});

--- a/tests/symbol_as_key.test.ts
+++ b/tests/symbol_as_key.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+// (#753) Symbol pode ser usado como key em obj literal computed,
+// computed assignment e como rhs de `in`. Ate antes do fix, o codegen
+// resolvia symbol via STRING_PTR/LEN (que falha em handles nao-string),
+// e `in` so' suportava Vec.
+
+const sym = Symbol("test");
+const obj: any = {};
+obj[sym] = "value";
+const hasViaIn = sym in obj;
+const valViaGet = obj[sym];
+
+const withSym = Object.assign({}, { [sym]: "ol", normal: "data" });
+const hasInAssigned = sym in withSym;
+const normalInMap = "normal" in withSym;
+const missingKey = "nope" in withSym;
+
+describe("Symbol as object key (#753)", () => {
+  test("obj[sym] = v + obj[sym] read", () => expect(valViaGet).toBe("value"));
+  test("sym in obj", () => expect(hasViaIn).toBe(true));
+  test("Object.assign preserva [sym] computed key", () => expect(hasInAssigned).toBe(true));
+  test("string key in Map handle (regressao geral do in)", () => expect(normalInMap).toBe(true));
+  test("ausente in Map retorna false", () => expect(missingKey).toBe(false));
+});


### PR DESCRIPTION
## Summary

Fecha #753 (`126_object_assign — rts_diverge`). Tres bugs interligados:

- `obj[sym] = v` caia em VEC_SET (key Symbol nao parseia como indice)
- `obj[sym]` chamava STRING_PTR em handle Symbol -> null -> MAP_GET=0
- `sym in obj` chamava VEC_HAS_INDEX, que retorna 0 em Map handles
  (regressao geral: ate `"key" in mapHandle` retornava false)

## Fix

Tres helpers runtime em `collections/map.rs` que aceitam key como
handle e resolvem Symbol via repr canonica `@@sym:<handle>`:

- `OBJ_HAS(obj_h, key_h)` — dispatcher universal `key in obj`
- `OBJ_SET(obj_h, key_h, v)` — dispatcher universal `obj[k] = v`
- `OBJ_GET(obj_h, key_h)` — dispatcher universal `obj[k]`
- `MAP_SET_KH` / `MAP_GET_KH` — variantes Map-only

Codegen:
- `BinaryOp::In` -> `OBJ_HAS`
- Computed key em obj literal -> `MAP_SET_KH`
- `obj[expr] = v` -> hot path I32/I64/U64 mantem VEC_SET (sem regressao em `arr[i]=v`); handle keys vao por `OBJ_SET`
- `obj[handle]` -> `MAP_GET_KH`

## Test plan

- [x] tests/symbol_as_key.test.ts (novo) — 5/5
- [x] Fixture 126_object_assign roda RTS == Bun/Node
- [x] `target/release/rts.exe test` — **1233/1233** (487 files)
- [x] `cargo test --release --lib` — 12/12
- [x] `cargo build --release` — sem warnings novos

Falha `mir_codegen::tests::inline_routing_caller_callee_e2e` em `cargo test --workspace` ja existia em `main` (verificado via `git stash`), nao relacionada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)