### PR TITLE
feat(generators): protocolo .next()/.value/.done para generators finitos

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -179,6 +179,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
 
     // ── namespaces::gc ────────────────────────────────────────────────
     use crate::namespaces::gc::string_pool::*;
+    add_fn!("__RTS_FN_NS_GC_GENERATOR_NEXT", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_NEXT);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_REGISTER", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_REGISTER);
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -81,6 +81,22 @@ pub fn compile_program(
     expand_spread_args(program);
     expand_rest_args(program);
 
+    // (generators) Detecta user fns que sao generators: o generator_desugar
+    // prepend `const __gen_buf = []` no body. Registra os nomes num
+    // thread-local pra que o decl marque `const it = g()` como generator_var
+    // e `it.next()` roteie para GENERATOR_NEXT (cursor lateral).
+    {
+        let mut gen_fns: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for item in &program.items {
+            if let Item::Function(f) = item {
+                if fn_body_declares_gen_buf(&f.body) {
+                    gen_fns.insert(f.name.clone());
+                }
+            }
+        }
+        set_generator_fns(gen_fns);
+    }
+
     // Single-file AOT path: imports are not stripped before compile_program,
     // so we scan them here to populate node_import_map (JIT multi-file path
     // already populated this in ModuleGraph::flatten_for_jit).
@@ -1038,6 +1054,41 @@ fn has_return_value(body: &[Statement]) -> bool {
         if let Some(stmt) = raw.stmt.as_ref() {
             if check_stmt(stmt) {
                 return true;
+            }
+        }
+    }
+    false
+}
+
+thread_local! {
+    static GENERATOR_FNS: std::cell::RefCell<std::collections::HashSet<String>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// (generators) Registra nomes de generator fns (detectadas via
+/// `const __gen_buf = []` no body — marcador do generator_desugar).
+pub(crate) fn set_generator_fns(fns: std::collections::HashSet<String>) {
+    GENERATOR_FNS.with(|c| *c.borrow_mut() = fns);
+}
+
+/// (generators) True se `name` eh uma generator fn registrada.
+pub(crate) fn is_generator_fn(name: &str) -> bool {
+    GENERATOR_FNS.with(|c| c.borrow().contains(name))
+}
+
+/// (generators) True se o body declara `const __gen_buf = ...` no topo —
+/// marcador do generator_desugar.
+fn fn_body_declares_gen_buf(body: &[Statement]) -> bool {
+    use crate::parser::ast::Statement;
+    use swc_ecma_ast::{Decl, Pat, Stmt};
+    for s in body {
+        let Statement::Raw(raw) = s;
+        let Some(Stmt::Decl(Decl::Var(v))) = raw.stmt.as_ref() else { continue };
+        for d in &v.decls {
+            if let Pat::Ident(id) = &d.name {
+                if id.id.sym.as_str() == "__gen_buf" {
+                    return true;
+                }
             }
         }
     }

--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -527,6 +527,11 @@ pub struct FnCtx<'m, 'fb> {
     /// string builtin (`__RTS_FN_GL_STRING_INDEX_OF`) e retorna lixo.
     pub local_array_vars: std::collections::HashSet<String>,
 
+    /// (generators) Vars inicializadas com chamada a uma generator fn
+    /// (`const it = g()`). `it.next()` roteia para GENERATOR_NEXT (cursor
+    /// lateral sobre o Vec); outras vars com `.next()` usam dispatch normal.
+    pub generator_vars: std::collections::HashSet<String>,
+
     /// Counter para gerar nomes únicos de locals temporários em
     /// optional chain calls aninhadas (#481). Usado por
     /// `lower_opt_chain` quando o receiver é uma expressão complexa
@@ -610,6 +615,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),
             local_array_vars: std::collections::HashSet::new(),
+            generator_vars: std::collections::HashSet::new(),
             local_nested_obj_field_types: HashMap::new(),
             opt_chain_temp_counter: 0,
             current_fn_name: String::new(),

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -169,6 +169,33 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         return lower_dynamic_import(ctx, call);
     }
     if let Callee::Expr(callee) = &call.callee {
+        // (generators) `<genVar>.next()` — protocolo de iterador finito.
+        // Roteia para GENERATOR_NEXT (cursor lateral sobre o Vec retornado
+        // pela generator fn), devolvendo `{value,done}` (Map). So' dispara
+        // para vars marcadas como generator (`const it = g()`), evitando
+        // conflito com objetos que tem `.next()` proprio.
+        if let Expr::Member(m) = callee.as_ref() {
+            if let MemberProp::Ident(prop) = &m.prop {
+                if prop.sym.as_str() == "next" && call.args.is_empty() {
+                    if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                        if ctx.generator_vars.contains(obj_id.sym.as_str()) {
+                            use cranelift_codegen::ir::types as cl;
+                            let recv_tv = lower_expr(ctx, &m.obj)?;
+                            let recv = ctx.coerce_to_i64(recv_tv).val;
+                            let next_fn = ctx.get_extern(
+                                "__RTS_FN_NS_GC_GENERATOR_NEXT",
+                                &[cl::I64],
+                                Some(cl::I64),
+                            )?;
+                            let inst = ctx.builder.ins().call(next_fn, &[recv]);
+                            let h = ctx.builder.inst_results(inst)[0];
+                            ctx.declare_gc_handle(h);
+                            return Ok(TypedVal::new(h, ValTy::Handle));
+                        }
+                    }
+                }
+            }
+        }
         if let Expr::SuperProp(sp) = callee.as_ref() {
             return lower_super_method_call(ctx, sp, call);
         }

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -23,6 +23,21 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         };
 
         if let Pat::Ident(id) = &decl.name {
+            // (generators) `const it = g()` onde `g` eh generator fn -> marca
+            // `it` como generator_var pra que `it.next()` use GENERATOR_NEXT.
+            if let Some(init) = &decl.init {
+                if let swc_ecma_ast::Expr::Call(c) = init.as_ref() {
+                    if let swc_ecma_ast::Callee::Expr(callee) = &c.callee {
+                        if let swc_ecma_ast::Expr::Ident(fid) = callee.as_ref() {
+                            if crate::codegen::lower::compile::program::is_generator_fn(
+                                fid.sym.as_str(),
+                            ) {
+                                ctx.generator_vars.insert(name.clone());
+                            }
+                        }
+                    }
+                }
+            }
             if let Some(ann) = id.type_ann.as_ref() {
                 // (372) `f: () => number` — fn que retorna number. Marca pra
                 // que `f()` reinterprete o i64-bits do invoke como f64.

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -1,0 +1,72 @@
+//! Generator MVP (finito) — protocolo `.next()/.value/.done`.
+//!
+//! Abordagem ON-DEMAND: o `generator_desugar` (parser) continua fazendo
+//! eager-buffer e `g()` retorna o **Vec** diretamente — for-of/spread iteram
+//! o Vec como hoje, SEM mudanca. Para `.next()`, mantemos um cursor lateral
+//! por-handle num HashMap thread-local. `GENERATOR_NEXT(vec_handle)` le/avanca
+//! esse cursor e devolve `{value,done}` (Map). Assim nao alteramos o tipo de
+//! retorno de g() nem o for-of (evita a regressao da tentativa anterior, onde
+//! envolver o Vec num wrapper quebrava o for-of de corpo simples).
+//!
+//! Generators INFINITOS (`while(true) yield`) estouram o eager-buffer e exigem
+//! state-machine real — follow-up (#477).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry};
+
+/// Sentinel `undefined` (i64::MIN+2) — convencao do codegen/INSPECT.
+const UNDEFINED: i64 = i64::MIN + 2;
+/// Sentinels de bool: MIN = false, MIN+1 = true (igual TPL_COERCE_AUTO).
+const BOOL_FALSE: i64 = i64::MIN;
+const BOOL_TRUE: i64 = i64::MIN + 1;
+
+thread_local! {
+    /// Cursor de iteracao por handle de Vec consumido via `.next()`.
+    static GEN_CURSORS: RefCell<HashMap<u64, usize>> = RefCell::new(HashMap::new());
+}
+
+/// `gen.next()` onde `gen` eh o Vec retornado por uma generator fn finita.
+/// Avanca o cursor lateral do handle e devolve `{value, done}` (Map). Quando
+/// o handle NAO eh um Vec (objeto com `.next()` proprio, etc), retorna
+/// `{value:undefined, done:true}` — caller deve rotear so' p/ generator_vars.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_NEXT(vec_handle: u64) -> u64 {
+    let len = with_entry(vec_handle, |e| match e {
+        Some(Entry::Vec(v)) => Some(v.len()),
+        _ => None,
+    });
+    let Some(len) = len else {
+        return make_result(UNDEFINED, true);
+    };
+    let cursor = GEN_CURSORS.with(|c| {
+        let mut m = c.borrow_mut();
+        let entry = m.entry(vec_handle).or_insert(0);
+        let cur = *entry;
+        if cur <= len {
+            *entry = cur + 1;
+        }
+        cur
+    });
+    if cursor < len {
+        let val = with_entry(vec_handle, |e| match e {
+            Some(Entry::Vec(v)) => v[cursor],
+            _ => UNDEFINED,
+        });
+        make_result(val, false)
+    } else {
+        // Esgotado. MVP nao captura `return X` do generator -> value undefined.
+        make_result(UNDEFINED, true)
+    }
+}
+
+/// Aloca o objeto-resultado `{value, done}` como Map.
+fn make_result(value: i64, done: bool) -> u64 {
+    let mut m: IndexMap<String, i64> = IndexMap::new();
+    m.insert("value".to_string(), value);
+    m.insert("done".to_string(), if done { BOOL_TRUE } else { BOOL_FALSE });
+    alloc_entry(Entry::Map(Box::new(m)))
+}

--- a/crates/rts-runtime/src/namespaces/gc/mod.rs
+++ b/crates/rts-runtime/src/namespaces/gc/mod.rs
@@ -11,6 +11,7 @@ pub mod collector;
 pub mod debug;
 pub mod env;
 pub mod error;
+pub mod generator;
 pub mod global_roots;
 pub mod handles;
 pub mod instance;

--- a/tests/generator_next_protocol.test.ts
+++ b/tests/generator_next_protocol.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (generators MVP): protocolo `.next()/.value/.done` para
+// generators FINITOS, via cursor lateral por-handle (on-demand). Antes,
+// `g().next()` crashava (SIGILL). Generators INFINITOS (`while(true) yield`)
+// ainda exigem state-machine real (follow-up #477).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// .next()/.value/.done
+function* g() { yield 1; yield 2; yield 3; }
+const it = g();
+print("" + it.next().value);   // 1
+print("" + it.next().value);   // 2
+print("" + it.next().value);   // 3
+print("" + it.next().done);    // true
+
+// for-of de generator finito continua funcionando (eager-buffer Vec)
+function* letters() { yield 10; yield 20; yield 30; }
+let sum = 0;
+for (const v of letters()) sum = sum + v;
+print("sum=" + sum);  // 60
+
+// spread
+const arr = [...letters()];
+print("len=" + arr.length);  // 3
+
+// duas instâncias do mesmo generator têm cursores independentes
+function* nums() { yield 5; yield 6; }
+const a = nums();
+const b = nums();
+print("ab=" + a.next().value + "," + b.next().value + "," + a.next().value);  // 5,5,6
+
+describe("generator next protocol (finite)", () => {
+  test("next/value/done", () => expect(out.startsWith("1\n2\n3\ntrue\n")).toBe(true));
+  test("for-of preservado", () => expect(out.indexOf("sum=60\n") >= 0).toBe(true));
+  test("spread preservado", () => expect(out.indexOf("len=3\n") >= 0).toBe(true));
+  test("cursores independentes", () => expect(out.indexOf("ab=5,5,6\n") >= 0).toBe(true));
+});


### PR DESCRIPTION
## O que

`g().next()` crashava (SIGILL) — não havia handler para o protocolo de iterador. Agora:

```ts
function* g() { yield 1; yield 2; yield 3; }
const it = g();
it.next().value;  // 1, depois 2, 3
it.next().done;   // true (esgotado)
```

## Como — abordagem on-demand (cursor lateral)

`g()` **continua retornando o Vec** do eager-buffer (`generator_desugar`) — for-of/spread iteram o Vec como antes, **sem mudança** (evita a regressão de uma tentativa anterior que envolvia o Vec num wrapper).

Para `.next()`, um `HashMap` thread-local guarda o cursor por handle de Vec. `GENERATOR_NEXT` lê/avança e devolve `{value,done}` (Map). Cursores por-handle dão **instâncias independentes** (`const a = nums(); const b = nums()` não compartilham posição).

- `.next()` roteia para GENERATOR_NEXT **só** quando a var está em `generator_vars` (marcada em `const it = g()` onde `g` é detectada como generator via `const __gen_buf` no body). Isso evita conflito com objetos que têm `.next()` próprio.
- `.value`/`.done` reusam o member-access de Map (o resultado é um `{value,done}` Map).

## Escopo

**Funciona:** `.next()/.value/.done` finito, for-of, spread, instâncias independentes.

**Follow-up (#477):** generators **infinitos** (`while(true) yield` estoura o eager-buffer), `return X` no gen (value undefined no MVP), `yield*`, `throw`, `return`, two-way `yield`. Exigem state-machine real.

## Validação

- Crash SIGILL **eliminado**
- Suite TS **1352/1352** (+4), zero regressão
- `cargo test --release --lib` 12/12
- Novo teste: `tests/generator_next_protocol.test.ts` (4 casos, incl. a combinação next+for-of que falhava antes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)