### PR TITLE
fix(codegen): for (const c of "abc") itera os chars da string

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -545,6 +545,10 @@ pub struct FnCtx<'m, 'fb> {
     /// Sem isso, `arr.indexOf(x)` em `let arr: number[] = [...]` cai em
     /// string builtin (`__RTS_FN_GL_STRING_INDEX_OF`) e retorna lixo.
     pub local_array_vars: std::collections::HashSet<String>,
+    /// (cross-runtime) Vars cujo valor eh string (literal, template, anotacao
+    /// `: string`). Usado por `for (const c of s)` p/ iterar os chars em vez
+    /// de tratar a string como Vec (que nao itera).
+    pub local_string_vars: std::collections::HashSet<String>,
 
     /// (generators) Vars inicializadas com chamada a uma generator fn
     /// (`const it = g()`). `it.next()` roteia para GENERATOR_NEXT (cursor
@@ -642,6 +646,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),
             local_array_vars: std::collections::HashSet::new(),
+            local_string_vars: std::collections::HashSet::new(),
             generator_vars: std::collections::HashSet::new(),
             local_ta_view: HashMap::new(),
             local_nested_obj_field_types: HashMap::new(),

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -105,6 +105,23 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             if matches!(init_peeled, swc_ecma_ast::Expr::Array(_)) {
                 ctx.local_array_vars.insert(name.clone());
             }
+            // (cross-runtime) `const s = "..."` / template — marca como string
+            // pra que `for (const c of s)` itere os chars. Tambem `: string`.
+            let ann_is_string = if let Pat::Ident(id) = &decl.name {
+                id.type_ann.as_ref().map(|t| matches!(
+                    t.type_ann.as_ref(),
+                    swc_ecma_ast::TsType::TsKeywordType(k)
+                        if matches!(k.kind, swc_ecma_ast::TsKeywordTypeKind::TsStringKeyword)
+                )).unwrap_or(false)
+            } else { false };
+            if ann_is_string
+                || matches!(
+                    init_peeled,
+                    swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(_)) | swc_ecma_ast::Expr::Tpl(_)
+                )
+            {
+                ctx.local_string_vars.insert(name.clone());
+            }
             // Alias direto de array: `const es = arr` onde `arr` ja' eh
             // array conhecido. Sem isso, `es.map(arrow)` nao reconhece o
             // receiver como Vec e cai no caminho string/map_get (trap).

--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -204,6 +204,22 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
         )?;
         let inst = ctx.builder.ins().call(keys_fn, &[handle]);
         handle = ctx.builder.inst_results(inst)[0];
+    } else if for_of_iterates_string(ctx, &for_of.right) {
+        // (cross-runtime) `for (const c of "abc")` / string var: itera os
+        // CHARS (codepoints). Converte a string num Vec de char-handles via
+        // VEC_NEW + SPREAD_INTO_VEC (mesmo helper do spread `[..."abc"]`).
+        // Sem isso, o for-of tratava a string como Vec (VEC_LEN=-1) e nao
+        // iterava.
+        let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+        let inst_v = ctx.builder.ins().call(vec_new, &[]);
+        let char_vec = ctx.builder.inst_results(inst_v)[0];
+        let spread_fn = ctx.get_extern(
+            "__RTS_FN_RT_SPREAD_INTO_VEC",
+            &[cl::I64, cl::I64],
+            None,
+        )?;
+        ctx.builder.ins().call(spread_fn, &[char_vec, handle]);
+        handle = char_vec;
     }
 
     let len_fref = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_LEN", &[cl::I64], Some(cl::I64))?;
@@ -478,4 +494,19 @@ pub(super) fn lower_for_in(ctx: &mut FnCtx, for_in: &swc_ecma_ast::ForInStmt) ->
     ctx.builder.switch_to_block(exit);
     ctx.builder.seal_block(exit);
     Ok(false)
+}
+
+/// (cross-runtime) `for (const c of <expr>)` itera os chars quando `<expr>`
+/// eh string: literal `"..."`, template, ou var rastreada como string.
+/// Conservador — so' dispara com sinal claro de string (nao afeta
+/// arrays/Map/Set).
+fn for_of_iterates_string(ctx: &FnCtx, e: &swc_ecma_ast::Expr) -> bool {
+    use swc_ecma_ast::Expr;
+    match e {
+        Expr::Lit(swc_ecma_ast::Lit::Str(_)) => true,
+        Expr::Tpl(_) => true,
+        Expr::Paren(p) => for_of_iterates_string(ctx, &p.expr),
+        Expr::Ident(id) => ctx.local_string_vars.contains(id.sym.as_str()),
+        _ => false,
+    }
 }

--- a/tests/for_of_string_chars.test.ts
+++ b/tests/for_of_string_chars.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const c of "abc")` / string var nao
+// iterava os chars — o for-of tratava a string como Vec (VEC_LEN=-1) e o
+// loop nao rodava. Fix: detecta iteravel string (literal/template/var
+// rastreada) e converte p/ Vec de char-handles via SPREAD_INTO_VEC (mesmo
+// helper do spread `[..."abc"]`).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// literal
+let lit = "";
+for (const c of "abc") lit += c + ".";
+print(lit);                       // a.b.c.
+
+// var
+const s = "hello";
+let v = "";
+for (const c of s) v += c;
+print(v);                         // hello
+
+// var anotada
+const w: string = "xyz";
+let parts = "";
+for (const c of w) parts += c.toUpperCase();
+print(parts);                     // XYZ
+
+// template literal
+const name = "rts";
+let t = "";
+for (const c of `${name}!`) t += c;
+print(t);                         // rts!
+
+describe("for-of string chars", () => {
+  test("itera codepoints da string", () =>
+    expect(out).toBe("a.b.c.\nhello\nXYZ\nrts!\n"));
+});


### PR DESCRIPTION
## Problema

`for (const c of <string>)` não iterava os chars — o for-of tratava a string como Vec (`VEC_LEN = -1`), e o loop não rodava. Spread `[..."abc"]` já funcionava.

## Fix

`for_of_iterates_string` detecta iterável string (literal/template/var rastreada em `local_string_vars` ou anotada `: string`); converte para Vec de char-handles via `VEC_NEW` + `SPREAD_INTO_VEC` (mesmo helper do spread). `decls` rastreia vars string.

Cobre literal, var, var anotada, template.

## Teste

`tests/for_of_string_chars.test.ts`.

Suite **1516/1516** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)