### PR TITLE
feat(parser): yield* com captura de return value em VarDecl init (#275 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -181,6 +181,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     use crate::namespaces::gc::string_pool::*;
     add_fn!("__RTS_FN_NS_GC_GENERATOR_NEXT", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_NEXT);
     add_fn!("__RTS_FN_NS_GC_GENERATOR_SET_RET", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_SET_RET);
+    add_fn!("__RTS_FN_NS_GC_GENERATOR_GET_RET", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_GET_RET);
     add_fn!("__RTS_FN_GL_ITERATOR_FROM", crate::namespaces::gc::generator::__RTS_FN_GL_ITERATOR_FROM);
     add_fn!("__RTS_FN_GL_ITERATOR_TO_ARRAY", crate::namespaces::gc::generator::__RTS_FN_GL_ITERATOR_TO_ARRAY);
     add_fn!("__RTS_FN_NS_GC_GENERATOR_RETURN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_RETURN);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -188,6 +188,24 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 let h = ctx.builder.inst_results(inst)[0];
                 return Ok(TypedVal::new(h, ValTy::Handle));
             }
+            // (#275/#379) `__RTS_GEN_GET_RET(vec)` — sentinela do
+            // generator_desugar p/ `const r = yield* gen()`: devolve o
+            // ret_value (`return X`) registrado pela generator delegada.
+            if id.sym.as_str() == "__RTS_GEN_GET_RET" && call.args.len() == 1 {
+                use cranelift_codegen::ir::types as cl;
+                let vec_tv = lower_expr(ctx, &call.args[0].expr)?;
+                let vec = ctx.coerce_to_i64(vec_tv).val;
+                let get_ret = ctx.get_extern(
+                    "__RTS_FN_NS_GC_GENERATOR_GET_RET",
+                    &[cl::I64],
+                    Some(cl::I64),
+                )?;
+                let inst = ctx.builder.ins().call(get_ret, &[vec]);
+                let v = ctx.builder.inst_results(inst)[0];
+                // ret_value eh ambiguo (i64/handle); marca para coercao auto.
+                ctx.var_member_call_values.insert(v);
+                return Ok(TypedVal::new(v, ValTy::I64));
+            }
         }
         // (generators) `<genVar>.next()` — protocolo de iterador finito.
         // Roteia para GENERATOR_NEXT (cursor lateral sobre o Vec retornado

--- a/crates/rts-parser/src/generator_desugar.rs
+++ b/crates/rts-parser/src/generator_desugar.rs
@@ -22,6 +22,21 @@ use swc_ecma_ast::{
 
 const BUF_NAME: &str = "__gen_buf";
 
+thread_local! {
+    /// Contador monotonico p/ nomes unicos de temporarios
+    /// `__yt_delegate_N` em `const r = yield* gen()` — unicidade global
+    /// entre todas as generator fns da compilacao.
+    static YT_COUNTER: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+fn next_yt_id() -> u32 {
+    YT_COUNTER.with(|c| {
+        let v = c.get();
+        c.set(v + 1);
+        v
+    })
+}
+
 pub fn desugar_generator_body(body: &BlockStmt) -> BlockStmt {
     let span = body.span;
     let mut stmts: Vec<Stmt> = Vec::with_capacity(body.stmts.len() + 2);
@@ -44,7 +59,7 @@ pub fn desugar_generator_body(body: &BlockStmt) -> BlockStmt {
     }))));
 
     for stmt in &body.stmts {
-        stmts.push(transform_stmt(stmt.clone()));
+        stmts.extend(transform_stmt(stmt.clone()));
     }
 
     // return __RTS_GEN_FINISH(__gen_buf, undefined);
@@ -68,75 +83,215 @@ pub fn desugar_generator_body(body: &BlockStmt) -> BlockStmt {
     }
 }
 
