### PR TITLE
fix(codegen): for-of sobre field string nao iterava

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -564,6 +564,54 @@ fn for_of_iterates_string(ctx: &FnCtx, e: &swc_ecma_ast::Expr) -> bool {
                 false
             }
         }
+        // (cross-runtime) `for (const ch of h.text)` / `this.content` onde o
+        // field eh `: string`. Resolve a classe do receiver (this/ident) e
+        // checa field_class_names == "string" na hierarquia.
+        Expr::Member(m) => {
+            if let swc_ecma_ast::MemberProp::Ident(prop) = &m.prop {
+                if let Some(cls) = receiver_class_for_string(ctx, &m.obj) {
+                    return field_is_string(ctx, &cls, prop.sym.as_str());
+                }
+            }
+            false
+        }
         _ => false,
     }
+}
+
+/// (cross-runtime) Resolve a classe do receiver de um member access, apenas
+/// para os casos comuns: `this` (classe atual) e ident de var tipada classe.
+fn receiver_class_for_string(ctx: &FnCtx, e: &swc_ecma_ast::Expr) -> Option<String> {
+    use swc_ecma_ast::Expr;
+    match e {
+        Expr::This(_) => ctx.current_class.clone(),
+        Expr::Ident(id) => ctx
+            .local_class_ty
+            .get(id.sym.as_str())
+            .cloned()
+            .or_else(|| ctx.global_class_ty.get(id.sym.as_str()).cloned()),
+        Expr::Paren(p) => receiver_class_for_string(ctx, &p.expr),
+        _ => None,
+    }
+}
+
+/// (cross-runtime) O field `prop` da classe `cls` (ou de um ancestral) eh
+/// declarado `: string`? Consulta field_class_names subindo a hierarquia.
+fn field_is_string(ctx: &FnCtx, cls: &str, prop: &str) -> bool {
+    let mut current = Some(cls.to_string());
+    let mut depth = 0u32;
+    while let Some(name) = current {
+        if depth > 16 {
+            break;
+        }
+        let Some(meta) = ctx.classes.get(&name) else {
+            break;
+        };
+        if let Some(ty) = meta.field_class_names.get(prop) {
+            return ty.trim() == "string";
+        }
+        current = meta.super_class.clone();
+        depth += 1;
+    }
+    false
 }

--- a/tests/for_of_field_string.test.ts
+++ b/tests/for_of_field_string.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const ch of h.text)` / `this.content` onde
+// o field eh `: string` nao iterava. for_of_iterates_string nao cobria
+// Expr::Member. Fix: resolve a classe do receiver (this/ident) e checa
+// field_class_names == "string" na hierarquia. Fecha a familia for-of-string
+// (#1270 param, #1271 fn/concat).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+class Holder { text: string = "hi"; }
+const h = new Holder();
+let r1 = "";
+for (const ch of h.text) r1 += ch + ".";
+print(r1);                       // h.i.
+
+class Doc {
+  content: string = "abc";
+  chars(): string {
+    let s = "";
+    for (const ch of this.content) s += ch + "-";
+    return s;
+  }
+}
+print(new Doc().chars());        // a-b-c-
+
+// field herdado
+class Base { label: string = "xy"; }
+class Derived extends Base {}
+const d = new Derived();
+let r3 = "";
+for (const ch of d.label) r3 += ch;
+print(r3);                       // xy
+
+describe("for-of field string", () => {
+  test("for-of sobre field/this string itera chars", () =>
+    expect(out).toBe("h.i.\na-b-c-\nxy\n"));
+});


### PR DESCRIPTION
## Problema

`for (const ch of h.text)` / `this.content` onde o field é `: string` não iterava. `for_of_iterates_string` não cobria `Expr::Member`. Fecha a família for-of-string (#1270 param, #1271 fn/concat).

## Fix

`for_of_iterates_string` reconhece `Expr::Member` resolvendo a classe do receiver (`this` → `current_class`; ident → `local/global_class_ty`) e checando `field_class_names == "string"` subindo a hierarquia (cobre field herdado).

## Teste

`tests/for_of_field_string.test.ts` — `h.text`, `this.content`, field herdado.

Suite **1596/1596** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)