### PR TITLE
fix(codegen): dynamic getter/setter em Class.prototype via defineProperty

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -937,6 +937,20 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                 if ctx.user_fns.contains_key(obj_name) && ctx.var_ty(obj_name).is_none() {
                     return lower_user_fn_getter(ctx, obj_name, prop_name);
                 }
+                // (cross-runtime #336) `Class.prototype` para classes user
+                // resolvem para o mesmo Map que `Object.getPrototypeOf(c)`.
+                // Reifica __class_X__init e chama FUNCTION_PROTOTYPE_GET.
+                // Sem isso, `Class.prototype` caia no path generico de
+                // member access em Ident desconhecido (handle = 0 ou novo).
+                if prop_name == "prototype"
+                    && ctx.classes.contains_key(obj_name)
+                    && ctx.var_ty(obj_name).is_none()
+                {
+                    let init_fn = crate::codegen::lower::compile::class::class_init_name(obj_name);
+                    if ctx.user_fns.contains_key(&init_fn) {
+                        return lower_user_fn_getter(ctx, &init_fn, "prototype");
+                    }
+                }
             }
         }
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -373,9 +373,35 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     } else {
                         false
                     };
+                    // (cross-runtime #1071) Mesmo para class instance, se a
+                    // classe NAO tem setter sintatic (`set x() {}`) para a
+                    // prop, tenta dynamic `__set_<key>` via walk __proto__
+                    // — cobre `Object.defineProperty(Widget.prototype, ...,
+                    // {set})`. Sem isso o assign caia em MAP_SET direto
+                    // sem invocar o setter dinamico.
+                    let has_static_setter = if is_class_instance {
+                        if let Expr::Ident(id) = m.obj.as_ref() {
+                            ctx.local_class_ty.get(id.sym.as_str())
+                                .and_then(|cls| {
+                                    ctx.classes.get(cls).map(|meta| {
+                                        meta.setters.iter().any(|s| s == prop_name)
+                                    })
+                                })
+                                .unwrap_or(false)
+                        } else if matches!(m.obj.as_ref(), Expr::This(_)) {
+                            ctx.current_class.as_deref()
+                                .and_then(|cls| ctx.classes.get(cls))
+                                .map(|meta| meta.setters.iter().any(|s| s == prop_name))
+                                .unwrap_or(false)
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
                     use cranelift_codegen::ir::types as cl;
-                    if is_class_instance {
-                        // deixa cair no fluxo normal abaixo (sem intercept)
+                    if is_class_instance && has_static_setter {
+                        // Setter sintatic existe — deixa fluxo normal abaixo despachar.
                     } else {
                     let obj_tv = lower_expr(ctx, &m.obj)?;
                     if matches!(obj_tv.ty, ValTy::Handle) {

--- a/crates/rts-codegen/src/codegen/lower/passes/hoist_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/hoist_fn.rs
@@ -202,6 +202,15 @@ pub(crate) fn hoist_fn_expressions(program: &mut Program) {
                     });
                 }
             } else if let Some(n) = pat_to_param_name(&p.pat) {
+                // (cross-runtime #341) `function(this: any, ...args)` — TS
+                // permite anotar o tipo do `this` implicito como primeiro
+                // pseudo-param. Em RTS, `this` eh thread-local slot, nao
+                // parametro. Filtrar evita que callers passem `obj` como
+                // valor de `this` e o body leia args+1 (lixo) em vez de
+                // THIS_GET correto.
+                if n == "this" {
+                    continue;
+                }
                 parameters.push(Parameter {
                     name: n,
                     type_annotation: None,

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -148,7 +148,27 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_DIRECT(
     let Some(key) = str_from_abi(key_ptr, key_len) else {
         return 0;
     };
-    with_map(handle, 0, |m| m.get(key).copied().unwrap_or(0))
+    // (cross-runtime #1071) Walk __proto__ chain sem disparar Proxy trap.
+    // Usado em lookup de slots sentinela `__get_<k>` / `__set_<k>` que
+    // podem viver no prototype Map de uma classe (caso classico:
+    // `Object.defineProperty(Widget.prototype, "visible", {get, set})`).
+    // Como o lookup eh para slots internos do RTS (nao chaves user-visible),
+    // walk recursivo eh seguro.
+    let mut current = handle;
+    let mut depth = 0u32;
+    while current != 0 && depth < 64 {
+        let found = with_map(current, 0i64, |m| m.get(key).copied().unwrap_or(0));
+        if found != 0 {
+            return found;
+        }
+        let next = with_map(current, 0i64, |m| m.get("__proto__").copied().unwrap_or(0));
+        if next == 0 {
+            return 0;
+        }
+        current = next as u64;
+        depth += 1;
+    }
+    0
 }
 
 /// (#264 PR5) Cria novo Map vazio com `__proto__` = proto_handle.


### PR DESCRIPTION
## Summary

Quatro mudancas para suportar \`Object.defineProperty(Class.prototype, key, {get, set})\`:

1. **\`members.rs\`**: \`Class.prototype\` resolve para o mesmo Map que \`Object.getPrototypeOf(new C())\` — antes retornava handle diferente e o \`defineProperty\` gravava no Map errado.

2. **\`map.rs MAP_GET_DIRECT\`**: walk \`__proto__\` chain (max 64 niveis) sem disparar Proxy trap. Usado em getter/setter sentinel lookup (\`__get_<key>\`/\`__set_<key>\`). Sem isso, slot definido em \`Widget.prototype\` nao era visivel em \`widgetInstance.key\`.

3. **\`mod.rs\`**: assignment \`instance.key = value\` em class instance agora tenta lookup dinamico de \`__set_<key>\` (via walk proto) quando a classe nao tem setter sintatico declarado.

4. **\`hoist_fn.rs\`**: hoisting de \`function(this: any, ...args)\` agora filtra o pseudo-param \`this\` — TS permite anotar tipo do this implicito, mas em RTS \`this\` eh thread-local slot. Sem isso, callers passavam o obj como valor de \`this\` e o body lia args+1 (lixo) em vez de THIS_GET correto.

### Resultado

\`Object.defineProperty(Widget.prototype, \"visible\", {get,set})\` + \`new Widget().visible = false\` agora invoca o setter corretamente.

Refs #341, #1071.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)