### PR TITLE
fix: WeakMap.set/get/has em metodos de classe (this como key) (#1059)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -400,6 +400,14 @@ pub fn compile_program(
                             if classes.contains_key(cn) {
                                 global_class_ty.insert(name.clone(), cn.to_string());
                             }
+                            // (#1059) Globais inicializadas com `new WeakMap/
+                            // WeakSet()` precisam ser detectadas pelo codegen
+                            // para que `wm.set/get/has/delete` rotem para o
+                            // dispatch WEAKMAP_*/WEAKSET_*, em vez do
+                            // MAP_SET genérico que coerce key como string.
+                            if matches!(cn, "WeakMap" | "WeakSet" | "Map" | "Set") {
+                                global_class_ty.insert(name.clone(), cn.to_string());
+                            }
                         }
                     }
                 }

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1790,7 +1790,13 @@ fn resolve_method_owner_local(ctx: &FnCtx, class: &str, method: &str) -> Option<
 pub(super) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
     match expr {
         Expr::This(_) => ctx.current_class.clone(),
-        Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
+        Expr::Ident(id) => ctx
+            .local_class_ty
+            .get(id.sym.as_str())
+            .cloned()
+            // (#1059) Quando o ident nao esta em scope local mas eh global
+            // (top-level `const wm = new WeakMap()`), consulta global_class_ty.
+            .or_else(|| ctx.global_class_ty.get(id.sym.as_str()).cloned()),
         Expr::Paren(p) => lhs_static_class(ctx, &p.expr),
         Expr::TsAs(a) => class_name_from_ts_type(&a.type_ann)
             .or_else(|| lhs_static_class(ctx, &a.expr)),


### PR DESCRIPTION
## Summary
- lhs_static_class agora consulta global_class_ty quando o ident nao esta em scope local — \`const wm = new WeakMap()\` top-level fica visivel dentro de metodos da classe.
- Sem isso, \`wm.set(this, value)\` dentro de constructor caia no path generico MAP_SET (coerce key=string), e WeakMap.has(this) sempre retornava false.
- Fecha #1059.

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 347_weak_collections.ts: output identico a Bun/Node