### PR TITLE
fix(#749 follow-up): descriptor reflete writable/enumerable de defineProperty

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1184,12 +1184,17 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY(
     // Bool eh empacotado em object literal via sentinela i64::MIN (false)
     // / i64::MIN+1 (true) pelo codegen. Strict check para evitar false
     // positive de handle nao-zero.
+    let bool_from = |v: &i64| -> bool {
+        if *v == i64::MIN { false }
+        else if *v == i64::MIN + 1 { true }
+        else { *v != 0 }
+    };
     let is_enumerable: Option<bool> = with_map(descriptor, None, |m| {
-        m.get("enumerable").map(|v| {
-            if *v == i64::MIN { false }
-            else if *v == i64::MIN + 1 { true }
-            else { *v != 0 }
-        })
+        m.get("enumerable").map(&bool_from)
+    });
+    // (#749) writable flag — Object.defineProperty(obj, k, { writable: false }).
+    let is_writable: Option<bool> = with_map(descriptor, None, |m| {
+        m.get("writable").map(&bool_from)
     });
     let key_str = match str_from_abi(key_ptr, key_len) {
         Some(s) => s.to_string(),
@@ -1207,6 +1212,11 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY(
             .lock()
             .unwrap()
             .remove(&(obj, key_str.clone()));
+    }
+    if matches!(is_writable, Some(false)) {
+        mark_non_writable(obj, &key_str);
+    } else if matches!(is_writable, Some(true)) {
+        unmark_non_writable(obj, &key_str);
     }
     __RTS_FN_NS_COLLECTIONS_MAP_SET(obj, key_ptr, key_len, value);
     obj

--- a/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/reflect/ops.rs
@@ -54,14 +54,24 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR(
         return alloc_undef();
     };
 
-    // (#795) Sintetiza { value, writable: true, enumerable: true, configurable: true }
-    // Bools como sentinel JS (i64::MIN+1 = true) — TPL_COERCE_AUTO/JSON
-    // renderiza como "true". Slot int 1 viraria string "1".
+    // (#795/#749) Sintetiza { value, writable, enumerable, configurable }.
+    // Consulta flags reais setadas via Object.defineProperty; default true.
     let bool_true: i64 = i64::MIN + 1;
+    let bool_false: i64 = i64::MIN;
+    let writable = if crate::namespaces::collections::map::is_non_writable(obj, &key_str) {
+        bool_false
+    } else {
+        bool_true
+    };
+    let enumerable = if crate::namespaces::collections::map::is_non_enumerable(obj, &key_str) {
+        bool_false
+    } else {
+        bool_true
+    };
     let mut desc: IndexMap<String, i64> = IndexMap::new();
     desc.insert("value".to_string(), v);
-    desc.insert("writable".to_string(), bool_true);
-    desc.insert("enumerable".to_string(), bool_true);
+    desc.insert("writable".to_string(), writable);
+    desc.insert("enumerable".to_string(), enumerable);
     desc.insert("configurable".to_string(), bool_true);
     alloc_entry(Entry::Map(Box::new(desc)))
 }
@@ -82,6 +92,7 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS(obj: u64) -> u
         _ => Vec::new(),
     });
     let bool_true: i64 = i64::MIN + 1;
+    let bool_false: i64 = i64::MIN;
     // Particiona: data props vs accessor slots. Accessors juntam
     // get/set pelo nome base e produzem um unico descriptor.
     let mut data_pairs: Vec<(String, i64)> = Vec::new();
