### PR TITLE
fix(codegen): inferencia ret_ty para globalThis[k] + arrow expr-body

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -891,9 +891,37 @@ fn inspect_return_kind(
     // retornam Handle. Sem isso, codegen tipa ret como F64 e callers
     // (e.g. JSON.stringify) interpretam handle como f64 bits.
     fn expr_yields_handle(e: &Expr) -> bool {
+        // (cross-runtime #1125/#1079) `(globalThis as any)[key]` — computed
+        // member access em globalThis sempre retorna any/handle. Sem isso,
+        // `function ensureGlobal(...) { return (globalThis as any)[key]; }`
+        // infere F64 e o map handle volta como f64-bits corrompido.
+        fn peel<'a>(e: &'a Expr) -> &'a Expr {
+            match e {
+                Expr::TsAs(a) => peel(&a.expr),
+                Expr::TsTypeAssertion(a) => peel(&a.expr),
+                Expr::TsConstAssertion(a) => peel(&a.expr),
+                Expr::TsNonNull(a) => peel(&a.expr),
+                Expr::Paren(p) => peel(&p.expr),
+                _ => e,
+            }
+        }
         match e {
             Expr::Object(_) | Expr::Array(_) | Expr::New(_) => true,
+            Expr::Member(m) => {
+                if let swc_ecma_ast::MemberProp::Computed(_) = &m.prop {
+                    if let Expr::Ident(id) = peel(m.obj.as_ref()) {
+                        if id.sym.as_str() == "globalThis" {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
             Expr::Paren(p) => expr_yields_handle(&p.expr),
+            Expr::TsAs(a) => expr_yields_handle(&a.expr),
+            Expr::TsTypeAssertion(a) => expr_yields_handle(&a.expr),
+            Expr::TsConstAssertion(a) => expr_yields_handle(&a.expr),
+            Expr::TsNonNull(a) => expr_yields_handle(&a.expr),
             Expr::Cond(c) => expr_yields_handle(&c.cons) || expr_yields_handle(&c.alt),
             _ => false,
         }

--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -928,23 +928,38 @@ impl LiftAcc {
                 let is_direct = matches!(&call.callee, Callee::Expr(ce) if matches!(ce.as_ref(), Expr::Ident(_)));
                 if is_direct {
                     for arg in call.args.iter_mut() {
-                        let body_stmts: Vec<Statement> = match arg.expr.as_ref() {
-                            Expr::Arrow(arrow) => arrow_body_to_stmts(arrow)
-                                .into_iter()
-                                .map(|s| Statement::Raw(
-                                    RawStmt::new("<lifted>".to_string(), Span::default()).with_stmt(s),
-                                ))
-                                .collect(),
+                        let (body_stmts, has_return_value): (Vec<Statement>, bool) = match arg.expr.as_ref() {
+                            Expr::Arrow(arrow) => {
+                                // (cross-runtime #1125) Expression-body arrows
+                                // (`() => expr`) returnam o expr — manter
+                                // ret_ty como i64 para que o caller leia o
+                                // valor de volta. Block-body arrows com
+                                // returns explicitos sao tratados como void
+                                // (compat com UI callbacks pre-existentes).
+                                let has_ret = matches!(arrow.body.as_ref(), swc_ecma_ast::BlockStmtOrExpr::Expr(_));
+                                let stmts = arrow_body_to_stmts(arrow)
+                                    .into_iter()
+                                    .map(|s| Statement::Raw(
+                                        RawStmt::new("<lifted>".to_string(), Span::default()).with_stmt(s),
+                                    ))
+                                    .collect();
+                                (stmts, has_ret)
+                            }
                             _ => continue,
                         };
                         let syn_name = format!("__lifted_arrow_{}", self.counter);
                         self.counter += 1;
                         let mut body_stmts = body_stmts;
                         self.lift_in_body(class_name, &mut body_stmts, in_class);
+                        let ret_ty = if has_return_value {
+                            Some("i64".to_string())
+                        } else {
+                            Some("void".to_string())
+                        };
                         self.new_fns.push(Item::Function(FunctionDecl {
                             name: syn_name.clone(),
                             parameters: Vec::new(),
-                            return_type: Some("void".to_string()),
+                            return_type: ret_ty,
                             body: body_stmts,
                             span: Span::default(),
                             is_async: false,


### PR DESCRIPTION
## Summary

Duas melhorias conservadoras na inferencia de tipo de retorno:

1. **\`expr_yields_handle\` reconhece \`(globalThis as any)[key]\`** (computed member em globalThis) como Handle. Sem isso, \`function ensureGlobal(...) { return (globalThis as any)[key]; }\` inferia \`F64\` e o map handle vinha como f64-bits corrompido.

2. **\`lift_inline_arrows_in_direct_call\`** agora classifica arrows expr-body (\`() => expr\`) com \`return_type: \"i64\"\` em vez de \`\"void\"\`. Block-body arrows continuam como void (compat com UI callbacks). Sem isso, \`factory: () => ({...})\` passada como callback em fn user retornava void e o resultado era descartado.

Nao fecha completamente #1125 — typeof + .version em handle de Map global ainda diverge — mas remove dois ramos de inferencia errada que apareciam em fixtures de polyfill-pattern.

## Test plan

- [x] \`cargo test --release --lib\` — 12/12 ok
- [x] \`target/release/rts.exe test\` — **1312/1312 passed**

Refs #1125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)