### PR TITLE
fix(codegen): await Promise.all*([...]) registra como array receiver (#83)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -57,6 +57,12 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
     fn init_looks_array(e: &Expr) -> bool {
         match e {
             Expr::Array(_) => true,
+            // (#83) `await <expr_que_retorna_array>` propaga: typicamente
+            // Promise.all/allSettled/any/race retornam Promise<Array>.
+            // Sem isso, `const r = await Promise.allSettled([...]); r.map(...)`
+            // nao registra `r` como array receiver e o lift falha (SIGILL
+            // ja' visto em #860 pattern).
+            Expr::Await(a) => init_looks_array(&a.arg),
             Expr::Call(c) => match &c.callee {
                 swc_ecma_ast::Callee::Expr(ce) => match ce.as_ref() {
                     Expr::Member(m) => {
@@ -88,7 +94,21 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
                                 | "getOwnPropertyNames" | "getOwnPropertySymbols"
                             )
                         );
-                        prop_is_array_returning || obj_is_array_static || obj_is_object_static
+                        // (#83) Promise.all/allSettled/any/race retornam
+                        // Promise<Array>. Detectado direto (sem await wrapper)
+                        // para chains tipo `Promise.all([...]).then(arr => ...)`.
+                        let obj_is_promise_combinator = matches!(
+                            m.obj.as_ref(),
+                            Expr::Ident(id) if id.sym.as_str() == "Promise"
+                        ) && matches!(
+                            &m.prop,
+                            MemberProp::Ident(p) if matches!(
+                                p.sym.as_str(),
+                                "all" | "allSettled" | "any" | "race"
+                            )
+                        );
+                        prop_is_array_returning || obj_is_array_static
+                            || obj_is_object_static || obj_is_promise_combinator
                     }
                     _ => false,
                 },


### PR DESCRIPTION
## Summary

Fixture: \`settled.map(x => ...)\` SIGILL quando \`settled\` vem de \`await Promise.allSettled(...)\`.

Causa: \`collect_array_receiver_idents\` não detectava \`Expr::Await\`. Sem o marker, o lifter de arrows inline em \`.map()\` rejeitava o callback, arrow virava \`__hoisted_arrow_N\`, e \`array_methods_pass\` (já rodado) não reescrevia para \`parallel.map\`. Dispatch genérico crashava.

Fix:
- \`Expr::Await(a)\` recursa em \`init_looks_array(&a.arg)\` — propaga array-ness através de await
- Detecta direto \`Promise.all|allSettled|any|race\` como array-returning (cobre chains sem await)

Fecha **#83**. Tracker #871 vai pra 8/8 (100% promises).

## Test plan
- [x] Fixture bate Bun: \`settled=fulfilled:1|rejected:x\` + \`any=b\`
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)