### PR TITLE
feat(codegen): dispatch [Symbol.toPrimitive] na coercao (#274 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -610,6 +610,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_SYMBOL_HAS_INSTANCE", __RTS_FN_GL_SYMBOL_HAS_INSTANCE);
         add_fn!("__RTS_FN_GL_SYMBOL_TO_PRIMITIVE", __RTS_FN_GL_SYMBOL_TO_PRIMITIVE);
         add_fn!("__RTS_FN_GL_SYMBOL_TO_STRING_TAG", __RTS_FN_GL_SYMBOL_TO_STRING_TAG);
+        add_fn!("__RTS_FN_RT_TO_PRIMITIVE", __RTS_FN_RT_TO_PRIMITIVE);
     }
 
     // Boolean class

--- a/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/basics.rs
@@ -209,30 +209,31 @@ pub(super) fn lower_unary(ctx: &mut FnCtx, u: &swc_ecma_ast::UnaryExpr) -> Resul
             // Handle string: parse numerico via NUM_COERCE.
             // I64/F64/I32: passthrough (ja sao numbers).
             match operand.ty {
-                ValTy::Handle => {
+                ValTy::Handle | ValTy::I64 | ValTy::U64 => {
+                    // (#216/274) ToNumber: primeiro ToPrimitive(obj, "number")
+                    // — se o operando for um objeto com [Symbol.toPrimitive],
+                    // invoca com hint "number". Sem o metodo, TO_PRIMITIVE
+                    // devolve o operando inalterado. Depois TO_NUMBER coage.
+                    let to_prim = ctx.get_extern(
+                        "__RTS_FN_RT_TO_PRIMITIVE",
+                        &[cl::I64, cl::I32],
+                        Some(cl::I64),
+                    )?;
+                    let hint = ctx.builder.ins().iconst(cl::I32, 0); // number
+                    let p_inst = ctx.builder.ins().call(to_prim, &[operand.val, hint]);
+                    let prim = ctx.builder.inst_results(p_inst)[0];
                     let coerce_fn = ctx.get_extern(
                         "__RTS_FN_RT_TO_NUMBER",
                         &[cl::I64],
                         Some(cl::F64),
                     )?;
-                    let inst = ctx.builder.ins().call(coerce_fn, &[operand.val]);
+                    let inst = ctx.builder.ins().call(coerce_fn, &[prim]);
                     let v = ctx.builder.inst_results(inst)[0];
                     Ok(TypedVal::new(v, ValTy::F64))
                 }
                 ValTy::Bool => {
                     // Bool i64 0/1 ja eh numero.
                     Ok(TypedVal::new(operand.val, ValTy::I64))
-                }
-                ValTy::I64 | ValTy::U64 => {
-                    // Pode ser sentinel (null/undefined). Routine via TO_NUMBER.
-                    let coerce_fn = ctx.get_extern(
-                        "__RTS_FN_RT_TO_NUMBER",
-                        &[cl::I64],
-                        Some(cl::F64),
-                    )?;
-                    let inst = ctx.builder.ins().call(coerce_fn, &[operand.val]);
-                    let v = ctx.builder.inst_results(inst)[0];
-                    Ok(TypedVal::new(v, ValTy::F64))
                 }
                 _ => Ok(operand),
             }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -228,13 +228,24 @@ pub(super) fn lower_coerce_to_string(ctx: &mut FnCtx, call: &CallExpr) -> Result
         // TPL_COERCE_AUTO. Caso geral.
         let needs_auto = matches!(tv.ty, crate::codegen::lower::ctx::ValTy::Handle | crate::codegen::lower::ctx::ValTy::U64);
         if needs_auto {
+            let val_i64 = ctx.coerce_to_i64(tv).val;
+            // (#216/274) ToString: primeiro ToPrimitive(obj, "string"). Se o
+            // obj tiver [Symbol.toPrimitive], invoca com hint "string"; senao
+            // devolve o operando inalterado. Depois TPL_COERCE_AUTO formata.
+            let to_prim = ctx.get_extern(
+                "__RTS_FN_RT_TO_PRIMITIVE",
+                &[cl::I64, cl::I32],
+                Some(cl::I64),
+            )?;
+            let hint = ctx.builder.ins().iconst(cl::I32, 1); // string
+            let p_inst = ctx.builder.ins().call(to_prim, &[val_i64, hint]);
+            let prim = ctx.builder.inst_results(p_inst)[0];
             let coerce_fn = ctx.get_extern(
                 "__RTS_FN_RT_TPL_COERCE_AUTO",
                 &[cl::I64],
                 Some(cl::I64),
             )?;
-            let val_i64 = ctx.coerce_to_i64(tv).val;
-            let inst = ctx.builder.ins().call(coerce_fn, &[val_i64]);
+            let inst = ctx.builder.ins().call(coerce_fn, &[prim]);
             let v = ctx.builder.inst_results(inst)[0];
             return Ok(Some(crate::codegen::lower::ctx::TypedVal::new(v, crate::codegen::lower::ctx::ValTy::Handle)));
         }

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1899,6 +1899,26 @@ pub(super) fn lower_add(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result
             )?;
             let inst = ctx.builder.ins().call(coerce_fn, &[lhs.val]);
             ctx.builder.inst_results(inst)[0]
+        } else if matches!(lhs.ty, ValTy::Handle) {
+            // (#216/274) ToPrimitive(obj, "default") antes do concat: se for
+            // Map com [Symbol.toPrimitive], invoca com hint "default"; senao
+            // (string/outros handles) devolve inalterado.
+            let to_prim = ctx.get_extern(
+                "__RTS_FN_RT_TO_PRIMITIVE",
+                &[cl::I64, cl::I32],
+                Some(cl::I64),
+            )?;
+            let hint = ctx.builder.ins().iconst(cl::I32, 2); // default
+            let p_inst = ctx.builder.ins().call(to_prim, &[lhs.val, hint]);
+            let prim = ctx.builder.inst_results(p_inst)[0];
+            // prim pode ser numero/string; TPL_COERCE_AUTO normaliza.
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_AUTO",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[prim]);
+            ctx.builder.inst_results(inst)[0]
         } else {
             ctx.coerce_to_handle(lhs)?.val
         };
