### PR TITLE
feat(runtime): arr[Symbol.iterator] -> function handle (#299 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -184,6 +184,8 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_GC_GENERATOR_GET_RET", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_GET_RET);
     add_fn!("__RTS_FN_GL_ITERATOR_FROM", crate::namespaces::gc::generator::__RTS_FN_GL_ITERATOR_FROM);
     add_fn!("__RTS_FN_GL_ITERATOR_TO_ARRAY", crate::namespaces::gc::generator::__RTS_FN_GL_ITERATOR_TO_ARRAY);
+    add_fn!("__RTS_FN_GL_ARRAY_VALUES_ITER", crate::namespaces::gc::generator::__RTS_FN_GL_ARRAY_VALUES_ITER);
+    add_fn!("__RTS_FN_GL_ARRAY_ITERATOR_FN", crate::namespaces::gc::generator::__RTS_FN_GL_ARRAY_ITERATOR_FN);
     add_fn!("__RTS_FN_NS_GC_GENERATOR_RETURN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_RETURN);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_REGISTER", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_REGISTER);

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -44,6 +44,15 @@ fn decode_symbol_key(k: &str) -> Option<u64> {
     k.strip_prefix("@@sym:").and_then(|s| s.parse::<u64>().ok())
 }
 
+/// (#216/299) True se a key `@@sym:<h>` referencia o well-known
+/// `Symbol.iterator` (handle sticky cacheado em globals/symbol/rt).
+fn key_is_well_known_iterator(k: &str) -> bool {
+    match decode_symbol_key(k) {
+        Some(h) => h == crate::namespaces::globals::symbol::rt::__RTS_FN_GL_SYMBOL_ITERATOR(),
+        None => false,
+    }
+}
+
 fn str_from_abi<'a>(ptr: *const u8, len: i64) -> Option<&'a str> {
     if ptr.is_null() || len < 0 {
         return None;
@@ -448,9 +457,21 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET_KH(obj_h: u64, key_h: u64) -> 
         if let Some(n) = parse_array_index(&key) {
             return super::vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(obj_h, n as i64);
         }
+        // (#216/299) `arr[Symbol.iterator]` -> handle Function nativo
+        // (ARRAY_VALUES_ITER). typeof === "function", chamavel com this=arr.
+        if key_is_well_known_iterator(&key) {
+            return crate::namespaces::gc::generator::__RTS_FN_GL_ARRAY_ITERATOR_FN() as i64;
+        }
         return 0;
     }
-    with_map(obj_h, 0, |m| m.get(&key).copied().unwrap_or(0))
+    // Map: valor armazenado vence (ex: custom [Symbol.iterator]); se ausente
+    // e a key for o iterator well-known, devolve o iterator nativo de array
+    // (Map iteravel via entries — fallback minimo).
+    let stored = with_map(obj_h, 0, |m| m.get(&key).copied().unwrap_or(0));
+    if stored == 0 && key_is_well_known_iterator(&key) {
+        return crate::namespaces::gc::generator::__RTS_FN_GL_ARRAY_ITERATOR_FN() as i64;
+    }
+    stored
 }
 
 /// (cross-runtime #753) Dispatcher universal pra `obj[key] = value`:

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -125,6 +125,40 @@ fn make_result(value: i64, done: bool) -> u64 {
 // elementos restantes (cursor..len) e avança o cursor ao fim — a 2a chamada
 // retorna vazio (iterator esgotado), igual a JS.
 
+/// (#216/299) Metodo nativo `arr[Symbol.iterator]()` — recebe o array como
+/// `this` (has_this_param=true no FunctionData) e devolve um iterator sobre
+/// uma copia (mesmo backing de Iterator.from). Permite `for-of`/spread sobre
+/// o resultado e protocolo iteravel manual (`it.next()`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ARRAY_VALUES_ITER(this_arr: i64) -> i64 {
+    __RTS_FN_GL_ITERATOR_FROM(this_arr as u64) as i64
+}
+
+/// (#216/299) Devolve um handle Function que, chamado com `this`=arr, produz
+/// o iterator (ARRAY_VALUES_ITER). Usado por `arr[Symbol.iterator]` — o
+/// resultado tem `typeof === "function"` e eh chamavel. So' faz sentido p/
+/// Vec/array-like; caller decide quando emitir.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_ARRAY_ITERATOR_FN() -> u64 {
+    use crate::namespaces::gc::handles::FunctionData;
+    alloc_entry(Entry::Function(Box::new(FunctionData {
+        fn_ptr: __RTS_FN_GL_ARRAY_VALUES_ITER as u64,
+        arity: 1,
+        name: "[Symbol.iterator]".into(),
+        bound_this: 0,
+        has_bound_this: false,
+        bound_args: Vec::new(),
+        is_arrow: false,
+        has_this_param: true,
+        param_kinds: Vec::new(),
+        return_kind: 0,
+        packed_shim: 0,
+        source: None,
+        keep_alive: None,
+        prototype_handle: 0,
+    })))
+}
+
 /// `Iterator.from(vec)` — novo handle de iterator sobre uma cópia do Vec,
 /// com cursor lateral em 0.
 #[unsafe(no_mangle)]

