### PR TITLE
fix(regexp): match.indices.groups via side-table (#1162)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -331,6 +331,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_REGEXP_MULTILINE", __RTS_FN_GL_REGEXP_MULTILINE);
     add_fn!("__RTS_FN_GL_REGEXP_LAST_INDEX_GET", __RTS_FN_GL_REGEXP_LAST_INDEX_GET);
     add_fn!("__RTS_FN_GL_REGEXP_LAST_INDEX_SET", __RTS_FN_GL_REGEXP_LAST_INDEX_SET);
+    add_fn!("__RTS_FN_GL_REGEXP_INDICES_GROUPS", __RTS_FN_GL_REGEXP_INDICES_GROUPS);
 
     // ── namespaces::globals::error (Error class family) ───────────────
     use crate::namespaces::globals::error::instance::*;

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1027,6 +1027,46 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 let v = ctx.builder.inst_results(inst)[0];
                 return Ok(TypedVal::new(v, ValTy::I64));
             }
+            // (cross-runtime #70/#1162) `arr.groups` em Vec handle —
+            // side-table lookup para regex `.indices.groups` (Vec da spec
+            // tem prop adicional). Retorna 0 (=> undefined) quando vec
+            // nao eh regex indices. Falls through pro MAP_GET path quando
+            // obj eh Map normal.
+            if key == "groups" && (matches!(obj_tv.ty, ValTy::Handle) || recv_is_ambiguous) {
+                let f = ctx.get_extern(
+                    "__RTS_FN_GL_REGEXP_INDICES_GROUPS",
+                    &[cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(f, &[obj_handle]);
+                let v = ctx.builder.inst_results(inst)[0];
+                // Se retornar 0 (handle invalido = undefined-ish), fallback
+                // para MAP_GET para casos Map nao-indices.
+                use cranelift_codegen::ir::condcodes::IntCC;
+                let zero = ctx.builder.ins().iconst(cl::I64, 0);
+                let is_zero = ctx.builder.ins().icmp(IntCC::Equal, v, zero);
+                let map_block = ctx.builder.create_block();
+                let merge = ctx.builder.create_block();
+                ctx.builder.append_block_param(merge, cl::I64);
+                ctx.builder.ins().brif(is_zero, map_block, &[], merge, &[v.into()]);
+
+                ctx.builder.switch_to_block(map_block);
+                ctx.builder.seal_block(map_block);
+                let (kp, kl) = ctx.emit_str_literal(b"groups")?;
+                let map_get = ctx.get_extern(
+                    "__RTS_FN_NS_COLLECTIONS_MAP_GET_CHAIN",
+                    &[cl::I64, cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst2 = ctx.builder.ins().call(map_get, &[obj_handle, kp, kl]);
+                let v2 = ctx.builder.inst_results(inst2)[0];
+                ctx.builder.ins().jump(merge, &[v2.into()]);
+
+                ctx.builder.switch_to_block(merge);
+                ctx.builder.seal_block(merge);
+                let result = ctx.builder.block_params(merge)[0];
+                return Ok(TypedVal::new(result, ValTy::Handle));
+            }
         }
     }
 

--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -4,8 +4,36 @@
 //! Instance methods delegate to the existing `regex` namespace ops.
 
 use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+use indexmap::IndexMap;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// (cross-runtime #70/#1162) Side-table indices_vec_handle -> groups_map_handle.
+/// `match.indices` eh um Vec (Array de [s,e]); a prop adicional `.groups`
+/// (named capture indices) eh resolvida via lookup nesta tabela.
+static INDICES_GROUPS: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<u64, u64>>> =
+    std::sync::OnceLock::new();
+
+fn indices_groups_table() -> &'static std::sync::Mutex<std::collections::HashMap<u64, u64>> {
+    INDICES_GROUPS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn register_indices_groups(indices_vec: u64, groups_map: u64) {
+    if let Ok(mut t) = indices_groups_table().lock() {
+        t.insert(indices_vec, groups_map);
+    }
+}
+
+/// (#70/#1162) Lookup: dado um handle de indices Vec, retorna o handle do
+/// Map de named groups indices. 0 se nao registrado (regex sem named groups).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_REGEXP_INDICES_GROUPS(vec_handle: u64) -> u64 {
+    indices_groups_table()
+        .lock()
+        .ok()
+        .and_then(|t| t.get(&vec_handle).copied())
+        .unwrap_or(0)
+}
 
 // ── Constructors ──────────────────────────────────────────────────────────────
 
@@ -163,18 +191,13 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
     // contrario. Slots [start, end] como Vec inner. JS spec espelha
     // a forma do match (Array-like com prop extra "groups": Map<name,
     // [start,end]>).
-    // (cross-runtime #70) JS spec: `match.indices` eh Array (cada elem
-    // [start,end] | undefined) com prop adicional `.groups`.
-    // JSON.stringify(indices) deve serializar como `[[s,e],...]`
-    // — Map com chaves "0".."N" + "length" + "groups" virava
-    // `{"0":...,"length":N,"groups":...}` incorreto. Usamos Vec direto;
-    // `.length` e `[i]` funcionam naturalmente em Vec, `.groups` eh
-    // anexado via slot extra dentro do Entry::Vec? Nao — Vec nao tem
-    // props nomeadas. Solucao: armazenar como Vec, e expor `.groups`
-    // via lookup separado quando user acessa match.indices.groups.
-    // Simplificacao: como JSON.stringify ja' trata Vec como Array,
-    // emitimos Vec sem `.groups` (named groups indices sao raramente
-    // testados em cross-runtime; pode ser adicionado em followup).
+    // (cross-runtime #70/#1162) JS spec: `match.indices` eh Array de
+    // [start,end] | undefined COM prop adicional `.groups` (Map de named
+    // capture indices). Usamos Entry::Vec + side-table de "groups por
+    // vec handle" para suportar ambos os patterns:
+    //   - `m.indices[i]` e `m.indices.length` => Vec direto
+    //   - `m.indices.groups.name` => lookup via REGEXP_INDICES_GROUPS_GET
+    //   - `JSON.stringify(m.indices)` => Vec serializa como array
     let indices_v = match indices.clone() {
         Some(vec) => {
             let mut ivec: Vec<i64> = Vec::with_capacity(vec.len());
@@ -188,7 +211,46 @@ pub extern "C" fn __RTS_FN_GL_REGEXP_EXEC(handle: u64, ptr: i64, len: i64) -> u6
                 };
                 ivec.push(pair_h);
             }
-            alloc_entry(Entry::Vec(Box::new(ivec))) as i64
+            let vec_h = alloc_entry(Entry::Vec(Box::new(ivec)));
+            // Registra named groups indices em side-table.
+            let g_vec_opt: Option<Vec<(String, Option<(usize, usize)>)>> =
+                with_entry(handle, |entry| match entry {
+                    Some(Entry::Regex(rx)) => {
+                        let names: Vec<Option<String>> = rx
+                            .regex
+                            .capture_names()
+                            .map(|o| o.map(|s| s.to_string()))
+                            .collect();
+                        let mut out: Vec<(String, Option<(usize, usize)>)> = Vec::new();
+                        for (i, name_opt) in names.iter().enumerate() {
+                            if let Some(name) = name_opt {
+                                let pair: Option<(usize, usize)> =
+                                    vec.get(i).and_then(|o| *o);
+                                out.push((name.clone(), pair));
+                            }
+                        }
+                        Some(out)
+                    }
+                    _ => None,
+                });
+            if let Some(g_pairs) = g_vec_opt {
+                if !g_pairs.is_empty() {
+                    let mut gmap: IndexMap<String, i64> = IndexMap::new();
+                    for (name, opt) in g_pairs {
+                        let pair_h: i64 = match opt {
+                            Some((s, e)) => {
+                                let pair = vec![s as i64, e as i64];
+                                alloc_entry(Entry::Vec(Box::new(pair))) as i64
+                            }
+                            None => i64::MIN + 2,
+                        };
+                        gmap.insert(name, pair_h);
+                    }
+                    let groups_h = alloc_entry(Entry::Map(Box::new(gmap)));
+                    register_indices_groups(vec_h, groups_h);
+                }
+            }
+            vec_h as i64
         }
         None => i64::MIN + 2,
     };


### PR DESCRIPTION
## Summary

\`m.indices.groups.year\` retornava null. PR anterior (#1161) trocou indices de Map para Vec — JSON.stringify ficou correto mas a prop adicional \`.groups\` (named capture indices) ficou perdida.

Solução: indices continua Vec (preserva \`.length\`, \`[i]\`, JSON.stringify), e \`.groups\` resolve via side-table \`INDICES_GROUPS: HashMap<u64, u64>\` mapeando vec_handle → groups_map_handle. Quando \`regex.exec\` produz o Vec, registra side-table com Map dos named captures.

Codegen intercepta \`.groups\` em handle Vec (ou ambiguous) → chama \`__RTS_FN_GL_REGEXP_INDICES_GROUPS(vec_handle)\`. Se retornar 0, fallback para MAP_GET_CHAIN normal (preserva \`.groups\` em Map regular).

Fecha **#1162**. Tracker #877 vai pra 12/12 (100% regex).

## Test plan
- [x] Fixture bate Bun exato
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)