### PR TITLE
feat(codegen): instanceof com funcao-construtora via __proto__ chain

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -521,6 +521,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_FUNCTION_PROTOTYPE_SET", __RTS_FN_GL_FUNCTION_PROTOTYPE_SET);
     add_fn!("__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE", __RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE);
     add_fn!("__RTS_FN_RT_INVOKE_AUTO", __RTS_FN_RT_INVOKE_AUTO);
+    add_fn!("__RTS_FN_RT_INSTANCEOF_PROTO", __RTS_FN_RT_INSTANCEOF_PROTO);
     {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_AUTO;
         add_fn!("__RTS_FN_RT_TPL_COERCE_AUTO", __RTS_FN_RT_TPL_COERCE_AUTO);

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1940,6 +1940,13 @@ fn lower_instanceof(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         if known_global {
             return lower_global_instanceof(ctx, &class_name, &bin.left);
         }
+        // (cross-runtime #387) RHS eh uma FUNCAO-CONSTRUTORA (pre-ES6,
+        // `function Animal(){}`). Reifica a fn, resolve seu prototype e anda
+        // a __proto__ chain da instancia via INSTANCEOF_PROTO. Cobre heranca
+        // por `Dog.prototype = Object.create(Animal.prototype)`.
+        if ctx.user_fns.contains_key(&class_name) {
+            return lower_ctor_fn_instanceof(ctx, &class_name, &bin.left);
+        }
         return Err(anyhow!("instanceof RHS `{class_name}` is not a known class"));
     }
 
@@ -1992,6 +1999,65 @@ fn lower_instanceof(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
     }
 
     Ok(TypedVal::new(acc, ValTy::Bool))
+}
+
+/// (cross-runtime #387) `lhs instanceof <CtorFn>` — fn-construtora pre-ES6.
+/// Reifica a fn como handle Function (carrega o fn_ptr que indexa o
+/// prototype registry) e chama INSTANCEOF_PROTO, que anda a `__proto__`
+/// chain da instancia comparando com `CtorFn.prototype`. Cobre heranca via
+/// `Sub.prototype = Object.create(Base.prototype)`.
+fn lower_ctor_fn_instanceof(
+    ctx: &mut FnCtx,
+    fn_name: &str,
+    lhs_expr: &Expr,
+) -> Result<TypedVal> {
+    use super::calls::emit_user_fn_addr;
+    let lhs = lower_expr(ctx, lhs_expr)?;
+    // Primitivos nunca casam — so' handles (Map de instancia).
+    if !matches!(lhs.ty, ValTy::Handle | ValTy::I64 | ValTy::U64) {
+        let zero = ctx.builder.ins().iconst(cl::I64, 0);
+        return Ok(TypedVal::new(zero, ValTy::Bool));
+    }
+    let recv = ctx.coerce_to_i64(lhs).val;
+
+    // Reifica a fn-construtora como handle Function (REIFY simples — so'
+    // precisamos do fn_ptr pra resolver o prototype no registry).
+    let fn_addr = emit_user_fn_addr(ctx, fn_name)?.val;
+    let arity = ctx
+        .user_fns
+        .get(fn_name)
+        .map(|f| f.params.len() as i64)
+        .unwrap_or(0);
+    let arity_v = ctx.builder.ins().iconst(cl::I64, arity);
+    let name_tv = ctx.emit_str_handle(fn_name.as_bytes())?;
+    let name_h = ctx.coerce_to_i64(name_tv).val;
+    let str_ptr_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+    let str_len_fn = ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+    let inst_p = ctx.builder.ins().call(str_ptr_fn, &[name_h]);
+    let n_ptr = ctx.builder.inst_results(inst_p)[0];
+    let inst_l = ctx.builder.ins().call(str_len_fn, &[name_h]);
+    let n_len = ctx.builder.inst_results(inst_l)[0];
+    let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let has_this_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let reify_fn = ctx.get_extern(
+        "__RTS_FN_GL_FUNCTION_REIFY",
+        &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32],
+        Some(cl::I64),
+    )?;
+    let inst_r = ctx
+        .builder
+        .ins()
+        .call(reify_fn, &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v]);
+    let fn_handle = ctx.builder.inst_results(inst_r)[0];
+
+    let check_fn = ctx.get_extern(
+        "__RTS_FN_RT_INSTANCEOF_PROTO",
+        &[cl::I64, cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst = ctx.builder.ins().call(check_fn, &[recv, fn_handle]);
+    let r = ctx.builder.inst_results(inst)[0];
+    Ok(TypedVal::new(r, ValTy::Bool))
 }
 
 /// `lhs instanceof <GlobalClass>` — dispatcha para runtime fn que detecta

--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -708,6 +708,37 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_PROTOTYPE_GET(handle: u64) -> u64 {
     new_proto
 }
 
+/// (cross-runtime #387) `instance instanceof Ctor` para FUNCAO-CONSTRUTORA
+/// (pre-ES6). Semantica JS: anda a `__proto__` chain de `instance` e
+/// retorna true se algum elo for identico a `Ctor.prototype` (`ctor_h` eh o
+/// handle Function da fn-construtora). Cobre heranca via
+/// `Dog.prototype = Object.create(Animal.prototype)`: a chain da instancia
+/// passa por Dog.prototype e Animal.prototype, entao `d instanceof Animal`
+/// tambem casa. Retorna 0/1 (bool sentinel decidido pelo codegen).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_INSTANCEOF_PROTO(instance_h: u64, ctor_h: u64) -> i64 {
+    use crate::namespaces::collections::map::with_map_mut;
+    // Resolve Ctor.prototype (lazy-aloca se preciso — mesma fn que `new` usa).
+    let target_proto = __RTS_FN_GL_FUNCTION_PROTOTYPE_GET(ctor_h);
+    if target_proto == 0 {
+        return 0;
+    }
+    let read_proto = |h: u64| -> i64 {
+        with_map_mut(h, 0i64, |m| m.get("__proto__").copied().unwrap_or(0))
+    };
+    // Anda a __proto__ chain da instancia.
+    let mut current = read_proto(instance_h);
+    let mut depth = 0u32;
+    while current != 0 && depth < 64 {
+        if current as u64 == target_proto {
+            return 1;
+        }
+        current = read_proto(current as u64);
+        depth += 1;
+    }
+    0
+}
+
 /// (#proto-method) Auto-dispatch: se \`callee\` eh handle Function valido,
 /// chama via invoke_typed (com return_kind correto). Senao trata como
 /// fn_ptr cru e faz invoke_n (todos i64). Usado por

