### PR TITLE
fix(codegen): m.get(k).arrayMethod() chain direto nao crasha (#222)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -835,6 +835,32 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                             return Ok(tv);
                         }
                     }
+                    // (cross-runtime #222) Receiver Call que devolve i64
+                    // AMBIGUO (ex: `m.get(k)` retorna o handle do array como
+                    // i64, nao ValTy::Handle) seguido de array method
+                    // (`.join`/`.map`/etc): tenta lower_array_builtin com o
+                    // recv coerido ANTES do fallback chain-Map abaixo. Sem
+                    // isto, `m.get(k).join(",")` caia em MAP_GET("join") +
+                    // trapz -> SIGILL. Var intermediaria ja' funcionava.
+                    if matches!(m.obj.as_ref(), Expr::Call(_))
+                        && matches!(recv_tv.ty, ValTy::I64 | ValTy::U64)
+                    {
+                        let is_array_method = matches!(
+                            method_name.as_str(),
+                            "join" | "map" | "filter" | "forEach" | "reduce"
+                            | "slice" | "concat" | "indexOf" | "lastIndexOf"
+                            | "includes" | "reverse" | "find" | "findIndex"
+                            | "every" | "some" | "flat" | "flatMap" | "at"
+                            | "fill" | "sort" | "push" | "pop" | "shift"
+                            | "unshift" | "splice" | "keys" | "values" | "entries"
+                        );
+                        if is_array_method {
+                            let recv_h = ctx.coerce_to_i64(recv_tv).val;
+                            if let Some(tv) = lower_array_builtin(ctx, &method_name, recv_h, call)? {
+                                return Ok(tv);
+                            }
+                        }
+                    }
                     // (#480 chain) Method chain em Call result: \`c.add(5).add(3)\`.
                     // Receiver i64 (return this) que e' handle de Map. Faz map_get +
                     // INVOKE_AUTO em qualquer Call obj.

--- a/tests/map_get_array_method_chain.test.ts
+++ b/tests/map_get_array_method_chain.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #222): `m.get(k).join(",")` (e outros array
+// methods) chamado DIRETO sobre o resultado de Map.get crashava com SIGILL.
+// Causa: `m.get(k)` retorna i64 AMBIGUO (handle do array, nao ValTy::Handle),
+// entao o `.join` nao tentava lower_array_builtin e caia no fallback
+// chain-Map -> MAP_GET("join") + trapz -> SIGILL. Var intermediaria
+// funcionava. Fix: receiver Call com tipo i64/u64 + array method conhecido
+// tenta lower_array_builtin com o recv coerido antes do fallback.
+
+const m = new Map<string, string[]>();
+m.set("k", ["x", "y", "z"]);
+const r1 = m.get("k").join(",");
+const r2 = m.get("k").slice(1).join("-");
+const r3 = m.get("k").includes("y");
+const r4 = m.get("k").indexOf("z");
+
+const mn = new Map<string, number[]>();
+mn.set("n", [10, 20, 30]);
+const r5 = mn.get("n").join("|");
+const r6 = mn.get("n").reverse().join(",");
+
+describe("map.get array method chain", () => {
+  test("join direto", () => expect(r1).toBe("x,y,z"));
+  test("slice().join()", () => expect(r2).toBe("y-z"));
+  test("includes", () => expect(r3).toBe(true));
+  test("indexOf", () => expect("" + r4).toBe("2"));
+  test("num join", () => expect(r5).toBe("10|20|30"));
+  test("reverse().join()", () => expect(r6).toBe("30,20,10"));
+});


### PR DESCRIPTION
## Problema

`m.get(k).join(",")` (e slice/includes/indexOf/reverse/etc) chamado direto sobre o resultado de `Map.get` crashava com SIGILL.

## Causa

`m.get(k)` retorna i64 **ambíguo** (handle do array, não `ValTy::Handle`). Então o array method não tentava `lower_array_builtin` e caía no fallback chain-Map → `MAP_GET("join")` + `trapz` → SIGILL. Var intermediária (`const a = m.get(k); a.join()`) já funcionava.

## Fix

Receiver `Call` com tipo i64/u64 seguido de array method conhecido tenta `lower_array_builtin` com o recv coerido **antes** do fallback chain-Map.

Cobre join/slice/includes/indexOf/reverse direto sobre `m.get()`.

## Limitação

3-chain com `.map(arrow)` no meio (`m.get(n).map(x=>x*2).join()`) ainda esbarra no limite f64/parallel (já documentado no roadmap) — fora de escopo.

## Teste

`tests/map_get_array_method_chain.test.ts` (6 casos).

Suite **1379 → 1380** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)