### PR TITLE
feat(codegen): structuredClone transfer/detach + anonymous TA views (#68 FECHA)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1886,6 +1886,7 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_GL_TA_SET_ELEM", buf::__RTS_FN_GL_TA_SET_ELEM);
     add_fn!("__RTS_FN_GL_TA_LENGTH", buf::__RTS_FN_GL_TA_LENGTH);
     add_fn!("__RTS_FN_GL_TA_SET_FROM", buf::__RTS_FN_GL_TA_SET_FROM);
+    add_fn!("__RTS_FN_GL_BUFFER_DETACH", buf::__RTS_FN_GL_BUFFER_DETACH);
     add_fn!("__RTS_FN_GL_ATOMICS_RMW", buf::__RTS_FN_GL_ATOMICS_RMW);
     add_fn!("__RTS_FN_GL_ATOMICS_CAS", buf::__RTS_FN_GL_ATOMICS_CAS);
     add_fn!("__RTS_FN_GL_ATOMICS_LOAD", buf::__RTS_FN_GL_ATOMICS_LOAD);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -571,6 +571,57 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                     }
                 }
             }
+            // (#68) `new Uint8Array(buf).set([...])` — receiver ANONIMO
+            // (view sem binding). `new TypedArray(arraybuffer-ident)` lowera
+            // pro handle do buffer (view-viva); extrai elem_bytes do nome da
+            // classe e roteia pra TA_SET_FROM. Espelha o caso Ident acima.
+            if let Expr::New(ne) = m.obj.as_ref() {
+                if let MemberProp::Ident(prop) = &m.prop {
+                    if prop.sym.as_str() == "set"
+                        && matches!(
+                            call.args.first().map(|a| a.expr.as_ref()),
+                            Some(Expr::Array(_))
+                        )
+                        && call.args.iter().all(|a| a.spread.is_none())
+                    {
+                        // (eb, signed, is_float) via typed_array_kind (bits->bytes).
+                        let ta_meta = match ne.callee.as_ref() {
+                            Expr::Ident(cid) => self::new_expr::typed_array_kind(cid.sym.as_str())
+                                .map(|e| ((e.bits / 8) as i64, e.signed as i64, e.is_float as i64)),
+                            _ => None,
+                        };
+                        // o arg do new precisa ser um (Shared)ArrayBuffer ident.
+                        let arg_is_buf = ne.args.as_ref()
+                            .and_then(|a| a.first())
+                            .map(|a| matches!(a.expr.as_ref(),
+                                Expr::Ident(id) if ctx.local_class_ty.get(id.sym.as_str())
+                                    .map(|c| c == "ArrayBuffer" || c == "SharedArrayBuffer")
+                                    .unwrap_or(false)))
+                            .unwrap_or(false);
+                        if let (Some((eb, _sg, fl)), true) = (ta_meta, arg_is_buf) {
+                            let recv_tv = lower_expr(ctx, &m.obj)?;
+                            let buf_h = ctx.coerce_to_i64(recv_tv).val;
+                            let src_tv = lower_expr(ctx, &call.args[0].expr)?;
+                            let src_h = ctx.coerce_to_i64(src_tv).val;
+                            let offset = if let Some(a) = call.args.get(1) {
+                                let tv = lower_expr(ctx, &a.expr)?;
+                                ctx.coerce_to_i64(tv).val
+                            } else {
+                                ctx.builder.ins().iconst(cl::I64, 0)
+                            };
+                            let eb_v = ctx.builder.ins().iconst(cl::I64, eb);
+                            let fl_v = ctx.builder.ins().iconst(cl::I64, fl);
+                            let f = ctx.get_extern(
+                                "__RTS_FN_GL_TA_SET_FROM",
+                                &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I64],
+                                None,
+                            )?;
+                            ctx.builder.ins().call(f, &[buf_h, src_h, offset, eb_v, fl_v]);
+                            return Ok(TypedVal::new(buf_h, ValTy::Handle));
+                        }
+                    }
+                }
+            }
             if let Some(qualified) = qualified_member_name(callee) {
                 // Console builtin precisa preceder o lookup (#380).
                 if let Some(tv) = lower_console_call(ctx, &qualified, call)? {
@@ -3044,7 +3095,34 @@ fn lower_js_global_call(
                     }
                 }
             }
