### PR TITLE
fix(#777): skip universal methods (toString/valueOf/...) em fallback GLOBAL_CLASS_SPECS

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -918,7 +918,26 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 }
             }
             let obj_is_call_result = chain_has_call_root(m.obj.as_ref(), &ctx.local_ambiguous_vars);
-            if receiver_class.is_none() && !is_known_obj_lit && !skip_function_meta && !obj_is_call_result {
+            // (#777) Methods universais que toda classe global define
+            // (toString/valueOf/hasOwnProperty/etc) NAO devem dispatch via
+            // GLOBAL_CLASS_SPECS fallback — o primeiro spec que define o
+            // metodo (ex: String) vence e retorna lixo quando o receiver
+            // nao eh dessa classe. Bug raiz: `Object.create(null).toString`
+            // retornava o proprio handle porque String.toString eh passthrough.
+            //
+            // Para esses, cai no map_get_chain abaixo que retorna 0 quando
+            // a key nao esta no Map (semantica correta: undefined).
+            let is_universal_method = matches!(
+                key,
+                "toString" | "valueOf" | "hasOwnProperty" | "toLocaleString"
+                | "isPrototypeOf" | "propertyIsEnumerable" | "constructor"
+            );
+            if receiver_class.is_none()
+                && !is_known_obj_lit
+                && !skip_function_meta
+                && !obj_is_call_result
+                && !is_universal_method
+            {
                 // (#216) Tenta instance_getter primeiro (description, source, flags, etc.)
                 for spec in crate::abi::GLOBAL_CLASS_SPECS {
                     if let Some(member) = spec.instance_getter(key) {

--- a/tests/object_create_null_methods.test.ts
+++ b/tests/object_create_null_methods.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+// (#777) `Object.create(null).toString` retornava o proprio handle do
+// obj em vez de 0/undefined. Bug raiz: o fallback em members.rs
+// iterava GLOBAL_CLASS_SPECS procurando instance_method por nome de
+// prop. `String.toString` (primeiro spec) era passthrough — retornava
+// o handle direto. Fix: skip-list de metodos universais
+// (toString/valueOf/hasOwnProperty/...) — esses devem cair em
+// map_get_chain que retorna 0 (key ausente) em vez de virar dispatch
+// arbitrario.
+
+const o = Object.create(null);
+const ts = (o as any).toString;
+const tsEqO = (ts as any) === (o as any);
+const tsZero = (ts as any) === 0;
+const noProp = (o as any).nonexistent;
+const tsTypeOf = typeof (o as any).toString;
+
+describe("Object.create(null) sem prototype methods (#777)", () => {
+  test("o.toString nao retorna o proprio handle", () => expect(tsEqO).toBe(false));
+  test("o.toString eh 0 (key ausente)", () => expect(tsZero).toBe(true));
+  test("o.nonexistent eh 0", () => expect((noProp as any) === 0).toBe(true));
+  test("typeof o.toString nao eh 'object'", () =>
+    expect(tsTypeOf === "object" ? "wrong" : "ok").toBe("ok"));
+});


### PR DESCRIPTION
## Summary

Reduz #777 (`162_object_create_null — rts_error → rts_diverge com 1 linha`). Empilhado em #1002.

Bug raiz: \`obj.toString\` em member access sem receiver_class identificado iterava \`GLOBAL_CLASS_SPECS\` procurando um \`instance_method\` por nome. O primeiro spec na lista (String) tem \`toString\` cujo runtime impl (\`STRING_TO_STRING\`) faz passthrough do handle direto quando nao eh String. Logo:

\`\`\`ts
const o = Object.create(null);
o.toString === o   // RTS retornava true (era pra ser false)
\`\`\`

E o mesmo padrao causava lixo para \`valueOf\`, \`hasOwnProperty\`, etc.

## Fix

Skip-list de metodos universais a toda classe global no fallback de \`GLOBAL_CLASS_SPECS\`:
\`toString | valueOf | hasOwnProperty | toLocaleString | isPrototypeOf | propertyIsEnumerable | constructor\`

Esses caem em \`MAP_GET_CHAIN\` que retorna 0 (semantica correta: chave ausente = undefined).

## Delta residual

Fixture 162 ainda diverge em 1 linha: \`(obj1.toString === undefined)\` agora retorna \`false\` mas Bun/Node retornam \`true\`. RTS encoda key ausente como 0 e o operator \`=== undefined\` so' aceita sentinels \`MIN+2\`/\`MIN+4\`. Fix separado (precisa propagar flag de \"resultado de member access\" para comparation aceitar 0).

## Test plan

- [x] tests/object_create_null_methods.test.ts (4/4)
- [x] \`rts.exe test\`: **1251/1251**
- [x] \`cargo --lib\`: 12/12

Stack: #998 → #999 → #1000 → #1001 → #1002 → este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)