### PR TITLE
fix(runtime): stack overflow lança RangeError real, nao string handle

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/stack.rs
+++ b/crates/rts-runtime/src/namespaces/gc/stack.rs
@@ -9,8 +9,6 @@
 use std::cell::Cell;
 use std::sync::OnceLock;
 
-use super::handles::{Entry, alloc_entry};
-
 thread_local! {
     static DEPTH: Cell<u32> = const { Cell::new(0) };
 }
@@ -27,8 +25,15 @@ fn stack_limit() -> u32 {
 }
 
 fn set_stack_overflow_error() {
-    let msg = b"RangeError: Maximum call stack size exceeded".to_vec();
-    let handle = alloc_entry(Entry::String(msg));
+    // (cross-runtime #200) Cria um `RangeError` real em vez de string handle —
+    // permite que `catch (e: any) { console.log(e.message, e.name) }` leia
+    // `"Maximum call stack size exceeded"` e `"RangeError"` respectivamente.
+    let msg = b"Maximum call stack size exceeded";
+    let handle = crate::namespaces::globals::error::instance::__RTS_FN_GL_RANGE_ERROR_NEW(
+        msg.as_ptr() as i64,
+        msg.len() as i64,
+        0,
+    );
     super::error::__RTS_FN_RT_ERROR_SET(handle);
 }
 


### PR DESCRIPTION
## Summary

\`set_stack_overflow_error\` em \`gc/stack.rs\` alocava \`Entry::String(\"RangeError: Maximum call stack size exceeded\")\` direto e armazenava no ERROR_SLOT. O catch entao recebia string handle, e \`e.message\` / \`e.name\` retornavam vazio porque string handle nao tem esses slots.

Fix: chama \`__RTS_FN_GL_RANGE_ERROR_NEW(msg, len, 0)\` que aloca \`Entry::ErrorObj { name: \"RangeError\", message: \"Maximum call stack size exceeded\" }\`. Catch JS-style funciona normalmente:

\`\`\`ts
try { f(); /* recursao infinita */ }
catch (e: any) {
  console.log(e.name);     // \"RangeError\"
  console.log(e.message);  // \"Maximum call stack size exceeded\"
}
\`\`\`

Fecha o caminho de leitura de \`e.name\`/\`e.message\` ja' coberto por \`MAP_GET_CHAIN\` em \`Entry::ErrorObj\`.

Refs #200.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] Repro manual: recursao infinita → catch acessa \`e.name\` e \`e.message\` corretos

🤖 Generated with [Claude Code](https://claude.com/claude-code)