### PR TITLE
fix(codegen): handle string literal duplicado por uso lexical (#1024)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -1107,13 +1107,11 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         // Cross-block reuse of raw Values causes Cranelift to spill them into
         // stack slots before GC calls, but if the defining block wasn't executed
         // the slot is uninitialized — breaking ternary chains (issue #359).
-        let cur_block = self.builder.current_block().unwrap_or_else(|| {
-            cranelift_codegen::ir::Block::with_number(0).unwrap()
-        });
-        let cache_key = (bytes.to_vec(), cur_block);
-        if let Some(&cached_val) = self.str_handle_cache.get(&cache_key) {
-            return Ok(TypedVal::new(cached_val, ValTy::Handle));
-        }
+        // (#1024) Não cachear o handle: o str_handle_cache reusava o mesmo
+        // SSA Value para múltiplos usos da mesma string literal no bloco,
+        // mas o handle pode ter sido movido para dentro de Vec/Map cujo
+        // dono libera a string antes do uso seguinte (ex: arr.map callback
+        // consome). Cada uso lexicográfico precisa alocar handle próprio.
         let (ptr, len) = self.emit_str_literal(bytes)?;
         let fref = self.get_extern(
             "__RTS_FN_NS_GC_STRING_FROM_STATIC",
@@ -1125,7 +1123,6 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         self.declare_gc_handle(val);
         self.fresh_handle_set.insert(val);
         self.register_temp_handle(val);
-        self.str_handle_cache.insert(cache_key, val);
         Ok(TypedVal::new(val, ValTy::Handle))
     }
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1315,6 +1315,31 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         let result = ctx.builder.ins().bor(eq, both_nan);
                         return Ok(TypedVal::new(result, ValTy::Bool));
                     }
+                    // (#1024) Strings sao handles distintos no HandleTable
+                    // mesmo com conteudo igual. Object.is("a","a") deve ser
+                    // true por spec — compara via gc.string_eq quando ambos
+                    // sao Handle (string ou outro objeto). Para String, eh
+                    // egal por conteudo (interning JS); para outros handles
+                    // (objeto/array/Map), eq do handle equivale a identity.
+                    if matches!(a_tv.ty, ValTy::Handle) && matches!(b_tv.ty, ValTy::Handle) {
+                        let a = a_tv.val;
+                        let b = b_tv.val;
+                        // Fast path: identity equal -> true.
+                        let id_eq = ctx.builder.ins().icmp(IntCC::Equal, a, b);
+                        // Slow path: gc.string_eq compara conteudo (retorna
+                        // 0/1 mesmo para handles que nao sao string).
+                        let str_eq_fn = ctx.get_extern(
+                            "__RTS_FN_NS_GC_STRING_EQ",
+                            &[cl::I64, cl::I64],
+                            Some(cl::I64),
+                        )?;
+                        let inst = ctx.builder.ins().call(str_eq_fn, &[a, b]);
+                        let content_eq_i64 = ctx.builder.inst_results(inst)[0];
+                        let zero = ctx.builder.ins().iconst(cl::I64, 0);
+                        let content_eq = ctx.builder.ins().icmp(IntCC::NotEqual, content_eq_i64, zero);
+                        let result = ctx.builder.ins().bor(id_eq, content_eq);
+                        return Ok(TypedVal::new(result, ValTy::Bool));
+                    }
                     // Ambos integers — compara diretamente.
                     let a = ctx.coerce_to_i64(a_tv).val;
                     let b = ctx.coerce_to_i64(b_tv).val;


### PR DESCRIPTION
## Summary
- O `str_handle_cache` deduplicava string literais por block; quando o handle cached era consumido (push em Vec/Map, parallel.map callback), reuso lia handle inválido — manifestava como número bruto no log.
- Cada uso lexicográfico agora chama `STRING_FROM_STATIC` próprio.
- `Object.is`/handle entre handles agora compara via `gc.string_eq` (identity OR conteúdo) para preservar `Object.is(\"a\",\"a\") === true`.

## Impacto
- Suite TS: **1312/1312 verde** (era 1311/1312 antes do fix de Object.is acompanhante).
- Fixture `tests/cross-runtime/40_object_deep` antes 6/10 linhas batiam com Node; agora 9/10.
- Repro mínimo do bug original (#1024) corrigido:
  ```ts
  const e = [[\"a\", 1], [\"b\", \"x\"]];
  e.map((pair) => \"\" + pair[1]);
  const inner1 = [\"x\", \"10\"];
  console.log(\"inner1[0]=\" + inner1[0]);  // antes: handle bruto; agora: x
  ```

## Test plan
- [x] `target/release/rts.exe test` — 1312/1312 passa
- [x] `cargo test --release --lib` — 12/12 passa
- [x] Repro mínimo de #1024 — OK
- [x] `tests/object_is.test.ts` — OK (regression fix)

Closes #1024