### PR TITLE
fix(codegen): in operator aceita I64/U64 lhs em callback

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -397,7 +397,14 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     if matches!(bin.op, BinaryOp::In) {
         let key_tv = lower_expr(ctx, &bin.left)?;
         let obj_tv = lower_expr(ctx, &bin.right)?;
-        if matches!(obj_tv.ty, ValTy::Handle) {
+        // (#83) Aceita tambem I64/U64 — em callbacks de array methods o
+        // param vem como I64 raw carregando handle. Sem isso `"key" in y`
+        // em arrow fail com "unsupported binary op: in". Primitives reais
+        // (F64/Bool/I32) caem no path original que retorna Err.
+        if matches!(
+            obj_tv.ty,
+            ValTy::Handle | ValTy::I64 | ValTy::U64
+        ) {
             // Coerce key para handle: string literals/handles passam direto,
             // numbers viram string handle via gc.string_from_i64/f64.
             let key_h = ctx.coerce_to_handle(key_tv)?.val;

--- a/tests/in_operator_in_callback.test.ts
+++ b/tests/in_operator_in_callback.test.ts
@@ -1,0 +1,13 @@
+import { describe, test, expect } from "rts:test";
+
+// (#83) `"key" in obj` em arrow callback de Array.map falhava com
+// "unsupported binary op: in". Causa: o path `BinaryOp::In` exigia
+// obj_tv.ty == Handle, mas callback params vem como I64 raw carregando
+// handle.
+
+const arr: any[] = [{ value: 1 }, { other: 2 }];
+const m = arr.map((y) => "value" in y ? "v" : "n").join(",");
+
+describe("in operator em callback (#83)", () => {
+  test("'value' in y dentro de map", () => expect(m).toBe("v,n"));
+});


### PR DESCRIPTION
## Summary

\`\"value\" in y\` em arrow callback de Array.map/filter/etc falhava com \"unsupported binary op: in\". Mesmo padrao do #1002 (instanceof em callback).

## Causa

\`BinaryOp::In\` em \`operators.rs\` so' disparava OBJ_HAS quando \`obj_tv.ty == Handle\`. Mas callback params (\`(y) => ...\`) vem como I64 raw carregando handle.

## Fix

Aceitar tambem I64/U64 — OBJ_HAS despacha por Entry type em runtime e retorna 0 para handle invalido. Primitives concretos (F64/Bool/I32) caem no path original que retorna Err.

## Test plan

- [x] tests/in_operator_in_callback.test.ts (1/1)
- [x] \`rts.exe test\`: 1303/1303
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)