### PR TITLE
fix(codegen): for-in em Array agora itera (#94)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -374,13 +374,26 @@ pub(super) fn lower_for_in(ctx: &mut FnCtx, for_in: &swc_ecma_ast::ForInStmt) ->
     };
 
     let iter_tv = lower_expr(ctx, &for_in.right)?;
-    let handle = ctx.coerce_to_i64(iter_tv).val;
-    let len_fref = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_MAP_LEN", &[cl::I64], Some(cl::I64))?;
+    let raw_handle = ctx.coerce_to_i64(iter_tv).val;
+
+    // (#94) for-in funciona em Map E Array. MAP_LEN/MAP_KEY_AT so'
+    // funciona em Map (retorna -1 em Vec). Materializa keys via
+    // OBJECT_KEYS_AUTO (Vec<i64> de handles de string das keys),
+    // depois itera por indice usando VEC_LEN/VEC_GET.
+    let keys_fref = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO",
+        &[cl::I64],
+        Some(cl::I64),
+    )?;
+    let keys_inst = ctx.builder.ins().call(keys_fref, &[raw_handle]);
+    let handle = ctx.builder.inst_results(keys_inst)[0];
+
+    let len_fref = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_LEN", &[cl::I64], Some(cl::I64))?;
     let inst = ctx.builder.ins().call(len_fref, &[handle]);
     let len = ctx.builder.inst_results(inst)[0];
 
     let key_at_fref = ctx.get_extern(
-        "__RTS_FN_NS_COLLECTIONS_MAP_KEY_AT",
+        "__RTS_FN_NS_COLLECTIONS_VEC_GET",
         &[cl::I64, cl::I64],
         Some(cl::I64),
     )?;

--- a/tests/for_in_array.test.ts
+++ b/tests/for_in_array.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+
+// (#94) `for (const k in arr)` em Array retornava 0 iteracoes porque o
+// codegen usava MAP_LEN/MAP_KEY_AT que so' funcionam em Entry::Map
+// (retornam -1 em Vec). Fix: usar OBJECT_KEYS_AUTO que retorna Vec<i64>
+// de handles de keys para Map E Vec, depois iterar via VEC_LEN/VEC_GET.
+
+const arr = [10, 20, 30];
+const arrKeys: string[] = [];
+for (const k in arr) {
+  arrKeys.push(k);
+}
+
+const obj: any = { a: 1, b: 2, c: 3 };
+const objKeys: string[] = [];
+for (const k in obj) {
+  objKeys.push(k);
+}
+
+const empty: any[] = [];
+const emptyKeys: string[] = [];
+for (const k in empty) {
+  emptyKeys.push(k);
+}
+
+describe("for-in em Array (#94)", () => {
+  test("for-in em [10,20,30] gera '0','1','2'", () =>
+    expect(arrKeys.join("|")).toBe("0|1|2"));
+  test("for-in em Map continua funcionando", () =>
+    expect(objKeys.join("|")).toBe("a|b|c"));
+  test("for-in em array vazio nao itera", () =>
+    expect(emptyKeys.length).toBe(0));
+});


### PR DESCRIPTION
## Summary

\`for (const k in arr)\` em Array nunca iterava — RTS retornava zero iteracoes.

## Causa

\`lower_for_in\` usava \`MAP_LEN\`/\`MAP_KEY_AT\`. Essas fns so' funcionam em \`Entry::Map\` e retornam \`-1\` para \`Entry::Vec\`. Logo \`i < -1\` era sempre false e o loop nao entrava.

## Fix

Chama \`OBJECT_KEYS_AUTO\` uma vez (retorna \`Vec<i64>\` com handles de string das keys, funciona pra Map E Vec), depois itera via \`VEC_LEN\`/\`VEC_GET\`. JS spec: \`for-in\` em array de 3 elementos retorna \`\"0\",\"1\",\"2\"\`.

## Test plan

- [x] tests/for_in_array.test.ts (3/3 incluindo regressao Map e array vazio)
- [x] Fixture 94_sparse_array_enumeration: \`forIn=\` (vazio) -> agora itera
- [x] \`rts.exe test\`: **1294/1294** (+4 — testes que antes passavam silenciosamente)
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)