### PR TITLE
fix(codegen): prototype chain multi-nivel + Object.prototype terminator

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -515,6 +515,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_FUNCTION_TO_STRING", __RTS_FN_GL_FUNCTION_TO_STRING);
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_GET", __RTS_FN_GL_FUNCTION_PROTOTYPE_GET);
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_SET", __RTS_FN_GL_FUNCTION_PROTOTYPE_SET);
+    add_fn!("__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE", __RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE);
     add_fn!("__RTS_FN_RT_INVOKE_AUTO", __RTS_FN_RT_INVOKE_AUTO);
     {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_AUTO;

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -562,40 +562,12 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
         // caia no default sentinel "[Object.prototype]" e perdia o
         // `.constructor` slot da classe — quebra iteracao de prototype
         // chain (`while (proto) { chain.push(proto.constructor.name); }`).
-        if let Ok(fn_addr) = super::emit_user_fn_addr(ctx, &class_init_name(&class_name)) {
-            let arity = ctx
-                .user_fns
-                .get(&class_init_name(&class_name))
-                .map(|f| f.params.len() as i64)
-                .unwrap_or(0);
-            let arity_v = ctx.builder.ins().iconst(cl::I64, arity);
-            let name_tv = ctx.emit_str_handle(class_name.as_bytes())?;
-            let name_h = ctx.coerce_to_i64(name_tv).val;
-            let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
-            let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
-            let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
-            let n_ptr = ctx.builder.inst_results(inst_p)[0];
-            let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
-            let n_len = ctx.builder.inst_results(inst_l)[0];
-            let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 0);
-            let has_this_v = ctx.builder.ins().iconst(cl::I32, 0);
-            let reify_fn = ctx.get_extern(
-                "__RTS_FN_GL_FUNCTION_REIFY",
-                &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32],
-                Some(cl::I64),
-            )?;
-            let inst_r = ctx.builder.ins().call(
-                reify_fn,
-                &[fn_addr.val, arity_v, n_ptr, n_len, is_arrow_v, has_this_v],
-            );
-            let fn_handle = ctx.builder.inst_results(inst_r)[0];
-            let proto_get = ctx.get_extern(
-                "__RTS_FN_GL_FUNCTION_PROTOTYPE_GET",
-                &[cl::I64],
-                Some(cl::I64),
-            )?;
-            let inst_proto = ctx.builder.ins().call(proto_get, &[fn_handle]);
-            let proto_h = ctx.builder.inst_results(inst_proto)[0];
+        //
+        // Tambem encadeia recursivamente: `proto_C.__proto__ = proto_B`,
+        // `proto_B.__proto__ = proto_A`, etc. — permitindo iteracao
+        // multi-nivel da prototype chain.
+        let proto_h_opt = emit_proto_for_class(ctx, &class_name, map_set)?;
+        if let Some(proto_h) = proto_h_opt {
             let (proto_kp, proto_kl) = ctx.emit_str_literal(b"__proto__")?;
             ctx.builder.ins().call(map_set, &[handle, proto_kp, proto_kl, proto_h]);
         }
@@ -1009,4 +981,72 @@ pub(super) fn lower_function_method_call(
         }
         _ => Ok(None),
     }
