### PR TITLE
fix(date): toLocaleString/toLocaleDateString/toLocaleTimeString em formato locale

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/date/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/date/instance.rs
@@ -162,7 +162,22 @@ pub extern "C" fn __RTS_FN_GL_DATE_TO_STRING(handle: u64) -> u64 {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_DATE_TO_LOCALE_DATE_STRING(handle: u64) -> u64 {
-    __RTS_FN_GL_DATE_TO_ISO_STRING(handle)
+    // Default locale: pt-BR-style `DD/MM/YYYY` (mesmo formato emitido
+    // por Bun em locale padrao do Windows). Sem Intl real, retorna o
+    // formato mais comum em vez do ISO completo. JS spec deixa em aberto
+    // o formato exato — qualquer impl deve gerar string parseable e
+    // estavel pra o user.
+    use crate::namespaces::date::ops::*;
+    let ms = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(v)) => *v,
+        _ => 0,
+    });
+    let year = __RTS_FN_NS_DATE_YEAR(ms);
+    // getMonth() retorna 0..11; locale strings sao 1-based (01..12).
+    let month = __RTS_FN_NS_DATE_MONTH(ms) + 1;
+    let day = __RTS_FN_NS_DATE_DAY(ms);
+    let s = format!("{:02}/{:02}/{:04}", day, month, year);
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 // (#220) UTC getters — RTS armazena ms em UTC, entao getUTCX = getX.
@@ -376,16 +391,43 @@ pub extern "C" fn __RTS_FN_GL_DATE_TO_JSON(handle: u64) -> u64 {
     __RTS_FN_GL_DATE_TO_ISO_STRING(handle)
 }
 
-/// `toLocaleString()` — alias de toISOString (sem locale support).
+/// `toLocaleString()` — formato `DD/MM/YYYY, HH:MM:SS` (locale pt-BR
+/// default no Windows, mesmo formato emitido por Bun). Sem Intl real,
+/// retorna o formato mais comum em vez do ISO completo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_DATE_TO_LOCALE_STRING(handle: u64) -> u64 {
-    __RTS_FN_GL_DATE_TO_ISO_STRING(handle)
+    use crate::namespaces::date::ops::*;
+    let ms = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(v)) => *v,
+        _ => 0,
+    });
+    let year = __RTS_FN_NS_DATE_YEAR(ms);
+    let month = __RTS_FN_NS_DATE_MONTH(ms) + 1;
+    let day = __RTS_FN_NS_DATE_DAY(ms);
+    let hour = __RTS_FN_NS_DATE_HOUR(ms);
+    let minute = __RTS_FN_NS_DATE_MINUTE(ms);
+    let second = __RTS_FN_NS_DATE_SECOND(ms);
+    let s = format!(
+        "{:02}/{:02}/{:04}, {:02}:{:02}:{:02}",
+        day, month, year, hour, minute, second
+    );
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 /// `toLocaleTimeString()` — pega depois do 'T' do ISO.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_DATE_TO_LOCALE_TIME_STRING(handle: u64) -> u64 {
-    __RTS_FN_GL_DATE_TO_TIME_STRING(handle)
+    // Locale time string: `HH:MM:SS` (sem ms nem timezone).
+    use crate::namespaces::date::ops::*;
+    let ms = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(v)) => *v,
+        _ => 0,
+    });
+    let hour = __RTS_FN_NS_DATE_HOUR(ms);
+    let minute = __RTS_FN_NS_DATE_MINUTE(ms);
+    let second = __RTS_FN_NS_DATE_SECOND(ms);
+    let s = format!("{:02}:{:02}:{:02}", hour, minute, second);
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 /// `toTimeString()` — pega depois do 'T' do ISO.

--- a/tests/date_to_json.test.ts
+++ b/tests/date_to_json.test.ts
@@ -11,7 +11,10 @@ out += d.toLocaleTimeString() + "\n";
 out += d.toTimeString() + "\n";
 
 describe("date_to_json", () => {
+  // (cross-runtime #220 + PR #1202) toLocaleString/toLocaleTimeString agora
+  // formatam em padrao locale-friendly (DD/MM/YYYY, HH:MM:SS) em vez de
+  // ISO, casando com Bun/Node em locale Windows default.
   test("toJSON/toLocaleString/toTimeString (#220)", () => expect(out).toBe(
-    "1970-01-01T00:00:00.000Z\n1970-01-01T00:00:00.000Z\n00:00:00.000Z\n00:00:00.000Z\n"
+    "1970-01-01T00:00:00.000Z\n01/01/1970, 00:00:00\n00:00:00\n00:00:00.000Z\n"
   ));
 });


### PR DESCRIPTION
## Summary

Antes essas tres fns retornavam ISO string (\`2024-01-15T03:00:00.000Z\`), divergindo de Bun/Node que usam locale do sistema (em Windows pt-BR default: \`DD/MM/YYYY\` para data, \`HH:MM:SS\` para hora).

Mudancas:

- \`toLocaleDateString()\` → \`DD/MM/YYYY\` (mes 1-based, day pad-zero)
- \`toLocaleString()\` → \`DD/MM/YYYY, HH:MM:SS\`
- \`toLocaleTimeString()\` → \`HH:MM:SS\`

Sem Intl real, RTS escolhe o formato mais comum em vez do ISO completo. JS spec deixa em aberto, qualquer impl deve gerar string parseable.

Atualiza \`tests/date_to_json.test.ts\` para refletir nova saida — antes o test esperava ISO em todos os tres metodos.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] \`new Date(2024,0,15).toLocaleDateString()\` bate com Bun

🤖 Generated with [Claude Code](https://claude.com/claude-code)