### PR TITLE
fix(runtime): (1/0).toString() retorna Infinity nao inf

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/number/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/number/rt.rs
@@ -230,6 +230,15 @@ fn js_exp_notation(s: &str) -> String {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_NUMBER_TO_STRING_RADIX(v: f64, radix: i64) -> u64 {
+    // (cross-runtime) JS spec: NaN/Infinity -> "NaN"/"Infinity"/"-Infinity"
+    // (Rust formataria como "NaN"/"inf"/"-inf"). Aplica antes de qualquer
+    // radix. `(1/0).toString()` deve dar "Infinity", nao "inf".
+    if v.is_nan() {
+        return alloc_str("NaN");
+    }
+    if v.is_infinite() {
+        return alloc_str(if v > 0.0 { "Infinity" } else { "-Infinity" });
+    }
     let r = radix.clamp(2, 36) as u32;
     if r == 10 {
         // Fast path: standard decimal representation.

--- a/tests/number_tostring_infinity.test.ts
+++ b/tests/number_tostring_infinity.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `(1/0).toString()` retornava "inf" (formato
+// Rust) em vez de "Infinity" (JS). NUMBER_TO_STRING_RADIX caia em
+// format!("{v}") sem tratar NaN/Infinity. Fix: guard no inicio (igual toFixed).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+print((1 / 0).toString());        // Infinity
+print((-1 / 0).toString());       // -Infinity
+print((0 / 0).toString());        // NaN
+const inf = Infinity;
+print(inf.toString());            // Infinity
+print((Number("x")).toString());  // NaN
+// radix tambem
+print((255).toString(16));        // ff (caso normal preservado)
+print((10).toString());           // 10
+print((3.14).toString());         // 3.14
+
+describe("number toString infinity", () => {
+  test("Infinity/NaN formatados como JS", () =>
+    expect(out).toBe("Infinity\n-Infinity\nNaN\nInfinity\nNaN\nff\n10\n3.14\n"));
+});


### PR DESCRIPTION
## Problema

`(1/0).toString()` dava `"inf"` (formato Rust) em vez de `"Infinity"` (JS); `(-1/0)` dava `"-inf"`.

## Causa

`NUMBER_TO_STRING_RADIX` caía em `format!("{v}")` sem tratar NaN/Infinity.

## Fix

Guard no início retornando `"NaN"`/`"Infinity"`/`"-Infinity"` — mesmo tratamento que `toFixed` já tinha. Template (`"" + Infinity`) já formatava certo; só `.toString()` errava.

## Teste

`tests/number_tostring_infinity.test.ts` — toString sem/com radix, NaN, casos normais.

Suite **1441/1441** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)