### PR TITLE
fix(invoke): INVOKE_AUTO preenche args faltantes com 0

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -636,6 +636,13 @@ pub extern "C" fn __RTS_FN_RT_INVOKE_AUTO(
     {
         let mut all_args = bound_args;
         all_args.extend(read_args_vec(args_handle));
+        // (engine multi-thread passivo) Preenche args faltantes com 0
+        // ate atender o numero de param_kinds. Caso: setTimeout(resolveFn, ms)
+        // chama com 0 args, mas resolveFn tem param_kinds=[0,0] (promise_h
+        // + value). Sem preencher, o trampolim lê lixo do stack como value.
+        while all_args.len() < param_kinds.len() {
+            all_args.push(0);
+        }
         let pushed_this = if !is_arrow && has_this_param {
             let effective = if has_bound_this { bound_this } else { this_arg };
             all_args.insert(0, effective);


### PR DESCRIPTION
## Por quê
Quando \`setTimeout(resolveFn, ms)\` invoca o callback sem args, mas \`resolveFn\` (Function handle de Promise.withResolvers) tem param_kinds=[0,0] (promise_h, value), o trampolim lia lixo do stack como \`value\`, settle a promise com endereço aleatório.

## Fix
INVOKE_AUTO preenche \`all_args\` com 0s até atender \`param_kinds.len()\`.

## Caso concreto

\`\`\`ts
const r = Promise.withResolvers();
setTimeout(r.resolve, 50);
const v = await r.promise;
// antes: v=2840468476592  (lixo do stack)
// agora: v=null  (resolve(0) -> sentinel null)
\`\`\`

## Test plan
- [x] Suite TS: 1312/1312.
- [x] Cross-runtime: 256/312 sem regressão.