-            Ok(Some(lower_ns_call(ctx, "text_encoding.structuredClone", call)?))
+            // (#68) structuredClone(buf, { transfer: [buf] }) — JS spec: o
+            // buffer fonte fica DETACHED (byteLength -> 0). Detecta o 2o arg
+            // com key `transfer` e, se o 1o arg eh um (Shared)ArrayBuffer
+            // ident, emite BUFFER_DETACH(src) APOS o clone.
+            let detach_src: Option<cranelift_codegen::ir::Value> = if call.args.len() >= 2 {
+                let has_transfer = matches!(call.args[1].expr.as_ref(),
+                    Expr::Object(o) if o.props.iter().any(|p| matches!(p,
+                        swc_ecma_ast::PropOrSpread::Prop(pp) if matches!(pp.as_ref(),
+                            swc_ecma_ast::Prop::KeyValue(kv) if matches!(&kv.key,
+                                swc_ecma_ast::PropName::Ident(id) if id.sym.as_str() == "transfer")))));
+                let src_is_buf = matches!(call.args[0].expr.as_ref(),
+                    Expr::Ident(id) if ctx.local_class_ty.get(id.sym.as_str())
+                        .map(|c| c == "ArrayBuffer" || c == "SharedArrayBuffer").unwrap_or(false));
+                if has_transfer && src_is_buf {
+                    let src_tv = lower_expr(ctx, &call.args[0].expr)?;
+                    Some(ctx.coerce_to_i64(src_tv).val)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            let cloned = lower_ns_call(ctx, "text_encoding.structuredClone", call)?;
+            if let Some(src) = detach_src {
+                let detach = ctx.get_extern("__RTS_FN_GL_BUFFER_DETACH", &[cl::I64], None)?;
+                ctx.builder.ins().call(detach, &[src]);
+            }
+            Ok(Some(cloned))
         }
         "queueMicrotask" => Ok(Some(lower_ns_call(ctx, "text_encoding.queueMicrotask", call)?)),
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -726,9 +726,9 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
 /// `None` quando o nome nao eh um TypedArray conhecido.
 #[derive(Clone, Copy)]
 pub(super) struct TaElem {
-    bits: u32,
-    signed: bool,
-    is_float: bool,
+    pub(super) bits: u32,
+    pub(super) signed: bool,
+    pub(super) is_float: bool,
 }
 
 pub(super) fn typed_array_kind(name: &str) -> Option<TaElem> {

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -742,6 +742,21 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                             // fetch() → Response
                             if fname == "fetch" {
                                 ctx.local_class_ty.insert(name.clone(), "Response".to_string());
+                            } else if fname == "structuredClone" {
+                                // (#68) structuredClone(buf) de (Shared)ArrayBuffer
+                                // devolve outro buffer (clone byte-a-byte). Propaga
+                                // ArrayBuffer p/ que `new Uint8Array(moved)` use o
+                                // path view-viva (sem isso vira Vec vazio).
+                                if let Some(a) = call.args.first() {
+                                    if let swc_ecma_ast::Expr::Ident(aid) = a.expr.as_ref() {
+                                        if ctx.local_class_ty.get(aid.sym.as_str())
+                                            .map(|c| c == "ArrayBuffer" || c == "SharedArrayBuffer")
+                                            .unwrap_or(false)
+                                        {
+                                            ctx.local_class_ty.insert(name.clone(), "ArrayBuffer".to_string());
+                                        }
+                                    }
+                                }
                             } else if let Some(cn) = ctx.fn_class_returns.get(fname) {
                                 ctx.local_class_ty.insert(name.clone(), cn.clone());
                             }

--- a/crates/rts-runtime/src/namespaces/buffer/ops.rs
+++ b/crates/rts-runtime/src/namespaces/buffer/ops.rs
@@ -648,3 +648,11 @@ pub extern "C" fn __RTS_FN_GL_TA_LENGTH(handle: u64, elem_bytes: i64) -> i64 {
         (b.len() as i64) / elem_bytes
     })
 }
