### PR TITLE
feat(codegen): string-array constant propagation k[N] + arr prop access (fecha #1052)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -308,6 +308,11 @@ pub fn compile_program(
     // de strings: `const X = ["a", "b", ...]`. Usado em inspect_return_kind
     // para inferir que `return X[idx]` produz String.
     let string_array_globals = collect_string_array_globals(program);
+    // (cross-runtime #1052) Popula thread_local com valores das string-arrays
+    // top-level pra que codegen possa propagar `k[N]` em compile time.
+    let sav = collect_string_array_values(program);
+    crate::codegen::lower::passes::parallelism::STRING_ARRAY_VALUES
+        .with(|c| *c.borrow_mut() = sav);
 
     // Phase 1: declare all user functions so forward calls resolve.
     let mut user_fns: HashMap<String, UserFn> = HashMap::new();
@@ -649,6 +654,53 @@ fn collect_string_array_globals(program: &crate::parser::ast::Program) -> std::c
             }
             if any && all_str {
                 out.insert(id.sym.as_str().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// (cross-runtime #1052) Coleta valores de strings literais top-level
+/// `const k = ["push", "length", ...]`. Permite codegen propagar
+/// `k[N]` para string literal em compile time, despachando
+/// `arr[k[N]](args)` como `arr.<method>(args)`.
+pub(crate) fn collect_string_array_values(
+    program: &crate::parser::ast::Program,
+) -> std::collections::HashMap<String, Vec<String>> {
+    use crate::parser::ast::{Item, Statement};
+    use swc_ecma_ast::{Decl, Expr, Lit, Pat, Stmt};
+    let mut out = std::collections::HashMap::new();
+    for item in &program.items {
+        let Item::Statement(Statement::Raw(raw)) = item else { continue };
+        let Some(Stmt::Decl(Decl::Var(var_decl))) = raw.stmt.as_ref() else { continue };
+        for d in &var_decl.decls {
+            let Pat::Ident(id) = &d.name else { continue };
+            let Some(init) = d.init.as_deref() else { continue };
+            let Expr::Array(arr) = init else { continue };
+            fn try_eval_str(e: &Expr) -> Option<String> {
+                let mut cur = e;
+                while let Expr::Paren(p) = cur { cur = &p.expr; }
+                match cur {
+                    Expr::Lit(Lit::Str(s)) => Some(s.value.to_string_lossy().to_string()),
+                    Expr::Bin(b) if matches!(b.op, swc_ecma_ast::BinaryOp::Add) => {
+                        let l = try_eval_str(&b.left)?;
+                        let r = try_eval_str(&b.right)?;
+                        Some(format!("{l}{r}"))
+                    }
+                    _ => None,
+                }
+            }
+            let mut vals: Vec<String> = Vec::new();
+            let mut ok = true;
+            for elem in &arr.elems {
+                let Some(e) = elem else { ok = false; break; };
+                match try_eval_str(&e.expr) {
+                    Some(s) => vals.push(s),
+                    None => { ok = false; break; }
+                }
+            }
+            if ok && !vals.is_empty() {
+                out.insert(id.sym.as_str().to_string(), vals);
             }
         }
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -2111,6 +2111,20 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 // ir pelo path otimizado (sem crashar em fn handle invalido).
                 let static_key: Option<String> = match c.expr.as_ref() {
                     Expr::Lit(swc_ecma_ast::Lit::Str(s)) => Some(s.value.to_string_lossy().to_string()),
+                    // (cross-runtime #1052) Constant propagation: `k[N]`
+                    // quando `k` eh top-level const array de strings.
+                    Expr::Member(inner) => {
+                        if let (Expr::Ident(arr_id), MemberProp::Computed(ic)) =
+                            (inner.obj.as_ref(), &inner.prop)
+                        {
+                            if let Expr::Lit(swc_ecma_ast::Lit::Num(n)) = ic.expr.as_ref() {
+                                let idx = n.value as usize;
+                                let arr_name = arr_id.sym.as_str().to_string();
+                                crate::codegen::lower::passes::parallelism::STRING_ARRAY_VALUES
+                                    .with(|c| c.borrow().get(&arr_name).and_then(|v| v.get(idx).cloned()))
+                            } else { None }
+                        } else { None }
+                    }
                     _ => None,
                 };
                 if let Some(method) = static_key {

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -665,6 +665,42 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             }
         }
     }
+    // (cross-runtime #1052) `obj[<StringLit>]` ou `obj[k[N]]` (k const array
+    // de strings) quando key resolve estaticamente para "length"/"name"
+    // (propriedade comum) — reescreve como `obj.<prop>` para usar path direto
+    // em vez de MAP_GET literal (que retorna 0 em Vec/Array).
+    if let MemberProp::Computed(c) = &m.prop {
+        let static_key: Option<String> = match c.expr.as_ref() {
+            Expr::Lit(swc_ecma_ast::Lit::Str(s)) => Some(s.value.to_string_lossy().to_string()),
+            Expr::Member(inner) => {
+                if let (Expr::Ident(arr_id), MemberProp::Computed(ic)) =
+                    (inner.obj.as_ref(), &inner.prop)
+                {
+                    if let Expr::Lit(swc_ecma_ast::Lit::Num(n)) = ic.expr.as_ref() {
+                        let idx = n.value as usize;
+                        let arr_name = arr_id.sym.as_str().to_string();
+                        crate::codegen::lower::passes::parallelism::STRING_ARRAY_VALUES
+                            .with(|c| c.borrow().get(&arr_name).and_then(|v| v.get(idx).cloned()))
+                    } else { None }
+                } else { None }
+            }
+            _ => None,
+        };
+        if let Some(prop_name) = static_key {
+            if matches!(prop_name.as_str(), "length" | "name" | "size" | "byteLength") {
+                let synth = Expr::Member(swc_ecma_ast::MemberExpr {
+                    span: m.span,
+                    obj: m.obj.clone(),
+                    prop: MemberProp::Ident(swc_ecma_ast::IdentName {
+                        span: m.span,
+                        sym: prop_name.into(),
+                    }),
+                });
+                return lower_expr(ctx, &synth);
+            }
+        }
+    }
+
     // (cross-runtime #1079) `globalThis.X` em posicao de valor — re-lower
     // como ident solo `X`. Cobre identidade (globalThis.Array === Array),
     // chamadas (globalThis.parseInt("42")), reflexao.

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -36,6 +36,12 @@ thread_local! {
     /// receiver eh claramente Array, para nao confundir com Map.forEach
     /// que tem (value, key, map).
     static ARRAY_RECEIVER_IDENTS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+
+    /// (cross-runtime #1052) Mapa de top-level `const k = ["str1", "str2", ...]`
+    /// para suas string literals. Permite codegen propagar `k[N]` em compile
+    /// time, despachando `arr[k[N]](args)` como `arr.<method>(args)`.
+    pub(crate) static STRING_ARRAY_VALUES: RefCell<std::collections::HashMap<String, Vec<String>>>
+        = RefCell::new(std::collections::HashMap::new());
 }
 
 /// Coleta nomes de vars top-level `let`/`var` com init numerico/bool


### PR DESCRIPTION
## Summary
Antes \`(arr as any)[_k[1]](1)\` onde \`_k = [\"l\"+\"e\",\"p\"+\"u\"]\` segfault — codegen nao resolvia \`_k[1]\` estaticamente.

Agora:
- \`collect_string_array_values\` coleta top-level \`const k = [str1, str2, ...]\` incluindo concat de literais (\`\"a\"+\"b\"\`). Armazena em thread_local \`STRING_ARRAY_VALUES\`.
- Detector em \`lower_call\` resolve \`k[N]\` para string literal em compile time, despachando \`arr[k[N]](args)\` como \`arr.<method>(args)\`.
- \`lower_member_expr\` faz mesmo trick para propriedades: \`arr[k[0]]\` quando \`k[0] == \"length\"\` reescreve para \`arr.length\`.

Fixture \`351_obf_string_array.ts\` agora 10/10 linhas matching Bun (antes 8/10 + segfault). Fecha #1052.

## Test plan
- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` 12/12
- [x] \`target/release/rts.exe test\` 1312/1312
- [x] Fixture \`351_obf_string_array.ts\` 10/10 linhas matching Bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)