### PR TITLE
fix(codegen): type predicate (v is T) return type eh Bool (parcial #1055)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -78,6 +78,12 @@ impl ValTy {
             "u16" | "U16" => return ValTy::U16,
             _ => {}
         }
+        // (cross-runtime followup) Type predicate `param is Type` ou
+        // `asserts param is Type` — semantica de retorno eh boolean.
+        // Sem isso, console.log(fn(...)) imprime 0/1 em vez de true/false.
+        if trimmed.contains(" is ") || trimmed.starts_with("asserts ") {
+            return ValTy::Bool;
+        }
         // Tipos de array (`T[]`, `Array<T>`, `ReadonlyArray<T>`) sao
         // representados como handles GC (Vec<i64>) — `.length`, `.push`,
         // `for...of` dispatcham via gc.handle_len/vec_*.


### PR DESCRIPTION
## Summary
Antes \`function f(v): v is T { ... }\` tinha return ValTy::I64 default, fazendo \`console.log(f(x))\` imprimir 0/1 em vez de true/false.

Agora: \`ValTy::from_annotation\` detecta padroes \`X is Y\` e \`asserts ...\` na annotation textual e retorna ValTy::Bool.

Fixture \`373_private_in_check.ts\`: linhas 1-4 + 5/6 corretas (true/true/false/false). Linhas 7-10 (\`static isCat(v: any) {...}\` sem return type annotation explicita) ainda imprimem 0/1 — bug separado de inferencia de return type via body.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`P.check(v): v is P\` retorna true/false (antes 1/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)