### PR TITLE
fix(codegen): Object.* proxy-aware + JSON.stringify(proxy) (#98 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -1343,13 +1343,15 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }
                 // Object.getOwnPropertyDescriptor(obj, key) — reusa Reflect.
+                // (#98) versao _PROXY: dispara o trap quando obj for Proxy,
+                // senao cai em forward_get_own_property_descriptor.
                 if method == "getOwnPropertyDescriptor" && call.args.len() == 2 {
                     let obj_tv = lower_expr(ctx, &call.args[0].expr)?;
                     let obj_h = ctx.coerce_to_i64(obj_tv).val;
                     let key_tv = lower_expr(ctx, &call.args[1].expr)?;
                     let key_h = ctx.coerce_to_handle(key_tv)?.val;
                     let f = ctx.get_extern(
-                        "__RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR",
+                        "__RTS_FN_GL_REFLECT_GET_OWN_PROPERTY_DESCRIPTOR_PROXY",
                         &[cl::I64, cl::I64],
                         Some(cl::I64),
                     )?;
@@ -1491,33 +1493,23 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 }
                 // (#208) Object.defineProperty(obj, key, descriptor) — v0
                 // suporta apenas { value: x }.
+                // (#98) roteia via REFLECT_DEFINE_PROPERTY_PROXY: quando obj
+                // for Proxy, dispara o trap `defineProperty`; senao cai em
+                // forward_define_property (mesma semantica do antigo
+                // MAP_DEFINE_PROPERTY, extraindo value+writable+enumerable).
                 if method == "defineProperty" && call.args.len() == 3 {
                     let obj_tv = lower_expr(ctx, &call.args[0].expr)?;
                     let obj = ctx.coerce_to_i64(obj_tv).val;
                     let key_tv = lower_expr(ctx, &call.args[1].expr)?;
-                    let key_h = ctx.coerce_to_i64(key_tv).val;
+                    let key_h = ctx.coerce_to_handle(key_tv)?.val;
                     let desc_tv = lower_expr(ctx, &call.args[2].expr)?;
                     let desc = ctx.coerce_to_i64(desc_tv).val;
-                    let kp_fn = ctx.get_extern(
-                        "__RTS_FN_NS_GC_STRING_PTR",
-                        &[cl::I64],
-                        Some(cl::I64),
-                    )?;
-                    let kl_fn = ctx.get_extern(
-                        "__RTS_FN_NS_GC_STRING_LEN",
-                        &[cl::I64],
-                        Some(cl::I64),
-                    )?;
-                    let inst_p = ctx.builder.ins().call(kp_fn, &[key_h]);
-                    let kp = ctx.builder.inst_results(inst_p)[0];
-                    let inst_l = ctx.builder.ins().call(kl_fn, &[key_h]);
-                    let kl = ctx.builder.inst_results(inst_l)[0];
                     let f = ctx.get_extern(
-                        "__RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY",
-                        &[cl::I64, cl::I64, cl::I64, cl::I64],
+                        "__RTS_FN_GL_REFLECT_DEFINE_PROPERTY_PROXY",
+                        &[cl::I64, cl::I64, cl::I64],
                         Some(cl::I64),
                     )?;
-                    let inst = ctx.builder.ins().call(f, &[obj, kp, kl, desc]);
+                    let inst = ctx.builder.ins().call(f, &[obj, key_h, desc]);
                     let v = ctx.builder.inst_results(inst)[0];
                     return Ok(TypedVal::new(v, ValTy::Handle));
                 }

--- a/crates/rts-codegen/src/codegen/lower/passes/args/new_collection_arg.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/args/new_collection_arg.rs
@@ -10,7 +10,7 @@
 //! arg pelo ident temporario. Roda ANTES de lift_inline_arrows_in_array_methods
 //! para que o `.map` extraido seja liftado como statement normal.
 
-use swc_ecma_ast::{Callee, Decl, Expr, Stmt, VarDecl, VarDeclKind, VarDeclarator, Pat};
+use swc_ecma_ast::{Decl, Expr, Stmt, VarDecl, VarDeclKind, VarDeclarator, Pat};
 
 use crate::parser::ast::{ClassMember, Item, Program, RawStmt, Statement};
 use crate::parser::span::Span;

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1203,9 +1203,11 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_OWN_PROPERTY_NAMES(handle: u64)
 /// Object.keys auto: se handle e' Map retorna keys; se Vec retorna ["0","1",...].
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_OBJECT_KEYS_AUTO(handle: u64) -> u64 {
-    // (#218 phase2) Proxy: trap `ownKeys(target)` ou forward.
+    // (#218 phase2 / #98) Proxy: trap `ownKeys` + filtragem por enumeravel
+    // via trap `getOwnPropertyDescriptor` por chave (ECMA-262
+    // OrdinaryOwnPropertyKeys). Reflect.ownKeys usa dispatch_own_keys cru.
     if let Some((target, handler)) = crate::namespaces::globals::proxy::ops::resolve_proxy(handle) {
-        return crate::namespaces::globals::proxy::ops::dispatch_own_keys(target, handler);
+        return crate::namespaces::globals::proxy::ops::dispatch_own_keys_enumerable(target, handler);
     }
     // (#253) StringBox unwrap antes do dispatch.
     let unwrap: Option<u64> = with_entry(handle, |e| match e {

--- a/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
@@ -37,6 +37,12 @@ unsafe extern "C" {
     fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64;
     fn __RTS_FN_NS_COLLECTIONS_MAP_GET_PROTO(handle: u64) -> u64;
     fn __RTS_FN_GL_FUNCTION_APPLY(fn_h: u64, this_arg: i64, args_handle: u64) -> i64;
+    fn __RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY(
+        obj: u64,
+        key_ptr: *const u8,
+        key_len: i64,
+        descriptor: u64,
+    ) -> u64;
 }
 
 /// Construtor Proxy: aloca Entry::Proxy { target, handler }.
@@ -152,6 +158,55 @@ pub fn dispatch_own_keys(target: u64, handler: u64) -> u64 {
     let h = r as u64;
     let is_vec = with_entry(h, |e| matches!(e, Some(Entry::Vec(_))));
     if is_vec { h } else { alloc_entry(Entry::Vec(Box::new(Vec::new()))) }
+}
+
+/// (#98) `Object.keys(proxy)` — ECMA-262 OrdinaryOwnPropertyKeys filtra
+/// para own properties **enumeraveis**. Para um Proxy, isso dispara o trap
+/// `ownKeys` e, para cada chave, o trap `getOwnPropertyDescriptor` pra
+/// checar `enumerable` (mesmo trace que Bun/Node produzem).
+///
+/// Diferente de `dispatch_own_keys` (usado por `Reflect.ownKeys`, que NAO
+/// filtra), aqui filtramos. Quando nao ha trap correspondente, os
+/// `forward_*` reproduzem o comportamento default do objeto.
+pub fn dispatch_own_keys_enumerable(target: u64, handler: u64) -> u64 {
+    let all = dispatch_own_keys(target, handler);
+    // Extrai os handles de string do Vec retornado.
+    let key_handles: Vec<u64> = with_entry(all, |e| match e {
+        Some(Entry::Vec(v)) => v.iter().map(|x| *x as u64).collect(),
+        _ => Vec::new(),
+    });
+    let mut kept: Vec<i64> = Vec::with_capacity(key_handles.len());
+    for kh in key_handles {
+        // [[GetOwnProperty]]: dispara trap getOwnPropertyDescriptor.
+        let desc = dispatch_get_own_property_descriptor(target, handler, kh);
+        if desc == 0 {
+            continue;
+        }
+        // undefined => prop ausente, pula.
+        let is_undef = with_entry(desc, |e| {
+            matches!(e, Some(Entry::String(b)) if b.as_slice() == b"undefined")
+        });
+        if is_undef {
+            continue;
+        }
+        // Le `enumerable` do descriptor Map. Ausente => trata como nao
+        // enumeravel (spec: default false em descriptors retornados por
+        // getOwnPropertyDescriptor; mas para objetos comuns o forward
+        // sempre popula true/false).
+        let enumerable = with_entry(desc, |e| match e {
+            Some(Entry::Map(m)) => match m.get("enumerable") {
+                Some(x) if *x == i64::MIN => false,
+                Some(x) if *x == i64::MIN + 1 => true,
+                Some(x) => *x != 0,
+                None => false,
+            },
+            _ => false,
+        });
+        if enumerable {
+            kept.push(kh as i64);
+        }
+    }
+    alloc_entry(Entry::Vec(Box::new(kept)))
 }
 
 /// Trap `getPrototypeOf(target)`. Retorna o handle do proto.
@@ -274,53 +329,24 @@ pub fn dispatch_define_property(
 }
 
 fn forward_define_property(target: u64, key_handle: u64, descriptor: u64) -> i64 {
+    // (#98) Delega ao MAP_DEFINE_PROPERTY completo (trata value, writable,
+    // enumerable, configurable, getter/setter `__get_`/`__set_` e TypeError
+    // de redefinicao non-configurable). Antes essa fn era uma v0 que so'
+    // tratava value+writable+enumerable, regredindo accessor descriptors
+    // (`{ get(){} }`) quando Object.defineProperty passou a rotear por aqui.
     let Some(key_bytes) = with_entry(key_handle, |e| match e {
         Some(Entry::String(b)) => Some(b.clone()),
         _ => None,
     }) else {
         return 0;
     };
-    // (cross-runtime #795) Extrai value + flags (writable/enumerable) do
-    // descriptor pra preservar via non_writable_set/non_enumerable_set.
-    // Bool sentinels: i64::MIN = false, i64::MIN+1 = true; outros valores
-    // tratados como truthy/falsy via != 0.
-    let (value, writable, enumerable) = with_entry(descriptor, |e| match e {
-        Some(Entry::Map(m)) => {
-            let v = m.get("value").copied().unwrap_or(0);
-            let w = m.get("writable").map(|x| {
-                if *x == i64::MIN { false }
-                else if *x == i64::MIN + 1 { true }
-                else { *x != 0 }
-            });
-            let en = m.get("enumerable").map(|x| {
-                if *x == i64::MIN { false }
-                else if *x == i64::MIN + 1 { true }
-                else { *x != 0 }
-            });
-            (v, w, en)
-        }
-        _ => (0, None, None),
-    });
-    use crate::namespaces::gc::handles::with_entry_mut;
-    let key_str = String::from_utf8_lossy(&key_bytes).into_owned();
-    let ok = with_entry_mut(target, |e| match e {
-        Some(Entry::Map(m)) => {
-            m.insert(key_str.clone(), value);
-            true
-        }
-        _ => false,
-    });
-    if !ok { return 0; }
-    // Atualiza flag tracking conforme descriptor.
-    match writable {
-        Some(false) => crate::namespaces::collections::map::mark_non_writable(target, &key_str),
-        Some(true) => crate::namespaces::collections::map::unmark_non_writable(target, &key_str),
-        None => {} // ausente — preserva estado anterior
-    }
-    match enumerable {
-        Some(false) => crate::namespaces::collections::map::mark_non_enumerable(target, &key_str),
-        Some(true) => crate::namespaces::collections::map::unmark_non_enumerable(target, &key_str),
-        None => {}
+    unsafe {
+        __RTS_FN_NS_COLLECTIONS_MAP_DEFINE_PROPERTY(
+            target,
+            key_bytes.as_ptr(),
+            key_bytes.len() as i64,
+            descriptor,
+        );
     }
     1
 }

--- a/crates/rts-runtime/src/namespaces/json/ops.rs
+++ b/crates/rts-runtime/src/namespaces/json/ops.rs
@@ -288,6 +288,63 @@ fn stringify_with_visited(
 ) -> Option<String> {
     use std::fmt::Write;
     if *circular { return None; }
+    // (#98) Proxy: JSON.stringify itera as own keys enumeraveis via trap
+    // `ownKeys` + `getOwnPropertyDescriptor`, e le cada valor via trap
+    // `get` (mesmo trace de Bun/Node). Resolvemos pra um objeto plano
+    // {key: value} e serializamos recursivamente.
+    if let Some((target, handler)) =
+        crate::namespaces::globals::proxy::ops::resolve_proxy(handle)
+    {
+        if !visited.insert(handle) {
+            *circular = true;
+            return None;
+        }
+        let keys_vec =
+            crate::namespaces::globals::proxy::ops::dispatch_own_keys_enumerable(target, handler);
+        let key_strs: Vec<String> = with_entry(keys_vec, |e| match e {
+            Some(Entry::Vec(v)) => v
+                .iter()
+                .filter_map(|kh| {
+                    with_entry(*kh as u64, |ke| match ke {
+                        Some(Entry::String(b)) => {
+                            Some(String::from_utf8_lossy(b).into_owned())
+                        }
+                        _ => None,
+                    })
+                })
+                .collect(),
+            _ => Vec::new(),
+        });
+        let mut out = String::new();
+        out.push('{');
+        let mut first = true;
+        for k in key_strs {
+            let val = crate::namespaces::globals::proxy::ops::dispatch_get(target, handler, &k);
+            if is_undefined_value(val) {
+                continue;
+            }
+            if !first {
+                out.push(',');
+            }
+            first = false;
+            out.push('"');
+            for c in k.bytes() {
+                match c {
+                    b'"' => out.push_str("\\\""),
+                    b'\\' => out.push_str("\\\\"),
+                    _ => out.push(c as char),
+                }
+            }
+            out.push_str("\":");
+            out.push_str(&stringify_value_visited(val, visited, circular));
+            if *circular {
+                return None;
+            }
+        }
+        out.push('}');
+        visited.remove(&handle);
+        return Some(out);
+    }
     // Snapshot do Entry com lock minimo: copia bytes/entries para
     // estruturas owned, depois solta o Mutex do shard. Sem isso,
     // recursao em Map/Vec self-ref toma lock duplo no mesmo shard

--- a/tests/proxy_phase2.test.ts
+++ b/tests/proxy_phase2.test.ts
@@ -77,6 +77,10 @@ const proto6 = Reflect.getPrototypeOf(p6);
 const proto6Kind: i64 = Reflect.has(proto6, "kind") ? 1 : 0;
 
 // 12. ownKeys + Object.keys
+// (#98) JS spec: Object.keys dispara [[GetOwnProperty]] por chave de
+// ownKeys pra filtrar enumeraveis. Como "only" NAO existe no target e
+// nao ha trap getOwnPropertyDescriptor, o forward retorna undefined ->
+// nao-enumeravel -> filtrada. Bun/Node retornam [] (length 0).
 const p7: any = new Proxy({ a: 1, b: 2 } as any, {
     ownKeys: (_t: any) => ["only"]
 });
@@ -87,7 +91,7 @@ describe("proxy_phase2", () => {
     test("ownKeys trap returns custom array", () => expect(k1Len).toBe(3));
     test("ownKeys forward returns target keys", () => expect(k2Len).toBe(3));
     test("ownKeys trap returns empty", () => expect(k3Len).toBe(0));
-    test("Object.keys via proxy ownKeys", () => expect(k7Len).toBe(1));
+    test("Object.keys via proxy ownKeys", () => expect(k7Len).toBe(0));
     // apply
     test("apply trap intercepts proxy()", () => expect(r1).toBe(42));
     test("apply forward calls target", () => expect(r2).toBe(100));


### PR DESCRIPTION
## Cluster H (plano parity-100) — quick win XS de altíssimo ROI

Fecha o `98_proxy_invariants` (cross-runtime), trazendo `Object.*` e `JSON.stringify` à conformidade com a spec ECMA-262 para Proxies.

### Mudanças
- **`Object.defineProperty`** → `REFLECT_DEFINE_PROPERTY_PROXY`: dispara o trap `defineProperty` em Proxy; senão `forward_define_property` agora **delega ao `MAP_DEFINE_PROPERTY` completo** (value/writable/enumerable/configurable + getter/setter + TypeError). A v0 antiga só tratava value+writable+enumerable e regrediria accessor descriptors.
- **`Object.getOwnPropertyDescriptor`** → `*_PROXY` (dispara o trap).
- **`dispatch_own_keys_enumerable`**: `Object.keys(proxy)` filtra own props enumeráveis via `[[GetOwnProperty]]` por chave (Reflect.ownKeys segue cru).
- **`JSON.stringify(proxy)`**: itera own keys enumeráveis + lê cada valor via trap `get` (antes vazava o handle cru).

### Antes / depois
```
RTS antes: keys=a    vals=281474976710659  log=ownKeys|del:b|ownKeys
RTS agora: keys=a,c  vals={"a":1,"c":3}    log=ownKeys|desc:a|desc:b|def:c=3|del:b|ownKeys|desc:a|desc:c|ownKeys|desc:a|desc:c   ← idêntico a Bun/Node
```

### Teste corrigido
`tests/proxy_phase2.test.ts` cravava `Object.keys(p7).length === 1` para um trap ownKeys retornando uma chave inexistente no target. JS spec retorna `[]` (length 0) — confirmado em Bun+Node. Corrigido para 0.

### Validação
- Suite TS: **1607/1607** ✅ (zero regressão)
- `rts-runtime --lib proxy`: 3/3
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)