### PR TITLE
fix(instanceof): aceita I64/U64 lhs em global instanceof (corrige 278_aggregate_error)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1487,8 +1487,11 @@ fn lower_global_instanceof(
     lhs_expr: &Expr,
 ) -> Result<TypedVal> {
     let lhs = lower_expr(ctx, lhs_expr)?;
-    // Primitives (F64/I64/I32/Bool) nunca passam instanceof <class>.
-    if !matches!(lhs.ty, ValTy::Handle) {
+    // F64/I32/Bool sao primitives puros — nunca passam instanceof <class>.
+    // I64/U64 podem carregar handles (ex: callback param sem tipo onde
+    // o array element eh handle). Caem no runtime check via IS_* que
+    // retorna 0 para handles invalidos — sem regressao em primitivos.
+    if matches!(lhs.ty, ValTy::F64 | ValTy::I32 | ValTy::Bool) {
         let zero = ctx.builder.ins().iconst(cl::I64, 0);
         return Ok(TypedVal::new(zero, ValTy::Bool));
     }

--- a/tests/instanceof_in_callback.test.ts
+++ b/tests/instanceof_in_callback.test.ts
@@ -1,0 +1,18 @@
+import { describe, test, expect } from "rts:test";
+
+// `x instanceof Error` dentro de callback de Array.map sem anotacao de
+// tipo no param caia em `lower_global_instanceof` -> primitive check
+// (lhs.ty == I64, nao Handle) -> retornava sempre false. JS spec: o
+// runtime check de Entry::ErrorObj deve rodar mesmo quando o codegen
+// infere I64 (array elements vem como i64 raw carregando handle).
+
+const err = new Error("a");
+const directly = err instanceof Error;
+
+const arr: any[] = [new Error("a"), "b"];
+const items = arr.map((x: any) => x instanceof Error ? x.message : String(x)).join("|");
+
+describe("instanceof em callback param sem tipo", () => {
+  test("instanceof direto continua funcionando", () => expect(directly).toBe(true));
+  test("arr.map(x => x instanceof Error)", () => expect(items).toBe("a|b"));
+});


### PR DESCRIPTION
## Summary

Corrige fixture cross-runtime `278_aggregate_error` (rts_diverge → 100% bate Bun/Node). Empilhado em #1001.

Bug raiz: \`lower_global_instanceof\` rejeitava lhs cujo ValTy fosse qualquer coisa ≠ Handle, retornando false direto. Mas array elements em callback de \`Array.map\` sem anotacao no param vem como I64 raw carregando o handle. Resultado: \`arr.map(x => x instanceof Error ? ...)\` sempre false mesmo quando x era Error.

## Fix

So rejeitar lhs primitivo concreto (F64 / I32 / Bool). I64/U64 passam pelo runtime check (IS_ERROR, IS_VEC, etc) — essas fns ja retornam 0 para handles invalidos via \`with_entry\`, sem regressao em integers primitivos.

## Test plan

- [x] tests/instanceof_in_callback.test.ts (2/2)
- [x] Fixture 278_aggregate_error: agora bate Bun/Node
- [x] \`rts.exe test\`: **1249/1249**
- [x] \`cargo --lib\`: 12/12

Stack: #998 → #999 → #1000 → #1001 → este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)