### PR TITLE
fix(#247): <Class>.prototype.isPrototypeOf(obj) -> obj instanceof Class

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -177,6 +177,50 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         if let Some(tv) = try_lower_object_to_string_call(ctx, callee, call)? {
             return Ok(tv);
         }
+        // (#247) `<Class>.prototype.isPrototypeOf(obj)` -> equivalente a
+        // `obj instanceof <Class>` para classes globais conhecidas.
+        // Sem isso, Object.prototype eh um string sentinel handle e o
+        // .isPrototypeOf falha em "unsupported call expression form".
+        if let Expr::Member(outer) = callee.as_ref() {
+            if let MemberProp::Ident(prop_id) = &outer.prop {
+                if prop_id.sym.as_str() == "isPrototypeOf" && call.args.len() == 1 {
+                    if let Expr::Member(inner) = outer.obj.as_ref() {
+                        let inner_is_proto = matches!(
+                            &inner.prop,
+                            MemberProp::Ident(id) if id.sym.as_str() == "prototype"
+                        );
+                        if inner_is_proto {
+                            if let Expr::Ident(cls_id) = inner.obj.as_ref() {
+                                let cls = cls_id.sym.as_str();
+                                let known = matches!(
+                                    cls,
+                                    "Object" | "Array" | "Function" | "String"
+                                    | "Number" | "Boolean" | "Date" | "RegExp"
+                                    | "Error" | "Map" | "Set"
+                                ) || crate::abi::global_class_lookup(cls).is_some();
+                                if known {
+                                    // Sintetiza `arg instanceof <cls>`.
+                                    let arg_expr = call.args[0].expr.clone();
+                                    let cls_ident = swc_ecma_ast::Ident {
+                                        span: cls_id.span,
+                                        ctxt: Default::default(),
+                                        sym: cls.into(),
+                                        optional: false,
+                                    };
+                                    let synth = swc_ecma_ast::BinExpr {
+                                        span: cls_id.span,
+                                        op: swc_ecma_ast::BinaryOp::InstanceOf,
+                                        left: arg_expr,
+                                        right: Box::new(Expr::Ident(cls_ident)),
+                                    };
+                                    return super::lower_bin(ctx, &synth);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // (#264 PR5) Fast path: `(var as any).method(...)` — TsAs/Paren etc
         // antes do member. Peel e despacha como var.method().
         // (#fix) NAO sequestra quando \`lhs_static_class\` resolve via TsAs

--- a/tests/prototype_isprototypeof.test.ts
+++ b/tests/prototype_isprototypeof.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+// (#247) `Object.prototype.isPrototypeOf(x)` (e variantes Array/etc)
+// caia em "unsupported call expression form" porque o codegen
+// renderiza `Object.prototype` como string sentinel handle, e o
+// `.isPrototypeOf(...)` no sentinel nao tem builtin. Fix: detectar
+// padrao `<Class>.prototype.isPrototypeOf(arg)` e tratar como
+// `arg instanceof <Class>`.
+
+const obj = {};
+const arr: any[] = [];
+
+const objProto = Object.prototype.isPrototypeOf(obj);
+const arrProto = Array.prototype.isPrototypeOf(arr);
+const objArr = Object.prototype.isPrototypeOf(arr);
+const arrObj = Array.prototype.isPrototypeOf(obj);
+
+describe("Object.prototype.isPrototypeOf (#247)", () => {
+  test("Object.prototype.isPrototypeOf({})", () => expect(objProto).toBe(true));
+  test("Array.prototype.isPrototypeOf([])", () => expect(arrProto).toBe(true));
+  test("Object.prototype.isPrototypeOf([])", () => expect(objArr).toBe(true));
+  test("Array.prototype.isPrototypeOf({})", () => expect(arrObj).toBe(false));
+});


### PR DESCRIPTION
## Summary

Fecha fixture cross-runtime \`247_object_isprototypeof\` (rts_diverge -> bate Bun/Node 100%).

\`Object.prototype.isPrototypeOf(obj)\` falhava em \"unsupported call expression form\" porque o codegen renderiza \`Object.prototype\` como string sentinel handle (\`[Object.prototype]\`) e nao tinha builtin pro .isPrototypeOf no sentinel.

## Fix

Detecta padrao \`Member { obj: Member { obj: Ident(Class), prop: \"prototype\" }, prop: \"isPrototypeOf\" }\` em \`lower_call\` e sintetiza \`arg instanceof Class\` quando Class eh classe global conhecida (Object/Array/Function/String/Number/Boolean/Date/RegExp/Error/Map/Set + lookup).

## Test plan

- [x] tests/prototype_isprototypeof.test.ts (4/4)
- [x] Fixture 247_object_isprototypeof: bate Bun/Node 100%
- [x] \`rts.exe test\`: **1269/1269**
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)