### PR TITLE
fix(codegen): captura em Set/Map.forEach + array methods em metodo de classe (#376)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -867,7 +867,30 @@ pub(super) fn lower_map_set_builtin(
             // MAP_FOR_EACH precisa disso pra invocar com a aridade correta.
             let cb_tv = if let Expr::Ident(id) = call.args[0].expr.as_ref() {
                 let name = id.sym.as_str().to_string();
-                if ctx.user_fns.contains_key(&name) {
+                // (#376) Callback liftado COM captura (`__lifted_cap_N` do
+                // parallelism pass, ou `__lifted_arrow_N` do this_arrow): reifica
+                // com bound_args via REIFY_CAPTURED. Sem isso ia por
+                // emit_hoisted_arrow_handle (sem bound_args) e a captura (`value`)
+                // colidia com o item do Set passado pelo MAP_FOR_EACH.
+                let caps_opt = crate::codegen::lower::passes::parallelism::LIFTED_CAPTURES
+                    .with(|c| c.borrow().get(&name).cloned())
+                    .or_else(|| crate::codegen::lower::passes::this_arrow::lifted_arrow_captures(&name));
+                if let Some(caps) = caps_opt {
+                    let cap_vals: Vec<TypedVal> = caps
+                        .iter()
+                        .filter_map(|c| {
+                            if c == "__captured_this" { ctx.read_local("this") }
+                            else { ctx.read_local(c) }
+                        })
+                        .collect();
+                    if cap_vals.len() == caps.len() {
+                        super::emit_lifted_arrow_handle_with_captures(ctx, &name, &cap_vals)?
+                    } else if ctx.user_fns.contains_key(&name) {
+                        super::emit_hoisted_arrow_handle(ctx, &name, None)?
+                    } else {
+                        lower_expr(ctx, &call.args[0].expr)?
+                    }
+                } else if ctx.user_fns.contains_key(&name) {
                     super::emit_hoisted_arrow_handle(ctx, &name, None)?
                 } else {
                     lower_expr(ctx, &call.args[0].expr)?

--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -658,6 +658,31 @@ pub(crate) fn lift_inline_arrows_in_array_methods(program: &mut Program) {
         }
     }
 
+    // (#376) Bodies de metodos/constructors de classe. Sem isto, callbacks de
+    // array/Set methods dentro de metodo (`this.subs.forEach(s => s + value)`)
+    // nao eram liftados com captura — caiam no hoist_fn sem captura -> "undefined
+    // variable value".
+    let class_indices: Vec<usize> = program.items.iter().enumerate()
+        .filter_map(|(i, it)| if matches!(it, Item::Class(_)) { Some(i) } else { None })
+        .collect();
+    for i in class_indices {
+        if let Item::Class(c) = &mut program.items[i] {
+            for mem in &mut c.members {
+                let body = match mem {
+                    crate::parser::ast::ClassMember::Method(m) => &mut m.body,
+                    crate::parser::ast::ClassMember::Constructor(ct) => &mut ct.body,
+                    _ => continue,
+                };
+                for stmt_raw in body {
+                    let Statement::Raw(raw) = stmt_raw;
+                    if let Some(stmt) = raw.stmt.as_mut() {
+                        lift_arrows_in_stmt(stmt, &mut user_fn_names, &mut new_fns, &counter);
+                    }
+                }
+            }
+        }
+    }
+
     // Prepend novas fns para que `array_methods_pass` veja-as no
     // user_fn_names snapshot inicial.
     for fn_item in new_fns.into_iter().rev() {


### PR DESCRIPTION
Dois bugs: (1) lift de array-methods não descia em métodos de classe → callback em método caía no hoist sem captura; (2) Set/Map.forEach com callback capturado usava handle sem bound_args → captura colidia com o item. Fix: visitar métodos de classe + reificar com REIFY_CAPTURED quando há captura. Set.forEach capturando var agora correto. Suite 1607/1607.