--- a/tests/array_symbol_iterator.test.ts
+++ b/tests/array_symbol_iterator.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from "rts:test";
+
+// (#216/299) `arr[Symbol.iterator]` resolve p/ um handle Function nativo
+// (ARRAY_VALUES_ITER) — typeof === "function", chamavel. Antes a key
+// ausente no Vec dava 0 -> typeof "number". Reusa ITERATOR_FROM.
+const a = [1, 2, 3];
+const iterType: string = typeof a[Symbol.iterator];
+
+// arguments tambem (array-like) — espelha o fixture 299.
+function f(): string {
+  return typeof (arguments as any)[Symbol.iterator];
+}
+const argsIterType = f(1, 2, 3);
+
+// chave symbol custom (nao-iterator) ausente continua undefined-ish.
+const s = Symbol("x");
+const sType: string = typeof a[s];
+
+describe("array_symbol_iterator (#299)", () => {
+  test("arr[Symbol.iterator] eh function", () => expect(iterType).toBe("function"));
+  test("arguments[Symbol.iterator] eh function", () => expect(argsIterType).toBe("function"));
+  test("symbol custom ausente nao eh function", () => expect(sType === "function").toBe(false));
+});


### PR DESCRIPTION
## Camada 3 da fundação #216 — fecha 299_arguments_object

`arr[Symbol.iterator]` resolvia para 0 (key ausente no Vec) → `typeof "number"`. Agora devolve um handle Function nativo → `typeof "function"`, chamável com `this`=arr.

```
RTS antes:  args=3|1|1,2,3|number
RTS agora:  args=3|1|1,2,3|function   ← idêntico a Bun/Node
```

### Implementação
- **`gc/generator.rs`**: `ARRAY_VALUES_ITER(this_arr)` → iterator (delega `ITERATOR_FROM`); `ARRAY_ITERATOR_FN()` → handle Function (has_this_param, fn_ptr=ARRAY_VALUES_ITER).
- **`MAP_GET_KH`**: quando a key é o well-known `Symbol.iterator` (`key_is_well_known_iterator` compara o handle decodificado de `@@sym:<h>` com `SYMBOL_ITERATOR()`), devolve `ARRAY_ITERATOR_FN` — em Vec sempre, em Map só quando não há valor armazenado (custom `[Symbol.iterator]` vence).

### Escopo honesto
Fecha o `typeof`/identidade. O **protocolo iterável manual completo** (`arr[Symbol.iterator]().next()` em loop) continua não suportado — **já crashava na main** (segfault), mesma classe de 305/272. **Sem regressão de failure-mode** (verificado: main também crashava esse path).

### Validação
- `tests/array_symbol_iterator.test.ts`: 3 casos
- 299 byte-idêntico a Bun
- Suite TS: **1650/1650** (+3, zero regressão — toquei MAP_GET_KH para todas as leituras symbol-key)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)