### PR TITLE
fix(codegen): reduceRight/findLast/findLastIndex com callback capturando local

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -2241,6 +2241,22 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             "__RTS_FN_NS_PARALLEL_EVERY_BOUND",
             parallel_ops::__RTS_FN_NS_PARALLEL_EVERY_BOUND
         );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_NO_INIT_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_NO_INIT_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_FIND_LAST_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_FIND_LAST_BOUND
+        );
+        add_fn!(
+            "__RTS_FN_NS_PARALLEL_FIND_LAST_INDEX_BOUND",
+            parallel_ops::__RTS_FN_NS_PARALLEL_FIND_LAST_INDEX_BOUND
+        );
     }
 
     // ── namespaces::path ──────────────────────────────────────────────

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -955,6 +955,8 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 | "parallel.reduce_bound" | "parallel.reduce_no_init_bound"
                 | "parallel.find_bound" | "parallel.find_index_bound"
                 | "parallel.some_bound" | "parallel.every_bound"
+                | "parallel.reduce_right_bound" | "parallel.reduce_right_no_init_bound"
+                | "parallel.find_last_bound" | "parallel.find_last_index_bound"
             ) {
                 if let Some(tv) = lower_parallel_bound_call(ctx, &qualified, call)? {
                     return Ok(tv);
@@ -3206,8 +3208,9 @@ fn lower_parallel_bound_call(
     call: &CallExpr,
 ) -> Result<Option<TypedVal>> {
     use cranelift_codegen::ir::types as cl;
-    // reduce_bound: (arr, init, fn). reduce_no_init/map/filter/for_each: (arr, fn).
-    let is_reduce_init = qualified == "parallel.reduce_bound";
+    // reduce_bound/reduce_right_bound: (arr, init, fn). Demais: (arr, fn).
+    let is_reduce_init =
+        qualified == "parallel.reduce_bound" || qualified == "parallel.reduce_right_bound";
     let expected_args = if is_reduce_init { 3 } else { 2 };
     if call.args.len() != expected_args {
         return Ok(None);
@@ -3238,15 +3241,16 @@ fn lower_parallel_bound_call(
     let arr_tv = lower_expr(ctx, &call.args[0].expr)?;
     let arr_h = ctx.coerce_to_i64(arr_tv).val;
 
-    // reduce com init: chama REDUCE_BOUND(arr, init, fn) -> i64.
+    // reduce/reduceRight com init: chama *_REDUCE[_RIGHT]_BOUND(arr, init, fn).
     if is_reduce_init {
+        let sym = if qualified == "parallel.reduce_right_bound" {
+            "__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_BOUND"
+        } else {
+            "__RTS_FN_NS_PARALLEL_REDUCE_BOUND"
+        };
         let init_tv = lower_expr(ctx, &call.args[1].expr)?;
         let init = ctx.coerce_to_i64(init_tv).val;
-        let f = ctx.get_extern(
-            "__RTS_FN_NS_PARALLEL_REDUCE_BOUND",
-            &[cl::I64, cl::I64, cl::I64],
-            Some(cl::I64),
-        )?;
+        let f = ctx.get_extern(sym, &[cl::I64, cl::I64, cl::I64], Some(cl::I64))?;
         let inst = ctx.builder.ins().call(f, &[arr_h, init, fn_handle]);
         let v = ctx.builder.inst_results(inst)[0];
         ctx.var_member_call_values.insert(v);
@@ -3268,6 +3272,13 @@ fn lower_parallel_bound_call(
         "parallel.find_index_bound" => ("__RTS_FN_NS_PARALLEL_FIND_INDEX_BOUND", 4),
         "parallel.some_bound" => ("__RTS_FN_NS_PARALLEL_SOME_BOUND", 4),
         "parallel.every_bound" => ("__RTS_FN_NS_PARALLEL_EVERY_BOUND", 4),
+        // reduceRight sem init -> ambiguo (val ou handle). findLast ambiguo;
+        // findLastIndex -> int puro.
+        "parallel.reduce_right_no_init_bound" => {
+            ("__RTS_FN_NS_PARALLEL_REDUCE_RIGHT_NO_INIT_BOUND", 2)
+        }
+        "parallel.find_last_bound" => ("__RTS_FN_NS_PARALLEL_FIND_LAST_BOUND", 2),
+        "parallel.find_last_index_bound" => ("__RTS_FN_NS_PARALLEL_FIND_LAST_INDEX_BOUND", 4),
         _ => return Ok(None),
     };
     match kind {

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1613,6 +1613,13 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                                 || matches!(n.as_str(), "Boolean" | "Number" | "String")
                         })
                         .unwrap_or(false);
+                    // Callback com captura por-valor (`__lifted_cap_*`): roteia
+                    // metodos sem variante nao-bound (reduceRight/findLast/...)
+                    // ao _bound so' nesse caso.
+                    let arg0_is_cap = matches!(
+                        call.args.first().map(|a| a.expr.as_ref()),
+                        Some(Expr::Ident(id)) if id.sym.as_str().starts_with("__lifted_cap_")
+                    );
 
                     // (#1044) Gate por receiver: so' reescreve quando m.obj
                     // eh claramente array. Sem isso, `set.forEach(fn)` /
@@ -1676,6 +1683,23 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                         }
                         "some" if call.args.len() == 1 && arg0_is_user_fn => Some("some"),
                         "every" if call.args.len() == 1 && arg0_is_user_fn => Some("every"),
+                        // (cross-runtime) reduceRight/findLast/findLastIndex
+                        // SO' quando o callback tem captura (`__lifted_cap_*`).
+                        // Sem captura seguem o caminho VEC_* (fn_ptr nu) que ja'
+                        // funciona; com captura roteamos ao _bound abaixo. O
+                        // nome aqui ja' eh o _bound pois nao ha variante nao-bound.
+                        "reduceRight" if call.args.len() == 2 && arg0_is_cap => {
+                            Some("reduce_right_bound")
+                        }
+                        "reduceRight" if call.args.len() == 1 && arg0_is_cap => {
+                            Some("reduce_right_no_init_bound")
+                        }
+                        "findLast" if call.args.len() == 1 && arg0_is_cap => {
+                            Some("find_last_bound")
+                        }
+                        "findLastIndex" if call.args.len() == 1 && arg0_is_cap => {
+                            Some("find_last_index_bound")
+                        }
                         _ => None,
                     }};
 
@@ -1710,7 +1734,7 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
                         // trapz -> SIGILL.
                         rewrite_array_methods_in_expr(&mut arr_expr, user_fn_names);
                         let fn_arg = call.args[0].expr.clone();
-                        let new_args: Vec<swc_ecma_ast::ExprOrSpread> = if par_method == "reduce" || par_method == "reduce_bound" {
+                        let new_args: Vec<swc_ecma_ast::ExprOrSpread> = if par_method == "reduce" || par_method == "reduce_bound" || par_method == "reduce_right_bound" {
                             let init_arg = call.args[1].expr.clone();
                             vec![
                                 swc_ecma_ast::ExprOrSpread { spread: None, expr: Box::new(arr_expr) },

--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -351,3 +351,62 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_EVERY_BOUND(vec_handle: u64, fn_handle: u
     if items.into_iter().enumerate()
         .all(|(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64]))) { 1 } else { 0 }
 }
+
+/// (cross-runtime) reduceRight BOUND com init. Callback (apos bound_args)
+/// recebe (acc, val, index). Itera da direita p/ esquerda.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_REDUCE_RIGHT_BOUND(
+    vec_handle: u64,
+    identity: i64,
+    fn_handle: u64,
+) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return identity; };
+    if fn_handle == 0 { return identity; }
+    let mut acc = identity;
+    for (i, &x) in items.iter().enumerate().rev() {
+        acc = invoke_array_callback(fn_handle, &[acc, x, i as i64]);
+    }
+    acc
+}
+
+/// (cross-runtime) reduceRight BOUND sem init. items.last() eh o acc inicial;
+/// callback roda dos demais (direita->esquerda).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_REDUCE_RIGHT_NO_INIT_BOUND(
+    vec_handle: u64,
+    fn_handle: u64,
+) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 0; };
+    if fn_handle == 0 || items.is_empty() { return 0; }
+    let mut acc = *items.last().unwrap();
+    for (i, &x) in items.iter().enumerate().rev().skip(1) {
+        acc = invoke_array_callback(fn_handle, &[acc, x, i as i64]);
+    }
+    acc
+}
+
+/// (cross-runtime) findLast BOUND — ultimo elemento que satisfaz, ou undefined.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_LAST_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return 0; };
+    if fn_handle == 0 { return 0; }
+    match items.iter().enumerate().rev()
+        .find(|&(i, &x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])))
+    {
+        Some((_, &v)) => v,
+        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+    }
+}
+
+/// (cross-runtime) findLastIndex BOUND — index do ultimo que satisfaz, ou -1.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_LAST_INDEX_BOUND(vec_handle: u64, fn_handle: u64) -> i64 {
+    let Some(items) = snapshot_vec(vec_handle) else { return -1; };
+    if fn_handle == 0 { return -1; }
+    for (i, &x) in items.iter().enumerate().rev() {
+        if cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])) {
+            return i as i64;
+        }
+    }
+    -1
+}

