### PR TITLE
fix(codegen): float fracionario em push/object/Map.set preserva valor (#1275 parte 2)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -688,8 +688,18 @@ pub(super) fn lower_map_set_builtin(
                 .args
                 .get(1)
                 .ok_or_else(|| anyhow!("Map.set requires value"))?;
+            // (#1275) value float fracionario literal -> bits f64.
+            let val_is_frac = super::super::members::expr_is_frac_float_lit(&val_arg.expr);
             let val_tv = lower_expr(ctx, &val_arg.expr)?;
-            let val_i64 = ctx.coerce_to_i64(val_tv).val;
+            let val_i64 = if matches!(val_tv.ty, ValTy::F64) && val_is_frac {
+                ctx.builder.ins().bitcast(
+                    cl::I64,
+                    cranelift_codegen::ir::MemFlags::new(),
+                    val_tv.val,
+                )
+            } else {
+                ctx.coerce_to_i64(val_tv).val
+            };
             let fref = ctx.get_extern(
                 "__RTS_FN_NS_COLLECTIONS_MAP_SET",
                 &[cl::I64, cl::I64, cl::I64, cl::I64],
@@ -1124,8 +1134,20 @@ pub(super) fn lower_array_builtin(
             // (cross-runtime #150) JS: push aceita N args, todos sao
             // pushed em ordem.
             for arg in &call.args {
+                // (#1275) Literal float fracionario: armazena bits f64 (igual
+                // ao array literal) p/ que `arr.push(1.5); arr[0]` preserve 1.5.
+                // Leitura de exibicao reinterpreta via heuristica >2^53.
+                let is_frac_lit = super::super::members::expr_is_frac_float_lit(&arg.expr);
                 let tv = lower_expr(ctx, &arg.expr)?;
-                let v = ctx.coerce_to_i64(tv).val;
+                let v = if matches!(tv.ty, ValTy::F64) && is_frac_lit {
+                    ctx.builder.ins().bitcast(
+                        cl::I64,
+                        cranelift_codegen::ir::MemFlags::new(),
+                        tv.val,
+                    )
+                } else {
+                    ctx.coerce_to_i64(tv).val
+                };
                 ctx.builder.ins().call(push_fn, &[obj_h, v]);
             }
             // JS: push retorna novo length.

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -12,6 +12,21 @@ use super::calls::{
 use super::lower_expr;
 use crate::codegen::lower::ctx::{FieldSlot, FnCtx, TypedVal, ValTy, is_class_flat_enabled};
 
+/// (#1275) `expr` eh um literal de float FRACIONARIO (`1.5`, `-3.5`)? So' esses
+/// precisam dos bits f64 preservados em slot de collection — F64 inteiro-valued
+/// (`3.0`, `i*10`) e int seguem i64 (destructuring/aritmetica de slot leem i64).
+/// Centraliza o gate usado em array literal, push, object literal, map.set.
+pub(crate) fn expr_is_frac_float_lit(e: &Expr) -> bool {
+    match e {
+        Expr::Lit(Lit::Num(n)) => n.value.fract() != 0.0,
+        Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus) => {
+            expr_is_frac_float_lit(&u.arg)
+        }
+        Expr::Paren(p) => expr_is_frac_float_lit(&p.expr),
+        _ => false,
+    }
+}
+
 pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> Result<TypedVal> {
     let new_fn = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
     let inst = ctx.builder.ins().call(new_fn, &[]);
@@ -61,20 +76,10 @@ pub(super) fn lower_array_lit(ctx: &mut FnCtx, arr: &swc_ecma_ast::ArrayLit) -> 
                     ctx.builder.ins().call(push_fn, &[handle, s]);
                     continue;
                 }
-                // (#1275) Elemento eh literal float FRACIONARIO (`1.5`, nao
-                // `3.0` nem `i*10`)? So' esses precisam dos bits f64 preservados.
-                // F64 inteiro-valued (`i*10`, `3.0`) continua via fcvt (vale
-                // inteiro; destructuring/aritmetica que leem o slot como i64
-                // funcionam). Sem este gate, `[i*10,i*100]` quebrava o
-                // destructuring (que le i64 cru, sem reinterpretar bits).
-                let is_frac_lit = matches!(
-                    e.expr.as_ref(),
-                    Expr::Lit(Lit::Num(n)) if n.value.fract() != 0.0
-                ) || matches!(
-                    e.expr.as_ref(),
-                    Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus)
-                        && matches!(u.arg.as_ref(), Expr::Lit(Lit::Num(n)) if n.value.fract() != 0.0)
-                );
+                // (#1275) Literal float fracionario armazena bits f64 (helper
+                // centralizado). F64 inteiro-valued/int seguem i64 — sem isso
+                // `[i*10]` quebraria destructuring que le i64 cru.
+                let is_frac_lit = expr_is_frac_float_lit(&e.expr);
                 let tv = lower_expr(ctx, &e.expr)?;
                 // Bool em array vira sentinela (i64::MIN = false, MIN+1 =
                 // true). Permite inspect_slot imprimir `true`/`false` sem
@@ -319,6 +324,9 @@ pub(super) fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -
             }
         };
 