--- a/tests/instanceof_ctor_fn.test.ts
+++ b/tests/instanceof_ctor_fn.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #387): `instance instanceof CtorFn` para
+// FUNCAO-CONSTRUTORA (pre-ES6) dava `error: instanceof RHS is not a known
+// class` (a fn nao esta em ctx.classes nem global classes). Fix: reifica a
+// fn, resolve seu prototype e anda a __proto__ chain da instancia via
+// INSTANCEOF_PROTO. Cobre heranca por Object.create(Base.prototype).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function Animal(name: string) { this.name = name; }
+Animal.prototype.speak = function () { return this.name + " som"; };
+
+function Dog(name: string) { Animal.call(this, name); }
+Dog.prototype = Object.create(Animal.prototype);
+Dog.prototype.constructor = Dog;
+Dog.prototype.bark = function () { return this.name + " late"; };
+
+const a = new Animal("Mimi");
+const d = new Dog("Rex");
+
+// instanceof direto
+print("" + (a instanceof Animal));   // true
+print("" + (d instanceof Dog));      // true
+// instanceof herdado via prototype chain
+print("" + (d instanceof Animal));   // true
+// negativo: Animal NAO eh instancia de Dog
+print("" + (a instanceof Dog));      // false
+// metodos herdados continuam funcionando (regressao de chain)
+print(d.speak());                    // Rex som
+print(d.bark());                     // Rex late
+
+// primitivo nunca casa
+const n = 42;
+print("" + ((n as any) instanceof Animal)); // false
+
+describe("instanceof ctor fn", () => {
+  test("chain", () =>
+    expect(out).toBe("true\ntrue\ntrue\nfalse\nRex som\nRex late\nfalse\n"));
+});


### PR DESCRIPTION
## Problema

`instance instanceof Animal` onde `Animal` é função-construtora (pre-ES6) dava erro de compilação:

```ts
function Animal(name) { this.name = name; }
const a = new Animal("Rex");
a instanceof Animal;  // error: instanceof RHS `Animal` is not a known class
```

A fn não está em `ctx.classes` (não é classe ES6) nem nas global classes.

## Fix

Novo helper runtime `__RTS_FN_RT_INSTANCEOF_PROTO(instance, ctor_h)` anda a `__proto__` chain da instância comparando cada elo com `Ctor.prototype` (resolvido via `PROTOTYPE_GET`). No codegen, `lower_instanceof` reconhece RHS user fn e reifica + chama o helper.

Cobre **herança via prototype chain**: `Dog.prototype = Object.create(Animal.prototype)` — a chain da instância passa por `Dog.prototype` e `Animal.prototype`, então `d instanceof Animal` também casa. Primitivos nunca casam.

Isso fecha o `instanceof` que faltava no bloco #336/#387/#341 (função-construtor + prototype chain) — a herança em si (`this.name`, métodos herdados) já funcionava.

## Teste

`tests/instanceof_ctor_fn.test.ts` — instanceof direto, herdado, negativo e primitivo.

Suite **1360/1360** + 1 teste novo (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)