### PR TITLE
fix(codegen): Buffer indexing direto retorna byte (#58)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -156,13 +156,22 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_INDEX_DELETE_AUTO(handle: u64, idx_or_
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO(handle: u64, index: i64) -> i64 {
     use super::super::gc::handles::with_entry;
-    enum Kind { Vec, Str(Vec<u8>), Other }
+    enum Kind { Vec, Str(Vec<u8>), Buf(u8), Other }
     let kind = with_entry(handle, |e| match e {
         Some(Entry::Vec(_)) => Kind::Vec,
         Some(Entry::String(b)) => Kind::Str(b.clone()),
+        Some(Entry::Buffer(b)) => {
+            if index < 0 || (index as usize) >= b.len() {
+                Kind::Other
+            } else {
+                Kind::Buf(b[index as usize])
+            }
+        }
         _ => Kind::Other,
     });
     match kind {
+        // (#58) Buffer indexing: bytes[i] retorna byte como i64.
+        Kind::Buf(byte) => byte as i64,
         Kind::Vec => __RTS_FN_NS_COLLECTIONS_VEC_GET(handle, index),
         Kind::Str(bytes) => {
             if index < 0 {

--- a/tests/buffer_indexing.test.ts
+++ b/tests/buffer_indexing.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+// (#58) `bytes[i]` em Buffer (TextEncoder.encode output) retornava
+// 0/null porque INDEX_GET_AUTO so' tratava Vec/String/Map. Buffer caia
+// no fallback Map_GET que retorna 0. Fix: ramo Buf que extrai byte
+// como i64.
+
+const enc = new TextEncoder();
+const bytes = enc.encode("hi");
+
+const b0 = bytes[0];
+const b1 = bytes[1];
+const oob = bytes[10];
+
+describe("Buffer indexing direto (#58)", () => {
+  test("bytes[0] = 'h' code = 104", () => expect(b0).toBe(104));
+  test("bytes[1] = 'i' code = 105", () => expect(b1).toBe(105));
+  test("bytes[OOB] retorna 0/undefined-ish", () => expect(oob === 0 || (oob as any) === undefined).toBe(true));
+});


### PR DESCRIPTION
## Summary

\`bytes[i]\` em Buffer (TextEncoder.encode output) retornava null porque \`INDEX_GET_AUTO\` so' tratava Vec/String/Map.

## Fix

Adicionado ramo \`Buf\` em \`INDEX_GET_AUTO\` que extrai byte como i64 quando index esta in-bounds. OOB cai no fallback existente.

## Test plan

- [x] tests/buffer_indexing.test.ts (3/3)
- [x] Fixture 58_text_encoding: \`bytes[0]\` retorna 104 (era 0/null)
- [x] \`rts.exe test\`: **1300/1300** (+3)
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)