### PR TITLE
fix(codegen): inferencia de Bool ret via &&/||/?: recursivo (fecha #1055)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -782,14 +782,26 @@ fn inspect_return_kind(
         use swc_ecma_ast::BinaryOp;
         match e {
             Expr::Lit(swc_ecma_ast::Lit::Bool(_)) => true,
-            Expr::Bin(b) => matches!(
-                b.op,
-                BinaryOp::EqEq | BinaryOp::EqEqEq | BinaryOp::NotEq | BinaryOp::NotEqEq
-                | BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq
-                | BinaryOp::In | BinaryOp::InstanceOf
-            ),
+            Expr::Bin(b) => {
+                if matches!(
+                    b.op,
+                    BinaryOp::EqEq | BinaryOp::EqEqEq | BinaryOp::NotEq | BinaryOp::NotEqEq
+                    | BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq
+                    | BinaryOp::In | BinaryOp::InstanceOf
+                ) {
+                    return true;
+                }
+                // (cross-runtime followup) `a && b` / `a || b` retornam bool
+                // quando AMBOS os lados sao bool. Cobre brand-check pattern:
+                // `v !== null && typeof v === "object" && #x in v`.
+                if matches!(b.op, BinaryOp::LogicalAnd | BinaryOp::LogicalOr) {
+                    return expr_yields_bool(&b.left) && expr_yields_bool(&b.right);
+                }
+                false
+            }
             Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Bang) => true,
             Expr::Paren(p) => expr_yields_bool(&p.expr),
+            Expr::Cond(c) => expr_yields_bool(&c.cons) && expr_yields_bool(&c.alt),
             _ => false,
         }
     }


### PR DESCRIPTION
## Summary
Antes \`function check(v) { return v !== null && typeof v === \"object\" && #x in v; }\` sem return annotation explicita tinha inferred ret = Number. \`console.log(check(x))\` imprimia 1/0 em vez de true/false.

Agora: \`expr_yields_bool\` em \`inspect_return_kind\` detecta recursivamente:
- \`LogicalAnd\` / \`LogicalOr\` quando ambos os lados sao bool;
- Conditional (ternario) quando ambos cons/alt sao bool.

Fixture \`373_private_in_check.ts\` agora produz 12/12 linhas matching Bun (antes 4/12). Combina com PR #1147 (type predicate \`v is T\`).

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Fixture \`373_private_in_check.ts\` 12/12 linhas corretas

🤖 Generated with [Claude Code](https://claude.com/claude-code)