### PR TITLE
fix(codegen): Boolean/Number/String como callback em array methods (#1137)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -482,7 +482,15 @@ fn lift_arrows_in_expr(
                             // usa `tail (f64) -> X`). Sem isso, parallel.* recebe ptr nu
                             // e callback interpreta i64 bits como f64 (#XXX).
                             if let Expr::Ident(ident) = call.args[arg_idx].expr.as_ref() {
-                                if user_fn_names.contains(ident.sym.as_str()) {
+                                // (cross-runtime #1137) Boolean/Number/String como callback —
+                                // sao coerce fns globais. Wrap em arrow `(x) => Boolean(x)`
+                                // pra que se torne uma user fn liftavel e o callback passe
+                                // pelo path comum em vez de tentar usar handle sentinel como fn ptr.
+                                let is_coerce_ident = matches!(
+                                    ident.sym.as_str(),
+                                    "Boolean" | "Number" | "String"
+                                );
+                                if user_fn_names.contains(ident.sym.as_str()) || is_coerce_ident {
                                     let ident_clone = ident.clone();
                                     // (#776) Cria wrap arrow com `arrow_arity` params para
                                     // casar com a ABI runtime nova. Determina quantos args


### PR DESCRIPTION
## Summary
Antes \`arr.filter(Boolean)\` crashava SIGILL: \`Boolean\` resolve como handle sentinel em \`lower_ident_expr\`, e o codegen usava o handle como fn ptr no \`call_indirect\` do array method.

Agora: \`lift_inline_arrows_in_array_methods\` reconhece \`Boolean\`/\`Number\`/\`String\` como callable globais e os wrappa em arrow inline \`(x) => Boolean(x)\`, fazendo com que sigam o path comum de user fn liftada.

\`.filter(Boolean)\` (idiomatico pra remover falsy) e \`.map(Number)\` (parse strings) agora funcionam em arrays simples. Arrays com \`null\`/\`undefined\` element ainda crasham (bug separado).

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`[1, 0, 2].filter(Boolean)\` retorna \`[1, 2]\` (antes SIGILL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)