### PR TITLE
feat(codegen): obj[k](args) computed member call via indirect (parcial #1067)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -2090,6 +2090,14 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             }
             return lower_user_call(ctx, &resolved, call);
         }
+        // (cross-runtime #1067) Callee eh member computed (`obj[k](args)`,
+        // `arr[i](x)`) ou outra expressao que produz fn handle. Lower o
+        // callee como expressao, depois faz indirect call via FUNCTION_APPLY.
+        if let Expr::Member(m) = callee.as_ref() {
+            if matches!(&m.prop, MemberProp::Computed(_)) {
+                return lower_indirect_call(ctx, callee, call);
+            }
+        }
     }
     Err(anyhow!("unsupported call expression form"))
 }


### PR DESCRIPTION
## Summary
Antes \`obj[k](args)\` (call em member computed, ex: \`_ops[opcode](a, b)\`) crashava com \"unsupported call expression form\".

Agora: fallback no final de \`lower_call\` detecta \`Expr::Member\` com \`MemberProp::Computed\` e delega para \`lower_indirect_call\` (FUNCTION_APPLY). Pattern dispatcher (\`ops[k](a, b)\`) funciona.

Limitacao: spread em indirect call (\`ops[k](...args)\`) ainda nao suportado — falha em \"spread not supported in indirect call\". Bug separado, fixture \`356_obf_dispatcher.ts\` progride mas nao passa inteira por causa disso.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`ops[1](3, 4)\` retorna 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)