### PR TITLE
fix(codegen): acesso a private em arrow liftada de metodo de classe (#376)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -137,6 +137,12 @@ pub(crate) fn compile_user_fn(
         fn_ctx.return_ty = info.ret;
         fn_ctx.is_tail_conv = call_conv == CallConv::Tail;
         fn_ctx.current_class = current_class.clone();
+        // (#376) Escopo private: current_class quando disponivel; senao, p/ uma
+        // arrow liftada de dentro de metodo de classe, a classe dona via registry
+        // lateral. So' habilita validate_private_scope — nao muda dispatch.
+        fn_ctx.private_scope_class = current_class.clone().or_else(|| {
+            crate::codegen::lower::passes::this_arrow::lifted_arrow_class(&fn_decl.name)
+        });
         fn_ctx.current_fn_name = fn_decl.name.clone();
         fn_ctx.current_file = fn_decl.span.file
             .and_then(rts_diagnostics::source_store::path_of)

--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -391,6 +391,12 @@ pub struct FnCtx<'m, 'fb> {
     /// Nome da classe atualmente sendo lowered (quando dentro de um
     /// metodo ou constructor). Usado para resolver `super`.
     pub current_class: Option<String>,
+    /// (#376) Classe cujo escopo PRIVATE esta visivel nesta fn, mesmo quando
+    /// current_class eh None (arrow liftada de dentro de metodo de classe).
+    /// Usado SO' por validate_private_scope — nao afeta dispatch de membros
+    /// (que continua guiado por current_class). Evita o efeito colateral de
+    /// setar current_class numa arrow liftada (que mudaria a leitura de this.x).
+    pub private_scope_class: Option<String>,
     /// True quando a função atual é um constructor de classe
     /// (`__class_C__init`). Usado pra permitir assign em readonly fields.
     pub current_is_ctor: bool,
@@ -622,6 +628,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             global_obj_field_types,
             global_nested_obj_field_types,
             current_class: None,
+            private_scope_class: None,
             current_is_ctor: false,
             super_already_called: false,
             module_scope,

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -2032,7 +2032,10 @@ pub(super) fn map_get_static_typed(
 }
 
 pub(super) fn validate_private_scope(ctx: &FnCtx, key: &str) -> Result<()> {
-    let Some(current) = ctx.current_class.as_deref() else {
+    // (#376) Usa private_scope_class (= current_class, OU a classe dona quando
+    // numa arrow liftada de dentro de metodo de classe). Sem isso, `this.#x`
+    // numa arrow retornada de metodo era rejeitada.
+    let Some(current) = ctx.private_scope_class.as_deref() else {
         return Err(anyhow!(
             "private `{key}` so pode ser acessado dentro do corpo da classe que o declara"
         ));

--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -430,6 +430,7 @@ pub(crate) fn lift_arrow_callbacks(program: &mut Program) -> HashSet<String> {
         needs_c_callconv: HashSet::new(),
         scope_vars: HashSet::new(),
         lifted_captures: HashMap::new(),
+        lifted_arrow_class: HashMap::new(),
     };
 
     // Pass 1: dentro de classes (constructors e métodos). Arrows que usam
@@ -565,11 +566,20 @@ pub(crate) fn lift_arrow_callbacks(program: &mut Program) -> HashSet<String> {
     // (#195) Publica o mapa de capturas pro codegen consumir ao materializar
     // os idents `__lifted_arrow_N` como handles Function com bound_args.
     set_lifted_captures(std::mem::take(&mut acc.lifted_captures));
+    set_lifted_arrow_class(std::mem::take(&mut acc.lifted_arrow_class));
     acc.needs_c_callconv
 }
 
 thread_local! {
     static LIFTED_ARROW_CAPTURES: std::cell::RefCell<HashMap<String, Vec<String>>> =
+        std::cell::RefCell::new(HashMap::new());
+    /// (#376) Mapa `__lifted_arrow_N -> classe dona`, quando a arrow foi liftada
+    /// de DENTRO de um metodo de classe. Canal lateral (em vez de embutir no
+    /// nome, que regride consumidores de `__lifted_arrow_`): o codegen consulta
+    /// p/ setar current_class quando extract_class_owner retorna None — assim a
+    /// validacao de private (`this.#x`) e o dispatch de membros funcionam dentro
+    /// da arrow liftada.
+    static LIFTED_ARROW_CLASS: std::cell::RefCell<HashMap<String, String>> =
         std::cell::RefCell::new(HashMap::new());
 }
 
@@ -577,6 +587,17 @@ thread_local! {
 /// pass de lift, pra o codegen reificar com REIFY_CAPTURED.
 pub(crate) fn set_lifted_captures(map: HashMap<String, Vec<String>>) {
     LIFTED_ARROW_CAPTURES.with(|c| *c.borrow_mut() = map);
+}
+
+/// (#376) Registra o mapa `__lifted_arrow_N -> classe dona`.
+pub(crate) fn set_lifted_arrow_class(map: HashMap<String, String>) {
+    LIFTED_ARROW_CLASS.with(|c| *c.borrow_mut() = map);
+}
+
+/// (#376) Consulta a classe dona de uma arrow liftada (None se a arrow nao
+/// veio de dentro de um metodo de classe).
+pub(crate) fn lifted_arrow_class(name: &str) -> Option<String> {
+    LIFTED_ARROW_CLASS.with(|c| c.borrow().get(name).cloned())
 }
 
 /// (#195) Consulta as capturas de um `__lifted_arrow_N`. None se a arrow nao
@@ -644,6 +665,9 @@ struct LiftAcc {
     /// estavel). O codegen consulta pra reificar via REIFY_CAPTURED, passando
     /// os valores das capturas como bound_args.
     lifted_captures: HashMap<String, Vec<String>>,
+    /// (#376) `__lifted_arrow_N -> classe dona` quando liftada de dentro de
+    /// metodo de classe. Canal lateral p/ o codegen recuperar current_class.
+    lifted_arrow_class: HashMap<String, String>,
 }
 
 
@@ -832,6 +856,13 @@ impl LiftAcc {
 
         let syn_name = format!("__lifted_arrow_{}", self.counter);
         self.counter += 1;
+
+        // (#376) Registra a classe dona (canal lateral, sem mudar o nome) p/ o
+        // codegen recuperar current_class na arrow liftada — habilita acesso a
+        // private (`this.#x`) e dispatch de membros de classe dentro dela.
+        if in_class && !class_name.is_empty() {
+            self.lifted_arrow_class.insert(syn_name.clone(), class_name.to_string());
+        }
 
         // (#195 parcial) Preserva os parametros proprios da arrow. Antes
         // descartados (parameters: Vec::new()), o que quebrava qualquer arrow


### PR DESCRIPTION
Arrow que acessa `this.#priv` retornada de método era liftada sem contexto de classe → validate_private_scope rejeitava. Fix via canal lateral (registry `lifted_arrow_class` + `private_scope_class` no FnCtx, usado só pela validação — não toca dispatch nem naming, que regridem). Suite 1607/1607.