@@ -1917,6 +1937,23 @@ pub(super) fn lower_add(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result
                 Some(cl::I64),
             )?;
             let inst = ctx.builder.ins().call(coerce_fn, &[rhs.val]);
+            ctx.builder.inst_results(inst)[0]
+        } else if matches!(rhs.ty, ValTy::Handle) {
+            // (#216/274) ToPrimitive(obj, "default") antes do concat.
+            let to_prim = ctx.get_extern(
+                "__RTS_FN_RT_TO_PRIMITIVE",
+                &[cl::I64, cl::I32],
+                Some(cl::I64),
+            )?;
+            let hint = ctx.builder.ins().iconst(cl::I32, 2); // default
+            let p_inst = ctx.builder.ins().call(to_prim, &[rhs.val, hint]);
+            let prim = ctx.builder.inst_results(p_inst)[0];
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_AUTO",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[prim]);
             ctx.builder.inst_results(inst)[0]
         } else {
             ctx.coerce_to_handle(rhs)?.val

--- a/crates/rts-runtime/src/namespaces/globals/symbol/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/symbol/rt.rs
@@ -148,6 +148,40 @@ pub extern "C" fn __RTS_FN_GL_SYMBOL_TO_STRING_TAG() -> u64 {
     well_known_handle("toStringTag")
 }
 
+unsafe extern "C" {
+    fn __RTS_FN_RT_INVOKE_AUTO(callee: i64, this_arg: i64, args_handle: u64) -> i64;
+}
+
+/// (#216/274) Coercao via `[Symbol.toPrimitive](hint)`. Se `obj` for um Map
+/// que tem a key `@@sym:<toPrimitive_handle>`, invoca o metodo passando o
+/// hint string ("number"/"string"/"default") e devolve o resultado. Caso
+/// contrario devolve `obj` inalterado (caller cai no coerce default).
+///
+/// hint_code: 0 = "number", 1 = "string", 2 = "default".
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_TO_PRIMITIVE(obj: i64, hint_code: i32) -> i64 {
+    let obj_h = obj as u64;
+    // So' Map pode ter [Symbol.toPrimitive]. Resolve o handle do well-known.
+    let tp_sym = __RTS_FN_GL_SYMBOL_TO_PRIMITIVE();
+    let key = format!("@@sym:{tp_sym}");
+    let method: Option<i64> = with_entry(obj_h, |e| match e {
+        Some(Entry::Map(m)) => m.get(&key).copied().filter(|v| *v != 0),
+        _ => None,
+    });
+    let Some(method) = method else {
+        return obj; // sem toPrimitive — caller usa coerce default.
+    };
+    let hint = match hint_code {
+        0 => "number",
+        1 => "string",
+        _ => "default",
+    };
+    let hint_h = alloc_entry(Entry::String(hint.as_bytes().to_vec()));
+    let args = alloc_entry(Entry::Vec(Box::new(vec![hint_h as i64])));
+    // this = obj (o metodo pode usar this.<campo>).
+    unsafe { __RTS_FN_RT_INVOKE_AUTO(method, obj, args) }
+}
+
 /// `sym.toString()` — "Symbol(description)" ou "Symbol()".
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_SYMBOL_TO_STRING(sym: u64) -> u64 {

--- a/tests/symbol_to_primitive.test.ts
+++ b/tests/symbol_to_primitive.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+// (#216/274) `[Symbol.toPrimitive](hint)` invocado na coercao:
+//   +obj          -> hint "number"
+//   String(obj)   -> hint "string"
+//   obj + ""      -> hint "default"
+// O metodo recebe o hint e seu retorno eh usado como valor primitivo.
+const obj: any = {
+  [Symbol.toPrimitive](hint: string) {
+    if (hint === "number") return 7;
+    if (hint === "string") return "str!";
+    return "def!";
+  },
+};
+
+const numHint = +obj;            // 7
+const strHint = String(obj);     // "str!"
+const defHint = (obj as any) + ""; // "def!"
+
+// objeto SEM toPrimitive continua "[object Object]" no default.
+const plain: any = { a: 1 };
+const plainConcat = (plain as any) + "";
+
+describe("symbol_to_primitive (#274)", () => {
+  test("hint number via +obj", () => expect(numHint).toBe(7));
+  test("hint string via String(obj)", () => expect(strHint).toBe("str!"));
+  test("hint default via obj + ''", () => expect(defHint).toBe("def!"));
+  test("objeto sem toPrimitive", () => expect(plainConcat).toBe("[object Object]"));
+});


### PR DESCRIPTION
## Camada 2 da fundação #216 — fecha 274_symbol_toprimitive

Após #1314 (value fidelity), os operadores de coerção agora detectam e invocam `[Symbol.toPrimitive](hint)` com o hint correto:

| Operação | hint |
|---|---|
| `+obj` | "number" |
| `String(obj)` | "string" |
| `obj + ""` | "default" |

```
RTS antes:  num=NaN   str=[object Object]   def=[object Object]
RTS agora:  num=7     str=str!              def=def!   ← idêntico a Bun/Node
```

### Implementação
- **runtime** `__RTS_FN_RT_TO_PRIMITIVE(obj, hint_code)` (symbol/rt.rs): busca a key `@@sym:<toPrimitive_handle>` no Map, invoca o método via `INVOKE_AUTO` com o hint string (this=obj), devolve o resultado. **Sem o método (ou operando não-Map: string/number), devolve o operando inalterado** — por isso o wrap em `lower_add` é transparente para concat comum.
- **codegen**: 3 call sites (`basics.rs` unary `+`, `coerce.rs` `String()`, `operators.rs` `lower_add` operando Handle).

### Validação
- `tests/symbol_to_primitive.test.ts`: 4 casos (3 hints + objeto sem toPrimitive → "[object Object]")
- 274 byte-idêntico a Bun; concat de string/number intactos
- Suite TS: **1647/1647** (+4, zero regressão — `lower_add` toca todo string-concat com Handle, validado)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)