### PR TITLE
fix(codegen): find/findIndex/some/every com predicate capturando var local

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -2225,6 +2225,22 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_PARALLEL_EVERY",
             parallel_ops::__RTS_FN_NS_PARALLEL_EVERY
         );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_FIND_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_FIND_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_FIND_INDEX_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_FIND_INDEX_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_SOME_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_SOME_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_EVERY_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_EVERY_BOUND
+        );
     }
 
     // ── namespaces::path ──────────────────────────────────────────────

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -953,6 +953,8 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 qualified.as_str(),
                 "parallel.map_bound" | "parallel.filter_bound" | "parallel.for_each_bound"
                 | "parallel.reduce_bound" | "parallel.reduce_no_init_bound"
+                | "parallel.find_bound" | "parallel.find_index_bound"
+                | "parallel.some_bound" | "parallel.every_bound"
             ) {
                 if let Some(tv) = lower_parallel_bound_call(ctx, &qualified, call)? {
                     return Ok(tv);
@@ -3257,6 +3259,15 @@ fn lower_parallel_bound_call(
         "parallel.filter_bound" => ("__RTS_FN_NS_PARALLEL_FILTER_BOUND", 0),
         "parallel.for_each_bound" => ("__RTS_FN_NS_PARALLEL_FOR_EACH_BOUND", 1),
         "parallel.reduce_no_init_bound" => ("__RTS_FN_NS_PARALLEL_REDUCE_NO_INIT_BOUND", 2),
+        // find/findIndex/some/every -> i64. find eh ambiguo (val ou handle
+        // "undefined"); os demais sao int/bool puros (kind 2 marca ambiguo
+        // tambem, inofensivo p/ int — TPL_COERCE_AUTO formata 0/1 como num).
+        // find eh ambiguo (val ou handle "undefined"): kind 2 (marca ambiguo).
+        // findIndex -> int; some/every -> bool. kind 4 = i64 puro sem marca.
+        "parallel.find_bound" => ("__RTS_FN_NS_PARALLEL_FIND_BOUND", 2),
+        "parallel.find_index_bound" => ("__RTS_FN_NS_PARALLEL_FIND_INDEX_BOUND", 4),
+        "parallel.some_bound" => ("__RTS_FN_NS_PARALLEL_SOME_BOUND", 4),
+        "parallel.every_bound" => ("__RTS_FN_NS_PARALLEL_EVERY_BOUND", 4),
         _ => return Ok(None),
     };
     match kind {
@@ -3269,11 +3280,18 @@ fn lower_parallel_bound_call(
             Ok(Some(TypedVal::new(v, ValTy::Handle)))
         }
         2 => {
-            // reduce_no_init -> i64.
+            // reduce_no_init/find -> i64 ambiguo (val ou handle).
             let f = ctx.get_extern(sym, &[cl::I64, cl::I64], Some(cl::I64))?;
             let inst = ctx.builder.ins().call(f, &[arr_h, fn_handle]);
             let v = ctx.builder.inst_results(inst)[0];
             ctx.var_member_call_values.insert(v);
+            Ok(Some(TypedVal::new(v, ValTy::I64)))
+        }
+        4 => {
+            // findIndex/some/every -> i64 puro (int/bool), sem marca ambigua.
+            let f = ctx.get_extern(sym, &[cl::I64, cl::I64], Some(cl::I64))?;
+            let inst = ctx.builder.ins().call(f, &[arr_h, fn_handle]);
+            let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         _ => {

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1694,8 +1694,10 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                                 "for_each" => "for_each_bound",
                                 "reduce" => "reduce_bound",
                                 "reduce_no_init" => "reduce_no_init_bound",
-                                // some/every/find/etc com captura: fora do
-                                // escopo inicial — mantem (cai no stub seguro).
+                                "find" => "find_bound",
+                                "find_index" => "find_index_bound",
+                                "some" => "some_bound",
+                                "every" => "every_bound",
                                 other => other,
                             };
                         }

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -309,3 +309,45 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_EVERY(vec_handle: u64, fn_ptr: u64) -> i6
     let arr = vec_handle as i64;
     if items.into_iter().enumerate().all(|(i, x)| cb_truthy(f(x, i as i64, arr))) { 1 } else { 0 }
 }
+
+/// (cross-runtime) Variantes BOUND de find/findIndex/some/every — predicate
+/// captura var local. fn_handle eh Entry::Function que carrega bound_args;
+/// invoke_array_callback prepende captures ++ [val, idx]. Sem isso, o ptr nu
+/// recebia o idx no slot da captura e o predicate dava lixo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 0; };
+    if fn_handle == 0 { return 0; }
+    match items.into_iter().enumerate()
+        .find(|&(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])))
+    {
+        Some((_, v)) => v,
+        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_INDEX_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return -1; };
+    if fn_handle == 0 { return -1; }
+    items.into_iter().enumerate()
+        .position(|(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])))
+        .map(|i| i as i64)
+        .unwrap_or(-1)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_SOME_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 0; };
+    if fn_handle == 0 { return 0; }
+    if items.into_iter().enumerate()
+        .any(|(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64]))) { 1 } else { 0 }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_EVERY_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 1; };
+    if fn_handle == 0 { return 1; }
+    if items.into_iter().enumerate()
+        .all(|(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64]))) { 1 } else { 0 }
+}

