### PR TITLE
fix(codegen): globalThis.X member access + typeof (parcial #1079)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -273,6 +273,15 @@ fn lower_typeof(ctx: &mut FnCtx, operand: &Expr) -> Result<TypedVal> {
         if name == "globalThis" {
             return ctx.emit_str_handle(b"object");
         }
+        // (cross-runtime #1079) Builtins sem GlobalClassSpec dedicado mas
+        // referenciaveis: Array/Object/Map/Set/Proxy/... -> "function";
+        // Math/JSON/Reflect/Atomics/Intl -> "object".
+        if matches!(name, "Array" | "Object" | "Map" | "Set" | "Proxy") {
+            return ctx.emit_str_handle(b"function");
+        }
+        if matches!(name, "Math" | "JSON" | "Reflect" | "Atomics" | "Intl") {
+            return ctx.emit_str_handle(b"object");
+        }
         if !is_js_global && ctx.read_local(name).is_none() {
             return ctx.emit_str_handle(b"undefined");
         }
@@ -305,9 +314,49 @@ fn lower_typeof(ctx: &mut FnCtx, operand: &Expr) -> Result<TypedVal> {
             }
         }
     }
-    // `typeof Math.f16round` etc — namespace function members sao
-    // "function" em JS, mas o lower geral abortaria com erro.
+    // (cross-runtime #1079) `typeof globalThis.X` — classifica X como se fosse
+    // ident solo. Cobre globalThis.Math/JSON/Promise/Array/parseInt/isNaN/etc.
     if let Expr::Member(m) = operand {
+        if let Expr::Ident(obj_id) = m.obj.as_ref() {
+            if obj_id.sym.as_str() == "globalThis" {
+                if let swc_ecma_ast::MemberProp::Ident(prop) = &m.prop {
+                    let n = prop.sym.as_str();
+                    // Classes globais sem GlobalClassSpec dedicado -> "function"
+                    if matches!(n, "Array" | "Object" | "Map" | "Set" | "Proxy") {
+                        return ctx.emit_str_handle(b"function");
+                    }
+                    // Classes globais (Promise/Error/Symbol/WeakMap/etc) via spec -> "function"
+                    if crate::abi::global_class_lookup(n).is_some() {
+                        return ctx.emit_str_handle(b"function");
+                    }
+                    // Namespaces objeto -> "object"
+                    if matches!(n,
+                        "Math" | "JSON" | "Reflect" | "console" | "performance"
+                        | "globalThis" | "Atomics" | "Intl"
+                    ) {
+                        return ctx.emit_str_handle(b"object");
+                    }
+                    // Funcoes globais soltas
+                    if matches!(n,
+                        "parseInt" | "parseFloat" | "isNaN" | "isFinite"
+                        | "encodeURIComponent" | "decodeURIComponent"
+                        | "encodeURI" | "decodeURI"
+                        | "atob" | "btoa" | "structuredClone"
+                        | "fetch" | "setTimeout" | "setInterval"
+                        | "clearTimeout" | "clearInterval" | "queueMicrotask"
+                    ) {
+                        return ctx.emit_str_handle(b"function");
+                    }
+                    // Valores especiais
+                    if matches!(n, "NaN" | "Infinity") {
+                        return ctx.emit_str_handle(b"number");
+                    }
+                    if n == "undefined" {
+                        return ctx.emit_str_handle(b"undefined");
+                    }
+                }
+            }
+        }
         if let Some(qualified) = crate::codegen::lower::expressions::members::qualified_member_name(operand) {
             let target: String = if let Some(prop) = qualified.strip_prefix("Math.") {
                 format!("math.{prop}")

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -665,6 +665,27 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             }
         }
     }
+    // (cross-runtime #1079) `globalThis.X` em posicao de valor — re-lower
+    // como ident solo `X`. Cobre identidade (globalThis.Array === Array),
+    // chamadas (globalThis.parseInt("42")), reflexao.
+    if let Expr::Ident(obj_id) = m.obj.as_ref() {
+        if obj_id.sym.as_str() == "globalThis" {
+            if let swc_ecma_ast::MemberProp::Ident(prop) = &m.prop {
+                let n = prop.sym.as_str();
+                // So' redireciona se 'n' nao for var local capturando o nome.
+                if ctx.read_local(n).is_none() {
+                    let synth = Expr::Ident(swc_ecma_ast::Ident {
+                        span: prop.span,
+                        ctxt: Default::default(),
+                        sym: prop.sym.clone(),
+                        optional: false,
+                    });
+                    return super::lower_expr(ctx, &synth);
+                }
+            }
+        }
+    }
+
     // (#162/155) `Object.prototype` / `Array.prototype` — referencia ao
     // prototype singleton da classe global. Sem suporte completo a prototype
     // chain ainda; retorna handle de string sentinel "[<class>.prototype]"

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -180,6 +180,17 @@ fn lower_ident_expr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal> {
     if is_global {
         return ctx.emit_str_handle(name.as_bytes());
     }
+    // (cross-runtime #1079) JS builtins sem GlobalClassSpec/Namespace dedicado
+    // — referenciados como valor (ex: `globalThis.Array === Array`, `typeof Map`,
+    // pattern `if (Array in globalThis)`). Retorna handle sentinel de string com
+    // o nome. Identidade via `===` funciona porque ambos os lados produzem o
+    // mesmo handle de string interna.
+    if matches!(name,
+        "Array" | "Object" | "Map" | "Set" | "Proxy" | "Reflect"
+        | "Math" | "JSON" | "Atomics" | "Intl"
+    ) {
+        return ctx.emit_str_handle(name.as_bytes());
+    }
     Err(anyhow!("undefined variable `{name}`"))
 }
 


### PR DESCRIPTION
## Summary
- `globalThis.X` em posicao de valor redireciona para o ident solo `X`, habilitando identidade (`globalThis.Array === Array`), chamadas e reflexao.
- `typeof globalThis.X` classifica X corretamente (function para Array/Map/Set/Proxy/classes; object para Math/JSON/Reflect/Atomics/Intl; function para parseInt/isNaN/encodeURIComponent/etc).
- Idents soltos Array/Object/Map/Set/Proxy/Reflect/Math/JSON/Atomics/Intl reificam como handle sentinel — antes eram "undefined variable" erro.

Fechamento parcial de #1079. Falta o pattern `globalThis[key] = factory()` (write mutavel no objeto global) usado em `ensureGlobal` — sera follow-up.

## Test plan
- [x] `cargo build --release` limpo
- [x] `cargo test --release --lib` 12/12
- [x] `target/release/rts.exe test` 1312/1312
- [x] `tests/cross-runtime/object-meta/388_globalThis.ts` agora produz 23/26 linhas corretas (antes: crash em "undefined variable Array" na linha 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)