### PR TITLE
fix(regex): m.indices.groups + matchAll com flag 'd' (#1087)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -142,23 +142,73 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
         alloc_entry(Entry::Map(Box::new(gmap))) as i64
     };
     map.insert("groups".to_string(), groups_v);
-    // (#regex-d) indices: Vec<[start, end]> quando flag 'd' setada;
-    // undefined caso contrario. JSON.stringify renderiza como
-    // `[[s,e],[s,e],...]`.
-    let indices_v = match indices {
+    // (#regex-d / #1087) indices: Map-like com slots "0".."N",
+    // "length" e "groups" quando flag 'd' setada; undefined caso
+    // contrario. Slots [start, end] como Vec inner. JS spec espelha
+    // a forma do match (Array-like com prop extra "groups": Map<name,
+    // [start,end]>).
+    let indices_v = match indices.clone() {
         Some(vec) => {
-            let mut outer: Vec<i64> = Vec::with_capacity(vec.len());
-            for opt in vec {
+            let mut imap: IndexMap<String, i64> = IndexMap::new();
+            for (i, opt) in vec.iter().enumerate() {
                 let pair_h: i64 = match opt {
                     Some((s, e)) => {
-                        let pair = vec![s as i64, e as i64];
+                        let pair = vec![*s as i64, *e as i64];
                         alloc_entry(Entry::Vec(Box::new(pair))) as i64
                     }
                     None => i64::MIN + 2,
                 };
-                outer.push(pair_h);
+                imap.insert(i.to_string(), pair_h);
             }
-            alloc_entry(Entry::Vec(Box::new(outer))) as i64
+            imap.insert("length".to_string(), vec.len() as i64);
+            // groups: Map<name, [start, end]> espelhando os named groups
+            // do match. Vazio quando regex nao tem named captures.
+            let g_v: i64 = {
+                // Recalcula mapping name -> indice numerico do capture
+                // (rx.captures_names() em sincronia com vec).
+                let g_vec_opt: Option<Vec<(String, Option<(usize, usize)>)>> =
+                    with_entry(handle, |entry| match entry {
+                        Some(Entry::Regex(rx)) => {
+                            let names: Vec<Option<String>> = rx
+                                .regex
+                                .capture_names()
+                                .map(|o| o.map(|s| s.to_string()))
+                                .collect();
+                            let mut out: Vec<(String, Option<(usize, usize)>)> = Vec::new();
+                            for (i, name_opt) in names.iter().enumerate() {
+                                if let Some(name) = name_opt {
+                                    let pair: Option<(usize, usize)> =
+                                        vec.get(i).and_then(|o| *o);
+                                    out.push((name.clone(), pair));
+                                }
+                            }
+                            Some(out)
+                        }
+                        _ => None,
+                    });
+                if let Some(g_pairs) = g_vec_opt {
+                    if g_pairs.is_empty() {
+                        i64::MIN + 2
+                    } else {
+                        let mut gmap: IndexMap<String, i64> = IndexMap::new();
+                        for (name, opt) in g_pairs {
+                            let pair_h: i64 = match opt {
+                                Some((s, e)) => {
+                                    let pair = vec![s as i64, e as i64];
+                                    alloc_entry(Entry::Vec(Box::new(pair))) as i64
+                                }
+                                None => i64::MIN + 2,
+                            };
+                            gmap.insert(name, pair_h);
+                        }
+                        alloc_entry(Entry::Map(Box::new(gmap))) as i64
+                    }
+                } else {
+                    i64::MIN + 2
+                }
+            };
+            imap.insert("groups".to_string(), g_v);
+            alloc_entry(Entry::Map(Box::new(imap))) as i64
         }
         None => i64::MIN + 2,
     };

--- a/crates/rts-runtime/src/namespaces/globals/string/search.rs
+++ b/crates/rts-runtime/src/namespaces/globals/string/search.rs
@@ -277,9 +277,16 @@ pub extern "C" fn __RTS_FN_NS_STRING_MATCH_ALL_REGEX(
     let empty_vec = || alloc_entry(Entry::Vec(Box::new(Vec::new())));
     let Some(s) = str_from_abi(s_ptr, s_len) else { return empty_vec(); };
     let s_owned = s.to_string();
-    type MatchInfo = (Vec<Option<String>>, Vec<(String, Option<String>)>, usize);
+    type MatchInfo = (
+        Vec<Option<String>>,
+        Vec<(String, Option<String>)>,
+        usize,
+        Option<Vec<Option<(usize, usize)>>>,
+        Vec<Option<String>>, // names em paralelo aos indices, para .groups
+    );
     let infos: Vec<MatchInfo> = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rts_rx)) => {
+            let has_indices = rts_rx.flags.contains('d');
             let names: Vec<Option<String>> = rts_rx
                 .regex
                 .capture_names()
@@ -299,12 +306,19 @@ pub extern "C" fn __RTS_FN_NS_STRING_MATCH_ALL_REGEX(
                     })
                     .collect();
                 let idx = caps.get(0).map(|m| m.start()).unwrap_or(0);
-                (groups, named, idx)
+                let indices = if has_indices {
+                    Some(
+                        (0..caps.len())
+                            .map(|i| caps.get(i).map(|m| (m.start(), m.end())))
+                            .collect::<Vec<_>>(),
+                    )
+                } else { None };
+                (groups, named, idx, indices, names.clone())
             }).collect()
         }
         _ => Vec::new(),
     });
