### PR TITLE
feat(inspect): Map(N)/Set(N) tag em inspect_handle (Node/Bun-compat)

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -960,11 +960,61 @@ fn inspect_handle(h: u64, depth: usize) -> String {
                 || entries
                     .iter()
                     .any(|(k, v)| k == b"__proto__" && *v == 0);
+            // (PR #1214) Map/Set instances — Bun/Node imprimem como `Map(N) { k: v, ... }`
+            // e `Set(N) { v1, v2, ... }`. RTS armazena Map JS como Entry::Map
+            // tagged em set_kind_set/map_kind_set (separado de obj literal Map).
+            let is_map_kind = crate::namespaces::collections::map::handle_is_map_kind(h);
+            let is_set_kind = crate::namespaces::collections::map::handle_is_set_kind(h);
             // Filtra slots internos das entries impressas.
             let visible: Vec<&(Vec<u8>, i64)> = entries
                 .iter()
                 .filter(|(k, _)| k != b"__proto__" && k != b"__rts_class")
                 .collect();
+            if is_set_kind {
+                // Set: em RTS, item.key eh a forma stringified do valor
+                // (via STRING_FROM_I64/F64) e item.value eh sentinel 1.
+                // Pra inspect, mostramos as keys (raw values), nao value=1.
+                // Para keys numericas, parsea de volta como number; senao
+                // mostra entre aspas (string).
+                if visible.is_empty() {
+                    return "Set(0) {}".to_string();
+                }
+                let n = visible.len();
+                let parts: Vec<String> = visible
+                    .iter()
+                    .map(|(k, _)| {
+                        let s = String::from_utf8_lossy(k);
+                        // Tenta number (i64 ou f64); senao mostra como string.
+                        if let Ok(_) = s.parse::<i64>() {
+                            s.to_string()
+                        } else if let Ok(f) = s.parse::<f64>() {
+                            format_js_number(f)
+                        } else if s == "true" || s == "false" || s == "null" || s == "undefined" {
+                            s.to_string()
+                        } else {
+                            format!("\"{}\"", s)
+                        }
+                    })
+                    .collect();
+                return format!("Set({}) {{ {} }}", n, parts.join(", "));
+            }
+            if is_map_kind {
+                if visible.is_empty() {
+                    return "Map(0) {}".to_string();
+                }
+                let n = visible.len();
+                let parts: Vec<String> = visible
+                    .iter()
+                    .map(|(k, v)| {
+                        format!(
+                            "\"{}\" => {}",
+                            String::from_utf8_lossy(k),
+                            inspect_slot(*v, depth + 1)
+                        )
+                    })
+                    .collect();
+                return format!("Map({}) {{ {} }}", n, parts.join(", "));
+            }
             let body = if visible.is_empty() {
                 "{}".to_string()
             } else {


### PR DESCRIPTION
## Summary

\`Map\` e \`Set\` instancias agora sao impressas com tag e count, como Bun/Node:

\`\`\`ts
const m = new Map(); m.set(\"k\", 1);
console.log(m);
// antes: { k: 1 }
// agora: Map(1) { \"k\" => 1 }

const s = new Set([1, 2, 3]);
console.log(s);
// antes: { 1: 1, 2: 1, 3: 1 }   ← interno: value=sentinel 1
// agora: Set(3) { 1, 2, 3 }     ← imprime keys (valores originais)
\`\`\`

Para Set, em RTS o storage interno e' \`Entry::Map\` com \`key=valor stringified\` e \`value=1\` (sentinel). Pra inspect, le as keys e parsea de volta (i64 → numero, \`\"true\"\`/\`\"false\"\`/\`\"null\"\`/\`\"undefined\"\` → literal, resto → string quoted).

Map JS usa formato \`\"k\" => v\` (key quoted entre \`=>\` e value).

Detecta tipo via \`handle_is_map_kind\`/\`handle_is_set_kind\` do \`collections/map\` (set populado em \`map_kind_set\`/\`set_kind_set\` tracker thread-safe).

## Test plan

- [x] \`cargo build --release\` zero warnings
- [x] \`target/release/rts.exe test\` **1312/1312 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)