### PR TITLE
feat(date): toGMTString() — alias deprecated de toUTCString

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/date/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/date/abi.rs
@@ -345,6 +345,18 @@ pub const MEMBERS: &[NamespaceMember] = &[
         pure: true,
     },
     NamespaceMember {
+        // Deprecated alias de toUTCString (mantido pra compat web legacy).
+        name: "toGMTString",
+        kind: MemberKind::InstanceMethod,
+        symbol: "__RTS_FN_GL_DATE_TO_UTC_STRING",
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Deprecated alias de toUTCString.",
+        ts_signature: "toGMTString(): string",
+        intrinsic: None,
+        pure: true,
+    },
+    NamespaceMember {
         name: "toDateString",
         kind: MemberKind::InstanceMethod,
         symbol: "__RTS_FN_GL_DATE_TO_DATE_STRING",


### PR DESCRIPTION
## Summary

Adiciona \`Date.prototype.toGMTString()\` como alias do \`toUTCString()\`.

JS spec marca \`toGMTString\` como deprecated em favor de \`toUTCString\`, mas ambos sao mantidos pela compat com web legacy. Bun/Node tem os dois; RTS antes so' tinha \`toUTCString\` — caso de \"method not found\" silencioso em codigo antigo.

Reusa o mesmo simbolo runtime — apenas adiciona um segundo \`NamespaceMember\` em \`globals/date/abi.rs\` apontando pra \`__RTS_FN_GL_DATE_TO_UTC_STRING\`.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] Repro: \`new Date(0).toGMTString()\` retorna \`Thu, 01 Jan 1970 00:00:00 GMT\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)