### PR TITLE
feat(codegen): SharedArrayBuffer como alias de ArrayBuffer (#69 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -31,7 +31,7 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
             _ => break,
         }
     }
-    let class_name = match callee_expr {
+    let mut class_name = match callee_expr {
         Expr::Ident(id) => id.sym.as_str().to_string(),
         _ => {
             return Err(anyhow!(
@@ -39,6 +39,14 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
             ));
         }
     };
+
+    // (#69) SharedArrayBuffer eh tratado como ArrayBuffer no RTS (sem memoria
+    // compartilhada entre threads via SAB — o backing eh o mesmo Buffer). Isso
+    // destrava `new SharedArrayBuffer(n)` + Int32Array view + Atomics.* sobre
+    // ela, que ja' funcionam para ArrayBuffer.
+    if class_name == "SharedArrayBuffer" && !ctx.classes.contains_key(&class_name) {
+        class_name = "ArrayBuffer".to_string();
+    }
 
     // Function global (#359): `new Function(...params, body)` — variadic.
     // Empacota todos args excerto o ultimo em string CSV de params, ultimo

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -205,6 +205,7 @@ fn lower_ident_expr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal> {
     if matches!(name,
         "Array" | "Object" | "Map" | "Set" | "Proxy" | "Reflect"
         | "Math" | "JSON" | "Atomics" | "Intl"
+        | "ArrayBuffer" | "SharedArrayBuffer"
     ) {
         return ctx.emit_str_handle(name.as_bytes());
     }


### PR DESCRIPTION
Destrava `new SharedArrayBuffer(n)` (alias de ArrayBuffer — RTS não tem SAB real entre threads). Resta `Atomics.*` sobre typed array p/ fechar o teste 69. Suite 1607/1607.