-    let outer: Vec<i64> = infos.into_iter().map(|(groups, named, idx)| {
+    let outer: Vec<i64> = infos.into_iter().map(|(groups, named, idx, indices_opt, names)| {
         let mut map: IndexMap<String, i64> = IndexMap::new();
         for (i, opt) in groups.iter().enumerate() {
             let v = match opt {
@@ -331,6 +345,38 @@ pub extern "C" fn __RTS_FN_NS_STRING_MATCH_ALL_REGEX(
             alloc_entry(Entry::Map(Box::new(gmap))) as i64
         };
         map.insert("groups".to_string(), groups_v);
+        // (#1087) indices Map quando flag 'd' setada.
+        let indices_v = match indices_opt {
+            Some(vec) => {
+                let mut imap: IndexMap<String, i64> = IndexMap::new();
+                for (i, opt) in vec.iter().enumerate() {
+                    let pair_h: i64 = match opt {
+                        Some((s, e)) => alloc_entry(Entry::Vec(Box::new(vec![*s as i64, *e as i64]))) as i64,
+                        None => i64::MIN + 2,
+                    };
+                    imap.insert(i.to_string(), pair_h);
+                }
+                imap.insert("length".to_string(), vec.len() as i64);
+                let any_named = names.iter().any(|n| n.is_some());
+                let g_v: i64 = if any_named {
+                    let mut gmap: IndexMap<String, i64> = IndexMap::new();
+                    for (i, name_opt) in names.iter().enumerate() {
+                        if let Some(name) = name_opt {
+                            let pair_h: i64 = match vec.get(i).and_then(|o| *o) {
+                                Some((s, e)) => alloc_entry(Entry::Vec(Box::new(vec![s as i64, e as i64]))) as i64,
+                                None => i64::MIN + 2,
+                            };
+                            gmap.insert(name.clone(), pair_h);
+                        }
+                    }
+                    alloc_entry(Entry::Map(Box::new(gmap))) as i64
+                } else { i64::MIN + 2 };
+                imap.insert("groups".to_string(), g_v);
+                alloc_entry(Entry::Map(Box::new(imap))) as i64
+            }
+            None => i64::MIN + 2,
+        };
+        map.insert("indices".to_string(), indices_v);
         alloc_entry(Entry::Map(Box::new(map))) as i64
     }).collect();
     alloc_entry(Entry::Vec(Box::new(outer)))


### PR DESCRIPTION
## Summary
- RegExp.exec: \`indices\` agora eh Map com slots numericos + \`groups\` Map<name, [start,end]>.
- String.matchAll: indices anexado em cada match quando regex tem flag 'd'.
- Fecha #1087.

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 395_regex_d_flag: output identico a Bun/Node