### PR TITLE
feat(generators): return X num generator finito via .next()

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -180,6 +180,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     // ── namespaces::gc ────────────────────────────────────────────────
     use crate::namespaces::gc::string_pool::*;
     add_fn!("__RTS_FN_NS_GC_GENERATOR_NEXT", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_NEXT);
+    add_fn!("__RTS_FN_NS_GC_GENERATOR_SET_RET", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_SET_RET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_REGISTER", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_REGISTER);
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -169,6 +169,26 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
         return lower_dynamic_import(ctx, call);
     }
     if let Callee::Expr(callee) = &call.callee {
+        // (generators) `__RTS_GEN_FINISH(buf, ret)` — sentinela do
+        // generator_desugar no `return`. Registra o ret_value (devolvido pelo
+        // `.next()` ao esgotar) e retorna o Vec `buf`.
+        if let Expr::Ident(id) = callee.as_ref() {
+            if id.sym.as_str() == "__RTS_GEN_FINISH" && call.args.len() == 2 {
+                use cranelift_codegen::ir::types as cl;
+                let buf_tv = lower_expr(ctx, &call.args[0].expr)?;
+                let buf = ctx.coerce_to_i64(buf_tv).val;
+                let ret_tv = lower_expr(ctx, &call.args[1].expr)?;
+                let ret = ctx.coerce_to_i64(ret_tv).val;
+                let set_ret = ctx.get_extern(
+                    "__RTS_FN_NS_GC_GENERATOR_SET_RET",
+                    &[cl::I64, cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(set_ret, &[buf, ret]);
+                let h = ctx.builder.inst_results(inst)[0];
+                return Ok(TypedVal::new(h, ValTy::Handle));
+            }
+        }
         // (generators) `<genVar>.next()` — protocolo de iterador finito.
         // Roteia para GENERATOR_NEXT (cursor lateral sobre o Vec retornado
         // pela generator fn), devolvendo `{value,done}` (Map). So' dispara

--- a/crates/rts-parser/src/generator_desugar.rs
+++ b/crates/rts-parser/src/generator_desugar.rs
@@ -47,14 +47,18 @@ pub fn desugar_generator_body(body: &BlockStmt) -> BlockStmt {
         stmts.push(transform_stmt(stmt.clone()));
     }
 
-    // return __gen_buf;
+    // return __RTS_GEN_FINISH(__gen_buf, undefined);
+    // O codegen mapeia FINISH(vec, ret) -> registra o ret_value do Vec no
+    // side-table do generator e retorna o Vec. `return X` no corpo (tratado
+    // em transform_stmt) ja' usa FINISH com o X. Este eh o caso "esgotou sem
+    // return explicito" -> ret undefined.
     stmts.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
         span,
-        arg: Some(Box::new(Expr::Ident(Ident::new(
-            BUF_NAME.into(),
+        arg: Some(Box::new(gen_finish_call(
+            Expr::Ident(Ident::new(BUF_NAME.into(), span, Default::default())),
+            None,
             span,
-            Default::default(),
-        )))),
+        ))),
     }));
 
     BlockStmt {
@@ -121,8 +125,42 @@ fn transform_stmt(stmt: Stmt) -> Stmt {
             right: Box::new(transform_expr(*fi.right)),
             body: Box::new(transform_stmt(*fi.body)),
         }),
+        // `return X` num generator: retorna o buffer-ate-aqui com X como
+        // ret_value (via FINISH). `return;` (sem arg) -> ret undefined.
+        Stmt::Return(r) => Stmt::Return(swc_ecma_ast::ReturnStmt {
+            span: r.span,
+            arg: Some(Box::new(gen_finish_call(
+                Expr::Ident(Ident::new(BUF_NAME.into(), r.span, Default::default())),
+                r.arg.as_deref().cloned(),
+                r.span,
+            ))),
+        }),
         other => other,
     }
