### PR TITLE
fix(inspect): slot Vec/Map renderiza sentinelas undefined/null

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -995,13 +995,16 @@ fn inspect_handle(h: u64, depth: usize) -> String {
 /// Slot cru de Vec/Map: < 2^48 = numero JS; >= 2^48 e handle valido =
 /// inspect recursivo; senao numero.
 fn inspect_slot(raw: i64, depth: usize) -> String {
-    // Sentinela bool em slot de Vec/Map (gerado pelo codegen).
-    if raw == i64::MIN {
-        return "false".to_string();
-    }
-    if raw == i64::MIN + 1 {
-        return "true".to_string();
-    }
+    // Sentinelas JS em slot de Vec/Map (gerados pelo codegen):
+    //   MIN     = false
+    //   MIN+1   = true
+    //   MIN+2   = undefined
+    //   MIN+3   = null
+    //   MIN+4   = sparse hole (renderiza como undefined isolado)
+    if raw == i64::MIN { return "false".to_string(); }
+    if raw == i64::MIN + 1 { return "true".to_string(); }
+    if raw == i64::MIN + 2 || raw == i64::MIN + 4 { return "undefined".to_string(); }
+    if raw == i64::MIN + 3 { return "null".to_string(); }
     let h = raw as u64;
     if h < (1u64 << 48) {
         return format_js_number(raw as f64);


### PR DESCRIPTION
## Summary

\`inspect_slot\` (usado por \`inspect_handle\` em console.log de arrays/maps) ja tratava sentinels bool (MIN/MIN+1) mas faltava \`undefined\` (MIN+2), sparse hole (MIN+4) e \`null\` (MIN+3). Como resultado, qualquer slot com \`undefined\` era renderizado como o numero \`-9223372036854776000\` (bits do sentinel).

### Exemplo classico

\`\`\`ts
\"abc123\".match(/(\d+)/);
// antes: { ..., groups: -9223372036854776000 }
// agora: { ..., groups: undefined }  ← bate com Bun
\`\`\`

Caso mais geral: qualquer Map/Vec slot que recebe undefined diretamente (ex: optional chain, RegExp match groups, sparse arr literal). Agora renderiza como \`\"undefined\"\` / \`\"null\"\` como Bun.

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)