### PR TITLE
fix(codegen): const c2 = inst.method():C; c2.method() nao crasha (builder)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -634,6 +634,25 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                                             }
                                         }
                                     }
+                                    // (cross-runtime builder) `const c2 = inst.method()`
+                                    // onde `inst` tem classe C conhecida e o metodo
+                                    // de instancia retorna `this` ou C: marca `c2`
+                                    // como C pra que `c2.method()` resolva o metodo
+                                    // (builder pattern). Sem isso, `c.inc().inc()`
+                                    // / `const c2 = c.inc(); c2.inc()` caia no
+                                    // fallback MAP_GET("inc") -> trapz -> SIGILL.
+                                    if let Some(recv_cls) = ctx.local_class_ty.get(obj_id.sym.as_str()).cloned() {
+                                        let mn = mid.sym.as_str();
+                                        let fname = crate::codegen::lower::compile::class::class_method_name(&recv_cls, mn);
+                                        // ret_class do metodo == a propria classe (ex:
+                                        // `inc(): C { ...; return this; }`).
+                                        let ret_is_self = ctx.user_fns.get(&fname)
+                                            .map(|abi| abi.ret_class.as_deref() == Some(recv_cls.as_str()))
+                                            .unwrap_or(false);
+                                        if ret_is_self {
+                                            ctx.local_class_ty.insert(name.clone(), recv_cls);
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/tests/builder_method_chain_var.test.ts
+++ b/tests/builder_method_chain_var.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `const c2 = inst.method(); c2.method()` onde o
+// metodo de instancia retorna a propria classe (`inc(): C { ...; return this }`)
+// crashava SIGILL — c2 nao era marcado com a classe C, entao `c2.inc()` caia
+// no fallback MAP_GET("inc") -> trapz. Fix: decls marca a var receptora com a
+// classe quando o metodo de instancia tem ret_class == classe do receiver.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+class Counter {
+  n: number = 0;
+  inc(): Counter { this.n++; return this; }
+  add(x: number): Counter { this.n += x; return this; }
+  get value(): number { return this.n; }
+}
+
+// var intermediaria de metodo que retorna a classe
+const c = new Counter();
+const c2 = c.inc();
+c2.inc();
+print("" + c.value);   // 2 (mesmo objeto)
+
+// encadeamento via vars
+const d = new Counter();
+const d1 = d.inc();
+const d2 = d1.add(10);
+d2.inc();
+print("" + d.value);   // 1+10+1 = 12
+
+describe("builder method chain var", () => {
+  test("var de metodo ret-classe eh reconhecida", () =>
+    expect(out).toBe("2\n12\n"));
+});


### PR DESCRIPTION
## Problema

`const c2 = c.inc(); c2.inc()` onde o método de instância retorna a própria classe (`inc(): Counter { ...; return this; }`) crashava SIGILL — `c2` não era marcado com a classe, então `c2.inc()` caía no fallback `MAP_GET("inc")` → `trapz`.

## Fix

`decls` marca a var receptora com a classe quando `inst.method()` e o método de instância tem `ret_class == classe do receiver`. Reusa o mesmo padrão de `Class.staticMethod()` (que já propagava `ret_class`).

## Limitação

Chain **direto** (`c.inc().inc()`) e ret `: this` (em vez de `: C` explícito) ainda usam o fallback — follow-up.

## Teste

`tests/builder_method_chain_var.test.ts`.

Suite **1434/1434** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)