### PR TITLE
fix(codegen): typeof param any/unknown em method classifica runtime (#1130)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -217,6 +217,22 @@ pub(crate) fn compile_user_fn(
             ) {
                 fn_ctx.var_member_call_values.insert(block_param);
             }
+            // (cross-runtime #1130) Param tipado `any`/`unknown`/sem anotacao
+            // pode receber handle (Map/Vec/String/Function/instance) ou
+            // numero. Marca como ambiguo pra que `typeof v` despache runtime
+            // helper que inspeciona Entry em vez de assumir "number".
+            // Brand check pattern `typeof v === "object" && #x in v` depende
+            // disso.
+            if ty == ValTy::I64 {
+                let ann = param.type_annotation.as_deref().map(str::trim);
+                let is_ambiguous_ann = match ann {
+                    None => true,
+                    Some(a) => matches!(a, "any" | "unknown" | "object" | "Object"),
+                };
+                if is_ambiguous_ann {
+                    fn_ctx.var_member_call_values.insert(block_param);
+                }
+            }
 
             // (#592) Param tipado `Cls[]` registra local_array_class_ty
             // pra que arr[i].field saiba o tipo do field na classe.


### PR DESCRIPTION
## Summary
Param tipado \`any\`/\`unknown\`/\`object\`/sem-anotacao chega como i64 puro no ABI extern \"C\". \`typeof v\` em \`crates/rts-codegen/src/codegen/lower/expressions/basics.rs:341\` so' despachava o helper runtime quando tv.ty era Handle/U64 ou var_member_call_value — params \`any\` em method nao se qualificavam, retornavam \"number\".

Agora: setup do user fn em \`compile/user_fn.rs\` marca esses params como \`var_member_call_values\`, fazendo typeof rotear pelo runtime helper que inspeciona Entry.

Desbloqueia brand check \`typeof v === \"object\" && #x in v\` (idiomatico ES2022) e similares.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Fixture \`373_private_in_check.ts\`: antes 0/0/0/0/5/...; agora 1/1/0/0/5/not a Point/1/0/1/0 (booleanos com return type \`v is T\` ainda imprimem 0/1 em vez de true/false — issue separada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)