### PR TITLE
fix(codegen): unary `+` implementa ToNumber para handle/sentinels

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -529,6 +529,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_TPL_COERCE_VEC_SLOT", __RTS_FN_RT_TPL_COERCE_VEC_SLOT);
     }
     {
+        use crate::namespaces::gc::string_pool::__RTS_FN_RT_TO_NUMBER;
+        add_fn!("__RTS_FN_RT_TO_NUMBER", __RTS_FN_RT_TO_NUMBER);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_INSPECT;
         add_fn!("__RTS_FN_RT_INSPECT", __RTS_FN_RT_INSPECT);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -182,7 +182,40 @@ pub(super) fn lower_unary(ctx: &mut FnCtx, u: &swc_ecma_ast::UnaryExpr) -> Resul
                 ))
             }
         },
-        UnaryOp::Plus => Ok(operand),
+        UnaryOp::Plus => {
+            // (cross-runtime #1069) JS spec: unary `+` faz ToNumber.
+            // Sentinels: true=1, false=0, null=0, undefined=NaN.
+            // Handle string: parse numerico via NUM_COERCE.
+            // I64/F64/I32: passthrough (ja sao numbers).
+            match operand.ty {
+                ValTy::Handle => {
+                    let coerce_fn = ctx.get_extern(
+                        "__RTS_FN_RT_TO_NUMBER",
+                        &[cl::I64],
+                        Some(cl::F64),
+                    )?;
+                    let inst = ctx.builder.ins().call(coerce_fn, &[operand.val]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    Ok(TypedVal::new(v, ValTy::F64))
+                }
+                ValTy::Bool => {
+                    // Bool i64 0/1 ja eh numero.
+                    Ok(TypedVal::new(operand.val, ValTy::I64))
+                }
+                ValTy::I64 | ValTy::U64 => {
+                    // Pode ser sentinel (null/undefined). Routine via TO_NUMBER.
+                    let coerce_fn = ctx.get_extern(
+                        "__RTS_FN_RT_TO_NUMBER",
+                        &[cl::I64],
+                        Some(cl::F64),
+                    )?;
+                    let inst = ctx.builder.ins().call(coerce_fn, &[operand.val]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    Ok(TypedVal::new(v, ValTy::F64))
+                }
+                _ => Ok(operand),
+            }
+        }
         UnaryOp::Bang => {
             use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
             // (#550) Handle: !handle === true quando handle == 0 OU handle

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -339,6 +339,64 @@ pub extern "C" fn __RTS_FN_RT_TRUTHY(value: i64) -> i64 {
     }
 }
 
+/// (cross-runtime #1069) JS ToNumber abstract operation. Usado para
+/// unary `+` quando operando eh handle/sentinel/bool ambiguo.
+/// - false=MIN -> 0; true=MIN+1 -> 1
+/// - undefined=MIN+2 -> NaN
+/// - null=MIN+3 -> 0
+/// - value==0 -> 0
+/// - Handle Entry::String: parseFloat-like (trim + numeric tail).
+///   Vazio/whitespace -> 0; nao-parseavel -> NaN; "0x10" hex -> 16.
+/// - Handle Entry::Vec len==0 -> 0; len==1 -> ToNumber(slot[0]); >1 -> NaN
+/// - Handle Entry::Map/outros -> NaN
+/// - i64 puro nao-handle: passthrough como f64.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_TO_NUMBER(value: i64) -> f64 {
+    if value == 0 || value == i64::MIN || value == i64::MIN + 3 {
+        return 0.0;
+    }
+    if value == i64::MIN + 1 {
+        return 1.0;
+    }
+    if value == i64::MIN + 2 || value == i64::MIN + 4 {
+        return f64::NAN;
+    }
+    if value > 0 {
+        let h = value as u64;
+        let result = with_entry(h, |entry| match entry {
+            Some(Entry::String(b)) => {
+                let s = std::str::from_utf8(b).unwrap_or("").trim();
+                if s.is_empty() {
+                    return Some(0.0);
+                }
+                // Hex/oct/bin prefixes (JS spec for unary +).
+                if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                    return Some(i64::from_str_radix(hex, 16).map(|n| n as f64).unwrap_or(f64::NAN));
+                }
+                if let Some(oct) = s.strip_prefix("0o").or_else(|| s.strip_prefix("0O")) {
+                    return Some(i64::from_str_radix(oct, 8).map(|n| n as f64).unwrap_or(f64::NAN));
+                }
+                if let Some(bin) = s.strip_prefix("0b").or_else(|| s.strip_prefix("0B")) {
+                    return Some(i64::from_str_radix(bin, 2).map(|n| n as f64).unwrap_or(f64::NAN));
+                }
+                Some(s.parse::<f64>().unwrap_or(f64::NAN))
+            }
+            Some(Entry::Vec(v)) => match v.len() {
+                0 => Some(0.0),
+                1 => Some(__RTS_FN_RT_TO_NUMBER(v[0])),
+                _ => Some(f64::NAN),
+            },
+            Some(_) => Some(f64::NAN),
+            None => None,
+        });
+        if let Some(r) = result {
+            return r;
+        }
+    }
+    // Fallback: trata como i64 raw (integer puro).
+    value as f64
+}
+
 /// Spread universal: copia elementos de `src` para o Vec `dst`.
 /// Detecta tipo de Entry e itera apropriadamente:
 /// - Entry::Vec -> push de cada slot


### PR DESCRIPTION
Implementa JS ToNumber para unary +. Antes +true/+null/+"42" retornavam handle bruto. Novo runtime helper TO_NUMBER cobre sentinels, strings (com 0x/0o/0b), Vec, Map. Suite 1312/1312, cross-runtime 301->302.