### PR TITLE
fix(codegen): Map.size/Set.size em chain direto mk().size (era 0)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1081,8 +1081,19 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
     // Set`, ou retorno de fn-Map): forca o caminho ambiguo p/ `.size` usar
     // UNIVERSAL_LENGTH (detecta Entry::Map). Sem isso, `const m = mk(); m.size`
     // caia em MAP_GET("size")=0 quando m nao era tipado Handle.
-    let recv_is_mapvar = matches!(m.obj.as_ref(), Expr::Ident(id)
-        if ctx.local_map_vars.contains(id.sym.as_str()));
+    let recv_is_mapvar = match m.obj.as_ref() {
+        Expr::Ident(id) => ctx.local_map_vars.contains(id.sym.as_str()),
+        // (cross-runtime) `mk().size` chain direto: receiver eh call de fn que
+        // retorna Map/Set (registrada em FNS_RET_MAPSET). Sem isso o chain sem
+        // var intermediaria caia em MAP_GET("size")=0.
+        Expr::Call(ce) => matches!(&ce.callee,
+            swc_ecma_ast::Callee::Expr(callee) if matches!(callee.as_ref(),
+                Expr::Ident(fid) if crate::codegen::lower::passes::parallelism::FNS_RET_MAPSET
+                    .with(|c| c.borrow().contains(fid.sym.as_str()))
+            )
+        ),
+        _ => false,
+    };
     let recv_is_ambiguous = matches!(obj_tv.ty, ValTy::U64)
         || recv_is_mapvar
         || (matches!(obj_tv.ty, ValTy::I64)

--- a/tests/map_set_size_chain.test.ts
+++ b/tests/map_set_size_chain.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `mk().size` (chain direto, sem var intermediaria)
+// dava 0 quando mk() retorna Map/Set. local_map_vars cobria so' Idents; o
+// receiver Call nao era reconhecido. Fix: recv_is_mapvar reconhece Expr::Call
+// de fn em FNS_RET_MAPSET. (Continuacao de #1260/#1261.)
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function mkMap(): Map<string, number> {
+  const m = new Map<string, number>();
+  m.set("a", 1);
+  m.set("b", 2);
+  return m;
+}
+print(mkMap().size + "");        // 2
+
+function mkSet(): Set<number> {
+  const s = new Set<number>();
+  s.add(1); s.add(2); s.add(3);
+  return s;
+}
+print(mkSet().size + "");        // 3
+
+// campo de classe continua OK (guard)
+class Store {
+  data: Map<string, number> = new Map<string, number>();
+  add(k: string, v: number): void { this.data.set(k, v); }
+  count(): number { return this.data.size; }
+}
+const st = new Store();
+st.add("x", 1);
+st.add("y", 2);
+print(st.count() + "");          // 2
+print(st.data.size + "");        // 2
+
+describe("Map/Set size em chain direto", () => {
+  test("mk().size sem var intermediaria", () =>
+    expect(out).toBe("2\n3\n2\n2\n"));
+});


### PR DESCRIPTION
## Problema

Continuação do #1260/#1261: `mk().size` (chain direto, sem var intermediária) dava 0 quando `mk()` retorna Map/Set. `recv_is_mapvar` só reconhecia Idents (`local_map_vars`); o receiver `Call` não era detectado.

## Fix

`recv_is_mapvar` reconhece também `Expr::Call` cujo callee é fn registrada em `FNS_RET_MAPSET` → `.size` usa `UNIVERSAL_LENGTH`.

## Teste

`tests/map_set_size_chain.test.ts` — `mk().size`, `mkSet().size`, campo de classe (guard).

Suite **1586/1586** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)