### PR TITLE
fix(collections): INDEX_GET_AUTO em Map com string key handle (refs #340)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -204,8 +204,19 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_INDEX_GET_AUTO(handle: u64, index: i64
             }
         }
         Kind::Other => {
-            // Map handle: numeric index → string key lookup (e.g. match result arrays).
-            use super::map::__RTS_FN_NS_COLLECTIONS_MAP_GET;
+            // (cross-runtime #340) Map handle: lookup com key string. O `index`
+            // pode ser:
+            // - String handle (computed key `obj[key]` onde key="a") -> usar MAP_GET_KH.
+            // - i64 raw (numeric index `arr[0]` aplicado a Map result) -> usar
+            //   index.to_string() como key.
+            use super::map::{__RTS_FN_NS_COLLECTIONS_MAP_GET, __RTS_FN_NS_COLLECTIONS_MAP_GET_KH};
+            // Detecta se index eh handle GC valido String/Symbol — usa MAP_GET_KH.
+            let is_str_handle = with_entry(index as u64, |e| matches!(e,
+                Some(Entry::String(_)) | Some(Entry::Symbol { .. })
+            ));
+            if is_str_handle {
+                return __RTS_FN_NS_COLLECTIONS_MAP_GET_KH(handle, index as u64);
+            }
             let key = index.to_string();
             let key_bytes = key.as_bytes();
             __RTS_FN_NS_COLLECTIONS_MAP_GET(handle, key_bytes.as_ptr(), key_bytes.len() as i64)


### PR DESCRIPTION
## Summary

\`obj[key]\` (computed key via variable) em obj Map retornava 0 quando key era string handle.

Causa: INDEX_GET_AUTO para Map handle convertia \`index\` (i64) direto para string via \`index.to_string()\` — funciona para numeric index, mas falha para string key handles (codegen passa key handle como i64 raw, ex: \`obj[\"a\"]\` onde \"a\" é handle 281474976710657).

Fix: detectar via \`with_entry\` se o i64 corresponde a handle GC válido String/Symbol — se sim, usa MAP_GET_KH (que resolve via key_handle_to_string). Senão mantém path numeric.

Cobre arrow trap em Proxy (\`get(t, key) { return t[key]; }\`) e qualquer \`obj[var_key]\` em obj Map.

**Refs** #340 (Proxy get trap agora retorna valor correto). Suite TS: 1312/1312.

## Test plan
- [x] \`function f(t, k) { return t[k]; } f({a:1}, \"a\")\` → 1 (era 0)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)