### PR TITLE
fix(promise): wait_blocking em tokio worker thread usa block_in_place

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/promise_slot.rs
+++ b/crates/rts-runtime/src/namespaces/gc/promise_slot.rs
@@ -127,6 +127,21 @@ pub fn wait_blocking(slot: &Arc<PromiseSlot>) -> (u8, i64) {
         waiters.push(tx);
     }
 
+    // (engine multi-thread passivo) Detecta se estamos dentro de uma
+    // tokio worker thread (callback de `.then`, `spawn_blocking`, etc).
+    // `rt.block_on(rx)` panica "Cannot start a runtime from within a
+    // runtime" nesse caso. Usar `block_in_place` para informar ao
+    // scheduler tokio que vamos bloquear, depois bloqueia via
+    // `Handle::block_on` da runtime atual.
+    if crate::runtime::async_rt::in_tokio_thread() {
+        return tokio::task::block_in_place(|| {
+            let handle = tokio::runtime::Handle::current();
+            match handle.block_on(rx) {
+                Ok(v) => v,
+                Err(_) => (STATE_REJECTED, 0),
+            }
+        });
+    }
     let rt = crate::runtime::async_rt::rt();
     match rt.block_on(rx) {
         Ok(v) => v,


### PR DESCRIPTION
## Por quê — segundo bug fundamental do engine multi-thread passivo

\`rt.block_on(rx)\` panica \"Cannot start a runtime from within a runtime\" quando chamado de dentro de uma tokio worker thread. Isso ocorre sempre que um callback de \`.then\` (que roda em \`spawn_blocking\`) faz \`await\` interno.

## Fix
- Detecta via \`in_tokio_thread()\` (já existia).
- Se true: \`tokio::task::block_in_place\` + \`Handle::current().block_on\`.
- Senão: caminho original (main thread).

## Impacto
Promise = thread real. Callbacks em \`.then\` rodam em worker tokio. Antes, qualquer await aninhado nesses callbacks causava panic. Agora funciona.

## Test plan
- [x] Suite TS: 1312/1312 verde.
- [x] Cross-runtime: 255/312 (sem regressão).
- [x] Repro \`async function outer() { await inner() }\` em callback async.