### PR TITLE
fix(codegen): curry N-nivel com args inteiros (#1281)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -464,6 +464,51 @@ pub(super) fn lower_indirect_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &Ca
     Ok(TypedVal::new(v, ValTy::I64))
 }
 
+/// (#1281 curry N-nivel) Callee eh ele proprio uma chamada (`add3(1)(2)(3)`):
+/// a subchamada retorna um handle de ARROW LIFTADA (i64-ABI), que le seus
+/// params number via `fcvt_from_sint` (espera INTEIRO, nao bits-f64). As
+/// capturas (bound_args) ja' chegam como inteiro (REIFY coerce_to_i64), entao
+/// os args proprios DEVEM seguir a mesma convencao — senao o nivel final
+/// recebe bits-f64 e o resultado corrompe (era `3.0000…013` em add3(1)(2)(3)).
+/// Diferente de lower_indirect_call (que empaca F64 como bits p/ callees com
+/// param_kinds=1), aqui empacotamos number como INTEIRO (coerce_to_i64). NB:
+/// fracao trunca — mesma limitacao que as capturas ja' tem (issue-pai f64).
+pub(super) fn lower_curry_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &CallExpr) -> Result<TypedVal> {
+    let callee = lower_expr(ctx, callee_expr)?;
+    let callee_val = ctx.coerce_to_i64(callee).val;
+
+    let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+    let vec_push = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[cl::I64, cl::I64], None)?;
+    let vec_extend = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM", &[cl::I64, cl::I64], None)?;
+    let new_inst = ctx.builder.ins().call(vec_new, &[]);
+    let args_vec = ctx.builder.inst_results(new_inst)[0];
+    ctx.declare_gc_handle(args_vec);
+    for arg in &call.args {
+        let tv = lower_expr(ctx, &arg.expr)?;
+        if arg.spread.is_some() {
+            let src = ctx.coerce_to_i64(tv).val;
+            ctx.builder.ins().call(vec_extend, &[args_vec, src]);
+            continue;
+        }
+        // INTEIRO (coerce_to_i64): casa com a convencao i64-ABI da arrow
+        // liftada (fcvt_from_sint no body) e com as capturas (REIFY).
+        let v = ctx.coerce_to_i64(tv).val;
+        ctx.builder.ins().call(vec_push, &[args_vec, v]);
+    }
+    let zero = ctx.builder.ins().iconst(cl::I64, 0);
+    let invoke = ctx.get_extern(
+        "__RTS_FN_RT_INVOKE_AUTO",
+        &[cl::I64, cl::I64, cl::I64],
+        Some(cl::I64),
+    )?;
+    let inst = ctx.builder.ins().call(invoke, &[callee_val, zero, args_vec]);
+    let v = ctx.builder.inst_results(inst)[0];
+    // I64 ambiguo (handle do proximo nivel OU number final). var_member_call
+    // p/ TPL_COERCE_AUTO no consumo. coerce_to_i64 (no-op) round-tripa handle.
+    ctx.var_member_call_values.insert(v);
+    Ok(TypedVal::new(v, ValTy::I64))
+}
+
 /// Despacha chamada via handle Function (bind/REIFY/new Function) através
 /// de __RTS_FN_GL_FUNCTION_CALL. Empacota args em Vec collections.
 pub(super) fn emit_function_handle_indirect_call(

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -7,7 +7,7 @@ mod ns_call;
 mod super_calls;
 
 use self::indirect::{
-    lower_indirect_call, lower_var_member_call,
+    lower_curry_call, lower_indirect_call, lower_var_member_call,
 };
 use self::new_expr::{lower_function_handle_method, lower_function_method_call};
 
@@ -2401,19 +2401,14 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
             }
         }
