### PR TITLE
fix(codegen): return g(n-1).concat(x) nao aplica TCO erroneamente

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -807,7 +807,16 @@ pub(super) fn lower_try_stmt(ctx: &mut FnCtx, t: &swc_ecma_ast::TryStmt) -> Resu
 
 fn is_direct_call_expr(expr: &swc_ecma_ast::Expr) -> bool {
     match expr {
-        swc_ecma_ast::Expr::Call(_) => true,
+        // (cross-runtime) So' eh tail-call quando o callee eh uma chamada
+        // DIRETA a fn (Ident), nao um method call. `g(n-1).concat([n])` tem
+        // callee Member (`.concat`) — o tail real eh o concat, NAO g. Sem
+        // essa checagem, o TCO aplicava return_call em g(n-1) e DESCARTAVA o
+        // .concat -> recursao retornando array.concat() dava vazio.
+        swc_ecma_ast::Expr::Call(c) => matches!(
+            &c.callee,
+            swc_ecma_ast::Callee::Expr(callee)
+                if matches!(callee.as_ref(), swc_ecma_ast::Expr::Ident(_))
+        ),
         swc_ecma_ast::Expr::Paren(p) => is_direct_call_expr(&p.expr),
         _ => false,
     }

--- a/tests/tco_method_chain_not_tail.test.ts
+++ b/tests/tco_method_chain_not_tail.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `return g(n-1).concat([n])` aplicava TCO
+// (return_call) em g(n-1) e DESCARTAVA o .concat — o callee real do tail eh
+// o method call .concat, nao g. Resultado: recursao retornando
+// array.concat() dava vazio. Fix: is_direct_call_expr so' eh tail-call
+// quando o callee eh Ident (chamada direta), nao Member (method call).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// quicksort recursivo (recursao + concat em tail)
+function quicksort(arr: number[]): number[] {
+  if (arr.length <= 1) return arr;
+  const pivot = arr[0];
+  const less: number[] = [];
+  const more: number[] = [];
+  for (let i = 1; i < arr.length; i++) {
+    if (arr[i] < pivot) less.push(arr[i]); else more.push(arr[i]);
+  }
+  return quicksort(less).concat([pivot]).concat(quicksort(more));
+}
+print(quicksort([3, 1, 4, 1, 5, 9, 2, 6]).join(",")); // 1,1,2,3,4,5,6,9
+
+// recursao retornando array.concat
+function build(n: number): number[] {
+  if (n <= 0) return [];
+  return build(n - 1).concat([n]);
+}
+print(build(4).join(","));  // 1,2,3,4
+
+// TCO genuino (tail-call direto) preservado — sem stack overflow
+function countdown(n: number): number {
+  if (n <= 0) return 0;
+  return countdown(n - 1);
+}
+print("cd=" + countdown(50000));  // 0
+
+describe("tco method chain not tail", () => {
+  test("recursao + method chain nao descarta o chain", () =>
+    expect(out).toBe("1,1,2,3,4,5,6,9\n1,2,3,4\ncd=0\n"));
+});


### PR DESCRIPTION
## Problema

`return g(n-1).concat([n])` aplicava tail-call-optimization (`return_call`) em `g(n-1)` e **descartava o `.concat`** — o callee real do tail é o method call `.concat`, não `g`. Resultado: recursão retornando `array.concat()` (quicksort, build recursivo) dava **vazio**.

## Causa

`is_direct_call_expr` retornava `true` para qualquer `Expr::Call`, incluindo `g(n-1).concat(...)` cujo callee externo é `Member` (`.concat`).

## Fix

Só é tail-call quando o callee é `Ident` (chamada direta a fn), não `Member` (method call).

TCO genuíno (`return f(x)` com `f` ident) preservado — `countdown(50000)` sem stack overflow.

## Teste

`tests/tco_method_chain_not_tail.test.ts` — quicksort, build recursivo, TCO genuíno.

Suite **1446/1446** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)