### PR TITLE
fix(codegen): infere return string p/ reduce_bound com init string (#345 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -947,7 +947,18 @@ fn inspect_return_kind(
                             }
                             // (#345) `arr.reduce(fn, "")` — initial value
                             // string implica retorno string. Detecta via 2o arg.
-                            if matches!(method, "reduce" | "reduceRight")
+                            // Inclui `reduce_bound`/`reduce_right_bound`: quando
+                            // o callback inline captura vars (ex: tagged template
+                            // tag com `...values`), lift_inline_arrows reescreve
+                            // o metodo para a variante _bound mantendo o init
+                            // string em args[1]. Sem aceitar _bound aqui, a fn
+                            // wrapper era inferida como Number (-> f64) e o handle
+                            // de string virava lixo no console.log.
+                            if matches!(
+                                method,
+                                "reduce" | "reduceRight"
+                                | "reduce_bound" | "reduce_right_bound"
+                            )
                                 && c.args.len() >= 2
                                 && matches!(
                                     c.args[1].expr.as_ref(),

--- a/tests/tagged_template_reduce_capture.test.ts
+++ b/tests/tagged_template_reduce_capture.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// (#345) Tagged template cuja tag faz `strings.reduce(cb, "")` onde o
+// callback inline CAPTURA o rest param `...values`. O lift reescreve para
+// `strings.reduce_bound(handle, "", ...)` e a inferencia de return type
+// precisa reconhecer `reduce_bound` com init string => fn retorna string
+// (Handle), nao Number (f64) — senao o handle vira lixo no console.log.
+function highlight(strings: TemplateStringsArray, ...values: any[]) {
+  return strings.reduce(
+    (acc, str, i) => acc + str + (values[i] !== undefined ? "[" + values[i] + "]" : ""),
+    "",
+  );
+}
+
+const name = "world";
+const n = 42;
+const r1 = highlight`hello ${name} the number is ${n}`;
+const r2 = highlight`no interpolation`;
+const r3 = highlight`${1}${2}${3}`;
+
+// reduce sem ternario (no-capture path) continua funcionando.
+function plain(strings: TemplateStringsArray, ...vals: any[]) {
+  return strings.reduce((acc, s) => acc + s, "");
+}
+const r4 = plain`a${1}b${2}c`;
+
+// spread sobre TemplateStringsArray.
+function parts(strings: TemplateStringsArray, ...vals: any[]) {
+  return [...strings];
+}
+const r5 = parts`x${1}y`.join("|");
+
+describe("tagged_template_reduce_capture (#345)", () => {
+  test("tag com capture + ternario", () =>
+    expect(r1).toBe("hello [world] the number is [42]"));
+  test("tag sem interpolacao", () => expect(r2).toBe("no interpolation"));
+  test("tag so interpolacao", () => expect(r3).toBe("[1][2][3]"));
+  test("tag plain reduce", () => expect(r4).toBe("abc"));
+  test("spread sobre strings", () => expect(r5).toBe("x|y"));
+});


### PR DESCRIPTION
## Quick win (plano parity-100) — fecha 345_string_template_tag

A maior parte do fixture já funcionava (String.raw, spread, raw access, reduce simples). Faltava: tag com `strings.reduce(cb, "")` onde o callback inline **captura** o rest param `...values`.

### Causa-raiz
`lift_inline_arrows_in_array_methods` roda **antes** de `declare_user_fn`. Quando o callback de reduce captura vars, o lift reescreve `strings.reduce(arrow, "")` → `strings.reduce_bound(handle, "", ...)` (renomeia o método). A heurística `inspect_return_kind` só reconhecia `reduce`/`reduceRight` com init string como retorno-string; `reduce_bound`/`reduce_right_bound` caíam no default **Number** → a fn `tag` era tipada `-> f64` → o handle de string virava lixo:

```
RTS antes:  281474976710675
RTS agora:  hello [world] the number is [42]   ← idêntico a Bun/Node
```

Sem captura o lift mantém `reduce` e já funcionava — por isso o bug só aparecia com o ternário que referencia `values[i]`.

### Fix
Aceitar `reduce_bound`/`reduce_right_bound` (além de `reduce`/`reduceRight`) na detecção de retorno-string em `inspect_return_kind`.

### Validação
- `tests/tagged_template_reduce_capture.test.ts`: 5 casos
- Fixture 345 byte-idêntico a Bun (`diff` limpo)
- Suite TS: **1630/1630** (+5, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)