### PR TITLE
fix(codegen): BigInt === Number sempre false (#317)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -395,6 +395,19 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
                 return Ok(TypedVal::new(v, ValTy::Bool));
             }
         }
+        // (cross-runtime #317) `BigInt === Number` ou `Number === BigInt`
+        // sempre false (tipos diferentes em JS spec). RTS representa
+        // BigInt como i64, entao comparacao raw retornaria true. Detecta
+        // o mismatch sintatico antes do lower.
+        let is_bigint = |e: &Expr| matches!(e, Expr::Lit(Lit::BigInt(_)));
+        let is_num = |e: &Expr| matches!(e, Expr::Lit(Lit::Num(_)));
+        if (is_bigint(&bin.left) && is_num(&bin.right))
+            || (is_num(&bin.left) && is_bigint(&bin.right))
+        {
+            let val = if matches!(bin.op, BinaryOp::NotEqEq) { 1 } else { 0 };
+            let v = ctx.builder.ins().iconst(cl::I8, val);
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
     }
     if let Some(tv) = try_operator_overload(ctx, bin)? {
         return Ok(tv);


### PR DESCRIPTION
## Summary

\`1n === 1\` retornava true (RTS comparava i64 raw). Spec ECMA: tipos diferentes em \`===\` sempre false.

Fix: detecta sintaticamente \`Lit::BigInt vs Lit::Num\` em ambos os lados de \`===\`/\`!==\` antes do lower normal e retorna constante false/true.

\`1n === 1n\` continua true. \`1n == 1\` continua true (loose equality preserva coerção).

Fecha **#317**.

## Test plan
- [x] Fixture bate Bun exato (3 linhas)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)