### PR TITLE
fix(codegen): return de handle propaga objeto cru sem stringificar (#1079/#1125)

### DIFF
--- a/.claude/rules/00-meta.md
+++ b/.claude/rules/00-meta.md
@@ -33,7 +33,7 @@ Ler estes arquivos em ordem (caminho relativo a raiz do repo):
 
 | Arquivo | Conteudo |
 |---|---|
-| `.claude/rules/00-meta.md` | Este arquivo — meta + RTK + local-rules + zero regressao |
+| `.claude/rules/00-meta.md` | Este arquivo — meta + RTK + local-rules + zero regressao + roadmap |
 | `.claude/rules/01-architecture.md` | Projeto + Arquitetura + ABI + Namespaces |
 | `.claude/rules/02-runtime.md` | HandleTable + tokio + GC + State |
 | `.claude/rules/03-features.md` | Silent parallelism + async/Promise/Function + capacidades |
@@ -46,9 +46,36 @@ Ler estes arquivos em ordem (caminho relativo a raiz do repo):
 - **REGRA OBRIGATORIA: USO DO RTK** (abaixo)
 - **REQUISITO OBRIGATORIO: local-rules.md** (abaixo)
 - **REGRA OBRIGATORIA: ZERO REGRESSAO ANTES DE MERGE** (abaixo)
+- **REGRA OBRIGATORIA: SEGUIR ROADMAP-CORRECAO.md** (abaixo)
 
 Adicionar/remover regras meta exige atualizar esta lista no mesmo
 commit.
+
+## REGRA OBRIGATORIA: SEGUIR ROADMAP-CORRECAO.md
+
+Antes de iniciar qualquer correcao de bug de paridade cross-runtime
+(issues `💥 cross-runtime`, categorias de tracking, falhas da suite TS),
+voce **DEVE** ler o arquivo `ROADMAP-CORRECAO.md` que fica **um nivel acima
+da raiz do repo** (`../ROADMAP-CORRECAO.md`, ao lado da pasta `rts1/`).
+
+Esse arquivo define a **ordem topologica** de correcao baseada no grafo de
+dependencias entre features. A ordem nao eh arbitraria: corrigir fora de
+ordem causa o padrao "conserta um, quebra outro", porque varios testes
+compartilham a mesma fundacao.
+
+### Como aplicar
+
+1. Sempre escolher a proxima tarefa do **nivel mais baixo ainda nao
+   concluido**. Nunca pular para um nivel superior antes de fechar as
+   fundacoes de que ele depende.
+2. Respeitar os blocos marcados ⚠️ no roadmap (ex: 336/387/341 sao uma
+   raiz so; cadeia 204→205→206 eh linear).
+3. Ao concluir um item (PR mergeado + suite verde), marcar `[x]` no
+   roadmap no mesmo PR.
+4. Se a analise mudar (nova dependencia descoberta), atualizar o grafo no
+   roadmap no mesmo PR — nunca deixar o roadmap desatualizado.
+5. Se o usuario pedir explicitamente para atacar um caso fora de ordem,
+   pedir confirmacao apontando a dependencia faltante antes de prosseguir.
 
 ## REGRA OBRIGATORIA: USO DO RTK PARA COMANDOS ESPECIFICOS
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ rts-types/
 # Regras locais do desenvolvedor — pessoal, nao versionar
 local-rules.md
 scripts/__pycache__/
+
+# Arquivos temporarios de debug/repro
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ e a aplicação de tudo o que ele determina.
 - **REQUISITO OBRIGATÓRIO: local-rules.md** (verificar e ler se existir)
 - **REGRA OBRIGATÓRIA: ZERO REGRESSÃO ANTES DE MERGE** (suite verde
   obrigatoria)
+- **REGRA OBRIGATÓRIA: SEGUIR `../ROADMAP-CORRECAO.md`** (ordem topologica
+  de correcao de bugs cross-runtime; detalhada em `.claude/rules/00-meta.md`)
 
 Esta lista deve ser mantida em sincronia com as proximas secoes deste
 arquivo. Se uma regra obrigatoria for adicionada/removida em outro lugar,

--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -1154,6 +1154,28 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         Ok(TypedVal::new(val, ValTy::Handle))
     }
 
