### PR TITLE
fix(runtime): find/findLast sem match retorna sentinel undefined, nao string

### DIFF
--- a/crates/rts-runtime/src/namespaces/parallel/ops.rs
+++ b/crates/rts-runtime/src/namespaces/parallel/ops.rs
@@ -252,13 +252,11 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND(vec_handle: u64, fn_ptr: u64) -> i64
     let arr = vec_handle as i64;
     match items.into_iter().enumerate().find(|&(i, x)| cb_truthy(f(x, i as i64, arr))) {
         Some((_, v)) => v,
-        None => {
-            // JS spec: find sem match retorna `undefined`. Aloca handle
-            // de string "undefined" — codegen marca .find(...) como
-            // ambiguo (var_member_call_values), template literal/console
-            // formata corretamente via TPL_COERCE_AUTO/INSPECT.
-            alloc_entry(Entry::String(b"undefined".to_vec())) as i64
-        }
+        // JS spec: find sem match retorna `undefined`. Retorna o sentinel
+        // (i64::MIN+2) em vez de handle-string "undefined", para que
+        // `?? -1` e `=== undefined` funcionem. Template/console formata o
+        // sentinel como "undefined" via TPL_COERCE_AUTO.
+        None => i64::MIN + 2,
     }
 }
 
@@ -322,7 +320,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_BOUND(vec_handle: u64, fn_handle: u6
         .find(|&(i, x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])))
     {
         Some((_, v)) => v,
-        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+        None => i64::MIN + 2,
     }
 }
 
@@ -394,7 +392,7 @@ pub extern "C" fn __RTS_FN_NS_PARALLEL_FIND_LAST_BOUND(vec_handle: u64, fn_handl
         .find(|&(i, &x)| cb_truthy(invoke_array_callback(fn_handle, &[x, i as i64])))
     {
         Some((_, &v)) => v,
-        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+        None => i64::MIN + 2,
     }
 }
 

--- a/tests/find_undefined_sentinel.test.ts
+++ b/tests/find_undefined_sentinel.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): find/findLast SEM match retornavam handle-string
+// "undefined" em vez do sentinel undefined real. Consequencia: `?? -1` e
+// `=== undefined` nao disparavam (typeof dava "string"). Fix: runtime retorna
+// i64::MIN+2 (sentinel) no caso None — template/console ainda formata
+// "undefined" via TPL_COERCE_AUTO.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// find sem match -> undefined real
+const r1 = [1, 2, 3].find(x => x === 99);
+print((r1 === undefined) + "");        // true
+print((r1 ?? -1) + "");                // -1
+print(("" + r1));                      // undefined
+
+// find com match continua OK
+const r2 = [1, 2, 3].find(x => x === 2);
+print((r2 ?? -1) + "");                // 2
+
+// findLast sem match com captura local + ??
+function lastNone(arr: number[], lim: number): number {
+  return arr.findLast(x => x > lim) ?? -1;
+}
+print(lastNone([1, 2, 3], 10) + "");   // -1
+
+// findLast com match
+function lastMatch(arr: number[], lim: number): number {
+  return arr.findLast(x => x > lim) ?? -1;
+}
+print(lastMatch([1, 5, 2, 8], 3) + ""); // 8
+
+describe("find undefined sentinel", () => {
+  test("find/findLast sem match -> undefined real (?? e === funcionam)", () =>
+    expect(out).toBe("true\n-1\nundefined\n2\n-1\n8\n"));
+});


### PR DESCRIPTION
## Problema

`[...].find(p)` / `findLast` **sem match** retornavam `alloc_entry(String("undefined"))` — um handle de string, não o sentinel undefined real. Consequência:
- `r === undefined` → `false` (era handle != null)
- `r ?? -1` → o handle (não disparava)
- `typeof r` → `"string"`

## Fix

Retorna `i64::MIN+2` (sentinel undefined) no caso `None` em `PARALLEL_FIND`, `PARALLEL_FIND_BOUND` e `PARALLEL_FIND_LAST_BOUND`. Template/console ainda formata como `"undefined"` via `TPL_COERCE_AUTO`. Nenhum template dependia do handle-string (suite verde).

## Teste

`tests/find_undefined_sentinel.test.ts` — `?? -1`, `=== undefined`, template, com/sem match, com captura local.

Suite **1581/1581** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)