### PR TITLE
feat(codegen): Array.prototype.<m>.call rewrite + slice() arg opcional (parcial #1064)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -164,7 +164,13 @@ pub(super) fn lower_string_builtin(
         }
         // ── slicing ───────────────────────────────────────────────────────
         "slice" => {
-            let start = arg_i64(ctx, call, 0)?;
+            // (cross-runtime followup) slice() sem args = slice(0). Antes
+            // chamava arg_i64(0) que falhava com "missing arg #0".
+            let start = if !call.args.is_empty() {
+                arg_i64(ctx, call, 0)?
+            } else {
+                ctx.builder.ins().iconst(cl::I64, 0)
+            };
             let end = if call.args.len() > 1 {
                 arg_i64(ctx, call, 1)?
             } else {

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -281,6 +281,9 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         // acima via inferencia de instanceof. Sem isso o callee
         // `Object.prototype.hasOwnProperty` vira sentinel string e o
         // `.call(...)` falha em "unsupported call expression form".
+        // (cross-runtime #1064) Tambem suporta `Array.prototype.<method>.call(obj, ...args)`
+        // -> `obj.<method>(...args)` para slice/push/concat/etc (pattern
+        // tsc/esbuild __spreadArray helper).
         if let Expr::Member(outer) = callee.as_ref() {
             if let MemberProp::Ident(call_id) = &outer.prop {
                 if call_id.sym.as_str() == "call" && !call.args.is_empty() {
@@ -291,7 +294,14 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                                 method,
                                 "hasOwnProperty" | "propertyIsEnumerable"
                             );
-                            if is_universal {
+                            let is_array_proto_method = matches!(
+                                method,
+                                "slice" | "concat" | "push" | "pop" | "shift" | "unshift"
+                                | "indexOf" | "lastIndexOf" | "includes" | "join"
+                                | "reverse" | "filter" | "map" | "forEach" | "find"
+                                | "findIndex" | "every" | "some" | "reduce" | "flat"
+                            );
+                            if is_universal || is_array_proto_method {
                                 if let Expr::Member(inner) = mid.obj.as_ref() {
                                     let proto_match = matches!(
                                         &inner.prop,
@@ -299,7 +309,7 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                                     );
                                     let obj_is_object = matches!(
                                         inner.obj.as_ref(),
-                                        Expr::Ident(id) if id.sym.as_str() == "Object"
+                                        Expr::Ident(id) if matches!(id.sym.as_str(), "Object" | "Array")
                                     );
                                     if proto_match && obj_is_object {
                                         // Sintetiza `<arg0>.<method>(...rest)`.


### PR DESCRIPTION
## Summary
Antes \`Array.prototype.slice.call(from)\` crashava com verifier error \"got 2, expected 3\".

Agora:
- Pattern \`Array.prototype.<method>.call(obj, ...args)\` (alem de \`Object.prototype\`) reescreve para \`obj.<method>(...args)\` em compile time. Cobre slice/push/concat/etc — patterns tsc/esbuild \`__spreadArray\`.
- \`String.slice()\` sem args agora usa start=0 default em vez de crashar com \"missing arg #0\".

Fixture \`344_bundler_helpers.ts\` progride da verifier error para \"yield\" (bug separado de generators).

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] \`Array.prototype.slice.call([1,2,3])\` retorna \`[1,2,3]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)