### PR TITLE
fix(codegen): Reflect.construct(UserClass, args) via path new (#1127 + #1072)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1567,6 +1567,32 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     // implicito via FUNCTION_APPLY com `this = inst`. Deixa
                     // newTarget como follow-up (afeta prototype chain).
                     "construct" if matches!(call.args.len(), 2 | 3) => {
+                        // (cross-runtime #1127) User class como target: monta
+                        // NewExpr sintetico e chama lower_new. Sem isso, Reflect.construct
+                        // tratava class como Function handle e retornava instancia com
+                        // campos null.
+                        if let Expr::Ident(target_id) = call.args[0].expr.as_ref() {
+                            let cls = target_id.sym.as_str();
+                            if ctx.classes.contains_key(cls) {
+                                // Args eh array literal? Extrai elementos pra passar como new args.
+                                if let Expr::Array(arr) = call.args[1].expr.as_ref() {
+                                    let mut new_args: Vec<swc_ecma_ast::ExprOrSpread> = Vec::new();
+                                    for elem_opt in &arr.elems {
+                                        if let Some(elem) = elem_opt {
+                                            new_args.push(elem.clone());
+                                        }
+                                    }
+                                    let new_expr_synth = swc_ecma_ast::NewExpr {
+                                        span: Default::default(),
+                                        ctxt: Default::default(),
+                                        callee: Box::new(Expr::Ident(target_id.clone())),
+                                        args: Some(new_args),
+                                        type_args: None,
+                                    };
+                                    return self::new_expr::lower_new(ctx, &new_expr_synth);
+                                }
+                            }
+                        }
                         let target_h = lower_callable_target_h(ctx, &call.args[0].expr)?;
                         let args_tv = lower_expr(ctx, &call.args[1].expr)?;
                         let args_h = ctx.coerce_to_i64(args_tv).val;


### PR DESCRIPTION
## Summary
Antes \`Reflect.construct(Point, [1,2])\` tratava Point como Function handle e tentava FUNCTION_APPLY → instancia com fields null.

Agora: quando target eh ident de user class registrada e args eh array literal, monta \`NewExpr\` sintetico e despacha pelo \`lower_new\`, que segue o path correto de instanciacao (alloc + constructor + fields).

Fechamento de #1127 (follow-up de #1072) e #1072 completo.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Fixture \`346_reflect_api.ts\` produz 11/11 linhas corretas (antes Reflect.construct retornava p.x=null, p instanceof Point=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)