### PR TITLE
fix(#245): Number instance methods recebem F64 corretamente

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -384,8 +384,17 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     if let Some(spec) = crate::abi::global_class_lookup(&class_name) {
                         if let Some(member) = spec.instance_method(&method_name) {
                             let recv_tv = lower_expr(ctx, &m.obj)?;
-                            let recv_i64 = ctx.coerce_to_i64(recv_tv).val;
-                            return lower_global_instance_call(ctx, member, recv_i64, call);
+                            // (#245) Receiver type must match member.args[0].
+                            // Number's instance_methods receive F64 directly,
+                            // not Handle — coerce_to_i64 would fcvt and break
+                            // verifier downstream.
+                            let recv_val = match member.args.first() {
+                                Some(crate::abi::AbiType::F64) => {
+                                    ctx.coerce_to_f64(recv_tv).val
+                                }
+                                _ => ctx.coerce_to_i64(recv_tv).val,
+                            };
+                            return lower_global_instance_call(ctx, member, recv_val, call);
                         }
                     }
                 }

--- a/tests/number_valueof_receiver.test.ts
+++ b/tests/number_valueof_receiver.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "rts:test";
+
+// (#245) Number prototype methods em receiver Number-typed (de
+// `new Number(x)`) ABI espera F64 no slot do receiver. Antes, o caller
+// (lower_global_instance_call) sempre passava i64 raw (via coerce_to_i64
+// que faz fcvt em F64), causando Verifier error
+// `arg has type i64, expected f64`. Fix: detectar member.args[0] == F64
+// e usar coerce_to_f64.
+
+const n = new Number(42);
+const v = n.valueOf();
+const z = new Number(0).valueOf();
+const m = new Number(7.5).valueOf();
+const t = (123).toString();
+const t2 = (3.14).toFixed(1);
+
+describe("Number instance methods em receiver Number (#245)", () => {
+  test("new Number(42).valueOf() === 42", () => expect(v).toBe(42));
+  test("new Number(0).valueOf() === 0", () => expect(z).toBe(0));
+  test("new Number(7.5).valueOf() === 7.5", () => expect(m).toBe(7.5));
+  test("(123).toString() === '123' (regressao primitivo)", () =>
+    expect(t).toBe("123"));
+  test("(3.14).toFixed(1) === '3.1'", () => expect(t2).toBe("3.1"));
+});


### PR DESCRIPTION
## Summary

Fecha fixture cross-runtime \`245_number_valueof\` no caso de receiver Number-typed. Antes:

\`\`\`
error: arg 0 (v9) has type i64, expected f64
\`\`\`

\`new Number(42).valueOf()\` falhava no Cranelift Verifier.

## Causa

\`lower_global_instance_call\` em \`mod.rs:387\` sempre passava recv como i64 (via \`coerce_to_i64\`). Mas \`Number.valueOf/toFixed/...\` tem \`args[0] = F64\` (recv eh number primitivo, nao Handle).

\`coerce_to_i64(F64)\` faz \`fcvt_to_sint_sat\` — converte 42.0 -> 42 i64. Mas o downstream call ainda espera f64 -> verifier error.

## Fix

Quando \`member.args[0]\` eh \`F64\`, usa \`coerce_to_f64\` em vez de \`coerce_to_i64\`. Outros tipos (Handle, Bool) seguem o path existente.

## Delta residual

\`typeof new Number === \"object\"\` ainda retorna \`\"number\"\` (RTS \`new Number(x)\` retorna F64 raw em vez de Entry::NumberBox). Refator separado.

## Test plan

- [x] tests/number_valueof_receiver.test.ts (5/5)
- [x] Fixture 245_number_valueof roda completo (era Verifier error)
- [x] \`rts.exe test\`: **1269/1269**
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)