-fn transform_stmt(stmt: Stmt) -> Stmt {
+/// Variante que sempre devolve UM Stmt (envolvendo em Block quando o
+/// transform produz multiplos) — p/ posicoes que exigem statement unico
+/// (cons/alt de if, body de loop). Nessas posicoes o Block extra nao
+/// quebra escopo de forma observavel (corpos de loop ja' tem escopo).
+fn transform_stmt_single(stmt: Stmt) -> Stmt {
+    let span = stmt_span(&stmt);
+    let mut v = transform_stmt(stmt);
+    if v.len() == 1 {
+        v.pop().unwrap()
+    } else {
+        Stmt::Block(BlockStmt { span, ctxt: Default::default(), stmts: v })
+    }
+}
+
+fn stmt_span(stmt: &Stmt) -> swc_common::Span {
+    match stmt {
+        Stmt::Expr(s) => s.span,
+        Stmt::Block(s) => s.span,
+        Stmt::If(s) => s.span,
+        Stmt::While(s) => s.span,
+        Stmt::DoWhile(s) => s.span,
+        Stmt::For(s) => s.span,
+        Stmt::ForOf(s) => s.span,
+        Stmt::ForIn(s) => s.span,
+        Stmt::Return(s) => s.span,
+        Stmt::Decl(Decl::Var(s)) => s.span,
+        _ => Default::default(),
+    }
+}
+
+fn transform_stmt(stmt: Stmt) -> Vec<Stmt> {
     match stmt {
         Stmt::Expr(es) => {
             // Caso comum: `yield expr;` -> __gen_buf.push(expr);
             // `yield* expr;` -> for (const __t of expr) __gen_buf.push(__t);
             if let Expr::Yield(y) = es.expr.as_ref() {
                 if y.delegate {
-                    return delegate_for_of(y.arg.as_deref().cloned(), es.span);
+                    return vec![delegate_for_of(y.arg.as_deref().cloned(), es.span)];
                 }
-                return push_call_stmt(y.arg.as_deref().cloned(), es.span);
+                return vec![push_call_stmt(y.arg.as_deref().cloned(), es.span)];
             }
-            Stmt::Expr(ExprStmt {
+            vec![Stmt::Expr(ExprStmt {
                 span: es.span,
                 expr: Box::new(transform_expr(*es.expr)),
-            })
+            })]
         }
-        Stmt::Block(b) => Stmt::Block(BlockStmt {
-            span: b.span,
-            ctxt: b.ctxt,
-            stmts: b.stmts.into_iter().map(transform_stmt).collect(),
-        }),
-        Stmt::If(i) => Stmt::If(swc_ecma_ast::IfStmt {
+        Stmt::Block(b) => {
+            let mut stmts: Vec<Stmt> = Vec::with_capacity(b.stmts.len());
+            for s in b.stmts {
+                stmts.extend(transform_stmt(s));
+            }
+            vec![Stmt::Block(BlockStmt { span: b.span, ctxt: b.ctxt, stmts })]
+        }
+        Stmt::If(i) => vec![Stmt::If(swc_ecma_ast::IfStmt {
             span: i.span,
             test: Box::new(transform_expr(*i.test)),
-            cons: Box::new(transform_stmt(*i.cons)),
-            alt: i.alt.map(|a| Box::new(transform_stmt(*a))),
-        }),
-        Stmt::While(w) => Stmt::While(swc_ecma_ast::WhileStmt {
+            cons: Box::new(transform_stmt_single(*i.cons)),
+            alt: i.alt.map(|a| Box::new(transform_stmt_single(*a))),
+        })],
+        Stmt::While(w) => vec![Stmt::While(swc_ecma_ast::WhileStmt {
             span: w.span,
             test: Box::new(transform_expr(*w.test)),
-            body: Box::new(transform_stmt(*w.body)),
-        }),
-        Stmt::DoWhile(d) => Stmt::DoWhile(swc_ecma_ast::DoWhileStmt {
+            body: Box::new(transform_stmt_single(*w.body)),
+        })],
+        Stmt::DoWhile(d) => vec![Stmt::DoWhile(swc_ecma_ast::DoWhileStmt {
             span: d.span,
             test: Box::new(transform_expr(*d.test)),
-            body: Box::new(transform_stmt(*d.body)),
-        }),
-        Stmt::For(f) => Stmt::For(swc_ecma_ast::ForStmt {
+            body: Box::new(transform_stmt_single(*d.body)),
+        })],
+        Stmt::For(f) => vec![Stmt::For(swc_ecma_ast::ForStmt {
             span: f.span,
             init: f.init,
             test: f.test.map(|t| Box::new(transform_expr(*t))),
             update: f.update.map(|u| Box::new(transform_expr(*u))),
-            body: Box::new(transform_stmt(*f.body)),
-        }),
-        Stmt::ForOf(fo) => Stmt::ForOf(swc_ecma_ast::ForOfStmt {
+            body: Box::new(transform_stmt_single(*f.body)),
+        })],
+        Stmt::ForOf(fo) => vec![Stmt::ForOf(swc_ecma_ast::ForOfStmt {
             span: fo.span,
             is_await: fo.is_await,
             left: fo.left,
             right: Box::new(transform_expr(*fo.right)),
-            body: Box::new(transform_stmt(*fo.body)),
-        }),
-        Stmt::ForIn(fi) => Stmt::ForIn(swc_ecma_ast::ForInStmt {
+            body: Box::new(transform_stmt_single(*fo.body)),
+        })],
+        Stmt::ForIn(fi) => vec![Stmt::ForIn(swc_ecma_ast::ForInStmt {
             span: fi.span,
             left: fi.left,
             right: Box::new(transform_expr(*fi.right)),
-            body: Box::new(transform_stmt(*fi.body)),
-        }),
+            body: Box::new(transform_stmt_single(*fi.body)),
+        })],
         // `return X` num generator: retorna o buffer-ate-aqui com X como
         // ret_value (via FINISH). `return;` (sem arg) -> ret undefined.
-        Stmt::Return(r) => Stmt::Return(swc_ecma_ast::ReturnStmt {
+        Stmt::Return(r) => vec![Stmt::Return(swc_ecma_ast::ReturnStmt {
             span: r.span,
             arg: Some(Box::new(gen_finish_call(
                 Expr::Ident(Ident::new(BUF_NAME.into(), r.span, Default::default())),
                 r.arg.as_deref().cloned(),
                 r.span,
             ))),
-        }),
-        other => other,
+        })],
+        // (#275/#379) `const r = yield* gen()` / `let r = yield v` — yield em
+        // posicao de init de VarDecl. transform_stmt antes deixava cru
+        // (catch-all) e o codegen rejeitava ("unsupported expression: yield").
+        // Reescreve cada declarator com init yield:
+        //   `const r = yield* gen()` ->
+        //     const __yt_delegate_N = gen();
+        //     for (const __t of __yt_delegate_N) __gen_buf.push(__t);
+        //     const r = __RTS_GEN_GET_RET(__yt_delegate_N);
+        //   `const r = yield v` -> __gen_buf.push(v); const r = undefined;
+        //     (eager model nao alimenta valor de volta no yield — r=undefined).
+        Stmt::Decl(Decl::Var(vd))
+            if vd.decls.iter().any(|d| {
+                matches!(d.init.as_deref(), Some(Expr::Yield(_)))
+            }) =>
+        {
+            let mut out: Vec<Stmt> = Vec::new();
+            let span = vd.span;
+            let kind = vd.kind;
+            for d in vd.decls.iter() {
+                match d.init.as_deref() {
+                    Some(Expr::Yield(y)) => {
+                        if y.delegate {
+                            // const __yt_delegate_N = <arg>;
+                            let tmp = format!("__yt_delegate_{}", next_yt_id());
+                            let iter = y.arg.as_deref().cloned().unwrap_or(Expr::Ident(
+                                Ident::new("undefined".into(), span, Default::default()),
+                            ));
+                            out.push(decl_const(&tmp, Some(iter), VarDeclKind::Const, span));
+                            // for (const __t of __yt_delegate_N) __gen_buf.push(__t);
+                            out.push(delegate_for_of(
+                                Some(Expr::Ident(Ident::new(tmp.clone().into(), span, Default::default()))),
+                                span,
+                            ));
+                            // <kind> r = __RTS_GEN_GET_RET(__yt_delegate_N);
+                            let get_ret = gen_get_ret_call(
+                                Expr::Ident(Ident::new(tmp.into(), span, Default::default())),
+                                span,
+                            );
+                            out.push(decl_from_pat(d.name.clone(), Some(get_ret), kind, span));
+                        } else {
+                            // const r = yield v -> push(v); const r = undefined;
+                            out.push(push_call_stmt(y.arg.as_deref().cloned(), span));
+                            let undef = Expr::Ident(Ident::new(
+                                "undefined".into(), span, Default::default(),
+                            ));
+                            out.push(decl_from_pat(d.name.clone(), Some(undef), kind, span));
+                        }
+                    }
+                    other_init => {
+                        // declarator sem yield: preserva (transform no init p/
+                        // pegar yields aninhados raros).
+                        let init = other_init.cloned().map(|e| Box::new(transform_expr(e)));
+                        out.push(decl_from_pat(d.name.clone(), init.map(|b| *b), kind, span));
+                    }
+                }
+            }
+            // Inline (sem Block) p/ preservar escopo: `const r` precisa ficar
+            // visivel aos statements seguintes do mesmo bloco.
+            out
+        }
+        other => vec![other],
     }
+}
+
+/// Helper: `<kind> <name> = <init>;` com nome ident.
+fn decl_const(name: &str, init: Option<Expr>, kind: VarDeclKind, span: swc_common::Span) -> Stmt {
+    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span,
+        ctxt: Default::default(),
+        kind,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span,
+            name: Pat::Ident(Ident::new(name.into(), span, Default::default()).into()),
+            init: init.map(Box::new),
+            definite: false,
+        }],
+    })))
+}
+
+/// Helper: `<kind> <pat> = <init>;` reusando o Pat original do declarator.
+fn decl_from_pat(pat: Pat, init: Option<Expr>, kind: VarDeclKind, span: swc_common::Span) -> Stmt {
+    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span,
+        ctxt: Default::default(),
+        kind,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span,
+            name: pat,
+            init: init.map(Box::new),
+            definite: false,
+        }],
+    })))
+}
+
+/// `__RTS_GEN_GET_RET(vec)` — sentinela que o codegen mapeia p/ ler o
+/// ret_value (`return X`) de uma generator delegada via `yield*`.
+fn gen_get_ret_call(vec: Expr, span: swc_common::Span) -> Expr {
+    Expr::Call(CallExpr {
+        span,
+        ctxt: Default::default(),
+        callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
+            "__RTS_GEN_GET_RET".into(),
+            span,
+            Default::default(),
+        )))),
+        args: vec![ExprOrSpread { spread: None, expr: Box::new(vec) }],
+        type_args: None,
+    })
 }
 
 /// Constroi `__RTS_GEN_FINISH(buf, ret)` — sentinela que o codegen mapeia

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -102,6 +102,15 @@ pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_RETURN(vec_handle: u64, value: i64) -
     make_result(value, true)
 }
 
