### PR TITLE
feat(#798): Object.getOwnPropertySymbols + filtra @@sym:* em keys/names

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1143,6 +1143,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY
         );
         add_fn!(
+            "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS",
+            map::__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS
+        );
+        add_fn!(
             "__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE",
             map::__RTS_FN_GL_OBJECT_PROPERTY_IS_ENUMERABLE
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -781,17 +781,18 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
-                // (#798/192) Object.getOwnPropertySymbols(obj) — RTS Maps usam
-                // chaves String, sem suporte real a Symbol keys (#216). Retorna
-                // sempre Vec vazio para satisfazer a shape API.
+                // (#798) Object.getOwnPropertySymbols(obj) — apos #753, Symbol
+                // keys sao gravadas como `@@sym:<handle>` no Map. Decodifica
+                // essas keys de volta para Vec de Symbol handles.
                 if method == "getOwnPropertySymbols" && call.args.len() == 1 {
-                    let _ = lower_expr(ctx, &call.args[0].expr)?;
+                    let arg_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let h = ctx.coerce_to_i64(arg_tv).val;
                     let f = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
-                        &[],
+                        "__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS",
+                        &[cl::I64],
                         Some(cl::I64),
                     )?;
-                    let inst = ctx.builder.ins().call(f, &[]);
+                    let inst = ctx.builder.ins().call(f, &[h]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -76,6 +76,34 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             if matches!(init_peeled, swc_ecma_ast::Expr::Array(_)) {
                 ctx.local_array_vars.insert(name.clone());
             }
+            // (#798) `const x = Object.keys/values/getOwnPropertyNames/getOwnPropertySymbols(...)`
+            // retorna Vec — marca pra que `x.includes(sym)` use VEC_INCLUDES e nao
+            // o string builtin (que ignora needle e retorna 0).
+            if let swc_ecma_ast::Expr::Call(call) = init_peeled {
+                if let swc_ecma_ast::Callee::Expr(callee) = &call.callee {
+                    if let swc_ecma_ast::Expr::Member(m) = callee.as_ref() {
+                        let is_object_recv = matches!(
+                            m.obj.as_ref(),
+                            swc_ecma_ast::Expr::Ident(id) if id.sym.as_str() == "Object"
+                        );
+                        let prop_name: Option<&str> = match &m.prop {
+                            swc_ecma_ast::MemberProp::Ident(id) => Some(id.sym.as_str()),
+                            _ => None,
+                        };
+                        if is_object_recv {
+                            if let Some(p) = prop_name {
+                                if matches!(
+                                    p,
+                                    "keys" | "values" | "entries"
+                                    | "getOwnPropertyNames" | "getOwnPropertySymbols"
+                                ) {
+                                    ctx.local_array_vars.insert(name.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             // (#592) Array de object literals — extrai field types do
             // primeiro elemento (heuristica: arrays homogeneos).
             if let swc_ecma_ast::Expr::Array(arr) = init_peeled {

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -31,6 +31,19 @@ fn parse_array_index(s: &str) -> Option<u32> {
     Some(n)
 }
 
+/// (#798) Keys com prefixo `@@sym:` sao a repr canonica de Symbol entries
+/// (escrita pelo codegen via OBJ_SET/MAP_SET_KH). NAO sao expostas em
+/// Object.keys/getOwnPropertyNames/values/entries — JS spec separa
+/// string-keyed (Object.keys) de symbol-keyed (getOwnPropertySymbols).
+fn is_symbol_key(k: &str) -> bool {
+    k.starts_with("@@sym:")
+}
+
+/// (#798) Decodifica `@@sym:<handle>` -> handle do Entry::Symbol.
+fn decode_symbol_key(k: &str) -> Option<u64> {
+    k.strip_prefix("@@sym:").and_then(|s| s.parse::<u64>().ok())
+}
+
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
         return None;
@@ -195,6 +208,19 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_HAS_OWN_PROPERTY(
         return r;
     }
     with_map(handle, 0, |m| if m.contains_key(key) { 1 } else { 0 })
+}
+
+/// (cross-runtime #798) `Object.getOwnPropertySymbols(obj)` — retorna
+/// Vec<i64> com handles de Symbol entries (keys `@@sym:<handle>`).
+/// Ordem: insercao no IndexMap.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS(handle: u64) -> u64 {
+    let syms: Vec<i64> = with_map(handle, Vec::new(), |m| {
+        m.keys()
+            .filter_map(|k| decode_symbol_key(k).map(|h| h as i64))
+            .collect()
+    });
+    alloc_entry(Entry::Vec(Box::new(syms)))
 }
 
 /// (cross-runtime #753) Resolve um handle de "chave qualquer" para a
@@ -664,6 +690,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
             if k.starts_with("__get_") || k.starts_with("__set_") {
                 continue;
             }
+            // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+            if is_symbol_key(k.as_str()) {
+                continue;
+            }
             if is_non_enumerable(handle, k.as_str()) {
                 continue;
             }
@@ -700,6 +730,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
         let mut str_entries: Vec<i64> = Vec::new();
         for (k, v) in m.iter() {
             if k.as_str() == "__proto__" { continue; }
+            // (#798) Symbol keys nao aparecem em Object.keys/values/entries/
+            // getOwnPropertyNames — JS spec.
+            if is_symbol_key(k.as_str()) { continue; }
             if is_non_enumerable(handle, k.as_str()) { continue; }
             match parse_array_index(k) {
                 Some(n) => int_entries.push((n, *v)),
@@ -732,6 +765,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(handle: u64) -> u64 {
         let mut str_entries: Vec<(String, i64)> = Vec::new();
         for (k, v) in m.iter() {
             if k.as_str() == "__proto__" { continue; }
+            // (#798) Symbol keys nao aparecem em Object.keys/values/entries/
+            // getOwnPropertyNames — JS spec.
+            if is_symbol_key(k.as_str()) { continue; }
             if is_non_enumerable(handle, k.as_str()) { continue; }
             match parse_array_index(k) {
                 Some(n) => int_entries.push((n, k.clone(), *v)),
@@ -852,6 +888,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64)
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+                if is_symbol_key(k.as_str()) { continue; }
                 // (#110) Slots internos `__get_*`/`__set_*` nao sao expostos.
                 if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
                 match parse_array_index(k) {
@@ -899,6 +937,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {
             let mut str_keys: Vec<String> = Vec::new();
             for k in m.keys() {
                 if k.as_str() == "__proto__" { continue; }
+                // (#798) Symbol keys: separadas via getOwnPropertySymbols.
+                if is_symbol_key(k.as_str()) { continue; }
                 // (#110) Slots internos `__get_<name>`/`__set_<name>` armazenam
                 // accessor handles. Object.keys/getOwnPropertyNames JS spec nao
                 // expoe estes — RTS os usa como mecanismo interno de getter/setter.

--- a/tests/object_own_property_symbols.test.ts
+++ b/tests/object_own_property_symbols.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+// (#798) Object.getOwnPropertySymbols deve retornar handles de Symbol
+// gravados como computed keys; Object.keys / getOwnPropertyNames devem
+// filtrar essas entries `@@sym:<handle>` da repr interna.
+
+const sym1 = Symbol("a");
+const sym2 = Symbol("b");
+const obj: any = {
+  normal: 1,
+  [sym1]: "value1",
+  [sym2]: "value2",
+};
+
+const symbols: any = Object.getOwnPropertySymbols(obj);
+const count = symbols.length;
+const has1 = symbols.includes(sym1);
+const has2 = symbols.includes(sym2);
+const keysJoined = Object.keys(obj).join(",");
+const namesJoined = Object.getOwnPropertyNames(obj).join(",");
+
+describe("Object.getOwnPropertySymbols (#798)", () => {
+  test("count == 2", () => expect(count).toBe(2));
+  test("includes sym1", () => expect(has1).toBe(true));
+  test("includes sym2", () => expect(has2).toBe(true));
+  test("Object.keys nao vaza @@sym:", () => expect(keysJoined).toBe("normal"));
+  test("Object.getOwnPropertyNames nao vaza @@sym:", () =>
+    expect(namesJoined).toBe("normal"));
+});


### PR DESCRIPTION
## Summary

Fecha #798 (`192_object_getownpropertysymbols — rts_error`). Empilhado em cima de #998 (que destravou Symbol keys gravadas como `@@sym:<handle>`).

Tres sintomas fixados:
- `Object.getOwnPropertySymbols(obj)` retornava Vec vazio (stub)
- `Object.keys(obj)` / `getOwnPropertyNames(obj)` vazavam entries `@@sym:<n>` na lista
- `symbolsArr.includes(sym)` ia pro string builtin (porque var sem anotacao com Handle entrava em `lower_string_builtin` antes de `lower_array_builtin`)

## Fix

- Helpers `is_symbol_key` / `decode_symbol_key` em `collections/map.rs`
- Novo `__RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_SYMBOLS` que filter_map decode sobre as keys
- Filtro `is_symbol_key` nos 5 sites de listing (MAP_KEYS, MAP_VALUES, MAP_ENTRIES, OBJECT_OWN_PROPERTY_NAMES, OBJECT_KEYS_AUTO)
- Codegen do `Object.getOwnPropertySymbols(x)` rota pra fn real (era VEC_NEW vazio)
- `decls.rs`: marca como `local_array_var` resultado de `Object.{keys,values,entries,getOwnPropertyNames,getOwnPropertySymbols}(...)` — destrava `arr.includes(sym)`

## Test plan

- [x] tests/object_own_property_symbols.test.ts (5/5)
- [x] Fixture 192_object_getownpropertysymbols bate com Bun/Node
- [x] `target/release/rts.exe test`: **1238/1238**
- [x] `cargo test --release --lib`: 12/12

Stack: rebase em #998 quando o anterior mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)