### PR TITLE
fix(#789): getOwnPropertyNames(new String) retorna keys

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -917,6 +917,17 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64)
             out.push(alloc_entry(Entry::String(b"length".to_vec())) as i64);
             out
         }
+        Some(Entry::String(b)) => {
+            // (#789) `new String("hi")` -> getOwnPropertyNames retorna
+            // ["0","1",...,"length"] usando UTF-16 code units (mesmo
+            // criterio de String.length em JS).
+            let char_count = String::from_utf8_lossy(b).encode_utf16().count();
+            let mut out: Vec<i64> = (0..char_count)
+                .map(|i| alloc_entry(Entry::String(i.to_string().into_bytes())) as i64)
+                .collect();
+            out.push(alloc_entry(Entry::String(b"length".to_vec())) as i64);
+            out
+        }
         _ => Vec::new(),
     });
     alloc_entry(Entry::Vec(Box::new(result)))

--- a/tests/getownpropertynames_string_box.test.ts
+++ b/tests/getownpropertynames_string_box.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from "rts:test";
+
+// (#789) Object.getOwnPropertyNames(new String("...")) deve retornar
+// ["0","1",...,"length"] usando UTF-16 code units. Antes do fix, faltava
+// o ramo Entry::String em OBJECT_OWN_PROPERTY_NAMES -> retornava vazio.
+
+const s = new String("hi");
+const names = (Object.getOwnPropertyNames(s) as any).sort().join(",");
+
+const empty = new String("");
+const emptyNames = (Object.getOwnPropertyNames(empty) as any).join(",");
+
+describe("getOwnPropertyNames em String box (#789)", () => {
+  test("'hi' -> 0,1,length", () => expect(names).toBe("0,1,length"));
+  test("string vazia -> so length", () => expect(emptyNames).toBe("length"));
+});


### PR DESCRIPTION
## Summary

Fecha #789 (`183_object_getownpropertynames — rts_error`). Empilhado em #999.

`OBJECT_OWN_PROPERTY_NAMES` tinha ramos pra `Entry::Map` e `Entry::Vec` mas faltava `Entry::String`. Logo `Object.getOwnPropertyNames(new String(\"hi\"))` caia no fallback `_ => Vec::new()` e retornava `[]`. JS spec: `[\"0\",\"1\",...,\"length\"]` por UTF-16 code units.

## Fix

Add ramo `Entry::String` iterando `encode_utf16().count()` indices + push `\"length\"`. Mesmo estilo do `OBJECT_KEYS_AUTO`.

## Test plan

- [x] tests/getownpropertynames_string_box.test.ts (2/2)
- [x] Fixture 183 bate com Bun/Node
- [x] `rts.exe test`: **1243/1243**
- [x] `cargo --lib`: 12/12

Stack: PR #998 -> PR #999 -> este. Rebase em main quando os anteriores merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)