### PR TITLE
fix(codegen): for-of de map.keys()/values() coage strings no template (#222)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -259,6 +259,19 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
     let elem = ctx.builder.inst_results(inst)[0];
     ctx.write_local(&bind_name, elem)?;
 
+    // (cross-runtime #222) Bind simples de for-of sem tipo Handle estatico:
+    // o slot pode carregar um handle (string/obj) OU i64 puro. Caso
+    // `for (const k of map.keys())` / `map.values()` onde os elementos sao
+    // strings. Marca o elem como vec-slot ambiguo pra que template
+    // (`ks + k`) use coercao runtime (detecta string) em vez de imprimir o
+    // handle cru. So' quando NAO ha destructuring (esse ja' marca por slot).
+    if array_destructure_names.is_none()
+        && !matches!(bind_ty, ValTy::Handle | ValTy::F64 | ValTy::I32)
+    {
+        ctx.var_member_call_values.insert(elem);
+        ctx.var_vec_slot_values.insert(elem);
+    }
+
     // (#210) for-of array destructuring: cada nome vira local extraindo
     // posicao correspondente do vec via vec_get. Fora-do-range retorna 0.
     if let Some(names) = &array_destructure_names {

--- a/tests/for_of_map_keys_values.test.ts
+++ b/tests/for_of_map_keys_values.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #222): `for (const k of map.keys())` /
+// `map.values()` com chaves/valores STRING imprimia o handle cru
+// (`562949953421320`) em vez do conteudo. Causa: bind simples de for-of sem
+// tipo Handle estatico ficava i64 nao-marcado; o slot (handle string) nao
+// era coerido no template. `[...map.keys()].join()` funcionava (spread coage
+// vec-slot em runtime). Fix: marca o elem do for-of como vec-slot ambiguo
+// quando o bind nao tem tipo Handle/F64/I32 estatico.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const m = new Map<string, string>();
+m.set("x", "1"); m.set("y", "2"); m.set("z", "3");
+
+// for-of keys
+let ks = "";
+for (const k of m.keys()) ks += k;
+print(ks);                          // xyz
+
+// for-of values
+let vs = "";
+for (const v of m.values()) vs += v;
+print(vs);                          // 123
+
+// spread continua OK
+print([...m.keys()].join("-"));     // x-y-z
+
+// for-of sobre array de strings tambem
+let ss = "";
+for (const s of ["a", "b", "c"]) ss += s;
+print(ss);                          // abc
+
+// array de numeros NAO deve quebrar (regressao guard)
+let sum = 0;
+for (const n of [10, 20, 30]) sum += n;
+print(sum + "");                    // 60
+
+describe("for-of map keys/values", () => {
+  test("string keys/values coage no template", () =>
+    expect(out).toBe("xyz\n123\nx-y-z\nabc\n60\n"));
+});


### PR DESCRIPTION
## Problema

`for (const k of map.keys())` num `Map<string,_>` imprimia o handle cru:

```ts
const m = new Map<string,string>(); m.set("x","1");
let ks = ""; for (const k of m.keys()) ks += k;  // "562949953421320" em vez de "x"
```

`[...m.keys()].join()` já funcionava (spread coage vec-slot em runtime); só o for-of bind falhava.

## Causa

Bind simples de for-of sem tipo `Handle` estático ficava `i64` não-marcado; o slot (handle string) não era coerido no template.

## Fix

Marca o `elem` do for-of como vec-slot ambíguo (`var_vec_slot_values` + `var_member_call_values`) quando o bind não tem tipo `Handle`/`F64`/`I32` estático — mesma estratégia do destructuring (#1233). Array de números não é afetado (guard testado).

Cobre keys, values e array de strings.

## Teste

`tests/for_of_map_keys_values.test.ts`.

Suite **1372 → 1379** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)