### PR TITLE
fix(in): class method registry + emit em __RTS_MAIN init (#1114)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1379,6 +1379,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_REGISTER_CLASS_METHOD",
+            map::__RTS_FN_NS_COLLECTIONS_REGISTER_CLASS_METHOD
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES",
             map::__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES
         );

--- a/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
@@ -87,6 +87,32 @@ pub(crate) fn compile_main(
             }
         }
 
+        // (#1114) Registra methods de classe (instance + getters/setters)
+        // no class_method_registry para que `\"method\" in instance` retorne
+        // true via OBJ_HAS.
+        {
+            for (cls_name, meta) in classes.iter() {
+                let mut all_methods: Vec<String> = meta.methods.clone();
+                for g in &meta.getters {
+                    all_methods.push(g.clone());
+                }
+                for s in &meta.setters {
+                    all_methods.push(s.clone());
+                }
+                if all_methods.is_empty() { continue; }
+                let (cp, cl_len) = fn_ctx.emit_str_literal(cls_name.as_bytes())?;
+                let reg_fn = fn_ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_REGISTER_CLASS_METHOD",
+                    &[cl::I64, cl::I64, cl::I64, cl::I64],
+                    None,
+                )?;
+                for method_name in &all_methods {
+                    let (mp, ml) = fn_ctx.emit_str_literal(method_name.as_bytes())?;
+                    fn_ctx.builder.ins().call(reg_fn, &[cp, cl_len, mp, ml]);
+                }
+            }
+        }
+
         // (#301) Var hoisting top-level: declarar vars `var x` antes de
         // executar body, com valor 0 (proxy undefined). Globals existentes
         // ja' tem registro em `globals` map — pulamos.

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -293,7 +293,19 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_HAS(obj_h: u64, key_h: u64) -> i64
         }),
         _ => None,
     });
-    if class_name.is_some() {
+    if let Some(cls) = class_name.as_ref() {
+        // (#1114) Class method registry: emit no init de __RTS_MAIN
+        // registra cada method declarado por classe; consulta por
+        // __rts_class tag da instancia.
+        if class_method_registry()
+            .lock()
+            .unwrap()
+            .get(cls)
+            .map(|set| set.contains(&key))
+            .unwrap_or(false)
+        {
+            return 1;
+        }
         // Object.prototype tem toString, hasOwnProperty, valueOf, isPrototypeOf,
         // propertyIsEnumerable, toLocaleString.
         if matches!(
@@ -318,6 +330,35 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_SET_KH(obj_h: u64, key_h: u64, val
     with_map_mut(obj_h, (), |m| {
         m.insert(key, value);
     });
+}
+
+/// (#1114) Registry de methods declarados por classe. Populado pelo
+/// codegen via __RTS_FN_NS_COLLECTIONS_REGISTER_CLASS_METHOD no inicio
+/// de __RTS_MAIN; consultado pelo `in` operator (OBJ_HAS).
+fn class_method_registry() -> &'static std::sync::Mutex<
+    std::collections::HashMap<String, std::collections::HashSet<String>>,
+> {
+    static R: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, std::collections::HashSet<String>>>,
+    > = std::sync::OnceLock::new();
+    R.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_REGISTER_CLASS_METHOD(
+    class_ptr: *const u8,
+    class_len: i64,
+    method_ptr: *const u8,
+    method_len: i64,
+) {
+    let Some(cls) = str_from_abi(class_ptr, class_len) else { return };
+    let Some(method) = str_from_abi(method_ptr, method_len) else { return };
+    class_method_registry()
+        .lock()
+        .unwrap()
+        .entry(cls.to_string())
+        .or_insert_with(std::collections::HashSet::new)
+        .insert(method.to_string());
 }
 
 /// (cross-runtime #753) `MAP_GET` aceitando key como handle. Retorna


### PR DESCRIPTION
## Summary
- Runtime: novo class_method_registry + REGISTER_CLASS_METHOD extern.
- OBJ_HAS consulta o registry via tag __rts_class.
- compile_main emite registros logo apos class_register_parent (methods + getters + setters).
- Fecha #1114 e finaliza 342_in_operator (100% Bun/Node).

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 342_in_operator: 13/13 batendo