### PR TITLE
feat(codegen): console.* override runtime (#311 #312 FECHAM)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -581,6 +581,13 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_RT_TRUTHY", __RTS_FN_RT_TRUTHY);
     }
     {
+        use crate::namespaces::globals::console::rt::{
+            __RTS_FN_RT_CONSOLE_GET_OVERRIDE, __RTS_FN_RT_CONSOLE_SET_OVERRIDE,
+        };
+        add_fn!("__RTS_FN_RT_CONSOLE_SET_OVERRIDE", __RTS_FN_RT_CONSOLE_SET_OVERRIDE);
+        add_fn!("__RTS_FN_RT_CONSOLE_GET_OVERRIDE", __RTS_FN_RT_CONSOLE_GET_OVERRIDE);
+    }
+    {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TYPEOF_HANDLE;
         add_fn!("__RTS_FN_RT_TYPEOF_HANDLE", __RTS_FN_RT_TYPEOF_HANDLE);
     }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -927,6 +927,85 @@ pub(super) fn lower_console_call(
         return Ok(None);
     };
 
+    // (#310/#311/#312) Override runtime: se `(console as any).<method>` foi
+    // reatribuido, despacha pro handle custom via INVOKE_AUTO. Checa em
+    // runtime (GET_OVERRIDE != 0) e cai no nativo caso contrario. So' para
+    // metodos sem spread nos args (variadic empacotado em Vec).
+    if call.args.iter().all(|a| a.spread.is_none()) {
+        let (mp, ml) = ctx.emit_str_literal(method.as_bytes())?;
+        let get_ov = ctx.get_extern(
+            "__RTS_FN_RT_CONSOLE_GET_OVERRIDE",
+            &[cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let ov_inst = ctx.builder.ins().call(get_ov, &[mp, ml]);
+        let ov = ctx.builder.inst_results(ov_inst)[0];
+        let zero = ctx.builder.ins().iconst(cl::I64, 0);
+        let has_ov = ctx.builder.ins().icmp(
+            cranelift_codegen::ir::condcodes::IntCC::NotEqual,
+            ov,
+            zero,
+        );
+        let ov_block = ctx.builder.create_block();
+        let native_block = ctx.builder.create_block();
+        let merge = ctx.builder.create_block();
+        ctx.builder.append_block_param(merge, cl::I64);
+        ctx.builder.ins().brif(has_ov, ov_block, &[], native_block, &[]);
+
+        // Override block: empacota args em Vec e INVOKE_AUTO(ov, 0, vec).
+        ctx.builder.switch_to_block(ov_block);
+        ctx.builder.seal_block(ov_block);
+        let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
+        let vn_inst = ctx.builder.ins().call(vec_new, &[]);
+        let args_vec = ctx.builder.inst_results(vn_inst)[0];
+        let push = ctx.get_extern(
+            "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+            &[cl::I64, cl::I64],
+            None,
+        )?;
+        for arg in &call.args {
+            let tv = lower_expr(ctx, &arg.expr)?;
+            let v = ctx.coerce_to_i64(tv).val;
+            ctx.builder.ins().call(push, &[args_vec, v]);
+        }
+        let invoke = ctx.get_extern(
+            "__RTS_FN_RT_INVOKE_AUTO",
+            &[cl::I64, cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let inv_inst = ctx.builder.ins().call(invoke, &[ov, zero, args_vec]);
+        let inv_ret = ctx.builder.inst_results(inv_inst)[0];
+        ctx.builder.ins().jump(merge, &[inv_ret.into()]);
+
+        // Native block: dispatch builtin original (recursao com o mesmo
+        // qualified — mas agora ja' dentro do native_block, sem re-checar
+        // override pois a recursao chega aqui de novo... evitamos recursao:
+        // movemos a logica nativa para uma fn separada).
+        ctx.builder.switch_to_block(native_block);
+        ctx.builder.seal_block(native_block);
+        let native_tv = lower_console_call_native(ctx, method, call)?;
+        let native_v = match native_tv {
+            Some(tv) => ctx.coerce_to_i64(tv).val,
+            None => ctx.builder.ins().iconst(cl::I64, i64::MIN + 2),
+        };
+        ctx.builder.ins().jump(merge, &[native_v.into()]);
+
+        ctx.builder.switch_to_block(merge);
+        ctx.builder.seal_block(merge);
+        let result = ctx.builder.block_params(merge)[0];
+        return Ok(Some(TypedVal::new(result, ValTy::I64)));
+    }
+
+    lower_console_call_native(ctx, method, call)
+}
+
+/// Dispatch nativo dos metodos de console (sem checar override runtime).
+/// Separado de lower_console_call p/ evitar recursao no path de override.
+fn lower_console_call_native(
+    ctx: &mut FnCtx,
+    method: &str,
+    call: &CallExpr,
+) -> Result<Option<TypedVal>> {
     let target_symbol: &str = match method {
         "log" | "info" | "debug" => "__RTS_FN_NS_IO_PRINT",
         "error" | "warn" => "__RTS_FN_NS_IO_EPRINT",

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -281,6 +281,31 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     _ => e,
                 }
             }
+            // (#310/#311/#312) `(console as any).<method> = fn` — grava
+            // override runtime no side-table CONSOLE_OVERRIDES. O call site
+            // de console.<method> checa o override antes do builtin nativo.
+            if let Expr::Ident(obj_id) = peel(m.obj.as_ref()) {
+                if obj_id.sym.as_str() == "console" {
+                    if let MemberProp::Ident(prop) = &m.prop {
+                        use cranelift_codegen::ir::InstBuilder;
+                        use cranelift_codegen::ir::types as cl;
+                        let method = prop.sym.as_str();
+                        let (mp, ml) = ctx.emit_str_literal(method.as_bytes())?;
+                        let val_tv = lower_expr(ctx, &a.right)?;
+                        // fn handle (arrow/Function) ou 0 quando restaura o
+                        // original (capturado em `const g = console.group`,
+                        // que devolve 0 — sem handle nativo reificado).
+                        let fn_h = ctx.coerce_to_i64(val_tv).val;
+                        let set_fn = ctx.get_extern(
+                            "__RTS_FN_RT_CONSOLE_SET_OVERRIDE",
+                            &[cl::I64, cl::I64, cl::I64],
+                            None,
+                        )?;
+                        ctx.builder.ins().call(set_fn, &[mp, ml, fn_h]);
+                        return Ok(TypedVal::new(fn_h, ValTy::I64));
+                    }
+                }
+            }
             if let Expr::Ident(obj_id) = peel(m.obj.as_ref()) {
                 if obj_id.sym.as_str() == "globalThis" {
                     if let MemberProp::Computed(c) = &m.prop {

--- a/crates/rts-runtime/src/namespaces/globals/console/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/console/mod.rs
@@ -1,1 +1,2 @@
 pub mod abi;
+pub mod rt;

--- a/crates/rts-runtime/src/namespaces/globals/console/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/console/rt.rs
@@ -1,0 +1,57 @@
+//! (#310/#311/#312) Override runtime de metodos de console.
+//!
+//! O codegen despacha `console.log/group/table/...` por pattern sintatico
+//! (compile-time), entao reatribuir `(console as any).group = fn` em runtime
+//! era ignorado. Aqui mantemos um side-table thread-local
+//! `method -> Function handle`. O assignment grava nele; o call site checa
+//! antes de cair no builtin nativo.
+//!
+//! Reatribuir para o valor original (capturado antes via `const g =
+//! console.group`) volta o override a 0 (slot apagado) — `console.group`
+//! captura devolve o sentinel 0 (sem handle), entao SET_OVERRIDE(method, 0)
+//! limpa o slot e o call site volta ao nativo.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    /// method-name -> Function handle (0 = sem override / nativo).
+    static CONSOLE_OVERRIDES: RefCell<HashMap<String, i64>> = RefCell::new(HashMap::new());
+}
+
+/// `(console as any).<method> = fn` — grava o override. `fn == 0` apaga.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_CONSOLE_SET_OVERRIDE(
+    method_ptr: *const u8,
+    method_len: i64,
+    fn_handle: i64,
+) {
+    let method = read_method(method_ptr, method_len);
+    CONSOLE_OVERRIDES.with(|c| {
+        let mut m = c.borrow_mut();
+        if fn_handle == 0 {
+            m.remove(&method);
+        } else {
+            m.insert(method, fn_handle);
+        }
+    });
+}
+
+/// `console.<method>(...)` call site — devolve o handle do override ou 0
+/// (nativo). O codegen, se != 0, invoca via INVOKE_AUTO com os args.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_CONSOLE_GET_OVERRIDE(
+    method_ptr: *const u8,
+    method_len: i64,
+) -> i64 {
+    let method = read_method(method_ptr, method_len);
+    CONSOLE_OVERRIDES.with(|c| c.borrow().get(&method).copied().unwrap_or(0))
+}
+
+fn read_method(ptr: *const u8, len: i64) -> String {
+    if ptr.is_null() || len <= 0 {
+        return String::new();
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    String::from_utf8_lossy(slice).into_owned()
+}

--- a/tests/console_method_override.test.ts
+++ b/tests/console_method_override.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "rts:test";
+
+// (#311/#312) Reatribuir um metodo de console em runtime
+// (`(console as any).table = fn`) agora dispara o handle custom em vez do
+// builtin nativo. O codegen mantem um side-table runtime CONSOLE_OVERRIDES:
+// o assignment grava; o call site checa antes do nativo. Callbacks de
+// aridade FIXA (1-2 params) funcionam; rest-param (...args) ainda usa o
+// nativo (precisa flag variadic no FunctionData — follow-up #310).
+
+// table: 1 arg (espelha fixture cross-runtime 311_console_table)
+const tcalls: string[] = [];
+const origTable = console.table;
+(console as any).table = (arg: any) => {
+  tcalls.push(Array.isArray(arg) ? String(arg.length) : typeof arg);
+};
+console.table([{ a: 1 }, { a: 2 }]);
+(console as any).table = origTable;
+const tableResult = tcalls.join("|");
+
+// dir: 2 args (espelha 312_console_dir)
+const dcalls: string[] = [];
+const origDir = console.dir;
+(console as any).dir = (arg: any, opts: any) => {
+  dcalls.push(typeof arg + ":" + String(opts?.depth));
+};
+console.dir({ a: { b: 1 } }, { depth: 1 });
+(console as any).dir = origDir;
+const dirResult = dcalls.join("|");
+
+describe("console_method_override (#311/#312)", () => {
+  test("override table dispara handle custom", () => expect(tableResult).toBe("2"));
+  test("override dir recebe arg + opts", () => expect(dirResult).toBe("object:1"));
+});


### PR DESCRIPTION
## Cluster D (plano parity-100) — fecha 311_console_table + 312_console_dir

Reatribuir um método de console em runtime (`(console as any).table = fn`) agora dispara o handle custom em vez do builtin nativo. Antes `lower_console_call` despachava por pattern sintático (compile-time) e ignorava a reatribuição.

```
RTS antes: calls=        (override ignorado, nativo rodou)
RTS agora: calls=2       ← idêntico a Bun/Node
```

### Mudanças
- **`console/rt.rs`**: side-table thread-local `CONSOLE_OVERRIDES` (method → Function handle). `SET_OVERRIDE` grava (0 apaga), `GET_OVERRIDE` lê.
- **`lower_assign_expr`**: `(console as any).<m> = fn` → `CONSOLE_SET_OVERRIDE`.
- **`lower_console_call`**: antes do dispatch nativo, `GET_OVERRIDE(method)`; se ≠ 0, empacota args em Vec e `INVOKE_AUTO`; senão cai no nativo (extraído para `lower_console_call_native`, evitando recursão).

### Escopo honesto
Callbacks de aridade **fixa** (1-2 params: table/dir) funcionam. **310_console_group** usa `(...args) =>` (rest param) — `INVOKE_AUTO` ainda não empacota o overflow no array do rest (falta flag `variadic` no `FunctionData`). Follow-up.

### Validação
- `tests/console_method_override.test.ts`: 2 casos
- 311 + 312 byte-idênticos a Bun (`diff` limpo); native console.log/error intactos
- Suite TS: **1638/1638** (+2, zero regressão — refactor tocou todos os console.*)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)