### PR TITLE
fix(parallelism): Object.entries qualifica como ARRAY_RECEIVER (#1101)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -70,7 +70,19 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
                             &m.prop,
                             MemberProp::Ident(p) if matches!(p.sym.as_str(), "from" | "of")
                         );
-                        prop_is_array_returning || obj_is_array_static
+                        // (#1101) Object.entries/keys/values retornam Vec.
+                        let obj_is_object_static = matches!(
+                            m.obj.as_ref(),
+                            Expr::Ident(id) if id.sym.as_str() == "Object"
+                        ) && matches!(
+                            &m.prop,
+                            MemberProp::Ident(p) if matches!(
+                                p.sym.as_str(),
+                                "keys" | "values" | "entries"
+                                | "getOwnPropertyNames" | "getOwnPropertySymbols"
+                            )
+                        );
+                        prop_is_array_returning || obj_is_array_static || obj_is_object_static
                     }
                     _ => false,
                 },


### PR DESCRIPTION
## Summary
- init_looks_array (em collect_array_receiver_idents) reconhece Object.entries/keys/values/getOwnPropertyNames/getOwnPropertySymbols.
- Fix regressao de SIGILL em \`const e = Object.entries(obj); e.map(fn)\`.
- Fecha #1101.

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 323_object_entries_fromEntries: 100% Bun/Node