### PR TITLE
fix(runtime): preserva configurable em getOwnPropertyDescriptor (#349 FECHA)

### DIFF
--- a/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
+++ b/crates/rts-runtime/src/namespaces/globals/proxy/ops.rs
@@ -388,13 +388,19 @@ fn forward_get_own_property_descriptor(target: u64, key_handle: u64) -> u64 {
     // writable/enumerable definidos via defineProperty.
     let writable_bool = !crate::namespaces::collections::map::is_non_writable(target, &key_str);
     let enumerable_bool = !crate::namespaces::collections::map::is_non_enumerable(target, &key_str);
+    // (#98/#1073/349) configurable rastreado via Object.defineProperty
+    // (is_non_configurable). Antes hardcodava true aqui, regredindo
+    // 349_object_descriptors quando getOwnPropertyDescriptor passou a
+    // rotear pela versao _PROXY.
+    let configurable_bool =
+        !crate::namespaces::collections::map::is_non_configurable(target, &key_str);
     let mut desc: indexmap::IndexMap<String, i64> = indexmap::IndexMap::new();
     desc.insert("value".to_string(), v);
     // Bool sentinels (i64::MIN+1 = true, i64::MIN = false) pra TPL_COERCE_AUTO
     // formatar como "true"/"false" em vez de inteiros raw.
     desc.insert("writable".to_string(), if writable_bool { i64::MIN + 1 } else { i64::MIN });
     desc.insert("enumerable".to_string(), if enumerable_bool { i64::MIN + 1 } else { i64::MIN });
-    desc.insert("configurable".to_string(), i64::MIN + 1);
+    desc.insert("configurable".to_string(), if configurable_bool { i64::MIN + 1 } else { i64::MIN });
     alloc_entry(Entry::Map(Box::new(desc)))
 }
 

--- a/tests/descriptor_configurable.test.ts
+++ b/tests/descriptor_configurable.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+// (#98/349) getOwnPropertyDescriptor deve preservar o flag `configurable`
+// definido via Object.defineProperty. Regressao introduzida quando o call
+// site passou a rotear pela versao _PROXY (forward_get_own_property_descriptor
+// hardcodava configurable=true). Cobre writable/enumerable/configurable.
+//
+// Coletamos tudo numa string no top-level (como o fixture cross-runtime
+// 349 faz) — comparar bool sentinels do descriptor diretamente em
+// closures test() eh fragil sob GC; a coercao via `"" + flag` eh estavel.
+const obj: any = {};
+Object.defineProperty(obj, "ro", { value: 42, writable: false, enumerable: true, configurable: false });
+Object.defineProperty(obj, "rw", { value: 7, writable: true, enumerable: false, configurable: true });
+
+const dRo = Object.getOwnPropertyDescriptor(obj, "ro")!;
+const dRw = Object.getOwnPropertyDescriptor(obj, "rw")!;
+
+const summary: string =
+  "ro=" + dRo.value + "," + dRo.writable + "," + dRo.enumerable + "," + dRo.configurable +
+  "|rw=" + dRw.writable + "," + dRw.enumerable + "," + dRw.configurable;
+
+describe("descriptor_configurable (#98/349)", () => {
+  test("descriptor flags preservados", () =>
+    expect(summary).toBe("ro=42,false,true,false|rw=true,false,true"));
+});


### PR DESCRIPTION
## Fix de regressão parcial do #98 — fecha 349_object_descriptors

Ao rotear `Object.getOwnPropertyDescriptor` pela versão `_PROXY` (#98), o caminho não-proxy `forward_get_own_property_descriptor` **hardcodava `configurable: true`**, ignorando o tracking `is_non_configurable` que a versão antiga já lia.

`desc.configurable` retornava `true` para props definidas com `configurable: false` → 349 divergia de Bun na 9ª linha:
```
RTS antes: ...true...   (configurable de prop non-configurable)
RTS agora: ...false...  ← idêntico a Bun/Node
```

A suite TS não pegou (sem caso cobrindo configurable em descriptor); o cross-runtime pegou.

### Fix
Ler `is_non_configurable` igual a `writable`/`enumerable` logo acima (1 linha de lógica real).

### Validação
- `tests/descriptor_configurable.test.ts` (compara flags via coerção string — estável sob GC)
- 349 + 98 byte-idênticos a Bun
- Suite TS: **1631/1631** (zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)