### PR TITLE
feat(class): infer Bool field type quando initializer eh bool literal

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/class.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/class.rs
@@ -386,6 +386,17 @@ pub(crate) fn synthesize_class_fns(
                         let ann = ann.trim();
                         field_types.insert(prop.name.clone(), ValTy::from_annotation(ann));
                         field_class_names.insert(prop.name.clone(), ann.to_string());
+                    } else if let Some(init) = prop.initializer.as_ref() {
+                        // (cross-runtime #341) Sem anotacao, inferir do init:
+                        // `_v = true` => Bool. Sem isso, console.log(this._v)
+                        // imprime 1 em vez de "true".
+                        let inferred = crate::codegen::lower::analysis::types::infer_expr_ty(
+                            Some(init.as_ref()),
+                        );
+                        if matches!(inferred, ValTy::Bool) {
+                            field_types.insert(prop.name.clone(), ValTy::Bool);
+                            field_class_names.insert(prop.name.clone(), "boolean".to_string());
+                        }
                     }
                     if prop.modifiers.readonly {
                         readonly_fields.insert(prop.name.clone());


### PR DESCRIPTION
## Summary

Class field sem anotação com init \`= true\`/\`= false\` agora registra \`ValTy::Bool\` em \`field_types\`. Sem isso, \`class W { _v = true }\` armazena o slot como i64 (1) e \`console.log(w._v)\` printa \"1\" em vez de \"true\".

Cobre case básico (read direto de instance field). Casos via \`defineProperty\` getter externo não são afetados (getter é fn separada, sem visibility da classe).

## Test plan
- [x] \`class W { _v = true }; new W()._v\` → \"true\" (era \"1\")
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)