### PR TITLE
feat(array): Array.fromAsync parcial — sync iter de promises (refs #861)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1163,6 +1163,9 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_NS_PROMISE_ANY", pr::__RTS_FN_NS_PROMISE_ANY);
         add_fn!("__RTS_FN_NS_PROMISE_ALL_SETTLED", pr::__RTS_FN_NS_PROMISE_ALL_SETTLED);
         add_fn!("__RTS_FN_NS_PROMISE_CREATE", pr::__RTS_FN_NS_PROMISE_CREATE);
+        // (#861) Array.fromAsync — implementacao vive em promise/ops.rs por
+        // reutilizar a infra de Promise.all e PromiseSlot.
+        add_fn!("__RTS_FN_GL_ARRAY_FROM_ASYNC", pr::__RTS_FN_GL_ARRAY_FROM_ASYNC);
     }
 
     // ── namespaces::collections ───────────────────────────────────────

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1669,6 +1669,29 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             }
             // (#208 / #476) Array static globals: isArray, from.
             if let Some(method) = qualified.strip_prefix("Array.") {
+                // (#861) Array.fromAsync(iter, mapper?) — Promise<Array>.
+                // Suporte parcial: array sync de promises (ou valores). Async
+                // generator depende de #211 (state machine generator).
+                if method == "fromAsync" && (call.args.len() == 1 || call.args.len() == 2) {
+                    if call.args.iter().any(|a| a.spread.is_some()) {
+                        return Err(anyhow!("spread not supported in Array.fromAsync"));
+                    }
+                    let iter_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let iter_h = ctx.coerce_to_i64(iter_tv).val;
+                    let mapper_h = if call.args.len() == 2 {
+                        lower_callable_target_h(ctx, &call.args[1].expr)?
+                    } else {
+                        ctx.builder.ins().iconst(cl::I64, 0)
+                    };
+                    let f = ctx.get_extern(
+                        "__RTS_FN_GL_ARRAY_FROM_ASYNC",
+                        &[cl::I64, cl::I64],
+                        Some(cl::I64),
+                    )?;
+                    let inst = ctx.builder.ins().call(f, &[iter_h, mapper_h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::Handle));
+                }
                 if method == "isArray" && call.args.len() == 1
                     && call.args[0].spread.is_none()
                 {

--- a/crates/rts-runtime/src/namespaces/promise/ops.rs
+++ b/crates/rts-runtime/src/namespaces/promise/ops.rs
@@ -389,6 +389,60 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_ALL(vec_handle: u64) -> u64 {
     result_handle
 }
 
+/// `Array.fromAsync(iterable, mapper?)` — coleta valores de iteravel sync ou
+/// async para Promise<Array>. Implementacao minima (issue #861):
+/// - Vec handle (array sync): aplica mapper a cada elem, wrap em Promise.resolve
+///   se nao for Promise ja, depois Promise.all.
+/// - Async iterable (gen()): nao suportado ate #211 (generator state machine).
+///   Retorna Promise rejeitado.
+///
+/// `fn_ptr=0` => sem mapper. Caller faz invoke_typed (1 arg, retorna i64/handle).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_ASYNC(iterable: u64, mapper_handle: u64) -> u64 {
+    // Suporte minimo: iterable e' Vec. Aplica mapper sync (se houver),
+    // wrap cada valor em Promise.resolve se ja' nao for, faz Promise.all.
+    use crate::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_APPLY_TYPED;
+
+    let snapshot: Option<Vec<i64>> = with_entry(iterable, |e| match e {
+        Some(Entry::Vec(v)) => Some(v.as_ref().clone()),
+        _ => None,
+    });
+    let Some(items) = snapshot else {
+        // Async iterable / outros tipos — retorna Promise rejected.
+        let result = promise_slot::new_pending();
+        let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
+        let msg = b"Array.fromAsync: only sync iterables supported (issue #211 blocks async generators)".to_vec();
+        let err_handle = alloc_entry(Entry::String(msg));
+        promise_slot::reject(&result, err_handle as i64);
+        return result_handle;
+    };
+
+    // Aplica mapper se fornecido. mapper(value, index) -> mapped.
+    let mapped: Vec<i64> = if mapper_handle != 0 {
+        items.iter().enumerate().map(|(i, &v)| {
+            let args_vec = alloc_entry(Entry::Vec(Box::new(vec![v, i as i64])));
+            unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(mapper_handle, 0, args_vec) }
+        }).collect()
+    } else {
+        items
+    };
+
+    // Wrap cada valor: se ja' for Promise handle, mantem; senao Promise.resolve.
+    let wrapped: Vec<i64> = mapped.iter().map(|&v| {
+        let is_promise = with_entry(v as u64, |e| matches!(e, Some(Entry::PromiseAsync(_))));
+        if is_promise {
+            v
+        } else {
+            let slot = promise_slot::new_pending();
+            promise_slot::resolve(&slot, v);
+            alloc_entry(Entry::PromiseAsync(slot)) as i64
+        }
+    }).collect();
+
+    let promises_vec = alloc_entry(Entry::Vec(Box::new(wrapped)));
+    __RTS_FN_NS_PROMISE_ALL(promises_vec)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PROMISE_RACE(vec_handle: u64) -> u64 {
     let handles = collect_promise_handles(vec_handle);


### PR DESCRIPTION
## Summary

Implementa `Array.fromAsync(iter, mapper?)` parcial:
- ✅ Array sync (Vec handle) de promises/valores → Promise.all com mapper opcional
- ❌ Async iterable (gen()): retorna Promise rejected; depende de #211 (generator state machine)

Fixture `tests/cross-runtime/array/303_array_fromasync.ts`:
- Linha 1 (`gen()` async generator): continua falhando (bloqueado por #211)
- Linha 2 (array de promises): ✅ passa

Componentes:
- Runtime `__RTS_FN_GL_ARRAY_FROM_ASYNC` em `promise/ops.rs` (reusa Promise.all infra)
- JIT symbol registration
- Codegen handler em `calls/mod.rs`

**Refs** #861 — não fecha; precisa de #211 para async generators completos.

## Test plan
- [x] `target/release/rts.exe test` → 1312/1312 (zero regressão)
- [x] `await Array.fromAsync([Promise.resolve("a"), Promise.resolve("b")])` retorna `["a", "b"]`
- [x] `cargo build --release` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)