### PR TITLE
fix(codegen): let sem init e sem tipo concreto -> undefined, nao 0

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -829,6 +829,17 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         let (init_val, inferred_ty) = if let Some(init) = &decl.init {
             let tv = lower_expr(ctx, init)?;
             (tv.val, tv.ty)
+        } else if ann_ty.is_none() {
+            // (cross-runtime) `let u;` / `let u: any;` sem init -> undefined real
+            // (sentinel i64::MIN+2), nao 0. Faz `typeof u`, `u === undefined` e
+            // template formatarem corretamente. So' quando nao ha tipo concreto
+            // anotado (number/string mantem zero_for_ty p/ nao quebrar uso
+            // tipado posterior `let n: number; n = 5`).
+            let undef = ctx.builder.ins().iconst(
+                cranelift_codegen::ir::types::I64,
+                i64::MIN + 2,
+            );
+            (undef, ValTy::I64)
         } else {
             let ty = ann_ty.unwrap_or(ValTy::I64);
             (zero_for_ty(ctx, ty), ty)
@@ -908,6 +919,13 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         // retornando campo f64): propaga ambiguidade pra que leituras/console
         // usem INSPECT/TPL_COERCE_AUTO em runtime em vez de fcvt.
         if init_is_ambiguous_call {
+            ctx.local_ambiguous_vars.insert(name.clone());
+            ctx.var_member_call_values.insert(init_coerced);
+        }
+        // (cross-runtime) `let u;`/`let u: any;` sem init (sentinel undefined):
+        // marca ambigua p/ typeof/concat despacharem runtime (TYPEOF_HANDLE
+        // detecta MIN+2 -> "undefined"). Sem isso, typeof via ValTy I64 -> "number".
+        if decl.init.is_none() && ann_ty.is_none() {
             ctx.local_ambiguous_vars.insert(name.clone());
             ctx.var_member_call_values.insert(init_coerced);
         }

--- a/tests/let_uninit_undefined.test.ts
+++ b/tests/let_uninit_undefined.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `let u;` / `let u: any;` sem init recebia 0 em
+// vez de undefined. Consequencia: `typeof u` -> "number", `u === undefined`
+// false, template "0". Fix: var sem init e sem tipo concreto inicializa com
+// sentinel i64::MIN+2 (undefined) e eh marcada ambigua (typeof via runtime).
+// Vars tipadas (`let n: number`) mantem zero_for_ty.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+let u: any;
+print(typeof u);                 // undefined
+print((u === undefined) + "");   // true
+print((u ?? "fb"));              // fb
+print("" + u);                   // undefined
+
+let u2;
+print(typeof u2);                // undefined
+
+// var tipada continua usavel apos atribuicao
+let n: number;
+n = 5;
+print(n + "");                   // 5
+let s: string;
+s = "hi";
+print(s);                        // hi
+
+// atribuir a var any depois funciona
+let v: any;
+v = 42;
+print(typeof v);                 // number
+print(v + "");                   // 42
+
+describe("let sem init -> undefined", () => {
+  test("var sem init e' undefined, tipada e' usavel", () =>
+    expect(out).toBe("undefined\ntrue\nfb\nundefined\nundefined\n5\nhi\nnumber\n42\n"));
+});


### PR DESCRIPTION
## Problema

`let u;` / `let u: any;` sem init recebia `0` em vez de `undefined`. Consequência: `typeof u` → "number", `u === undefined` false, template "0". Em JS deveria ser `undefined`.

## Fix

Var sem init **e** sem anotação de tipo concreto inicializa com o sentinel `i64::MIN+2` (undefined) e é marcada ambígua (`local_ambiguous_vars` + `var_member_call_values`) para `typeof` despachar runtime (`TYPEOF_HANDLE` já mapeia `MIN+2` → "undefined"). Vars tipadas (`let n: number`) mantêm `zero_for_ty` para não quebrar uso tipado posterior.

## Teste

`tests/let_uninit_undefined.test.ts` — `typeof`, `===`, `??`, template; var tipada usável após atribuição; var any atribuída depois.

Suite **1590/1590** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)