### PR TITLE
fix(console): coerce com bias numerico em member access value=0 (#335)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -520,6 +520,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_TPL_COERCE_AUTO", __RTS_FN_RT_TPL_COERCE_AUTO);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_NUM_BIAS;
+        add_fn!("__RTS_FN_RT_TPL_COERCE_NUM_BIAS", __RTS_FN_RT_TPL_COERCE_NUM_BIAS);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_VEC_SLOT;
         add_fn!("__RTS_FN_RT_TPL_COERCE_VEC_SLOT", __RTS_FN_RT_TPL_COERCE_VEC_SLOT);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1012,6 +1012,11 @@ pub(super) fn lower_console_call(
         &[cl::I64],
         Some(cl::I64),
     )?;
+    let num_bias = ctx.get_extern(
+        "__RTS_FN_RT_TPL_COERCE_NUM_BIAS",
+        &[cl::I64],
+        Some(cl::I64),
+    )?;
     for arg in &call.args {
         if arg.spread.is_some() {
             return Err(anyhow!("spread not supported in console.* args"));
@@ -1024,12 +1029,25 @@ pub(super) fn lower_console_call(
         // (#573) U64 tambem pode ser handle ambiguo (ex: JSON.parse retorno
         // de '42' eh i64 raw com tipo U64). Auto-coerce decide em runtime.
         let needs_auto = matches!(tv.ty, ValTy::Handle | ValTy::U64) && !is_known_str;
-        let h = ctx.coerce_to_handle(tv)?.val;
-        let h = if needs_auto {
-            let inst = ctx.builder.ins().call(auto_coerce, &[h]);
+        // (cross-runtime #335/#1056) I64 marcado var_member_call_values (ex:
+        // `obj.field`, `getter()`, member call result) — coerce com bias
+        // numerico: value=0 vira "0" em vez de "null" (TPL_COERCE_AUTO).
+        // Casos legitimos de `null` continuam cobertos via sentinel `i64::MIN+3`.
+        let needs_num_bias = matches!(tv.ty, ValTy::I64)
+            && ctx.var_member_call_values.contains(&tv.val)
+            && !is_known_str;
+        let h = if needs_num_bias {
+            let val_i64 = ctx.coerce_to_i64(tv).val;
+            let inst = ctx.builder.ins().call(num_bias, &[val_i64]);
             ctx.builder.inst_results(inst)[0]
         } else {
-            h
+            let h0 = ctx.coerce_to_handle(tv)?.val;
+            if needs_auto {
+                let inst = ctx.builder.ins().call(auto_coerce, &[h0]);
+                ctx.builder.inst_results(inst)[0]
+            } else {
+                h0
+            }
         };
         acc = Some(match acc {
             None => h,

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -184,8 +184,41 @@ pub extern "C" fn __RTS_FN_RT_TPL_COERCE_AUTO(value: i64) -> u64 {
     if value == 0 {
         return alloc_entry(Entry::String(b"null".to_vec()));
     }
+    coerce_auto_inner(value)
+}
+
+/// (cross-runtime #335/#1056) Variante de TPL_COERCE_AUTO que prefere
+/// renderizar `value=0` como "0" em vez de "null". Usado em contextos
+/// onde o valor vem de getter/computacao/member access — caso onde
+/// retornar 0 numerico eh mais comum que null literal. O caso `null` em
+/// concat continua coberto via sentinel `i64::MIN+3`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_TPL_COERCE_NUM_BIAS(value: i64) -> u64 {
+    if value == i64::MIN { return alloc_entry(Entry::String(b"false".to_vec())); }
+    if value == i64::MIN + 1 { return alloc_entry(Entry::String(b"true".to_vec())); }
+    if value == i64::MIN + 2 || value == i64::MIN + 4 {
+        return alloc_entry(Entry::String(b"undefined".to_vec()));
+    }
+    if value == i64::MIN + 3 {
+        return alloc_entry(Entry::String(b"null".to_vec()));
+    }
+    // value=0 sem snapshot valido vira "0" (em vez de "null").
     let h = value as u64;
     let snap = snapshot_entry(h);
+    if matches!(snap, EntrySnap::None) && value == 0 {
+        return alloc_entry(Entry::String(b"0".to_vec()));
+    }
+    coerce_auto_inner_with_snap(value, snap)
+}
+
+fn coerce_auto_inner(value: i64) -> u64 {
+    let h = value as u64;
+    let snap = snapshot_entry(h);
+    coerce_auto_inner_with_snap(value, snap)
+}
+
+fn coerce_auto_inner_with_snap(value: i64, snap: EntrySnap) -> u64 {
+    let h = value as u64;
     match snap {
         // (#1041) Sempre clona quando o handle ja' eh string. O codegen
         // libera o handle retornado tratando-o como "fresh"; sem o


### PR DESCRIPTION
## Summary

\`obj.value\` (getter retornando 0) printava \"null\" em vez de \"0\".

Causa: \`console.log(handle_marker)\` usa TPL_COERCE_AUTO que trata \`value == 0\` como handle inválido → \"null\". Mas getter/member access que retorna 0 numérico é caso mais comum.

Tentativa anterior de mudar TPL_COERCE_AUTO direto regrediu 7 tests que esperavam \"null\" para handle 0 em concat. Solução cirúrgica: nova fn \`__RTS_FN_RT_TPL_COERCE_NUM_BIAS\` idêntica ao AUTO exceto que value=0 sem snapshot vira \"0\". Usada apenas em \`console.log/info/debug/error/warn\` para args I64 marcados \`var_member_call_values\`.

Path antigo (concat com string literal) e \`console.log(null)\` literal continuam \"null\" via sentinel.

Fecha **#335**. Tracker #870 vai pra 28/32.

## Test plan
- [x] Fixture bate Bun exato (diff vazio)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)