### PR TITLE
fix(codegen): c.inc().inc() chain direto de builder nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -2294,6 +2294,23 @@ pub(super) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
                                 }
                             }
                         }
+                        // (cross-runtime builder) Metodo de instancia de classe
+                        // de USUARIO que retorna a propria classe (`inc(): C {
+                        // return this }`). Permite chain direto `c.inc().inc()`.
+                        // RESTRITIVO: so' quando ret_class do metodo == a classe
+                        // do receiver (builder genuino), pra nao resolver classe
+                        // indevida (regressao da tentativa anterior).
+                        if ctx.classes.contains_key(&recv_cls) {
+                            let fname = crate::codegen::lower::compile::class::class_method_name(
+                                &recv_cls,
+                                method_id.sym.as_str(),
+                            );
+                            if let Some(abi) = ctx.user_fns.get(&fname) {
+                                if abi.ret_class.as_deref() == Some(recv_cls.as_str()) {
+                                    return Some(recv_cls);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/tests/builder_method_chain_direct.test.ts
+++ b/tests/builder_method_chain_direct.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): chain DIRETO de builder `c.inc().inc()` onde o
+// metodo retorna a propria classe (`inc(): C { return this }`) crashava SIGILL
+// — class_of_expr nao resolvia a classe do receiver `c.inc()` (Call), entao o
+// 2o `.inc` caia no fallback MAP_GET -> trapz. Fix: class_of_expr resolve
+// metodo de instancia de classe de usuario com ret_class == classe do receiver
+// (builder genuino, restritivo p/ nao regredir). Complementa #1245 (caso var).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+class Counter {
+  n: number = 0;
+  inc(): Counter { this.n++; return this; }
+  add(x: number): Counter { this.n += x; return this; }
+  get value(): number { return this.n; }
+}
+
+const c = new Counter();
+c.inc().inc().inc();
+print("" + c.value);   // 3
+
+const d = new Counter();
+d.inc().add(10).inc();
+print("" + d.value);   // 12
+
+// builder com build final (string)
+class Builder {
+  parts: string[] = [];
+  add(s: string): Builder { this.parts.push(s); return this; }
+  build(): string { return this.parts.join("-"); }
+}
+print(new Builder().add("a").add("b").add("c").build());  // a-b-c
+
+describe("builder method chain direct", () => {
+  test("chain direto de metodo ret-classe nao crasha", () =>
+    expect(out).toBe("3\n12\na-b-c\n"));
+});


### PR DESCRIPTION
## Problema

Complementa #1245: chain **direto** `c.inc().inc()` (sem var) onde o método retorna a própria classe (`inc(): C { return this }`) crashava SIGILL — `class_of_expr` não resolvia a classe do receiver `c.inc()` (Call), então o 2º `.inc` caía no fallback `MAP_GET` → `trapz`.

## Fix

`class_of_expr` resolve método de instância de classe de **usuário** com `ret_class == classe do receiver` (builder genuíno). **Restritivo** a `ret_class == recv_cls` para não resolver classe indevida — a tentativa anterior sem essa restrição deu 3 regressões. Reusa o `recv_cls` já resolvido por `lhs_static_class` no ramo de global class instance methods.

Cobre chain direto de N métodos + build final misto.

## Teste

`tests/builder_method_chain_direct.test.ts`.

Suite **1435/1435** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)