### PR TITLE
fix(codegen): for-of sobre string de fn/metodo/concat nao iterava

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -48,6 +48,11 @@ thread_local! {
     /// local_map_vars, fazendo `.size` rotear ao UNIVERSAL_LENGTH.
     pub(crate) static FNS_RET_MAPSET: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 
+    /// (cross-runtime) Nomes de fns/metodos com return_type string. Populado em
+    /// collect_fns_ret_string (array_methods_pass); lido por for_of_iterates_string
+    /// (loops.rs) p/ `for (const ch of f())` iterar os chars.
+    pub(crate) static FNS_RET_STRING: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+
     /// (cross-runtime #1052) Mapa de top-level `const k = ["str1", "str2", ...]`
     /// para suas string literals. Permite codegen propagar `k[N]` em compile
     /// time, despachando `arr[k[N]](args)` como `arr.<method>(args)`.
@@ -133,6 +138,35 @@ fn collect_fns_ret_mapset(program: &Program) -> HashSet<String> {
             }
             Item::Function(f) => {
                 if ret_is_mapset(f.return_type.as_deref()) {
+                    out.insert(f.name.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// (cross-runtime) Coleta nomes de fns/metodos cujo return_type eh `string`.
+/// Usado p/ `for (const ch of f())` iterar os chars (for_of_iterates_string).
+fn collect_fns_ret_string(program: &Program) -> HashSet<String> {
+    fn ret_is_string(rt: Option<&str>) -> bool {
+        rt.map(|r| r.trim() == "string").unwrap_or(false)
+    }
+    let mut out = HashSet::new();
+    for item in &program.items {
+        match item {
+            Item::Class(c) => {
+                for mem in &c.members {
+                    if let crate::parser::ast::ClassMember::Method(method) = mem {
+                        if ret_is_string(method.return_type.as_deref()) {
+                            out.insert(method.name.clone());
+                        }
+                    }
+                }
+            }
+            Item::Function(f) => {
+                if ret_is_string(f.return_type.as_deref()) {
                     out.insert(f.name.clone());
                 }
             }
@@ -1601,6 +1635,8 @@ pub(crate) fn array_methods_pass(program: &mut Program) {
     // `const m = mk()` como local_map_vars (-> `.size` via UNIVERSAL_LENGTH).
     let frm = collect_fns_ret_mapset(program);
     FNS_RET_MAPSET.with(|c| *c.borrow_mut() = frm);
+    let frs = collect_fns_ret_string(program);
+    FNS_RET_STRING.with(|c| *c.borrow_mut() = frs);
 
     // Visita top-level statements.
     let n_items = program.items.len();

--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -542,6 +542,28 @@ fn for_of_iterates_string(ctx: &FnCtx, e: &swc_ecma_ast::Expr) -> bool {
         Expr::Tpl(_) => true,
         Expr::Paren(p) => for_of_iterates_string(ctx, &p.expr),
         Expr::Ident(id) => ctx.local_string_vars.contains(id.sym.as_str()),
+        // (cross-runtime) `for (const ch of a + b)` concat -> string quando
+        // algum lado eh string. So' `+` (outros ops nao produzem string).
+        Expr::Bin(b) if matches!(b.op, swc_ecma_ast::BinaryOp::Add) => {
+            for_of_iterates_string(ctx, &b.left) || for_of_iterates_string(ctx, &b.right)
+        }
+        // (cross-runtime) `for (const ch of f())` / `obj.m()` onde a fn/metodo
+        // retorna string (FNS_RET_STRING populado no array_methods_pass).
+        Expr::Call(c) => {
+            if let swc_ecma_ast::Callee::Expr(callee) = &c.callee {
+                match callee.as_ref() {
+                    Expr::Ident(fid) => crate::codegen::lower::passes::parallelism::FNS_RET_STRING
+                        .with(|s| s.borrow().contains(fid.sym.as_str())),
+                    Expr::Member(m) => matches!(&m.prop,
+                        swc_ecma_ast::MemberProp::Ident(p)
+                            if crate::codegen::lower::passes::parallelism::FNS_RET_STRING
+                                .with(|s| s.borrow().contains(p.sym.as_str()))),
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
         _ => false,
     }
 }

--- a/tests/for_of_string_expr.test.ts
+++ b/tests/for_of_string_expr.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const ch of <expr>)` onde expr produz string
+// nao-literal/var (fn ret string, metodo ret string, concat a+b) nao iterava.
+// for_of_iterates_string so' reconhecia literal/Tpl/Ident(local_string_vars).
+// Fix: estende p/ Bin Add (concat) + Call de fn/metodo em FNS_RET_STRING.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function getStr(): string { return "abc"; }
+let r1 = "";
+for (const ch of getStr()) r1 += ch + "-";
+print(r1);                       // a-b-c-
+
+class Box { val(): string { return "xyz"; } }
+const b = new Box();
+let r2 = "";
+for (const ch of b.val()) r2 += ch;
+print(r2);                       // xyz
+
+// concat a + b
+let r3 = "";
+for (const ch of ("a" + "b" + "c")) r3 += ch;
+print(r3);                       // abc
+
+// concat com var string
+const prefix = "X";
+let r4 = "";
+for (const ch of (prefix + "yz")) r4 += ch;
+print(r4);                       // Xyz
+
+// guard: literal e var local continuam OK
+let r5 = "";
+for (const ch of "12") r5 += ch + ".";
+print(r5);                       // 1.2.
+
+describe("for-of string expr", () => {
+  test("for-of sobre fn/metodo/concat string itera chars", () =>
+    expect(out).toBe("a-b-c-\nxyz\nabc\nXyz\n1.2.\n"));
+});


### PR DESCRIPTION
## Problema

`for (const ch of f())` / `obj.m()` / `a + b` — onde a expr produz string não-literal/var — não iterava. `for_of_iterates_string` só reconhecia literal/Tpl/Ident(`local_string_vars`). Continuação do #1270 (param string).

## Fix

Estende `for_of_iterates_string` para:
1. `Bin Add` (concat → string quando algum lado é string)
2. `Call` de fn/método cujo `return_type` é `string` (novo `FNS_RET_STRING`, populado em `collect_fns_ret_string` no array_methods_pass)

Field string fica follow-up (precisa tracking de tipo de field).

## Teste

`tests/for_of_string_expr.test.ts` — fn ret string, método ret string, concat (literal e com var); guards (literal, var local).

Suite **1595/1595** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)