### PR TITLE
fix(codegen): float fracionario literal em array preserva valor (#1275 parte 1)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -61,6 +61,20 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
                     ctx.builder.ins().call(push_fn, &[handle, s]);
                     continue;
                 }
+                // (#1275) Elemento eh literal float FRACIONARIO (`1.5`, nao
+                // `3.0` nem `i*10`)? So' esses precisam dos bits f64 preservados.
+                // F64 inteiro-valued (`i*10`, `3.0`) continua via fcvt (vale
+                // inteiro; destructuring/aritmetica que leem o slot como i64
+                // funcionam). Sem este gate, `[i*10,i*100]` quebrava o
+                // destructuring (que le i64 cru, sem reinterpretar bits).
+                let is_frac_lit = matches!(
+                    e.expr.as_ref(),
+                    Expr::Lit(Lit::Num(n)) if n.value.fract() != 0.0
+                ) || matches!(
+                    e.expr.as_ref(),
+                    Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus)
+                        && matches!(u.arg.as_ref(), Expr::Lit(Lit::Num(n)) if n.value.fract() != 0.0)
+                );
                 let tv = lower_expr(ctx, &e.expr)?;
                 // Bool em array vira sentinela (i64::MIN = false, MIN+1 =
                 // true). Permite inspect_slot imprimir `true`/`false` sem
@@ -72,6 +86,15 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
                     // i64::MIN + b: b=0 -> MIN (false), b=1 -> MIN+1 (true)
                     let min = ctx.builder.ins().iconst(cl::I64, i64::MIN);
                     ctx.builder.ins().iadd(min, b)
+                } else if matches!(tv.ty, ValTy::F64) && is_frac_lit {
+                    // (#1275) Float fracionario literal: armazena os BITS f64.
+                    // Leitura (TPL_COERCE_VEC_SLOT/inspect_slot/join) reinterpreta
+                    // via heuristica >2^53 -> from_bits. `[1.5,2.5]` -> 1.5,2.5.
+                    ctx.builder.ins().bitcast(
+                        cl::I64,
+                        cranelift_codegen::ir::MemFlags::new(),
+                        tv.val,
+                    )
                 } else {
                     ctx.coerce_to_i64(tv).val
                 };

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -447,6 +447,19 @@ fn join_into(out: &mut Vec<u8>, elems: &[i64], sep_bytes: &[u8], depth: u32) {
             }
             continue;
         }
+        // (#1275) Slot float: armazenado como bits f64 (codegen). Heuristica:
+        // valor fora do range de safe integer (>2^53) que decodifica como f64
+        // finito eh um float. Formata via format_js_number (3.0 -> "3").
+        const MAX_SAFE: i64 = (1i64 << 53) - 1;
+        if *e > MAX_SAFE || *e < -MAX_SAFE {
+            let f = f64::from_bits(*e as u64);
+            if f.is_finite() && !f.is_nan() {
+                out.extend_from_slice(
+                    crate::namespaces::gc::string_pool::format_js_number(f).as_bytes(),
+                );
+                continue;
+            }
+        }
         out.extend_from_slice(e.to_string().as_bytes());
     }
 }

--- a/tests/array_float_literal.test.ts
+++ b/tests/array_float_literal.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #1275): float fracionario literal em array era
+// TRUNCADO (`[1.5,2.5][0]` -> 1, join -> 1,2). Fix: literal float fracionario
+// armazena bits-f64 (bitcast) em vez de fcvt_to_sint; leitura (index/join/
+// template/inspect) reinterpreta via heuristica >2^53 -> from_bits. F64
+// inteiro-valued (i*10, 3.0) e int continuam i64 (destructuring/aritmetica OK).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// acesso por indice
+print([1.5, 2.5, 3.0][0] + "");          // 1.5
+print([1.5, 2.5, 3.0][1] + "");          // 2.5
+
+// join
+print([9.99, 19.99, 4.5].join(","));     // 9.99,19.99,4.5
+print([1.5, 2.5, 3.0].join(","));        // 1.5,2.5,3 (3.0 -> "3")
+
+// negativo fracionario
+print([-3.5, 1.25].join(","));           // -3.5,1.25
+
+// int continua int (guard)
+print([1, 2, 3].join(","));              // 1,2,3
+print([-5, 0, 1000000].join(","));       // -5,0,1000000
+
+// F64 inteiro-valued via expr nao quebra destructuring (guard #368)
+function destr(): string {
+  const o: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    const [a, b] = [i * 10, i * 100];
+    o.push(a + b);
+  }
+  return o.join(",");
+}
+print(destr());                          // 0,110,220
+
+describe("array float literal (#1275)", () => {
+  test("float fracionario literal preserva valor; int/destruct intactos", () =>
+    expect(out).toBe("1.5\n2.5\n9.99,19.99,4.5\n1.5,2.5,3\n-3.5,1.25\n1,2,3\n-5,0,1000000\n0,110,220\n"));
+});


### PR DESCRIPTION
Primeira fatia da issue-raiz #1275 (float em storage de collection truncado).

## Problema

`[1.5, 2.5][0]` → `1`, `[9.99, 19.99].join(",")` → `1,2` — float literal em array era truncado via `fcvt_to_sint` no armazenamento.

## Fix

Literal float **fracionário** (`1.5`, `-3.5`; **não** `3.0` nem `i*10`) armazena os **bits f64** (bitcast) em vez de truncar. A leitura já reinterpretava via heurística `>2^53 → from_bits` (`TPL_COERCE_VEC_SLOT`, `inspect_slot`); estendi `join_into` (`VEC_JOIN`) com a mesma heurística.

F64 inteiro-valued (`i*10`, `3.0`) e int continuam i64 cru — destructuring/aritmética de slot que leem i64 **não regridem** (guard #368: `[i*10,i*100]` destruct OK).

## Cobre

index, join, template de array de float literal. `[1.5,2.5,3.0].join(",")` → `1.5,2.5,3`.

## Follow-up (próximas fatias da #1275)

- Aritmética direta sobre slot float (`for(x of [1.5]) s+=x`) ainda soma bits — precisa reinterpretar na leitura para uso numérico.
- push/map/Map-value/object literal de float.

## Teste

`tests/array_float_literal.test.ts` — index/join/negativo + guards (int, destructuring int-valued).

Suite **1599/1599** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)