+/// `__RTS_GEN_GET_RET(vec)` — devolve o ret_value (`return X`) registrado
+/// por uma generator fn finita, ou undefined se ausente. Usado por
+/// `const r = yield* gen()` (#275/#379): o desugar empurra os elementos do
+/// Vec delegado em __gen_buf e captura o ret_value em `r`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_GET_RET(vec_handle: u64) -> i64 {
+    GEN_RETS.with(|c| c.borrow().get(&vec_handle).copied()).unwrap_or(UNDEFINED)
+}
+
 /// Aloca o objeto-resultado `{value, done}` como Map.
 fn make_result(value: i64, done: bool) -> u64 {
     let mut m: IndexMap<String, i64> = IndexMap::new();

--- a/tests/generator_yield_star_return.test.ts
+++ b/tests/generator_yield_star_return.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "rts:test";
+
+// (#275) `const r = yield* gen()` — yield* em posicao de init de VarDecl,
+// capturando o ret_value (`return X`) do generator delegado. Antes o
+// desugar deixava o yield cru (catch-all) e o codegen rejeitava
+// ("unsupported expression: yield"). Agora reescreve para:
+//   const __yt = inner(); for (const __t of __yt) __gen_buf.push(__t);
+//   const r = __RTS_GEN_GET_RET(__yt);
+// e transform_stmt devolve Vec<Stmt> (inline) p/ preservar escopo de `r`.
+function* inner() { yield 1; yield 2; return 9; }
+function* outer() { const r = yield* inner(); yield r + 1; return r + 2; }
+
+const g = outer();
+const s0 = g.next();
+const s1 = g.next();
+const s2 = g.next();
+const s3 = g.next();
+const steps =
+  s0.value + ":" + s0.done + "|" +
+  s1.value + ":" + s1.done + "|" +
+  s2.value + ":" + s2.done + "|" +
+  s3.value + ":" + s3.done;
+
+// spread sobre generator com yield* delegando array/string.
+function* multi() {
+  yield 0;
+  yield* [10, 11];
+  yield* "ab";
+}
+const spread = [...multi()].join(",");
+
+describe("generator_yield_star_return (#275)", () => {
+  test("yield* captura ret_value do delegado", () =>
+    expect(steps).toBe("1:false|2:false|10:false|11:true"));
+  test("yield* delega array e string", () =>
+    expect(spread).toBe("0,10,11,a,b"));
+});


### PR DESCRIPTION
## Generator desugar B1 (plano parity-100) — fecha 275_generator_yieldstar

`const r = yield* gen()` — `yield*` em posição de **init de VarDecl** — ficava cru no catch-all de `transform_stmt` e o codegen rejeitava (`unsupported expression: yield`).

```
RTS antes: error: undefined variable `r` / unsupported expression: yield
RTS agora: steps=1:false|2:false|10:false|11:true   ← idêntico a Bun/Node
```

### Mudanças
**`generator_desugar.rs`**
- `transform_stmt` agora devolve `Vec<Stmt>` (era 1): permite reescrever uma decl em vários statements **inline**, preservando escopo (`const r` visível aos statements seguintes). `transform_stmt_single` envolve em Block só nas posições que exigem statement único (cons/alt, body de loop).
- Novo arm `Stmt::Decl(Var)` com init yield:
  ```
  const r = yield* gen()  ->
    const __yt_delegate_N = gen();
    for (const __t of __yt_delegate_N) __gen_buf.push(__t);
    const r = __RTS_GEN_GET_RET(__yt_delegate_N);
  ```

**`gc/generator.rs`**: `GENERATOR_GET_RET(vec)` lê o ret_value do side-table. Codegen: sentinela `__RTS_GEN_GET_RET`. Símbolo no JIT.

### Escopo honesto
Não fecha 276 (`.return`/`.throw` + finally), 368 (generator infinito → state machine #477), 379 (async generator). Fundação separada.

### Validação
- `tests/generator_yield_star_return.test.ts`: 2 casos
- Suite TS: **1636/1636** (+2, zero regressão — refactor Vec não quebrou generators existentes)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)