### PR TITLE
feat(codegen): user fn aceita args extras (ignora silenciosamente)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -2832,7 +2832,12 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
     let func_id = *ctx.extern_cache.get(mangled.as_str()).unwrap();
     let fref = ctx.fref_for_id(func_id);
 
-    if call.args.len() != abi.params.len() {
+    // (cross-runtime #299) JS spec: chamada com MENOS args completa com
+    // undefined; MAIS args sao acessiveis via `arguments` (RTS nao
+    // tem `arguments` real mas silenciosamente ignora extras pra
+    // compat com pattern \`function f() { ... arguments... }\`).
+    // RTS antes rejeitava ambos os casos.
+    if call.args.len() < abi.params.len() {
         return Err(anyhow!(
             "function `{name}` expects {} argument(s), got {}",
             abi.params.len(),
@@ -2841,7 +2846,7 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
     }
 
     let mut values = Vec::new();
-    for (arg, expected_ty) in call.args.iter().zip(abi.params.iter().copied()) {
+    for (arg, expected_ty) in call.args.iter().take(abi.params.len()).zip(abi.params.iter().copied()) {
         if arg.spread.is_some() {
             return Err(anyhow!("spread not supported"));
         }


### PR DESCRIPTION
## Summary

JS spec: chamada com mais args que params declarados não é erro — args extras ficam acessíveis via \`arguments\`. RTS rejeitava com \"function \`f\` expects N argument(s), got M\".

Fix: rejeita apenas quando \`args.len() < params.len()\` (caso JS de undefined fill). Args extras são silenciosamente ignorados.

**Antes**: \`function f(){...}; f(1,2,3)\` → compile error.
**Depois**: f roda; args extras ignorados.

\`arguments\` object propriamente não é suportado (issue separada).

## Test plan
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)