### PR TITLE
fix(codegen): private static Map + new Map(tuplas) sem crash (#1056 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -263,8 +263,46 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
             let mark_fn = ctx.get_extern(mark_sym, &[cl::I64], None)?;
             ctx.builder.ins().call(mark_fn, &[h]);
             // Initial entries: \`new Set([1,2,3])\` ou \`new Map([[\"a\",1],[\"b\",2]])\`.
-            // v0: aceita Expr::Array literal; outros casos sao no-op.
+            // Aceita Expr::Array literal (caminho estatico abaixo) E tambem
+            // arg que NAO eh array literal (var/expr que resolve pra Vec em
+            // runtime, ex: `new Map(entries)`) via MAP_FROM_ENTRIES.
             let init_arg = new_expr.args.as_ref().and_then(|args| args.first());
+            // (374) `new Map(<expr-nao-literal>)` — popula via runtime.
+            // Restrito a Ident/Member (var que ja' materializou o Vec de
+            // pares). CallExpr inline (`new Map(arr.map(...))`) e' excluido:
+            // o Vec temporario do .map+parallel ainda nao tem materializacao
+            // estavel e crashava no MAP_FROM_ENTRIES — usar var intermediaria
+            // (`const r = arr.map(...); new Map(r)`) funciona. Follow-up.
+            if class_name == "Map" {
+                if let Some(arg) = init_arg {
+                    let arg_is_safe = matches!(
+                        arg.expr.as_ref(),
+                        Expr::Ident(_) | Expr::Member(_)
+                            | Expr::Paren(_) | Expr::TsAs(_) | Expr::TsNonNull(_)
+                    );
+                    if arg.spread.is_none()
+                        && !matches!(arg.expr.as_ref(), Expr::Array(_))
+                        && arg_is_safe
+                    {
+                        let src_tv = lower_expr(ctx, &arg.expr)?;
+                        let src_h = ctx.coerce_to_i64(src_tv).val;
+                        let from_entries = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES",
+                            &[cl::I64],
+                            Some(cl::I64),
+                        )?;
+                        let inst_fe = ctx.builder.ins().call(from_entries, &[src_h]);
+                        let m2 = ctx.builder.inst_results(inst_fe)[0];
+                        let mark_fn2 = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_MARK_AS_MAP",
+                            &[cl::I64],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(mark_fn2, &[m2]);
+                        return Ok(TypedVal::new(m2, ValTy::Handle));
+                    }
+                }
+            }
             if let Some(arg) = init_arg {
                 if let Expr::Array(arr) = arg.expr.as_ref() {
                     if class_name == "Set" {

--- a/crates/rts-codegen/src/codegen/lower/passes/static_fields.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/static_fields.rs
@@ -238,6 +238,33 @@ fn default_expr_for_ann(ann: Option<&str>) -> Expr {
             span: Default::default(),
             value: false,
         })),
+        Some(t) if !t.ends_with("[]") => {
+            let base = t.split('<').next().unwrap_or(t).trim();
+            // (374) Map/Set sem init: default `new Map()`/`new Set()` (em vez
+            // de `0` numerico, que tipava o global como numero e fazia o
+            // member call crashar). O static block sobrescreve com o valor
+            // real; o default so' garante que o global ja' eh um handle valido.
+            if matches!(base, "Map" | "Set" | "WeakMap" | "WeakSet") {
+                Expr::New(swc_ecma_ast::NewExpr {
+                    span: Default::default(),
+                    ctxt: Default::default(),
+                    callee: Box::new(Expr::Ident(swc_ecma_ast::Ident {
+                        span: Default::default(),
+                        ctxt: Default::default(),
+                        sym: base.into(),
+                        optional: false,
+                    })),
+                    args: Some(Vec::new()),
+                    type_args: None,
+                })
+            } else {
+                Expr::Lit(Lit::Num(swc_ecma_ast::Number {
+                    span: Default::default(),
+                    value: 0.0,
+                    raw: None,
+                }))
+            }
+        }
         _ => Expr::Lit(Lit::Num(swc_ecma_ast::Number {
             span: Default::default(),
             value: 0.0,
@@ -250,12 +277,45 @@ fn default_expr_for_ann(ann: Option<&str>) -> Expr {
 /// ou "string". Tipos compostos sao deixados como undefined-ann; o
 /// codegen ainda usara o tipo do initializer.
 fn build_type_ann(ann: &str) -> Option<Box<swc_ecma_ast::TsTypeAnn>> {
-    use swc_ecma_ast::{TsKeywordType, TsKeywordTypeKind, TsType, TsTypeAnn};
-    let kind = match ann.trim() {
+    use swc_ecma_ast::{
+        Ident, TsEntityName, TsKeywordType, TsKeywordTypeKind, TsType, TsTypeAnn, TsTypeRef,
+    };
+    let trimmed = ann.trim();
+    let kind = match trimmed {
         "number" | "i64" | "f64" | "i32" => TsKeywordTypeKind::TsNumberKeyword,
         "string" => TsKeywordTypeKind::TsStringKeyword,
         "boolean" | "bool" => TsKeywordTypeKind::TsBooleanKeyword,
-        _ => return None,
+        _ => {
+            // (374) Tipos compostos por classe (Map<...>, Set<...>, RegExp,
+            // ou classe do usuario): preserva como TsTypeRef pra que o
+            // codegen registre a var global em global_class_ty e roteie
+            // `.set`/`.get` etc. Sem isso o static field private virava `0`
+            // numerico sem tipo e o member call crashava (SIGILL).
+            //
+            // Extrai o nome-base do tipo generico: `Map<number,string>` ->
+            // `Map`. `T[]` mantemos como None (array ja' tem heuristica
+            // propria via local_array_vars no caminho de field).
+            if trimmed.ends_with("[]") {
+                return None;
+            }
+            let base = trimmed.split('<').next().unwrap_or(trimmed).trim();
+            if base.is_empty() || !base.chars().next().unwrap().is_ascii_uppercase() {
+                return None;
+            }
+            return Some(Box::new(TsTypeAnn {
+                span: Default::default(),
+                type_ann: Box::new(TsType::TsTypeRef(TsTypeRef {
+                    span: Default::default(),
+                    type_name: TsEntityName::Ident(Ident {
+                        span: Default::default(),
+                        ctxt: Default::default(),
+                        sym: base.into(),
+                        optional: false,
+                    }),
+                    type_params: None,
+                })),
+            }));
+        }
     };
     Some(Box::new(TsTypeAnn {
         span: Default::default(),

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1903,22 +1903,26 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES(arr: u64) -> u64 {
     let m = alloc_entry(Entry::Map(Box::new(IndexMap::new())));
     for ph in pair_handles {
         let pair_h = ph as u64;
-        let kv: Option<(String, i64)> = with_entry(pair_h, |entry| match entry {
-            Some(Entry::Vec(pair)) if pair.len() >= 2 => {
-                let key_h = pair[0] as u64;
-                let key_str: Option<String> = with_entry(key_h, |ke| match ke {
-                    Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-                    _ => None,
-                });
-                key_str.map(|k| (k, pair[1]))
-            }
+        // Extrai (key_handle, value) SEM aninhar with_entry (evita reentrar
+        // no lock do mesmo shard -> deadlock). Resolve a String da chave
+        // numa segunda passada, ja' fora do lock do par.
+        let pair_kv: Option<(i64, i64)> = with_entry(pair_h, |entry| match entry {
+            Some(Entry::Vec(pair)) if pair.len() >= 2 => Some((pair[0], pair[1])),
             _ => None,
         });
-        if let Some((k, v)) = kv {
-            with_map_mut(m, (), |mm| {
-                mm.insert(k, v);
-            });
-        }
+        let Some((key_raw, val)) = pair_kv else { continue };
+        let key_h = key_raw as u64;
+        let key_str: Option<String> = with_entry(key_h, |ke| match ke {
+            Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            _ => None,
+        });
+        // (374) Chave numerica (`new Map([[1,"one"]])`): key_raw eh um i64
+        // cru, nao handle de String. Usa a representacao decimal como key,
+        // consistente com string_from_i64 do caminho de array literal.
+        let key = key_str.unwrap_or_else(|| key_raw.to_string());
+        with_map_mut(m, (), |mm| {
+            mm.insert(key, val);
+        });
     }
     m
 }

--- a/tests/private_static_map.test.ts
+++ b/tests/private_static_map.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (374, parcial): private static fields do tipo Map + static
+// initializer blocks. Cobre os casos que agora funcionam (antes crashavam
+// com SIGILL por causa do tipo Map perdido no static field).
+//
+// Follow-up: `new Map(arr.map(([k,v]) => [v,k]))` INLINE (Vec temporário de
+// .map+parallel) ainda não popula — usar var intermediária funciona.
+
+// (1) private static Map: set/get via método estático.
+class Counter {
+  static #counts: Map<string, number>;
+  static { Counter.#counts = new Map(); }
+  static bump(key: string): number {
+    const cur = Counter.#counts.get(key) ?? 0;
+    Counter.#counts.set(key, cur + 1);
+    return Counter.#counts.get(key) ?? -1;
+  }
+}
+const c1 = Counter.bump("a");
+const c2 = Counter.bump("a");
+const c3 = Counter.bump("b");
+
+// (2) new Map(entries) com array de tuplas (chave numérica) via var.
+const entries: [number, string][] = [[1, "one"], [2, "two"], [3, "three"]];
+const table = new Map(entries);
+const w1 = table.get(1);
+const w3 = table.get(3);
+
+// (3) new Map(arr.map(...)) com var intermediária (reverse lookup).
+const rev = entries.map(([k, v]) => [v, k] as [string, number]);
+const reverse = new Map(rev);
+const n = reverse.get("two");
+
+// (4) static initializer block simples (private static number).
+class Config {
+  static #version: string;
+  static #limit: number;
+  static { Config.#version = "1.0"; Config.#limit = 42; }
+  static get version(): string { return Config.#version; }
+  static get limit(): number { return Config.#limit; }
+}
+
+describe("private static map", () => {
+  test("private static Map bump 1", () => expect(c1).toBe(1));
+  test("private static Map bump 2 mesma chave", () => expect(c2).toBe(2));
+  test("private static Map bump outra chave", () => expect(c3).toBe(1));
+  test("new Map(tuplas) chave numérica get(1)", () => expect(w1).toBe("one"));
+  test("new Map(tuplas) chave numérica get(3)", () => expect(w3).toBe("three"));
+  test("new Map(arr.map) via var — reverse lookup", () => expect(n).toBe(2));
+  test("static block: version", () => expect(Config.version).toBe("1.0"));
+  test("static block: limit", () => expect(Config.limit).toBe(42));
+});


### PR DESCRIPTION
## Problema

`374_private_static_methods` crashava com **SIGILL** ao acessar private static field do tipo `Map`. Raiz: o static_fields pass descartava o tipo composto (`Map<...>`), o global virava um `0` numérico sem tipo, e o member call `.get/.set` saltava para lixo.

## Fixes

1. **`build_type_ann`** preserva tipos compostos por classe (`Map<...>`, `Set<...>`, etc.) como `TsTypeRef` em vez de retornar `None`. **`default_expr_for_ann`** gera `new Map()`/`new Set()` para o default (em vez de `0`).

2. **`new Map(<expr-não-array>)`** (ex: `new Map(entries)`) popula via `MAP_FROM_ENTRIES` em runtime, aceitando chave numérica (`[[1,"one"]]` → key `"1"`).

3. **`MAP_FROM_ENTRIES`**: corrige **deadlock** por aninhamento de `with_entry` (par + chave no mesmo shard) — extrai os handles antes de resolver a String fora do lock.

## Bail seguro (não-regressivo)

`new Map(<callExpr inline>)` (ex: `new Map(arr.map(([k,v])=>[v,k]))`) restrito a Ident/Member: o Vec temporário do `.map`+parallel inline crashava. **Usar var intermediária funciona** (`const r = arr.map(...); new Map(r)`). O caso inline cai no comportamento antigo (Map vazio) em vez de crash. **#1056 segue aberta** para o follow-up.

## Validação

- Crash SIGILL **eliminado**; vários sub-casos de 374 destravados
- Suite TS **1329/1329** (+8 destravados), zero regressão
- `cargo test --release --lib` 12/12
- Novo teste: `tests/private_static_map.test.ts` (8 casos)

Segue `ROADMAP-CORRECAO.md` (Nível 1, parcial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)