### PR TITLE
fix(codegen): Map.size/Set.size de Map retornado de fn (era 0)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -545,6 +545,11 @@ pub struct FnCtx<'m, 'fb> {
     /// Sem isso, `arr.indexOf(x)` em `let arr: number[] = [...]` cai em
     /// string builtin (`__RTS_FN_GL_STRING_INDEX_OF`) e retorna lixo.
     pub local_array_vars: std::collections::HashSet<String>,
+    /// (cross-runtime) Vars cujo valor eh Map/Set/WeakMap/WeakSet (anotacao
+    /// `: Map<...>`, init `new Map/Set`, ou retorno de fn que devolve Map/Set).
+    /// Usado por `.size` para rotear ao UNIVERSAL_LENGTH (detecta Entry::Map em
+    /// runtime). Sem isso, `const m = mk(); m.size` caia em MAP_GET("size")=0.
+    pub local_map_vars: std::collections::HashSet<String>,
     /// (cross-runtime) Vars cujo valor eh string (literal, template, anotacao
     /// `: string`). Usado por `for (const c of s)` p/ iterar os chars em vez
     /// de tratar a string como Vec (que nao itera).
@@ -646,6 +651,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),
             local_array_vars: std::collections::HashSet::new(),
+            local_map_vars: std::collections::HashSet::new(),
             local_string_vars: std::collections::HashSet::new(),
             generator_vars: std::collections::HashSet::new(),
             local_ta_view: HashMap::new(),

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1077,7 +1077,14 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
     // ex: JSON.parse) e I64+var_member_call_values — usa UNIVERSAL_LENGTH
     // que detecta tipo de Entry em runtime. Sem isso
     // `JSON.parse("[1,2,3]").length` caia no MAP_GET("length") -> 0.
+    // (cross-runtime) Var marcada local_map_vars (Map/Set anotado, `new Map/
+    // Set`, ou retorno de fn-Map): forca o caminho ambiguo p/ `.size` usar
+    // UNIVERSAL_LENGTH (detecta Entry::Map). Sem isso, `const m = mk(); m.size`
+    // caia em MAP_GET("size")=0 quando m nao era tipado Handle.
+    let recv_is_mapvar = matches!(m.obj.as_ref(), Expr::Ident(id)
+        if ctx.local_map_vars.contains(id.sym.as_str()));
     let recv_is_ambiguous = matches!(obj_tv.ty, ValTy::U64)