+
+/// (#68) Detach de ArrayBuffer (transferencia via structuredClone
+/// `{transfer:[buf]}`). JS spec: o buffer fonte fica detached — byteLength
+/// vira 0 e views sobre ele leem 0. RTS modela truncando o Buffer a vazio.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_BUFFER_DETACH(handle: u64) {
+    with_buffer_mut(handle, (), |b| b.clear());
+}

--- a/tests/arraybuffer_transfer_clone.test.ts
+++ b/tests/arraybuffer_transfer_clone.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "rts:test";
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+// (#68) structuredClone(buf, { transfer: [buf] }) — buffer fonte detached
+// (byteLength 0), clone independente com os bytes. Cobre: anonymous view
+// set/read (`new Uint8Array(buf).set(...)` / `Array.from(new Uint8Array)`)
+// + structuredClone byte-copy + detach.
+const buffer = new ArrayBuffer(4);
+new Uint8Array(buffer).set([10, 20, 30, 40]);
+const moved = structuredClone(buffer, { transfer: [buffer] });
+
+const origLen = buffer.byteLength;       // 0 (detached)
+const movedLen = moved.byteLength;       // 4
+const movedBytes = Array.from(new Uint8Array(moved)).join(","); // 10,20,30,40
+
+// clone SEM transfer nao detacha.
+const keep = new ArrayBuffer(2);
+new Uint8Array(keep).set([1, 2]);
+const copy = structuredClone(keep);
+const keepLen = keep.byteLength;         // 2 (intacto)
+const copyBytes = Array.from(new Uint8Array(copy)).join(","); // 1,2
+
+describe("arraybuffer_transfer_clone (#68)", () => {
+  test("buffer fonte detached (byteLength 0)", () => expect(origLen).toBe(0));
+  test("clone preserva byteLength", () => expect(movedLen).toBe(4));
+  test("clone preserva bytes", () => expect(movedBytes).toBe("10,20,30,40"));
+  test("clone sem transfer nao detacha", () => expect(keepLen).toBe(2));
+  test("clone sem transfer copia bytes", () => expect(copyBytes).toBe("1,2"));
+});


### PR DESCRIPTION
## Fecha 68_arraybuffer_transfer_clone — completa as 3 peças (camada 1 foi #1311)

```
RTS antes:  orig_len=4  moved_len=4  moved=          (3 bugs)
RTS agora:  orig_len=0  moved_len=4  moved=10,20,30,40   ← idêntico a Bun/Node
```

### As 3 peças
1. **structuredClone → ArrayBuffer**: `const moved = structuredClone(buf)` propaga `local_class_ty "ArrayBuffer"` (decls.rs) p/ que `new Uint8Array(moved)` use o path view-viva (era Vec vazio).
2. **Anonymous TA view set**: `new Uint8Array(buf).set([...])` (receiver `New` sem binding) roteia p/ `TA_SET_FROM` extraindo elem_bytes de `typed_array_kind`, espelhando o caso Ident.
3. **Transfer/detach**: `structuredClone(buf, { transfer: [buf] })` detecta a key `transfer` no 2º arg e, se o 1º é (Shared)ArrayBuffer, emite `BUFFER_DETACH` (trunca o Buffer fonte a vazio → byteLength 0) **após** o clone.

### Validação
- `tests/arraybuffer_transfer_clone.test.ts`: 5 casos (detach, byteLength, bytes, no-transfer-keeps, no-transfer-copy)
- 68 byte-idêntico a Bun; clone sem transfer NÃO detacha; structuredClone de objeto comum intacto
- Suite TS: **1656/1656** (+5, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)