+    /// Passa um valor adiante como Handle SEM stringificar.
+    ///
+    /// `coerce_to_handle` significa "produza uma string GC" — apropriado em
+    /// contexto de template/concat, mas destrutivo quando o valor ja eh um
+    /// handle de objeto/array/Map que deve ser propagado cru (ex: `return
+    /// (globalThis as any)[key]`, `const x: any = obj; return x`). Nestes
+    /// casos um valor i64/U64/Handle ja carrega os bits do handle e so'
+    /// precisa ser reinterpretado como Handle. F64/Bool caem no caminho de
+    /// coercao normal (sao genuinamente escalares e viram string).
+    pub fn pass_as_handle(&mut self, tv: TypedVal) -> Result<TypedVal> {
+        match tv.ty {
+            ValTy::Handle => Ok(tv),
+            ValTy::U64 | ValTy::I64 | ValTy::I32
+            | ValTy::I8 | ValTy::I16 | ValTy::U8 | ValTy::U16 => {
+                let v = self.coerce_to_i64(tv).val;
+                Ok(TypedVal::new(v, ValTy::Handle))
+            }
+            // F64/Bool: nao sao handles — delega pra coercao que stringifica.
+            _ => self.coerce_to_handle(tv),
+        }
+    }
+
     /// Coerces any value to a GC string handle.
     pub fn coerce_to_handle(&mut self, tv: TypedVal) -> Result<TypedVal> {
         match tv.ty {

--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -402,7 +402,12 @@ pub(super) fn lower_return_stmt(
                 let coerced = match ret_ty {
                     ValTy::I32 => ctx.coerce_to_i32(tv),
                     ValTy::F64 => ctx.coerce_to_f64(tv),
-                    ValTy::Handle => ctx.coerce_to_handle(tv)?,
+                    // Handle no return: propaga o handle CRU. Usar
+                    // coerce_to_handle aqui stringificava objetos/arrays/Maps
+                    // (TPL_COERCE_AUTO), corrompendo `return (globalThis as
+                    // any)[key]` e similares — o caller via o objeto como um
+                    // handle de string. pass_as_handle so reinterpreta i64.
+                    ValTy::Handle => ctx.pass_as_handle(tv)?,
                     _ => ctx.coerce_to_i64(tv),
                 };
                 ctx.emit_trace_pop()?;

--- a/tests/return_handle_passthrough.test.ts
+++ b/tests/return_handle_passthrough.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression: `return <objeto/handle>` numa fn sem anotacao de retorno
+// (inferida como Handle) deve propagar o handle CRU, sem stringificar via
+// TPL_COERCE_AUTO. Antes, `return (globalThis as any)[key]` e similares
+// corrompiam o objeto, e o acesso a campo no caller dava 0.
+
+// (1) ensureGlobal pattern (bundler/polyfill) — globalThis[key] dinamico.
+function ensureGlobal(key: string, factory: () => any) {
+  if (!(key in globalThis)) {
+    (globalThis as any)[key] = factory();
+  }
+  return (globalThis as any)[key];
+}
+const libA = ensureGlobal("__rtsLibA", () => ({ version: "1.0", ready: true }));
+const libA2 = ensureGlobal("__rtsLibA", () => ({ version: "2.0", ready: false }));
+
+// (2) return direto de computed-get de globalThis (sem `as any`).
+(globalThis as any)["__rtsK"] = { tag: "obj-k" };
+function getK(key: string) {
+  return globalThis[key];
+}
+const k = getK("__rtsK");
+
+// (3) return de objeto vindo de member access, fn sem anotacao.
+function pick(): any {
+  return { name: "picked", n: 42 };
+}
+const p = pick();
+
+describe("return handle passthrough", () => {
+  test("ensureGlobal retorna instancia com campos intactos", () =>
+    expect(libA.version).toBe("1.0"));
+  test("ensureGlobal nao substitui na 2a chamada", () =>
+    expect(libA2.version).toBe("1.0"));
+  test("return globalThis[key] propaga objeto cru", () =>
+    expect(k.tag).toBe("obj-k"));
+  test("return de objeto literal em fn :any", () =>
+    expect(p.name).toBe("picked"));
+  test("campo numerico do objeto retornado", () =>
+    expect(p.n).toBe(42));
+});


### PR DESCRIPTION
## Problema

`return <expr>` numa fn cujo tipo de retorno é **inferido** como Handle chamava `coerce_to_handle`. Para valores i64 marcados como member-call (`var_member_call_values`), esse caminho aplicava `TPL_COERCE_AUTO` — que **stringifica** o valor. Resultado: objetos/arrays/Maps retornados eram convertidos em handle de string, e o acesso a campo no caller dava `0`.

Caso canônico (pattern de bundler/polyfill):

```ts
function ensureGlobal(key: string, factory: () => any) {
  if (!(key in globalThis)) (globalThis as any)[key] = factory();
  return (globalThis as any)[key];   // objeto voltava corrompido
}
```

## Causa raiz

`coerce_to_handle` significa "produza uma string GC" (apropriado em template/concat). Usá-lo no `return` para propagar um objeto destrói o handle.

## Fix

Novo `pass_as_handle`: propaga o handle **cru** (reinterpreta i64/U64/Handle como Handle) no return statement. F64/Bool continuam pelo caminho de stringificação normal.

## Validação

- Resolve **#1079** e **#1125** (388_globalThis, object-meta)
- Suite TS: **1312/1312** verde (zero regressão)
- `cargo test --release --lib`: 12/12
- Novo teste de regressão: `tests/return_handle_passthrough.test.ts`

Segue a ordem topológica de `ROADMAP-CORRECAO.md` (Nível 0, fundação isolada de risco baixo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)