### PR TITLE
fix(runtime): invoke_all_i64 com aridade N variavel via trampolim asm (#1281)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/function/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/function/ops.rs
@@ -109,6 +109,73 @@ unsafe fn invoke_typed(
     }
 }
 
+/// Invoca `fn_ptr` (convencao Win64 fastcall, todos os params i64 -> i64) com
+/// um numero ARBITRARIO de args. As fns geradas pelo codegen (user fns
+/// address-taken, arrows liftadas) usam `default_call_conv` = Win64 fastcall,
+/// que coincide com `extern "C"` no MSVC ABI.
+///
+/// (#1281) Antes era um `match` por aridade ate 8 (depois 16), com `_ => 0`
+/// que retornava lixo ou segfault em curry profundo (`add10(...)`). Este
+/// trampolim em asm monta os args dinamicamente — aridade N variavel, sem teto
+/// artificial. Win64: primeiros 4 args em RCX/RDX/R8/R9, resto na stack (ordem
+/// inversa de push), shadow space de 32 bytes, stack alinhada a 16 antes do
+/// `call`.
+#[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+unsafe fn invoke_all_i64(fn_ptr: u64, args: &[i64]) -> i64 {
+    use std::arch::asm;
+    let n = args.len();
+    let argp = args.as_ptr();
+    let ret: i64;
+    // Bytes a reservar na stack p/ args alem dos 4 em registrador, mais o
+    // shadow space (32) exigido pelo Win64 ABI. Mantemos multiplo de 16.
+    let stack_args = n.saturating_sub(4);
+    // shadow(32) + stack_args*8, arredondado p/ 16.
+    let raw = 32 + stack_args * 8;
+    let frame = (raw + 15) & !15usize;
+    unsafe {
+        asm!(
+            // Reserva o frame (shadow + args na stack), 16-aligned.
+            "sub rsp, {frame}",
+            // Copia args[4..] para a stack: dst = rsp+32 + i*8.
+            "xor {i}, {i}",
+            "2:",
+            "cmp {i}, {sa}",
+            "jae 3f",
+            "mov {tmp}, [{argp} + 32 + {i}*8]", // args[4 + i]
+            "mov [rsp + 32 + {i}*8], {tmp}",
+            "inc {i}",
+            "jmp 2b",
+            "3:",
+            // Carrega os 4 primeiros em RCX/RDX/R8/R9 (se existirem).
+            "cmp {n}, 0", "jbe 4f", "mov rcx, [{argp}]",
+            "cmp {n}, 1", "jbe 4f", "mov rdx, [{argp} + 8]",
+            "cmp {n}, 2", "jbe 4f", "mov r8,  [{argp} + 16]",
+            "cmp {n}, 3", "jbe 4f", "mov r9,  [{argp} + 24]",
+            "4:",
+            "call {fp}",
+            "add rsp, {frame}",
+            frame = in(reg) frame,
+            sa = in(reg) stack_args,
+            n = in(reg) n,
+            argp = in(reg) argp,
+            fp = in(reg) fn_ptr,
+            i = out(reg) _,
+            tmp = out(reg) _,
+            out("rax") ret,
+            // Caller-saved (Win64) que o callee pode destruir + os de argumento.
+            out("rcx") _, out("rdx") _, out("r8") _, out("r9") _,
+            out("r10") _, out("r11") _,
+            // SSE caller-saved (callee pode usar mesmo recebendo so' i64).
+            out("xmm0") _, out("xmm1") _, out("xmm2") _, out("xmm3") _,
+            out("xmm4") _, out("xmm5") _,
+        );
+    }
+    ret
+}
+
+/// Fallback portavel (nao-Windows-x64): mantem o despacho por aridade. Usado em
+/// builds de teste/CI noutras plataformas; o alvo de producao eh Windows x64.
+#[cfg(not(all(target_arch = "x86_64", target_os = "windows")))]
 unsafe fn invoke_all_i64(fn_ptr: u64, args: &[i64]) -> i64 {
     use std::mem::transmute;
     unsafe {
@@ -116,30 +183,13 @@ unsafe fn invoke_all_i64(fn_ptr: u64, args: &[i64]) -> i64 {
             0 => transmute::<u64, extern "C" fn() -> i64>(fn_ptr)(),
             1 => transmute::<u64, extern "C" fn(i64) -> i64>(fn_ptr)(args[0]),
             2 => transmute::<u64, extern "C" fn(i64, i64) -> i64>(fn_ptr)(args[0], args[1]),
-            3 => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2],
-            ),
-            4 => transmute::<u64, extern "C" fn(i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3],
-            ),
-            5 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4],
-            ),
-            6 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4], args[5],
-            ),
-            7 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64>(
-                fn_ptr,
-            )(
-                args[0], args[1], args[2], args[3], args[4], args[5], args[6],
-            ),
-            8 => transmute::<
-                u64,
-                extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64,
-            >(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
-            ),
-            _ => 0,
+            3 => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2]),
+            4 => transmute::<u64, extern "C" fn(i64, i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2], args[3]),
+            5 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2], args[3], args[4]),
+            6 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2], args[3], args[4], args[5]),
+            7 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2], args[3], args[4], args[5], args[6]),
+            8 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]),
+            n => panic!("invoke_all_i64 (fallback portavel): aridade {n} > 8 nao suportada nesta plataforma"),
         }
     }
 }

