### PR TITLE
fix(json): JSON.stringify top-level (+-Infinity/NaN) → null

### DIFF
--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -658,10 +658,14 @@ pub extern "C" fn __RTS_FN_NS_JSON_STRINGIFY_TYPED(value: i64, kind: i32) -> u64
         2 => if value != 0 { "true".to_string() } else { "false".to_string() },
         // null/undefined -> "null" (JS spec: JSON.stringify(null) === "null")
         3 => "null".to_string(),
-        // f64 bits: numero JS-format
+        // f64 bits: numero JS-format. NaN/+-Infinity viram "null" (JS spec).
         1 => {
             let f = f64::from_bits(value as u64);
-            crate::namespaces::gc::string_pool::format_js_number(f)
+            if !f.is_finite() {
+                "null".to_string()
+            } else {
+                crate::namespaces::gc::string_pool::format_js_number(f)
+            }
         }
         // i64/handle: tenta como handle valido; senao formata como numero.
         _ => {


### PR DESCRIPTION
## Summary

Complementa PR #1211 — agora top-level (\`JSON.stringify(1/0)\`) tambem retorna \"null\" alem do caso em obj field.

JS spec: \`JSON.stringify(NaN) === \"null\"\`, mesma coisa pra \`+Infinity\`/\`-Infinity\`. Antes RTS retornava \`\"Infinity\"\`/\`\"NaN\"\` (formato JS printable) que nao eh valid JSON.

Fix em \`JSON_STRINGIFY_TYPED\` \`kind=1\` (f64 bits): testa \`f.is_finite()\` antes de \`format_js_number\`. Aqui \`-Infinity\` tambem funciona porque \`kind\` eh f64 explicit (top-level number) — diferente de field em obj onde o slot eh i64 raw e colide com sentinel false.

\`\`\`ts
JSON.stringify(1/0);   // antes: \"Infinity\"   → agora: \"null\"
JSON.stringify(-1/0);  // antes: \"-Infinity\"  → agora: \"null\"
JSON.stringify(0/0);   // antes: \"NaN\"        → agora: \"null\"
\`\`\`

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**
- [x] Output bate exato com Bun pra todos os casos top-level finitos + nao-finitos

🤖 Generated with [Claude Code](https://claude.com/claude-code)