### PR TITLE
fix(codegen): sentinela undefined eh falsy em branch cond (#1133)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -1213,11 +1213,22 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             _ => {
                 let i64v = self.coerce_to_i64(tv).val;
                 let zero = self.builder.ins().iconst(cl::I64, 0);
-                self.builder.ins().icmp(
+                // (cross-runtime #1133) Sentinel undefined (i64::MIN+2) deve
+                // ser falsy em branch context. Sem isso `while (cur?.next)`
+                // / `if (x?.missing)` sao sempre truthy quando o lado direito
+                // eh undefined. JS spec: undefined eh falsy.
+                let undef = self.builder.ins().iconst(cl::I64, i64::MIN + 2);
+                let not_zero = self.builder.ins().icmp(
                     cranelift_codegen::ir::condcodes::IntCC::NotEqual,
                     i64v,
                     zero,
-                )
+                );
+                let not_undef = self.builder.ins().icmp(
+                    cranelift_codegen::ir::condcodes::IntCC::NotEqual,
+                    i64v,
+                    undef,
+                );
+                self.builder.ins().band(not_zero, not_undef)
             }
         }
     }


### PR DESCRIPTION
## Summary
Antes \`to_branch_cond\` comparava \`i64v != 0\`. O sentinel undefined eh \`i64::MIN+2 = -9223372036854775806\`, que eh \`!= 0\`, entao branches eram sempre truthy quando o valor era undefined.

Quebrava:
- \`while (cur?.next)\` — loop infinito (cur.next undefined permanece truthy)
- \`if (obj?.missing)\` — sempre entra no then-branch
- \`x ? a : b\` quando x eh undefined

Fix: branch cond agora eh \`i64v != 0 && i64v != (i64::MIN+2)\`. JS spec: undefined eh falsy.

Desbloqueia patterns idiomaticos de LinkedList/tree iteration. Fixture \`372_private_methods.ts\`: com PR #1132 + este fix, roda inteira (5/10 linhas corretas, restantes sao imprecisao FP em constantes — issue separada).

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro minima \`while (cur?.next)\` agora termina corretamente
- [x] Fixture \`372_private_methods.ts\` roda sem timeout (antes loop infinito apos PR #1132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)