### PR TITLE
fix(codegen): for-of sobre param string nao iterava

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -171,6 +171,12 @@ pub(crate) fn compile_user_fn(
                 ) {
                     fn_ctx.local_map_vars.insert(p.name.clone());
                 }
+                // (cross-runtime) param `: string` marca local_string_vars p/
+                // `for (const ch of s)` iterar os chars. Sem isso, for-of sobre
+                // param string nao iterava (so' var string top-level/local).
+                if base == "string" {
+                    fn_ctx.local_string_vars.insert(p.name.clone());
+                }
             }
         }
 

--- a/tests/for_of_param_string.test.ts
+++ b/tests/for_of_param_string.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const ch of s)` onde s eh PARAMETRO string
+// nao iterava (vazio/crash). for_of_iterates_string so' reconhecia
+// local_string_vars (var top-level/local), nao params anotados `: string`.
+// Fix: param `: string` marca local_string_vars em user_fn.rs (mesma rota do
+// local_map_vars #1261).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function countChar(s: string, c: string): number {
+  let n = 0;
+  for (const ch of s) {
+    if (ch === c) n++;
+  }
+  return n;
+}
+print(countChar("banana", "a") + "");   // 3
+print(countChar("hello", "l") + "");     // 2
+
+function upper(s: string): string {
+  let r = "";
+  for (const ch of s) r += ch.toUpperCase();
+  return r;
+}
+print(upper("abc"));                      // ABC
+
+function reverse(s: string): string {
+  let r = "";
+  for (const ch of s) r = ch + r;
+  return r;
+}
+print(reverse("hello"));                  // olleh
+
+// var local string continua OK (guard)
+const local = "xyz";
+let lc = "";
+for (const ch of local) lc += ch + ".";
+print(lc);                                // x.y.z.
+
+describe("for-of param string", () => {
+  test("for-of sobre param string itera chars", () =>
+    expect(out).toBe("3\n2\nABC\nolleh\nx.y.z.\n"));
+});


### PR DESCRIPTION
## Problema

`for (const ch of s)` onde `s` é **parâmetro** `: string` não iterava (vazio/crash). `for_of_iterates_string` só reconhecia `local_string_vars` (var top-level/local), não params anotados `: string`. Mesma classe do `local_map_vars` (#1261).

## Fix

Param com anotação base `string` marca `local_string_vars` em `user_fn.rs`.

## Teste

`tests/for_of_param_string.test.ts` — countChar (`ch === c`), upper, reverse com for-of sobre param string; var local string (guard).

Suite **1594/1594** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)