### PR TITLE
fix(codegen): const p = Promise.resolve(x); p.then(cb) nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -581,6 +581,25 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                                 if mid.sym.as_str() == "bind" {
                                     ctx.local_class_ty.insert(name.clone(), "Function".to_string());
                                 }
+                                // (cross-runtime) `const p = Promise.resolve(x)`
+                                // (e .reject/.all/.race/.allSettled/.any) marca
+                                // `p` como Promise pra que `p.then(cb)` resolva
+                                // o handler de Promise em vez de cair no
+                                // fallback Map -> trapz -> SIGILL. O chain
+                                // direto `Promise.resolve(x).then(...)` ja'
+                                // funciona; faltava o caso com var.
+                                if let swc_ecma_ast::Expr::Ident(obj_id) = m.obj.as_ref() {
+                                    if obj_id.sym.as_str() == "Promise"
+                                        && matches!(
+                                            mid.sym.as_str(),
+                                            "resolve" | "reject" | "all" | "race"
+                                            | "allSettled" | "any"
+                                        )
+                                    {
+                                        ctx.local_class_ty
+                                            .insert(name.clone(), "Promise".to_string());
+                                    }
+                                }
                                 // Class.staticMethod(...) → propaga ret_class.
                                 if let swc_ecma_ast::Expr::Ident(obj_id) = m.obj.as_ref() {
                                     let cls_name = obj_id.sym.as_str();

--- a/tests/promise_var_then.test.ts
+++ b/tests/promise_var_then.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `const p = Promise.resolve(x); p.then(cb)`
+// crashava SIGILL (var nao marcada como Promise -> p.then caia no fallback
+// Map -> trapz). Fix: decls marca var como Promise quando init eh
+// Promise.resolve/reject/all/race/allSettled/any. Aqui validamos que a
+// COMPILACAO+EXECUCAO nao crasha (o timing do callback async nao eh
+// deterministico no harness, entao checamos so' que o programa roda ate o
+// fim e produz o marcador sincrono).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const p = Promise.resolve("hello");
+p.then(x => print("s=" + x));
+
+const n = Promise.resolve(42);
+n.then(x => print("n=" + x));
+
+const a = Promise.all([1, 2, 3]);
+const b = Promise.race([1, 2]);
+print("sync-end");   // marcador sincrono — chega aqui = nao crashou
+
+describe("promise var then", () => {
+  test("var promise + then nao crasha", () =>
+    expect(out.includes("sync-end")).toBe(true));
+});


### PR DESCRIPTION
## Problema

`const p = Promise.resolve(x); p.then(cb)` crashava com SIGILL. O chain direto `Promise.resolve(x).then(...)` funcionava, mas com var intermediária o `p` não era marcado como Promise → `p.then` caía no fallback Map → `MAP_GET("then")` → `trapz`.

## Fix

`decls` marca a var como classe `Promise` quando o init é `Promise.resolve/reject/all/race/allSettled/any`. Mesmo padrão já usado para `Response` (fetch), `Function` (.bind) e `Class.staticMethod`.

## Teste

`tests/promise_var_then.test.ts`.

Suite **1393** (zero regressão).

> Nota: callback com param `:number` via fn nomeada ainda recebe NaN (limite f64/invoke documentado); arrow callbacks funcionam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)