### PR TITLE
chore: limpa warnings do workspace — zero warnings agora

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/class.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/class.rs
@@ -432,7 +432,7 @@ pub(crate) fn synthesize_class_fns(
         // chamando Animal.__init(this) sem propagar args, e GuideDog que
         // chama `super(name)` falha em Dog.__init com "espera 0 args".
         let inherited_ctor_params: Vec<crate::parser::ast::Parameter> = {
-            let mut cur = class.super_class.clone();
+            let cur = class.super_class.clone();
             let mut found: Vec<crate::parser::ast::Parameter> = Vec::new();
             // Sobe a chain ate achar uma classe com ctor explicito.
             while let Some(parent_name) = cur {

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -7,8 +7,7 @@
 //!   reificado (com bound_this/bound_args).
 
 use anyhow::{Result, anyhow};
-use cranelift_codegen::ir::{AbiParam, InstBuilder, Signature, types as cl};
-use cranelift_module::Module;
+use cranelift_codegen::ir::{InstBuilder, types as cl};
 use swc_ecma_ast::{CallExpr, Expr};
 
 use crate::codegen::lower::ctx::{FnCtx, TypedVal, ValTy};

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -3089,7 +3089,7 @@ fn try_lower_object_to_string_call(
 /// registrada com metodo `toJSON`, retorna `<expr>.toJSON()` para que o
 /// codegen lower invoque o metodo antes de stringify.
 fn rewrite_to_json_call(ctx: &FnCtx, expr: &swc_ecma_ast::Expr) -> Option<swc_ecma_ast::Expr> {
-    use swc_ecma_ast::{Expr, MemberExpr, MemberProp, Ident, CallExpr, Callee};
+    use swc_ecma_ast::{Expr, MemberExpr, MemberProp, CallExpr, Callee};
     let class_name = match expr {
         Expr::New(n) => match n.callee.as_ref() {
             Expr::Ident(id) => Some(id.sym.to_string()),

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -851,7 +851,7 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
     if let AssignTarget::Pat(pat) = &a.left {
         if matches!(a.op, AssignOp::Assign) {
             if let swc_ecma_ast::AssignTargetPat::Array(arr_pat) = pat {
-                use swc_ecma_ast::{Expr as SwcExpr, ExprOrSpread};
+                use swc_ecma_ast::Expr as SwcExpr;
                 let rhs_tv = lower_expr(ctx, &a.right)?;
                 let rhs_h = ctx.coerce_to_i64(rhs_tv).val;
                 let vec_get = ctx.get_extern(

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1014,10 +1014,9 @@ fn try_lift_arrow_arg(
         }
     }
     let ret_string = body_stmts.iter().any(|st| {
-        if let Statement::Raw(raw) = st {
-            if let Some(Stmt::Return(r)) = raw.stmt.as_ref() {
-                return r.arg.as_deref().is_some_and(yields_string);
-            }
+        let Statement::Raw(raw) = st;
+        if let Some(Stmt::Return(r)) = raw.stmt.as_ref() {
+            return r.arg.as_deref().is_some_and(yields_string);
         }
         false
     });

--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -35,7 +35,7 @@ use super::super::analysis::captures::{
 /// se o corpo do for contem uma arrow que referencia esse ident,
 /// promove a global `__cap_<i>_<var>`. Reescreve os usos no for inteiro.
 fn promote_top_level_captures(program: &mut Program, new_globals: &mut Vec<String>) {
-    use std::collections::HashSet;
+    
     let mut counter: u32 = 0;
     let mut promoted_globals: Vec<(String, ())> = Vec::new();
     for item in program.items.iter_mut() {
@@ -92,7 +92,7 @@ fn scan_and_promote_stmt(
     new_globals: &mut Vec<String>,
     promoted_globals: &mut Vec<(String, ())>,
 ) {
-    use std::collections::HashSet;
+    
     // Caso direto: Stmt::For com init=let.
     if let Stmt::For(for_stmt) = stmt {
         if let Some(swc_ecma_ast::VarDeclOrExpr::VarDecl(init_vd)) = for_stmt.init.as_ref() {

--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -218,7 +218,7 @@ fn coerce_auto_inner(value: i64) -> u64 {
 }
 
 fn coerce_auto_inner_with_snap(value: i64, snap: EntrySnap) -> u64 {
-    let h = value as u64;
+    let _h = value as u64;
     match snap {
         // (#1041) Sempre clona quando o handle ja' eh string. O codegen
         // libera o handle retornado tratando-o como "fresh"; sem o

--- a/crates/rts-runtime/src/namespaces/globals/abort/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/abort/instance.rs
@@ -88,9 +88,9 @@ fn invoke_listeners(listeners_h: u64) {
         // INVOKE_AUTO(fn_h, this=0, args=empty_vec).
         let empty_args = alloc_entry(Entry::Vec(Box::new(Vec::new())));
         unsafe extern "C" {
-            fn __RTS_FN_RT_INVOKE_AUTO(fn_h: i64, this_h: i64, args_h: i64) -> i64;
+            fn __RTS_FN_RT_INVOKE_AUTO(callee: i64, this_arg: i64, args_handle: u64) -> i64;
         }
-        let _ = unsafe { __RTS_FN_RT_INVOKE_AUTO(fp as i64, 0, empty_args as i64) };
+        let _ = unsafe { __RTS_FN_RT_INVOKE_AUTO(fp as i64, 0, empty_args) };
     }
 }
 

--- a/crates/rts-runtime/src/namespaces/globals/event_target/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/event_target/instance.rs
@@ -132,9 +132,9 @@ pub extern "C" fn __RTS_FN_GL_EVENT_TARGET_DISPATCH(h: u64, event_h: u64) -> i64
         }
         let args = alloc_entry(Entry::Vec(Box::new(vec![event_h as i64])));
         unsafe extern "C" {
-            fn __RTS_FN_RT_INVOKE_AUTO(fn_h: i64, this_h: i64, args_h: i64) -> i64;
+            fn __RTS_FN_RT_INVOKE_AUTO(callee: i64, this_arg: i64, args_handle: u64) -> i64;
         }
-        let _ = unsafe { __RTS_FN_RT_INVOKE_AUTO(fp as i64, h as i64, args as i64) };
+        let _ = unsafe { __RTS_FN_RT_INVOKE_AUTO(fp as i64, h as i64, args) };
     }
     1
 }

--- a/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
@@ -476,9 +476,9 @@ pub extern "C" fn __RTS_FN_GL_PROMISE_WITH_RESOLVERS() -> u64 {
 fn make_resolver_fn(promise_h: u64, is_resolve: bool) -> u64 {
     use crate::namespaces::gc::handles::{Entry, FunctionData, alloc_entry};
     let fn_ptr = if is_resolve {
-        __RTS_FN_GL_PROMISE_RESOLVER_TRAMP_RESOLVE as usize as u64
+        __RTS_FN_GL_PROMISE_RESOLVER_TRAMP_RESOLVE as *const () as usize as u64
     } else {
-        __RTS_FN_GL_PROMISE_RESOLVER_TRAMP_REJECT as usize as u64
+        __RTS_FN_GL_PROMISE_RESOLVER_TRAMP_REJECT as *const () as usize as u64
     };
     alloc_entry(Entry::Function(Box::new(FunctionData {
         fn_ptr,

--- a/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
@@ -206,11 +206,9 @@ pub extern "C" fn __RTS_FN_GL_REFLECT_CONSTRUCT(target: u64, args_handle: u64) -
     }
     // Forward default: aloca instancia + apply.
     let inst = alloc_entry(Entry::Map(Box::new(indexmap::IndexMap::new())));
-    let _ = unsafe {
-        crate::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_APPLY_TYPED(
-            target, inst as i64, args_handle,
-        )
-    };
+    let _ = crate::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_APPLY_TYPED(
+        target, inst as i64, args_handle,
+    );
     inst
 }
 

--- a/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/regexp/instance.rs
@@ -4,7 +4,6 @@
 //! Instance methods delegate to the existing `regex` namespace ops.
 
 use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
-use indexmap::IndexMap;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -110,7 +110,7 @@ fn apply_reviver(reviver_h: u64, holder: u64, key: &str) -> u64 {
     // Invoca reviver.call(holder, key, value).
     let key_h = alloc_entry(Entry::String(key.as_bytes().to_vec()));
     let args = alloc_entry(Entry::Vec(Box::new(vec![key_h as i64, value as i64])));
-    let result = unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(reviver_h, holder as i64, args) };
+    let result = __RTS_FN_GL_FUNCTION_APPLY_TYPED(reviver_h, holder as i64, args);
     let _ = v_ns::__RTS_FN_NS_COLLECTIONS_VEC_GET;
     result as u64
 }
@@ -460,7 +460,7 @@ fn apply_stringify_replacer(replacer_h: u64, key: &str, value: u64) -> u64 {
     use crate::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_APPLY_TYPED;
     let key_h = alloc_entry(Entry::String(key.as_bytes().to_vec()));
     let args = alloc_entry(Entry::Vec(Box::new(vec![key_h as i64, value as i64])));
-    let result = unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(replacer_h, 0, args) };
+    let result = __RTS_FN_GL_FUNCTION_APPLY_TYPED(replacer_h, 0, args);
     let new_value = result as u64;
     if is_undefined_handle(new_value) {
         return new_value;

--- a/crates/rts-runtime/src/namespaces/promise/ops.rs
+++ b/crates/rts-runtime/src/namespaces/promise/ops.rs
@@ -421,7 +421,7 @@ pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_ASYNC(iterable: u64, mapper_handle: u64
     let mapped: Vec<i64> = if mapper_handle != 0 {
         items.iter().enumerate().map(|(i, &v)| {
             let args_vec = alloc_entry(Entry::Vec(Box::new(vec![v, i as i64])));
-            unsafe { __RTS_FN_GL_FUNCTION_APPLY_TYPED(mapper_handle, 0, args_vec) }
+            __RTS_FN_GL_FUNCTION_APPLY_TYPED(mapper_handle, 0, args_vec)
         }).collect()
     } else {
         items

--- a/crates/rts-runtime/src/namespaces/regex/ops.rs
+++ b/crates/rts-runtime/src/namespaces/regex/ops.rs
@@ -1,7 +1,7 @@
 //! Regex runtime operations — backend `regex` crate.
 
 use super::super::gc::handles::{Entry, alloc_entry, free_handle, with_entry};
-use regex::{Regex, RegexBuilder};
+use regex::RegexBuilder;
 
 unsafe fn slice_from(ptr: *const u8, len: i64) -> &'static [u8] {
     if ptr.is_null() || len <= 0 {
@@ -17,16 +17,6 @@ unsafe fn str_from(ptr: *const u8, len: i64) -> &'static str {
 
 fn alloc_string(bytes: Vec<u8>) -> u64 {
     alloc_entry(Entry::String(bytes))
-}
-
-fn with_regex<F, R>(handle: u64, default: R, f: F) -> R
-where
-    F: FnOnce(&Regex) -> R,
-{
-    with_entry(handle, |entry| match entry {
-        Some(Entry::Regex(rx)) => f(&rx.regex),
-        _ => default,
-    })
 }
 
 /// (#1107) Helper agnostico ao engine — usar quando o callsite precisar


### PR DESCRIPTION
## Summary

Limpeza geral de warnings que estavam acumulados:

- **Imports nao usados** removidos (AbiParam, Signature, Module, Ident, ExprOrSpread, HashSet, Regex) — detectados via \`cargo fix\`.
- **\`unsafe\` blocks desnecessarios** tirados em 4 locais (proxy, json x2, promise) — as fns chamadas ja' eram \`extern \"C\"\` safe-wrapped.
- **Signatures de \`__RTS_FN_RT_INVOKE_AUTO\`** padronizadas em forward decls (abort, event_target) para casar \`(i64, i64, u64) -> i64\` com a definicao real em function/ops.rs. Antes havia divergencia \`args_handle: i64\` vs \`u64\` causando 3 warnings de redeclare.
- **Fn morta \`with_regex\`** removida em regex/ops.rs (substituida por with_engine).
- **\`if let Statement::Raw(...)\` irrefutavel** trocado por \`let\` em parallelism.rs.

Build agora termina **sem nenhum warning** (era ~12 antes).

## Test plan

- [x] \`cargo build --release\` — zero warnings
- [x] \`cargo test --release --lib\` — 12/12 ok
- [x] \`target/release/rts.exe test\` — **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)