### PR TITLE
fix(codegen): String(arr[k]==0) -> '0' nao 'null' (#94 FECHA, regressao #1314)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/coerce.rs
@@ -224,6 +224,32 @@ pub(super) fn lower_coerce_to_string(ctx: &mut FnCtx, call: &CallExpr) -> Result
             }
         }
         let tv = super::lower_expr(ctx, &arg.expr)?;
+        use crate::codegen::lower::ctx::ValTy as _VT;
+        // (#216/94) Operando I64 AMBIGUO (arr[k]/obj[k]/map.get — pode ser
+        // handle de string/function OU number puro). Sem isso, String(arr[k])
+        // onde arr[k]==0 caia em coerce_to_handle(I64) e formatava "null".
+        // ToPrimitive(string) primeiro (objetos c/ toPrimitive), depois
+        // TPL_COERCE_NUM_BIAS (0 -> "0", nao "null"; sentinel null -> "null").
+        let is_ambig = matches!(tv.ty, _VT::I64 | _VT::U64)
+            && ctx.var_member_call_values.contains(&tv.val);
+        if is_ambig {
+            let to_prim = ctx.get_extern(
+                "__RTS_FN_RT_TO_PRIMITIVE",
+                &[cl::I64, cl::I32],
+                Some(cl::I64),
+            )?;
+            let hint = ctx.builder.ins().iconst(cl::I32, 1); // string
+            let p_inst = ctx.builder.ins().call(to_prim, &[tv.val, hint]);
+            let prim = ctx.builder.inst_results(p_inst)[0];
+            let coerce_fn = ctx.get_extern(
+                "__RTS_FN_RT_TPL_COERCE_NUM_BIAS",
+                &[cl::I64],
+                Some(cl::I64),
+            )?;
+            let inst = ctx.builder.ins().call(coerce_fn, &[prim]);
+            let v = ctx.builder.inst_results(inst)[0];
+            return Ok(Some(crate::codegen::lower::ctx::TypedVal::new(v, _VT::Handle)));
+        }
         // Handle 0 (null em RTS) tambem stringifica como "null" via
         // TPL_COERCE_AUTO. Caso geral.
         let needs_auto = matches!(tv.ty, crate::codegen::lower::ctx::ValTy::Handle | crate::codegen::lower::ctx::ValTy::U64);


### PR DESCRIPTION
## Fecha 94_sparse_array_enumeration — corrige regressão exposta pelo #1314

A camada 1 de #216 (#1314) passou a devolver `arr[k]`/`obj[k]` como I64 **ambíguo** em vez de coerce eager. Isso expôs um buraco em `String()`: o operando I64 ambíguo **não** entrava no path `needs_auto` (só Handle/U64), caía em `coerce_to_handle(I64)` e value=0 formatava "null".

```
RTS antes:  forIn=0:null|2:2|...
RTS agora:  forIn=0:0|2:2|...    ← idêntico a Bun/Node
```

### Fix
Em `lower_coerce_to_string`, detecta operando I64 ambíguo (`var_member_call_values`) e usa `ToPrimitive(string)` + `TPL_COERCE_NUM_BIAS` (0→"0"; sentinel null→"null"), espelhando o que `lower_add` já faz.

### Validação
- 94 byte-idêntico a Bun; 274 (toPrimitive) intacto
- Suite TS: **1647/1647**
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)