### PR TITLE
fix(runtime): Promise.then/catch/finally pending deterministico (#207 parcial)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
@@ -217,6 +217,25 @@ pub(crate) enum Microtask {
         fulfilled: bool,
         result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
     },
+    /// (#207) Promise.then sobre promise PENDING — em vez de spawn_blocking
+    /// (thread nao-deterministica), faz polling na microtask queue: a cada
+    /// drain, se a source ainda esta pending re-enfileira; quando settle,
+    /// invoca o callback e settle o result. Preserva ordem FIFO determinista
+    /// (JS spec) entre chains de Promise no mesmo task sync.
+    PendingThen {
+        source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+        fn_ptr: u64,
+        bound: Vec<i64>,
+        is_catch: bool,
+        result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+    },
+    /// (#207) promise.finally sobre source PENDING — polling determinista.
+    /// Quando settle, invoca fp() sem args e PRESERVA state/value original.
+    PendingFinally {
+        source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+        fn_ptr: u64,
+        result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+    },
 }
 thread_local! {
     static MICROTASK_QUEUE: RefCell<Vec<Microtask>> = const { RefCell::new(Vec::new()) };
@@ -272,15 +291,98 @@ pub fn enqueue_microtask_finally(
     });
 }
 
+/// (#207) Enfileira `.then`/`.catch` sobre promise PENDING como PendingThen
+/// (polling determinista no drain). Evita spawn_blocking nao-deterministico.
+pub fn enqueue_microtask_pending_then(
+    source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+    fn_ptr: u64,
+    bound: Vec<i64>,
+    is_catch: bool,
+    result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+) {
+    MICROTASK_QUEUE.with(|q| {
+        q.borrow_mut().push(Microtask::PendingThen {
+            source, fn_ptr, bound, is_catch, result_slot,
+        })
+    });
+}
+
+/// (#207) Enfileira `.finally` sobre promise PENDING (polling determinista).
+pub fn enqueue_microtask_pending_finally(
+    source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+    fn_ptr: u64,
+    result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+) {
+    MICROTASK_QUEUE.with(|q| {
+        q.borrow_mut().push(Microtask::PendingFinally { source, fn_ptr, result_slot })
+    });
+}
+
 /// Drena microtasks pendentes. Chamada pelo pipeline pos-main e tambem
 /// pode ser chamada pelo codegen no fim de cada task (futuro).
 pub fn drain_microtasks() {
     use crate::namespaces::gc::promise_slot;
+    // (#207) Guard contra loop infinito: se varios ciclos so' contem
+    // PendingThen cuja source nunca settla (Promise pending por I/O real que
+    // resolveria numa thread tokio), faz fallback p/ spawn_blocking nesses
+    // restantes e encerra o polling. Caso sync (chains resolviveis no drain)
+    // nunca atinge o limite.
+    let mut stall = 0u32;
+    const STALL_LIMIT: u32 = 10_000;
     loop {
         let queue: Vec<Microtask> =
             MICROTASK_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
         if queue.is_empty() {
             break;
+        }
+        // Detecta ciclo sem progresso: todos PendingThen ainda pending.
+        let all_stalled_pending = queue.iter().all(|t| match t {
+            Microtask::PendingThen { source, .. }
+            | Microtask::PendingFinally { source, .. } => {
+                promise_slot::current_state(source) == promise_slot::STATE_PENDING
+            }
+            _ => false,
+        });
+        if all_stalled_pending {
+            stall += 1;
+            if stall >= STALL_LIMIT {
+                // Fallback: resolve os PendingThen restantes via spawn_blocking
+                // (caminho thread original) p/ Promises que dependem de I/O.
+                for task in queue {
+                    if let Microtask::PendingThen { source, fn_ptr, bound, is_catch, result_slot } = task {
+                        let rt = crate::runtime::async_rt::handle();
+                        rt.spawn_blocking(move || {
+                            let (st, value) = promise_slot::wait_blocking(&source);
+                            let fulfilled = st == promise_slot::STATE_FULFILLED;
+                            let runs = if is_catch { !fulfilled } else { fulfilled };
+                            if runs && fn_ptr != 0 {
+                                let r = unsafe { invoke_microtask_callback(fn_ptr, &bound, Some(value)) };
+                                promise_slot::resolve(&result_slot, r);
+                            } else if fulfilled {
+                                promise_slot::resolve(&result_slot, value);
+                            } else {
+                                promise_slot::reject(&result_slot, value);
+                            }
+                        });
+                    } else if let Microtask::PendingFinally { source, fn_ptr, result_slot } = task {
+                        let rt = crate::runtime::async_rt::handle();
+                        rt.spawn_blocking(move || {
+                            let (st, value) = promise_slot::wait_blocking(&source);
+                            if fn_ptr != 0 {
+                                let _ = unsafe { invoke_microtask_callback(fn_ptr, &[], None) };
+                            }
+                            if st == promise_slot::STATE_FULFILLED {
+                                promise_slot::resolve(&result_slot, value);
+                            } else {
+                                promise_slot::reject(&result_slot, value);
+                            }
+                        });
+                    }
+                }
+                break;
+            }
+        } else {
+            stall = 0;
         }
         for task in queue {
             match task {
@@ -327,6 +429,61 @@ pub fn drain_microtasks() {
                         promise_slot::resolve(&result_slot, value);
                     } else {
                         promise_slot::reject(&result_slot, value);
+                    }
+                }
+                // (#207) Polling determinista de .then sobre source pending.
+                Microtask::PendingThen {
+                    source,
+                    fn_ptr,
+                    bound,
+                    is_catch,
+                    result_slot,
+                } => {
+                    let st = promise_slot::current_state(&source);
+                    if st == promise_slot::STATE_PENDING {
+                        // Ainda nao settled — re-enfileira no FIM da fila atual
+                        // p/ re-checar no proximo ciclo do drain (apos outras
+                        // microtasks avancarem o estado das chains).
+                        MICROTASK_QUEUE.with(|q| {
+                            q.borrow_mut().push(Microtask::PendingThen {
+                                source, fn_ptr, bound, is_catch, result_slot,
+                            })
+                        });
+                    } else {
+                        let value = promise_slot::current_value(&source);
+                        let fulfilled = st == promise_slot::STATE_FULFILLED;
+                        // .then: roda no fulfilled; .catch: roda no rejected.
+                        let runs = if is_catch { !fulfilled } else { fulfilled };
+                        if runs && fn_ptr != 0 {
+                            let r = unsafe {
+                                invoke_microtask_callback(fn_ptr, &bound, Some(value))
+                            };
+                            promise_slot::resolve(&result_slot, r);
+                        } else if fulfilled {
+                            promise_slot::resolve(&result_slot, value);
+                        } else {
+                            promise_slot::reject(&result_slot, value);
+                        }
+                    }
+                }
+                Microtask::PendingFinally { source, fn_ptr, result_slot } => {
+                    let st = promise_slot::current_state(&source);
+                    if st == promise_slot::STATE_PENDING {
+                        MICROTASK_QUEUE.with(|q| {
+                            q.borrow_mut().push(Microtask::PendingFinally {
+                                source, fn_ptr, result_slot,
+                            })
+                        });
+                    } else {
+                        if fn_ptr != 0 {
+                            let _ = unsafe { invoke_microtask_callback(fn_ptr, &[], None) };
+                        }
+                        let value = promise_slot::current_value(&source);
+                        if st == promise_slot::STATE_FULFILLED {
+                            promise_slot::resolve(&result_slot, value);
+                        } else {
+                            promise_slot::reject(&result_slot, value);
+                        }
                     }
                 }
             }

--- a/crates/rts-runtime/src/namespaces/promise/ops.rs
+++ b/crates/rts-runtime/src/namespaces/promise/ops.rs
@@ -208,20 +208,14 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_THEN_NS(p_handle: u64, fp: u64) -> u64 {
         return result_handle;
     }
 
-    let rt = crate::runtime::async_rt::handle();
-    rt.spawn_blocking(move || {
-        let (state, value) = promise_slot::wait_blocking(&arc);
-        if state == promise_slot::STATE_FULFILLED {
-            if fn_ptr == 0 {
-                promise_slot::resolve(&result_clone, value);
-            } else {
-                let r = unsafe { invoke_callback(fn_ptr, &bound, Some(value)) };
-                promise_slot::resolve(&result_clone, r);
-            }
-        } else {
-            promise_slot::reject(&result_clone, value);
-        }
-    });
+    // (#207) Source PENDING: enfileira como PendingThen na microtask queue
+    // (polling determinista no drain) em vez de spawn_blocking (thread nao-
+    // deterministica). Preserva ordem FIFO entre chains de Promise no mesmo
+    // task sync — `Promise.resolve().then().then()` interleaving correto.
+    // O drain re-checa o estado a cada ciclo; quando settle, executa.
+    crate::namespaces::globals::text_encoding::instance::enqueue_microtask_pending_then(
+        arc, fn_ptr, bound, false, result_clone,
+    );
     result_handle
 }
 
@@ -237,20 +231,11 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CATCH_NS(p_handle: u64, fp: u64) -> u64 {
     let result_handle = alloc_entry(Entry::PromiseAsync(result));
 
     let (fn_ptr, bound, _h, _t) = resolve_callback_ptr(fp);
-    let rt = crate::runtime::async_rt::handle();
-    rt.spawn_blocking(move || {
-        let (state, value) = promise_slot::wait_blocking(&arc);
-        if state == promise_slot::STATE_FULFILLED {
-            promise_slot::resolve(&result_clone, value);
-        } else {
-            if fn_ptr == 0 {
-                promise_slot::reject(&result_clone, value);
-            } else {
-                let r = unsafe { invoke_callback(fn_ptr, &bound, Some(value)) };
-                promise_slot::resolve(&result_clone, r);
-            }
-        }
-    });
+    // (#207) Determinista via microtask queue (igual ao .then). is_catch=true:
+    // o callback so' roda no rejected; fulfilled propaga o valor.
+    crate::namespaces::globals::text_encoding::instance::enqueue_microtask_pending_then(
+        arc, fn_ptr, bound, true, result_clone,
+    );
     result_handle
 }
 
@@ -265,19 +250,11 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_FINALLY_NS(p_handle: u64, fp: u64) -> u64 
     let result_clone = result.clone();
     let result_handle = alloc_entry(Entry::PromiseAsync(result));
 
-    let (fn_ptr, bound, _h, _t) = resolve_callback_ptr(fp);
-    let rt = crate::runtime::async_rt::handle();
-    rt.spawn_blocking(move || {
-        let (state, value) = promise_slot::wait_blocking(&arc);
-        if fn_ptr != 0 {
-            let _ = unsafe { invoke_callback(fn_ptr, &bound, None) };
-        }
-        if state == promise_slot::STATE_FULFILLED {
-            promise_slot::resolve(&result_clone, value);
-        } else {
-            promise_slot::reject(&result_clone, value);
-        }
-    });
+    let (fn_ptr, _bound, _h, _t) = resolve_callback_ptr(fp);
+    // (#207) Determinista via microtask queue (igual ao .then/.catch).
+    crate::namespaces::globals::text_encoding::instance::enqueue_microtask_pending_finally(
+        arc, fn_ptr, result_clone,
+    );
     result_handle
 }
 

