### PR TITLE
feat(codegen): reduce com init string trata acc como handle (refs #345)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -808,14 +808,28 @@ fn inspect_return_kind(
                 if let swc_ecma_ast::Callee::Expr(callee) = &c.callee {
                     if let Expr::Member(m) = callee.as_ref() {
                         if let swc_ecma_ast::MemberProp::Ident(id) = &m.prop {
-                            return matches!(
-                                id.sym.as_str(),
+                            let method = id.sym.as_str();
+                            if matches!(
+                                method,
                                 "toString" | "join" | "concat" | "replace"
                                 | "replaceAll" | "trim" | "trimStart" | "trimEnd"
                                 | "toUpperCase" | "toLowerCase" | "padStart"
                                 | "padEnd" | "repeat" | "substring" | "substr"
                                 | "slice" | "charAt" | "normalize"
-                            );
+                            ) {
+                                return true;
+                            }
+                            // (#345) `arr.reduce(fn, "")` — initial value
+                            // string implica retorno string. Detecta via 2o arg.
+                            if matches!(method, "reduce" | "reduceRight")
+                                && c.args.len() >= 2
+                                && matches!(
+                                    c.args[1].expr.as_ref(),
+                                    Expr::Lit(swc_ecma_ast::Lit::Str(_)) | Expr::Tpl(_)
+                                )
+                            {
+                                return true;
+                            }
                         }
                     }
                     if let Expr::Ident(id) = callee.as_ref() {

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -501,6 +501,17 @@ fn lift_arrows_in_expr(
                                     call.args[0].expr.as_ref(),
                                     Expr::Lit(swc_ecma_ast::Lit::Str(_)) | Expr::Tpl(_)
                                 );
+                            // (#345) Para `arr.reduce(fn, init)` com init
+                            // string literal, slot 0 (acc) eh string handle.
+                            // Sem isso, o lifter assume i64 e `acc + s` vira
+                            // iadd em vez de string concat.
+                            let reduce_init_is_string = (method == "reduce"
+                                || method == "reduceRight")
+                                && call.args.len() >= 2
+                                && matches!(
+                                    call.args[1].expr.as_ref(),
+                                    Expr::Lit(swc_ecma_ast::Lit::Str(_)) | Expr::Tpl(_)
+                                );
                             // Quando arg eh Ident referenciando user fn (named callback),
                             // wrappamos em arrow inline `(p1..pN) => ident(p1..pN)` antes
                             // do try_lift_arrow_arg. Garante adapter de signature
@@ -635,7 +646,8 @@ fn lift_arrows_in_expr(
                                     new_fns,
                                     counter,
                                     method == "forEach",
-                                    recv_is_object_entries || mapper_slot0_is_string,
+                                    recv_is_object_entries || mapper_slot0_is_string
+                                        || reduce_init_is_string,
                                     method == "reduce" || method == "reduceRight",
                                 ) {
                                     // Substitui arg por Ident.


### PR DESCRIPTION
## Summary

\`arr.reduce(fn, \"\")\` com init string literal:
- Slot 0 (acc) do lifted callback marca como string handle (não i64) — \`acc + s\` lifta para STRING_CONCAT em vez de iadd
- \`inspect_return_kind\` reconhece \`.reduce(*, \"init\")\` como retornando string, propaga para fn_signature do caller

**Antes**: \`function f() { return arr.reduce((a,s) => a+s, \"\"); }\` declarava return F64; lifted callback fazia iadd; resultado lixo.

**Depois**: 2-param reduce com init string concat funciona corretamente.

**Refs** #345 (parcial — fixture usa arrow 3-param \`(acc, str, i)\` que é rejeitada pelo lifter porque \`PARALLEL_REDUCE\` só tem ABI 2-arg. Refator do runtime para 3-arg fica pra followup).

## Test plan
- [x] \`const r = arr.reduce((a,s) => a+s, \"\")\` retorna concat correto
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)