### PR TITLE
feat(regex): lookbehind/lookahead via fancy-regex fallback (#1107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +980,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2343,6 +2369,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "colored",
+ "fancy-regex",
  "flate2",
  "fltk",
  "indexmap",

--- a/crates/rts-runtime/Cargo.toml
+++ b/crates/rts-runtime/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 rayon = "1.10"
 sha2 = "0.10"
 regex = "1"
+fancy-regex = "0.13"
 unicode-normalization = "0.1"
 rustls = { version = "0.23", default-features = false, features = [
     "std", "ring", "tls12"

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -552,7 +552,7 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN(
     // o getter builtin em vez de retornar 0.
     let regex_field: Option<String> = with_entry(handle, |e| match e {
         Some(Entry::Regex(rx)) => match key {
-            "source" => Some(rx.regex.as_str().to_string()),
+            "source" => Some(rx.engine.source()),
             "flags" => Some(rx.flags.clone()),
             _ => None,
         },

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -30,9 +30,276 @@ const SENTINEL_INVALID: u64 = 0;
 /// Wrapper que armazena a regex compilada + flags JS canonicas.
 /// O crate `regex` nao expoe flags pos-compile de forma uniforme; RTS
 /// guarda flags do callsite para `re.flags/global/ignoreCase/multiline`.
+/// (#1107) Engine de regex usado. `Fast` (crate `regex`, RE2) eh o
+/// caminho rapido O(n) garantido; `Fancy` (crate `fancy-regex`) eh
+/// usado quando o pattern tem features que RE2 nao suporta
+/// (lookbehind/lookahead, backreferences).
+#[derive(Debug)]
+pub enum RegexEngine {
+    Fast(regex::Regex),
+    Fancy(fancy_regex::Regex),
+}
+
+/// Match agnostico ao engine: somente boundaries (start/end) e a string
+/// matched. Suficiente para is_match, find, e iteracao top-level.
+#[derive(Debug, Clone)]
+pub struct EngineMatch {
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+}
+
+/// Captures agnostico ao engine: lista de Option<(start, end, text)> em
+/// ordem (grupo 0 = full match, grupos 1..N = capture groups). None
+/// quando o grupo nao participou.
+#[derive(Debug, Clone)]
+pub struct EngineCaptures {
+    pub groups: Vec<Option<EngineMatch>>,
+}
+
+impl RegexEngine {
+    pub fn is_match(&self, s: &str) -> bool {
+        match self {
+            RegexEngine::Fast(r) => r.is_match(s),
+            RegexEngine::Fancy(r) => r.is_match(s).unwrap_or(false),
+        }
+    }
+
+    pub fn find(&self, s: &str) -> Option<EngineMatch> {
+        match self {
+            RegexEngine::Fast(r) => r.find(s).map(|m| EngineMatch {
+                start: m.start(),
+                end: m.end(),
+                text: m.as_str().to_string(),
+            }),
+            RegexEngine::Fancy(r) => r.find(s).ok().flatten().map(|m| EngineMatch {
+                start: m.start(),
+                end: m.end(),
+                text: m.as_str().to_string(),
+            }),
+        }
+    }
+
+    pub fn captures(&self, s: &str) -> Option<EngineCaptures> {
+        match self {
+            RegexEngine::Fast(r) => r.captures(s).map(|caps| EngineCaptures {
+                groups: (0..caps.len())
+                    .map(|i| caps.get(i).map(|m| EngineMatch {
+                        start: m.start(),
+                        end: m.end(),
+                        text: m.as_str().to_string(),
+                    }))
+                    .collect(),
+            }),
+            RegexEngine::Fancy(r) => r.captures(s).ok().flatten().map(|caps| EngineCaptures {
+                groups: (0..caps.len())
+                    .map(|i| caps.get(i).map(|m| EngineMatch {
+                        start: m.start(),
+                        end: m.end(),
+                        text: m.as_str().to_string(),
+                    }))
+                    .collect(),
+            }),
+        }
+    }
+
+    pub fn captures_all(&self, s: &str) -> Vec<EngineCaptures> {
+        match self {
+            RegexEngine::Fast(r) => r
+                .captures_iter(s)
+                .map(|caps| EngineCaptures {
+                    groups: (0..caps.len())
+                        .map(|i| caps.get(i).map(|m| EngineMatch {
+                            start: m.start(),
+                            end: m.end(),
+                            text: m.as_str().to_string(),
+                        }))
+                        .collect(),
+                })
+                .collect(),
+            RegexEngine::Fancy(r) => r
+                .captures_iter(s)
+                .filter_map(|res| res.ok())
+                .map(|caps| EngineCaptures {
+                    groups: (0..caps.len())
+                        .map(|i| caps.get(i).map(|m| EngineMatch {
+                            start: m.start(),
+                            end: m.end(),
+                            text: m.as_str().to_string(),
+                        }))
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+
+    pub fn find_all(&self, s: &str) -> Vec<EngineMatch> {
+        match self {
+            RegexEngine::Fast(r) => r
+                .find_iter(s)
+                .map(|m| EngineMatch {
+                    start: m.start(),
+                    end: m.end(),
+                    text: m.as_str().to_string(),
+                })
+                .collect(),
+            RegexEngine::Fancy(r) => r
+                .find_iter(s)
+                .filter_map(|res| res.ok())
+                .map(|m| EngineMatch {
+                    start: m.start(),
+                    end: m.end(),
+                    text: m.as_str().to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Nomes dos capture groups (None para grupos nao-nomeados).
+    /// Indices alinhados com `groups` de EngineCaptures.
+    pub fn capture_names(&self) -> Vec<Option<String>> {
+        match self {
+            RegexEngine::Fast(r) => r
+                .capture_names()
+                .map(|n| n.map(|s| s.to_string()))
+                .collect(),
+            RegexEngine::Fancy(r) => r
+                .capture_names()
+                .map(|n| n.map(|s| s.to_string()))
+                .collect(),
+        }
+    }
+
+    pub fn captures_len(&self) -> usize {
+        match self {
+            RegexEngine::Fast(r) => r.captures_len(),
+            RegexEngine::Fancy(r) => r.captures_len(),
+        }
+    }
+
+    /// Source pattern como string (usado por `re.source`).
+    pub fn source(&self) -> String {
+        match self {
+            RegexEngine::Fast(r) => r.as_str().to_string(),
+            RegexEngine::Fancy(r) => r.as_str().to_string(),
+        }
+    }
+
+    /// Replace primeiro match com `replacement` (sintaxe Rust-regex:
+    /// `$N` para grupo numerico, `${name}` para named). Para Fancy, faz
+    /// substituicao manual mas suporta apenas `${name}` / `$N` simples.
+    pub fn replace_first(&self, s: &str, replacement: &str) -> String {
+        match self {
+            RegexEngine::Fast(r) => r.replace(s, replacement).into_owned(),
+            RegexEngine::Fancy(_) => self.replace_n(s, replacement, 1),
+        }
+    }
+
+    pub fn replace_all(&self, s: &str, replacement: &str) -> String {
+        match self {
+            RegexEngine::Fast(r) => r.replace_all(s, replacement).into_owned(),
+            RegexEngine::Fancy(_) => self.replace_n(s, replacement, usize::MAX),
+        }
+    }
+
+    fn replace_n(&self, s: &str, replacement: &str, limit: usize) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut last_end = 0usize;
+        let mut count = 0usize;
+        for caps in self.captures_all(s) {
+            if count >= limit { break; }
+            let m0 = match caps.groups.first().and_then(|o| o.clone()) {
+                Some(m) => m,
+                None => continue,
+            };
+            out.push_str(&s[last_end..m0.start]);
+            out.push_str(&substitute_replacement(replacement, &caps));
+            last_end = m0.end;
+            count += 1;
+        }
+        out.push_str(&s[last_end..]);
+        out
+    }
+}
+
+/// Aplica substituicao no replacement string. Suporta:
+/// - `$N` (N de 0-9) -> grupo numerico
+/// - `${name}` -> grupo nomeado
+/// - `$&` -> match completo
+/// - `$$` -> literal `$`
+fn substitute_replacement(repl: &str, caps: &EngineCaptures) -> String {
+    let mut out = String::with_capacity(repl.len());
+    let bytes = repl.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' {
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+        if i + 1 >= bytes.len() {
+            out.push('$');
+            i += 1;
+            continue;
+        }
+        let next = bytes[i + 1];
+        if next == b'$' {
+            out.push('$');
+            i += 2;
+        } else if next == b'&' {
+            if let Some(Some(m)) = caps.groups.first() {
+                out.push_str(&m.text);
+            }
+            i += 2;
+        } else if next == b'{' {
+            if let Some(end_rel) = repl[i + 2..].find('}') {
+                let name = &repl[i + 2..i + 2 + end_rel];
+                // tenta nome (em order) — fancy-regex nao tem name lookup
+                // direto via EngineCaptures, entao recompila names.
+                // Heuristica: index numerico OK; nome requer caller fornecer
+                // tabela name->idx separadamente. Aqui ignoramos name lookup
+                // (caller pre-processa ${name} -> $N quando precisa).
+                if let Ok(n) = name.parse::<usize>() {
+                    if let Some(Some(m)) = caps.groups.get(n) {
+                        out.push_str(&m.text);
+                    }
+                }
+                i = i + 2 + end_rel + 1;
+            } else {
+                out.push('$');
+                i += 1;
+            }
+        } else if next.is_ascii_digit() {
+            // $N (1 ou 2 digitos)
+            let n_end = if i + 2 < bytes.len() && bytes[i + 2].is_ascii_digit() {
+                i + 3
+            } else {
+                i + 2
+            };
+            let n: usize = repl[i + 1..n_end].parse().unwrap_or(0);
+            if let Some(Some(m)) = caps.groups.get(n) {
+                out.push_str(&m.text);
+            }
+            i = n_end;
+        } else {
+            out.push('$');
+            i += 1;
+        }
+    }
+    out
+}
+
 #[derive(Debug)]
 pub struct RtsRegex {
+    /// Mantido para compat com callsites que assumem `regex::Regex`.
+    /// Quando o pattern requer fancy-regex, este campo eh inicializado
+    /// com um placeholder vazio (`.*?` ou similar) e o `engine` carrega
+    /// a versao fancy real. Callsites novos devem ler `engine`.
     pub regex: regex::Regex,
+    /// (#1107) Engine real usado. Para patterns sem lookaround eh
+    /// Fast(regex::Regex) (mesma instancia que `regex`); para patterns
+    /// com lookaround eh Fancy(fancy_regex::Regex).
+    pub engine: RegexEngine,
     pub global: bool,
     /// Flags JS canonicas em ordem (`d g i m s u y` apenas as setadas).
     pub flags: String,

--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -82,38 +82,44 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
                 rx.last_index = 0;
                 return None;
             }
-            let caps_opt = rx.regex.captures(&s_full[start..]);
+            let caps_opt = rx.engine.captures(&s_full[start..]);
             let Some(caps) = caps_opt else {
                 if use_last_idx { rx.last_index = 0; }
                 return None;
             };
-            let m0 = caps.get(0).unwrap();
+            let m0 = match caps.groups.first().and_then(|o| o.clone()) {
+                Some(m) => m,
+                None => {
+                    if use_last_idx { rx.last_index = 0; }
+                    return None;
+                }
+            };
             // Sticky: match precisa comecar em pos=0 (relativo ao start absoluto).
-            if sticky && m0.start() != 0 {
+            if sticky && m0.start != 0 {
                 rx.last_index = 0;
                 return None;
             }
-            let abs_start = start + m0.start();
-            let abs_end = start + m0.end();
+            let abs_start = start + m0.start;
+            let abs_end = start + m0.end;
             if use_last_idx {
                 rx.last_index = abs_end;
             }
             // Coleta captures (0..N).
-            let mut groups_vec: Vec<Option<String>> = Vec::with_capacity(caps.len());
-            // (#regex-d) Coleta indices [start, end] absolutos por capture
-            // quando flag 'd' (hasIndices) esta setada.
             let has_indices = rx.flags.contains('d');
-            let mut indices_vec: Vec<Option<(usize, usize)>> = Vec::with_capacity(caps.len());
-            for i in 0..caps.len() {
-                let m = caps.get(i);
-                groups_vec.push(m.map(|mm| mm.as_str().to_string()));
-                indices_vec.push(m.map(|mm| (start + mm.start(), start + mm.end())));
+            let mut groups_vec: Vec<Option<String>> = Vec::with_capacity(caps.groups.len());
+            let mut indices_vec: Vec<Option<(usize, usize)>> = Vec::with_capacity(caps.groups.len());
+            for opt in &caps.groups {
+                groups_vec.push(opt.as_ref().map(|m| m.text.clone()));
+                indices_vec.push(opt.as_ref().map(|m| (start + m.start, start + m.end)));
             }
             // Coleta named groups.
+            let names = rx.engine.capture_names();
             let mut named_groups: Vec<(String, Option<String>)> = Vec::new();
-            for name in rx.regex.capture_names().flatten() {
-                let m = caps.name(name).map(|m| m.as_str().to_string());
-                named_groups.push((name.to_string(), m));
+            for (i, name_opt) in names.iter().enumerate() {
+                if let Some(name) = name_opt {
+                    let text = caps.groups.get(i).and_then(|o| o.as_ref()).map(|m| m.text.clone());
+                    named_groups.push((name.clone(), text));
+                }
             }
             let indices = if has_indices { Some(indices_vec) } else { None };
             Some((groups_vec, named_groups, abs_start, s_full.clone(), indices))
@@ -293,7 +299,7 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_LAST_INDEX_SET(handle: u64, n: i64) {
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_REGEXP_SOURCE(handle: u64) -> u64 {
     let source: Option<String> = with_entry(handle, |entry| match entry {
-        Some(Entry::Regex(rx)) => Some(rx.regex.as_str().to_owned()),
+        Some(Entry::Regex(rx)) => Some(rx.engine.source()),
         _ => None,
     });
     match source {

--- a/crates/rts-runtime/src/namespaces/globals/string/search.rs
+++ b/crates/rts-runtime/src/namespaces/globals/string/search.rs
@@ -119,23 +119,23 @@ pub extern "C" fn __RTS_FN_NS_STRING_MATCH_REGEX(
     let mr: MatchResultExt = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rts_rx)) => {
             if rts_rx.global {
-                let all: Vec<Vec<u8>> = rts_rx.regex
-                    .find_iter(&s_owned)
-                    .map(|m| m.as_str().as_bytes().to_vec())
+                let all: Vec<Vec<u8>> = rts_rx
+                    .engine
+                    .find_all(&s_owned)
+                    .into_iter()
+                    .map(|m| m.text.into_bytes())
                     .collect();
                 MatchResultExt::All(all)
             } else {
-                match rts_rx.regex.captures(&s_owned) {
+                match rts_rx.engine.captures(&s_owned) {
                     Some(caps) => {
-                        let index = caps.get(0).map(|m| m.start()).unwrap_or(0);
-                        let items: Vec<Option<Vec<u8>>> = (0..caps.len())
-                            .map(|i| caps.get(i).map(|m| m.as_str().as_bytes().to_vec()))
+                        let index = caps.groups.first().and_then(|o| o.as_ref()).map(|m| m.start).unwrap_or(0);
+                        let items: Vec<Option<Vec<u8>>> = caps
+                            .groups
+                            .iter()
+                            .map(|o| o.as_ref().map(|m| m.text.clone().into_bytes()))
                             .collect();
-                        let names: Vec<Option<String>> = rts_rx
-                            .regex
-                            .capture_names()
-                            .map(|n| n.map(|s| s.to_string()))
-                            .collect();
+                        let names = rts_rx.engine.capture_names();
                         MatchResultExt::First { items, index, names }
                     }
                     None => MatchResultExt::None,
@@ -206,7 +206,7 @@ pub extern "C" fn __RTS_FN_NS_STRING_SEARCH_REGEX(
     };
     let s_owned = s.to_string();
     with_entry(regex_handle, |e| match e {
-        Some(Entry::Regex(rx)) => rx.regex.find(&s_owned).map(|m| m.start() as i64).unwrap_or(-1),
+        Some(Entry::Regex(rx)) => rx.engine.find(&s_owned).map(|m| m.start as i64).unwrap_or(-1),
         _ => -1,
     })
 }
@@ -257,9 +257,9 @@ pub extern "C" fn __RTS_FN_NS_STRING_REPLACE_REGEX(
     let out = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rx)) => {
             if rx.global {
-                Some(rx.regex.replace_all(&s_owned, repl_rust.as_str()).into_owned())
+                Some(rx.engine.replace_all(&s_owned, repl_rust.as_str()))
             } else {
-                Some(rx.regex.replace(&s_owned, repl_rust.as_str()).into_owned())
+                Some(rx.engine.replace_first(&s_owned, repl_rust.as_str()))
             }
         }
         _ => None,
@@ -339,29 +339,28 @@ pub extern "C" fn __RTS_FN_NS_STRING_MATCH_ALL_REGEX(
     let infos: Vec<MatchInfo> = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rts_rx)) => {
             let has_indices = rts_rx.flags.contains('d');
-            let names: Vec<Option<String>> = rts_rx
-                .regex
-                .capture_names()
-                .map(|n| n.map(|s| s.to_string()))
-                .collect();
-            rts_rx.regex.captures_iter(&s_owned).map(|caps| {
-                let groups: Vec<Option<String>> = (0..caps.len())
-                    .map(|i| caps.get(i).map(|m| m.as_str().to_string()))
+            let names: Vec<Option<String>> = rts_rx.engine.capture_names();
+            rts_rx.engine.captures_all(&s_owned).into_iter().map(|caps| {
+                let groups: Vec<Option<String>> = caps
+                    .groups
+                    .iter()
+                    .map(|o| o.as_ref().map(|m| m.text.clone()))
                     .collect();
                 let named: Vec<(String, Option<String>)> = names
                     .iter()
                     .enumerate()
                     .filter_map(|(i, n)| {
                         n.as_ref().map(|name| {
-                            (name.clone(), caps.get(i).map(|m| m.as_str().to_string()))
+                            (name.clone(), caps.groups.get(i).and_then(|o| o.as_ref()).map(|m| m.text.clone()))
                         })
                     })
                     .collect();
-                let idx = caps.get(0).map(|m| m.start()).unwrap_or(0);
+                let idx = caps.groups.first().and_then(|o| o.as_ref()).map(|m| m.start).unwrap_or(0);
                 let indices = if has_indices {
                     Some(
-                        (0..caps.len())
-                            .map(|i| caps.get(i).map(|m| (m.start(), m.end())))
+                        caps.groups
+                            .iter()
+                            .map(|o| o.as_ref().map(|m| (m.start, m.end)))
                             .collect::<Vec<_>>(),
                     )
                 } else { None };
@@ -451,28 +450,20 @@ pub extern "C" fn __RTS_FN_NS_STRING_REPLACE_REGEX_FN(
     // Coleta matches primeiro para nao ter borrow mutavel simultaneo.
     let matches: Vec<(usize, usize, Vec<String>)> = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rts_rx)) => {
-            if rts_rx.global {
-                rts_rx.regex.captures_iter(&s_owned).map(|caps| {
-                    let start = caps.get(0).unwrap().start();
-                    let end = caps.get(0).unwrap().end();
-                    let groups: Vec<String> = (0..caps.len())
-                        .map(|i| caps.get(i).map(|m| m.as_str().to_owned()).unwrap_or_default())
-                        .collect();
-                    (start, end, groups)
-                }).collect()
+            let caps_iter: Vec<_> = if rts_rx.global {
+                rts_rx.engine.captures_all(&s_owned)
             } else {
-                match rts_rx.regex.captures(&s_owned) {
-                    Some(caps) => {
-                        let start = caps.get(0).unwrap().start();
-                        let end = caps.get(0).unwrap().end();
-                        let groups: Vec<String> = (0..caps.len())
-                            .map(|i| caps.get(i).map(|m| m.as_str().to_owned()).unwrap_or_default())
-                            .collect();
-                        vec![(start, end, groups)]
-                    }
-                    None => Vec::new(),
-                }
-            }
+                rts_rx.engine.captures(&s_owned).map(|c| vec![c]).unwrap_or_default()
+            };
+            caps_iter.into_iter().map(|caps| {
+                let full = caps.groups.first().and_then(|o| o.clone()).unwrap();
+                let groups: Vec<String> = caps
+                    .groups
+                    .iter()
+                    .map(|o| o.as_ref().map(|m| m.text.clone()).unwrap_or_default())
+                    .collect();
+                (full.start, full.end, groups)
+            }).collect()
         }
         _ => Vec::new(),
     });
@@ -574,25 +565,22 @@ pub extern "C" fn __RTS_FN_GL_STRING_SPLIT_REGEX_LIMIT(
     // \"a1b2c3\".split(/(\\d)/) -> [\"a\", \"1\", \"b\", \"2\", \"c\", \"3\", \"\"].
     let parts: Vec<Option<String>> = with_entry(regex_handle, |e| match e {
         Some(Entry::Regex(rts_rx)) => {
-            let has_groups = rts_rx.regex.captures_len() > 1;
-            if !has_groups {
-                return rts_rx.regex.split(&s).take(lim).map(|p| Some(p.to_owned())).collect();
-            }
-            // Manual split com injecao de capture groups.
+            let has_groups = rts_rx.engine.captures_len() > 1;
+            let all_caps = rts_rx.engine.captures_all(&s);
+            // Manual split com (e sem) capture groups intercalados.
             let mut out: Vec<Option<String>> = Vec::new();
             let mut last_end = 0usize;
-            for caps in rts_rx.regex.captures_iter(&s) {
+            for caps in all_caps {
                 if out.len() >= lim { break; }
-                let full = caps.get(0).unwrap();
-                // segmento antes do match
-                out.push(Some(s[last_end..full.start()].to_owned()));
-                if out.len() >= lim { break; }
-                // capture groups (1..N) intercalados
-                for i in 1..caps.len() {
-                    if out.len() >= lim { break; }
-                    out.push(caps.get(i).map(|m| m.as_str().to_owned()));
+                let full = caps.groups.first().and_then(|o| o.clone()).unwrap();
+                out.push(Some(s[last_end..full.start].to_owned()));
+                if has_groups {
+                    for i in 1..caps.groups.len() {
+                        if out.len() >= lim { break; }
+                        out.push(caps.groups[i].as_ref().map(|m| m.text.clone()));
+                    }
                 }
-                last_end = full.end();
+                last_end = full.end;
             }
             if out.len() < lim {
                 out.push(Some(s[last_end..].to_owned()));

--- a/crates/rts-runtime/src/namespaces/regex/ops.rs
+++ b/crates/rts-runtime/src/namespaces/regex/ops.rs
@@ -29,6 +29,18 @@ where
     })
 }
 
+/// (#1107) Helper agnostico ao engine — usar quando o callsite precisar
+/// suportar lookaround/backref. Closure recebe `&RegexEngine`.
+fn with_engine<F, R>(handle: u64, default: R, f: F) -> R
+where
+    F: FnOnce(&crate::namespaces::gc::handles::RegexEngine) -> R,
+{
+    with_entry(handle, |entry| match entry {
+        Some(Entry::Regex(rx)) => f(&rx.engine),
+        _ => default,
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_COMPILE(
     pat_ptr: *const u8,
@@ -67,8 +79,51 @@ pub extern "C" fn __RTS_FN_NS_REGEX_COMPILE(
         }
     }
     match builder.build() {
-        Ok(rx) => alloc_entry(Entry::Regex(Box::new(crate::namespaces::gc::handles::RtsRegex { regex: rx, global, flags: canon, last_index: 0 }))),
-        Err(_) => 0,
+        Ok(rx) => {
+            let engine = crate::namespaces::gc::handles::RegexEngine::Fast(rx.clone());
+            alloc_entry(Entry::Regex(Box::new(crate::namespaces::gc::handles::RtsRegex {
+                regex: rx,
+                engine,
+                global,
+                flags: canon,
+                last_index: 0,
+            })))
+        }
+        Err(_) => {
+            // (#1107) Fallback fancy-regex para patterns que RE2 rejeita
+            // (lookbehind, lookahead, backreferences). Preserva flags JS
+            // via prefixo inline (?ims) quando aplicavel.
+            let mut prefix = String::new();
+            let has_inline_flags = pattern.starts_with("(?");
+            if !has_inline_flags {
+                let mut flag_chars = String::new();
+                if flags.contains('i') { flag_chars.push('i'); }
+                if flags.contains('m') { flag_chars.push('m'); }
+                if flags.contains('s') { flag_chars.push('s'); }
+                if flags.contains('x') { flag_chars.push('x'); }
+                if !flag_chars.is_empty() {
+                    prefix = format!("(?{flag_chars})");
+                }
+            }
+            let full_pat = format!("{prefix}{pattern}");
+            match fancy_regex::Regex::new(&full_pat) {
+                Ok(fancy) => {
+                    // Placeholder vazio para o campo `regex` legado (so' usado
+                    // por callsites pre-1107 que nao foram migrados; chamadas
+                    // sob fancy devem rotear pelo `engine`).
+                    let placeholder = regex::Regex::new("").unwrap();
+                    let engine = crate::namespaces::gc::handles::RegexEngine::Fancy(fancy);
+                    alloc_entry(Entry::Regex(Box::new(crate::namespaces::gc::handles::RtsRegex {
+                        regex: placeholder,
+                        engine,
+                        global,
+                        flags: canon,
+                        last_index: 0,
+                    })))
+                }
+                Err(_) => 0,
+            }
+        }
     }
 }
 
@@ -91,9 +146,9 @@ pub extern "C" fn __RTS_FN_NS_REGEX_TEST(handle: u64, ptr: *const u8, len: i64) 
                     rx.last_index = 0;
                     return 0;
                 }
-                match rx.regex.find(&s_full[start..]) {
+                match rx.engine.find(&s_full[start..]) {
                     Some(m) => {
-                        rx.last_index = start + m.end();
+                        rx.last_index = start + m.end;
                         1
                     }
                     None => {
@@ -101,7 +156,7 @@ pub extern "C" fn __RTS_FN_NS_REGEX_TEST(handle: u64, ptr: *const u8, len: i64) 
                         0
                     }
                 }
-            } else if rx.regex.is_match(s_full) {
+            } else if rx.engine.is_match(s_full) {
                 1
             } else {
                 0
@@ -132,11 +187,11 @@ pub extern "C" fn __RTS_FN_NS_REGEX_FIND(handle: u64, ptr: *const u8, len: i64) 
                         rx.last_index = 0;
                         return None;
                     }
-                    match rx.regex.find(&s_full[start..]) {
+                    match rx.engine.find(&s_full[start..]) {
                         Some(m) => {
-                            let abs_end = start + m.end();
+                            let abs_end = start + m.end;
                             rx.last_index = abs_end;
-                            Some(m.as_str().as_bytes().to_vec())
+                            Some(m.text.into_bytes())
                         }
                         None => {
                             rx.last_index = 0;
@@ -144,7 +199,7 @@ pub extern "C" fn __RTS_FN_NS_REGEX_FIND(handle: u64, ptr: *const u8, len: i64) 
                         }
                     }
                 } else {
-                    rx.regex.find(s_full).map(|m| m.as_str().as_bytes().to_vec())
+                    rx.engine.find(s_full).map(|m| m.text.into_bytes())
                 }
             }
             _ => None,
@@ -159,8 +214,8 @@ pub extern "C" fn __RTS_FN_NS_REGEX_FIND(handle: u64, ptr: *const u8, len: i64) 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_FIND_AT(handle: u64, ptr: *const u8, len: i64) -> i64 {
     let s = unsafe { str_from(ptr, len) };
-    with_regex(handle, -1i64, |rx| {
-        rx.find(s).map(|m| m.start() as i64).unwrap_or(-1)
+    with_engine(handle, -1i64, |eng| {
+        eng.find(s).map(|m| m.start as i64).unwrap_or(-1)
     })
 }
 
@@ -174,7 +229,7 @@ pub extern "C" fn __RTS_FN_NS_REGEX_REPLACE(
 ) -> u64 {
     let s = unsafe { str_from(ptr, len) };
     let rep = unsafe { str_from(rep_ptr, rep_len) };
-    let out = with_regex(handle, s.to_string(), |rx| rx.replace(s, rep).into_owned());
+    let out = with_engine(handle, s.to_string(), |eng| eng.replace_first(s, rep));
     alloc_string(out.into_bytes())
 }
 
@@ -188,14 +243,12 @@ pub extern "C" fn __RTS_FN_NS_REGEX_REPLACE_ALL(
 ) -> u64 {
     let s = unsafe { str_from(ptr, len) };
     let rep = unsafe { str_from(rep_ptr, rep_len) };
-    let out = with_regex(handle, s.to_string(), |rx| {
-        rx.replace_all(s, rep).into_owned()
-    });
+    let out = with_engine(handle, s.to_string(), |eng| eng.replace_all(s, rep));
     alloc_string(out.into_bytes())
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_REGEX_MATCH_COUNT(handle: u64, ptr: *const u8, len: i64) -> i64 {
     let s = unsafe { str_from(ptr, len) };
-    with_regex(handle, 0i64, |rx| rx.find_iter(s).count() as i64)
+    with_engine(handle, 0i64, |eng| eng.find_all(s).len() as i64)
 }


### PR DESCRIPTION
## Summary
- Novo enum \`RegexEngine\` em RtsRegex: Fast(regex::Regex) | Fancy(fancy_regex::Regex).
- REGEX_COMPILE: tenta Fast primeiro; ao falhar (lookaround/backref), faz fallback para Fancy preservando flags JS via prefixo inline.
- API unificada: is_match/find/captures/captures_all/find_all/capture_names/captures_len/source/replace_first/replace_all com tipos agnosticos (EngineMatch, EngineCaptures).
- replace em Fancy via substituicao manual (\$N, \${N}, \$&, \$\$).
- Todos os callsites migrados para usar engine (REGEX_TEST/FIND/REPLACE/etc, STRING_MATCH/SEARCH/REPLACE/SPLIT/MATCH_ALL, REGEXP_EXEC, re.source).
- Fecha #1107 e ultimo residual de #1086 (lookbehind).

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 366_regex_advanced: 100% bate com Bun/Node (era 9/13)
- [x] Fixture 395_regex_d_flag: continua 100%
- [x] Repro lookbehind/negative lookahead: funciona