### PR TITLE
fix(#103): JSON.stringify filtra Symbol keys (@@sym:*)

### DIFF
--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -252,6 +252,9 @@ fn stringify_with_visited(
                 if k == "__proto__" { continue; }
                 // (#110) Slots internos getter/setter — nao sao props publicas.
                 if k.starts_with("__get_") || k.starts_with("__set_") { continue; }
+                // (#103) Symbol keys (encoded como `@@sym:<handle>` pelo
+                // codegen) NAO sao serializadas em JSON.stringify — JS spec.
+                if k.starts_with("@@sym:") { continue; }
                 // (#680/50) JSON spec: omite props com valor undefined em obj.
                 if is_undefined_value(val) { continue; }
                 if !first { out.push(','); }
@@ -393,6 +396,7 @@ fn stringify_with_keys(handle: u64, keys: &[String]) -> Option<String> {
                 let mut first = true;
                 for k in keys {
                     if k == "__proto__" { continue; }
+                    if k.starts_with("@@sym:") { continue; }
                     if let Some(val) = m.get(k) {
                         if !first { out.push(','); }
                         first = false;
@@ -497,7 +501,13 @@ fn stringify_pretty_inner_str(handle: u64, indent: &str, depth: usize) -> Option
             Entry::String(_) => stringify_any_inner(handle),
             Entry::Map(m) => {
                 let entries: Vec<(&String, &i64)> = m.iter()
-                    .filter(|(k, _)| k.as_str() != "__proto__")
+                    .filter(|(k, _)| {
+                        let s = k.as_str();
+                        s != "__proto__"
+                            && !s.starts_with("@@sym:")
+                            && !s.starts_with("__get_")
+                            && !s.starts_with("__set_")
+                    })
                     .collect();
                 if entries.is_empty() {
                     out.push_str("{}");

--- a/tests/json_stringify_filters_symbol_keys.test.ts
+++ b/tests/json_stringify_filters_symbol_keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+// (#103) JSON.stringify deve filtrar Symbol keys (encoded como
+// `@@sym:<handle>` internamente pelo RTS apos #753). JS spec: Symbol
+// keys nunca aparecem em JSON output.
+
+const sym = Symbol("z");
+const obj: any = {};
+obj["a"] = 1;
+obj[sym] = "secret";
+obj["b"] = 2;
+
+const json = JSON.stringify(obj);
+
+const empty: any = {};
+empty[Symbol("x")] = "v";
+const emptyJson = JSON.stringify(empty);
+
+describe("JSON.stringify filtra Symbol keys (#103)", () => {
+  test("nao vaza @@sym:* em output normal", () =>
+    expect(json).toBe('{"a":1,"b":2}'));
+  test("obj so' com Symbol key -> {}", () => expect(emptyJson).toBe("{}"));
+});


### PR DESCRIPTION
## Summary

Corrige fixture cross-runtime \`103_property_order_weird\` (rts_diverge → 100% bate Bun/Node). Empilhado em #1003.

Apos #753 (PR #998), Symbol como obj key e' gravado como \`@@sym:<handle>\` no IndexMap interno. JSON.stringify nao filtrava essas entries — output incluia \`\"@@sym:281474976710657\":\"sym\"\` em vez de omitir (JS spec: Symbol keys nunca aparecem em JSON).

## Fix

Filtro \`@@sym:\` em 3 sites em \`json/ops.rs\`:
- \`stringify_with_visited\` (path generico)
- \`stringify_with_keys\` (path com replacer array)
- \`stringify_pretty_inner_str\` (path pretty-print)

Pretty-print path tambem ganhou filtro para \`__get_\`/\`__set_\`/\`__proto__\` em uma so passada (estava so' filtrando \`__proto__\`).

## Test plan

- [x] tests/json_stringify_filters_symbol_keys.test.ts (2/2)
- [x] Fixture 103_property_order_weird: bate Bun/Node 100%
- [x] \`rts.exe test\`: **1255/1255**
- [x] \`cargo --lib\`: 12/12

Stack: #998 → #999 → #1000 → #1001 → #1002 → #1003 → este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)