### PR TITLE
fix(runtime+codegen): structuredClone deep + chain method calls (#97/#316)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1780,6 +1780,25 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     let prop_name = prop_id.sym.as_str();
                     let obj_tv = lower_expr(ctx, &m.obj)?;
                     let obj_h = ctx.coerce_to_i64(obj_tv).val;
+                    // (#97) Antes de tentar GLOBAL_CLASS_SPECS, tenta
+                    // array/string/map builtins — cobre o caso comum
+                    // `copy.list.push(4)` onde `copy.list` retorna handle
+                    // mas push nao esta em nenhum spec global.
+                    if let Some(tv) = self::builtins::lower_array_builtin(
+                        ctx, prop_name, obj_h, call,
+                    )? {
+                        return Ok(tv);
+                    }
+                    if let Some(tv) = self::builtins::lower_string_builtin(
+                        ctx, prop_name, obj_h, call,
+                    )? {
+                        return Ok(tv);
+                    }
+                    if let Some(tv) = self::builtins::lower_map_set_builtin(
+                        ctx, prop_name, obj_h, call,
+                    )? {
+                        return Ok(tv);
+                    }
                     for spec in crate::abi::GLOBAL_CLASS_SPECS {
                         if let Some(member) = spec.instance_method(prop_name) {
                             let sig = crate::abi::signature::lower_member(member);

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1064,6 +1064,12 @@ pub(crate) fn handle_is_set_kind(handle: u64) -> bool {
     set_kind_set().lock().unwrap().contains(&handle)
 }
 
+/// (#316) Helper interno para estruturas que clonam (structuredClone)
+/// preservarem kind=Set do source no novo handle.
+pub(crate) fn mark_set_kind(handle: u64) {
+    set_kind_set().lock().unwrap().insert(handle);
+}
+
 fn sealed_set() -> &'static Mutex<HashSet<u64>> {
     static S: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
     S.get_or_init(|| Mutex::new(HashSet::new()))

--- a/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
@@ -113,21 +113,80 @@ pub extern "C" fn __RTS_FN_GL_TEXTENC_ATOB(ptr: i64, len: i64) -> u64 {
     }
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_TEXTENC_STRUCTURED_CLONE(handle: u64) -> u64 {
-    let result = with_entry(handle, |entry| match entry {
+/// (#316) Helper recursivo: clona handle preservando set_kind/map_kind
+/// flags. Slots que parecem handles validos sao clonados recursivamente.
+/// `visited` mapeia handle_original -> handle_clone para suportar
+/// self-references (JS spec do structuredClone preserva ciclos).
+fn clone_handle_deep(
+    handle: u64,
+    visited: &mut std::collections::HashMap<u64, u64>,
+) -> u64 {
+    if let Some(&existing) = visited.get(&handle) {
+        return existing;
+    }
+    let entry_clone = with_entry(handle, |entry| match entry {
         Some(Entry::String(v)) => Some(Entry::String(v.clone())),
         Some(Entry::Buffer(v)) => Some(Entry::Buffer(v.clone())),
-        Some(Entry::Vec(v)) => Some(Entry::Vec(Box::new(v.as_ref().clone()))),
-        Some(Entry::Map(m)) => Some(Entry::Map(Box::new(m.as_ref().clone()))),
-        Some(Entry::Json(j)) => Some(Entry::Json(Box::new(j.as_ref().clone()))),
-        // Primitivos (número, bool): caller já tem o valor direto, não handle
+        Some(Entry::Vec(v)) => Some(Entry::Vec(v.clone())),
+        Some(Entry::Map(m)) => Some(Entry::Map(m.clone())),
+        Some(Entry::Json(j)) => Some(Entry::Json(j.clone())),
+        Some(Entry::DateMs(ms)) => Some(Entry::DateMs(*ms)),
+        // Regex nao tem Clone — passa handle original (shared, imutavel).
         _ => None,
     });
-    match result {
-        Some(entry) => alloc_entry(entry),
-        None => handle,
+    let Some(entry) = entry_clone else { return handle; };
+    let new_h = alloc_entry(entry);
+    visited.insert(handle, new_h);
+    // Preserva kind flags
+    if crate::namespaces::collections::map::handle_is_set_kind(handle) {
+        crate::namespaces::collections::map::mark_set_kind(new_h);
     }
+    // Deep clone de slots que sao handles a estruturas clonaveis.
+    use crate::namespaces::gc::handles::with_entry_mut;
+    let _ = with_entry_mut(new_h, |entry| match entry {
+        Some(Entry::Map(m)) => {
+            let pairs: Vec<(String, i64)> = m.iter().map(|(k, v)| (k.clone(), *v)).collect();
+            for (k, v) in pairs {
+                let v_u = v as u64;
+                if v_u > 0xFFFF_FFFF {
+                    let v_kind = with_entry(v_u, |e| matches!(
+                        e,
+                        Some(Entry::Map(_)) | Some(Entry::Vec(_)) | Some(Entry::String(_))
+                        | Some(Entry::Buffer(_)) | Some(Entry::Json(_))
+                        | Some(Entry::DateMs(_)) | Some(Entry::Regex(_))
+                    ));
+                    if v_kind {
+                        let cloned = clone_handle_deep(v_u, visited);
+                        m.insert(k, cloned as i64);
+                    }
+                }
+            }
+        }
+        Some(Entry::Vec(v)) => {
+            for slot in v.iter_mut() {
+                let s_u = *slot as u64;
+                if s_u > 0xFFFF_FFFF {
+                    let v_kind = with_entry(s_u, |e| matches!(
+                        e,
+                        Some(Entry::Map(_)) | Some(Entry::Vec(_)) | Some(Entry::String(_))
+                        | Some(Entry::Buffer(_)) | Some(Entry::Json(_))
+                        | Some(Entry::DateMs(_)) | Some(Entry::Regex(_))
+                    ));
+                    if v_kind {
+                        *slot = clone_handle_deep(s_u, visited) as i64;
+                    }
+                }
+            }
+        }
+        _ => {}
+    });
+    new_h
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_TEXTENC_STRUCTURED_CLONE(handle: u64) -> u64 {
+    let mut visited = std::collections::HashMap::new();
+    clone_handle_deep(handle, &mut visited)
 }
 
 type CallbackFn = unsafe extern "C" fn(i64) -> i64;

--- a/tests/structured_clone_deep.test.ts
+++ b/tests/structured_clone_deep.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "rts:test";
+
+// (#97) structuredClone agora faz deep clone com cycle detection
+// e preserva flags set_kind/map_kind. Antes era shallow e nao
+// preservava self-references nem nested Set/Map flags.
+
+const original: any = { count: 1, list: [1, 2, 3] };
+original.self = original;
+
+const copy: any = structuredClone(original);
+
+const sameRef = copy.self === copy;
+const cloned = copy !== original;
+const countEq = copy.count === 1;
+
+// Modificar copy nao afeta original (deep clone real)
+copy.list.push(4);
+const origListLen = original.list.length;
+const copyListLen = copy.list.length;
+
+const s = new Set([10, 20]);
+const cs: any = structuredClone(s);
+const cs_vals = Array.from(cs.values()).join(",");
+
+describe("structuredClone deep + cycle (#97)", () => {
+  test("self reference preservada no clone", () => expect(sameRef).toBe(true));
+  test("copy diferente do original", () => expect(cloned).toBe(true));
+  test("copy.count == 1", () => expect(countEq).toBe(true));
+  test("mutacao do copy nao afeta original (deep)", () =>
+    expect(origListLen).toBe(3));
+  test("copy mutado tem 4 itens", () => expect(copyListLen).toBe(4));
+  test("structuredClone(Set) preserva set_kind", () =>
+    expect(cs_vals).toBe("10,20"));
+});


### PR DESCRIPTION
## Summary

Dois bugs interligados resolvidos:

1. **structuredClone era shallow.** Para \`{ list: [1,2,3] }\`, \`copy.list\` era o MESMO handle do original. Modificar copy.list afetava original. Tambem nao preservava self-references (#97) nem set_kind em nested Sets/Maps (#316).

2. **\`copy.list.push(4)\` falhava** com \"unsupported call expression form\" porque o codegen entrava no path GLOBAL_CLASS_SPECS para callee Member.Member, e \`push\` nao esta em nenhum spec global.

## Fix runtime

- \`clone_handle_deep\` recursivo com \`visited: HashMap<u64, u64>\` para cycle detection (preserva self-refs).
- Preserva flags set_kind via \`mark_set_kind\` nos handles novos.
- Slots de Map e Vec recursivamente clonados quando apontam para estruturas.

## Fix codegen (mod.rs call dispatch)

Antes de iterar GLOBAL_CLASS_SPECS para callee Member.Member, tenta \`lower_array_builtin\`/\`lower_string_builtin\`/\`lower_map_set_builtin\` primeiro. Cobre \`copy.list.push(...)\`, \`obj.s.toUpperCase()\`, etc.

## Test plan

- [x] tests/structured_clone_deep.test.ts (6/6 incluindo self-ref e deep clone via mutacao real)
- [x] Fixture 97_structured_clone_edge: era timeout (loop infinito por ciclo), agora bate Bun/Node 100%
- [x] \`rts.exe test\`: **1312/1312** (+6), **508/508 files** (+1)
- [x] \`cargo --lib\`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)