### PR TITLE
fix(codegen): for-of com object destructuring no bind

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -125,6 +125,10 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
     // `for (const [k, v] of pairs)`. No segundo caso, geramos bind temp
     // `__forof_pair_N` e capturamos os nomes pra extrair via vec_get
     // dentro do body.
+    // object_destructure_keys: Some(vec[(var_name, key)]) quando o bind eh
+    // object pattern (`for (const {a, b} of items)`). Extraido via MAP_GET por
+    // chave no body (analogo ao array pattern via vec_get por indice).
+    let mut object_destructure_keys: Option<Vec<(String, String)>> = None;
     let (bind_name, bind_ty, array_destructure_names) = match &for_of.left {
         ForHead::VarDecl(vd) => {
             if vd.decls.len() != 1 {
@@ -138,6 +142,45 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
                         .and_then(|t| ts_type_to_val_ty(&t.type_ann))
                         .unwrap_or(ValTy::I64);
                     (id.sym.as_str().to_string(), ty, None)
+                }
+                // (cross-runtime) `for (const {a, b} of items)` — object pattern.
+                // Coleta (var_name, key) de cada prop. Suporta shorthand `{a}` e
+                // rename `{a: b}`. Extrai via MAP_GET no body.
+                Pat::Object(obj_pat) => {
+                    use swc_ecma_ast::ObjectPatProp;
+                    let mut keys: Vec<(String, String)> = Vec::new();
+                    for prop in &obj_pat.props {
+                        match prop {
+                            ObjectPatProp::Assign(a) => {
+                                // `{a}` ou `{a = default}` — var e key sao iguais.
+                                keys.push((a.key.id.sym.to_string(), a.key.id.sym.to_string()));
+                            }
+                            ObjectPatProp::KeyValue(kv) => {
+                                let key = match &kv.key {
+                                    swc_ecma_ast::PropName::Ident(i) => i.sym.to_string(),
+                                    swc_ecma_ast::PropName::Str(s) => {
+                                        s.value.to_string_lossy().to_string()
+                                    }
+                                    _ => return Err(anyhow!(
+                                        "for-of object destructuring: chave nao suportada"
+                                    )),
+                                };
+                                if let Pat::Ident(id) = kv.value.as_ref() {
+                                    keys.push((id.id.sym.to_string(), key));
+                                } else {
+                                    return Err(anyhow!(
+                                        "for-of object destructuring: valor deve ser ident"
+                                    ));
+                                }
+                            }
+                            ObjectPatProp::Rest(_) => return Err(anyhow!(
+                                "for-of object destructuring: rest nao suportado"
+                            )),
+                        }
+                    }
+                    object_destructure_keys = Some(keys);
+                    let tmp = format!("__forof_objpat_{:p}", &for_of.span);
+                    (tmp, ValTy::Handle, None)
                 }
                 Pat::Array(arr_pat) => {
                     // Coleta (nome, tipo) dos elementos. Aceita Ident
@@ -402,6 +445,26 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
                 ctx.var_member_call_values.insert(val);
                 ctx.var_vec_slot_values.insert(val);
             }
+        }
+    }
+
+    // (cross-runtime) for-of object destructuring: cada (var, key) extrai
+    // `elem[key]` via MAP_GET. elem eh o objeto iterado (handle Map). Valor
+    // marcado ambiguo (campo pode ser string/number/handle) p/ template/uso
+    // despachar coercao runtime.
+    if let Some(keys) = &object_destructure_keys {
+        let get_fn = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_MAP_GET",
+            &[cl::I64, cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        for (var_name, key) in keys {
+            let (kp, kl) = ctx.emit_str_literal(key.as_bytes())?;
+            let g = ctx.builder.ins().call(get_fn, &[elem, kp, kl]);
+            let val = ctx.builder.inst_results(g)[0];
+            ctx.declare_local(var_name, ValTy::I64, val);
+            ctx.var_member_call_values.insert(val);
+            ctx.var_vec_slot_values.insert(val);
         }
     }
 

--- a/tests/for_of_object_destructure.test.ts
+++ b/tests/for_of_object_destructure.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime): `for (const {a, b} of items)` (object pattern no
+// bind do for-of) dava "for-of bind deve ser ident ou array pattern" e nao
+// iterava. Fix: coleta (var, key) do object pattern e extrai via MAP_GET por
+// chave no body (analogo ao array pattern via vec_get por indice).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const items = [{ id: 1, n: "a" }, { id: 2, n: "b" }, { id: 3, n: "c" }];
+
+// shorthand {id, n}
+let r1 = "";
+for (const { id, n } of items) r1 += id + n;
+print(r1);                       // 1a2b3c
+
+// rename {id: x}
+let r2 = "";
+for (const { id: x } of items) r2 += x;
+print(r2);                       // 123
+
+// campo nested acessado depois
+const data = [{ pos: { x: 1, y: 2 } }, { pos: { x: 3, y: 4 } }];
+let r3 = "";
+for (const { pos } of data) r3 += pos.x + "/" + pos.y + " ";
+print(r3.trim());                // 1/2 3/4
+
+// soma de campo via destructuring
+const txs = [{ amount: 100 }, { amount: 50 }, { amount: 25 }];
+let total = 0;
+for (const { amount } of txs) total += amount;
+print(total + "");               // 175
+
+// array pattern continua OK (guard)
+const pairs: [string, number][] = [["a", 1], ["b", 2]];
+let r5 = "";
+for (const [k, v] of pairs) r5 += k + v;
+print(r5);                       // a1b2
+
+describe("for-of object destructuring", () => {
+  test("object pattern no bind do for-of", () =>
+    expect(out).toBe("1a2b3c\n123\n1/2 3/4\n175\na1b2\n"));
+});


### PR DESCRIPTION
## Problema

`for (const {a, b} of items)` (object pattern no bind) dava `"for-of bind deve ser ident ou array pattern"` e não iterava — só `ident` e `array pattern` eram aceitos.

## Fix

Coleta `(var_name, key)` do object pattern (shorthand `{a}`, rename `{a: b}`) e extrai cada campo via `MAP_GET` por chave no body — análogo ao array pattern que extrai via `vec_get` por índice, no **mesmo block** (evita o problema cross-block do desugar via decl injetado, que causava verifier errors). Valores marcados ambíguos para coerção runtime. Rest pattern fica follow-up.

## Teste

`tests/for_of_object_destructure.test.ts` — shorthand, rename, campo nested acessado depois, soma via destructuring; array pattern (guard).

Suite **1597/1597** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)