### PR TITLE
fix(collections): Set.values retorna elementos, nao marker (#316)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -723,8 +723,31 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
 /// (#266) Object.values(obj) — retorna Vec<i64> com valores em ordem
 /// JS: integer-indexed keys ascendentes, depois string keys em ordem
 /// de insercao (mesmo criterio de Object.keys).
+///
+/// (#316) Para Set (storage interno Map<key_str, 1>), os "values"
+/// sao na verdade as keys (elementos do Set). Detecta via
+/// handle_is_set_kind e retorna parse_array_index(key) ou string handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
+    if handle_is_set_kind(handle) {
+        // Set.values() retorna os elementos (= keys do storage Map).
+        // Cada key foi armazenada como string — se parseia como int,
+        // converte de volta, senao retorna handle string.
+        let elems: Vec<i64> = with_map(handle, Vec::new(), |m| {
+            m.keys()
+                .filter(|k| k.as_str() != "__proto__")
+                .map(|k| match k.parse::<i64>() {
+                    Ok(n) => n,
+                    Err(_) => crate::namespaces::gc::handles::alloc_entry(
+                        crate::namespaces::gc::handles::Entry::String(k.clone().into_bytes()),
+                    ) as i64,
+                })
+                .collect()
+        });
+        return crate::namespaces::gc::handles::alloc_entry(
+            crate::namespaces::gc::handles::Entry::Vec(Box::new(elems)),
+        );
+    }
     let vals: Vec<i64> = with_map(handle, Vec::new(), |m| {
         let mut int_entries: Vec<(u32, i64)> = Vec::new();
         let mut str_entries: Vec<i64> = Vec::new();

--- a/tests/set_values_returns_elements.test.ts
+++ b/tests/set_values_returns_elements.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+// (#316) `Set.values()` retornava [1, 1] em vez de [2, 3] porque o
+// dispatch caia em MAP_VALUES que retorna `m.values()` do storage
+// interno (Map<elemento_str, 1>). JS spec: Set.values() retorna os
+// elementos (= keys do storage). Fix: MAP_VALUES detecta Set via
+// handle_is_set_kind e retorna keys parseadas (parse_array_index ou
+// string handle).
+
+const s = new Set([2, 3, 5]);
+const v = Array.from(s.values()).join(",");
+
+const sStr = new Set(["a", "b"]);
+const vStr = Array.from(sStr.values()).join(",");
+
+describe("Set.values retorna elementos, nao internal values (#316)", () => {
+  test("Set numerico", () => expect(v).toBe("2,3,5"));
+  test("Set string", () => expect(vStr).toBe("a,b"));
+});


### PR DESCRIPTION
## Summary

\`Set.values()\` retornava \`[1, 1, ...]\` em vez dos elementos porque o dispatch caia em \`MAP_VALUES\` que retorna os values do storage interno (\`Map<element_str, 1>\` onde \`1\` eh marker de presenca).

JS spec: \`Set.values()\` retorna os elementos (= keys do storage).

## Fix

\`MAP_VALUES\` detecta Set via \`handle_is_set_kind\` e retorna keys parseadas — \`parse_array_index\` converte de volta a int, ou aloca handle string se nao parsea. Map normal continua com path existente.

## Test plan

- [x] tests/set_values_returns_elements.test.ts (2/2 numerico + string)
- [x] \`rts.exe test\`: 1304/1304
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)