--- a/tests/promise_microtask_order.test.ts
+++ b/tests/promise_microtask_order.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+import { promise } from "rts";
+
+// Regression (cross-runtime #207): ordem de microtask de Promise.then/catch/
+// finally sobre promise PENDING era NAO-DETERMINISTICA (spawn_blocking em
+// threads tokio). Fix: enfileira PendingThen/PendingFinally na microtask queue
+// (polling determinista no drain) em vez de spawn_blocking. Chains resolvem
+// FIFO na ordem JS spec, deterministicamente.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+// chain de .then sobre pending (cada .then cria pending p/ o proximo)
+let log = "";
+const p = promise.create(() => 1, []);
+promise.wait(
+  promise.then(
+    promise.then(p, (v: number) => { log += "a" + v; return v + 1; }),
+    (v: number) => { log += "b" + v; return v; }
+  )
+);
+print(log);   // a1b2
+
+// .finally preserva valor e roda na ordem
+let f = "";
+const p2 = promise.create(() => 42, []);
+const r = promise.wait(
+  promise.finally(p2, () => { f += "fin"; })
+);
+print("fin=" + f + " val=" + r);   // fin=fin val=42
+
+describe("promise microtask order (#207)", () => {
+  test("then/finally sobre pending sao deterministas", () =>
+    expect(out).toBe("a1b2\nfin=fin val=42\n"));
+});


