### PR TITLE
fix(json): JSON.parse preserva ordem de insercao (preserve_order feature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,6 +2619,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/crates/rts-runtime/Cargo.toml
+++ b/crates/rts-runtime/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2024"
 rts-abi = { path = "../rts-abi" }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# preserve_order: JS spec ECMA-262 OrdinaryOwnPropertyKeys exige ordem de
+# insercao para string keys. Sem isso, JSON.parse(...) seguido de Object.keys
+# retornava ordem alfabetica em vez da ordem do JSON source.
+serde_json = { version = "1.0", features = ["preserve_order"] }
 json5 = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 rayon = "1.10"


### PR DESCRIPTION
## Summary

JS spec ECMA-262 OrdinaryOwnPropertyKeys exige ordem de insercao para string keys. Sem \`preserve_order\` no \`serde_json\`, \`JSON.parse('{\"name\":\"Alice\",\"age\":30}')\` seguido de \`Object.keys(...)\` retornava \`[\"age\",\"name\"]\` (ordem alfabetica) em vez de \`[\"name\",\"age\"]\` (ordem do source).

Adiciona feature \`preserve_order\` em \`rts-runtime/Cargo.toml\`. Internamente \`serde_json::Map\` passa a usar IndexMap (mesmo backing que RTS ja usa no resto do codigo), entao a transformacao para \`Entry::Map\` preserva naturalmente a ordem.

\`\`\`ts
const f = JSON.parse('{\"name\":\"Alice\",\"age\":30}');
Object.keys(f);
// antes: [\"age\",\"name\"]
// agora: [\"name\",\"age\"]  ← bate com Bun/Node
\`\`\`

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)