### PR TITLE
fix(codegen): String.match aceita regex em var/new (#39)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -363,10 +363,24 @@ pub(super) fn lower_string_builtin(
         // STRING_MATCH_REGEX que aceita Entry::Regex handle direto.
         "match" => {
             use swc_ecma_ast::{Expr, Lit};
+            // (#39) Detecta tambem ident de var tipada RegExp: `const r =
+            // /pat/; text.match(r)`. Sem isso, vai pelo path string-only.
             let is_regex_literal = call
                 .args
                 .first()
-                .map(|a| matches!(a.expr.as_ref(), Expr::Lit(Lit::Regex(_))))
+                .map(|a| match a.expr.as_ref() {
+                    Expr::Lit(Lit::Regex(_)) => true,
+                    Expr::Ident(id) => ctx
+                        .local_class_ty
+                        .get(id.sym.as_str())
+                        .map(|c| c == "RegExp")
+                        .unwrap_or(false),
+                    Expr::New(n) => matches!(
+                        n.callee.as_ref(),
+                        Expr::Ident(id) if id.sym.as_str() == "RegExp"
+                    ),
+                    _ => false,
+                })
                 .unwrap_or(false);
             let p1 = call_h!("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64), &[recv_h]);
             let l1 = call_h!("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64), &[recv_h]);

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -381,6 +381,12 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
 
         if !ctx.local_class_ty.contains_key(&name) {
             if let Some(init) = decl.init.as_ref() {
+                // (#39) `const r = /pat/` -> marca como RegExp para que
+                // `s.match(r)` use STRING_MATCH_REGEX (aceita handle Regex)
+                // em vez do path string-only que falha.
+                if matches!(init.as_ref(), swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Regex(_))) {
+                    ctx.local_class_ty.insert(name.clone(), "RegExp".to_string());
+                }
                 if let swc_ecma_ast::Expr::New(ne) = init.as_ref() {
                     if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
                         let cn = cid.sym.as_str().to_string();

--- a/tests/string_match_regex_var.test.ts
+++ b/tests/string_match_regex_var.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+// (#39) `text.match(regexVar)` retornava null porque o codegen so'
+// detectava regex literal direto (`text.match(/pat/)`), nao ident
+// de var registrada como RegExp. Fix: marca var inicializada com
+// regex literal como local_class_ty="RegExp" e detecta no
+// lower_string_builtin do `match`.
+
+const text = "Item-42";
+const basic = /item-(\d+)/i;
+const m = text.match(basic);
+const m0 = m ? m[0] : "none";
+const m1 = m ? m[1] : "none";
+
+// Literal direto continua funcionando.
+const lit = text.match(/(\d+)/);
+const lit0 = lit ? lit[0] : "none";
+
+describe("String.match com regex em var (#39)", () => {
+  test("text.match(regexVar) retorna match", () => expect(m0).toBe("Item-42"));
+  test("text.match(regexVar) captura grupo", () => expect(m1).toBe("42"));
+  test("text.match(/.../) literal continua OK", () => expect(lit0).toBe("42"));
+});


### PR DESCRIPTION
## Summary

\`text.match(regexVar)\` retornava null porque o codegen so' detectava regex literal direto (\`text.match(/pat/)\`). Quando o pattern era ident de var ou \`new RegExp(...)\`, caia no path string-only que falha em regex syntax.

## Fix

- \`decls.rs\`: \`const r = /pat/\` marca var como \`local_class_ty=\"RegExp\"\`.
- \`builtins.rs match\`: detecta tambem Ident com class_ty=RegExp e \`new RegExp(...)\` para usar \`STRING_MATCH_REGEX\`.

Fixture 39_regex_deep: \`match0/match1\` agora retornam \`Item-42/42\` em vez de \`none/none\`.

## Test plan

- [x] tests/string_match_regex_var.test.ts (3/3)
- [x] \`rts.exe test\`: **1297/1297** (+3)
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)