### PR TITLE
fix(codegen): builder com return type : this (inc(): this) nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -398,6 +398,16 @@ pub fn compile_program(
             let ret_trim = ret.trim();
             if classes.contains_key(ret_trim) {
                 fn_class_returns.insert(fn_decl.name.clone(), ret_trim.to_string());
+            } else if ret_trim == "this" {
+                // (cross-runtime builder) Metodo `inc(): this { return this }`:
+                // o return eh a propria classe. Extrai o owner do nome mangled
+                // `__class_<C>_<method>` e usa como ret_class. Permite o chain
+                // builder (`c.inc().inc()`) com `: this` (nao so' `: C`).
+                if let Some(owner) = extract_class_owner(&fn_decl.name) {
+                    if classes.contains_key(&owner) {
+                        fn_class_returns.insert(fn_decl.name.clone(), owner);
+                    }
+                }
             }
         }
     }

--- a/tests/builder_method_chain_this.test.ts
+++ b/tests/builder_method_chain_this.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): builder com return type `: this` (em vez de
+// `: C` explicito) — `inc(): this { return this }` — crashava no chain
+// `c.inc().inc()` porque ret_class ficava None p/ "this". Fix: program.rs
+// detecta return_type=="this" e extrai a classe owner do nome mangled
+// __class_<C>_<method>, setando ret_class=C. Completa #1245/#1246.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+class Counter {
+  n: number = 0;
+  inc(): this { this.n++; return this; }
+  add(x: number): this { this.n += x; return this; }
+  get value(): number { return this.n; }
+}
+
+// chain direto com : this
+const c = new Counter();
+c.inc().inc().inc();
+print("" + c.value);   // 3
+
+// chain misto
+const d = new Counter();
+d.inc().add(10).inc();
+print("" + d.value);   // 12
+
+// builder string com : this + build final
+class B {
+  items: string[] = [];
+  add(s: string): this { this.items.push(s); return this; }
+  build(): string { return this.items.join(","); }
+}
+print(new B().add("x").add("y").add("z").build());  // x,y,z
+
+// via var
+const b = new B();
+const b2 = b.add("a");
+b2.add("b");
+print(b.build());   // a,b
+
+describe("builder method chain this", () => {
+  test("return : this resolve a classe", () =>
+    expect(out).toBe("3\n12\nx,y,z\na,b\n"));
+});


### PR DESCRIPTION
## Problema

Completa #1245/#1246: builder com `inc(): this { return this }` (em vez de `: C` explícito) crashava no chain — `ret_class` ficava None para `"this"`.

## Fix

`program.rs` detecta `return_type == "this"` e extrai a classe owner do nome mangled `__class_<C>_<method>` (via `extract_class_owner`), setando `ret_class = C`. Assim o chain direto e via var funcionam igual ao `: C`.

## Teste

`tests/builder_method_chain_this.test.ts` — chain direto, misto, build final, via var, com `: this`.

Suite **1436/1436** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)