### PR TITLE
fix(codegen): literal inteiro grande nao satura em i64 (vira f64)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -32,20 +32,28 @@ pub(super) fn lower_lit(ctx: &mut FnCtx, lit: &Lit) -> Result<TypedVal> {
             if let Some(&cached) = ctx.num_val_cache.get(&cache_key) {
                 let ty = if !wrote_as_float && v.fract() == 0.0 && v >= i32::MIN as f64 && v <= i32::MAX as f64 {
                     ValTy::I32
-                } else if !wrote_as_float && v.fract() == 0.0 && v.is_finite() {
+                } else if !wrote_as_float && v.fract() == 0.0 && v.is_finite()
+                    && v >= i64::MIN as f64 && v <= i64::MAX as f64
+                {
                     ValTy::I64
                 } else {
                     ValTy::F64
                 };
                 return Ok(TypedVal::new(cached, ty));
             }
+            // (cross-runtime) Literal inteiro so' vira iconst se CABE no range
+            // do tipo. `1e21` (`v.fract()==0` e finito) NAO cabe em i64 — sem
+            // o range check, `v as i64` saturava em i64::MAX (9223372036854775807)
+            // em vez de manter o valor como f64 (JS: number sempre f64).
             let tv = if !wrote_as_float
                 && v.fract() == 0.0
                 && v >= i32::MIN as f64
                 && v <= i32::MAX as f64
             {
                 TypedVal::new(ctx.builder.ins().iconst(cl::I32, v as i64), ValTy::I32)
-            } else if !wrote_as_float && v.fract() == 0.0 && v.is_finite() {
+            } else if !wrote_as_float && v.fract() == 0.0 && v.is_finite()
+                && v >= i64::MIN as f64 && v <= i64::MAX as f64
+            {
                 TypedVal::new(ctx.builder.ins().iconst(cl::I64, v as i64), ValTy::I64)
             } else {
                 TypedVal::new(ctx.builder.ins().f64const(v), ValTy::F64)

--- a/tests/number_literal_overflow_i64.test.ts
+++ b/tests/number_literal_overflow_i64.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): literal numerico inteiro grande (`1e21`,
+// `1e20`) que NAO cabe em i64 saturava em i64::MAX (9223372036854775807)
+// porque o lowering fazia `v as i64` sem checar o range. JS: number eh
+// sempre f64. Fix: literal inteiro so' vira iconst se cabe no range i64;
+// senao mantem f64const.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const a = 1e20;
+print("" + a);            // 100000000000000000000
+const b = 1e21;
+print("" + b);            // 1e+21
+print("" + (b > a));      // true
+const big = 9e18;         // ~cabe i64 (i64::MAX ~9.2e18) — limite
+print("" + (big > 1e18)); // true
+
+// valores que CABEM em i64 continuam como int exato
+const small = 1000000;
+print("" + small);        // 1000000
+
+describe("number literal overflow i64", () => {
+  test("literal grande nao satura", () =>
+    expect(out).toBe("100000000000000000000\n1e+21\ntrue\ntrue\n1000000\n"));
+});


### PR DESCRIPTION
## Problema

`1e21` / `1e20` saturavam em `i64::MAX` (9223372036854775807) em vez de manter o valor:

```ts
const b = 1e21;
"" + b;  // "9223372036854775807" (errado, esperado "1e+21")
```

## Causa

O lowering de literal numérico fazia `v as i64` quando `v.fract() == 0.0 && v.is_finite()`, sem checar se `v` cabe no range i64. `1e21` é finito e inteiro mas não cabe → saturava.

## Fix

Literal inteiro só vira `iconst i64` se cabe em `[i64::MIN, i64::MAX]`; senão mantém `f64const`. JS: number é sempre f64.

## Teste

`tests/number_literal_overflow_i64.test.ts`.

Suite **1365 → 1366** (zero regressão).

> Nota: literal grande no lado direito de `/` (`x / 1e20`) ainda satura — o operador de divisão reclassifica o literal por outro caminho. Follow-up separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)