### PR TITLE
feat(classes): private fields escopados por declaring class (#267)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/class.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/class.rs
@@ -200,7 +200,10 @@ fn scan_this_expr(
     }
 }
 
-pub(crate) fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<FunctionDecl>) {
+pub(crate) fn synthesize_class_fns(
+    class: &ClassDecl,
+    classes_with_init: &std::collections::HashSet<String>,
+) -> (ClassMeta, Vec<FunctionDecl>) {
     let mut methods: Vec<String> = Vec::new();
     let mut getters: Vec<String> = Vec::new();
     let mut setters: Vec<String> = Vec::new();
@@ -230,7 +233,13 @@ pub(crate) fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<Functio
                 if !prop.modifiers.is_static && prop.initializer.is_some() =>
             {
                 let init = prop.initializer.as_ref().unwrap().clone();
-                Some(make_field_init_stmt(&prop.name, init, prop.span))
+                // (cross-runtime #267) Privates escopados por declaring class.
+                let mangled_name = if let Some(rest) = prop.name.strip_prefix('#') {
+                    format!("#{}_{}", class.name, rest)
+                } else {
+                    prop.name.clone()
+                };
+                Some(make_field_init_stmt(&mangled_name, init, prop.span))
             }
             _ => None,
         })
@@ -396,20 +405,53 @@ pub(crate) fn synthesize_class_fns(class: &ClassDecl) -> (ClassMeta, Vec<Functio
     // com `extends` mas sem ctor explícito, TS gera um pass-through
     // `constructor(...args) { super(...args); }` — não suportamos rest
     // args ainda (#58/#59), então damos erro claro nesse caso.
-    if !has_constructor && !init_stmts.is_empty() {
-        if class.super_class.is_some() {
-            // Sub sem ctor + extends + initializers: precisaria de
-            // `super(...args)` implícito. Por simplicidade do MVP, exija
-            // ctor explícito nesse caso.
-            // (Ainda emitimos o ctor implícito sem super — funciona se
-            // a classe pai não tem ctor com args.)
+    // (cross-runtime #267) Mesmo sem initializers proprios, se super tem
+    // init, precisa gerar __init que chama super.__init. Caso contrario,
+    // privates declarados em ancestrais nao sao inicializados em
+    // subclasses sem ctor explicito.
+    let super_needs_init = class
+        .super_class
+        .as_deref()
+        .map(|s| classes_with_init.contains(s))
+        .unwrap_or(false);
+    if !has_constructor && (!init_stmts.is_empty() || super_needs_init) {
+        // Prepend chamada para `__class_<super>__init(this)` quando aplicavel.
+        let mut prelude: Vec<Statement> = Vec::new();
+        if super_needs_init {
+            let parent = class.super_class.as_deref().unwrap();
+            let super_init_call = Stmt::Expr(swc_ecma_ast::ExprStmt {
+                span: Default::default(),
+                expr: Box::new(Expr::Call(swc_ecma_ast::CallExpr {
+                    span: Default::default(),
+                    ctxt: Default::default(),
+                    callee: swc_ecma_ast::Callee::Expr(Box::new(Expr::Ident(
+                        swc_ecma_ast::Ident {
+                            span: Default::default(),
+                            ctxt: Default::default(),
+                            sym: class_init_name(parent).into(),
+                            optional: false,
+                        },
+                    ))),
+                    args: vec![swc_ecma_ast::ExprOrSpread {
+                        spread: None,
+                        expr: Box::new(Expr::This(swc_ecma_ast::ThisExpr {
+                            span: Default::default(),
+                        })),
+                    }],
+                    type_args: None,
+                })),
+            });
+            prelude.push(Statement::Raw(
+                RawStmt::new("<super-init>".to_string(), class.span).with_stmt(super_init_call),
+            ));
         }
-        let init_only_body = weave_initializers(&[], &init_stmts, false);
+        let mut full_body = prelude;
+        full_body.extend(weave_initializers(&[], &init_stmts, false));
         fns.push(FunctionDecl {
             name: class_init_name(&class.name),
             parameters: vec![this_param(class.span)],
             return_type: None,
-            body: init_only_body,
+            body: full_body,
             span: class.span,
             is_async: false,
         });

--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -139,10 +139,41 @@ pub fn compile_program(
         })
         .collect();
 
+    // (cross-runtime #267) Pre-computa set de classes que tem field
+    // initializers (NAO ctor). Usado pelo synthesize para decidir se a
+    // subclasse sem ctor explicito deve chamar super.__init. Ctors com
+    // args ficam de fora — chamada implicita super() requer match de
+    // assinatura que MVP nao cobre.
+    let mut classes_with_init: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for class in &class_decls {
+        let has_field_init = class.members.iter().any(|m| matches!(m,
+            crate::parser::ast::ClassMember::Property(p)
+                if !p.modifiers.is_static && p.initializer.is_some()
+        ));
+        if has_field_init {
+            classes_with_init.insert(class.name.clone());
+        }
+    }
+    // Propaga: se classe X tem init, e Y extends X, Y eh marcada como
+    // has_init (precisa chamar X.__init via chain). Iteramos ate fixed point.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for class in &class_decls {
+            if classes_with_init.contains(&class.name) { continue; }
+            if let Some(parent) = class.super_class.as_deref() {
+                if classes_with_init.contains(parent) {
+                    classes_with_init.insert(class.name.clone());
+                    changed = true;
+                }
+            }
+        }
+    }
+
     let mut classes: HashMap<String, ClassMeta> = HashMap::new();
     let mut synthetic_fns: Vec<FunctionDecl> = Vec::new();
     for class in &class_decls {
-        let (meta, fns) = synthesize_class_fns(class);
+        let (meta, fns) = synthesize_class_fns(class, &classes_with_init);
         classes.insert(class.name.clone(), meta);
         synthetic_fns.extend(fns);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1356,11 +1356,19 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             }
         }
         MemberProp::PrivateName(pn) => {
-            let key = format!("#{}", pn.name.as_ref());
-            validate_private_scope(ctx, &key)?;
+            let raw_name = pn.name.as_ref();
+            let raw_key = format!("#{}", raw_name);
+            validate_private_scope(ctx, &raw_key)?;
+            // (cross-runtime #267) Mangle por current_class (declaring class).
+            let key = if let Some(cur) = ctx.current_class.as_deref() {
+                format!("#{}_{}", cur, raw_name)
+            } else {
+                raw_key.clone()
+            };
             let field_ty = receiver_class
                 .as_deref()
-                .and_then(|c| field_type_in_hierarchy(ctx, c, &key));
+                .and_then(|c| field_type_in_hierarchy(ctx, c, &key)
+                    .or_else(|| field_type_in_hierarchy(ctx, c, &raw_key)));
             map_get_static_typed(ctx, obj_handle, key.as_bytes(), field_ty)
         }
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -680,8 +680,15 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                 }
             }
             MemberProp::PrivateName(pn) => {
-                let key = format!("#{}", pn.name.as_ref());
-                validate_private_scope(ctx, &key)?;
+                let raw_name = pn.name.as_ref();
+                let raw_key = format!("#{}", raw_name);
+                validate_private_scope(ctx, &raw_key)?;
+                // (cross-runtime #267) Mangle por current_class.
+                let key = if let Some(cur) = ctx.current_class.as_deref() {
+                    format!("#{}_{}", cur, raw_name)
+                } else {
+                    raw_key.clone()
+                };
                 let (kp, kl) = ctx.emit_str_literal(key.as_bytes())?;
                 ctx.builder.ins().call(set_fn, &[obj_h, kp, kl, rhs_i64]);
             }


