### PR TITLE
feat(codegen): spread em chamada a user fn (f(...xs)) via INVOKE_AUTO

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -3008,6 +3008,69 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
         .ok_or_else(|| anyhow!("call to undeclared user function `{name}`"))?
         .clone();
 
+    // (cross-runtime #348) Spread em chamada a user fn: o call direto eh
+    // posicional (aridade fixa), incompativel com `f(...xs)` onde o numero
+    // de args so' se conhece em runtime. Roteia via INVOKE_AUTO sobre um
+    // handle Function reificado COM param_kinds/return_kind (lower_callable
+    // _target_h) — assim invoke_typed reinterpreta f64-bits corretamente.
+    // Monta o args Vec: push normal (f64 -> bits) + VEC_EXTEND_FROM p/ spread.
+    if call.args.iter().any(|a| a.spread.is_some()) {
+        let callee = lower_callable_target_h(
+            ctx,
+            &swc_ecma_ast::Expr::Ident(swc_ecma_ast::Ident {
+                span: Default::default(),
+                ctxt: Default::default(),
+                sym: name.into(),
+                optional: false,
+            }),
+        )?;
+        let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+        let vec_push = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+            &[cl::I64, cl::I64],
+            None,
+        )?;
+        let vec_extend = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM",
+            &[cl::I64, cl::I64],
+            None,
+        )?;
+        let new_inst = ctx.builder.ins().call(vec_new, &[]);
+        let args_vec = ctx.builder.inst_results(new_inst)[0];
+        ctx.declare_gc_handle(args_vec);
+        for arg in &call.args {
+            let tv = lower_expr(ctx, &arg.expr)?;
+            if arg.spread.is_some() {
+                // Source eh um Vec/array — extend com seus elementos.
+                let src = ctx.coerce_to_i64(tv).val;
+                ctx.builder.ins().call(vec_extend, &[args_vec, src]);
+            } else {
+                // Arg posicional: f64 viaja como BITS (invoke_typed
+                // reinterpreta via param_kinds[i]==1); o resto como i64.
+                let v = if matches!(tv.ty, ValTy::F64) {
+                    ctx.builder.ins().bitcast(
+                        cl::I64,
+                        cranelift_codegen::ir::MemFlags::new(),
+                        tv.val,
+                    )
+                } else {
+                    ctx.coerce_to_i64(tv).val
+                };
+                ctx.builder.ins().call(vec_push, &[args_vec, v]);
+            }
+        }
+        let invoke = ctx.get_extern(
+            "__RTS_FN_RT_INVOKE_AUTO",
+            &[cl::I64, cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let zero = ctx.builder.ins().iconst(cl::I64, 0);
+        let inst = ctx.builder.ins().call(invoke, &[callee, zero, args_vec]);
+        let v = ctx.builder.inst_results(inst)[0];
+        ctx.var_member_call_values.insert(v);
+        return Ok(TypedVal::new(v, ValTy::I64));
+    }
+
     let mangled: String = format!("__user_{name}");
     if !ctx.extern_cache.contains_key(mangled.as_str()) {
         return Err(anyhow!("call to undeclared user function `{name}`"));

--- a/tests/spread_user_fn_call.test.ts
+++ b/tests/spread_user_fn_call.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #348 parcial): spread em chamada a user fn
+// (`f(...xs)`) dava `error: spread not supported` — o call direto eh
+// posicional (aridade fixa). Fix: rotear via INVOKE_AUTO sobre handle
+// Function reificado com param_kinds (invoke_typed reinterpreta f64-bits).
+// Cobre args number (f64) e int, spread puro e misto com posicionais.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function adder(a: number, b: number, c: number): number { return a + b + c; }
+function sum2(a: number, b: number): number { return a + b; }
+
+// spread puro
+const xs = [1, 2, 3];
+print("" + adder(...xs));        // 6
+
+// spread misto: posicional + spread
+const tail = [20, 30];
+print("" + adder(10, ...tail));  // 60
+
+// spread no meio
+const mid = [2];
+print("" + adder(1, ...mid));    // adder(1,2,undefined) -> NaN-ish; usa 2 args validos
+print("" + sum2(...[7, 8]));     // 15
+
+// floats
+function favg(a: number, b: number): number { return (a + b) / 2; }
+print("" + favg(...[3.0, 4.0])); // 3.5
+
+describe("spread em user fn call", () => {
+  test("number args via spread", () =>
+    expect(out.indexOf("6\n") === 0).toBe(true));
+  test("spread misto", () =>
+    expect(out.indexOf("60\n") >= 0).toBe(true));
+  test("float spread", () =>
+    expect(out.indexOf("3.5\n") >= 0).toBe(true));
+  test("sum2 spread", () =>
+    expect(out.indexOf("15\n") >= 0).toBe(true));
+});


### PR DESCRIPTION
## Problema

Spread numa chamada a user fn dava erro de compilação:

```ts
function adder(a: number, b: number, c: number) { return a + b + c; }
const xs = [1, 2, 3];
adder(...xs);  // error: spread not supported
```

`lower_user_call` é posicional (aridade fixa), incompatível com `f(...xs)` cujo número de args só se conhece em runtime.

## Fix

Quando a chamada a user fn tem qualquer arg spread, reifica a fn como handle Function **com param_kinds/return_kind** (`lower_callable_target_h`) e roteia via `INVOKE_AUTO`. Monta o args Vec com:
- `VEC_PUSH` para args posicionais (f64 → bits, para `invoke_typed` reinterpretar)
- `VEC_EXTEND_FROM` para spread (itera o array source)

Cobre spread puro, misto (posicional + spread) e args float.

## Limitação conhecida (follow-up #348)

Spread **dentro de arrow liftada** que também captura array por valor (`(...r) => f(...bound, ...r)` — o padrão curry/partial completo) ainda não fecha: combina spread + lift + captura-por-valor num só caminho. Fica registrado no roadmap.

## Teste

`tests/spread_user_fn_call.test.ts` — spread puro, misto, float, fn binária.

Suite **1356 → 1360** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)