### PR TITLE
fix(codegen): new Set(arr) com arr var/param popula o Set (era vazio)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1420,6 +1420,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_SET_FROM_VEC",
+            map::__RTS_FN_NS_COLLECTIONS_SET_FROM_VEC
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -314,6 +314,34 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
                     }
                 }
             }
+            // (cross-runtime) `new Set(<expr-nao-literal>)` — popula via runtime
+            // SET_FROM_VEC. Antes so' literal `new Set([...])` populava; com var/
+            // param (`new Set(arr)`) o Set ficava vazio. Restrito a Ident/Member/
+            // etc (var que ja' materializou o Vec) — inline Call segue follow-up.
+            if class_name == "Set" {
+                if let Some(arg) = init_arg {
+                    let arg_is_safe = matches!(
+                        arg.expr.as_ref(),
+                        Expr::Ident(_) | Expr::Member(_)
+                            | Expr::Paren(_) | Expr::TsAs(_) | Expr::TsNonNull(_)
+                    );
+                    if arg.spread.is_none()
+                        && !matches!(arg.expr.as_ref(), Expr::Array(_))
+                        && arg_is_safe
+                    {
+                        let src_tv = lower_expr(ctx, &arg.expr)?;
+                        let src_h = ctx.coerce_to_i64(src_tv).val;
+                        let from_vec = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_SET_FROM_VEC",
+                            &[cl::I64],
+                            Some(cl::I64),
+                        )?;
+                        let inst_fv = ctx.builder.ins().call(from_vec, &[src_h]);
+                        let s2 = ctx.builder.inst_results(inst_fv)[0];
+                        return Ok(TypedVal::new(s2, ValTy::Handle));
+                    }
+                }
+            }
             if let Some(arg) = init_arg {
                 if let Expr::Array(arr) = arg.expr.as_ref() {
                     if class_name == "Set" {

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1936,6 +1936,34 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES(arr: u64) -> u64 {
     m
 }
 
+/// (cross-runtime) `new Set(vec)` onde vec NAO eh literal (vem por param/var).
+/// Cria um Map marcado como Set e adiciona cada elemento como key (value=1).
+/// Espelha a conversao do caminho de array literal: elemento handle-string usa
+/// o conteudo; inteiro usa a representacao decimal. Dedup natural (HashMap).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_FROM_VEC(src: u64) -> u64 {
+    use crate::namespaces::gc::handles::{Entry, with_entry};
+    let elems: Vec<i64> = with_entry(src, |entry| match entry {
+        Some(Entry::Vec(v)) => v.as_ref().clone(),
+        _ => Vec::new(),
+    });
+    let m = alloc_entry(Entry::Map(Box::new(IndexMap::new())));
+    __RTS_FN_NS_COLLECTIONS_MARK_AS_SET(m);
+    for raw in elems {
+        // hole sentinel: ignora.
+        if raw == i64::MIN + 4 { continue; }
+        let key_str: Option<String> = with_entry(raw as u64, |ke| match ke {
+            Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            _ => None,
+        });
+        let key = key_str.unwrap_or_else(|| raw.to_string());
+        with_map_mut(m, (), |mm| {
+            mm.insert(key, 1);
+        });
+    }
+    m
+}
+
 #[cfg(test)]
 mod object_tests {
     use super::*;

--- a/tests/set_from_var.test.ts
+++ b/tests/set_from_var.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `new Set(arr)` onde arr eh var/param (nao literal)
+// criava um Set VAZIO — so' `new Set([1,2,3])` literal populava. Fix: runtime
+// SET_FROM_VEC, roteado quando o arg eh Ident/Member (Vec ja' materializado).
+// Espelha o MAP_FROM_ENTRIES do Map.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// dedup via Set(param)
+function dedup(arr: number[]): number[] {
+  return [...new Set(arr)];
+}
+print(dedup([1, 2, 2, 3, 3, 3]).join(","));   // 1,2,3
+
+// Set(param) + has em filter
+function intersect(a: number[], b: number[]): number[] {
+  const setB = new Set(b);
+  return a.filter(x => setB.has(x));
+}
+print(intersect([1, 2, 3, 4], [2, 4, 6]).join(","));  // 2,4
+
+// Set de strings via var
+const words = ["a", "b", "a", "c", "b"];
+const us = new Set(words);
+print(us.size + "");                          // 3
+print(us.has("a") + "");                      // true
+print(us.has("z") + "");                      // false
+
+// Set(literal) continua OK (guard)
+print([...new Set([5, 5, 6])].join(","));     // 5,6
+
+describe("new Set(var/param)", () => {
+  test("Set populado a partir de var/param", () =>
+    expect(out).toBe("1,2,3\n2,4\n3\ntrue\nfalse\n5,6\n"));
+});


### PR DESCRIPTION
## Problema

`new Set(arr)` onde `arr` é var/param (não array literal) criava um Set **vazio** — só `new Set([1,2,3])` literal populava. Quebrava padrões comuns: dedup `[...new Set(arr)]`, interseção `new Set(b)`, contagem, etc.

## Fix

- **Runtime:** `SET_FROM_VEC` — cria Map marcado como Set, adiciona cada elemento como key (conversão handle-string|decimal espelhando o caminho de array literal)
- **JIT:** registra o símbolo
- **Codegen:** roteia quando o arg é `Ident`/`Member`/etc (Vec já materializado), espelhando o `MAP_FROM_ENTRIES` que o Map já tinha

Inline Call (`new Set(arr.map(...))`) segue follow-up — usar var intermediária funciona.

## Teste

`tests/set_from_var.test.ts` — dedup, intersect, Set de strings via var, `.has`, guard de literal.

Suite **1583/1583** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)