### PR TITLE
fix(runtime): setTimeout(0)/setImmediate deterministicos via macrotask queue (#207)

### DIFF
--- a/crates/rts-codegen/src/pipeline.rs
+++ b/crates/rts-codegen/src/pipeline.rs
@@ -183,6 +183,11 @@ pub fn run_jit_with_imports(input: &Path, options: CompileOptions) -> Result<(i3
     // (#286) setImmediate roda na "check phase" — antes de timers
     // setTimeout(0). Drena fila propria primeiro.
     crate::namespaces::globals::timers::instance::drain_immediates();
+    // (#207 timer ordering) Macrotasks (setTimeout delay-0) rodam na thread do
+    // main APOS microtasks — ordem JS spec (macrotask > microtask). Cada
+    // macrotask drena as microtasks que gera. Antes setTimeout spawnava thread
+    // (rodava em paralelo, fora de ordem).
+    crate::namespaces::globals::timers::instance::drain_macrotasks();
     crate::namespaces::globals::timers::instance::drain_pending_timers();
     // (#376) Aguarda async fns fire-and-forget (chamadas sem `await` no
     // top-level) settarem antes de exit. Sem isso `main()` async sem

--- a/crates/rts-runtime/src/namespaces/globals/timers/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/timers/instance.rs
@@ -20,6 +20,44 @@ fn register_timer(handle: u64, flag: Arc<AtomicBool>) {
     timers().lock().unwrap().insert(handle, flag);
 }
 
+// (#207 timer ordering) Macrotask queue p/ setTimeout(fp, 0): em JS, timers
+// rodam na thread principal APOS todas as microtasks drenarem (macrotask >
+// microtask). spawn_blocking/thread roda em paralelo e fora de ordem. Esta
+// fila (thread-local do main) eh drenada pelo pipeline pos-main, intercalando
+// com microtasks na ordem JS spec correta.
+thread_local! {
+    static MACROTASK_QUEUE: std::cell::RefCell<Vec<(u64, Arc<AtomicBool>, u64)>>
+        = const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Enfileira um setTimeout(fp, 0) como macrotask na thread do main.
+fn enqueue_macrotask(fp: u64, flag: Arc<AtomicBool>, handle: u64) {
+    MACROTASK_QUEUE.with(|q| q.borrow_mut().push((fp, flag, handle)));
+}
+
+/// (#207) Drena a fila de macrotask (setTimeout delay-0) APOS as microtasks.
+/// Cada macrotask: se nao cancelada, invoca o callback; depois as microtasks
+/// que ela gerou sao drenadas (JS spec: cada macrotask esvazia a microtask
+/// queue). Processa em ordem FIFO de registro.
+pub fn drain_macrotasks() {
+    loop {
+        let batch: Vec<(u64, Arc<AtomicBool>, u64)> =
+            MACROTASK_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+        if batch.is_empty() {
+            break;
+        }
+        for (fp, flag, handle) in batch {
+            if !flag.load(Ordering::Relaxed) {
+                invoke_timer_cb(fp);
+            }
+            free_handle(handle);
+            cancel_timer(handle);
+            // JS spec: apos cada macrotask, drena todas as microtasks geradas.
+            crate::namespaces::globals::text_encoding::instance::drain_microtasks();
+        }
+    }
+}
+
 fn cancel_timer(handle: u64) {
     if let Some(flag) = timers().lock().unwrap().remove(&handle) {
         flag.store(true, Ordering::Relaxed);
@@ -64,19 +102,24 @@ pub extern "C" fn __RTS_FN_GL_TIMERS_SET_TIMEOUT(fp: u64, delay_ms: i64) -> u64 
 
     let handle = alloc_entry(Entry::Env(vec![0]));
 
+    register_timer(handle, cancelled);
+
+    // (#207 timer ordering) delay 0: macrotask na thread do main (roda APOS
+    // microtasks drenarem — ordem JS spec). delay > 0: thread com sleep real.
+    if delay == 0 {
+        enqueue_macrotask(fp, flag, handle);
+        return handle;
+    }
+
     let flag2 = flag.clone();
     thread::spawn(move || {
-        if delay > 0 {
-            thread::sleep(Duration::from_millis(delay));
-        }
+        thread::sleep(Duration::from_millis(delay));
         if !flag2.load(Ordering::Relaxed) {
             invoke_timer_cb(fp);
         }
         free_handle(handle);
         cancel_timer(handle);
     });
-
-    register_timer(handle, cancelled);
     handle
 }
 
@@ -138,18 +181,10 @@ pub extern "C" fn __RTS_FN_GL_TIMERS_SET_IMMEDIATE(fp: u64) -> u64 {
     let ran = Arc::new(AtomicBool::new(false));
     let handle = alloc_entry(Entry::Env(vec![0]));
     immediate_queue().lock().unwrap().push((fp, cancelled.clone(), ran.clone()));
-
-    let flag = cancelled.clone();
-    let ran_t = ran.clone();
-    thread::spawn(move || {
-        if !flag.load(Ordering::Relaxed) && fp != 0
-            && !ran_t.swap(true, Ordering::AcqRel)
-        {
-            invoke_timer_cb(fp);
-        }
-        free_handle(handle);
-        cancel_timer(handle);
-    });
+    // (#207 timer ordering) NAO spawna thread — setImmediate enfileira e roda
+    // na "check phase" via drain_immediates (apos microtasks drenarem). O
+    // thread::spawn antigo corria em paralelo e podia rodar ANTES das
+    // microtasks (ordem errada: immediate|micro em vez de micro|immediate).
     register_timer(handle, cancelled);
     handle
 }

--- a/crates/rts-runtime/src/namespaces/time/sleep.rs
+++ b/crates/rts-runtime/src/namespaces/time/sleep.rs
@@ -5,6 +5,13 @@ use std::time::Duration;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_TIME_SLEEP_MS(ms: i64) {
+    // (#207 timer ordering) sleep eh ponto de quiescencia: drena microtasks,
+    // setImmediate e setTimeout(0) pendentes ANTES de dormir. Assim
+    // `setImmediate(cb); sleep_ms(20)` ve o efeito de cb — o setImmediate nao
+    // spawna mais thread (rodava em paralelo), entao precisa ser drenado aqui.
+    crate::namespaces::globals::text_encoding::instance::drain_microtasks();
+    crate::namespaces::globals::timers::instance::drain_immediates();
+    crate::namespaces::globals::timers::instance::drain_macrotasks();
     if ms > 0 {
         thread::sleep(Duration::from_millis(ms as u64));
     }

--- a/tests/timer_macrotask_order.test.ts
+++ b/tests/timer_macrotask_order.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+import { time } from "rts";
+
+// Regression (cross-runtime #207 timer ordering): setTimeout(0) e setImmediate
+// rodavam em THREADS paralelas — ordem nao-deterministica vs microtasks.
+// Fix: setTimeout(0) vira macrotask na thread do main (drena APOS microtasks);
+// setImmediate enfileira (sem thread) e roda na check phase. Ordem JS spec:
+// sync -> microtask -> immediate -> timeout, deterministico.
+
+let out = "";
+function print(v: string): void { out += v + "\n"; }
+
+const order: string[] = [];
+order.push("sync");
+queueMicrotask(() => order.push("micro"));
+setImmediate(() => order.push("immediate"));
+setTimeout(() => order.push("timeout"), 0);
+
+// sleep eh ponto de quiescencia: drena microtask/immediate/macrotask.
+time.sleep_ms(5);
+
+print(order.join("|"));   // sync|micro|immediate|timeout
+
+// setImmediate dispara antes do fim (via drain no sleep)
+let fired = 0;
+setImmediate(() => { fired = fired + 1; });
+time.sleep_ms(5);
+print("fired=" + fired);  // fired=1
+
+describe("timer macrotask order (#207)", () => {
+  test("sync->micro->immediate->timeout deterministico", () =>
+    expect(out).toBe("sync|micro|immediate|timeout\nfired=1\n"));
+});


### PR DESCRIPTION
Continuação do #1278 — completa a ordenação determinística do event loop (timers vs microtasks). Reduz a oscilação da parity badge.

## Problema

`setTimeout(fp, 0)` e `setImmediate` spawnavam **threads paralelas** → callbacks fora de ordem: `immediate|micro` em vez de `micro|immediate`, `timeout` antes dos microtasks drenarem.

## Fix

- **setTimeout(fp, 0)**: enfileira `MACROTASK_QUEUE` (thread do main), drenada **após** microtasks no pipeline pós-main. Cada macrotask drena as microtasks que gera (JS spec: macrotask > microtask). delay > 0 mantém thread (timing real).
- **setImmediate**: enfileira (sem thread); roda via `drain_immediates` na check phase (após microtasks).
- **time.sleep_ms**: ponto de quiescência — drena microtask/immediate/macrotask antes de dormir, para `setImmediate(cb); sleep_ms(n)` ver o efeito (preserva #377, que dependia do paralelismo antigo).

## Resultado (determinístico, ordem JS spec)

- `56_microtask_order` → `sync:start|sync:end|micro:qm|micro:promise|macro:timeout` ✓
- `285_queuemicrotask_order` → `sync|qm|then|timeout` ✓
- `286_setimmediate` → `micro|immediate|timeout` ✓

Estabiliza a parity badge (esses testes deixam de oscilar).

## Teste

`tests/timer_macrotask_order.test.ts`.

Suite **1602/1602** (zero regressão — setTimeout/setInterval/setImmediate/#377 intactos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)