### PR TITLE
fix(in): private field + prototype chain + Object.prototype methods (parcial #1091)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -395,6 +395,31 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     // aceita Vec ou Map, com key como handle (String, Symbol, etc).
     // Chama OBJ_HAS que despacha por Entry type do obj.
     if matches!(bin.op, BinaryOp::In) {
+        // (#1091) Private field check: `#name in obj` (ES2022). SWC
+        // representa LHS como Expr::PrivateName. RTS mangla private
+        // fields como `#<class>_<name>` na declaracao; aqui usamos
+        // current_class para construir a key correta.
+        if let Expr::PrivateName(pn) = bin.left.as_ref() {
+            let raw = pn.name.as_ref();
+            let key_str = if let Some(cur) = ctx.current_class.as_deref() {
+                format!("#{}_{}", cur, raw)
+            } else {
+                format!("#{}", raw)
+            };
+            let key_tv = ctx.emit_str_handle(key_str.as_bytes())?;
+            let obj_tv = lower_expr(ctx, &bin.right)?;
+            if matches!(obj_tv.ty, ValTy::Handle | ValTy::I64 | ValTy::U64) {
+                let obj_h = obj_tv.val;
+                let fref = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_OBJ_HAS",
+                    &[cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(fref, &[obj_h, key_tv.val]);
+                let v = ctx.builder.inst_results(inst)[0];
+                return Ok(TypedVal::new(v, ValTy::Bool));
+            }
+        }
         let key_tv = lower_expr(ctx, &bin.left)?;
         let obj_tv = lower_expr(ctx, &bin.right)?;
         // (#83) Aceita tambem I64/U64 — em callbacks de array methods o

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -266,7 +266,45 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_HAS(obj_h: u64, key_h: u64) -> i64
     if let Some(r) = vec_result {
         return r;
     }
-    with_map(obj_h, 0, |m| if m.contains_key(&key) { 1 } else { 0 })
+    // (#1091) `in` walking prototype chain + class methods.
+    // Para instances de classe, methods sao fns globais (nao slots em
+    // instance), entao consultamos class registry via __rts_class tag.
+    if with_map(obj_h, 0, |m| if m.contains_key(&key) { 1 } else { 0 }) == 1 {
+        return 1;
+    }
+    // Walk __proto__ chain.
+    let mut visited: HashSet<u64> = HashSet::new();
+    let mut cur = with_map(obj_h, 0i64, |m| m.get("__proto__").copied().unwrap_or(0)) as u64;
+    let mut steps = 0u32;
+    while cur != 0 && steps < 64 {
+        steps += 1;
+        if !visited.insert(cur) { break; }
+        let found = with_map(cur, 0, |m| if m.contains_key(&key) { 1 } else { 0 });
+        if found == 1 { return 1; }
+        cur = with_map(cur, 0i64, |m| m.get("__proto__").copied().unwrap_or(0)) as u64;
+    }
+    // Class method: consulta global class registry pelo __rts_class.
+    let class_name: Option<String> = with_entry(obj_h, |e| match e {
+        Some(Entry::Map(m)) => m.get("__rts_class").and_then(|v| {
+            with_entry(*v as u64, |ce| match ce {
+                Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+                _ => None,
+            })
+        }),
+        _ => None,
+    });
+    if class_name.is_some() {
+        // Object.prototype tem toString, hasOwnProperty, valueOf, isPrototypeOf,
+        // propertyIsEnumerable, toLocaleString.
+        if matches!(
+            key.as_str(),
+            "toString" | "hasOwnProperty" | "valueOf" | "isPrototypeOf"
+            | "propertyIsEnumerable" | "toLocaleString" | "constructor"
+        ) {
+            return 1;
+        }
+    }
+    0
 }
 
 /// (cross-runtime #753) `MAP_SET` aceitando key como handle (resolve


### PR DESCRIPTION
## Summary
- \`#field in obj\` (ES2022) reconhecido — usa mangling de current_class.
- OBJ_HAS walking __proto__ chain ate 64 niveis.
- Instances com __rts_class retornam true para methods herdados de Object.prototype.
- Fixture passa de runtime_error -> 12/13 batendo com Bun/Node.
- Residual: \"method\" in instance (class method user) — follow-up.

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)