### PR TITLE
fix(codegen): coerce_traps — Boolean sentinels + null relacionais (#1069)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -254,9 +254,25 @@ pub(super) fn lower_coerce_to_boolean(ctx: &mut FnCtx, call: &CallExpr) -> Resul
             let truthy = ctx.builder.ins().bxor(falsy, one);
             return Ok(Some(TypedVal::new(truthy, ValTy::Bool)));
         }
+        // (cross-runtime #1069) Argumento i64 generico (param de arrow
+        // liftado em `arr.filter(Boolean)`, slot Vec): rotear via runtime
+        // __RTS_FN_GL_BOOLEAN_COERCE que trata sentinels JS:
+        //   - i64::MIN+2 (undefined), i64::MIN+3 (null), i64::MIN (false) → 0
+        //   - handle de string vazio → 0
+        //   - 0 → 0
+        //   - resto → 1
+        // Sem isso, `[null, undefined, "", false, NaN].filter(Boolean)`
+        // sobrevive porque icmp ne 0 trata sentinels (i64 muito negativos)
+        // como truthy.
+        let _ = IntCC::NotEqual;
         let v = ctx.coerce_to_i64(tv).val;
-        let zero = ctx.builder.ins().iconst(cl::I64, 0);
-        let result = ctx.builder.ins().icmp(IntCC::NotEqual, v, zero);
+        let coerce_fn = ctx.get_extern(
+            "__RTS_FN_GL_BOOLEAN_COERCE",
+            &[cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(coerce_fn, &[v]);
+        let result = ctx.builder.inst_results(inst)[0];
         return Ok(Some(TypedVal::new(result, ValTy::Bool)));
     }
     let v = ctx.builder.ins().iconst(cl::I64, 0);

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -588,6 +588,64 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         }
     }
 
+    // (cross-runtime #1069) Relacionais `<`, `<=`, `>`, `>=` com null/undefined
+    // literais: spec 7.2.13 + 13.10.1.
+    //
+    // - `null` coerge para 0 via ToNumber. `null >= 0` = !(0 < 0) = true.
+    // - `undefined` coerge para NaN. Qualquer comparacao com NaN retorna false.
+    //
+    // Sem este shortcut, `null` (sentinel i64::MIN+3) era comparado raw vs 0
+    // pelo icmp signed e retornava resultado errado.
+    if matches!(
+        bin.op,
+        BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq
+    ) {
+        let is_null_lit = |e: &Expr| matches!(e, Expr::Lit(Lit::Null(_)));
+        let is_undef_ident = |e: &Expr| matches!(e, Expr::Ident(id) if id.sym.as_str() == "undefined");
+        let lhs_null = is_null_lit(&bin.left);
+        let rhs_null = is_null_lit(&bin.right);
+        let lhs_undef = is_undef_ident(&bin.left);
+        let rhs_undef = is_undef_ident(&bin.right);
+        // Caso 1: algum lado e' undefined literal → sempre false.
+        if lhs_undef || rhs_undef {
+            let v = ctx.builder.ins().iconst(cl::I8, 0);
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
+        // Caso 2: ambos null → null<null,null<=null,null>null,null>=null
+        // todos seguem regra ToNumber(null)=0: 0<0=false, 0<=0=true,
+        // 0>0=false, 0>=0=true.
+        if lhs_null && rhs_null {
+            let val = matches!(bin.op, BinaryOp::LtEq | BinaryOp::GtEq) as i64;
+            let v = ctx.builder.ins().iconst(cl::I8, val);
+            return Ok(TypedVal::new(v, ValTy::Bool));
+        }
+        // Caso 3: um lado eh null → substitui por 0 e segue path numerico.
+        if lhs_null || rhs_null {
+            let other_expr = if lhs_null { &bin.right } else { &bin.left };
+            let other_tv = lower_expr(ctx, other_expr)?;
+            // null vira f64 0.0 para combinar com qualquer tipo numerico.
+            let zero_f = ctx.builder.ins().f64const(0.0);
+            let zero_tv = TypedVal::new(zero_f, ValTy::F64);
+            let (lv, rv, _ty) = if lhs_null {
+                promote_numeric(ctx, zero_tv, other_tv)?
+            } else {
+                promote_numeric(ctx, other_tv, zero_tv)?
+            };
+            let lhs_p = TypedVal::new(lv, ValTy::F64);
+            let rhs_p = TypedVal::new(rv, ValTy::F64);
+            use cranelift_codegen::ir::condcodes::FloatCC;
+            let cc = match bin.op {
+                BinaryOp::Lt => FloatCC::LessThan,
+                BinaryOp::LtEq => FloatCC::LessThanOrEqual,
+                BinaryOp::Gt => FloatCC::GreaterThan,
+                BinaryOp::GtEq => FloatCC::GreaterThanOrEqual,
+                _ => unreachable!(),
+            };
+            let result = ctx.builder.ins().fcmp(cc, lhs_p.val, rhs_p.val);
+            return Ok(TypedVal::new(result, ValTy::Bool));
+        }
+    }
+
     // (#643/null-undef) `null == undefined` deve ser true em JS abstract
     // equality. Em RTS, null vira (0, Handle) e undefined vira handle
     // de string "undefined" — comparacao normal falharia. Detecta caso

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1298,7 +1298,13 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                             Expr::Ident(i) => Some(i.sym.to_string()),
                             _ => None,
                         })
-                        .map(|n| user_fn_names.contains(&n))
+                        .map(|n| {
+                            // (cross-runtime #1069) Coerce idents (Boolean/Number/String)
+                            // tambem sao validos como callback de map/filter/etc — o wrap
+                            // arrow logo abaixo trata is_coerce_ident explicitamente.
+                            user_fn_names.contains(&n)
+                                || matches!(n.as_str(), "Boolean" | "Number" | "String")
+                        })
                         .unwrap_or(false);
 
                     // (#1044) Gate por receiver: so' reescreve quando m.obj


### PR DESCRIPTION
Closes #1069.

## Summary

Tres ajustes pequenos para fechar `tests/cross-runtime/numeric/367_coercion_traps.ts` vs Bun/Node.

- **\`lower_coerce_to_boolean\` i64 path** agora chama \`__RTS_FN_GL_BOOLEAN_COERCE\` em vez de \`icmp ne 0\`, tratando sentinels JS (\`null\`, \`undefined\`, \`false\`, empty-string handle).
- **\`arg0_is_user_fn\`** aceita \`Boolean\`/\`Number\`/\`String\` como callback elegivel — o wrap-arrow ja' tinha suporte interno, faltava o gate externo.
- **Relacionais \`< <= > >=\`** com \`null\`/\`undefined\` literais seguem spec 7.2.13 + 13.10.1: \`undefined\` → sempre false; \`null\` → ToNumber=0 antes do fcmp.

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`cargo test --release --lib\` — 12/12 ok
- [x] \`target/release/rts.exe test\` — **1312/1312 passed**
- [x] \`target/release/rts.exe run tests/cross-runtime/numeric/367_coercion_traps.ts\` bate diff zero com Bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)