### PR TITLE
feat(classes): private methods sem dispatch virtual (#268)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/class_dispatch.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/class_dispatch.rs
@@ -307,6 +307,11 @@ pub(crate) fn emit_named_method_call(
 }
 
 fn collect_method_overrides(ctx: &FnCtx, base: &str, method: &str) -> Vec<(String, String)> {
+    // (cross-runtime #268) Private methods (`#m`) NAO tem dispatch virtual
+    // por JS spec — sao fixos na declaring class. Skip overrides.
+    if method.starts_with('#') {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     for (cname, _meta) in ctx.classes.iter() {
         if !is_subclass_of(ctx, cname, base) {

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -583,8 +583,25 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 MemberProp::PrivateName(pn) => Some(format!("#{}", pn.name.as_ref())),
                 _ => None,
             };
+            // (cross-runtime #268) Private methods sao escopados por
+            // declaring class — sem dispatch virtual. Em \`this.#m()\` dentro
+            // de A.call, queremos A.#m (nao B.#m). Forca a resolucao para
+            // current_class ao acessar private de \`this\`.
+            let is_private = matches!(&m.prop, MemberProp::PrivateName(_));
+            let force_class_for_private: Option<String> = if is_private
+                && matches!(m.obj.as_ref(), Expr::This(_))
+            {
+                ctx.current_class.clone()
+            } else {
+                None
+            };
             if let Some(method_name) = prop_method_name {
-                if let Some(class_name) = lhs_static_class(ctx, &m.obj) {
+                // (cross-runtime #268) Para private method (this.#m), forca
+                // class_name = current_class para evitar dispatch virtual.
+                let class_name_opt = force_class_for_private
+                    .clone()
+                    .or_else(|| lhs_static_class(ctx, &m.obj));
+                if let Some(class_name) = class_name_opt {
                     if resolve_method_owner(ctx, &class_name, &method_name).is_some() {
                         let recv_tv = lower_expr(ctx, &m.obj)?;
                         let recv_i64 = ctx.coerce_to_i64(recv_tv).val;


### PR DESCRIPTION
## Summary
JS spec: private methods (\`#m\`) são fixos na declaring class. \`A.call()\` chamando \`this.#m()\` SEMPRE invoca \`A.#m\`, mesmo em instance de subclass \`B\` que tem seu próprio \`B.#m\`.

## Fix
1. \`collect_method_overrides\` skip métodos com \`#\` — não tem override virtual.
2. Call site \`this.#m()\` força \`class_name = current_class\` (declaring class), não dispatch virtual.

## Caso

\`\`\`ts
class A { #m(v) { return v + 1; } call(v) { return this.#m(v); } }
class B extends A { #m(v) { return v + 10; } both(v) { return this.call(v) + \":\" + this.#m(v); } }
new B().both(5);
// antes: \"15:15\". Agora: \"6:15\" (A.#m + B.#m).
\`\`\`

Fecha \`tests/cross-runtime/268_private_methods\`.

## Test plan
- [x] Suite TS: 1312/1312 verde.
- [x] Cross-runtime: 258/312 sem regressão.