### PR TITLE
fix(codegen): Object.prototype.<method>.call(obj, ...) -> obj.<method>(...)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -221,6 +221,69 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
             }
         }
+        // (#40) `Object.prototype.<method>.call(obj, ...args)` -> reescreve
+        // como `obj.<method>(...args)` quando method eh universal
+        // (hasOwnProperty, propertyIsEnumerable). isPrototypeOf ja' tratado
+        // acima via inferencia de instanceof. Sem isso o callee
+        // `Object.prototype.hasOwnProperty` vira sentinel string e o
+        // `.call(...)` falha em "unsupported call expression form".
+        if let Expr::Member(outer) = callee.as_ref() {
+            if let MemberProp::Ident(call_id) = &outer.prop {
+                if call_id.sym.as_str() == "call" && !call.args.is_empty() {
+                    if let Expr::Member(mid) = outer.obj.as_ref() {
+                        if let MemberProp::Ident(method_id) = &mid.prop {
+                            let method = method_id.sym.as_str();
+                            let is_universal = matches!(
+                                method,
+                                "hasOwnProperty" | "propertyIsEnumerable"
+                            );
+                            if is_universal {
+                                if let Expr::Member(inner) = mid.obj.as_ref() {
+                                    let proto_match = matches!(
+                                        &inner.prop,
+                                        MemberProp::Ident(id) if id.sym.as_str() == "prototype"
+                                    );
+                                    let obj_is_object = matches!(
+                                        inner.obj.as_ref(),
+                                        Expr::Ident(id) if id.sym.as_str() == "Object"
+                                    );
+                                    if proto_match && obj_is_object {
+                                        // Sintetiza `<arg0>.<method>(...rest)`.
+                                        let recv_expr = call.args[0].expr.clone();
+                                        let rest_args: Vec<_> = call
+                                            .args
+                                            .iter()
+                                            .skip(1)
+                                            .cloned()
+                                            .collect();
+                                        let synth_callee = Expr::Member(
+                                            swc_ecma_ast::MemberExpr {
+                                                span: method_id.span,
+                                                obj: recv_expr,
+                                                prop: MemberProp::Ident(
+                                                    swc_ecma_ast::IdentName {
+                                                        span: method_id.span,
+                                                        sym: method.into(),
+                                                    },
+                                                ),
+                                            },
+                                        );
+                                        let synth_call = swc_ecma_ast::CallExpr {
+                                            span: call.span,
+                                            ctxt: call.ctxt,
+                                            callee: Callee::Expr(Box::new(synth_callee)),
+                                            args: rest_args,
+                                            type_args: None,
+                                        };
+                                        return super::lower_call(ctx, &synth_call);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // (#264 PR5) Fast path: `(var as any).method(...)` — TsAs/Paren etc
         // antes do member. Peel e despacha como var.method().
         // (#fix) NAO sequestra quando \`lhs_static_class\` resolve via TsAs

--- a/tests/object_prototype_call_methods.test.ts
+++ b/tests/object_prototype_call_methods.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+
+// (#40) `Object.prototype.hasOwnProperty.call(obj, key)` (e .propertyIsEnumerable)
+// falhava em "unsupported call expression form" porque
+// `Object.prototype.hasOwnProperty` virava string sentinel handle e
+// `.call(...)` no sentinel nao tinha builtin.
+// Fix: reescreve como `obj.hasOwnProperty(key)` no codegen.
+
+const obj: any = { a: 1, b: "x" };
+
+const ownA = Object.prototype.hasOwnProperty.call(obj, "a");
+const ownZ = Object.prototype.hasOwnProperty.call(obj, "z");
+const enumA = Object.prototype.propertyIsEnumerable.call(obj, "a");
+const enumZ = Object.prototype.propertyIsEnumerable.call(obj, "z");
+
+describe("Object.prototype.<method>.call(obj, ...) (#40)", () => {
+  test("hasOwnProperty.call obj 'a' eh true", () => expect(ownA).toBe(true));
+  test("hasOwnProperty.call obj 'z' eh false", () => expect(ownZ).toBe(false));
+  test("propertyIsEnumerable.call obj 'a' eh true", () => expect(enumA).toBe(true));
+  test("propertyIsEnumerable.call obj 'z' eh false", () => expect(enumZ).toBe(false));
+});


### PR DESCRIPTION
## Summary

Estende o padrao do #247 (isPrototypeOf) para outros metodos universais: \`hasOwnProperty\` e \`propertyIsEnumerable\`.

\`Object.prototype.hasOwnProperty.call(obj, key)\` falhava em \"unsupported call expression form\" porque o codegen renderiza \`Object.prototype.hasOwnProperty\` como string sentinel handle, e \`.call(...)\` no sentinel nao tinha builtin.

## Fix

Detecta padrao \`Member { obj: Member { obj: Member { obj: Ident(Object), prop: prototype }, prop: <method> }, prop: call }\` e sintetiza \`arg0.<method>(rest_args)\`.

## Test plan

- [x] tests/object_prototype_call_methods.test.ts (4/4)
- [x] Fixture 40_object_deep: \`own_a/own_z\` agora corretos
- [x] \`rts.exe test\`: **1290/1290** (+3)
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)