### PR TITLE
feat(codegen): console override variadic (...args) (#310 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -585,9 +585,11 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     {
         use crate::namespaces::globals::console::rt::{
             __RTS_FN_RT_CONSOLE_GET_OVERRIDE, __RTS_FN_RT_CONSOLE_SET_OVERRIDE,
+            __RTS_FN_RT_CONSOLE_OVERRIDE_IS_VARIADIC,
         };
         add_fn!("__RTS_FN_RT_CONSOLE_SET_OVERRIDE", __RTS_FN_RT_CONSOLE_SET_OVERRIDE);
         add_fn!("__RTS_FN_RT_CONSOLE_GET_OVERRIDE", __RTS_FN_RT_CONSOLE_GET_OVERRIDE);
+        add_fn!("__RTS_FN_RT_CONSOLE_OVERRIDE_IS_VARIADIC", __RTS_FN_RT_CONSOLE_OVERRIDE_IS_VARIADIC);
     }
     {
         use crate::namespaces::gc::string_pool::__RTS_FN_RT_TYPEOF_HANDLE;

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -968,12 +968,33 @@ pub(super) fn lower_console_call(
             let v = ctx.coerce_to_i64(tv).val;
             ctx.builder.ins().call(push, &[args_vec, v]);
         }
+        // (#310) Callback variadic (`...args`): a lifted fn espera UM param
+        // (o array de args, pos expand_rest_args). Empacota args_vec dentro
+        // de outro Vec [args_vec] e passa esse como args. Senao (aridade
+        // fixa) passa os args individuais direto.
+        let is_var_fn = ctx.get_extern(
+            "__RTS_FN_RT_CONSOLE_OVERRIDE_IS_VARIADIC",
+            &[cl::I64, cl::I64],
+            Some(cl::I64),
+        )?;
+        let iv_inst = ctx.builder.ins().call(is_var_fn, &[mp, ml]);
+        let is_var = ctx.builder.inst_results(iv_inst)[0];
+        let is_var_b = ctx.builder.ins().icmp(
+            cranelift_codegen::ir::condcodes::IntCC::NotEqual,
+            is_var,
+            zero,
+        );
+        // wrapped = [args_vec]
+        let vn2 = ctx.builder.ins().call(vec_new, &[]);
+        let wrapped = ctx.builder.inst_results(vn2)[0];
+        ctx.builder.ins().call(push, &[wrapped, args_vec]);
+        let final_args = ctx.builder.ins().select(is_var_b, wrapped, args_vec);
         let invoke = ctx.get_extern(
             "__RTS_FN_RT_INVOKE_AUTO",
             &[cl::I64, cl::I64, cl::I64],
             Some(cl::I64),
         )?;
-        let inv_inst = ctx.builder.ins().call(invoke, &[ov, zero, args_vec]);
+        let inv_inst = ctx.builder.ins().call(invoke, &[ov, zero, final_args]);
         let inv_ret = ctx.builder.inst_results(inv_inst)[0];
         ctx.builder.ins().jump(merge, &[inv_ret.into()]);
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -291,17 +291,28 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                         use cranelift_codegen::ir::types as cl;
                         let method = prop.sym.as_str();
                         let (mp, ml) = ctx.emit_str_literal(method.as_bytes())?;
+                        // (#310) Detecta se o callback eh variadic (`...args`):
+                        // apos hoist_fn, a.right vira Ident da lifted fn.
+                        let is_variadic = match peel(a.right.as_ref()) {
+                            Expr::Ident(rid) => {
+                                crate::codegen::lower::passes::hoist_fn::is_lifted_variadic(
+                                    rid.sym.as_str(),
+                                )
+                            }
+                            _ => false,
+                        };
                         let val_tv = lower_expr(ctx, &a.right)?;
                         // fn handle (arrow/Function) ou 0 quando restaura o
                         // original (capturado em `const g = console.group`,
                         // que devolve 0 — sem handle nativo reificado).
                         let fn_h = ctx.coerce_to_i64(val_tv).val;
+                        let var_flag = ctx.builder.ins().iconst(cl::I64, is_variadic as i64);
                         let set_fn = ctx.get_extern(
                             "__RTS_FN_RT_CONSOLE_SET_OVERRIDE",
-                            &[cl::I64, cl::I64, cl::I64],
+                            &[cl::I64, cl::I64, cl::I64, cl::I64],
                             None,
                         )?;
-                        ctx.builder.ins().call(set_fn, &[mp, ml, fn_h]);
+                        ctx.builder.ins().call(set_fn, &[mp, ml, fn_h, var_flag]);
                         return Ok(TypedVal::new(fn_h, ValTy::I64));
                     }
                 }

--- a/crates/rts-codegen/src/codegen/lower/passes/hoist_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/hoist_fn.rs
@@ -15,6 +15,26 @@ use crate::parser::ast::{
 };
 use crate::parser::span::Span;
 
+thread_local! {
+    /// (#310) Nomes de fns hoisted/lifted cujo ULTIMO param eh variadic
+    /// (`...rest`). Lido no reify p/ marcar o FunctionData como variadic,
+    /// fazendo INVOKE_AUTO empacotar os args excedentes num array.
+    static LIFTED_VARIADIC: std::cell::RefCell<std::collections::HashSet<String>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+}
+
+/// (#310) Registra que `name` (fn lifted) tem rest param variadic.
+pub(crate) fn mark_lifted_variadic(name: &str) {
+    LIFTED_VARIADIC.with(|c| {
+        c.borrow_mut().insert(name.to_string());
+    });
+}
+
+/// (#310) True se `name` foi marcada variadic (rest param no fim).
+pub(crate) fn is_lifted_variadic(name: &str) -> bool {
+    LIFTED_VARIADIC.with(|c| c.borrow().contains(name))
+}
+
 pub(crate) fn hoist_fn_expressions(program: &mut Program) {
     use swc_ecma_ast::{ArrowExpr, BlockStmtOrExpr};
 
@@ -375,6 +395,11 @@ pub(crate) fn hoist_fn_expressions(program: &mut Program) {
             }
             _ => unreachable!(),
         };
