### PR TITLE
fix(date): toDateString() em formato JS spec, nao ISO date

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/date/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/date/instance.rs
@@ -276,16 +276,33 @@ pub extern "C" fn __RTS_FN_GL_DATE_TO_UTC_STRING(handle: u64) -> u64 {
     alloc_entry(Entry::String(s.into_bytes()))
 }
 
-/// (#220) `toDateString()` — pega ate o 'T' do ISO.
+/// (#220) `toDateString()` — JS spec format `Sat Jun 15 2024`.
+/// Antes RTS retornava `YYYY-MM-DD` (ISO date), divergindo de Bun/Node
+/// que usam o formato `<weekday> <month> <day> <year>` definido pela spec.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_DATE_TO_DATE_STRING(handle: u64) -> u64 {
-    let iso_h = __RTS_FN_GL_DATE_TO_ISO_STRING(handle);
-    let bytes: Vec<u8> = with_entry(iso_h, |e| match e {
-        Some(Entry::String(b)) => b.clone(),
-        _ => Vec::new(),
+    use crate::namespaces::date::ops::*;
+    let ms = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(v)) => *v,
+        _ => 0,
     });
-    let take = bytes.iter().position(|&b| b == b'T').unwrap_or(bytes.len());
-    alloc_entry(Entry::String(bytes[..take].to_vec()))
+    let year = __RTS_FN_NS_DATE_YEAR(ms);
+    let month = __RTS_FN_NS_DATE_MONTH(ms);
+    let day = __RTS_FN_NS_DATE_DAY(ms);
+    let dow = __RTS_FN_NS_DATE_WEEKDAY(ms);
+    let day_names = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    let mon_names = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let s = format!(
+        "{} {} {:02} {:04}",
+        day_names[dow.clamp(0, 6) as usize],
+        mon_names[month.clamp(0, 11) as usize],
+        day,
+        year,
+    );
+    alloc_entry(Entry::String(s.into_bytes()))
 }
 
 // (#220) Date setters — mutate Entry::DateMs in-place.

--- a/tests/date_utc_getters.test.ts
+++ b/tests/date_utc_getters.test.ts
@@ -18,10 +18,11 @@ const tz = d.getTimezoneOffset();
 out += (typeof tz === "number") + "\n"; // true
 
 // toUTCString / toDateString
-out += d.toDateString() + "\n";       // 1970-01-01
+// (PR #1203) toDateString agora segue JS spec: "Thu Jan 01 1970"
+out += d.toDateString() + "\n";
 
 describe("date_utc_getters", () => {
   test("UTC getters + extras (#220)", () => expect(out).toBe(
-    "1970\n0\n1\n0\n0\n0\n0\ntrue\n1970-01-01\n"
+    "1970\n0\n1\n0\n0\n0\n0\ntrue\nThu Jan 01 1970\n"
   ));
 });


### PR DESCRIPTION
## Summary

Antes RTS retornava \`YYYY-MM-DD\` (substring do ISO ate o 'T'), divergindo de Bun/Node que usam o formato JS spec: \`<weekday> <month> <day> <year>\` (ex: \`Sat Jun 15 2024\`).

Reescreve \`__RTS_FN_GL_DATE_TO_DATE_STRING\` para construir a string a partir dos parts do timestamp (year/month/day/weekday) usando os mesmos arrays de nomes que \`toString()\` ja usava.

Atualiza \`tests/date_utc_getters.test.ts\` — antes esperava \`1970-01-01\`, agora \`Thu Jan 01 1970\` (refletindo a nova saida alinhada com Bun/Node).

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] \`new Date(2024,5,15).toDateString()\` retorna \`Sat Jun 15 2024\` (== Bun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)