### PR TITLE
fix(codegen): new Set(["a","a"]) deduplica chaves string (#316)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -352,6 +352,13 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
                             let key_h = if matches!(tv.ty, ValTy::F64) {
                                 let inst_s = ctx.builder.ins().call(from_f64, &[tv.val]);
                                 ctx.builder.inst_results(inst_s)[0]
+                            } else if matches!(tv.ty, ValTy::Handle) {
+                                // (cross-runtime #316) Elemento string/handle: a
+                                // KEY do Set eh o CONTEUDO da string, nao o numero
+                                // do handle. Sem isto `new Set(["a","b","a"])` nao
+                                // deduplicava (cada "a" tinha handle distinto) e
+                                // has("a") falhava. Usa o proprio handle string.
+                                tv.val
                             } else {
                                 let i = ctx.coerce_to_i64(tv).val;
                                 let inst_s = ctx.builder.ins().call(from_i64, &[i]);

--- a/tests/set_string_dedup.test.ts
+++ b/tests/set_string_dedup.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #316): `new Set(["a","b","a"])` nao deduplicava
+// chaves string (size 3 em vez de 2) e has("a") retornava false. Causa: o
+// constructor coergia o ELEMENTO string (handle) para i64 e usava o numero
+// do handle como key — cada "a" tinha handle distinto. Fix: usar o conteudo
+// da string (proprio handle) como key. (numericos ja' deduplicavam OK)
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const s = new Set(["a", "b", "a", "c", "b"]);
+print(s.size + "");                    // 3
+print([...s].join(","));               // a,b,c
+print(s.has("a") + " " + s.has("z"));  // true false
+
+// numerico continua OK
+const n = new Set([1, 1, 2, 3, 3]);
+print(n.size + "");                    // 3
+print([...n].join(","));               // 1,2,3
+
+describe("set string dedup", () => {
+  test("dedup + has por conteudo", () =>
+    expect(out).toBe("3\na,b,c\ntrue false\n3\n1,2,3\n"));
+});


### PR DESCRIPTION
## Problema

`new Set(["a","b","a"])` dava `size === 3` (deveria 2) e `has("a") === false`.

## Causa

O constructor de Set coagia o elemento string (handle) para i64 e usava o **número do handle** como key — cada `"a"` tinha handle distinto, então não deduplicava, e `has("a")` (que busca pelo conteúdo) não encontrava.

## Fix

Quando o elemento é `ValTy::Handle` (string), usa o próprio handle (conteúdo) como key. Numéricos já deduplicavam OK.

Completa o #316 junto com o PR #1229 (spread de Set).

## Teste

`tests/set_string_dedup.test.ts`.

Suite **1362 → 1365** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)