### PR TITLE
fix(runtime): spread de Set itera elementos, nao values dummy (#316)

### DIFF
--- a/crates/rts-runtime/src/namespaces/gc/string_pool.rs
+++ b/crates/rts-runtime/src/namespaces/gc/string_pool.rs
@@ -416,6 +416,21 @@ pub extern "C" fn __RTS_FN_RT_SPREAD_INTO_VEC(dst: u64, src: u64) {
         Map(Vec<i64>),
         Empty,
     }
+    // (cross-runtime #316) Set spread (`[...set]`) itera os ELEMENTOS, que no
+    // storage interno sao as KEYS do Map<keyStr,1> — nao os values (dummy 1).
+    // Sem isto `[...new Set([1,2,3])]` virava `[1,1,1]`. Reusa a mesma
+    // conversao key->valor de MAP_VALUES (parse int, senao handle string).
+    if crate::namespaces::collections::map::handle_is_set_kind(src) {
+        let elems = crate::namespaces::collections::map::__RTS_FN_NS_COLLECTIONS_MAP_VALUES(src);
+        let items = with_entry(elems, |entry| match entry {
+            Some(Entry::Vec(slots)) => slots.as_ref().clone(),
+            _ => Vec::new(),
+        });
+        for v in items {
+            push_vec_slot(dst, v);
+        }
+        return;
+    }
     let snap = with_entry(src, |entry| match entry {
         Some(Entry::Vec(slots)) => Snap::Vec(slots.as_ref().clone()),
         Some(Entry::String(b)) => Snap::Str(b.clone()),

--- a/tests/set_spread.test.ts
+++ b/tests/set_spread.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #316): `[...set]` / Array.from(set) repetia o
+// primeiro elemento N vezes (`[1,1,1]`). Causa: SPREAD_INTO_VEC tratava Set
+// como Map e iterava m.values() (dummy 1), nao as keys (elementos reais do
+// Set, storage interno Map<keyStr,1>). Fix: detecta Set e extrai elementos
+// via MAP_VALUES (mesma conversao key->valor).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+print([...new Set([1, 2, 3])].join(","));         // 1,2,3
+print(Array.from(new Set([5, 5, 6])).join(","));  // 5,6 (dedup numerico)
+print([...new Set(["x", "y", "z"])].join(","));   // x,y,z
+// spread misto com Set
+print([0, ...new Set([1, 2]), 3].join(","));      // 0,1,2,3
+
+describe("set spread", () => {
+  test("itera elementos reais (nao repete o 1o)", () =>
+    expect(out).toBe("1,2,3\n5,6\nx,y,z\n0,1,2,3\n"));
+});


### PR DESCRIPTION
## Problema

`[...new Set([1,2,3])]` virava `[1,1,1]` — repetia o primeiro elemento.

## Causa

`SPREAD_INTO_VEC` tratava Set como Map e iterava `m.values()` (todos o dummy `1`), em vez das keys — Set usa storage interno `Map<keyStr, 1>`, então os elementos são as **keys**.

## Fix

Detecta `handle_is_set_kind` e extrai os elementos via `MAP_VALUES` (mesma conversão key→valor: parse int, senão handle string). Cobre `[...set]`, `Array.from(set)` e spread misto.

## Teste

`tests/set_spread.test.ts`.

Suite **1362** + 1 teste novo (zero regressão).

> Nota: dedup de Set com chaves string (`new Set(["a","a"])`) é bug separado, fora do escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)