### PR TITLE
fix(json): reviver `this` binding e typeof em params hoisted (#862)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -216,6 +216,10 @@ pub(crate) fn compile_user_fn(
                 || (is_reduce_lifted && (i == 0 || i == 1))
             ) {
                 fn_ctx.var_member_call_values.insert(block_param);
+                // (#862) Tambem marca pelo nome para que reads em blocks
+                // sucessores propaguem ambiguity — use_var em block diferente
+                // gera SSA Value novo que nao esta em var_member_call_values.
+                fn_ctx.local_ambiguous_vars.insert(param.name.clone());
             }
             // (cross-runtime #1130) Param tipado `any`/`unknown`/sem anotacao
             // pode receber handle (Map/Vec/String/Function/instance) ou
@@ -231,6 +235,8 @@ pub(crate) fn compile_user_fn(
                 };
                 if is_ambiguous_ann {
                     fn_ctx.var_member_call_values.insert(block_param);
+                    // (#862) Idem — propagar por nome via local_ambiguous_vars.
+                    fn_ctx.local_ambiguous_vars.insert(param.name.clone());
                 }
             }
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -434,7 +434,10 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     )?;
                     let inst = ctx.builder.ins().call(f, &[s_ptr, s_len, r_h]);
                     let v = ctx.builder.inst_results(inst)[0];
-                    return Ok(TypedVal::new(v, ValTy::U64));
+                    // Handle (nao U64) para que a var seja registrada como
+                    // GC root e o Map/Vec resultante nao seja coletado antes
+                    // do consumer (ex: JSON.stringify subsequente).
+                    return Ok(TypedVal::new(v, ValTy::Handle));
                 }
                 // JSON.stringify(value, replacer) — 2-arg. Replacer pode ser
                 // array de keys (filtra props) ou fn (transforma valores).

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -52,23 +52,38 @@ pub extern "C" fn __RTS_FN_NS_JSON_PARSE_REVIVER(ptr: u64, len: i64, reviver_h: 
     if reviver_h == 0 {
         return root_handle;
     }
-    // JS spec: cria objeto raiz `{ "": root }` e chama reviver com key="".
-    apply_reviver(reviver_h, "", root_handle)
+    // JS spec InternalizeJSONProperty: cria holder raiz `{ "": root }` e chama
+    // reviver com this=holder, key="", value=root.
+    use indexmap::IndexMap;
+    let mut root_holder: IndexMap<String, i64> = IndexMap::new();
+    root_holder.insert(String::new(), root_handle as i64);
+    let holder_h = alloc_entry(Entry::Map(Box::new(root_holder)));
+    apply_reviver(reviver_h, holder_h, "")
 }
 
-/// Walk bottom-up: para cada slot, recursa primeiro, depois invoca reviver.
-fn apply_reviver(reviver_h: u64, key: &str, value: u64) -> u64 {
+/// Walk bottom-up (ECMA InternalizeJSONProperty): para cada child, recursa
+/// primeiro com o holder atual como `this`, depois invoca reviver(key, value)
+/// com `this`=holder.
+fn apply_reviver(reviver_h: u64, holder: u64, key: &str) -> u64 {
     use crate::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_APPLY_TYPED;
     use crate::namespaces::collections::vec as v_ns;
-    // Recursa em children primeiro.
+    // Pega o value (child) do holder.
+    let value: u64 = with_entry(holder, |e| match e {
+        Some(Entry::Map(m)) => m.get(key).copied().unwrap_or(0) as u64,
+        Some(Entry::Vec(arr)) => key.parse::<usize>().ok()
+            .and_then(|i| arr.get(i).copied())
+            .unwrap_or(0) as u64,
+        _ => 0,
+    });
+    // Recursa em children do value (que vira novo holder).
     let kind = with_entry(value, |e| match e {
         Some(Entry::Map(m)) => Some(("map", m.iter().map(|(k,v)| (k.clone(), *v)).collect::<Vec<_>>())),
         Some(Entry::Vec(arr)) => Some(("vec", arr.iter().enumerate().map(|(i,v)| (i.to_string(), *v)).collect::<Vec<_>>())),
         _ => None,
     });
     if let Some((k_type, entries)) = kind {
-        for (k, v) in entries {
-            let new_v = apply_reviver(reviver_h, &k, v as u64);
+        for (k, _v) in entries {
+            let new_v = apply_reviver(reviver_h, value, &k);
             // Atualiza slot.
             use crate::namespaces::gc::handles::with_entry_mut;
             with_entry_mut(value, |e| {
@@ -92,11 +107,11 @@ fn apply_reviver(reviver_h: u64, key: &str, value: u64) -> u64 {
             });
         }
     }
-    // Invoca reviver(key, value).
+    // Invoca reviver.call(holder, key, value).
     let key_h = alloc_entry(Entry::String(key.as_bytes().to_vec()));
     let args = alloc_entry(Entry::Vec(Box::new(vec![key_h as i64, value as i64])));
-    let result = unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(reviver_h, 0, args) };
-    let _ = v_ns::__RTS_FN_NS_COLLECTIONS_VEC_GET; // keep import
+    let result = unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(reviver_h, holder as i64, args) };
+    let _ = v_ns::__RTS_FN_NS_COLLECTIONS_VEC_GET;
     result as u64
 }
 


### PR DESCRIPTION
## Summary

Resolve a fixture `293_json_reviver_this` (3/3 bugs combinados).

- **`this` binding**: `JSON.parse(text, reviver)` chamava reviver com `this=0`. Agora segue ECMA InternalizeJSONProperty: propaga `holder` recursivamente.
- **GC root**: retorno de `JSON.parse` com reviver vinha como U64 (não marcado como root). Map era coletado antes do `JSON.stringify` consumer. Fix: retornar `Handle`.
- **typeof param**: `typeof value` em arrow inline `function(this,key,value){value*2}` resolvia como literal `"number"` em compile-time. `read_local` em block sucessor cria SSA Value novo não-marcado. Fix: popular `local_ambiguous_vars` por nome (propagado em `lower_ident_expr`).

Fecha #862.

## Test plan
- [x] `target/release/rts.exe run tests/cross-runtime/json/293_json_reviver_this.ts` bate Bun
- [x] `target/release/rts.exe test` → 1312/1312 passa
- [x] `cargo build --release` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)