### PR TITLE
fix(codegen): for-of de Set numerico itera valores, nao handles

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1802,6 +1802,7 @@ fn apply_reduce_pass_to_top_level(
         fn_name: String,
         op: AssocOp,
     }
+    let set_map_vars = collect_set_map_var_names_items(items);
     let mut matches: Vec<Match> = Vec::new();
     let n_items = items.len();
     for i in 0..n_items.saturating_sub(1) {
@@ -1867,6 +1868,15 @@ fn apply_reduce_pass_to_top_level(
         };
 
         if !is_pure_expr_for_parallel(&rhs_expr, &loop_var, &HashSet::new(), pure_ns) {
+            continue;
+        }
+
+        // (cross-runtime) NAO reescrever p/ parallel.reduce quando o iteravel
+        // eh Set/Map (inline `new Set(...)` OU var `const s = new Set(...)`) —
+        // parallel.reduce faz snapshot_vec que so' aceita Vec, nao Map/Set
+        // storage. Sem este gate, `for (const x of set) sum += x` virava
+        // parallel.reduce sobre o Set e dava 0.
+        if expr_is_set_or_map(for_of.right.as_ref(), &set_map_vars) {
             continue;
         }
 
@@ -1997,6 +2007,7 @@ fn apply_reduce_pass_to_body(
         fn_name: String,
         op: AssocOp,
     }
+    let set_map_vars = collect_set_map_var_names_body(body);
     let mut matches: Vec<Match> = Vec::new();
     let n = body.len();
     for i in 0..n.saturating_sub(1) {
@@ -2050,6 +2061,11 @@ fn apply_reduce_pass_to_body(
             _ => continue,
         };
         if !is_pure_expr_for_parallel(&rhs_expr, &loop_var, &HashSet::new(), pure_ns) {
+            continue;
+        }
+        // (cross-runtime) NAO reescrever reduce sobre Set/Map (snapshot_vec
+        // so' aceita Vec). Ver gate equivalente em apply_reduce_pass_to_top_level.
+        if expr_is_set_or_map(for_of.right.as_ref(), &set_map_vars) {
             continue;
         }
         let fn_name = format!("__par_reduce_{counter}");
@@ -2340,5 +2356,58 @@ fn apply_purity_pass_to_body(
     for t in &transforms {
         let Statement::Raw(raw) = &mut body[t.idx];
         raw.stmt = Some(make_par_foreach_stmt(&t.arr_expr, &t.fn_name));
+    }
+}
+
+/// (cross-runtime) `e` eh um Set/Map: `new Set/Map(...)` inline ou ident de
+/// var coletada em `set_map_vars`. Usado pra gatear reduce_pass (parallel.
+/// reduce nao funciona sobre Set/Map storage).
+fn expr_is_set_or_map(e: &Expr, set_map_vars: &HashSet<String>) -> bool {
+    match e {
+        Expr::New(ne) => matches!(
+            ne.callee.as_ref(),
+            Expr::Ident(cid) if matches!(cid.sym.as_str(), "Set" | "Map" | "WeakSet" | "WeakMap")
+        ),
+        Expr::Ident(id) => set_map_vars.contains(id.sym.as_str()),
+        Expr::Paren(p) => expr_is_set_or_map(&p.expr, set_map_vars),
+        _ => false,
+    }
+}
+
+/// Coleta nomes de vars `const/let x = new Set/Map(...)` em items top-level.
+fn collect_set_map_var_names_items(items: &[Item]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for item in items {
+        if let Item::Statement(Statement::Raw(raw)) = item {
+            if let Some(Stmt::Decl(Decl::Var(vd))) = raw.stmt.as_ref() {
+                collect_set_map_from_vardecl(vd, &mut out);
+            }
+        }
+    }
+    out
+}
+
+/// Coleta nomes de vars `const/let x = new Set/Map(...)` num body de fn.
+fn collect_set_map_var_names_body(body: &[Statement]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for Statement::Raw(raw) in body {
+        if let Some(Stmt::Decl(Decl::Var(vd))) = raw.stmt.as_ref() {
+            collect_set_map_from_vardecl(vd, &mut out);
+        }
+    }
+    out
+}
+
+fn collect_set_map_from_vardecl(vd: &swc_ecma_ast::VarDecl, out: &mut HashSet<String>) {
+    for d in &vd.decls {
+        if let (Pat::Ident(id), Some(init)) = (&d.name, d.init.as_deref()) {
+            if let Expr::New(ne) = init {
+                if let Expr::Ident(cid) = ne.callee.as_ref() {
+                    if matches!(cid.sym.as_str(), "Set" | "Map" | "WeakSet" | "WeakMap") {
+                        out.insert(id.id.sym.to_string());
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -180,12 +180,23 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
 
     // (#222) Map/Set iteracao via for-of:
     // - Map: converte para Vec de [k,v] entries preservando insertion order
-    // - Set: usa as proprias keys do Map subjacente (Vec de keys)
-    // Detecta classe via local_class_ty[var_name] = "Map"|"Set".
-    let iter_class: Option<String> = if let swc_ecma_ast::Expr::Ident(id) = for_of.right.as_ref() {
-        ctx.local_class_ty.get(id.sym.as_str()).cloned()
-    } else {
-        None
+    // - Set: usa MAP_VALUES (elementos reconvertidos)
+    // Detecta classe via local_class_ty[var_name] OU `new Map/Set(...)` inline.
+    let iter_class: Option<String> = match for_of.right.as_ref() {
+        swc_ecma_ast::Expr::Ident(id) => ctx.local_class_ty.get(id.sym.as_str()).cloned(),
+        // (cross-runtime) `for (const x of new Set([...]))` inline (sem var).
+        swc_ecma_ast::Expr::New(ne) => {
+            if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
+                match cid.sym.as_str() {
+                    "Set" => Some("Set".to_string()),
+                    "Map" => Some("Map".to_string()),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
     };
     if matches!(iter_class.as_deref(), Some("Map")) {
         let entries_fn = ctx.get_extern(
@@ -196,13 +207,18 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
         let inst = ctx.builder.ins().call(entries_fn, &[handle]);
         handle = ctx.builder.inst_results(inst)[0];
     } else if matches!(iter_class.as_deref(), Some("Set")) {
-        // Set internamente eh Map<key, 1> — keys preservam ordem.
-        let keys_fn = ctx.get_extern(
-            "__RTS_FN_NS_COLLECTIONS_MAP_KEYS",
+        // Set internamente eh Map<key, 1> — os ELEMENTOS sao as keys.
+        // (cross-runtime) Usa MAP_VALUES (nao MAP_KEYS): p/ Set, MAP_VALUES
+        // reconverte cada key string de volta ao valor (parse int -> number,
+        // senao handle string). MAP_KEYS retornava as keys string CRUAS, e
+        // `for (const x of setNum) sum += x` somava o handle (lixo). Mesma
+        // conversao usada no spread de Set (#1229).
+        let vals_fn = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_MAP_VALUES",
             &[cl::I64],
             Some(cl::I64),
         )?;
-        let inst = ctx.builder.ins().call(keys_fn, &[handle]);
+        let inst = ctx.builder.ins().call(vals_fn, &[handle]);
         handle = ctx.builder.inst_results(inst)[0];
     } else if for_of_iterates_string(ctx, &for_of.right) {
         // (cross-runtime) `for (const c of "abc")` / string var: itera os

--- a/tests/for_of_set_numeric.test.ts
+++ b/tests/for_of_set_numeric.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const x of setNumerico) sum += x` somava
+// o HANDLE da key string (lixo) — o for-of de Set usava MAP_KEYS (keys string
+// cruas) em vez de MAP_VALUES (que reconverte key -> number via parse). Set de
+// strings funcionava (key ja' eh string). Fix: usar MAP_VALUES (mesma
+// conversao do spread de Set #1229).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// Set numerico: soma
+const s = new Set([1, 2, 3, 4]);
+let sum = 0;
+for (const x of s) sum += x;
+print(sum + "");                  // 10
+
+// Set numerico: multiplicacao
+let prod = 1;
+for (const x of new Set([2, 3, 5])) prod *= x;
+print(prod + "");                 // 30
+
+// Set de strings preservado
+const ss = new Set(["a", "b", "c"]);
+let r = "";
+for (const x of ss) r += x;
+print(r);                         // abc
+
+// dedup + soma (Set de duplicatas)
+let s2 = 0;
+for (const x of new Set([1, 1, 2, 2, 3])) s2 += x;
+print(s2 + "");                   // 6
+
+describe("for-of set numeric", () => {
+  test("Set numerico soma os valores, nao handles", () =>
+    expect(out).toBe("10\n30\nabc\n6\n"));
+});


### PR DESCRIPTION
## Problema

`for (const x of setNumerico) sum += x` dava 0/lixo.

## Duas causas

1. **for-of de Set** usava `MAP_KEYS` (keys string cruas) em vez de `MAP_VALUES`, que reconverte cada key de volta ao valor (parse int → number). Set de strings funcionava (key já é string). Agora usa `MAP_VALUES` (mesma conversão do spread de Set #1229). Também detecta Set/Map em `new Set(...)` **inline** no for-of (não só var).
2. **reduce_pass** reescrevia `for (x of set) sum += x` para `parallel.reduce`, que faz `snapshot_vec` (só Vec). Gate: não reescrever quando o iterável é Set/Map (inline ou var coletada).

## Teste

`tests/for_of_set_numeric.test.ts` — soma/produto, strings, dedup, inline e via var.

Suite **1545/1545** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)