### PR TITLE
fix(codegen): ler campo bool de obj literal decodifica sentinel

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1873,7 +1873,29 @@ pub(super) fn map_get_static_typed(
             ValTy::I32,
         )),
         Some(ValTy::Handle) => Ok(TypedVal::new(v, ValTy::Handle)),
-        Some(ValTy::Bool) => Ok(TypedVal::new(v, ValTy::Bool)),
+        Some(ValTy::Bool) => {
+            // Bool em obj literal eh armazenado como sentinel (i64::MIN =
+            // false, i64::MIN+1 = true; ver store em lower de obj literal).
+            // O resto do codegen espera ValTy::Bool == 0/1, entao
+            // decodificamos aqui. Se o valor NAO esta no range sentinel
+            // (campo flat de classe nativa, que guarda 0/1 puro), usa
+            // `v != 0` — cobre ambos os layouts com seguranca.
+            use cranelift_codegen::ir::condcodes::IntCC;
+            let min = ctx.builder.ins().iconst(cl::I64, i64::MIN);
+            let min1 = ctx.builder.ins().iconst(cl::I64, i64::MIN + 1);
+            // is_sentinel = (v == MIN) || (v == MIN+1)
+            let eq_min = ctx.builder.ins().icmp(IntCC::Equal, v, min);
+            let eq_min1 = ctx.builder.ins().icmp(IntCC::Equal, v, min1);
+            let is_sentinel = ctx.builder.ins().bor(eq_min, eq_min1);
+            // decoded_sentinel = v - i64::MIN  (0 -> false, 1 -> true)
+            let decoded = ctx.builder.ins().isub(v, min);
+            // raw_bool = (v != 0) as i64 — fallback flat
+            let zero = ctx.builder.ins().iconst(cl::I64, 0);
+            let nz = ctx.builder.ins().icmp(IntCC::NotEqual, v, zero);
+            let raw_bool = ctx.builder.ins().uextend(cl::I64, nz);
+            let result = ctx.builder.ins().select(is_sentinel, decoded, raw_bool);
+            Ok(TypedVal::new(result, ValTy::Bool))
+        }
         // Campo `number` (F64): armazenado como os BITS do f64 (store
         // simetrico bitcasta f64->i64). Reinterpreta i64->f64 via bitcast.
         Some(ValTy::F64) => {

--- a/tests/obj_field_bool_read.test.ts
+++ b/tests/obj_field_bool_read.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): ler um campo `bool` de object literal cujo
+// valor eh `false` retornava `true`. Causa: obj literal armazena bool como
+// sentinel (i64::MIN = false, i64::MIN+1 = true), mas o map_get tipado
+// devolvia o sentinel bruto tagueado como Bool — o resto do codegen espera
+// Bool == 0/1, entao `false` (i64::MIN, nao-zero) coercia para "true".
+// Fix: decodificar o sentinel de volta para 0/1 na leitura.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const o = { a: true, b: false };
+print("" + o.a);          // true
+print("" + o.b);          // false (era "true")
+const viaDot = o.b;
+print("" + viaDot);       // false
+
+// destructuring (desugara para member access)
+const { a, b } = o;
+print("" + a);            // true
+print("" + b);            // false
+
+// usar bool de campo em condicional
+print(o.b ? "yes" : "no"); // no
+print(o.a ? "yes" : "no"); // yes
+
+// padrao generator-like { value, done }
+const r = { value: 42, done: false };
+const { value, done } = r;
+print("" + value + ":" + done); // 42:false
+
+describe("obj field bool read", () => {
+  test("false nao vira true", () =>
+    expect(out).toBe("true\nfalse\nfalse\ntrue\nfalse\nno\nyes\n42:false\n"));
+});


### PR DESCRIPTION
## Problema

Ler um campo `bool` de object literal cujo valor é `false` retornava `true`.

```ts
const o = { a: true, b: false };
o.b  // => true (errado!)
```

## Causa

Object literal armazena bool como sentinel (`i64::MIN` = false, `i64::MIN+1` = true) para distinguir de int 0/1 em `JSON.stringify`/`console.log`. Mas `map_get_static_typed` com `declared_ty=Bool` devolvia o sentinel bruto tagueado como `ValTy::Bool`. O resto do codegen espera `Bool == 0/1`, então `false` (= `i64::MIN`, não-zero) coercia para `"true"`.

## Fix

No branch `Some(ValTy::Bool)` de `map_get_static_typed`, decodifica o sentinel de volta para 0/1 (`v - i64::MIN`) quando `v` está no range sentinel; fallback `v != 0` para campos flat de classe nativa que guardam 0/1 puro — cobre ambos os layouts.

Afeta member access direto, **destructuring de objeto** (que desugara para member access) e o padrão `{ value, done }` de generators.

## Teste

`tests/obj_field_bool_read.test.ts` cobre member access, destructuring, condicional e o padrão `{value, done}`.

Suite **1354 → 1358** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)