### PR TITLE
fix(codegen): infer ret_ty Handle quando body retorna Fn/Arrow expression

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -907,6 +907,12 @@ fn inspect_return_kind(
         }
         match e {
             Expr::Object(_) | Expr::Array(_) | Expr::New(_) => true,
+            // (cross-runtime #41) `return function() {...}` / `return () => ...`
+            // produz fn handle (ponteiro de user fn liftada via hoist).
+            // Sem isso, body inferia Number/F64 e o ponteiro era convertido
+            // via fcvt_from_sint perdendo bits — chamada subsequente
+            // `f(...)` falhava.
+            Expr::Fn(_) | Expr::Arrow(_) => true,
             Expr::Member(m) => {
                 if let swc_ecma_ast::MemberProp::Computed(_) = &m.prop {
                     if let Expr::Ident(id) = peel(m.obj.as_ref()) {


### PR DESCRIPTION
## Summary

Adiciona deteccao em \`expr_yields_handle\` (em \`inspect_return_kind\`) para \`Expr::Fn(_)\` e \`Expr::Arrow(_)\` — esses produzem fn handle/ptr e nao devem ser classificados como Number/F64 (default).

Cobre o caso pre-hoist em que o body ainda contem \`Expr::Fn\` direto. Apos \`hoist_fn_expressions\`, o expr ja' virou \`Expr::Ident(__hoisted_*)\` e o detector nao pega — esse caso requer cross-reference com program.items, fora de escopo deste commit.

Mudanca defensiva: nao move o ponteiro de paridade cross-runtime (302/302 exact matches mantidos), mas evita inferencia errada em scripts que ainda nao tocaram \`hoist_fn\` (test fixtures, etc).

## Test plan

- [x] \`cargo build --release\` limpo
- [x] \`target/release/rts.exe test\` — **1312/1312 passed**

Refs #41 (closures_deep — investigacao de inferencia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)