--- a/tests/array_reduceright_findlast_capture.test.ts
+++ b/tests/array_reduceright_findlast_capture.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): reduceRight/findLast/findLastIndex cujo callback
+// captura var local davam lixo — esses metodos nao eram roteados ao caminho
+// BOUND (so' map/filter/find/some/every estavam). Fix: variantes
+// PARALLEL_{REDUCE_RIGHT,REDUCE_RIGHT_NO_INIT,FIND_LAST,FIND_LAST_INDEX}_BOUND;
+// roteadas SO' quando o callback tem captura (`__lifted_cap_*`).
+//
+// Nota: o `?? -1` em find/findLast SEM match eh bug ortogonal (find retorna
+// handle-string "undefined", nao o sentinel) — coberto por casos COM match.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// reduceRight com init capturando local
+function joinR(arr: string[], sep: string): string {
+  return arr.reduceRight((acc, x) => acc + sep + x, "");
+}
+print(joinR(["a", "b", "c"], "-"));        // -c-b-a
+
+function sumR(arr: number[], base: number): number {
+  return arr.reduceRight((acc, x) => acc + x + base, 0);
+}
+print(sumR([1, 2, 3], 100) + "");          // 306
+
+// findLast capturando local (com match)
+function lastDiv(arr: number[], m: number): number {
+  const r = arr.findLast(x => x % m === 0);
+  return r === undefined ? -1 : r;
+}
+print(lastDiv([2, 3, 4, 5, 6], 2) + "");   // 6
+print(lastDiv([1, 3, 9, 5], 3) + "");      // 9
+
+// findLastIndex capturando local
+function lastDivIdx(arr: number[], m: number): number {
+  return arr.findLastIndex(x => x % m === 0);
+}
+print(lastDivIdx([2, 3, 4, 5], 2) + "");   // 2
+
+describe("reduceRight/findLast captura local", () => {
+  test("callback capturando local roteia ao BOUND", () =>
+    expect(out).toBe("-c-b-a\n306\n6\n9\n2\n"));
+});


### PR DESCRIPTION
## Problema

`reduceRight`/`findLast`/`findLastIndex` não eram roteados ao caminho BOUND (#195) — só `map/filter/find/some/every` estavam. Callback capturando var local dava lixo (`reduceRight` somava handle, `findLast` retornava lixo).

## Fix

- **Runtime:** variantes `PARALLEL_{REDUCE_RIGHT,REDUCE_RIGHT_NO_INIT,FIND_LAST,FIND_LAST_INDEX}_BOUND` (iteram reverso, `invoke_array_callback` com `bound_args`)
- **JIT:** registra os 4 símbolos
- **Pass:** roteia ao `_bound` **só** quando o callback tem captura (`__lifted_cap_*`) — sem captura seguem o caminho `VEC_*` que já funciona (evita regressão)
- **lower:** trata os qualifiers (`reduce_right` com init via `is_reduce_init`; `findLast` ambíguo kind 2; `findLastIndex` int puro kind 4)

## Nota

`?? -1` em `find`/`findLast` **sem match** é bug ortogonal (`find` retorna handle-string "undefined", não o sentinel) — fora de escopo, coberto por casos com match.

## Teste

`tests/array_reduceright_findlast_capture.test.ts`.

Suite **1580/1580** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)