### PR TITLE
fix(codegen): lift/rewrite de array methods desce em TsAs cast (#394 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1042,6 +1042,18 @@ fn lift_arrows_in_expr(
         Expr::Paren(p) => {
             lift_arrows_in_expr(&mut p.expr, user_fn_names, new_fns, counter);
         }
+        // (#394) Cast TS envolvendo a call: `arr.filter(fn) as T[]`. Sem
+        // descer no TsAs/TsTypeAssertion, o arrow inline nao era liftado e o
+        // `arr.filter(inline_arrow)` cru chegava ao codegen -> SIGILL.
+        Expr::TsAs(a) => {
+            lift_arrows_in_expr(&mut a.expr, user_fn_names, new_fns, counter);
+        }
+        Expr::TsTypeAssertion(a) => {
+            lift_arrows_in_expr(&mut a.expr, user_fn_names, new_fns, counter);
+        }
+        Expr::TsNonNull(n) => {
+            lift_arrows_in_expr(&mut n.expr, user_fn_names, new_fns, counter);
+        }
         Expr::Unary(u) => {
             lift_arrows_in_expr(&mut u.arg, user_fn_names, new_fns, counter);
         }
@@ -1812,6 +1824,21 @@ fn rewrite_array_methods_in_expr(expr: &mut Expr, user_fn_names: &HashSet<String
         }
         Expr::Paren(p) => {
             rewrite_array_methods_in_expr(&mut p.expr, user_fn_names);
+            return;
+        }
+        // (#394) Cast TS envolvendo a call: `arr.filter(fn) as T[]`. Sem
+        // descer, o `arr.filter(lifted)` cru chega ao codegen e mis-despacha
+        // (MAP_GET("filter") em Vec) -> SIGILL.
+        Expr::TsAs(a) => {
+            rewrite_array_methods_in_expr(&mut a.expr, user_fn_names);
+            return;
+        }
+        Expr::TsTypeAssertion(a) => {
+            rewrite_array_methods_in_expr(&mut a.expr, user_fn_names);
+            return;
+        }
+        Expr::TsNonNull(n) => {
+            rewrite_array_methods_in_expr(&mut n.expr, user_fn_names);
             return;
         }
         Expr::Unary(u) => {

--- a/tests/array_method_ts_cast.test.ts
+++ b/tests/array_method_ts_cast.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "rts:test";
+
+// (#394) `arr.filter(fn) as T[]` — o cast TS envolvendo a call de array
+// method impedia os passes de lift/rewrite de descer no TsAs, deixando o
+// `arr.filter(inline_arrow)` cru chegar ao codegen -> SIGILL. Agora os
+// passes descem em TsAs/TsTypeAssertion/TsNonNull.
+const s = [1, 2, 3, 4];
+
+// cast direto sobre filter
+const evens = s.filter((v) => v % 2 === 0) as number[];
+const evensStr = evens.join(",");
+
+// cast sobre map
+const doubled = s.map((v) => v * 2) as number[];
+const doubledStr = doubled.join(",");
+
+// destructuring + cast (caso do 394)
+const [firstEven] = s.filter((v) => v > 2) as number[];
+
+// cast aninhado em template/expr
+const total = (s.filter((v) => v > 1) as number[]).length;
+
+describe("array_method_ts_cast (#394)", () => {
+  test("filter as T[]", () => expect(evensStr).toBe("2,4"));
+  test("map as T[]", () => expect(doubledStr).toBe("2,4,6,8"));
+  test("destructuring de filter cast", () => expect(firstEven).toBe(3));
+  test("length de filter cast", () => expect(total).toBe(3));
+});


### PR DESCRIPTION
## Corrige SIGILL em `arr.filter(fn) as T[]` (avança #394)

`arr.filter(fn) as T[]` (cast TS direto sobre a call de array method) causava **illegal instruction**: os passes de silent-parallelism (`lift_arrows_in_expr` e `rewrite_array_methods_in_expr`) tinham caso para Paren/Unary/Member mas **não** para TsAs/TsTypeAssertion/TsNonNull. O arrow inline não era liftado → `arr.filter(inline_arrow)` cru chegava ao codegen → mis-despacho (`MAP_GET("filter")` em Vec) → SIGILL.

```
RTS antes:  illegal instruction (132)
RTS agora:  funciona (lift + rewrite descem no cast)
```

### Fix
Ambos os passes descem em `TsAs`/`TsTypeAssertion`/`TsNonNull` (espelhando Paren). Corrige `arr.filter()/map()/etc as T[]`, com destructuring (`const [a] = arr.filter() as T[]`) e em sub-expr (`(arr.filter() as T[]).length`).

### Escopo honesto
Avança 394 (passa do SIGILL/`undefined __destruct_0` para um erro posterior de `parallel.filter_bound` dispatch — follow-up). **Não fecha 394 sozinho** (precisa também do deep-clone de Map/Set aninhado + instanceof filter).

### Validação
- `tests/array_method_ts_cast.test.ts`: 4 casos
- Suite TS: **1660/1660** (+4, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)