+}
+
+/// (cross-runtime #336) Emite IR para obter o handle do prototype Map de
+/// `class_name`, garantindo que `proto.__proto__` aponta para o proto da
+/// super classe (recursivo). Retorna None quando a classe nao tem
+/// `__class_X__init` registrado (classes vazias sem super).
+fn emit_proto_for_class(
+    ctx: &mut FnCtx,
+    class_name: &str,
+    map_set: cranelift_codegen::ir::FuncRef,
+) -> Result<Option<cranelift_codegen::ir::Value>> {
+    let init_name = class_init_name(class_name);
+    let Ok(fn_addr) = super::emit_user_fn_addr(ctx, &init_name) else {
+        return Ok(None);
+    };
+    let arity = ctx.user_fns.get(&init_name).map(|f| f.params.len() as i64).unwrap_or(0);
+    let arity_v = ctx.builder.ins().iconst(cl::I64, arity);
+    let name_tv = ctx.emit_str_handle(class_name.as_bytes())?;
+    let name_h = ctx.coerce_to_i64(name_tv).val;
+    let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+    let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+    let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+    let n_ptr = ctx.builder.inst_results(inst_p)[0];
+    let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+    let n_len = ctx.builder.inst_results(inst_l)[0];
+    let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let has_this_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let reify_fn = ctx.get_extern(
+        "__RTS_FN_GL_FUNCTION_REIFY",
+        &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32],
+        Some(cl::I64),
+    )?;
+    let inst_r = ctx.builder.ins().call(
+        reify_fn,
+        &[fn_addr.val, arity_v, n_ptr, n_len, is_arrow_v, has_this_v],
+    );
+    let fn_handle = ctx.builder.inst_results(inst_r)[0];
+    let proto_get = ctx.get_extern(
+        "__RTS_FN_GL_FUNCTION_PROTOTYPE_GET",
+        &[cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst_proto = ctx.builder.ins().call(proto_get, &[fn_handle]);
+    let proto_h = ctx.builder.inst_results(inst_proto)[0];
+
+    let super_name = ctx
+        .classes
+        .get(class_name)
+        .and_then(|m| m.super_class.clone());
+    if let Some(super_name) = super_name {
+        if let Some(super_proto) = emit_proto_for_class(ctx, &super_name, map_set)? {
+            let (proto_kp, proto_kl) = ctx.emit_str_literal(b"__proto__")?;
+            ctx.builder.ins().call(map_set, &[proto_h, proto_kp, proto_kl, super_proto]);
+        }
+    } else {
+        // (cross-runtime #336) Classe raiz: `proto.__proto__ = Object.prototype`.
+        // Object.prototype singleton com `constructor.name === "Object"`.
+        let obj_proto_fn = ctx.get_extern(
+            "__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE",
+            &[],
+            Some(cl::I64),
+        )?;
+        let inst_op = ctx.builder.ins().call(obj_proto_fn, &[]);
+        let obj_proto = ctx.builder.inst_results(inst_op)[0];
+        let (proto_kp, proto_kl) = ctx.emit_str_literal(b"__proto__")?;
+        ctx.builder.ins().call(map_set, &[proto_h, proto_kp, proto_kl, obj_proto]);
+    }
+    Ok(Some(proto_h))
 }

--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -559,6 +559,39 @@ fn proto_registry() -> &'static std::sync::Mutex<std::collections::HashMap<u64, 
     FN_PROTOTYPE_REGISTRY.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
+/// (cross-runtime #336) Object.prototype singleton — Map cacheado com
+/// `constructor: {name: "Object"}`. Usado em prototype chain inspection:
+/// quando uma classe raiz (sem super) e' criada, seu proto Map recebe
+/// `__proto__ = OBJECT_PROTOTYPE_HANDLE()`, garantindo que iteracao
+/// chain `while (proto) { ... proto = Object.getPrototypeOf(proto); }`
+/// termine com `proto.constructor.name === "Object"` antes do null.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE() -> u64 {
+    static SINGLETON: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+    *SINGLETON.get_or_init(|| {
+        let proto = crate::namespaces::collections::map::__RTS_FN_NS_COLLECTIONS_MAP_NEW();
+        let ctor_stub = alloc_entry(Entry::Function(Box::new(crate::namespaces::gc::handles::FunctionData {
+            fn_ptr: 0,
+            arity: 0,
+            name: "Object".into(),
+            bound_this: 0,
+            has_bound_this: false,
+            bound_args: Vec::new(),
+            is_arrow: false,
+            has_this_param: false,
+            param_kinds: Vec::new(),
+            return_kind: 0,
+            source: None,
+            keep_alive: None,
+            prototype_handle: 0,
+        })));
+        crate::namespaces::collections::map::with_map_mut(proto, (), |m| {
+            m.insert("constructor".to_string(), ctor_stub as i64);
+        });
+        proto
+    })
+}
+
 /// (#264) Lazy-aloca e retorna o handle de `fn.prototype`.
 /// Constructor functions usam isto pra anexar metodos compartilhados.
 /// Primeiro acesso aloca um Map vazio; chamadas subsequentes retornam o mesmo


### PR DESCRIPTION
## Summary

Estende #1196 com encadeamento multi-nivel (\`C->B->A->Object\`):

1. **\`emit_proto_for_class\`** (helper recursiva em new_expr.rs): para cada classe na hierarquia, popula \`proto.__proto__ = super_proto\`. Antes, apenas o primeiro nivel era setado e iteracao via \`Object.getPrototypeOf(proto)\` parava no segundo passo.

2. **\`__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE\`** (novo): singleton runtime do \`Object.prototype\` Map. Contem \`constructor.name === \"Object\"\` para que a iteracao da chain termine corretamente. Cacheado via OnceLock.

3. Classe raiz (sem super_class) tem \`proto.__proto__ = Object.prototype\`, fechando a chain.

### Resultado

\`\`\`ts
class A {}
class B extends A {}
class C extends B {}
const chain = [];
let proto = Object.getPrototypeOf(new C());
while (proto) { chain.push(proto.constructor.name); proto = Object.getPrototypeOf(proto); }
// RTS antes: \"C\"
// RTS agora: \"C->B->A->Object\" (== Bun/Node)
\`\`\`

Refs #336, #1049.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)