--- a/tests/call_of_call_curry.test.ts
+++ b/tests/call_of_call_curry.test.ts
@@ -34,7 +34,18 @@ function add4(a: number) {
 }
 print(add4(1)(2)(3)(4) + "");    // 10
 
+// (#1281) curry de 5 niveis — aridade variavel via trampolim asm Win64
+// (invoke_all_i64), sem teto de 8. Antes >8 niveis dava 0/ACCESS_VIOLATION.
+// NB: curry MUITO profundo (10+) sob pressao de muitas closures no mesmo
+// modulo tem GC coletando capturas intermediarias (handles realocados) —
+// bug de GC rooting separado, rastreado a parte.
+function add5(a: number) {
+  return (b: number) => (c: number) => (d: number) => (e: number) =>
+    a + b + c + d + e;
+}
+print(add5(10)(20)(30)(40)(50) + "");  // 150
+
 describe("call-of-call / curry (#41, #1281)", () => {
-  test("f(x)(y) e curry 2-nivel", () =>
-    expect(out).toBe("15\n7\n42\n6\n10\n"));
+  test("f(x)(y) e curry 2..5-nivel", () =>
+    expect(out).toBe("15\n7\n42\n6\n10\n150\n"));
 });


### PR DESCRIPTION
## Problema

O despacho de invocação (`invoke_all_i64`) era um `match` por aridade **até 8**, com `_ => 0`. Acima de 8 params:
- **9 níveis** de curry → retornava `0` (resultado errado, silencioso)
- **10 níveis** → chamava ptr inválido → **ACCESS_VIOLATION** (segfault)

Limite artificial — não deveria existir.

## Fix

Trampolim em **assembly Win64** (x86-64) que monta os args **dinamicamente**:
- Primeiros 4 args em RCX/RDX/R8/R9
- Resto na stack, com shadow space (32 bytes) e alinhamento de 16 antes do `call`

Aridade **arbitrária**, sem teto. Fallback portável por-aridade (até 8) mantido para plataformas não-Windows-x64 (testes/CI).

## Testado

Curry de 2, 3, 4, 5, 8, 9, 10, **15** níveis — todos corretos isoladamente (`add(...)=120` em 15 níveis).

## Limitação conhecida (bug SEPARADO)

Curry **muito profundo (10+) sob pressão de muitas closures no mesmo módulo** ainda tem o **GC coletando capturas intermediárias** (handles realocados — resultado vira não-determinístico). Isso é GC rooting, **não** este fix de aridade — rastreado à parte. O teste de regressão cobre até 5 níveis (determinístico e estável, 3/3 runs).

## Verificação

Suite **1604/1604**, `cargo test --lib` 12/12, zero regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)