### PR DESCRIPTION
## Summary
JS spec: \`class Box { #x = 7 }\` e \`class Sub extends Box { #x = 20 }\` têm keys **distintas** — \`Box.getX()\` retorna 7 mesmo em instância de \`Sub\`.

Antes RTS armazenava ambos como \`#x\`, sobrescrevendo. \`Sub.getX()\` lia o \`#x = 20\`.

## Fix
1. **Mangle por declaring class**: \`Box.#x\` → \`#Box_x\`, \`Sub.#x\` → \`#Sub_x\`.
2. Aplicado em read (\`members.rs\`), write (\`mod.rs\`), e field init (\`class.rs\`).
3. **Super init chain**: subclasses sem ctor com parent tendo field initializers agora geram \`__init\` que chama \`__class_<super>__init(this)\` primeiro.
4. \`classes_with_init\` pre-computa só classes com **field initializers** (não ctors com args) para decidir chamada super.__init segura.

## Caso

\`\`\`ts
class Box { #x = 7; getX() { return this.#x; } }
class Sub extends Box { #x = 20; both() { return this.getX() + \":\" + this.#x; } }
new Sub().both();  // antes: \"20:20\". Agora: \"7:20\"
\`\`\`

## Test plan
- [x] Suite TS: 1312/1312 verde.
- [x] Cross-runtime: 258/312 (+1: 267_private_fields).