### PR TITLE
fix(codegen): array literal em obj field como Handle (#1092)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -225,6 +225,13 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                                 {
                                     field_types.insert(key.clone(), ValTy::I64);
                                 }
+                                // (#1092) Array literal field: armazena handle de Vec.
+                                // Sem isso, `data.keys` retorna I64 default, e
+                                // `data.keys[0]` / `data.keys.length` operam sobre
+                                // valor errado.
+                                swc_ecma_ast::Expr::Array(_) => {
+                                    field_types.insert(key.clone(), ValTy::Handle);
+                                }
                                 // (#210) Sub-object literal: registra tipos
                                 // dos campos do nested para nested
                                 // destructuring conseguir inferir.


### PR DESCRIPTION
## Summary
- \`const data = { keys: [10, 20] }\` agora registra \`keys\` como Handle em local_obj_field_types, em vez de cair no default I64.
- Sem isso, \`data.keys[0]\` e \`data.keys.length\` operavam sobre valor errado.
- Fecha #1092.

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 343_optional_chaining: output identico a Bun/Node