### PR TITLE
fix(json): marca JSON.parse result como ambiguo — sub-obj.flags nao colide com RegExp.flags

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/ns_call.rs
@@ -321,6 +321,13 @@ pub(super) fn lower_ns_call_body(
             // (#92) promise.wait retorna i64 ambiguo: handle de string OU
             // valor inteiro. Marca pra TPL_COERCE_AUTO resolver em runtime.
             | "__RTS_FN_NS_PROMISE_WAIT"
+            // (PR #1207) JSON.parse retorna handle ambiguo — pode ser
+            // Map, Vec, String, scalar i64, ou sentinel JS (true/false/null).
+            // Marca pra `.flags`/`.source`/`.port` em sub-obj NAO colidir
+            // com GLOBAL_CLASS_SPECS getters (RegExp.flags, URL.port, etc).
+            | "__RTS_FN_NS_JSON_PARSE"
+            | "__RTS_FN_NS_JSON_PARSE_REVIVER"
+            | "__RTS_FN_NS_JSON_PARSE5"
         ) {
             ctx.var_member_call_values.insert(v);
         }


### PR DESCRIPTION
## Summary

JSON.parse retorna Map handle, e em \`f.flags\` quando \`f = JSON.parse(...)\`, o codegen caia no GLOBAL_CLASS_SPECS \`instance_getter\` fallback que mapeava \`flags\` → \`RegExp.flags\` getter, retornando \`null\` (porque o handle nao era \`Entry::Regex\`).

Mesma colisao acontecia com \`.source\` (RegExp.source) e \`.port\` (URL.port). O \`chain_has_call_root\` em members.rs ja' filtrava esse caminho para Call results, mas so' quando o root da cadeia estava em \`local_ambiguous_vars\` — set populado apenas por declaracoes com \`: any\` explicito.

Fix: marca o retorno de \`JSON.parse\`/\`JSON.parseReviver\`/\`JSON5.parse\` em \`var_member_call_values\` no momento da chamada. Isso permite que \`decls.rs\` propague o flag para a var local, e subsequentes \`f.X\` passem pelo MAP_GET_CHAIN normal em vez do getter GLOBAL_CLASS_SPECS.

### Caso reproduzivel

\`\`\`ts
const f = JSON.parse('{\"flags\": {\"debug\": true}}');
console.log(f.flags);       // antes: null            → agora: [object Object]
console.log(f.flags.debug); // antes: 0               → agora: true
\`\`\`

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] Repros nested: \`f.flags.debug\`, \`f.source\`, \`f.port\` em JSON.parse retornam valores corretos

🤖 Generated with [Claude Code](https://claude.com/claude-code)