### PR TITLE
fix(codegen): fn top-level ret-array em chain mx(2,3).map() nao crasha

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -70,14 +70,24 @@ fn collect_methods_ret_array(program: &Program) -> HashSet<String> {
     }
     let mut out = HashSet::new();
     for item in &program.items {
-        if let Item::Class(c) = item {
-            for mem in &c.members {
-                if let crate::parser::ast::ClassMember::Method(method) = mem {
-                    if ret_type_is_array(method.return_type.as_deref()) {
-                        out.insert(method.name.clone());
+        match item {
+            Item::Class(c) => {
+                for mem in &c.members {
+                    if let crate::parser::ast::ClassMember::Method(method) = mem {
+                        if ret_type_is_array(method.return_type.as_deref()) {
+                            out.insert(method.name.clone());
+                        }
                     }
                 }
             }
+            // (cross-runtime) Fns top-level retornando array (`function mx():
+            // number[][]`). Permite `mx(2,3).map(...)` chain direto e via var.
+            Item::Function(f) => {
+                if ret_type_is_array(f.return_type.as_deref()) {
+                    out.insert(f.name.clone());
+                }
+            }
+            _ => {}
         }
     }
     out
@@ -99,6 +109,10 @@ fn collect_array_receiver_idents(program: &Program) -> HashSet<String> {
             Expr::Await(a) => rec(&a.arg, methods_ret_array),
             Expr::Call(c) => match &c.callee {
                 swc_ecma_ast::Callee::Expr(ce) => match ce.as_ref() {
+                    // (cross-runtime) Fn top-level retornando array
+                    // (`mx(): number[][]`). `mx(2,3).map(...)` / `const v =
+                    // mx(...)`. O nome esta no set methods_ret_array.
+                    Expr::Ident(id) if methods_ret_array.contains(id.sym.as_str()) => true,
                     Expr::Member(m) => {
                         // (cross-runtime) `inst.method()` cujo metodo de classe
                         // declara return array (`getItems(): string[]`). Sem
@@ -1492,6 +1506,11 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                     fn looks_array_call(e: &Expr) -> bool {
                         let Expr::Call(c) = e else { return false };
                         let Callee::Expr(ce) = &c.callee else { return false };
+                        // (cross-runtime) Fn top-level retornando array
+                        // (`mx(): number[][]`): `mx(2,3).map(...)` chain direto.
+                        if let Expr::Ident(id) = ce.as_ref() {
+                            return METHODS_RET_ARRAY.with(|s| s.borrow().contains(id.sym.as_str()));
+                        }
                         let Expr::Member(mm) = ce.as_ref() else { return false };
                         let MemberProp::Ident(p) = &mm.prop else { return false };
                         let prop = p.sym.as_str();

--- a/tests/fn_ret_array_chain_map.test.ts
+++ b/tests/fn_ret_array_chain_map.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): fn top-level retornando array (`mx(): number[][]`)
+// chamada em chain direto `mx(2,3).map(...)` crashava SIGILL — collect_methods
+// _ret_array / looks_array_call so' reconheciam METODOS de classe e methods de
+// array, nao fns top-level com return_type array. Fix: estende a coleta p/
+// Item::Function ret-array e os reconhecedores (init_looks_array +
+// looks_array_call) p/ Call de Ident no set. Completa #1241/#1246.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function mx(rows: number, cols: number): number[][] {
+  const m: number[][] = [];
+  for (let i = 0; i < rows; i++) {
+    const row: number[] = [];
+    for (let j = 0; j < cols; j++) row.push(i * cols + j);
+    m.push(row);
+  }
+  return m;
+}
+// chain direto sobre fn-ret-array
+print(mx(2, 3).map(r => r.join("-")).join("|"));   // 0-1-2|3-4-5
+
+function words(): string[] { return ["a", "b", "c"]; }
+print(words().filter(w => w !== "b").join(""));     // ac
+print(words().map(w => w.toUpperCase()).join(""));  // ABC
+
+// via var continua OK
+const w = words();
+print(w.map(x => x + "!").join(""));                // a!b!c!
+
+describe("fn ret array chain map", () => {
+  test("fn top-level ret-array em chain direto", () =>
+    expect(out).toBe("0-1-2|3-4-5\nac\nABC\na!b!c!\n"));
+});


### PR DESCRIPTION
## Problema

Fn top-level com `return_type` array (`function mx(): number[][]`) chamada em chain direto `mx(2,3).map(r => ...)` crashava SIGILL — `collect_methods_ret_array`/`looks_array_call` só reconheciam **métodos de classe** e methods de array, não fns top-level ret-array.

## Fix

- `collect_methods_ret_array` também coleta `Item::Function` ret-array.
- `init_looks_array` e `looks_array_call` reconhecem `Call` de `Ident` no set.

Cobre chain direto (map/filter), via var, e `number[][]` aninhado.

## Teste

`tests/fn_ret_array_chain_map.test.ts`.

Suite **1499/1499** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)