### PR TITLE
fix(codegen): optchain em arrow inline .map() agora lifta (#860)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1114,6 +1114,27 @@ fn has_capture(expr: &Expr, params: &[String], user_fn_names: &HashSet<String>) 
             lhs_cap || has_capture(&a.right, params, user_fn_names)
         }
         Expr::Seq(s) => s.exprs.iter().any(|e| has_capture(e, params, user_fn_names)),
+        // (#860) Optional chain `obj?.prop` / `obj?.[k]` / `obj?.fn()` — recursa
+        // no obj e em args. Sem isso, `arr.map(x => x.groups?.l)` falha o lift,
+        // arrow vira __hoisted_arrow_N e o array_methods_pass nao reescreve,
+        // resultando em path codegen quebrado (SIGILL).
+        Expr::OptChain(o) => match o.base.as_ref() {
+            swc_ecma_ast::OptChainBase::Member(m) => {
+                has_capture(&m.obj, params, user_fn_names)
+                    || matches!(&m.prop,
+                        swc_ecma_ast::MemberProp::Computed(c)
+                            if has_capture(&c.expr, params, user_fn_names))
+            }
+            swc_ecma_ast::OptChainBase::Call(c) => {
+                let callee_cap = has_capture(&c.callee, params, user_fn_names);
+                if callee_cap { return true; }
+                for a in &c.args {
+                    if a.spread.is_some() { return true; }
+                    if has_capture(&a.expr, params, user_fn_names) { return true; }
+                }
+                false
+            }
+        },
         // Conservador: qualquer outra forma (Fn, Arrow nested, etc) → captura.
         _ => true,
     }


### PR DESCRIPTION
## Summary

`arr.map((x) => x.groups?.l)` causava SIGILL. `has_capture` em `lift_inline_arrows_in_array_methods` não tratava `Expr::OptChain`, caindo no `_ => true`. Arrow não era lifted → virava `__hoisted_arrow_N` via hoist_fn pass posterior → `array_methods_pass` (já rodado) não reescrevia para `parallel.map`. Codegen dispatch genérico chamava parallel.reduce 3-arg sig com ptr inválido.

Fix: adicionar arm `Expr::OptChain` em `has_capture` recursando no obj/args, igual a `Expr::Member`/`Expr::Call`.

Fecha #860.

## Test plan
- [x] `target/release/rts.exe run tests/cross-runtime/string/261_string_matchall.ts` bate Bun
- [x] `target/release/rts.exe test` → 1312/1312 passa
- [x] `cargo build --release` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)