### PR TITLE
fix(codegen): private inheritance + default params em constructor/super (#1057)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/class.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/class.rs
@@ -246,6 +246,50 @@ pub(crate) fn synthesize_class_fns(
         })
         .collect();
 
+    // (375) Pre-passada: coleta tipos de campos ANTES de processar metodos,
+    // pra que getters sem anotacao (`get name() { return this.#name; }`)
+    // possam inferir o return_type do tipo do campo retornado — mesmo quando
+    // o getter aparece antes da propriedade no fonte. Cobre tanto a anotacao
+    // explicita quanto a inferida do initializer.
+    let mut prescan_field_ty: HashMap<String, String> = HashMap::new();
+    for member in &class.members {
+        match member {
+            ClassMember::Property(prop) if !prop.modifiers.is_static => {
+                if let Some(ann) = prop.type_annotation.as_deref() {
+                    prescan_field_ty.insert(prop.name.clone(), ann.trim().to_string());
+                } else if let Some(init) = prop.initializer.as_ref() {
+                    // Infere tipo do initializer quando nao ha anotacao:
+                    // string lit / template -> "string"; bool -> "boolean".
+                    // Cobre `#v = "A-priv"` (private string sem `: string`).
+                    if matches!(
+                        init.as_ref(),
+                        swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(_))
+                            | swc_ecma_ast::Expr::Tpl(_)
+                    ) {
+                        prescan_field_ty.insert(prop.name.clone(), "string".to_string());
+                    } else {
+                        let inferred = crate::codegen::lower::analysis::types::infer_expr_ty(
+                            Some(init.as_ref()),
+                        );
+                        if matches!(inferred, ValTy::Bool) {
+                            prescan_field_ty.insert(prop.name.clone(), "boolean".to_string());
+                        }
+                    }
+                }
+            }
+            ClassMember::Constructor(ctor) => {
+                for p in &ctor.parameters {
+                    if let Some(ann) = p.type_annotation.as_deref() {
+                        prescan_field_ty
+                            .entry(p.name.clone())
+                            .or_insert_with(|| ann.trim().to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     for member in &class.members {
         match member {
             ClassMember::Constructor(ctor) => {
@@ -362,10 +406,23 @@ pub(crate) fn synthesize_class_fns(
                     let mut params = Vec::with_capacity(method.parameters.len() + 1);
                     params.push(this_param(method.span));
                     params.extend(method.parameters.iter().cloned());
+                    // (375) Getter OU metodo sem anotacao cujo corpo eh
+                    // `return this.<field>`: herda o tipo do campo. Sem isso a
+                    // inferencia caia em F64 e um campo string voltava como
+                    // handle cru (`d.name`/`b.getV()` imprimiam o numero do
+                    // handle). Cobre tanto `get name()` quanto `getV()`.
+                    let return_type = if method.return_type.is_none()
+                        && matches!(method.role, MethodRole::Getter | MethodRole::Method)
+                    {
+                        getter_field_return_ty(&method.body, &prescan_field_ty)
+                            .or_else(|| method.return_type.clone())
+                    } else {
+                        method.return_type.clone()
+                    };
                     fns.push(FunctionDecl {
                         name: synth_name,
                         parameters: params,
-                        return_type: method.return_type.clone(),
+                        return_type,
                         body: method.body.clone(),
                         span: method.span,
                         is_async: false,
@@ -579,6 +636,48 @@ pub(crate) fn synthesize_class_fns(
 }
 
 /// `this.<name> = <init>;` como Statement RTS.
+/// (375) Para um getter sem anotacao cujo corpo retorna `this.<field>`,
+/// devolve a anotacao de tipo do campo (de `prescan_field_ty`). Permite que a
+/// inferencia de return_type herde o tipo do campo em vez de cair em F64.
+/// Conservador: so' reconhece `return this.<ident>` / `return this.#<priv>`
+/// como unico statement relevante; qualquer outra forma retorna None.
+fn getter_field_return_ty(
+    body: &[Statement],
+    prescan_field_ty: &HashMap<String, String>,
+) -> Option<String> {
+    use swc_ecma_ast::{Expr, MemberProp, Stmt};
+    fn field_of_return(e: &Expr) -> Option<String> {
+        // Peel Paren/TsAs/TsNonNull.
+        let inner = match e {
+            Expr::Paren(p) => return field_of_return(&p.expr),
+            Expr::TsAs(a) => return field_of_return(&a.expr),
+            Expr::TsNonNull(n) => return field_of_return(&n.expr),
+            other => other,
+        };
+        let Expr::Member(m) = inner else { return None };
+        if !matches!(m.obj.as_ref(), Expr::This(_)) {
+            return None;
+        }
+        match &m.prop {
+            MemberProp::Ident(id) => Some(id.sym.to_string()),
+            MemberProp::PrivateName(pn) => Some(format!("#{}", pn.name.as_ref())),
+            MemberProp::Computed(_) => None,
+        }
+    }
+    for s in body {
+        let Statement::Raw(rs) = s;
+        let Some(stmt) = rs.stmt.as_ref() else { continue };
+        if let Stmt::Return(r) = stmt {
+            if let Some(arg) = r.arg.as_deref() {
+                if let Some(field) = field_of_return(arg) {
+                    return prescan_field_ty.get(&field).cloned();
+                }
+            }
+        }
+    }
+    None
+}
+
 fn make_field_init_stmt(
     name: &str,
     init: Box<swc_ecma_ast::Expr>,

--- a/crates/rts-codegen/src/codegen/lower/passes/args/default_args.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/args/default_args.rs
@@ -7,6 +7,64 @@ use swc_ecma_ast::{Callee, Expr, Stmt};
 
 use crate::parser::ast::{ClassMember, Item, Parameter, Program, Statement};
 
+/// (375) Preenche args omitidos numa chamada `super(...)` com os defaults do
+/// constructor do pai. `super(name)` com `Animal`'s `constructor(name, e=100)`
+/// vira `super(name, 100)`. Percorre o stmt procurando `Expr::Call` com callee
+/// Super (top-level ou dentro de Expr/If/Block).
+fn fill_super_call_defaults(
+    stmt: &mut Stmt,
+    param_names: &[String],
+    defaults: &[Option<Box<Expr>>],
+) {
+    fn fill_in_expr(e: &mut Expr, param_names: &[String], defaults: &[Option<Box<Expr>>]) {
+        if let Expr::Call(call) = e {
+            if matches!(call.callee, Callee::Super(_)) {
+                let provided = call.args.len();
+                let total = defaults.len();
+                if provided < total {
+                    let mut bindings: std::collections::HashMap<String, Expr> =
+                        std::collections::HashMap::new();
+                    for (idx, arg) in call.args.iter().enumerate() {
+                        if let Some(pn) = param_names.get(idx) {
+                            bindings.insert(pn.clone(), (*arg.expr).clone());
+                        }
+                    }
+                    for i in provided..total {
+                        if let Some(def) = &defaults[i] {
+                            let mut def_clone = (**def).clone();
+                            substitute_param_refs(&mut def_clone, &bindings);
+                            if let Some(pn) = param_names.get(i) {
+                                bindings.insert(pn.clone(), def_clone.clone());
+                            }
+                            call.args.push(swc_ecma_ast::ExprOrSpread {
+                                spread: None,
+                                expr: Box::new(def_clone),
+                            });
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    match stmt {
+        Stmt::Expr(e) => fill_in_expr(&mut e.expr, param_names, defaults),
+        Stmt::Block(b) => {
+            for s in &mut b.stmts {
+                fill_super_call_defaults(s, param_names, defaults);
+            }
+        }
+        Stmt::If(i) => {
+            fill_super_call_defaults(&mut i.cons, param_names, defaults);
+            if let Some(alt) = i.alt.as_deref_mut() {
+                fill_super_call_defaults(alt, param_names, defaults);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// (#640) Substitui referencias a Ident(param_name) por exprs ja resolvidas
 /// do callsite. Isso permite defaults que referenciam outros params funcionarem
 /// quando o callsite preenche o slot indireto (ex: `rect(5)` com
@@ -66,6 +124,10 @@ pub(crate) fn expand_default_args(program: &mut Program) {
     // callsite.
     let mut fn_defaults: HashMap<String, (Vec<String>, Vec<Option<Box<Expr>>>)> = HashMap::new();
     let mut method_defaults: HashMap<(String, String), (Vec<String>, Vec<Option<Box<Expr>>>)> = HashMap::new();
+    // (375) Hierarquia + quais classes tem constructor proprio, pra propagar
+    // o constructor herdado a subclasses sem `constructor` declarado.
+    let mut class_super: HashMap<String, Option<String>> = HashMap::new();
+    let mut has_own_ctor: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     fn extract_names(params: &[Parameter]) -> Vec<String> {
         params.iter().map(|p| p.name.clone()).collect()
@@ -82,6 +144,10 @@ pub(crate) fn expand_default_args(program: &mut Program) {
                 }
             }
             Item::Class(c) => {
+                class_super.insert(c.name.clone(), c.super_class.clone());
+                if c.members.iter().any(|m| matches!(m, ClassMember::Constructor(_))) {
+                    has_own_ctor.insert(c.name.clone());
+                }
                 for m in &c.members {
                     if let ClassMember::Method(method) = m {
                         if method.parameters.iter().any(|p| p.default.is_some()) {
@@ -97,9 +163,61 @@ pub(crate) fn expand_default_args(program: &mut Program) {
                             );
                         }
                     }
+                    // (375) Constructor com default params: registra sob chave
+                    // especial `(Class, "<constructor>")` pra que `new Class()`
+                    // preencha os slots omitidos. Sem isso `constructor(e=100)`
+                    // + `new A()` deixava `e` como sentinel/0.
+                    if let ClassMember::Constructor(ctor) = m {
+                        if ctor.parameters.iter().any(|p| p.default.is_some()) {
+                            let names = extract_names(&ctor.parameters);
+                            let defaults: Vec<Option<Box<Expr>>> = ctor
+                                .parameters
+                                .iter()
+                                .map(|p| p.default.clone())
+                                .collect();
+                            method_defaults.insert(
+                                (c.name.clone(), "<constructor>".to_string()),
+                                (names, defaults),
+                            );
+                        }
+                    }
                 }
             }
             _ => {}
+        }
+    }
+
+    // (375) Propaga o constructor herdado: subclasse sem `constructor`
+    // proprio usa os defaults do constructor do ancestral mais proximo que
+    // tem um. `class Dog extends Animal {}` + `new Dog("Rex")` aplica os
+    // defaults de `Animal`'s constructor.
+    let class_names: Vec<String> = class_super.keys().cloned().collect();
+    for cn in class_names {
+        if has_own_ctor.contains(&cn) {
+            continue;
+        }
+        if method_defaults.contains_key(&(cn.clone(), "<constructor>".to_string())) {
+            continue;
+        }
+        // Caminha ancestrais ate achar um com constructor-defaults.
+        let mut cur = class_super.get(&cn).cloned().flatten();
+        let mut guard = 0;
+        while let Some(parent) = cur {
+            guard += 1;
+            if guard > 64 {
+                break;
+            }
+            if let Some(defs) =
+                method_defaults.get(&(parent.clone(), "<constructor>".to_string())).cloned()
+            {
+                method_defaults.insert((cn.clone(), "<constructor>".to_string()), defs);
+                break;
+            }
+            if has_own_ctor.contains(&parent) {
+                // Ancestral tem constructor proprio mas sem defaults — para.
+                break;
+            }
+            cur = class_super.get(&parent).cloned().flatten();
         }
     }
 
@@ -119,6 +237,15 @@ pub(crate) fn expand_default_args(program: &mut Program) {
                 }
             }
             Item::Class(c) => {
+                // (375) Defaults do constructor do pai pra preencher
+                // `super(...)` com args omitidos.
+                let parent_ctor_defaults = class_super
+                    .get(&c.name)
+                    .cloned()
+                    .flatten()
+                    .and_then(|p| {
+                        method_defaults.get(&(p, "<constructor>".to_string())).cloned()
+                    });
                 for m in c.members.iter_mut() {
                     match m {
                         ClassMember::Constructor(ctor) => {
@@ -126,6 +253,9 @@ pub(crate) fn expand_default_args(program: &mut Program) {
                                 let Statement::Raw(raw) = s;
                                 if let Some(stmt) = raw.stmt.as_mut() {
                                     expand_in_stmt(stmt, &fn_defaults, &method_defaults);
+                                    if let Some((pnames, pdefs)) = &parent_ctor_defaults {
+                                        fill_super_call_defaults(stmt, pnames, pdefs);
+                                    }
                                 }
                             }
                         }
@@ -323,9 +453,52 @@ fn expand_in_expr(
             expand_in_expr(&mut a.right, fn_defaults, method_defaults);
         }
         Expr::New(n) => {
+            // Recurse nos args providos primeiro.
             if let Some(args) = n.args.as_mut() {
                 for a in args {
                     expand_in_expr(&mut a.expr, fn_defaults, method_defaults);
+                }
+            }
+            // (375) Preenche defaults do constructor da classe quando o
+            // callsite omite args. `new A()` com `constructor(e = 100)` ->
+            // `new A(100)`.
+            let class_name = if let Expr::Ident(id) = n.callee.as_ref() {
+                Some(id.sym.to_string())
+            } else {
+                None
+            };
+            if let Some(cn) = class_name {
+                if let Some((param_names, defaults)) =
+                    method_defaults.get(&(cn, "<constructor>".to_string()))
+                {
+                    let args_vec = n.args.get_or_insert_with(Vec::new);
+                    let provided = args_vec.len();
+                    let total = defaults.len();
+                    if provided < total {
+                        let mut bindings: std::collections::HashMap<String, Expr> =
+                            std::collections::HashMap::new();
+                        for (idx, arg) in args_vec.iter().enumerate() {
+                            if let Some(pn) = param_names.get(idx) {
+                                bindings.insert(pn.clone(), (*arg.expr).clone());
+                            }
+                        }
+                        for i in provided..total {
+                            if let Some(def) = &defaults[i] {
+                                let mut def_clone = (**def).clone();
+                                substitute_param_refs(&mut def_clone, &bindings);
+                                expand_in_expr(&mut def_clone, fn_defaults, method_defaults);
+                                if let Some(pn) = param_names.get(i) {
+                                    bindings.insert(pn.clone(), def_clone.clone());
+                                }
+                                args_vec.push(swc_ecma_ast::ExprOrSpread {
+                                    spread: None,
+                                    expr: Box::new(def_clone),
+                                });
+                            } else {
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tests/private_inheritance_defaults.test.ts
+++ b/tests/private_inheritance_defaults.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (375): private fields através de herança + default params em
+// constructor (próprio, herdado e via super) + getter/método retornando
+// campo string herdam o tipo correto (não handle cru).
+
+class Animal {
+  #name: string;
+  #energy: number;
+  constructor(name: string, energy = 100) {
+    this.#name = name;
+    this.#energy = energy;
+  }
+  #consume(amount: number) { this.#energy = Math.max(0, this.#energy - amount); }
+  eat(food: string, restore: number) {
+    this.#energy = Math.min(100, this.#energy + restore);
+    return this.#name + " eats " + food;
+  }
+  move(cost: number) { this.#consume(cost); return this.#name + " moves:" + this.#energy; }
+  get name() { return this.#name; }
+  get energy() { return this.#energy; }
+}
+class Dog extends Animal {
+  #tricks: string[] = [];
+  learn(trick: string) { this.#tricks.push(trick); return this.name + " learned " + trick; }
+}
+class GuideDog extends Dog {
+  #owner: string;
+  constructor(name: string, owner: string) { super(name); this.#owner = owner; }
+  guide() { return this.name + " guides " + this.#owner; }
+}
+
+// Dog herda constructor(name, energy=100) de Animal — default aplicado.
+const d = new Dog("Rex");
+const dEat = d.eat("bone", 10);   // 100
+const dMove = d.move(20);         // 80
+const dLearn = d.learn("sit");
+const dEnergy = d.energy;         // 80
+
+// GuideDog: super(name) aplica default energy=100 de Animal.
+const g = new GuideDog("Buddy", "Alice");
+const gGuide = g.guide();
+g.eat("kibble", 5);               // 100
+const gMove = g.move(10);         // 90
+
+// private com mesmo nome em hierarquia — slots distintos.
+class A { #v = "A-priv"; getV() { return this.#v; } }
+class B extends A { #v = "B-priv"; getBV() { return this.#v; } }
+const b = new B();
+
+describe("private inheritance + defaults", () => {
+  test("getter string herdado retorna nome", () => expect(dEat).toBe("Rex eats bone"));
+  test("default energy=100 herdado, move atualiza", () => expect(dMove).toBe("Rex moves:80"));
+  test("getter name via this em método de subclasse", () => expect(dLearn).toBe("Rex learned sit"));
+  test("energy persiste através de método privado", () => expect(dEnergy).toBe(80));
+  test("super(name) aplica default energy", () => expect(gMove).toBe("Buddy moves:90"));
+  test("guide usa getter herdado + private próprio", () => expect(gGuide).toBe("Buddy guides Alice"));
+  test("private #v slot da base", () => expect(b.getV()).toBe("A-priv"));
+  test("private #v slot da subclasse", () => expect(b.getBV()).toBe("B-priv"));
+});


### PR DESCRIPTION
## Problema

`375_private_inheritance` produzia handles crus (`281474976710733` em vez de `"Rex"`) e `energy:0`. Dois grupos de gaps:

### 1. Inferência de retorno de getter/método retornando `this.<campo>`

`get name() { return this.#name; }` e `getV() { return this.#v; }` **sem anotação** infeririam `F64` → um campo string voltava como o número do handle.

**Fix:** pré-passada coleta os tipos dos campos (anotação explícita + init string/bool) e o getter/método cujo corpo é `return this.<campo>` herda o tipo do campo.

### 2. Default params em constructor não aplicados

`expand_default_args` cobria fns top-level e métodos, mas **não constructors**. Cobertos agora:
- `new A()` com `constructor(e = 100)` → `new A(100)`
- **constructor herdado**: `class Dog extends Animal {}` + `new Dog("Rex")` usa os defaults do constructor de `Animal`
- **`super(name)`** com args omitidos → `super(name, 100)`

## Validação

- Resolve **#1057** (375_private_inheritance: energy 80/90, getters string, A-priv/B-priv, instanceof)
- Suite TS **1321/1321** verde (zero regressão)
- `cargo test --release --lib` 12/12
- Novo teste: `tests/private_inheritance_defaults.test.ts` (8 casos)

Nota: os comentários `// 90` no fixture do Rex divergem do cálculo real por spec (eat 10→100, move 20→80 = **80**); a saída do RTS é a correta por spec JS.

Segue `ROADMAP-CORRECAO.md` (Nível 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)