### PR TITLE
fix(codegen): arrow liftada preserva seus próprios parâmetros (#195 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -649,6 +649,94 @@ impl LiftAcc {
     /// `__lifted_arrow_N`. Retorna o `Ident` que substitui a arrow no AST.
     /// Não trata captura de `this` — caller é responsável por garantir que
     /// a arrow não usa `this` (ou está fora de classe).
+    /// (#195 parcial) Converte os parametros proprios de uma arrow
+    /// (`Vec<Pat>`) em `Vec<Parameter>` + prologo de destructuring, espelhando
+    /// `hoist_fn::build_fn_decl`. Sem isso a arrow liftada perdia os proprios
+    /// params (`(i) => values[i]` virava fn sem `i` -> "undefined variable i").
+    /// Cobre rest (`...args`), destructuring (`[k,v]`/`{a}`) e filtra `this`.
+    fn arrow_params_to_parameters(
+        arrow: &swc_ecma_ast::ArrowExpr,
+        syn_name: &str,
+    ) -> (Vec<Parameter>, Vec<Stmt>) {
+        let mut prologue: Vec<Stmt> = Vec::new();
+        let mut parameters: Vec<Parameter> = Vec::with_capacity(arrow.params.len());
+        for (i, pat) in arrow.params.iter().enumerate() {
+            let pat_for_destruct: Option<&Pat> = match pat {
+                Pat::Array(_) | Pat::Object(_) => Some(pat),
+                Pat::Assign(a) if matches!(a.left.as_ref(), Pat::Array(_) | Pat::Object(_)) => {
+                    Some(a.left.as_ref())
+                }
+                _ => None,
+            };
+            if let Some(dpat) = pat_for_destruct {
+                let synth_name = format!("__lift_destruct_{}_{}", syn_name, i);
+                let synth_ident = swc_ecma_ast::Ident::new(
+                    synth_name.as_str().into(),
+                    Default::default(),
+                    Default::default(),
+                );
+                let var_decl = swc_ecma_ast::VarDecl {
+                    span: Default::default(),
+                    ctxt: Default::default(),
+                    kind: swc_ecma_ast::VarDeclKind::Const,
+                    declare: false,
+                    decls: vec![swc_ecma_ast::VarDeclarator {
+                        span: Default::default(),
+                        name: dpat.clone(),
+                        init: Some(Box::new(Expr::Ident(synth_ident))),
+                        definite: false,
+                    }],
+                };
+                prologue.push(Stmt::Decl(swc_ecma_ast::Decl::Var(Box::new(var_decl))));
+                parameters.push(Parameter {
+                    name: synth_name,
+                    type_annotation: None,
+                    modifiers: MemberModifiers::default(),
+                    variadic: false,
+                    default: None,
+                    span: Span::default(),
+                });
+            } else if let Pat::Rest(rest) = pat {
+                if let Pat::Ident(b) = rest.arg.as_ref() {
+                    parameters.push(Parameter {
+                        name: b.id.sym.to_string(),
+                        type_annotation: None,
+                        modifiers: MemberModifiers::default(),
+                        variadic: true,
+                        default: None,
+                        span: Span::default(),
+                    });
+                }
+            } else if let Pat::Ident(b) = pat {
+                let n = b.id.sym.to_string();
+                if n == "this" {
+                    continue;
+                }
+                parameters.push(Parameter {
+                    name: n,
+                    type_annotation: None,
+                    modifiers: MemberModifiers::default(),
+                    variadic: false,
+                    default: None,
+                    span: Span::default(),
+                });
+            } else if let Pat::Assign(a) = pat {
+                // Param com default `(x = 1) => ...` — nome simples + default.
+                if let Pat::Ident(b) = a.left.as_ref() {
+                    parameters.push(Parameter {
+                        name: b.id.sym.to_string(),
+                        type_annotation: None,
+                        modifiers: MemberModifiers::default(),
+                        variadic: false,
+                        default: Some(a.right.clone()),
+                        span: Span::default(),
+                    });
+                }
+            }
+        }
+        (parameters, prologue)
+    }
+
     fn lift_arrow_to_ident(
         &mut self,
         class_name: &str,
@@ -657,7 +745,19 @@ impl LiftAcc {
     ) -> swc_ecma_ast::Ident {
         let has_return_value = matches!(arrow.body.as_ref(), swc_ecma_ast::BlockStmtOrExpr::Expr(_));
         let raw_stmts = arrow_body_to_stmts(arrow);
-        let mut body_stmts: Vec<Statement> = raw_stmts
+
+        let syn_name = format!("__lifted_arrow_{}", self.counter);
+        self.counter += 1;
+
+        // (#195 parcial) Preserva os parametros proprios da arrow. Antes
+        // descartados (parameters: Vec::new()), o que quebrava qualquer arrow
+        // com params: `(i) => values[i]` perdia `i`. Prologo cobre
+        // destructuring; rest vira variadic (expand_rest_args trata depois).
+        let (parameters, prologue) = Self::arrow_params_to_parameters(arrow, &syn_name);
+
+        let mut all_stmts: Vec<Stmt> = prologue;
+        all_stmts.extend(raw_stmts);
+        let mut body_stmts: Vec<Statement> = all_stmts
             .into_iter()
             .map(|s| {
                 Statement::Raw(
@@ -665,9 +765,6 @@ impl LiftAcc {
                 )
             })
             .collect();
-
-        let syn_name = format!("__lifted_arrow_{}", self.counter);
-        self.counter += 1;
 
         // Recurse para arrows aninhadas.
         self.lift_in_body(class_name, &mut body_stmts, in_class);
@@ -679,7 +776,7 @@ impl LiftAcc {
 
         self.new_fns.push(Item::Function(FunctionDecl {
             name: syn_name.clone(),
-            parameters: Vec::new(),
+            parameters,
             return_type: ret_ty,
             body: body_stmts,
             span: Span::default(),

--- a/tests/lifted_arrow_params.test.ts
+++ b/tests/lifted_arrow_params.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (#195 parcial): arrow liftada (em const/return dentro de fn)
+// deve PRESERVAR seus próprios parâmetros. Antes, lift_arrow_to_ident
+// descartava os params (`parameters: Vec::new()`), então `(i) => i*2`
+// virava uma fn sem `i` → "undefined variable i".
+
+// arrow com 1 param, chamada direta
+const dbl = (x: number) => x * 2;
+
+// arrow com 2 params
+const add = (a: number, b: number) => a + b;
+
+// arrow com param dentro de fn, chamada local
+function useLocal(): number {
+  const g = (i: number) => i + 100;
+  return g(5);
+}
+
+// arrow com destructuring de param
+const pt = ({ x, y }: { x: number; y: number }) => x + y;
+
+// arrow com param default
+const inc = (n: number, by = 1) => n + by;
+
+describe("lifted arrow params", () => {
+  test("arrow 1 param", () => expect(dbl(21)).toBe(42));
+  test("arrow 2 params", () => expect(add(20, 22)).toBe(42));
+  test("arrow param dentro de fn", () => expect(useLocal()).toBe(105));
+  test("arrow destructuring de param", () => expect(pt({ x: 40, y: 2 })).toBe(42));
+  test("arrow param com default (fornecido)", () => expect(inc(40, 2)).toBe(42));
+  test("arrow param com default (omitido)", () => expect(inc(41)).toBe(42));
+});


### PR DESCRIPTION
## Problema

`lift_arrow_to_ident` (this_arrow.rs) descartava os parâmetros da arrow (`parameters: Vec::new()`). Qualquer arrow com params em `const`/`return` dentro de uma fn os perdia:

```ts
function f() { const g = (i: number) => i * 2; return g(5); }
// erro: undefined variable `i` em __lifted_arrow_0
```

O próprio param `i` sumia — nem chegava a ser captura.

## Fix

Novo `arrow_params_to_parameters` converte `arrow.params` (`Vec<Pat>`) em `Vec<Parameter>` + prólogo, espelhando `hoist_fn::build_fn_decl`. Cobre:
- param simples e múltiplos
- rest (`...args` → variadic)
- destructuring (`({x,y}) =>`)
- default (`(n, by=1) =>`)
- filtra o pseudo-param `this`

Arrows zero-param (callbacks UI/C-ABI típicos) não mudam.

## Escopo

**Não** resolve captura de variáveis livres (`(b) => a + b` onde `a` é do escopo externo) — isso é a captura-por-valor / env-record do #195, follow-up. Mas o param próprio agora funciona, destravando vários casos.

## Validação

- Suite TS **1337/1337** (+8 destravados), zero regressão
- `cargo test --release --lib` 12/12
- Novo teste: `tests/lifted_arrow_params.test.ts` (6 casos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)