### PR TITLE
fix(proto): chain termina + Map/Set sentinels + inspect filtra interno (#1080)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1354,10 +1354,38 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO(handle: u64) -> u64 {
     if let Some((target, handler)) = crate::namespaces::globals::proxy::ops::resolve_proxy(handle) {
         return crate::namespaces::globals::proxy::ops::dispatch_get_proto(target, handler);
     }
+    // (#1080) Sentinel proto strings: JS spec:
+    // - Object.getPrototypeOf(Object.prototype) === null (depth termina)
+    // - Object.getPrototypeOf(Array.prototype) === Object.prototype
+    // - Object.getPrototypeOf(Map.prototype) === Object.prototype
+    // - Object.getPrototypeOf(Set.prototype) === Object.prototype
+    let sentinel_kind: Option<&'static [u8]> = with_entry(handle, |e| match e {
+        Some(Entry::String(b)) => match b.as_slice() {
+            b"[Object.prototype]" => Some(b"object".as_slice()),
+            b"[Array.prototype]" | b"[Map.prototype]" | b"[Set.prototype]" => {
+                Some(b"chained".as_slice())
+            }
+            _ => None,
+        },
+        _ => None,
+    });
+    match sentinel_kind {
+        Some(b"object") => return 0,
+        Some(b"chained") => return alloc_entry(Entry::String(b"[Object.prototype]".to_vec())),
+        _ => {}
+    }
     // Vec → Array.prototype sentinel.
     let is_vec = with_entry(handle, |e| matches!(e, Some(Entry::Vec(_))));
     if is_vec {
         return alloc_entry(Entry::String(b"[Array.prototype]".to_vec()));
+    }
+    // (#1080) new Map() / new Set() retornam Map/Set kind handles —
+    // o proto deles eh Map.prototype / Set.prototype, nao Object.prototype.
+    if handle_is_map_kind(handle) {
+        return alloc_entry(Entry::String(b"[Map.prototype]".to_vec()));
+    }
+    if handle_is_set_kind(handle) {
+        return alloc_entry(Entry::String(b"[Set.prototype]".to_vec()));
     }
     // Map: se __proto__ slot setado explicit (por Object.create), retorna ele.
     // Se slot ausente, default Object.prototype sentinel.

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -856,20 +856,36 @@ fn inspect_handle(h: u64, depth: usize) -> String {
             format!("[ {} ]", parts.join(", "))
         }
         R::Map(entries) => {
-            if entries.is_empty() {
-                return "{}".to_string();
-            }
-            let parts: Vec<String> = entries
+            // (#1080) Object.create(null) — slot __proto__ existe com
+            // valor 0. Node/Bun imprimem como `[Object: null prototype] {...}`.
+            let is_null_proto = entries
                 .iter()
-                .map(|(k, v)| {
-                    format!(
-                        "{}: {}",
-                        String::from_utf8_lossy(k),
-                        inspect_slot(*v, depth + 1)
-                    )
-                })
+                .any(|(k, v)| k == b"__proto__" && *v == 0);
+            // Filtra slots internos das entries impressas.
+            let visible: Vec<&(Vec<u8>, i64)> = entries
+                .iter()
+                .filter(|(k, _)| k != b"__proto__" && k != b"__rts_class")
                 .collect();
-            format!("{{ {} }}", parts.join(", "))
+            let body = if visible.is_empty() {
+                "{}".to_string()
+            } else {
+                let parts: Vec<String> = visible
+                    .iter()
+                    .map(|(k, v)| {
+                        format!(
+                            "{}: {}",
+                            String::from_utf8_lossy(k),
+                            inspect_slot(*v, depth + 1)
+                        )
+                    })
+                    .collect();
+                format!("{{ {} }}", parts.join(", "))
+            };
+            if is_null_proto {
+                format!("[Object: null prototype] {body}")
+            } else {
+                body
+            }
         }
         R::Json(s) => s,
         R::Other(name) => format!("[object {}]", name),


### PR DESCRIPTION
## Summary
- MAP_GET_PROTO: detecta proto sentinels e termina (Object.prototype -> null; Array/Map/Set -> Object.prototype).
- new Map() / new Set() retornam Map.prototype / Set.prototype.
- inspect filtra __proto__ / __rts_class das entries; prefixa [Object: null prototype] quando __proto__ slot = 0.
- Fecha #1080 (loop infinito em protoDepth + valores corretos).

## Test plan
- [x] cargo test --release --lib (12/12)
- [x] target/release/rts.exe test (1312/1312)
- [x] Fixture 389_proto_accessor: protoDepth correto (1,2,2,0)