### PR TITLE
fix(codegen): array_methods_pass/lift_arrows recursa em Expr::Member (refs #367)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -707,6 +707,15 @@ fn lift_arrows_in_expr(
         Expr::Unary(u) => {
             lift_arrows_in_expr(&mut u.arg, user_fn_names, new_fns, counter);
         }
+        // (cross-runtime followup) `arr.filter(Boolean).length` —
+        // o `.length` eh Member; sem recursar, o `.filter(...)` dentro
+        // nao tem arrow inline liftado.
+        Expr::Member(m) => {
+            lift_arrows_in_expr(&mut m.obj, user_fn_names, new_fns, counter);
+            if let MemberProp::Computed(c) = &mut m.prop {
+                lift_arrows_in_expr(&mut c.expr, user_fn_names, new_fns, counter);
+            }
+        }
         _ => {}
     }
 }
@@ -1264,6 +1273,17 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
         }
         Expr::Unary(u) => {
             rewrite_array_methods_in_expr(&mut u.arg, user_fn_names);
+            return;
+        }
+        // (cross-runtime followup #54) `arr.filter(Boolean).length` —
+        // o `.length` eh um Member; sem recursar no obj, o `.filter(...)`
+        // dentro fica sem rewrite e o codegen tenta MAP_GET("filter") em
+        // Vec -> trapz -> SIGILL.
+        Expr::Member(m) => {
+            rewrite_array_methods_in_expr(&mut m.obj, user_fn_names);
+            if let MemberProp::Computed(c) = &mut m.prop {
+                rewrite_array_methods_in_expr(&mut c.expr, user_fn_names);
+            }
             return;
         }
         _ => {}


### PR DESCRIPTION
## Summary

\`arr.filter(Boolean).length\` em chain inline crashava com SIGILL.

Causa: tanto \`lift_inline_arrows_in_array_methods\` quanto \`array_methods_pass\` tinham match descend que cobria Tpl/Bin/Cond/Paren/Unary mas NÃO \`Expr::Member\`.

Para \`arr.filter(Boolean).length\`:
- expr é \`Member { obj: Call(filter), prop: length }\`
- Sem recursar em obj, o Call(filter) interno não tinha arrow lifted nem rewrite para parallel.filter
- Codegen tentava MAP_GET_CHAIN(\"filter\", 6) em Vec handle → 0 → trapz → SIGILL

Fix: ambos passes recursam em \`m.obj\` (e em \`m.prop.expr\` se Computed).

**Refs** #367.

## Test plan
- [x] \`arr.filter(Boolean).length\` compila e retorna valor correto
- [x] \`target/release/rts.exe test\` → 1312/1312
- [x] \`cargo build --release\` zero erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)