### PR TITLE
style(inspect): aspas duplas em inspect de strings (Bun-compat)

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -938,7 +938,11 @@ fn inspect_handle(h: u64, depth: usize) -> String {
         None => R::None,
     });
     match r {
-        R::Str(b) => format!("'{}'", String::from_utf8_lossy(&b)),
+        // (PR #1209) Bun/Node usam aspas duplas em inspect de strings dentro
+        // de arrays/objects (Node usa simples por default, Bun duplas; RTS
+        // segue Bun pela maior parte das fixtures cross-runtime usarem
+        // Bun como referencia).
+        R::Str(b) => format!("\"{}\"", String::from_utf8_lossy(&b)),
         R::Vec(slots) => {
             if slots.is_empty() {
                 return "[]".to_string();


### PR DESCRIPTION
## Summary

\`inspect_handle\` rendia string handle em arrays/objects com aspas simples (\`'abc'\`), divergindo de Bun que usa aspas duplas (\`\"abc\"\`).

\`\`\`ts
console.log([\"a\", \"b\", \"c\"]);
// antes: [ 'a', 'b', 'c' ]
// agora: [ \"a\", \"b\", \"c\" ]  ← bate com Bun
\`\`\`

Node usa aspas simples por default (config util.inspect), mas Bun usa duplas, e a maioria das fixtures cross-runtime usa Bun como referencia. Cosmetico — nao afeta comportamento semantico.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)