### PR TITLE
fix(codegen): Map.size/Set.size de Map passado como parametro (era 0)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -161,6 +161,16 @@ pub(crate) fn compile_user_fn(
                         .local_class_ty
                         .insert(p.name.clone(), ann.to_string());
                 }
+                // (cross-runtime) param `: Map<...>`/`Set<...>`/Weak* marca
+                // local_map_vars p/ `.size` rotear ao UNIVERSAL_LENGTH. Sem
+                // isso `function f(m: Map<...>){ return m.size }` dava 0.
+                let base = ann.split('<').next().unwrap_or(ann).trim();
+                if matches!(
+                    base,
+                    "Map" | "Set" | "WeakMap" | "WeakSet" | "ReadonlyMap" | "ReadonlySet"
+                ) {
+                    fn_ctx.local_map_vars.insert(p.name.clone());
+                }
             }
         }
 

--- a/tests/map_set_size_param.test.ts
+++ b/tests/map_set_size_param.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): Map/Set passado como PARAMETRO -> `.size` dava 0.
+// `.values()`/`.has` funcionavam mas `.size` caia em MAP_GET("size")=0 pois o
+// param nao era marcado local_map_vars. Fix: param `: Map/Set/Weak*` marca
+// local_map_vars em user_fn.rs (mesma rota do retorno #1260).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function countEntries(m: Map<string, number>): number {
+  return m.size;
+}
+const mm = new Map<string, number>([["a", 1], ["b", 2], ["c", 3]]);
+print(countEntries(mm) + "");          // 3
+
+function setSize(s: Set<number>): number {
+  return s.size;
+}
+print(setSize(new Set([1, 2, 3, 4])) + "");  // 4
+
+// param Map iterando values continua OK
+function sumValues(m: Map<string, number>): number {
+  let total = 0;
+  for (const v of m.values()) total += v;
+  return total;
+}
+print(sumValues(mm) + "");             // 6
+
+// param Set + has
+function hasIt(s: Set<number>, x: number): boolean {
+  return s.has(x);
+}
+print(hasIt(new Set([5, 6]), 6) + ""); // true
+
+describe("Map/Set size como parametro", () => {
+  test("size funciona em Map/Set passado por param", () =>
+    expect(out).toBe("3\n4\n6\ntrue\n"));
+});


### PR DESCRIPTION
## Problema

Continuação do #1260: Map/Set passado como **parâmetro** (`function f(m: Map<...>)`) dava `.size`=0. `.values()`/`.has` funcionavam mas `.size` caía em `MAP_GET("size")=0` porque o param não era marcado `local_map_vars`.

## Fix

Em `user_fn.rs`, param com anotação base `Map`/`Set`/`WeakMap`/`WeakSet`/`Readonly*` marca `local_map_vars` (mesma rota do retorno de fn). `.size` passa a usar `UNIVERSAL_LENGTH`.

## Teste

`tests/map_set_size_param.test.ts` — Map/Set como param, `.size`, `.values()`, `.has`.

Suite **1585/1585** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)