### PR TITLE
fix(codegen): arr.filter(f).map(g) encadeado direto nao crasha (#54)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1361,7 +1361,14 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                     }};
 
                     if let Some(par_method) = target_method {
-                        let arr_expr = (*m.obj).clone();
+                        let mut arr_expr = (*m.obj).clone();
+                        // (cross-runtime #54) O receiver pode ser ELE PROPRIO
+                        // uma chain de array methods (`arr.filter(f).map(g)`):
+                        // ao reescrever o `.map`, recursar no `.filter` interno
+                        // ANTES de montar o arg, senao o `.filter` fica sem
+                        // rewrite e o codegen faz MAP_GET("filter") em Vec ->
+                        // trapz -> SIGILL.
+                        rewrite_array_methods_in_expr(&mut arr_expr, user_fn_names);
                         let fn_arg = call.args[0].expr.clone();
                         let new_args: Vec<swc_ecma_ast::ExprOrSpread> = if par_method == "reduce" {
                             let init_arg = call.args[1].expr.clone();

--- a/tests/array_filter_map_chain.test.ts
+++ b/tests/array_filter_map_chain.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #54): `arr.filter(f).map(g)` encadeado DIRETO
+// (sem var intermediaria) crashava com ILLEGAL_INSTRUCTION. Causa: o
+// array_methods_pass reescrevia o `.map` externo para `parallel.map(arr, g)`
+// e retornava cedo SEM reescrever o `.filter` interno (clonado como arr_expr)
+// — o `.filter` ficava sem rewrite e o codegen fazia MAP_GET("filter") em
+// Vec -> trapz -> SIGILL. Fix: recursar em arr_expr antes de montar o arg.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// chain com arrows
+const words = ["hi", "world", "ab", "hello"];
+print(words.filter(w => w.length > 2).map(w => w.toUpperCase()).join(","));  // WORLD,HELLO
+
+// chain com user fns nomeadas
+function even(n: number): boolean { return n % 2 === 0; }
+function sq(n: number): number { return n * n; }
+const nums = [1, 2, 3, 4, 5, 6];
+print(nums.filter(even).map(sq).join(","));   // 4,16,36
+
+// chain de 3: filter -> map -> filter
+print(nums.filter(even).map(sq).filter(x => x > 10).join(","));  // 16,36
+
+// var intermediaria continua OK
+const f = words.filter(w => w.length > 2);
+print(f.map(w => w.length).join(","));  // 5,5
+
+describe("array filter map chain", () => {
+  test("chain direto nao crasha", () =>
+    expect(out).toBe("WORLD,HELLO\n4,16,36\n16,36\n5,5\n"));
+});


### PR DESCRIPTION
## Problema

`arr.filter(f).map(g)` encadeado direto (sem var intermediária) crashava com `ILLEGAL_INSTRUCTION`:

```ts
words.filter(w => w.length > 2).map(w => w.toUpperCase()).join(",")  // SIGILL
```

## Causa

O `array_methods_pass` reescrevia o `.map` externo para `parallel.map(arr, g)` e **retornava cedo sem reescrever o `.filter` interno** (clonado como `arr_expr`). O `.filter` ficava sem rewrite, e o codegen fazia `MAP_GET("filter")` num Vec → `trapz` → SIGILL.

## Fix

Recursar `rewrite_array_methods_in_expr` em `arr_expr` **antes** de montá-lo nos args do `parallel.*`, reescrevendo a chain inteira.

Cobre `filter→map`, `filter→map→filter`, arrows e user fns nomeadas. Var intermediária já funcionava.

## Teste

`tests/array_filter_map_chain.test.ts`.

Suite **1369 → 1372** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)