### PR TITLE
fix(codegen): captura de param de metodo em arrow aninhada/retornada (#376 cluster A)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -445,7 +445,22 @@ pub(crate) fn lift_arrow_callbacks(program: &mut Program) -> HashSet<String> {
                     acc.lift_in_body(&class_name, &mut ctor.body, /*in_class=*/ true);
                 }
                 ClassMember::Method(method) if !method.modifiers.is_static => {
+                    // (#376) Popula scope_vars com os PARAMS do metodo antes do
+                    // lift, p/ que arrows aninhadas/retornadas (`return () =>
+                    // this.#x.delete(fn)`) detectem `fn` como captura-por-valor
+                    // (bound_arg) em vez de "undefined variable". Espelha o que
+                    // process_fn faz p/ top-level fns. Restaura depois.
+                    let mparams: Vec<String> =
+                        method.parameters.iter().map(|p| p.name.clone()).collect();
+                    let added: Vec<String> = mparams
+                        .iter()
+                        .filter(|n| acc.scope_vars.insert((*n).clone()))
+                        .cloned()
+                        .collect();
                     acc.lift_in_body(&class_name, &mut method.body, /*in_class=*/ true);
+                    for n in &added {
+                        acc.scope_vars.remove(n);
+                    }
                 }
                 _ => {}
             }


### PR DESCRIPTION
Arrow retornada de método de classe (`make(base) { return (x) => base + x }`) não capturava `base` — lift de classe não populava scope_vars com params do método (top-level já fazia via process_fn). Fix: popula scope_vars com params do método antes do lift. Cobre captura-de-param sem this; com this é camada separada. Suite 1607/1607.