### PR TITLE
fix(parser): enum numerico gera reverse mapping (State[0] -> Idle)

### DIFF
--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -563,15 +563,20 @@ fn lower_ts_enum_to_const(enum_decl: &swc_ecma_ast::TsEnumDecl) -> Option<Stmt> 
         };
 
         // Determina o valor: usa init se presente, senão auto-incremento.
+        // numeric_val: Some(n) quando o valor eh inteiro literal — habilita o
+        // reverse mapping `[n]: "name"` (JS spec para enum numerico).
+        let mut numeric_val: Option<i64> = None;
         let value_expr: Expr = if let Some(init) = &member.init {
             // Quando init é Lit::Num, atualiza o counter.
             if let Expr::Lit(Lit::Num(n)) = init.as_ref() {
                 next_numeric = n.value as i64 + 1;
+                numeric_val = Some(n.value as i64);
             }
             (**init).clone()
         } else {
             let val = next_numeric;
             next_numeric += 1;
+            numeric_val = Some(val);
             Expr::Lit(Lit::Num(Number {
                 span: Default::default(),
                 value: val as f64,
@@ -582,11 +587,29 @@ fn lower_ts_enum_to_const(enum_decl: &swc_ecma_ast::TsEnumDecl) -> Option<Stmt> 
         let prop = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
             key: PropName::Ident(IdentName {
                 span: Default::default(),
-                sym: key_str.into(),
+                sym: key_str.clone().into(),
             }),
             value: Box::new(value_expr),
         })));
         props.push(prop);
+
+        // (cross-runtime) Reverse mapping para enum numerico: `State[0]` ->
+        // "Idle". JS gera as entradas reversas `[value]: "name"`. String enums
+        // nao tem reverse. Key numerica via PropName::Num.
+        if let Some(n) = numeric_val {
+            props.push(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                key: PropName::Num(Number {
+                    span: Default::default(),
+                    value: n as f64,
+                    raw: Some(format!("{n}").into()),
+                }),
+                value: Box::new(Expr::Lit(Lit::Str(Str {
+                    span: Default::default(),
+                    value: key_str.clone().into(),
+                    raw: None,
+                }))),
+            }))));
+        }
     }
 
     let obj_lit = Expr::Object(ObjectLit {

--- a/tests/enum_reverse_mapping.test.ts
+++ b/tests/enum_reverse_mapping.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): enum numerico nao tinha reverse mapping —
+// `State[0]` dava 0 em vez de "Idle". JS gera entradas reversas `[value]:
+// "name"` para enums numericos. Fix: o desugar enum->const adiciona a prop
+// reversa quando o valor eh inteiro literal. String enums nao tem reverse.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+enum State { Idle, Running, Done }
+
+// forward continua OK
+print(State.Running + "");        // 1
+print(State.Done + "");          // 2
+
+// reverse mapping
+print(State[0]);                 // Idle
+print(State[1]);                 // Running
+print(State[2]);                 // Done
+
+// reverse via var
+const k = 2;
+print(State[k]);                 // Done
+
+// enum com valores explicitos
+enum Code { Ok = 200, NotFound = 404 }
+print(Code.Ok + "");             // 200
+print(Code[404]);                // NotFound
+
+// string enum NAO tem reverse (forward so')
+enum Color { Red = "RED", Blue = "BLUE" }
+print(Color.Red);                // RED
+
+describe("enum reverse mapping", () => {
+  test("enum numerico tem reverse mapping bidirecional", () =>
+    expect(out).toBe("1\n2\nIdle\nRunning\nDone\nDone\n200\nNotFound\nRED\n"));
+});


### PR DESCRIPTION
## Problema

Enum numérico não tinha reverse mapping — `State[0]` dava `0` em vez de `"Idle"`. JS gera entradas reversas `[value]: "name"` para enums numéricos (mapeamento bidirecional). String enums não têm reverse.

## Fix

No desugar `enum`→`const` (`lower_ts_enum_to_const`), quando o valor do membro é inteiro literal, adiciona a prop reversa `[n]: "name"` via `PropName::Num`. Forward e string enum inalterados.

## Teste

`tests/enum_reverse_mapping.test.ts` — forward, reverse (literal e via var), valores explícitos, string enum (sem reverse).

Suite **1588/1588** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)