### PR DESCRIPTION
Ataca a raiz da **oscilação da parity badge** (84.9↔85.5) — microtask ordering não-determinístico.

## Problema

`.then`/`.catch`/`.finally` sobre Promise **pending** usava `spawn_blocking` (threads tokio). A ordem de resolução entre chains era **não-determinística** — `285_queuemicrotask_order`, `116_promise_finally`, `393_promise_microtask` davam resultados **diferentes a cada execução** do mesmo binário. Era a causa da oscilação da badge (não regressão dos PRs).

## Fix

Novas variantes `Microtask::PendingThen`/`PendingFinally` na microtask queue. O `.then`/`.catch`/`.finally` sobre pending enfileira **polling determinístico** (re-checa o estado a cada ciclo do drain; quando settle, executa na ordem FIFO) em vez de `spawn_blocking`.

**Guard `STALL_LIMIT`:** se a source nunca settla (Promise por I/O real que resolveria numa thread), fallback para `spawn_blocking` — preserva async com I/O de verdade.

## Resultado

- `285_queuemicrotask_order` → **determinístico e correto** (5 runs idênticos = `sync|qm|then|timeout`)
- `116_promise_finally` → **determinístico e correto** (`finally1,finally2` na ordem JS)
- `393_promise_microtask` → melhorou (chains corretas) mas ainda depende de timer/await interleaving (follow-up)

## Teste

`tests/promise_microtask_order.test.ts`.

Suite **1601/1601** (zero regressão — async/await/http_server intactos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)