### PR TITLE
fix(codegen): private field via this capturado em arrow de metodo (#376)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -170,6 +170,18 @@ pub(crate) fn compile_user_fn(
                 .local_class_ty
                 .insert("this".to_string(), cls.to_string());
         }
+        // (#376 camada 3) `__captured_this` (param de captura do `this` numa
+        // arrow liftada de metodo de classe) tem o tipo da classe dona — registra
+        // p/ que `__captured_this.#priv` / dispatch de membros resolva a classe.
+        if fn_decl.parameters.iter().any(|p| p.name == "__captured_this") {
+            if let Some(cls) =
+                crate::codegen::lower::passes::this_arrow::lifted_arrow_class(&fn_decl.name)
+            {
+                fn_ctx
+                    .local_class_ty
+                    .insert("__captured_this".to_string(), cls);
+            }
+        }
         // Parametros tipados como classe registrada → trackear.
         for p in &fn_decl.parameters {
             if let Some(ann) = p.type_annotation.as_deref() {

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1696,7 +1696,12 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             let raw_key = format!("#{}", raw_name);
             validate_private_scope(ctx, &raw_key)?;
             // (cross-runtime #267) Mangle por current_class (declaring class).
-            let key = if let Some(cur) = ctx.current_class.as_deref() {
+            // (#376) Quando current_class eh None (arrow liftada de metodo),
+            // usa private_scope_class (classe dona via registry) p/ o mangling —
+            // senao a key fica `#x` (sem mangle) e nao acha o campo `#x_C`.
+            let mangle_cls = ctx.current_class.as_deref()
+                .or(ctx.private_scope_class.as_deref());
+            let key = if let Some(cur) = mangle_cls {
                 format!("#{}_{}", cur, raw_name)
             } else {
                 raw_key.clone()


### PR DESCRIPTION
Após #1300 o `this` viaja como `__captured_this`, mas `this.#items` dava -1: (1) private key mangled por current_class (None na arrow) e (2) `__captured_this` sem tipo de classe. Fix: registra local_class_ty p/ __captured_this + mangling usa private_scope_class como fallback. Private via this-capturado funciona (leitura+mutação). Suite 1607/1607.