### PR TITLE
fix(codegen): Math.min/max(...arr) com array var/param (2 bugs)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1456,6 +1456,14 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             vec::__RTS_FN_NS_COLLECTIONS_VEC_POP
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_MIN",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_MIN
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_VEC_MAX",
+            vec::__RTS_FN_NS_COLLECTIONS_VEC_MAX
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_SET_LENGTH
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1075,6 +1075,24 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
             // ABI namespace fixou em 2 args; aqui suportamos N reduzindo
             // pairwise. Caso 1 arg: retorna `Number(arg)` (sem call).
             if (qualified == "Math.max" || qualified == "Math.min") && call.args.len() == 1 {
+                // (cross-runtime) `Math.min(...arr)` / `Math.max(...arr)`: o
+                // unico arg eh spread de um array -> reduz sobre o Vec via
+                // VEC_MIN/MAX. Sem isto, coerce_to_f64(arr_handle) virava lixo
+                // (handle interpretado como f64). Standalone passava por outro
+                // caminho; em fn caia aqui.
+                if call.args[0].spread.is_some() {
+                    let src_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    let src_h = ctx.coerce_to_i64(src_tv).val;
+                    let sym = if qualified == "Math.max" {
+                        "__RTS_FN_NS_COLLECTIONS_VEC_MAX"
+                    } else {
+                        "__RTS_FN_NS_COLLECTIONS_VEC_MIN"
+                    };
+                    let f = ctx.get_extern(sym, &[cl::I64], Some(cl::F64))?;
+                    let inst = ctx.builder.ins().call(f, &[src_h]);
+                    let v = ctx.builder.inst_results(inst)[0];
+                    return Ok(TypedVal::new(v, ValTy::F64));
+                }
                 let tv = lower_expr(ctx, &call.args[0].expr)?;
                 let v = ctx.coerce_to_f64(tv).val;
                 return Ok(TypedVal::new(v, ValTy::F64));

--- a/crates/rts-codegen/src/codegen/lower/passes/args/spread_args.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/args/spread_args.rs
@@ -43,10 +43,18 @@ pub(crate) fn expand_spread_args(program: &mut Program) {
     for item in program.items.iter_mut() {
         match item {
             Item::Function(f) => {
+                // (cross-runtime) Params da fn fazem SHADOW de consts top-level
+                // homonimas. `const arr=[...]; function f(arr){ g(...arr) }` —
+                // o `...arr` refere ao PARAM, nao a const. Sem remover, o pass
+                // expandia com os elementos da const errada.
+                let mut scoped = const_arrays.clone();
+                for p in &f.parameters {
+                    scoped.remove(&p.name);
+                }
                 for s in f.body.iter_mut() {
                     let Statement::Raw(raw) = s;
                     if let Some(stmt) = raw.stmt.as_mut() {
-                        spread_in_stmt(stmt, &const_arrays);
+                        spread_in_stmt(stmt, &scoped);
                     }
                 }
             }
@@ -54,18 +62,26 @@ pub(crate) fn expand_spread_args(program: &mut Program) {
                 for m in c.members.iter_mut() {
                     match m {
                         ClassMember::Constructor(ctor) => {
+                            let mut scoped = const_arrays.clone();
+                            for p in &ctor.parameters {
+                                scoped.remove(&p.name);
+                            }
                             for s in ctor.body.iter_mut() {
                                 let Statement::Raw(raw) = s;
                                 if let Some(stmt) = raw.stmt.as_mut() {
-                                    spread_in_stmt(stmt, &const_arrays);
+                                    spread_in_stmt(stmt, &scoped);
                                 }
                             }
                         }
                         ClassMember::Method(method) => {
+                            let mut scoped = const_arrays.clone();
+                            for p in &method.parameters {
+                                scoped.remove(&p.name);
+                            }
                             for s in method.body.iter_mut() {
                                 let Statement::Raw(raw) = s;
                                 if let Some(stmt) = raw.stmt.as_mut() {
-                                    spread_in_stmt(stmt, &const_arrays);
+                                    spread_in_stmt(stmt, &scoped);
                                 }
                             }
                         }

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -93,9 +93,24 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle: u64, value: i64) {
     }
 }
 
+/// (cross-runtime) `Math.min(...arr)` / `Math.max(...arr)`. Reduz os elementos
+/// do Vec (i64) como f64. Vec vazio -> Infinity (min) / -Infinity (max), JS spec.
+/// Retorna f64 (codegen reinterpreta).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_MIN(handle: u64) -> f64 {
+    with_vec(handle, f64::INFINITY, |v| {
+        v.iter().fold(f64::INFINITY, |acc, &x| acc.min(x as f64))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_MAX(handle: u64) -> f64 {
+    with_vec(handle, f64::NEG_INFINITY, |v| {
+        v.iter().fold(f64::NEG_INFINITY, |acc, &x| acc.max(x as f64))
+    })
+}
+
 /// Remove e retorna o ultimo valor. JS spec: undefined se vazio.
-/// Retorna handle de Entry::String("undefined") em vez de 0 — codegen
-/// marca o resultado como ambiguo para template literal formatar.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_POP(handle: u64) -> i64 {
     let popped: Option<i64> = with_vec_mut(handle, None, |v| v.pop());

--- a/tests/math_minmax_spread.test.ts
+++ b/tests/math_minmax_spread.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `Math.min(...arr)`/`Math.max(...arr)` com arr
+// var/param dentro de fn davam lixo — o caso 1-arg (spread) caia em
+// coerce_to_f64(arr_handle) (handle interpretado como f64) em vez de reduzir
+// sobre o Vec. Standalone com const-array funcionava (spread expandido p/ N
+// args). Fix: VEC_MIN/VEC_MAX no runtime; caso 1-arg-spread roteia p/ eles.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// param array
+function minMax(arr: number[]): [number, number] {
+  return [Math.min(...arr), Math.max(...arr)];
+}
+const r = minMax([3, 1, 4, 1, 5]);
+print(r.join(","));              // 1,5
+
+// const local dentro de fn
+function f2(): number[] {
+  const local = [7, 2, 9];
+  return [Math.min(...local), Math.max(...local)];
+}
+print(f2().join(","));           // 2,9
+
+// standalone top-level continua OK
+const arr = [10, 5, 8];
+print(Math.min(...arr) + "," + Math.max(...arr));  // 5,10
+
+// Math.min/max literal (sem spread) continua OK
+print(Math.min(3, 1) + "," + Math.max(3, 1));      // 1,3
+
+describe("Math.min/max com spread", () => {
+  test("spread de array var/param reduz corretamente", () =>
+    expect(out).toBe("1,5\n2,9\n5,10\n1,3\n"));
+});


### PR DESCRIPTION
## Problema

`Math.min(...arr)` / `Math.max(...arr)` com `arr` var/param dava lixo. **Dois bugs** mascarados pelo fato de que standalone com const-array funcionava (o spread era expandido para N args).

### Bug 1: caso 1-arg-spread

`Math.min(...arr)` tem 1 arg (o spread). O handler 1-arg fazia `coerce_to_f64(arr_handle)` — o handle do array interpretado como f64 (lixo). **Fix:** runtime `VEC_MIN`/`VEC_MAX` (reduz o Vec como f64); o caso 1-arg-spread roteia para eles.

### Bug 2: shadowing em expand_spread_args

`const arr=[...]; function f(arr){ g(...arr) }` — o pass expandia `...arr` com a const top-level em vez do **param** `arr` (shadow). **Fix:** remove do map os nomes que colidem com params da fn/método/constructor.

## Teste

`tests/math_minmax_spread.test.ts` — param array, const local, standalone, literal.

Suite **1590/1590** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)