### PR TITLE
test(edge_json5): valida nested bool em JSON.parse com toBe real

### DIFF
--- a/tests/edge_json5.test.ts
+++ b/tests/edge_json5.test.ts
@@ -46,13 +46,11 @@ describe("JSON5 — superset (#json5)", () => {
   test("trailing comma em array", () => expect(e.length).toBe(3));
   test("nested obj sobrevive parse", () => expect(f !== 0).toBe(true));
   test("nested array com strings", () => expect(f.hosts.length).toBe(2));
-  // (#json5) NOTE: nested bool em parse atualmente perde valor (member
-  // access em sub-Map retorna 0 — bug preexistente do JSON.parse pipeline
-  // pra nested objs com scalars). Antes do PR #1206 o test esperava `1`
-  // (i64 raw) mas tambem nao batia em runtime — o suite reportava verde
-  // erroneamente. Verifica que codigo nao crasha; valor exato fica
-  // como limitacao conhecida ate fix de nested-scalar lookup.
-  test("nested obj com bool", () => expect(debug_value !== undefined).toBe(true));
+  // (PR #1206 + #1207) JSON.parse bool retorna sentinel JS (MIN+1=true),
+  // e nested obj.flags.debug resolve para sentinel apos PR #1207 marcar
+  // JSON.parse result como ambiguo (evita colisao com RegExp.flags getter).
+  // toBe espera string — usa template literal pra coerce explicit.
+  test("nested obj com bool", () => expect(`${debug_value}`).toBe(`${true}`));
   test("stringify produz JSON estrito", () => expect(stringified).toBe('{"a":1,"b":"two"}'));
   test("parse invalido retorna 0", () => expect(bad).toBe(0));
 });


### PR DESCRIPTION
## Summary

Apos PR #1206 + #1207, \`JSON.parse('{\"flags\":{\"debug\":true}}').flags.debug\` agora retorna o sentinel JS true (i64::MIN+1) e propaga corretamente pelo \`f.flags.debug\` chain.

Antes do PR #1207 esse caminho perdia o valor (colisao com RegExp.flags getter), e o test estava com assertion fraca (\`expect(debug_value !== undefined).toBe(true)\`).

Agora valida o valor real:

\`\`\`ts
expect(\`\${debug_value}\`).toBe(\`\${true}\`);
// template literals coerce sentinel → \"true\" via TPL_COERCE_AUTO
\`\`\`

Mantem o \`expect(actual: string)\` signature do bundle (que prefere template literal pra valores nao-string — ver comment em \`bundle.ts:42-46\`).

## Test plan

- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)