### PR TITLE
fix(codegen): const s = arr.sort(cmp); s.map() nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -1156,7 +1156,7 @@ fn fn_body_returns_f64(body: &[Statement]) -> bool {
                                     "sqrt" | "cbrt" | "pow" | "exp" | "expm1" | "log"
                                     | "log2" | "log10" | "log1p" | "sin" | "cos" | "tan"
                                     | "asin" | "acos" | "atan" | "atan2" | "sinh" | "cosh"
-                                    | "tanh" | "hypot" | "random" | "fround" | "cbrt");
+                                    | "tanh" | "hypot" | "random" | "fround");
                             }
                         }
                     }

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -73,6 +73,11 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
                                 "map" | "filter" | "slice" | "concat" | "flat"
                                 | "flatMap" | "toReversed" | "toSorted" | "toSpliced"
                                 | "with" | "splice"
+                                // (cross-runtime) Mutators in-place que retornam
+                                // o proprio array (this). `const s = arr.sort(cmp)`
+                                // precisa registrar `s` como array, senao
+                                // `s.map(...)` nao eh reconhecido -> SIGILL.
+                                | "sort" | "reverse" | "fill" | "copyWithin"
                             )
                         );
                         let obj_is_array_static = matches!(

--- a/tests/array_sort_alias_map.test.ts
+++ b/tests/array_sort_alias_map.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `const s = arr.sort(cmp); s.map(...)` crashava
+// SIGILL. Causa: collect_array_receiver_idents nao reconhecia sort/reverse/
+// fill/copyWithin como array-returning, entao a var alias `s` nao era
+// registrada em ARRAY_RECEIVER_IDENTS — `s.map(...)` nao era reconhecido como
+// array method e caia em rota errada -> crash. Fix: adicionar os mutators
+// in-place (que retornam o proprio array/this) a lista array-returning.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// sort + alias + map
+const items = [{ n: "c", p: 3 }, { n: "a", p: 1 }, { n: "b", p: 2 }];
+const s = items.sort((x, y) => x.p - y.p);
+print(s.map(i => i.n).join(""));        // abc
+
+// reverse + alias + map
+const arr = [1, 2, 3];
+const r = arr.reverse();
+print(r.map(x => x).join(""));          // 321
+
+// sort chain direto (sem alias)
+const nums = [{ v: 9 }, { v: 1 }, { v: 5 }];
+print(nums.sort((a, b) => a.v - b.v).map(o => o.v).join(",")); // 1,5,9
+
+// fill + alias
+const f = [0, 0, 0].fill(7);
+print(f.map(x => x).join(","));         // 7,7,7
+
+describe("array sort alias map", () => {
+  test("mutators registram var alias como array", () =>
+    expect(out).toBe("abc\n321\n1,5,9\n7,7,7\n"));
+});


### PR DESCRIPTION
## Problema

`const s = arr.sort(cmp); s.map(...)` crashava com SIGILL.

## Causa

`collect_array_receiver_idents` não reconhecia `sort`/`reverse`/`fill`/`copyWithin` como array-returning. A var alias `s` não era registrada em `ARRAY_RECEIVER_IDENTS`, então `s.map(...)` não era roteado como array method → crash. Esses mutators in-place retornam o próprio array (this).

## Fix

Adicionar `sort`/`reverse`/`fill`/`copyWithin` à lista array-returning.

Também corrige um **warning pré-existente**: `cbrt` duplicado no `matches!` de Math methods (program.rs:1159, unreachable pattern) — build agora zero-warning.

## Teste

`tests/array_sort_alias_map.test.ts` — sort/reverse/fill alias + map, e chain direto.

Suite **1380 → 1387** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)