### PR TITLE
fix(proxy/codegen): has trap + OBJ_SET com computed key handle (#340)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -781,9 +781,13 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     ctx.builder.ins().call(set_fn, &[obj_h, kp, kl, rhs_i64]);
                 } else {
                     let key_tv = lower_expr(ctx, &c.expr)?;
-                    // Hot path: key claramente numerica -> VEC_SET direto
-                    // (sem alocar handle string por iteracao).
-                    if matches!(key_tv.ty, ValTy::I32 | ValTy::I64 | ValTy::U64) {
+                    // (cross-runtime #340) Hot path: key claramente numerica
+                    // (literal Num) -> VEC_SET direto. Caso ambiguo (param,
+                    // member call result, I64 marcado) cai em OBJ_SET que
+                    // detecta tipo (Vec usa numeric, Map usa key handle).
+                    let is_clear_num = matches!(c.expr.as_ref(), Expr::Lit(Lit::Num(_)))
+                        || matches!(key_tv.ty, ValTy::I32);
+                    if is_clear_num {
                         let idx = ctx.coerce_to_i64(key_tv).val;
                         let vec_set = ctx.get_extern(
                             "__RTS_FN_NS_COLLECTIONS_VEC_SET",

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -274,6 +274,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJ_HAS(obj_h: u64, key_h: u64) -> i64
         Some(s) => s,
         None => return 0,
     };
+    // (cross-runtime #340) Proxy: dispatch `has` trap quando obj_h eh Proxy.
+    if let Some((target, handler)) = crate::namespaces::globals::proxy::ops::resolve_proxy(obj_h) {
+        return crate::namespaces::globals::proxy::ops::dispatch_has(target, handler, &key);
+    }
     // Vec: index `i` esta "in" array se 0 <= i < length E slot != hole.
     let vec_result: Option<i64> = with_entry(obj_h, |e| match e {
         Some(Entry::Vec(v)) => {


### PR DESCRIPTION
## Summary

Fixture \`340_proxy_basics.ts\` esperava:
- \`\"b\" in proxy\` chama trap \`has\` (RTS pulava direto MAP_HAS)
- \`pos.x = 5; pos.x\` retorna 5 (RTS retornava 0)

**Causas + fixes:**

1. \`OBJ_HAS\` não dispatchava Proxy → adicionado \`resolve_proxy → dispatch_has\` no início (padrão de MAP_HAS/GET/SET)
2. \`t[key] = val\` em fn param ambíguo escrevia em slot Vec errado: codegen tinha hot path \"key I64 → VEC_SET\". Param \`key: any\` é I64 marcado (handle de string em runtime), VEC_SET escrevia handle como numeric index. Restringido VEC_SET a key clearly numeric (Lit::Num ou I32); senão cai em OBJ_SET que dispatcha por tipo do obj

Fecha **#340**.

## Test plan
- [x] Fixture bate Bun exato (diff vazio)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)