### PR TITLE
fix(codegen): null/undefined == Number sempre false (refs #367)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -604,6 +604,15 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
             let v = ctx.builder.ins().iconst(cl::I64, val);
             return Ok(TypedVal::new(v, ValTy::Bool));
         }
+        // (cross-runtime #367) `null/undefined == Number` ou `Number ==
+        // null/undefined` sempre false em JS spec — coerce nao se aplica.
+        // RTS antes comparava 0 == 0 (true) porque null vira 0 raw.
+        let is_num_lit = |e: &Expr| matches!(e, Expr::Lit(Lit::Num(_)));
+        if (lhs_nu && is_num_lit(&bin.right)) || (rhs_nu && is_num_lit(&bin.left)) {
+            let val = if matches!(bin.op, BinaryOp::NotEq) { 1 } else { 0 };
+            let v = ctx.builder.ins().iconst(cl::I8, val);
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
     }
 
     // (#786) `expr === undefined` / `expr !== undefined` quando expr eh


### PR DESCRIPTION
## Summary

\`null == 0\` retornava true em RTS (compara raw 0 == 0). Spec ECMA: \`null == undefined\` true; mas \`null == X\` para qualquer outro X (incluindo 0) é sempre false.

Fix: detecta sintaticamente \`Lit::Null|undef vs Lit::Num\` em ambos os lados de \`==\`/\`!=\` antes do lower normal.

**Refs** #367. Suite TS: 1312/1312.

## Test plan
- [x] \`null == 0\` → false
- [x] \`undefined == 5\` → false
- [x] \`null == undefined\` → true (caso já tratado)
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)