-        // (cross-runtime #300) Call em result de outra Call ou Expr generica
-        // (ex: `Function("body")()` ou `obj.getFn()()`) — avalia callee como
-        // expressao, despacha via Function handle indirect.
+        // (cross-runtime #300 / #1281 curry) Call em result de outra Call
+        // (`add3(1)(2)(3)`, `Function("body")()`, `obj.getFn()()`). O callee-call
+        // retorna handle de arrow liftada i64-ABI (le params via fcvt_from_sint,
+        // espera INTEIRO). lower_curry_call empaca os args como inteiro p/ casar
+        // com as capturas (REIFY) — sem isso o nivel final recebia bits-f64 e
+        // corrompia (`add3(1)(2)(3)` dava 3.0000…013).
         if matches!(callee.as_ref(), Expr::Call(_)) {
-            let callee_tv = super::lower_expr(ctx, callee)?;
-            use crate::codegen::lower::ctx::ValTy as VT;
-            if matches!(callee_tv.ty, VT::Handle | VT::I64 | VT::U64) {
-                return self::indirect::emit_function_handle_indirect_call(
-                    ctx,
-                    callee_tv.val,
-                    call,
-                );
-            }
+            return self::indirect::lower_curry_call(ctx, callee, call);
         }
         if let Expr::Ident(id) = callee.as_ref() {
             let name = id.sym.as_str();
@@ -2504,8 +2499,13 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
     // acima — tipicamente `f(x)(y)` (call-of-call) ou `(expr)(args)`. O callee
     // produz um fn_ptr/handle Function; despacha via lower_indirect_call.
     if let Callee::Expr(callee) = &call.callee {
+        // (#1281 curry N-nivel) callee-call (`add3(1)(2)(3)`) retorna arrow
+        // liftada i64-ABI — empaca args como INTEIRO via lower_curry_call.
+        if matches!(callee.as_ref(), Expr::Call(_)) {
+            return lower_curry_call(ctx, callee, call);
+        }
         if matches!(callee.as_ref(),
-            Expr::Call(_) | Expr::Paren(_) | Expr::Cond(_) | Expr::Bin(_)
+            Expr::Paren(_) | Expr::Cond(_) | Expr::Bin(_)
         ) {
             return lower_indirect_call(ctx, callee, call);
         }

--- a/tests/call_of_call_curry.test.ts
+++ b/tests/call_of_call_curry.test.ts
@@ -23,10 +23,18 @@ print(adder(3)(4) + "");         // 7
 const f = (x: number) => x * 2;
 print((f)(21) + "");             // 42
 
-// NOTA: curry de 3+ niveis (`add3(1)(2)(3)`) ainda tem residuo do elo
-// f64/invoke encadeado (3o nivel perde precisao) — follow-up.
+// (#1281) curry de 3 niveis — args inteiros agora corretos. A arrow liftada
+// eh i64-ABI (le params via fcvt_from_sint, espera inteiro); lower_curry_call
+// empaca os args como inteiro p/ casar com as capturas (REIFY). NB: capturas
+// f64 FRACIONARIAS ainda truncam (limitacao i64-ABI conhecida).
+function add3(a: number) { return (b: number) => (c: number) => a + b + c; }
+print(add3(1)(2)(3) + "");       // 6
+function add4(a: number) {
+  return (b: number) => (c: number) => (d: number) => a + b + c + d;
+}
+print(add4(1)(2)(3)(4) + "");    // 10
 
-describe("call-of-call / curry (#41)", () => {
+describe("call-of-call / curry (#41, #1281)", () => {
   test("f(x)(y) e curry 2-nivel", () =>
-    expect(out).toBe("15\n7\n42\n"));
+    expect(out).toBe("15\n7\n42\n6\n10\n"));
 });


### PR DESCRIPTION
## Problema

`add3(1)(2)(3)` dava `3.0000000000000013` em vez de `6`. Curry de 3+ níveis quebrava.

## Causa raiz (descoberta via debug do runtime)

A arrow liftada é **i64-ABI** e lê seus params number via `fcvt_from_sint` — ou seja, **espera INTEIRO**, não bits-f64. Confirmado instrumentando `invoke_all_i64`:

```
add3(1)(2)(3):
  args=[1, 2]                          // nivel 2: capturas OK (inteiro)
  args=[1, 2, 4613937818241073152]     // nivel 3: c = BITS-f64 de 3.0 (errado!)
```

As capturas (bound_args) chegam como inteiro (REIFY `coerce_to_i64`), mas o handler de callee-call em `calls/mod.rs:2407` empacotava os args próprios como **bits-f64** (via `emit_function_handle_indirect_call`). Inconsistência → o nível final recebia bits-f64 e o resultado corrompia.

## Fix

`lower_curry_call` empaca os args do curry como **inteiro** (`coerce_to_i64`), casando com a convenção i64-ABI da arrow liftada e com as capturas. Roteado a partir do handler de callee-call `Expr::Call`.

## Cobre

Curry de 2, 3 e 4 níveis com inteiros (`tests/call_of_call_curry.test.ts`):
- `add2(1)(2)=3`, `add2(5)(10)=15`
- `add3(1)(2)(3)=6`
- `add4(1)(2)(3)(4)=10`

## Limitação conhecida

Capturas **f64 fracionárias** ainda truncam (`adderF(40.5)(1.5)→41`) — limitação da ABI i64 da arrow liftada, a mesma que as capturas REIFY já têm. Rastreada em #1281 como o refator f64-ABI uniforme futuro (com mapa completo dos 4 pontos).

## Verificação

Suite **1604/1604** (zero regressão).

🤖 Generated with [Claude Code](https://claude.com/claude-code)