### PR TITLE
fix(codegen): for-of [i,v] of arr.entries() coage value string (#208)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -327,6 +327,17 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
                 *ann_ty
             };
             ctx.declare_local(name, resolved_ty, val);
+            // (cross-runtime #208/#494) Sem tipo estatico Handle, o slot pode
+            // carregar um handle (string/obj) OU i64 puro — caso `arr.entries()`
+            // onde o slot 1 e' o elemento do array (string quando arr eh de
+            // strings). Marca o valor como vec-slot ambiguo pra que template
+            // (`i + ":" + v`) use TPL_COERCE_VEC_SLOT/INSPECT e detecte string
+            // em runtime, em vez de imprimir o handle cru. Sem isso,
+            // `for (const [i,v] of arr.entries())` imprimia o numero do handle.
+            if !matches!(resolved_ty, ValTy::Handle) {
+                ctx.var_member_call_values.insert(val);
+                ctx.var_vec_slot_values.insert(val);
+            }
         }
     }
 

--- a/tests/for_of_entries_destructure.test.ts
+++ b/tests/for_of_entries_destructure.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #208/#494): `for (const [i, v] of arr.entries())`
+// onde o array eh de strings imprimia o handle CRU do valor
+// (`0:281474976710658`) em vez do conteudo (`0:a`). Causa: o destructuring
+// no for-of so' marcava slot 0 de Object.entries como Handle; o slot 1
+// (valor) de arr.entries() ficava i64 nao-marcado, e o template imprimia
+// o numero do handle. Fix: marca slots sem tipo Handle estatico como
+// vec-slot ambiguo (var_vec_slot_values/var_member_call_values) pra que a
+// coercao template detecte string/handle em runtime.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// arr.entries() de strings — value (slot 1) eh string handle
+const arr = ["a", "b", "c"];
+for (const [i, v] of arr.entries()) { out += i + ":" + v + " "; }
+out += "\n";
+
+// pares numericos continuam OK
+for (const [i, v] of [[10, 20], [30, 40]]) { out += i + "+" + v + " "; }
+out += "\n";
+
+// Object.entries (slot 0 = key string) continua OK
+for (const [k, val] of Object.entries({ x: 1, y: 2 })) { out += k + "=" + val + " "; }
+out += "\n";
+
+// entries de numeros
+const nums = [100, 200];
+for (const [i, n] of nums.entries()) { out += i + "@" + n + " "; }
+
+describe("for-of entries destructure", () => {
+  test("value string nao vira handle cru", () =>
+    expect(out).toBe("0:a 1:b 2:c \n10+20 30+40 \nx=1 y=2 \n0@100 1@200 "));
+});


### PR DESCRIPTION
## Problema

`for (const [i, v] of arr.entries())` num array de strings imprimia o handle cru do value:

```ts
const arr = ["a", "b"];
for (const [i, v] of arr.entries()) print(i + ":" + v);
// "0:281474976710658" em vez de "0:a"
```

## Causa

O destructuring no for-of só marcava o slot 0 de `Object.entries` como `Handle`. O slot 1 (value) de `arr.entries()` ficava i64 não-marcado, e o template `i + ":" + v` imprimia o número do handle em vez de coergir a string.

## Fix

Marca slots sem tipo `Handle` estático como vec-slot ambíguo (`var_vec_slot_values` + `var_member_call_values`), para que a coerção template detecte string/handle em runtime — o mesmo caminho que `pair[1]` direto (que já funcionava). `Object.entries` (slot 0 key) e pares numéricos permanecem corretos.

## Teste

`tests/for_of_entries_destructure.test.ts` — entries de strings, pares numéricos, Object.entries.

Suite **1368 → 1369** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)