+        || recv_is_mapvar
         || (matches!(obj_tv.ty, ValTy::I64)
             && ctx.var_member_call_values.contains(&obj_tv.val));
     if (matches!(obj_tv.ty, ValTy::Handle) || recv_is_ambiguous) && rc_for_size.is_none() {

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -42,6 +42,12 @@ thread_local! {
     /// `inst.method().filter()` (chain direto) como receiver array.
     static METHODS_RET_ARRAY: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 
+    /// (cross-runtime) Nomes de fns/metodos com return_type Map/Set/WeakMap/
+    /// WeakSet. Populado em collect_fns_ret_mapset (chamado no array_methods_pass);
+    /// lido por fn_returns_map_set (decls.rs) p/ marcar `const m = mk()` como
+    /// local_map_vars, fazendo `.size` rotear ao UNIVERSAL_LENGTH.
+    pub(crate) static FNS_RET_MAPSET: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+
     /// (cross-runtime #1052) Mapa de top-level `const k = ["str1", "str2", ...]`
     /// para suas string literals. Permite codegen propagar `k[N]` em compile
     /// time, despachando `arr[k[N]](args)` como `arr.<method>(args)`.
@@ -92,6 +98,41 @@ fn collect_methods_ret_array(program: &Program) -> HashSet<String> {
             // number[][]`). Permite `mx(2,3).map(...)` chain direto e via var.
             Item::Function(f) => {
                 if ret_type_is_array(f.return_type.as_deref()) {
+                    out.insert(f.name.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// (cross-runtime) Coleta nomes de fns/metodos cujo return_type eh Map/Set/
+/// WeakMap/WeakSet. Usado p/ marcar `const m = mk()` como local_map_vars.
+fn collect_fns_ret_mapset(program: &Program) -> HashSet<String> {
+    fn ret_is_mapset(rt: Option<&str>) -> bool {
+        rt.map(|r| {
+            let t = r.trim();
+            t.starts_with("Map<") || t.starts_with("Set<")
+                || t.starts_with("WeakMap<") || t.starts_with("WeakSet<")
+                || t.starts_with("ReadonlyMap<") || t.starts_with("ReadonlySet<")
+                || matches!(t, "Map" | "Set" | "WeakMap" | "WeakSet")
+        }).unwrap_or(false)
+    }
+    let mut out = HashSet::new();
+    for item in &program.items {
+        match item {
+            Item::Class(c) => {
+                for mem in &c.members {
+                    if let crate::parser::ast::ClassMember::Method(method) = mem {
+                        if ret_is_mapset(method.return_type.as_deref()) {
+                            out.insert(method.name.clone());
+                        }
+                    }
+                }
+            }
+            Item::Function(f) => {
+                if ret_is_mapset(f.return_type.as_deref()) {
                     out.insert(f.name.clone());
                 }
             }
@@ -1466,6 +1507,10 @@ pub(crate) fn array_methods_pass(program: &mut Program) {
     // reconhecer `inst.method().filter()` como receiver array.
     let mra = collect_methods_ret_array(program);
     METHODS_RET_ARRAY.with(|c| *c.borrow_mut() = mra);
+    // (cross-runtime) Popula o set de fns ret-Map/Set p/ decls marcar
+    // `const m = mk()` como local_map_vars (-> `.size` via UNIVERSAL_LENGTH).
+    let frm = collect_fns_ret_mapset(program);
+    FNS_RET_MAPSET.with(|c| *c.borrow_mut() = frm);
 
     // Visita top-level statements.
     let n_items = program.items.len();

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -77,6 +77,11 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                         if matches!(n, "Array" | "ReadonlyArray") {
                             ctx.local_array_vars.insert(name.clone());
                         }
+                        // (cross-runtime) anotacao `: Map/Set/WeakMap/WeakSet`
+                        // marca a var p/ `.size` rotear ao UNIVERSAL_LENGTH.
+                        if matches!(n, "Map" | "Set" | "WeakMap" | "WeakSet" | "ReadonlyMap" | "ReadonlySet") {
+                            ctx.local_map_vars.insert(name.clone());
+                        }
                     }
                 }
             }
@@ -104,6 +109,27 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             // array. Marca pra preferir lower_array_builtin.
             if matches!(init_peeled, swc_ecma_ast::Expr::Array(_)) {
                 ctx.local_array_vars.insert(name.clone());
+            }
+            // (cross-runtime) `const m = new Map/Set(...)` ou `const m = f()`
+            // onde f retorna Map/Set — marca p/ `.size` rotear corretamente.
+            match init_peeled {
+                swc_ecma_ast::Expr::New(ne) => {
+                    if let swc_ecma_ast::Expr::Ident(cid) = ne.callee.as_ref() {
+                        if matches!(cid.sym.as_str(), "Map" | "Set" | "WeakMap" | "WeakSet") {
+                            ctx.local_map_vars.insert(name.clone());
+                        }
+                    }
+                }
+                swc_ecma_ast::Expr::Call(ce) => {
+                    if let swc_ecma_ast::Callee::Expr(callee) = &ce.callee {
+                        if let swc_ecma_ast::Expr::Ident(fid) = callee.as_ref() {
+                            if fn_returns_map_set(fid.sym.as_str()) {
+                                ctx.local_map_vars.insert(name.clone());
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
             // (cross-runtime) `const s = "..."` / template — marca como string
             // pra que `for (const c of s)` itere os chars. Tambem `: string`.
@@ -999,6 +1025,13 @@ fn zero_for_ty(ctx: &mut FnCtx, ty: ValTy) -> cranelift_codegen::ir::Value {
         ValTy::F64 => ctx.builder.ins().f64const(0.0),
         _ => ctx.builder.ins().iconst(cl::I64, 0),
     }
+}
+
+/// (cross-runtime) `f` eh user fn/metodo cujo return_type eh Map/Set/WeakMap/
+/// WeakSet? Consulta o set populado no array_methods_pass.
+fn fn_returns_map_set(name: &str) -> bool {
+    crate::codegen::lower::passes::parallelism::FNS_RET_MAPSET
+        .with(|c| c.borrow().contains(name))
 }
 
 /// (#811/205) Metadados do elemento de um TypedArray: (elem_bytes, signed,

--- a/tests/map_set_size_returned.test.ts
+++ b/tests/map_set_size_returned.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): Map.size/Set.size davam 0 quando o Map/Set vinha
+// de retorno de fn (`const m = mk(); m.size`). `.get`/`.has` funcionavam (handle
+// resolvia) mas `.size` caia em MAP_GET("size")=0 pois a var nao era tipada
+// Handle. Fix: local_map_vars marca a var (anotacao Map/Set, `new Map/Set`, ou
+// fn que retorna Map/Set via FNS_RET_MAPSET) -> `.size` usa UNIVERSAL_LENGTH.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function mkMap(): Map<string, number> {
+  const m = new Map<string, number>();
+  m.set("a", 1);
+  m.set("b", 2);
+  return m;
+}
+const mm = mkMap();               // sem anotacao -> via FNS_RET_MAPSET
+print(mm.size + "");              // 2
+print(mm.get("b") + "");         // 2
+
+const mm2: Map<string, number> = mkMap();  // anotacao explicita
+print(mm2.size + "");            // 2
+
+function mkSet(): Set<number> {
+  const s = new Set<number>();
+  s.add(1); s.add(2); s.add(3); s.add(2);
+  return s;
+}
+const ss = mkSet();
+print(ss.size + "");             // 3
+print(ss.has(2) + "");           // true
+
+// new Map/Set local continua OK (guard)
+const local = new Map<string, number>();
+local.set("x", 1);
+print(local.size + "");          // 1
+
+describe("Map/Set size retornado de fn", () => {
+  test("size funciona em Map/Set de retorno e anotado", () =>
+    expect(out).toBe("2\n2\n2\n3\ntrue\n1\n"));
+});


### PR DESCRIPTION
## Problema

`const m = mk(); m.size` dava **0** quando `mk()` retorna Map/Set. `.get`/`.has` funcionavam (o handle resolvia), mas `.size` caía em `MAP_GET("size")=0` porque a var não era tipada como Handle.

## Fix

Novo `local_map_vars` no `FnCtx` marca a var quando:
- anotação `: Map/Set/WeakMap/WeakSet`
- init `new Map/Set(...)`
- init de fn que retorna Map/Set (via novo thread-local `FNS_RET_MAPSET`, populado no array_methods_pass por `collect_fns_ret_mapset`)

No handler de `.size`, `recv_is_mapvar` força o caminho ambíguo → `UNIVERSAL_LENGTH` (que detecta `Entry::Map` em runtime e retorna `map.len()`).

## Teste

`tests/map_set_size_returned.test.ts` — Map/Set de retorno (com e sem anotação), `new Map` local (guard).

Suite **1584/1584** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)