### PR TITLE
feat(generators): gen.return(v) encerra generator finito

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -181,6 +181,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     use crate::namespaces::gc::string_pool::*;
     add_fn!("__RTS_FN_NS_GC_GENERATOR_NEXT", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_NEXT);
     add_fn!("__RTS_FN_NS_GC_GENERATOR_SET_RET", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_SET_RET);
+    add_fn!("__RTS_FN_NS_GC_GENERATOR_RETURN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_RETURN);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_REGISTER", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_REGISTER);
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -214,6 +214,29 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         }
                     }
                 }
+                // (generators) `<genVar>.return(v)` — encerra o generator,
+                // devolve `{value:v, done:true}` e marca esgotado. So' p/
+                // generator_vars.
+                if prop.sym.as_str() == "return" && call.args.len() == 1 {
+                    if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                        if ctx.generator_vars.contains(obj_id.sym.as_str()) {
+                            use cranelift_codegen::ir::types as cl;
+                            let recv_tv = lower_expr(ctx, &m.obj)?;
+                            let recv = ctx.coerce_to_i64(recv_tv).val;
+                            let val_tv = lower_expr(ctx, &call.args[0].expr)?;
+                            let val = ctx.coerce_to_i64(val_tv).val;
+                            let ret_fn = ctx.get_extern(
+                                "__RTS_FN_NS_GC_GENERATOR_RETURN",
+                                &[cl::I64, cl::I64],
+                                Some(cl::I64),
+                            )?;
+                            let inst = ctx.builder.ins().call(ret_fn, &[recv, val]);
+                            let h = ctx.builder.inst_results(inst)[0];
+                            ctx.declare_gc_handle(h);
+                            return Ok(TypedVal::new(h, ValTy::Handle));
+                        }
+                    }
+                }
             }
         }
         if let Expr::SuperProp(sp) = callee.as_ref() {

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -84,6 +84,24 @@ pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_NEXT(vec_handle: u64) -> u64 {
     }
 }
 
+/// `gen.return(v)` — encerra o generator antecipadamente. Marca o cursor
+/// como esgotado (proximos `.next()` dao done:true) e devolve `{value:v,
+/// done:true}` — semantica JS. `for-of` que ja' terminou nao eh afetado.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_RETURN(vec_handle: u64, value: i64) -> u64 {
+    let len = with_entry(vec_handle, |e| match e {
+        Some(Entry::Vec(v)) => Some(v.len()),
+        _ => None,
+    });
+    // Marca esgotado: cursor > len pra que NEXT devolva undefined/done.
+    if let Some(len) = len {
+        GEN_CURSORS.with(|c| {
+            c.borrow_mut().insert(vec_handle, len + 1);
+        });
+    }
+    make_result(value, true)
+}
+
 /// Aloca o objeto-resultado `{value, done}` como Map.
 fn make_result(value: i64, done: bool) -> u64 {
     let mut m: IndexMap<String, i64> = IndexMap::new();

--- a/tests/generator_return_method.test.ts
+++ b/tests/generator_return_method.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (generators MVP): `gen.return(v)` encerra o generator
+// antecipadamente — devolve `{value:v, done:true}` e marca esgotado, então
+// `.next()` subsequente dá done:true. Antes crashava (SIGILL, sem handler).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function* g() { yield 1; yield 2; yield 3; }
+const it = g();
+print("" + it.next().value);    // 1
+print("" + it.return(99).value); // 99 (encerra)
+print("" + it.next().done);     // true (esgotado, não continua yield 2)
+
+describe("generator return method", () => {
+  test("return(v) encerra e devolve v", () =>
+    expect(out).toBe("1\n99\ntrue\n"));
+});


### PR DESCRIPTION
## O que

`it.return(99)` crashava (SIGILL, sem handler). Agora encerra o generator: devolve `{value:99, done:true}` e marca esgotado, então `.next()` subsequente dá `done:true` (não continua os yields).

## Como

- **runtime** `__RTS_FN_NS_GC_GENERATOR_RETURN(vec, value)`: seta o cursor lateral `> len` (esgotado) e retorna `{value, done:true}`.
- **codegen**: `<genVar>.return(v)` (1 arg) roteia para GENERATOR_RETURN, só para `generator_vars` (mesma guarda do `.next()` — evita conflito com objetos que têm `.return` próprio).

Reusa a infra de cursor lateral do #1222/#1223.

## Validação

- Suite TS **1354/1354**, zero regressão
- `cargo test --release --lib` 12/12
- Novo teste: `tests/generator_return_method.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)