### PR TITLE
fix(codegen): arr.map((c,i)=>c+i) em array-de-strings (slot 0 string)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -146,6 +146,52 @@ fn collect_fns_ret_mapset(program: &Program) -> HashSet<String> {
 /// ret-array (METHODS_RET_ARRAY), Object.keys/values/entries, Array.from/of, e
 /// metodos de instancia que retornam array (map/filter/.../fill/sort/etc).
 /// Usado pra reconhecer receiver chain `[..].fill(0).map((_,i)=>i)` no lift.
+/// (cross-runtime) Heuristica: `e` eh um array cujos elementos sao strings?
+/// Cobre `.split(...)` chain (+ `.slice/.filter/...` sobre ele via recursao
+/// rasa), array literal de so'-strings, e Ident em STRING_ARRAY_VALUES.
+/// Usado p/ marcar slot 0 do callback de map/forEach como string handle.
+fn receiver_is_string_array(e: &Expr) -> bool {
+    match e {
+        // array literal cujos elementos (nao-vazios) sao todos string lit/tpl.
+        Expr::Array(a) => {
+            !a.elems.is_empty()
+                && a.elems.iter().flatten().all(|el| {
+                    el.spread.is_none()
+                        && matches!(
+                            el.expr.as_ref(),
+                            Expr::Lit(swc_ecma_ast::Lit::Str(_)) | Expr::Tpl(_)
+                        )
+                })
+        }
+        Expr::Ident(id) => {
+            STRING_ARRAY_VALUES.with(|s| s.borrow().contains_key(id.sym.as_str()))
+        }
+        // `x.split(...)` -> array de strings. `.slice/.filter/.concat/.reverse/
+        // .sort/.toReversed/.toSorted` preservam strings -> recursa no receiver.
+        Expr::Call(c) => {
+            if let Callee::Expr(ce) = &c.callee {
+                if let Expr::Member(m) = ce.as_ref() {
+                    if let MemberProp::Ident(p) = &m.prop {
+                        let prop = p.sym.as_str();
+                        if prop == "split" {
+                            return true;
+                        }
+                        if matches!(prop,
+                            "slice" | "filter" | "concat" | "reverse" | "sort"
+                            | "toReversed" | "toSorted"
+                        ) {
+                            return receiver_is_string_array(m.obj.as_ref());
+                        }
+                    }
+                }
+            }
+            false
+        }
+        Expr::Paren(p) => receiver_is_string_array(&p.expr),
+        _ => false,
+    }
+}
+
 fn expr_is_array_returning_call(e: &Expr) -> bool {
     let Expr::Call(c) = e else { return false };
     let Callee::Expr(ce) = &c.callee else { return false };
@@ -720,11 +766,20 @@ fn lift_arrows_in_expr(
                             // sem type-annotation default para I64 e member
                             // call \`c.toUpperCase()\` cai em map_get + trapz.
                             // Detecta call.args[0] como Tpl/Lit::Str.
-                            let mapper_slot0_is_string = is_array_from
+                            let mapper_slot0_is_string = (is_array_from
                                 && matches!(
                                     call.args[0].expr.as_ref(),
                                     Expr::Lit(swc_ecma_ast::Lit::Str(_)) | Expr::Tpl(_)
-                                );
+                                ))
+                                // (cross-runtime) `arr.map/forEach/filter` onde
+                                // arr eh array-de-strings (`.split(...)` chain,
+                                // array literal so'-strings, ou STRING_ARRAY_VALUES).
+                                // Slot 0 (elem) eh string handle — sem isto,
+                                // `(c, i) => c + i` somava handle+idx em vez de
+                                // concat. So' p/ metodos cujo slot 0 eh o elemento.
+                                || (matches!(method, "map" | "forEach" | "filter"
+                                        | "find" | "findIndex" | "some" | "every")
+                                    && receiver_is_string_array(m.obj.as_ref()));
                             // (#345) Para `arr.reduce(fn, init)` com init
                             // string literal, slot 0 (acc) eh string handle.
                             // Sem isso, o lifter assume i64 e `acc + s` vira

--- a/tests/string_array_map_idx.test.ts
+++ b/tests/string_array_map_idx.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `arr.map((c, i) => c + i)` onde arr eh array-de-
+// strings (split, array literal de strings) dava lixo — o slot 0 (elem) era
+// tratado como i64, entao `c + i` somava handle+idx em vez de concatenar.
+// Fix: receiver_is_string_array marca slot0_is_string p/ map/forEach/filter/etc.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// split chain + callback 2-param
+print("abc".split("").map((c, i) => c + i).join(","));   // a0,b1,c2
+
+// array literal de strings
+print(["x", "y", "z"].map((c, i) => c + i).join(","));   // x0,y1,z2
+
+// callback 1-param continua OK
+print("ab".split("").map(c => c + "!").join(","));       // a!,b!
+
+// number array com idx NAO afetado (slot0 nao string)
+print([10, 20].map((x, i) => x + i).join(","));          // 10,21
+
+// filter sobre string array com idx
+print(["a", "bb", "ccc"].filter((s, i) => s.length > i).join(",")); // a,bb,ccc
+
+// split().slice().map preserva string
+print("a,b,c,d".split(",").slice(1).map((c, i) => c + i).join(",")); // b0,c1,d2
+
+describe("string array map com idx", () => {
+  test("slot 0 string em map/filter de array-de-strings", () =>
+    expect(out).toBe("a0,b1,c2\nx0,y1,z2\na!,b!\n10,21\na,bb,ccc\nb0,c1,d2\n"));
+});


### PR DESCRIPTION
## Problema

`arr.map((c, i) => c + i)` onde `arr` é array-de-strings (`.split()`, array literal de strings) dava lixo — o slot 0 (elemento) era tratado como i64, então `c + i` somava handle+idx em vez de concatenar string. Callback 1-param funcionava (slot 0 já ambíguo via outro caminho); o **2-param** caía no default i64.

## Fix

Novo helper `receiver_is_string_array` (reconhece `.split()` chain, array literal só-strings, `STRING_ARRAY_VALUES`, e `.slice/.filter/.concat/.reverse/.sort` preservando strings) marca `mapper_slot0_is_string` para `map/forEach/filter/find/some/every`. Number arrays não afetados.

## Teste

`tests/string_array_map_idx.test.ts` — split/literal map(c,i), 1-param, number array (guard), filter, split().slice().map.

Suite **1592/1592** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)