+        // (#310) Registra variadic se o ultimo param eh rest — INVOKE_AUTO
+        // empacota os args excedentes num array ao invocar via handle.
+        if fn_decl.parameters.last().map(|p| p.variadic).unwrap_or(false) {
+            mark_lifted_variadic(&name);
+        }
         new_fns.push(Item::Function(fn_decl));
         *expr = fresh_ident(&name);
     }

--- a/crates/rts-runtime/src/namespaces/globals/console/rt.rs
+++ b/crates/rts-runtime/src/namespaces/globals/console/rt.rs
@@ -15,16 +15,20 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 thread_local! {
-    /// method-name -> Function handle (0 = sem override / nativo).
-    static CONSOLE_OVERRIDES: RefCell<HashMap<String, i64>> = RefCell::new(HashMap::new());
+    /// method-name -> (Function handle, variadic). handle 0 = sem override.
+    static CONSOLE_OVERRIDES: RefCell<HashMap<String, (i64, bool)>> =
+        RefCell::new(HashMap::new());
 }
 
 /// `(console as any).<method> = fn` — grava o override. `fn == 0` apaga.
+/// `variadic != 0` indica callback `(...args)` — o call site empacota todos
+/// os args num unico array (#310).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_RT_CONSOLE_SET_OVERRIDE(
     method_ptr: *const u8,
     method_len: i64,
     fn_handle: i64,
+    variadic: i64,
 ) {
     let method = read_method(method_ptr, method_len);
     CONSOLE_OVERRIDES.with(|c| {
@@ -32,7 +36,7 @@ pub extern "C" fn __RTS_FN_RT_CONSOLE_SET_OVERRIDE(
         if fn_handle == 0 {
             m.remove(&method);
         } else {
-            m.insert(method, fn_handle);
+            m.insert(method, (fn_handle, variadic != 0));
         }
     });
 }
@@ -45,7 +49,20 @@ pub extern "C" fn __RTS_FN_RT_CONSOLE_GET_OVERRIDE(
     method_len: i64,
 ) -> i64 {
     let method = read_method(method_ptr, method_len);
-    CONSOLE_OVERRIDES.with(|c| c.borrow().get(&method).copied().unwrap_or(0))
+    CONSOLE_OVERRIDES.with(|c| c.borrow().get(&method).map(|(h, _)| *h).unwrap_or(0))
+}
+
+/// (#310) True (1) se o override do metodo eh variadic (`...args`) — o call
+/// site empacota os args num unico array antes de INVOKE_AUTO.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_CONSOLE_OVERRIDE_IS_VARIADIC(
+    method_ptr: *const u8,
+    method_len: i64,
+) -> i64 {
+    let method = read_method(method_ptr, method_len);
+    CONSOLE_OVERRIDES.with(|c| {
+        c.borrow().get(&method).map(|(_, v)| *v as i64).unwrap_or(0)
+    })
 }
 
 fn read_method(ptr: *const u8, len: i64) -> String {

--- a/tests/console_override_variadic.test.ts
+++ b/tests/console_override_variadic.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "rts:test";
+
+// (#310) Override de console.* com callback REST (`...args`). Apos
+// expand_rest_args a lifted fn espera 1 param (o array). O call site
+// detecta variadic (LIFTED_VARIADIC) e empacota os args num unico array
+// antes de INVOKE_AUTO. Antes o arrow recebia args individuais -> "null".
+const ev: string[] = [];
+const origGroup = console.group;
+const origEnd = console.groupEnd;
+(console as any).group = (...args: any[]) => { ev.push("g:" + args.join(",")); };
+(console as any).groupEnd = () => { ev.push("end"); };
+console.group("x");
+console.group("a", "b", "c");
+console.groupEnd();
+(console as any).group = origGroup;
+(console as any).groupEnd = origEnd;
+const result = ev.join("|");
+
+describe("console_override_variadic (#310)", () => {
+  test("rest callback recebe args empacotados", () =>
+    expect(result).toBe("g:x|g:a,b,c|end"));
+});


### PR DESCRIPTION
## Follow-up do #1313 — fecha 310_console_group

Override de console.* com callback REST (`(...args) =>`) recebia os args individuais; o arrow (que após `expand_rest_args` espera 1 param = o array) lia só o 1º → `g:null`. Agora o call site empacota os args num único array quando o callback é variadic.

```
RTS antes:  ev=g:null
RTS agora:  ev=g:x|g:a,b,c|end   ← idêntico a Bun/Node
```

### Implementação (registry LIFTED_VARIADIC → flag no override → packing no call site)
- **`hoist_fn.rs`**: registry `LIFTED_VARIADIC` + `mark/is_lifted_variadic`. Marca a lifted fn quando o último param é variadic.
- **`mod.rs`** (assign): detecta via `is_lifted_variadic` no Ident da lifted fn e passa flag para `SET_OVERRIDE`.
- **`console/rt.rs`**: `CONSOLE_OVERRIDES` guarda `(handle, variadic)`; `OVERRIDE_IS_VARIADIC` expõe.
- **`builtins.rs`** (call site): se variadic, embrulha `args_vec` em `[args_vec]` (select runtime); senão args individuais.

### Validação
- `tests/console_override_variadic.test.ts`: rest 1-arg + multi-arg + groupEnd 0-arg + restore
- 310/311/312 byte-idênticos a Bun
- Suite TS: **1651/1651** (+1, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)