### PR TITLE
feat(codegen): globalThis[k] write/read/in via Map singleton (parcial #1125)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1173,6 +1173,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_NEW
         );
         add_fn!(
+            "__RTS_FN_RT_GLOBAL_THIS_MAP",
+            map::__RTS_FN_RT_GLOBAL_THIS_MAP
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_MAP_FREE",
             map::__RTS_FN_NS_COLLECTIONS_MAP_FREE
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -668,8 +668,45 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
     // (cross-runtime #1079) `globalThis.X` em posicao de valor — re-lower
     // como ident solo `X`. Cobre identidade (globalThis.Array === Array),
     // chamadas (globalThis.parseInt("42")), reflexao.
-    if let Expr::Ident(obj_id) = m.obj.as_ref() {
+    // (cross-runtime #1125) `globalThis[key]` (computed) — despacha pra Map
+    // singleton via __RTS_FN_RT_GLOBAL_THIS_MAP. Pattern `ensureGlobal`.
+    // Peel TsAs/Paren para `(globalThis as any)`.
+    fn peel_obj<'a>(e: &'a Expr) -> &'a Expr {
+        match e {
+            Expr::TsAs(a) => peel_obj(&a.expr),
+            Expr::TsTypeAssertion(a) => peel_obj(&a.expr),
+            Expr::TsConstAssertion(a) => peel_obj(&a.expr),
+            Expr::TsNonNull(a) => peel_obj(&a.expr),
+            Expr::Paren(p) => peel_obj(&p.expr),
+            _ => e,
+        }
+    }
+    if let Expr::Ident(obj_id) = peel_obj(m.obj.as_ref()) {
         if obj_id.sym.as_str() == "globalThis" {
+            // Computed key — Map dinamico do globalThis.
+            if let swc_ecma_ast::MemberProp::Computed(c) = &m.prop {
+                use cranelift_codegen::ir::InstBuilder;
+                let key_tv = lower_expr(ctx, &c.expr)?;
+                let key_h = ctx.coerce_to_handle(key_tv)?.val;
+                let gt_fn = ctx.get_extern("__RTS_FN_RT_GLOBAL_THIS_MAP", &[], Some(cl::I64))?;
+                let gt_inst = ctx.builder.ins().call(gt_fn, &[]);
+                let gt = ctx.builder.inst_results(gt_inst)[0];
+                let str_ptr = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+                let str_len = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+                let p_inst = ctx.builder.ins().call(str_ptr, &[key_h]);
+                let kp = ctx.builder.inst_results(p_inst)[0];
+                let l_inst = ctx.builder.ins().call(str_len, &[key_h]);
+                let kl = ctx.builder.inst_results(l_inst)[0];
+                let get_fn = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_MAP_GET",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let g_inst = ctx.builder.ins().call(get_fn, &[gt, kp, kl]);
+                let v = ctx.builder.inst_results(g_inst)[0];
+                ctx.var_member_call_values.insert(v);
+                return Ok(TypedVal::new(v, ValTy::I64));
+            }
             if let swc_ecma_ast::MemberProp::Ident(prop) = &m.prop {
                 let n = prop.sym.as_str();
                 // So' redireciona se 'n' nao for var local capturando o nome.

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -232,6 +232,48 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
     }
 
     if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Member(m)) = &a.left {
+        // (cross-runtime #1125) `globalThis[key] = v` — Map global singleton.
+        if matches!(a.op, AssignOp::Assign) {
+            // Peel TsAs/Paren para detectar `(globalThis as any)["k"]`.
+            fn peel<'a>(e: &'a Expr) -> &'a Expr {
+                match e {
+                    Expr::TsAs(a) => peel(&a.expr),
+                    Expr::TsTypeAssertion(a) => peel(&a.expr),
+                    Expr::TsConstAssertion(a) => peel(&a.expr),
+                    Expr::TsNonNull(a) => peel(&a.expr),
+                    Expr::Paren(p) => peel(&p.expr),
+                    _ => e,
+                }
+            }
+            if let Expr::Ident(obj_id) = peel(m.obj.as_ref()) {
+                if obj_id.sym.as_str() == "globalThis" {
+                    if let MemberProp::Computed(c) = &m.prop {
+                        use cranelift_codegen::ir::InstBuilder;
+                        use cranelift_codegen::ir::types as cl;
+                        let key_tv = lower_expr(ctx, &c.expr)?;
+                        let key_h = ctx.coerce_to_handle(key_tv)?.val;
+                        let val_tv = lower_expr(ctx, &a.right)?;
+                        let val = ctx.coerce_to_i64(val_tv).val;
+                        let gt_fn = ctx.get_extern("__RTS_FN_RT_GLOBAL_THIS_MAP", &[], Some(cl::I64))?;
+                        let gt_inst = ctx.builder.ins().call(gt_fn, &[]);
+                        let gt = ctx.builder.inst_results(gt_inst)[0];
+                        let str_ptr = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+                        let str_len = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+                        let p_inst = ctx.builder.ins().call(str_ptr, &[key_h]);
+                        let kp = ctx.builder.inst_results(p_inst)[0];
+                        let l_inst = ctx.builder.ins().call(str_len, &[key_h]);
+                        let kl = ctx.builder.inst_results(l_inst)[0];
+                        let set_fn = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_MAP_SET",
+                            &[cl::I64, cl::I64, cl::I64, cl::I64],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(set_fn, &[gt, kp, kl, val]);
+                        return Ok(TypedVal::new(val, ValTy::I64));
+                    }
+                }
+            }
+        }
         // `arr.length = N` — JS spec: trunca/extende o array.
         // Detecta via prop name; runtime decide se eh Vec mesmo.
         if matches!(a.op, AssignOp::Assign) {

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -441,6 +441,42 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     // aceita Vec ou Map, com key como handle (String, Symbol, etc).
     // Chama OBJ_HAS que despacha por Entry type do obj.
     if matches!(bin.op, BinaryOp::In) {
+        // (cross-runtime #1125) `key in globalThis` — Map global singleton.
+        // Peel TsAs/Paren para `(globalThis as any)`.
+        fn peel_gt<'a>(e: &'a Expr) -> &'a Expr {
+            match e {
+                Expr::TsAs(a) => peel_gt(&a.expr),
+                Expr::TsTypeAssertion(a) => peel_gt(&a.expr),
+                Expr::TsConstAssertion(a) => peel_gt(&a.expr),
+                Expr::TsNonNull(a) => peel_gt(&a.expr),
+                Expr::Paren(p) => peel_gt(&p.expr),
+                _ => e,
+            }
+        }
+        if let Expr::Ident(rid) = peel_gt(&bin.right) {
+            if rid.sym.as_str() == "globalThis" {
+                use cranelift_codegen::ir::InstBuilder;
+                let key_tv = lower_expr(ctx, &bin.left)?;
+                let key_h = ctx.coerce_to_handle(key_tv)?.val;
+                let gt_fn = ctx.get_extern("__RTS_FN_RT_GLOBAL_THIS_MAP", &[], Some(cl::I64))?;
+                let gt_inst = ctx.builder.ins().call(gt_fn, &[]);
+                let gt = ctx.builder.inst_results(gt_inst)[0];
+                let str_ptr = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+                let str_len = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+                let p_inst = ctx.builder.ins().call(str_ptr, &[key_h]);
+                let kp = ctx.builder.inst_results(p_inst)[0];
+                let l_inst = ctx.builder.ins().call(str_len, &[key_h]);
+                let kl = ctx.builder.inst_results(l_inst)[0];
+                let has_fn = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_MAP_HAS",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let h_inst = ctx.builder.ins().call(has_fn, &[gt, kp, kl]);
+                let v = ctx.builder.inst_results(h_inst)[0];
+                return Ok(TypedVal::new(v, ValTy::Bool));
+            }
+        }
         // (#1091) Private field check: `#name in obj` (ES2022). SWC
         // representa LHS como Expr::PrivateName. RTS mangla private
         // fields como `#<class>_<name>` na declaracao; aqui usamos

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -78,6 +78,19 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_NEW() -> u64 {
     alloc_entry(Entry::Map(Box::new(IndexMap::new())))
 }
 
