### PR TITLE
fix(codegen): map(String/Number/Boolean) sem wrap aritmetico

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -605,6 +605,12 @@ fn lift_arrows_in_expr(
                                                 },
                                             ))),
                                         })
+                                    } else if is_coerce_ident {
+                                        // (#1137 follow-up) Coerce idents (String/Number/Boolean)
+                                        // ja' retornam tipo certo. `String(p) + 0` faria string
+                                        // concat ("10" + 0 = "100"), quebrando map(String). Skip
+                                        // o wrap aritmetico — retorna inner_call direto.
+                                        inner_call
                                     } else {
                                         // `cb(p) + 0` quebra TCO e forca conversao numerica
                                         // (user fn retorna f64, lifted ABI retorna i64).


### PR DESCRIPTION
## Summary

\`[10].map(String)\` retornava \`[\"100\"]\` em vez de \`[\"10\"]\`.

Causa: \`array_methods_pass\` wrappa ident callbacks em arrow \`(p) => ident(p)\` e adiciona \`+ 0\` ao body para forçar conversão numérica. Para coerce idents (String/Number/Boolean), \`String(10) + 0\` = \`\"10\" + 0\` = \`\"100\"\` (string concat).

Fix: skip wrap aritmético quando ident é coerce builtin. Retorna inner_call direto.

**Refs** #317 (bigint literals): fix corrige linha \`vals\`. Suite TS: 1312/1312.

## Test plan
- [x] \`[10].map(String)\` → \`[\"10\"]\` (era \`[\"100\"]\`)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)