### PR TITLE
fix(codegen): const parts = s.split(sep); parts.map() nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -78,6 +78,10 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
                                 // precisa registrar `s` como array, senao
                                 // `s.map(...)` nao eh reconhecido -> SIGILL.
                                 | "sort" | "reverse" | "fill" | "copyWithin"
+                                // (cross-runtime) `str.split(sep)` retorna array
+                                // de strings. `const parts = s.split("-")` precisa
+                                // registrar `parts` como array p/ `parts.map(...)`.
+                                | "split"
                             )
                         );
                         let obj_is_array_static = matches!(

--- a/tests/string_split_var_map.test.ts
+++ b/tests/string_split_var_map.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `const parts = s.split(sep); parts.map(...)`
+// crashava SIGILL. collect_array_receiver_idents nao reconhecia `split` como
+// array-returning, entao a var `parts` nao era registrada e `parts.map(...)`
+// nao era roteado como array method -> crash. (split em chain direto ja'
+// funcionava — estava em looks_array_call mas faltava no collect.)
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const parts = "a-b-c".split("-");
+print(parts.map(p => p + "!").join(""));      // a!b!c!
+
+const nums = "1,2,3".split(",");
+print(nums.filter(n => n !== "2").join(""));  // 13
+
+const words = "hello world foo".split(" ");
+print(words.map(w => w.length).join(","));    // 5,5,3
+
+// chain direto continua OK
+print("x.y.z".split(".").map(s => s.toUpperCase()).join("")); // XYZ
+
+describe("string split var map", () => {
+  test("var de split eh reconhecida como array", () =>
+    expect(out).toBe("a!b!c!\n13\n5,5,3\nXYZ\n"));
+});


### PR DESCRIPTION
## Problema

`const parts = s.split("-"); parts.map(...)` crashava com SIGILL.

## Causa

`collect_array_receiver_idents` não reconhecia `split` como array-returning. A var `parts` não era registrada em `ARRAY_RECEIVER_IDENTS`, então `parts.map(...)` não era roteado como array method → crash. (Chain direto `s.split(".").map(...)` já funcionava — `split` estava em `looks_array_call`, faltava só no `collect`.)

## Fix

Adicionar `split` à lista array-returning do `collect_array_receiver_idents`.

## Teste

`tests/string_split_var_map.test.ts`.

Suite **1393 → 1394** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)