### PR TITLE
fix(codegen): preserva precisao f64 em this.k = c + 273.15 (fecha #1144)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -219,6 +219,16 @@ pub(super) fn rhs_is_non_integer_float_lit(e: &Expr) -> bool {
             Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus) => {
                 cur = &u.arg;
             }
+            // (cross-runtime #1144) `c + 273.15` — binary com pelo menos
+            // um operando float lit non-integer eh garantidamente F64.
+            Expr::Bin(b) if matches!(
+                b.op,
+                swc_ecma_ast::BinaryOp::Add | swc_ecma_ast::BinaryOp::Sub
+                    | swc_ecma_ast::BinaryOp::Mul | swc_ecma_ast::BinaryOp::Div
+            ) => {
+                return rhs_is_non_integer_float_lit(&b.left)
+                    || rhs_is_non_integer_float_lit(&b.right);
+            }
             _ => return false,
         }
     }


### PR DESCRIPTION
Fecha #1144. Estende rhs_is_non_integer_float_lit para detectar binary expr (add/sub/mul/div) com pelo menos 1 operando float lit non-integer. Conservador — nao toca em c+d ambiguo. Suite 1312/1312, cross-runtime 301->303.