### PR TITLE
fix(codegen): obj[key] preserva tipo real do valor (#216 fundacao)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -1657,19 +1657,15 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
                     )?;
                     let inst = ctx.builder.ins().call(get_fn, &[obj_handle, idx_tv.val]);
                     let raw = ctx.builder.inst_results(inst)[0];
-                    // (#261/#94) Pos-MAP_GET_KH com chave dinamica (string):
-                    // value=0 eh quase sempre um numero literal (`arr[k]`
-                    // em Vec, `m.get(k)` com valor 0). Usa VEC_SLOT que
-                    // formata 0 como "0" (nao "null"). Trade-off com
-                    // `map.set(k, null)` que tambem retorna 0 — caso raro.
-                    let coerce_fn = ctx.get_extern(
-                        "__RTS_FN_RT_TPL_COERCE_VEC_SLOT",
-                        &[cl::I64],
-                        Some(cl::I64),
-                    )?;
-                    let coerced_inst = ctx.builder.ins().call(coerce_fn, &[raw]);
-                    let coerced = ctx.builder.inst_results(coerced_inst)[0];
-                    Ok(TypedVal::new(coerced, ValTy::Handle))
+                    // (#216) NAO coerce eager pra string: o valor pode ser
+                    // function/number/symbol/object. Devolve o raw como I64
+                    // AMBIGUO (var_member_call_values) — `typeof` despacha
+                    // runtime (TYPEOF_HANDLE), chamada usa o handle Function,
+                    // e concat/template ainda coerce via TPL_COERCE_AUTO.
+                    // Antes TPL_COERCE_VEC_SLOT convertia tudo p/ string,
+                    // quebrando `obj[Symbol.x]()` e `typeof obj[Symbol.x]`.
+                    ctx.var_member_call_values.insert(raw);
+                    Ok(TypedVal::new(raw, ValTy::I64))
                 }
                 _ => {
                     let idx = ctx.coerce_to_i64(idx_tv).val;

--- a/tests/computed_var_key.test.ts
+++ b/tests/computed_var_key.test.ts
@@ -1,5 +1,7 @@
-// (#261 follow-up) `obj[k]` com k variavel — aplica TPL_COERCE_AUTO
-// no resultado pra que retorno seja string handle correto.
+// (#261/#216) `obj[k]` com k variavel — devolve o valor com o tipo REAL
+// (number/string/function/...), NAO coerce eager pra string. JS spec:
+// `o["age"]` eh o number 30, nao "30". A coercao p/ string acontece so'
+// no contexto de uso (concat/template via TPL_COERCE_AUTO).
 
 import { describe, test, expect } from "rts:test";
 
@@ -36,7 +38,8 @@ const fnRes = getField(o, "name");
 
 describe("computed_var_key", () => {
     test("o[k] string field", () => expect(v1).toBe("Alice"));
-    test("o[k] number field", () => expect(v2).toBe("30"));
+    // JS spec: o["age"] eh o number 30 (nao a string "30").
+    test("o[k] number field", () => expect(v2).toBe(30));
     test("o[k] tag field", () => expect(v3).toBe("admin"));
     test("template hi + o[k]", () => expect(t1).toBe("hi Alice"));
     test("template id= + o[age]", () => expect(t2).toBe("id=30"));

--- a/tests/symbol_key_value_fidelity.test.ts
+++ b/tests/symbol_key_value_fidelity.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "rts:test";
+
+// (#216) Ler `obj[symbolKey]` / `obj[varKey]` preserva o TIPO REAL do
+// valor (number/function/string), em vez de coerce eager pra string.
+// Antes TPL_COERCE_VEC_SLOT convertia tudo p/ string handle, quebrando
+// `typeof obj[k]`, chamada de funcao armazenada, e identidade numerica.
+
+const s = Symbol("k");
+
+// number sob chave symbol
+const oNum: any = {};
+oNum[s] = 42;
+const numVal = oNum[s];
+const numType: string = typeof numVal;
+
+// function sob chave symbol — armazena e chama
+const oFn: any = {};
+oFn[s] = (a: number, b: number) => a + b;
+const fnVal = oFn[s];
+const fnCall = fnVal(10, 5);
+
+// string sob chave symbol
+const oStr: any = {};
+oStr[s] = "hello";
+const strVal = oStr[s];
+
+// number sob chave string-var continua coercivel em concat
+const oo: any = { age: 30 };
+const k: string = "age";
+const concat = "id=" + oo[k];
+
+describe("symbol_key_value_fidelity (#216)", () => {
+  test("number sob symbol key mantem tipo", () => expect(numType).toBe("number"));
+  test("number sob symbol key mantem valor", () => expect(numVal).toBe(42));
+  test("function sob symbol key eh chamavel", () => expect(fnCall).toBe(15));
+  test("string sob symbol key", () => expect(strVal).toBe("hello"));
+  test("number sob var key coerce em concat", () => expect(concat).toBe("id=30"));
+});


### PR DESCRIPTION
## Fundação Symbol-as-key (#216) — value fidelity

Ler `obj[symbolKey]` ou `obj[varKey]` (chave Handle via `MAP_GET_KH`) passava o resultado por `TPL_COERCE_VEC_SLOT`, que convertia **qualquer** valor para string handle. Isso quebrava:
- `typeof obj[k]` → sempre "string" (era number/function/object)
- chamada de função armazenada sob chave symbol → retornava 0 (a função virava string)
- identidade numérica: `o["age"]` virava "30" em vez do number 30

```
RTS antes:  typeof=string   fn call=0
RTS agora:  typeof=number   fn call=99   (handle Function preservado e chamável)
```

### Fix
Devolve o valor raw como I64 **ambíguo** (`var_member_call_values`) em vez de coerce eager. `typeof` despacha runtime (`TYPEOF_HANDLE`), chamada usa o handle Function, e concat/template ainda coerce via `TPL_COERCE_AUTO`. Espelha o tratamento de `arr[i]`/`map.get(k)`.

### Teste corrigido (expectativa errada vs JS)
`computed_var_key.test.ts`: `o["age"]` agora espera o **number 30** (era `"30"` — encodava o bug; JS spec: `o["age"] === 30`, não `"30"`).

### Escopo honesto
Avança 274/299 (symbol-keyed values corretos) mas **não os fecha**: 274 precisa invocar `[Symbol.toPrimitive]` na coerção; 299 precisa `arr[Symbol.iterator]` → function handle real. Follow-up.

### Validação
- `tests/symbol_key_value_fidelity.test.ts`: 5 casos
- Suite TS: **1643/1643** (zero regressão — `m["x"]=0→undefined` é bug pré-existente separado no path string-literal, confirmado igual na main)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)