+/// (cross-runtime #1125) Storage do `globalThis` para escrita/leitura
+/// dinamica (`globalThis[k] = v` / `globalThis[k]` / `k in globalThis`).
+/// Singleton lazy-init via OnceLock — handle Map persistente durante
+/// toda a sessao.
+static GLOBAL_THIS_HANDLE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_GLOBAL_THIS_MAP() -> u64 {
+    *GLOBAL_THIS_HANDLE.get_or_init(|| {
+        alloc_entry(Entry::Map(Box::new(IndexMap::new())))
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FREE(handle: u64) {
     free_handle(handle);


### PR DESCRIPTION
## Summary
Novo extern fn \`__RTS_FN_RT_GLOBAL_THIS_MAP\` retorna handle de Map singleton (lazy via OnceLock). Codegen detecta padroes \`globalThis\` em 3 lugares:
- \`lower_assign_expr\`: \`globalThis[k] = v\` -> MAP_SET no singleton
- \`lower_member_expr\`: \`globalThis[k]\` -> MAP_GET no singleton
- BinaryOp::In: \`k in globalThis\` -> MAP_HAS no singleton

Cobre \`(globalThis as any)[k]\` (peel TsAs/Paren/TsNonNull/TsConstAssertion).

Funciona em local direto: \`globalThis[k] = literal; globalThis[k]\` round-trip OK. Nao funciona ainda em pattern \`ensureGlobal(k, factory)\` quando factory eh arrow passada como param e invocada — bug separado de callback indirection.

Cobertura parcial de #1125 (typeof/identity ja' coberto em PR #1124).

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`globalThis[\"x\"] = 42; globalThis[\"x\"]\` -> 42
- [x] Repro \`\"x\" in globalThis\` -> true apos set

🤖 Generated with [Claude Code](https://claude.com/claude-code)