### PR TITLE
fix(runtime): getPrototypeOf(Object.prototype) retorna null (#336)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1446,6 +1446,15 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO(handle: u64) -> u64 {
     if is_null_proto_handle(handle) {
         return 0;
     }
+    // (cross-runtime #336) Topo da prototype chain: o singleton
+    // Object.prototype (Map real instalado como __proto__ raiz das classes)
+    // nao tem proto — getPrototypeOf retorna null. Sem isso, iterar a chain
+    // (`while (proto) { ...; proto = getPrototypeOf(proto); }`) dava uma
+    // volta extra retornando o sentinel `[Object.prototype]` em vez de
+    // terminar, imprimindo lixo (` 0`) apos "Object".
+    if handle == crate::namespaces::globals::function::ops::__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE() {
+        return 0;
+    }
     // (#1080) Sentinel proto strings: JS spec:
     // - Object.getPrototypeOf(Object.prototype) === null (depth termina)
     // - Object.getPrototypeOf(Array.prototype) === Object.prototype

--- a/tests/prototype_chain_terminates.test.ts
+++ b/tests/prototype_chain_terminates.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #336): iterar a prototype chain com
+// `while (proto) { ...; proto = Object.getPrototypeOf(proto); }` dava uma
+// VOLTA EXTRA apos "Object" — getPrototypeOf(Object.prototype) retornava o
+// sentinel `[Object.prototype]` em vez de null, e o loop imprimia lixo.
+// Fix: o singleton Object.prototype retorna null em getPrototypeOf (topo
+// da chain).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+class Animal { constructor(public name: string) {} }
+class Dog extends Animal {}
+
+const d = new Dog("Rex");
+
+// constructor.name em cada nivel
+print(d.constructor.name);                        // Dog
+print(Object.getPrototypeOf(d).constructor.name); // Dog
+
+// getPrototypeOf(Object.prototype) === null (topo termina)
+const a = new Animal("X");
+const p1 = Object.getPrototypeOf(a);   // Animal.prototype
+const p2 = Object.getPrototypeOf(p1);  // Object.prototype
+const p3 = Object.getPrototypeOf(p2);  // null
+print("p3 null? " + (p3 === null));    // true
+print("p3 falsy? " + (!p3));           // true
+
+// iteracao completa da chain termina em Object (sem volta extra)
+let proto = Object.getPrototypeOf(d);
+let chain = "";
+let guard = 0;
+while (proto && guard < 10) {
+  chain += proto.constructor.name + " ";
+  proto = Object.getPrototypeOf(proto);
+  guard++;
+}
+print(chain.trim());                   // Dog Animal Object
+
+describe("prototype chain terminates", () => {
+  test("no extra loop after Object", () =>
+    expect(out).toBe("Dog\nDog\np3 null? true\np3 falsy? true\nDog Animal Object\n"));
+});


### PR DESCRIPTION
## Problema

Iterar a prototype chain dava uma **volta extra** após `Object`, imprimindo lixo:

```ts
let proto = Object.getPrototypeOf(d);
while (proto) {
  chain += proto.constructor.name + " ";
  proto = Object.getPrototypeOf(proto);
}
// "Dog Animal Object 0"  <- ` 0` extra
```

## Causa

Ao chegar no singleton `Object.prototype` (Map real instalado como `__proto__` raiz das classes), `MAP_GET_PROTO` caía no ramo default e retornava o sentinel string `[Object.prototype]` em vez de `null`. O `while` não terminava e dava mais uma volta lendo `.constructor.name` (= 0).

## Fix

`MAP_GET_PROTO` detecta `handle == OBJECT_PROTOTYPE_HANDLE()` e retorna `0` (null), terminando a chain corretamente.

`constructor.name` em cada nível já funcionava (`Dog`, `Animal`, `Object`) — só faltava o topo da chain terminar.

## Teste

`tests/prototype_chain_terminates.test.ts` — constructor.name por nível, `getPrototypeOf(Object.prototype) === null`, iteração completa.

Suite **1360 → 1361** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)