### PR TITLE
fix(codegen): HOF — user fn passada como valor (issue-pai invoke/param_kinds)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -525,6 +525,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE", __RTS_FN_RT_OBJECT_PROTOTYPE_HANDLE);
     add_fn!("__RTS_FN_RT_INVOKE_AUTO", __RTS_FN_RT_INVOKE_AUTO);
     add_fn!("__RTS_FN_RT_INVOKE_AUTO_TYPED", __RTS_FN_RT_INVOKE_AUTO_TYPED);
+    add_fn!("__RTS_FN_RT_INVOKE_AUTO_AS_F64", __RTS_FN_RT_INVOKE_AUTO_AS_F64);
     add_fn!("__RTS_FN_RT_INSTANCEOF_PROTO", __RTS_FN_RT_INSTANCEOF_PROTO);
     {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TPL_COERCE_AUTO;

--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -22,6 +22,18 @@ use super::mir_route::try_compile_via_mir;
 use super::program::UserFn;
 use super::util::{collect_var_decls, user_call_conv};
 
+/// (issue-pai invoke/param_kinds, metade b) Anotacao textual eh fn-type
+/// retornando `number`? Ex: `(n: number) => number`. Marca o param p/ que `f(n)`
+/// normalize o retorno via INVOKE_AUTO_AS_F64.
+fn ann_is_fn_returning_number(ann: &str) -> bool {
+    let t = ann.trim();
+    if let Some(idx) = t.rfind("=>") {
+        let ret = t[idx + 2..].trim().trim_end_matches(|c| c == ';' || c == ' ');
+        return ret == "number";
+    }
+    false
+}
+
 pub(crate) fn compile_user_fn(
     module: &mut dyn Module,
     extern_cache: &mut HashMap<String, cranelift_module::FuncId>,
@@ -176,6 +188,14 @@ pub(crate) fn compile_user_fn(
                 // param string nao iterava (so' var string top-level/local).
                 if base == "string" {
                     fn_ctx.local_string_vars.insert(p.name.clone());
+                }
+                // (issue-pai invoke/param_kinds, metade b) param fn-type
+                // retornando number (`f: (n: number) => number`): marca
+                // local_fn_ret_f64 p/ que `f(n)` use INVOKE_AUTO_AS_F64 e
+                // normalize o retorno como f64 (user fn f64-ret OU function
+                // expression i64-ret). Sem isto, HOF retornava bits crus.
+                if ann_is_fn_returning_number(ann) {
+                    fn_ctx.local_fn_ret_f64.insert(p.name.clone());
                 }
             }
         }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -415,16 +415,45 @@ pub(super) fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &Ca
             let src = ctx.coerce_to_i64(tv).val;
             ctx.builder.ins().call(vec_extend, &[args_vec, src]);
         } else {
-            let v = ctx.coerce_to_i64(tv).val;
+            // (issue-pai invoke/param_kinds) F64 viaja como to_bits; invoke_typed
+            // (via handle com param_kinds) le from_bits. Sem isto `apply(inc,2.5)`
+            // truncava. Args int/handle como i64 cru (param_kind reflete o tipo).
+            let v = match tv.ty {
+                ValTy::F64 => ctx.builder.ins().bitcast(
+                    cl::I64,
+                    cranelift_codegen::ir::MemFlags::new(),
+                    tv.val,
+                ),
+                _ => ctx.coerce_to_i64(tv).val,
+            };
             ctx.builder.ins().call(vec_push, &[args_vec, v]);
         }