+}
+
+/// Constroi `__RTS_GEN_FINISH(buf, ret)` — sentinela que o codegen mapeia
+/// pra registrar o ret_value do generator e devolver o Vec.
+fn gen_finish_call(buf: Expr, ret: Option<Expr>, span: swc_common::Span) -> Expr {
+    let ret_expr = ret.unwrap_or(Expr::Ident(Ident::new(
+        "undefined".into(),
+        span,
+        Default::default(),
+    )));
+    Expr::Call(CallExpr {
+        span,
+        ctxt: Default::default(),
+        callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
+            "__RTS_GEN_FINISH".into(),
+            span,
+            Default::default(),
+        )))),
+        args: vec![
+            ExprOrSpread { spread: None, expr: Box::new(buf) },
+            ExprOrSpread { spread: None, expr: Box::new(ret_expr) },
+        ],
+        type_args: None,
+    })
 }
 
 fn transform_expr(expr: Expr) -> Expr {

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -27,6 +27,22 @@ const BOOL_TRUE: i64 = i64::MIN + 1;
 thread_local! {
     /// Cursor de iteracao por handle de Vec consumido via `.next()`.
     static GEN_CURSORS: RefCell<HashMap<u64, usize>> = RefCell::new(HashMap::new());
+    /// Valor de `return X` do generator por handle de Vec. Devolvido pelo
+    /// primeiro `.next()` apos esgotar os yields (`{value:X, done:true}`).
+    static GEN_RETS: RefCell<HashMap<u64, i64>> = RefCell::new(HashMap::new());
+}
+
+/// `__RTS_GEN_FINISH(buf, ret)` — registra o ret_value do generator (do
+/// `return X`) e devolve o proprio Vec. Chamado no `return` desugarado.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_SET_RET(vec_handle: u64, ret: i64) -> u64 {
+    // So' registra ret nao-undefined (evita poluir o side-table a toa).
+    if ret != UNDEFINED {
+        GEN_RETS.with(|c| {
+            c.borrow_mut().insert(vec_handle, ret);
+        });
+    }
+    vec_handle
 }
 
 /// `gen.next()` onde `gen` eh o Vec retornado por uma generator fn finita.
@@ -57,8 +73,13 @@ pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_NEXT(vec_handle: u64) -> u64 {
             _ => UNDEFINED,
         });
         make_result(val, false)
+    } else if cursor == len {
+        // Primeiro next apos esgotar os yields: devolve o ret_value (`return
+        // X`) com done:true. Se nao houver, undefined.
+        let ret = GEN_RETS.with(|c| c.borrow().get(&vec_handle).copied()).unwrap_or(UNDEFINED);
+        make_result(ret, true)
     } else {
-        // Esgotado. MVP nao captura `return X` do generator -> value undefined.
+        // Esgotado e ja' devolveu o ret: value undefined, done:true (JS spec).
         make_result(UNDEFINED, true)
     }
 }

--- a/tests/generator_return_value.test.ts
+++ b/tests/generator_return_value.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (generators MVP): `return X` num generator finito. O primeiro
+// `.next()` após esgotar os yields devolve `{value: X, done: true}`; os
+// seguintes `{value: undefined, done: true}` (JS spec). for-of NÃO inclui o
+// valor de return entre os iterados.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function* withReturn() { yield 1; yield 2; return 99; }
+const g = withReturn();
+print("" + g.next().value);   // 1
+print("" + g.next().value);   // 2
+print("" + g.next().value);   // 99 (valor de return)
+print("" + g.next().done);    // true
+
+// for-of não itera o valor de return (só os yields)
+function* a() { yield 10; yield 20; return 999; }
+let sum = 0;
+for (const v of a()) sum += v;
+print("sum=" + sum);  // 30 (não inclui 999)
+
+describe("generator return value", () => {
+  test("return X via next ao esgotar", () => expect(out.startsWith("1\n2\n99\ntrue\n")).toBe(true));
+  test("for-of ignora valor de return", () => expect(out.indexOf("sum=30\n") >= 0).toBe(true));
+});


### PR DESCRIPTION
## O que

`function* g() { yield 1; yield 2; return 99; }` — o primeiro `.next()` após esgotar os yields agora devolve `{value: 99, done: true}`.

Antes dava `undefined` para tudo (e até os yields anteriores quebravam, porque `return X` permanecia cru no body e abortava a produção antes do `return __gen_buf`).

## Como

- **`generator_desugar`**: `return X` → `return __RTS_GEN_FINISH(__gen_buf, X)` (em vez de cair em `other => other`). O return final (esgotou sem `return` explícito) usa ret `undefined`.
- **runtime**: side-table `GEN_RETS` por handle de Vec; `GENERATOR_SET_RET` registra, `GENERATOR_NEXT` devolve o ret no primeiro `.next()` pós-esgotamento, `undefined` nos seguintes (JS spec).
- **codegen**: mapeia `__RTS_GEN_FINISH(buf, ret)` → SET_RET, retorna o buf.

`for-of`/spread **não** incluem o valor de `return` (só os yields) — preservado.

## Escopo

Reusa toda a infra do #1222 (cursor lateral). **Follow-up (#477):** infinito, `yield*`, `throw`, `return()`, two-way yield.

## Validação

- Suite TS **1352/1352**, zero regressão
- `cargo test --release --lib` 12/12
- Novo teste: `tests/generator_return_value.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)