### PR TITLE
fix(codegen): throw lexico dentro de try interrompe o fluxo (#128 fase2)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -417,6 +417,13 @@ pub struct FnCtx<'m, 'fb> {
     /// estes blocos (mais interno primeiro) antes de emitir `return_` —
     /// semantica JS: finally roda antes do return efetivar.
     pub finally_stack: Vec<swc_ecma_ast::BlockStmt>,
+    /// (#128 fase 2) Stack de (catch_block, foi_alvejado) ativos. Um `throw`
+    /// LEXICO dentro de um `try`-com-catch faz jump pro catch_block (interrompe
+    /// o fluxo) e marca `foi_alvejado=true` no topo. O lower_try_stmt usa esse
+    /// flag pra distinguir try-terminado-por-throw (catch tem predecessor,
+    /// processa normal) de por-return (catch orfao, sela). So' cobre throw
+    /// lexico; throw em fn chamada continua via error slot + check pos-call.
+    pub catch_target_stack: Vec<(Block, bool)>,
     /// Quando \`Stmt::Labeled\` envolve o próximo loop, registra aqui o
     /// nome do label. O loop seguinte consome (via \`take()\`) ao fazer
     /// push no \`loop_stack\`.
@@ -608,6 +615,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             var_counter: 0,
             loop_stack: Vec::new(),
             finally_stack: Vec::new(),
+            catch_target_stack: Vec::new(),
             pending_label: None,
             warnings: Vec::new(),
             node_import_map,

--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -603,6 +603,17 @@ pub(super) fn lower_throw_stmt(
     let set_fref = ctx.get_extern("__RTS_FN_RT_ERROR_SET", &[cl::I64], None)?;
     ctx.builder.ins().call(set_fref, &[handle.val]);
 
+    // (#128 fase 2) Se ha catch-block lexico ativo, `throw` desvia direto pra
+    // ele (interrompe o fluxo) e marca o catch como alvejado (tem predecessor).
+    // Retorna `true` (bloco terminou). Sem isso, `if (c) throw e; return x;`
+    // executava o `return x` apos o throw.
+    if let Some((catch_blk, targeted)) = ctx.catch_target_stack.last_mut() {
+        let cb = *catch_blk;
+        *targeted = true;
+        ctx.builder.ins().jump(cb, &[]);
+        return Ok(true);
+    }
+
     Ok(false)
 }
 
@@ -613,24 +624,36 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
     let clear_fref = ctx.get_extern("__RTS_FN_RT_ERROR_CLEAR", &[], None)?;
     ctx.builder.ins().call(clear_fref, &[]);
 
-    // (#128 fase 2) Empurra o corpo do finally no finally_stack ANTES de
-    // lowerar o try-body, pra que um `return` dentro do try inline o finally
-    // antes de emitir `return_`. Pop apos o try-body (catch/finally proprios
-    // nao devem re-inlinar este finally).
-    if has_finally {
-        ctx.finally_stack
-            .push(t.finalizer.as_ref().unwrap().clone());
-    }
-    let try_terminated = lower_block(ctx, &t.block)?;
-    if has_finally {
-        ctx.finally_stack.pop();
-    }
-
+    // (#128 fase 2) Cria o catch_block ANTES de lowerar o try-body pra que um
+    // `throw` lexico dentro do try faca jump direto pra ele.
     let catch_block = if has_catch {
         Some(ctx.builder.create_block())
     } else {
         None
     };
+
+    // (#128 fase 2) Empurra o corpo do finally no finally_stack ANTES de
+    // lowerar o try-body, pra que um `return` dentro do try inline o finally
+    // antes de emitir `return_`. Pop apos o try-body.
+    if has_finally {
+        ctx.finally_stack
+            .push(t.finalizer.as_ref().unwrap().clone());
+    }
+    // (#128 fase 2) Empurra (catch_block, alvejado=false). Throw lexico marca
+    // alvejado=true. Pop apos o body e captura se o catch recebeu jump.
+    if let Some(cb) = catch_block {
+        ctx.catch_target_stack.push((cb, false));
+    }
+    let try_terminated = lower_block(ctx, &t.block)?;
+    let catch_was_targeted = if catch_block.is_some() {
+        ctx.catch_target_stack.pop().map(|(_, t)| t).unwrap_or(false)
+    } else {
+        false
+    };
+    if has_finally {
+        ctx.finally_stack.pop();
+    }
+
     let finally_block = if has_finally {
         Some(ctx.builder.create_block())
     } else {
@@ -638,11 +661,7 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
     };
     let after_block = ctx.builder.create_block();
 
-    // (#128 fase 2) Se o try-body terminou com terminator (ex: `return` que
-    // ja' inlinou o finally), nao emitir o error-check brif — o bloco esta
-    // preenchido. (No modelo fase-1, `throw` nao desvia o fluxo; um try que
-    // termina com `return` incondicional torna o catch inalcancavel de
-    // qualquer forma — unwind real eh follow-up.)
+    // (#128 fase 2) Fall-through do try (sem terminator): error-check brif.
     if !try_terminated && !ctx.builder.is_unreachable() {
         let get_fref = ctx.get_extern("__RTS_FN_RT_ERROR_GET", &[], Some(cl::I64))?;
         let inst = ctx.builder.ins().call(get_fref, &[]);
@@ -656,12 +675,12 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
             .brif(is_err, err_target, &[], ok_target, &[]);
     }
 
-    // (#128 fase 2) try-body terminou (return inlinou o finally): no modelo
-    // fase-1 (throw nao desvia), nenhum caminho alcanca catch/finally/after
-    // — sao blocos orfaos. Sela-os (Cranelift remove blocos selados sem
-    // predecessores) e sinaliza terminado. Sem isto o after_block ficava
-    // vazio sem terminator ("block does not end in terminator").
-    if try_terminated {
+    // (#128 fase 2) try-body terminou por RETURN (nao por throw-pro-catch):
+    // catch/finally/after sao orfaos. Sela-os e sinaliza terminado. Quando o
+    // catch FOI alvejado por throw lexico (catch_was_targeted), NAO selamos —
+    // seguimos pro processamento do catch abaixo (ele tem o predecessor do
+    // jump do throw).
+    if try_terminated && !catch_was_targeted {
         if let Some(cb) = catch_block {
             ctx.builder.seal_block(cb);
         }

--- a/tests/throw_conditional_in_try.test.ts
+++ b/tests/throw_conditional_in_try.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #128 fase 2): `throw` LEXICO dentro de try (nao
+// como ultima instrucao) nao interrompia o fluxo — `if(c) throw e; return x`
+// executava o `return x` apos o throw. Fix: throw faz jump direto pro
+// catch_block (criado antes do body), com flag catch_was_targeted pra
+// distinguir try-terminado-por-throw (catch tem predecessor) de por-return
+// (catch orfao). lower_throw_stmt marca o topo do catch_target_stack.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// throw condicional + codigo depois no try
+function f(b: number): number {
+  try {
+    if (b === 0) throw new Error("zero");
+    return 100 / b;
+  } catch (e) { return -1; }
+}
+print("" + f(0));   // -1 (throw desvia, nao executa return 100/0)
+print("" + f(2));   // 50
+
+// throw condicional com varios statements depois
+function g(n: number): string {
+  try {
+    if (n < 0) throw new Error("neg");
+    const x = n * 2;
+    return "val:" + x;
+  } catch (e) { return "negative"; }
+}
+print(g(5));        // val:10
+print(g(-1));       // negative
+
+// throw incondicional (ultima instrucao) continua OK
+function h(): string {
+  try { throw new Error("boom"); } catch (e) { return "caught"; }
+}
+print(h());         // caught
+
+// try/catch/finally com return (regressao guard #1232)
+function k(): string {
+  try { return "ok"; } catch (e) { return "err"; } finally { out += "kf\n"; }
+}
+print(k());         // kf, ok
+
+describe("throw conditional in try", () => {
+  test("throw lexico interrompe fluxo", () =>
+    expect(out).toBe("-1\n50\nval:10\nnegative\ncaught\nkf\nok\n"));
+});


### PR DESCRIPTION
## Problema

`throw` léxico dentro de `try` (não como última instrução) não interrompia o fluxo:

```ts
function f(b) { try { if (b === 0) throw new Error(); return 100/b; } catch(e){ return -1; } }
f(0)  // retornava Infinity (executava return 100/0) em vez de -1
```

`lower_throw_stmt` só fazia `ERROR_SET` sem desviar o controle.

## Fix

- `catch_target_stack: Vec<(Block, bool)>` em FnCtx.
- `lower_try_stmt` cria o `catch_block` **antes** do body e empilha `(cb, false)`.
- `lower_throw_stmt`, com catch ativo, faz **jump direto pro catch** (interrompe o fluxo) e marca `alvejado=true`.
- `lower_try_stmt` usa o flag `catch_was_targeted` para distinguir try-terminado-**por-throw** (catch tem predecessor → processa) de **por-return** (catch órfão → sela). Sem o flag, `return`+catch+finally dava verifier error (bloco órfão).

## Cobre

throw condicional + código depois, throw incondicional, e **preserva** return-in-try-finally (#1232).

## Limitação

`throw` em fn chamada continua via error slot + check pós-call (fase-1) — follow-up.

## Teste

`tests/throw_conditional_in_try.test.ts`.

Suite **1409/1409** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)