### PR TITLE
feat(codegen): view.set(arr) Buffer-aware p/ TypedArray-view (#68 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1872,6 +1872,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_TA_GET_ELEM", buf::__RTS_FN_GL_TA_GET_ELEM);
     add_fn!("__RTS_FN_GL_TA_SET_ELEM", buf::__RTS_FN_GL_TA_SET_ELEM);
     add_fn!("__RTS_FN_GL_TA_LENGTH", buf::__RTS_FN_GL_TA_LENGTH);
+    add_fn!("__RTS_FN_GL_TA_SET_FROM", buf::__RTS_FN_GL_TA_SET_FROM);
     add_fn!("__RTS_FN_GL_ATOMICS_RMW", buf::__RTS_FN_GL_ATOMICS_RMW);
     add_fn!("__RTS_FN_GL_ATOMICS_CAS", buf::__RTS_FN_GL_ATOMICS_CAS);
     add_fn!("__RTS_FN_GL_ATOMICS_LOAD", buf::__RTS_FN_GL_ATOMICS_LOAD);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -511,6 +511,48 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     }
                 }
             }
+            // (#68) `view.set(srcArray, offset?)` onde view eh TypedArray-view
+            // sobre (Shared)ArrayBuffer (local_ta_view). O path generico
+            // (VEC_SET_FROM) so' escreve em Entry::Vec — sobre Buffer era no-op
+            // silencioso. Rota dedicada TA_SET_FROM escreve os elementos como
+            // `elem_bytes` bytes little-endian no buffer subjacente.
+            if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                if let MemberProp::Ident(prop) = &m.prop {
+                    if prop.sym.as_str() == "set"
+                        && matches!(
+                            call.args.first().map(|a| a.expr.as_ref()),
+                            Some(Expr::Array(_))
+                        )
+                        && call.args.iter().all(|a| a.spread.is_none())
+                    {
+                        if let Some(&(eb, _sg, fl)) =
+                            ctx.local_ta_view.get(obj_id.sym.as_str())
+                        {
+                            let recv_tv = lower_expr(ctx, &m.obj)?;
+                            let buf_h = ctx.coerce_to_i64(recv_tv).val;
+                            let src_tv = lower_expr(ctx, &call.args[0].expr)?;
+                            let src_h = ctx.coerce_to_i64(src_tv).val;
+                            let offset = if let Some(a) = call.args.get(1) {
+                                let tv = lower_expr(ctx, &a.expr)?;
+                                ctx.coerce_to_i64(tv).val
+                            } else {
+                                ctx.builder.ins().iconst(cl::I64, 0)
+                            };
+                            let eb_v = ctx.builder.ins().iconst(cl::I64, eb);
+                            let fl_v = ctx.builder.ins().iconst(cl::I64, fl);
+                            let f = ctx.get_extern(
+                                "__RTS_FN_GL_TA_SET_FROM",
+                                &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I64],
+                                None,
+                            )?;
+                            ctx.builder
+                                .ins()
+                                .call(f, &[buf_h, src_h, offset, eb_v, fl_v]);
+                            return Ok(TypedVal::new(buf_h, ValTy::Handle));
+                        }
+                    }
+                }
+            }
             if let Some(qualified) = qualified_member_name(callee) {
                 // Console builtin precisa preceder o lookup (#380).
                 if let Some(tv) = lower_console_call(ctx, &qualified, call)? {

--- a/crates/rts-runtime/src/namespaces/buffer/ops.rs
+++ b/crates/rts-runtime/src/namespaces/buffer/ops.rs
@@ -616,6 +616,30 @@ pub extern "C" fn __RTS_FN_GL_ATOMICS_STORE(
     value
 }
 
+/// (#68) `view.set(srcArray, offset)` onde `view` eh uma TypedArray-view
+/// sobre (Shared)ArrayBuffer. Escreve cada elemento de `src` (Vec<i64>) como
+/// `elem_bytes` bytes little-endian no buffer, a partir de `offset` (em
+/// elementos). Reusa TA_SET_ELEM para respeitar signed/float e bounds.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_TA_SET_FROM(
+    handle: u64,
+    src: u64,
+    offset: i64,
+    elem_bytes: i64,
+    is_float: i64,
+) {
+    if offset < 0 {
+        return;
+    }
+    let items: Vec<i64> = with_entry(src, |e| match e {
+        Some(Entry::Vec(v)) => v.as_ref().clone(),
+        _ => Vec::new(),
+    });
+    for (i, x) in items.into_iter().enumerate() {
+        __RTS_FN_GL_TA_SET_ELEM(handle, offset + i as i64, elem_bytes, is_float, x);
+    }
+}
+
 /// `typedArray.length` quando o backing eh um ArrayBuffer: byteLength/elem_bytes.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_TA_LENGTH(handle: u64, elem_bytes: i64) -> i64 {

--- a/tests/typed_array_view_set.test.ts
+++ b/tests/typed_array_view_set.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// (#68 parcial) `view.set(srcArray, offset?)` onde `view` eh uma
+// TypedArray-view nomeada sobre (Shared)ArrayBuffer escreve os elementos
+// no buffer subjacente. Antes caia em VEC_SET_FROM (so' Entry::Vec) e era
+// no-op silencioso sobre Buffer. Agora roteia para TA_SET_FROM.
+const ab = new ArrayBuffer(16);
+
+const i32 = new Int32Array(ab);
+i32.set([100, 200, 300]);
+const i32Read = i32[0] + "," + i32[1] + "," + i32[2];
+
+const u8 = new Uint8Array(ab);
+u8.set([5, 6, 7], 1); // offset 1
+const u8Read = u8[0] + "," + u8[1] + "," + u8[2] + "," + u8[3];
+
+// SharedArrayBuffer tambem (backing identico).
+const sab = new SharedArrayBuffer(8);
+const sv = new Int32Array(sab);
+sv.set([42, 99]);
+const svRead = sv[0] + "," + sv[1];
+
+describe("typed_array_view_set (#68 parcial)", () => {
+  test("Int32Array.set escreve no buffer", () => expect(i32Read).toBe("100,200,300"));
+  test("Uint8Array.set com offset", () => expect(u8Read).toBe("100,5,6,7"));
+  test("SharedArrayBuffer view.set", () => expect(svRead).toBe("42,99"));
+});


### PR DESCRIPTION
## Correção isolada — `view.set` Buffer-aware (avança #68)

`view.set(srcArray, offset?)` sobre uma TypedArray-view **nomeada** de (Shared)ArrayBuffer não escrevia nada — caía em `VEC_SET_FROM` (só `Entry::Vec`), no-op silencioso sobre `Entry::Buffer`. Os reads voltavam 0.

```
RTS antes:  v=0,0,0,0
RTS agora:  v=10,20,30,40   ← idêntico a Bun/Node
```

### Fix
Codegen: quando o receiver é Ident em `local_ta_view` e o método é `set` com array literal, roteia para nova `TA_SET_FROM(buffer, src, offset, elem_bytes, is_float)` (reusa `TA_SET_ELEM` por elemento, respeita signed/float/bounds). Símbolo registrado no JIT.

### Escopo honesto
**Não fecha 68_arraybuffer_transfer_clone** — esse ainda precisa de views **anônimas** (`new Uint8Array(buf)` sem binding) + `structuredClone` transfer/detach, que são fundação separada. Este PR fecha o sub-caso de views nomeadas (usado em vários lugares).

### Validação
- `tests/typed_array_view_set.test.ts`: 3 casos (Int32, Uint8 c/ offset, SharedArrayBuffer)
- Suite TS: **1634/1634** (+3, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)