### PR TITLE
fix: arr.at(oor)/pop()/shift() vazio retornam sentinel undefined, nao string

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -1192,13 +1192,14 @@ pub(super) fn lower_array_builtin(
             let inst = ctx.builder.ins().call(get_fn, &[obj_h, final_idx]);
             let v = ctx.builder.inst_results(inst)[0];
             // (cross-runtime #897) OOR (idx<0 ou idx>=len apos ajuste) retorna
-            // undefined sentinel; senao retorna o valor cru (i64). Marca como
-            // ambiguo via var_member_call_values pra TPL_COERCE_AUTO formatar.
+            // undefined; senao retorna o valor cru (i64). Usa o SENTINEL
+            // undefined (i64::MIN+2), nao handle-string, p/ que `?? -1` e
+            // `=== undefined` funcionem. TPL_COERCE_AUTO formata o sentinel.
             let below = ctx.builder.ins().icmp(IntCC::SignedLessThan, final_idx, zero);
             let above = ctx.builder.ins().icmp(IntCC::SignedGreaterThanOrEqual, final_idx, len);
             let oor = ctx.builder.ins().bor(below, above);
-            let undef_h = ctx.emit_str_handle(b"undefined")?.val;
-            let result = ctx.builder.ins().select(oor, undef_h, v);
+            let undef_s = ctx.builder.ins().iconst(cl::I64, i64::MIN + 2);
+            let result = ctx.builder.ins().select(oor, undef_s, v);
             ctx.var_member_call_values.insert(result);
             Ok(Some(TypedVal::new(result, ValTy::I64)))
         }

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -101,7 +101,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_POP(handle: u64) -> i64 {
     let popped: Option<i64> = with_vec_mut(handle, None, |v| v.pop());
     match popped {
         Some(v) => v,
-        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+        // Vazio: undefined real (sentinel), nao handle-string. Faz `?? -1`
+        // e `=== undefined` funcionarem; template formata via TPL_COERCE_AUTO.
+        None => i64::MIN + 2,
     }
 }
 
@@ -560,7 +562,8 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_SHIFT(handle: u64) -> i64 {
     });
     match first {
         Some(v) => v,
-        None => alloc_entry(Entry::String(b"undefined".to_vec())) as i64,
+        // Vazio: undefined real (sentinel), nao handle-string.
+        None => i64::MIN + 2,
     }
 }
 
@@ -1224,11 +1227,9 @@ mod tests {
         assert_eq!(handle_to_vec(h), vec![2, 3]);
         assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), 2);
         assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), 3);
-        // Vazio: retorna handle de string "undefined" (nao 0). JS spec.
-        let undef_h = __RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h);
-        assert_ne!(undef_h, 0);
-        let s = crate::namespaces::gc::string_pool::read_string_handle(undef_h as u64);
-        assert_eq!(s.as_deref(), Some("undefined"));
+        // Vazio: retorna o sentinel undefined (i64::MIN+2), nao handle-string,
+        // p/ que `?? -1` e `=== undefined` funcionem no codegen.
+        assert_eq!(__RTS_FN_NS_COLLECTIONS_VEC_SHIFT(h), i64::MIN + 2);
     }
 
     #[test]

--- a/tests/at_pop_shift_undefined.test.ts
+++ b/tests/at_pop_shift_undefined.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): arr.at(oor) / pop()/shift() de vazio retornavam
+// handle-string "undefined" em vez do sentinel — `?? -1` e `=== undefined`
+// nao disparavam. Fix: at usa sentinel i64::MIN+2; VEC_POP/VEC_SHIFT idem.
+// (Mesma familia do find/findLast #1257.)
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const arr = [1, 2, 3];
+
+// at fora de range -> undefined real
+print((arr.at(10) === undefined) + "");   // true
+print((arr.at(10) ?? -1) + "");           // -1
+print(("" + arr.at(10)));                 // undefined
+// at valido (inclui negativo)
+print((arr.at(0) ?? -1) + "");            // 1
+print((arr.at(-1) ?? -1) + "");           // 3
+
+// pop/shift de vazio -> undefined real
+const empty: number[] = [];
+print((empty.pop() ?? -1) + "");          // -1
+print((empty.shift() ?? -1) + "");        // -1
+
+// pop/shift com valor continuam OK
+const ne = [7, 8];
+print((ne.pop() ?? -1) + "");             // 8
+print((ne.shift() ?? -1) + "");           // 7
+
+describe("at/pop/shift undefined", () => {
+  test("sem valor -> undefined real (?? e === funcionam)", () =>
+    expect(out).toBe("true\n-1\nundefined\n1\n3\n-1\n-1\n8\n7\n"));
+});


### PR DESCRIPTION
## Problema

Mesma família do find/findLast (#1257): `arr.at(fora de range)` e `pop()`/`shift()` de array vazio retornavam handle-string `"undefined"` em vez do sentinel → `?? -1` e `=== undefined` não disparavam (`typeof` dava "string").

## Fix

- `at`: `iconst i64::MIN+2` no ramo OOR (era `emit_str_handle("undefined")`)
- `VEC_POP`/`VEC_SHIFT`: retornam o sentinel no caso vazio
- Teste unit do `VEC_SHIFT` atualizado (esperava handle-string)

Template/console ainda formata como "undefined" via `TPL_COERCE_AUTO`.

## Teste

`tests/at_pop_shift_undefined.test.ts` — at OOR/válido/negativo, pop/shift vazio e com valor, `??` e `===`.

Suite **1582/1582** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)