+        // (#1275) value float fracionario literal -> bits f64 (leitura via
+        // MAP_GET_CHAIN/template reinterpreta heuristica >2^53).
+        let val_is_frac = expr_is_frac_float_lit(&value_expr);
         let value_tv = lower_expr(ctx, &value_expr)?;
         // (#680/50) Bool em obj literal vira sentinel (i64::MIN = false,
         // i64::MIN+1 = true). Permite JSON.stringify/console.log
@@ -327,6 +335,12 @@ pub(super) fn lower_object_lit(ctx: &mut FnCtx, obj: &swc_ecma_ast::ObjectLit) -
             let b = ctx.coerce_to_i64(value_tv).val;
             let min = ctx.builder.ins().iconst(cl::I64, i64::MIN);
             ctx.builder.ins().iadd(min, b)
+        } else if matches!(value_tv.ty, ValTy::F64) && val_is_frac {
+            ctx.builder.ins().bitcast(
+                cl::I64,
+                cranelift_codegen::ir::MemFlags::new(),
+                value_tv.val,
+            )
         } else {
             ctx.coerce_to_i64(value_tv).val
         };

--- a/tests/float_collection_storage.test.ts
+++ b/tests/float_collection_storage.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "rts:test";
+
+// Regression (cross-runtime #1275 parte 2): float fracionario literal em push,
+// object literal e Map.set era truncado. Fix: armazena bits f64 (helper
+// expr_is_frac_float_lit centralizado); leitura (index/join/member/Map.get +
+// template) reinterpreta via heuristica >2^53. Int e F64 inteiro-valued seguem
+// i64 (sem regredir destructuring/aritmetica de slot).
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// push de float
+const arr: number[] = [];
+arr.push(1.5);
+arr.push(2.5);
+arr.push(3.0);
+print(arr[0] + "");              // 1.5
+print(arr.join(","));            // 1.5,2.5,3
+
+// object literal float
+const o = { price: 9.99, qty: 3 };
+print(o.price + "");             // 9.99
+print(o.qty + "");               // 3
+
+// Map.set float
+const m = new Map<string, number>();
+m.set("pi", 3.14);
+m.set("n", 42);
+print(m.get("pi") + "");         // 3.14
+print(m.get("n") + "");          // 42
+
+// guards: int em push/Map nao regride
+const ai: number[] = [];
+ai.push(10);
+ai.push(20);
+print(ai.join(","));             // 10,20
+
+describe("float em collection storage (#1275 parte 2)", () => {
+  test("push/object/Map.set de float preservam valor; int intacto", () =>
+    expect(out).toBe("1.5\n1.5,2.5,3\n9.99\n3\n3.14\n42\n10,20\n"));
+});


### PR DESCRIPTION
Segunda fatia da issue-raiz #1275 (float em storage de collection truncado).

## Problema

```ts
const arr:number[]=[]; arr.push(1.5); arr[0]   // dava 1   -> agora 1.5
const o = {price: 9.99}; o.price               // dava 9   -> agora 9.99
const m=new Map<string,number>(); m.set("pi",3.14); m.get("pi")  // dava 3 -> agora 3.14
```

## Fix

Helper centralizado `expr_is_frac_float_lit` (extraído do array literal do #1276). Literal float **fracionário** armazena bits f64 (bitcast) em `push`, value de object literal e value de `Map.set`. A leitura (index/join/member access/Map.get + template) já reinterpreta via heurística `>2^53 → from_bits`.

F64 inteiro-valued (`3.0`, `i*10`) e int seguem i64 — destructuring/aritmética de slot **não regridem**.

## Cobre

Exibição de float em todas as collections (array/push/object/Map).

## Follow-up (próxima fatia)

Aritmética sobre slot float (`for-of s+=x`, reduce, map) e F64 não-literal — precisam reinterpretar no nível de leitura numérica.

## Teste

`tests/float_collection_storage.test.ts`.

Suite **1600/1600** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)