### PR TITLE
fix(codegen): INVOKE_AUTO retorno marcado como var_member_call_value (fecha #1067)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -394,6 +394,11 @@ pub(super) fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &Ca
     let zero = ctx.builder.ins().iconst(cl::I64, 0);
     let inst = ctx.builder.ins().call(invoke, &[callee_val, zero, args_vec]);
     let v = ctx.builder.inst_results(inst)[0];
+    // (cross-runtime followup #1067) INVOKE_AUTO retorna i64 ambiguo
+    // (handle de string/object/Vec ou numero direto). Marca como
+    // var_member_call_values para que console.log/template use
+    // TPL_COERCE_AUTO/INSPECT (detecta handle em runtime).
+    ctx.var_member_call_values.insert(v);
     Ok(TypedVal::new(v, ValTy::I64))
 }
 


### PR DESCRIPTION
## Summary
Antes \`sops[key](\"hello\")\` (indirect call retornando string) tinha resultado tipado i64 puro. console.log imprimia bit pattern bruto.

Agora: \`lower_indirect_call\` marca o resultado de INVOKE_AUTO como \`var_member_call_value\`, fazendo console.log/template usar TPL_COERCE_AUTO/INSPECT que detecta handle de string em runtime.

Fixture \`356_obf_dispatcher.ts\`: 8/8 linhas matching Bun (antes 5/8). Fecha #1067.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Repro \`sops[\"rev\"](\"hello\")\` retorna \"olleh\" (antes handle bruto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)