--- a/tests/array_predicate_capture.test.ts
+++ b/tests/array_predicate_capture.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): find/findIndex/some/every cujo predicate captura
+// var local davam lixo — o pass roteava map/filter/forEach/reduce ao caminho
+// BOUND mas deixava find/some/every com fn_ptr nu (sem bound_args), entao a
+// captura recebia o indice. Fix: variantes PARALLEL_{FIND,FIND_INDEX,SOME,
+// EVERY}_BOUND que invocam via invoke_array_callback com bound_args.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function findFirst(arr: number[], target: number): number {
+  return arr.find(x => x === target) ?? -1;
+}
+print(findFirst([10, 20, 30], 20) + "");   // 20
+
+function findIdx(arr: number[], t: number): number {
+  return arr.findIndex(x => x === t);
+}
+print(findIdx([10, 20, 30], 30) + "");     // 2
+
+function allAbove(arr: number[], min: number): boolean {
+  return arr.every(x => x >= min);
+}
+print(allAbove([5, 6, 7], 5) + "");        // true
+print(allAbove([5, 6, 7], 6) + "");        // false
+
+function someBelow(arr: number[], max: number): boolean {
+  return arr.some(x => x < max);
+}
+print(someBelow([5, 6, 7], 6) + "");       // true
+print(someBelow([5, 6, 7], 4) + "");       // false
+
+// filter/map com captura continuam OK (regressao guard)
+function above(arr: number[], lim: number): number[] {
+  return arr.filter(x => x > lim);
+}
+print(above([1, 5, 2, 8], 4).join(","));   // 5,8
+
+describe("array predicate captura local", () => {
+  test("find/findIndex/some/every com captura", () =>
+    expect(out).toBe("20\n2\ntrue\nfalse\ntrue\nfalse\n5,8\n"));
+});


### PR DESCRIPTION
## Problema

`arr.find(x => x === target)` / `arr.every(x => x >= min)` etc. onde o predicate captura var local davam lixo. O pass roteava `map/filter/forEach/reduce` ao caminho BOUND (#195) mas deixava `find/some/every/findIndex` com `fn_ptr` nu (sem `bound_args`) → a captura recebia o índice (`find`=lixo, `every`=false).

## Fix

- **Runtime:** variantes `PARALLEL_{FIND,FIND_INDEX,SOME,EVERY}_BOUND` que invocam via `invoke_array_callback` prependendo `bound_args ++ [val, idx]`
- **JIT:** registra os 4 novos símbolos
- **Pass:** roteia `find→find_bound`, `findIndex→find_index_bound`, `some→some_bound`, `every→every_bound`
- **lower_parallel_bound_call:** trata os novos qualifiers (`find` ambíguo via kind 2; `findIndex/some/every` i64 puro via kind 4)

## Teste

`tests/array_predicate_capture.test.ts`.

Suite **1579/1579** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)