@@ -98,10 +109,21 @@ pub extern "C" fn __RTS_FN_GL_OBJECT_GET_OWN_PROPERTY_DESCRIPTORS(obj: u64) -> u
     }
     let mut out: IndexMap<String, i64> = IndexMap::new();
     for (k, v) in data_pairs {
+        // (#749) Consulta flags reais setadas via Object.defineProperty.
+        let writable = if crate::namespaces::collections::map::is_non_writable(obj, &k) {
+            bool_false
+        } else {
+            bool_true
+        };
+        let enumerable = if crate::namespaces::collections::map::is_non_enumerable(obj, &k) {
+            bool_false
+        } else {
+            bool_true
+        };
         let mut desc: IndexMap<String, i64> = IndexMap::new();
         desc.insert("value".to_string(), v);
-        desc.insert("writable".to_string(), bool_true);
-        desc.insert("enumerable".to_string(), bool_true);
+        desc.insert("writable".to_string(), writable);
+        desc.insert("enumerable".to_string(), enumerable);
         desc.insert("configurable".to_string(), bool_true);
         let desc_h = alloc_entry(Entry::Map(Box::new(desc))) as i64;
         out.insert(k, desc_h);

--- a/tests/descriptor_writable_enumerable.test.ts
+++ b/tests/descriptor_writable_enumerable.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "rts:test";
+
+// (#749 follow-up) Object.getOwnPropertyDescriptors deve refletir
+// writable/enumerable=false setados via Object.defineProperty. Antes
+// eram sempre sintetizados como true; agora consulta non_writable_set/
+// non_enumerable_set. Bools sao storage interno como sentinel; uso
+// String() para comparar via stringification.
+
+const obj: any = { a: 1 };
+Object.defineProperty(obj, "b", { value: 2, writable: false, enumerable: false });
+Object.defineProperty(obj, "c", { value: 3, writable: false });
+Object.defineProperty(obj, "d", { value: 4, enumerable: false });
+
+const descs: any = Object.getOwnPropertyDescriptors(obj);
+
+const bStr = String(descs.b.writable) + "/" + String(descs.b.enumerable);
+const cStr = String(descs.c.writable) + "/" + String(descs.c.enumerable);
+const dStr = String(descs.d.writable) + "/" + String(descs.d.enumerable);
+const aStr = String(descs.a.writable) + "/" + String(descs.a.enumerable);
+
+describe("descriptor writable/enumerable reflete defineProperty (#749)", () => {
+  test("b com writable+enumerable false", () => expect(bStr).toBe("false/false"));
+  test("c so' writable false", () => expect(cStr).toBe("false/true"));
+  test("d so' enumerable false", () => expect(dStr).toBe("true/false"));
+  test("a sem flags -> default true", () => expect(aStr).toBe("true/true"));
+});


### PR DESCRIPTION
## Summary

Fecha mais um delta de #749 (\`110_object_getownpropertydescriptors\`).

Apos #1001 emitir accessor descriptor para getters, sobravam 2 deltas:
1. \`b.get === \"function\"\` — escopo separado (precisa Function entry no slot do getter)
2. \`c.writable/enumerable = false\` em \`Object.defineProperty(obj, c, {writable:false, enumerable:false})\` — RTS sempre sintetizava true

## Fix

\`MAP_DEFINE_PROPERTY\`:
- Le \`writable\` do descriptor (alem do existente \`enumerable\`)
- Chama \`mark_non_writable\` / \`unmark_non_writable\`

\`OBJECT_GET_OWN_PROPERTY_DESCRIPTORS\` + \`REFLECT_GET_OWN_PROPERTY_DESCRIPTOR\`:
- Consulta \`is_non_writable(obj, k)\` / \`is_non_enumerable(obj, k)\` ao sintetizar
- Default permanece true; flag false vira sentinel \`i64::MIN\`

## Delta residual

\`typeof descs.b.get === \"function\"\` (RTS retorna \`\"number\"\`) — getter armazena fn_ptr raw, refator de Function entry fica em escopo separado.

## Test plan

- [x] tests/descriptor_writable_enumerable.test.ts (4/4)
- [x] Fixture 110_object_getownpropertydescriptors agora bate Bun/Node em writable+enumerable (3 deltas fixos)
- [x] \`rts.exe test\`: **1269/1269**
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)