### PR TITLE
fix(runtime): constructor slot non-enumerable em prototype Maps

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -588,6 +588,8 @@ pub extern "C" fn __RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE() -> u64 {
         crate::namespaces::collections::map::with_map_mut(proto, (), |m| {
             m.insert("constructor".to_string(), ctor_stub as i64);
         });
+        // (cross-runtime #377) constructor eh non-enumerable em Object.prototype.
+        crate::namespaces::collections::map::mark_non_enumerable(proto, "constructor");
         proto
     })
 }
@@ -626,6 +628,11 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_PROTOTYPE_GET(handle: u64) -> u64 {
     crate::namespaces::collections::map::with_map_mut(new_proto, (), |m| {
         m.insert("constructor".to_string(), handle as i64);
     });
+    // (cross-runtime #377) `constructor` slot eh non-enumerable em JS spec
+    // — class methods (incluindo constructor sintetico) nao aparecem em
+    // `for...in`. Sem isso, fixture 377_for_in_detail reportava
+    // `x,constructor` em vez de so' `x`.
+    crate::namespaces::collections::map::mark_non_enumerable(new_proto, "constructor");
     // Insere; se outra thread venceu a corrida, descarta o nosso.
     let mut registry = proto_registry().lock().unwrap_or_else(|e| e.into_inner());
     if let Some(&existing) = registry.get(&fn_ptr) {


### PR DESCRIPTION
## Summary

Apos #1196/#1198, \`constructor\` foi adicionado ao prototype Map de cada classe e ao Object.prototype singleton. Mas a chave ficou ENUMERAVEL, fazendo \`for...in obj\` em instancia de classe retornar \`x,constructor\` em vez de so' \`x\` — quebrando o padrao classico de iteracao de proprios + herdados sem methods.

Fix: chama \`mark_non_enumerable(proto, \"constructor\")\` em:
- \`__RTS_FN_GL_FUNCTION_PROTOTYPE_GET\` (proto Map por classe)
- \`__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE\` (singleton Object.prototype)

JS spec exige que \`constructor\` (e demais metodos de class syntax) sejam non-enumerable. \`FOR_IN_KEYS\` ja' filtra via \`is_non_enumerable\`.

Fecha fixture \`tests/cross-runtime/object-meta/377_for_in_detail.ts\` (diff vazio vs Bun).

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] \`diff <(rts.exe run 377_for_in_detail.ts) <(bun ...)\` vazio

🤖 Generated with [Claude Code](https://claude.com/claude-code)