### PR TITLE
feat(codegen+runtime): spread (...args) em indirect/handle Function calls (#1067)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1407,6 +1407,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_POP",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_POP
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -369,13 +369,22 @@ pub(super) fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &Ca
     let new_inst = ctx.builder.ins().call(vec_new, &[]);
     let args_vec = ctx.builder.inst_results(new_inst)[0];
     ctx.declare_gc_handle(args_vec);
+    let vec_extend = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM",
+        &[cl::I64, cl::I64],
+        None,
+    )?;
     for arg in &call.args {
-        if arg.spread.is_some() {
-            return Err(anyhow!("spread not supported in indirect call"));
-        }
         let tv = lower_expr(ctx, &arg.expr)?;
-        let v = ctx.coerce_to_i64(tv).val;
-        ctx.builder.ins().call(vec_push, &[args_vec, v]);
+        if arg.spread.is_some() {
+            // (cross-runtime #1067) Spread em indirect call: extend o args
+            // vec com elementos do source vec/array.
+            let src = ctx.coerce_to_i64(tv).val;
+            ctx.builder.ins().call(vec_extend, &[args_vec, src]);
+        } else {
+            let v = ctx.coerce_to_i64(tv).val;
+            ctx.builder.ins().call(vec_push, &[args_vec, v]);
+        }
     }
     let invoke = ctx.get_extern(
         "__RTS_FN_RT_INVOKE_AUTO",
@@ -404,9 +413,18 @@ pub(super) fn emit_function_handle_indirect_call(
         &[cl::I64, cl::I64],
         None,
     )?;
+    let vec_extend_h = ctx.get_extern(
+        "__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM",
+        &[cl::I64, cl::I64],
+        None,
+    )?;
     for a in &call.args {
         if a.spread.is_some() {
-            return Err(anyhow!("spread em call de handle Function nao suportado"));
+            // (cross-runtime #1067) Spread em call de handle Function: extend.
+            let tv = lower_expr(ctx, &a.expr)?;
+            let src = ctx.coerce_to_i64(tv).val;
+            ctx.builder.ins().call(vec_extend_h, &[args_handle, src]);
+            continue;
         }
         let tv = lower_expr(ctx, &a.expr)?;
         // Args numéricos são empacotados como `f64::to_bits` (i64) para

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -37,6 +37,20 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_LEN(handle: u64) -> i64 {
     with_vec(handle, -1, |v| v.len() as i64)
 }
 
+/// (cross-runtime #1067) Suporte a spread em indirect call: copia todos
+/// os elementos de `src` para `dst`. Usado pelo codegen para `f(...args)`
+/// onde args eh Vec.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM(dst: u64, src: u64) {
+    let items: Vec<i64> = with_vec(src, Vec::new(), |v| v.clone());
+    with_vec_mut(dst, (), |v| {
+        for x in items {
+            if v.len() >= 1_000_000 { break; }
+            v.push(x);
+        }
+    });
+}
+
 /// Limite duro de elementos por vec — protege contra OOM em cenarios
 /// patologicos (ex: generator infinito desugared para buffer eager,
 /// loop sem condicao de parada). 1M i64 = 8MiB por vec, suficiente


### PR DESCRIPTION
## Summary
Antes \`f(...args)\` onde f eh handle (member computed, bind, REIFY, new Function) falhava com \"spread not supported in indirect call\".

Agora:
- Novo runtime fn \`__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM(dst, src)\` copia elementos de src para dst.
- Codegen em ambos os paths de indirect call detecta arg com spread e usa VEC_EXTEND_FROM em vez de VEC_PUSH.

Pattern dispatcher \`ops[opcode](...args)\` (obfuscadores tipo js-confuser) funciona.

Fixture \`356_obf_dispatcher.ts\`: linhas 1-5 (aritmetica numerica) agora corretas. Linhas 6+ (string opcode lookup com handles) ainda divergentes — bug separado.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`ops[1](...[3, 4])\` retorna 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)