+    }
+    let zero = ctx.builder.ins().iconst(cl::I64, 0);
+    // (issue-pai invoke/param_kinds, metade b) Callee declara retorno number
+    // (`f: (n)=>number`): usa INVOKE_AUTO_AS_F64 que NORMALIZA o retorno p/
+    // f64-bits qualquer que seja o callee (user fn f64-ret OU function
+    // expression i64-ret). Resultado eh F64 — sem bits crus no template.
+    if ret_is_f64 {
+        let invoke_f = ctx.get_extern(
+            "__RTS_FN_RT_INVOKE_AUTO_AS_F64",
+            &[cl::I64, cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(invoke_f, &[callee_val, zero, args_vec]);
+        let raw = ctx.builder.inst_results(inst)[0];
+        let f = ctx.builder.ins().bitcast(
+            cl::F64,
+            cranelift_codegen::ir::MemFlags::new(),
+            raw,
+        );
+        return Ok(TypedVal::new(f, ValTy::F64));
     }
     let invoke = ctx.get_extern(
         "__RTS_FN_RT_INVOKE_AUTO",
         &[cl::I64, cl::I64, cl::I64],
         Some(cl::I64),
     )?;
-    let zero = ctx.builder.ins().iconst(cl::I64, 0);
     let inst = ctx.builder.ins().call(invoke, &[callee_val, zero, args_vec]);
     let v = ctx.builder.inst_results(inst)[0];
     // (cross-runtime followup #1067) INVOKE_AUTO retorna i64 ambiguo

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -2952,6 +2952,24 @@ fn lower_js_global_call(
 /// fn_ptr nu. Quando target eh ident de user fn, reifica em handle com
 /// param_kinds/return_kind corretos pra invoke_typed reinterpretar bits
 /// f64 vs i64; senao usa coerce normal (handle ja eh i64).
+/// (issue-pai invoke/param_kinds) `expr` eh um ident de user fn NOMEADA pelo
+/// usuario (nao var local, nao fn sintetica hoistada/liftada)? So' essas tem
+/// kinds confiaveis p/ reificacao; function expressions anonimas hoistadas
+/// seguem o caminho antigo (func_addr) que ja' funcionava.
+fn arg_is_bare_user_fn(ctx: &FnCtx, expr: &swc_ecma_ast::Expr) -> bool {
+    if let swc_ecma_ast::Expr::Ident(id) = expr {
+        let name = id.sym.as_str();
+        if name.starts_with("__hoisted_")
+            || name.starts_with("__lifted_")
+            || name.starts_with("__async_inner_")
+        {
+            return false;
+        }
+        return ctx.user_fns.contains_key(name) && ctx.var_ty(name).is_none();
+    }
+    false
+}
+
 fn lower_callable_target_h(
     ctx: &mut FnCtx,
     expr: &swc_ecma_ast::Expr,
@@ -3454,12 +3472,22 @@ fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> Result<Typed
             if arg.spread.is_some() {
                 return Err(anyhow!("spread not supported"));
             }
-            let tv = lower_expr(ctx, &arg.expr)?;
-            match expected_ty {
-                ValTy::I32 => ctx.coerce_to_i32(tv).val,
-                ValTy::I64 | ValTy::Bool | ValTy::Handle | ValTy::U64
-                | ValTy::I8 | ValTy::I16 | ValTy::U8 | ValTy::U16 => ctx.coerce_to_i64(tv).val,
-                ValTy::F64 => to_f64(ctx, tv),
+            // (issue-pai invoke/param_kinds, metade a) Arg que eh ident de user
+            // fn NOMEADA passado a param nao-numerico: reifica como handle
+            // Function COM param_kinds/return_kind (lower_callable_target_h) em
+            // vez de func_addr cru. Resolve HOF: `apply(inc,10)` invoca inc com
+            // a ABI certa. Function expressions hoistadas seguem o caminho antigo
+            // (arg_is_bare_user_fn as exclui).
+            if !matches!(expected_ty, ValTy::F64) && arg_is_bare_user_fn(ctx, &arg.expr) {
+                lower_callable_target_h(ctx, &arg.expr)?
+            } else {
+                let tv = lower_expr(ctx, &arg.expr)?;
+                match expected_ty {
+                    ValTy::I32 => ctx.coerce_to_i32(tv).val,
+                    ValTy::I64 | ValTy::Bool | ValTy::Handle | ValTy::U64
+                    | ValTy::I8 | ValTy::I16 | ValTy::U8 | ValTy::U16 => ctx.coerce_to_i64(tv).val,
+                    ValTy::F64 => to_f64(ctx, tv),
+                }
             }
         } else {
             // Param ausente — fill com undefined sentinel (ou 0.0 pra F64).

--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -798,6 +798,70 @@ pub extern "C" fn __RTS_FN_RT_INVOKE_AUTO_TYPED(
     invoke_auto_impl(callee, this_arg, args_handle, ov)
 }
 
+/// (issue-pai invoke/param_kinds) Invoca o callable e NORMALIZA o retorno para
+/// f64-bits, qualquer que seja o return_kind real. Resolve HOF: `apply(f, x)`
+/// onde `f: (n)=>number` — o callee pode ser user fn f64-ret (handle, retorna
+/// bits f64), OU function expression i64-ret (fn_ptr raw, retorna int). Esta fn
+/// unifica: f64-ret -> bits ja' corretos; i64-ret -> converte (i as f64) e
+/// devolve os bits. O codegen sempre bitcast o resultado p/ f64. Sem isto, o
+/// mesmo `f(x)` no body de `apply` nao saberia tratar os dois callees.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_INVOKE_AUTO_AS_F64(
+    callee: i64,
+    this_arg: i64,
+    args_handle: u64,
+) -> i64 {
+    // Handle Function declara param_kinds/return_kind; fn_ptr raw (function
+    // expression hoistada) eh i64-ABI sem kinds.
+    let fdata = read_function_data(callee as u64);
+    let is_handle = fdata.is_some();
+    let rk = fdata
+        .map(|(_, _, _, _, _, _, _, return_kind)| return_kind)
+        .unwrap_or(0);
+    if !is_handle {
+        // fn_ptr raw i64-ABI: o caller empacotou os args number como bits f64.
+        // Converte cada arg de bits-f64 -> i64 truncado antes de invocar, p/
+        // que a fn i64-param (function expression) receba o numero correto.
+        // Depois converte o retorno i64 -> bits f64 (normalizacao).
+        let conv = convert_f64bits_args_to_i64(args_handle);
+        let r = invoke_auto_impl(callee, this_arg, conv, None);
+        return f64_to_i64(r as f64);
+    }
+    let r = invoke_auto_impl(callee, this_arg, args_handle, None);
+    if rk == 1 {
+        // Handle f64-ret ja' retorna bits f64 — passa direto.
+        r
+    } else {
+        // Handle i64-ret/bool: converte p/ f64 e devolve os bits.
+        f64_to_i64(r as f64)
+    }
+}
+
+/// (issue-pai) Para invoke de fn_ptr raw i64-ABI: os args number vieram como
+/// bits-f64 (convencao do call site dinamico). Aloca um novo args Vec com cada
+/// elemento convertido de bits-f64 -> i64 truncado, p/ a fn i64-param ler o
+/// valor inteiro correto. Handles/sentinels (fora do range f64 finito comum)
+/// passam direto.
+fn convert_f64bits_args_to_i64(args_handle: u64) -> u64 {
+    let args = read_args_vec(args_handle);
+    let conv: Vec<i64> = args
+        .iter()
+        .map(|&a| {
+            let f = i64_to_f64(a);
+            // So' converte quando parece um number f64 finito "limpo"; handles
+            // (valores grandes/NaN bits) passam crus.
+            if f.is_finite() && f.fract() == 0.0 && f.abs() < 9.007e15 {
+                f as i64
+            } else {
+                a
+            }
+        })
+        .collect();
+    crate::namespaces::gc::handles::alloc_entry(
+        crate::namespaces::gc::handles::Entry::Vec(Box::new(conv)),
+    )
+}
+
 fn invoke_auto_impl(
     callee: i64,
     this_arg: i64,

--- a/tests/hof_fn_param.test.ts
+++ b/tests/hof_fn_param.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from "rts:test";
+
+// (issue-pai invoke/param_kinds) HOF: user fn NOMEADA passada como valor e
+// chamada. Antes: `apply(inc,10)` -> lixo (func_addr cru sem param_kinds;
+// invoke_n tratava (f64->f64) como (i64->i64)). Fix em 3 partes:
+// (a) reificar arg user-fn-nomeada como handle com param_kinds/return_kind;
+// (b) INVOKE_AUTO_AS_F64 normaliza retorno p/ f64 (handle f64-ret OU fn_ptr
+//     raw i64-ret); (c) normalizar args bits-f64 -> i64 p/ fn_ptr raw i64-param.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+function inc(n: number): number { return n + 1; }
+function dbl(n: number): number { return n * 2; }
+function apply(f: (n: number) => number, n: number): number { return f(n); }
+
+print((apply(inc, 10)) + "");        // 11
+print((apply(dbl, 21)) + "");        // 42
+print((apply(dbl, 2.5)) + "");       // 5 (float nao truncado)
+
+// function expression inline passada a HOF
+print((apply(function(x: number): number { return x + 10; }, 5)) + "");  // 15
+
+// applyTwice (chamada aninhada)
+function applyTwice(f: (n: number) => number, n: number): number { return f(f(n)); }
+print((applyTwice(inc, 10)) + "");   // 12
+
+// first-class i32 (guard: nao deve regredir)
+function double(x: i32): i32 { return x * 2; }
+function applyI(fn: i64, x: i32): i32 { return fn(x); }
+print((applyI(double, 5)) + "");     // 10
+
+describe("HOF fn-param (issue-pai invoke)", () => {
+  test("user fn passada como valor e chamada", () =>
+    expect(out).toBe("11\n42\n5\n15\n12\n10\n"));
+});


### PR DESCRIPTION
## Issue-pai

A **raiz compartilhada** documentada no roadmap: invoke dinâmico perdia `param_kinds`/`return_kind`. `apply(inc, 10)` onde `inc: (n:number)=>number` dava lixo — o arg virava `func_addr` cru e o `f(n)` via `invoke_n` tratava `(f64→f64)` como `(i64→i64)`.

É a raiz de HOF, #341, #348, e vários `arr.map(q=>q.id)`.

## Fix (3 partes coordenadas — as três juntas, sem regressão)

**(a)** `lower_user_call`: arg que é ident de user fn **nomeada** passado a param não-F64 é reificado como handle Function **com param_kinds/return_kind** (`lower_callable_target_h`), não `func_addr` cru. `arg_is_bare_user_fn` exclui fns sintéticas (`__hoisted_`/`__lifted_`) que seguem o caminho antigo.

**(b)** `lower_indirect_call`: param `f:(n)=>number` usa o novo runtime `INVOKE_AUTO_AS_F64`, que **normaliza** o retorno para f64-bits qualquer que seja o callee (user fn f64-ret → from_bits; fn_ptr raw i64-ret → fcvt). Args F64 empacotados como `to_bits`.

**(c)** `INVOKE_AUTO_AS_F64` (runtime): para fn_ptr raw i64-ABI (function expression hoistada), converte args bits-f64 → i64 antes de invocar. Unifica os dois tipos de callee no mesmo `f(n)`.

## Resolve

`apply(inc,10)=11`, `apply(dbl,2.5)=5` (float não trunca), function expression inline=15, `applyTwice(inc,10)=12`. first-class i32 inalterado.

## Follow-up

Callback de 2 params com acumulador (`fold([..],add,0)`) ainda dá denormal (fluxo de tipo acc I32→F64) — registrado no roadmap.

## Teste

`tests/hof_fn_param.test.ts`.

Suite **1598/1598** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)