### PR TITLE
fix(codegen): classes globais em callback nao sao captura de escopo (#394 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/parallelism.rs
@@ -1415,7 +1415,16 @@ fn is_known_global_ident(name: &str) -> bool {
         | "collections" | "crypto" | "regex" | "json" | "date"
         | "Math" | "String" | "Number" | "Date" | "JSON" | "RegExp"
         | "Error" | "TypeError" | "RangeError" | "SyntaxError"
+        | "ReferenceError" | "EvalError" | "URIError" | "AggregateError"
         | "Array" | "Object" | "Boolean" | "Symbol"
+        // (#394) classes globais construtoras usadas em `x instanceof C` /
+        // `new C()` dentro de callbacks — NAO sao capturas de escopo.
+        | "Set" | "Map" | "WeakMap" | "WeakSet" | "Promise" | "Proxy"
+        | "Reflect" | "BigInt" | "ArrayBuffer" | "SharedArrayBuffer"
+        | "DataView" | "Int8Array" | "Uint8Array" | "Uint8ClampedArray"
+        | "Int16Array" | "Uint16Array" | "Int32Array" | "Uint32Array"
+        | "Float32Array" | "Float64Array" | "BigInt64Array" | "BigUint64Array"
+        | "Function" | "URL" | "URLSearchParams" | "TextEncoder" | "TextDecoder"
         | "console" | "performance" | "globalThis"
         | "undefined" | "null" | "NaN" | "Infinity"
         | "true" | "false"

--- a/tests/callback_global_ident.test.ts
+++ b/tests/callback_global_ident.test.ts
@@ -1,0 +1,25 @@
+import { describe, test, expect } from "rts:test";
+
+// (#394) Callbacks de array methods que referenciam classes globais
+// construtoras (`v instanceof Set`, `new Array(v)`, `Array.isArray(v)`)
+// NAO devem tratar o nome global como captura de escopo. Antes, `Set`/
+// `Map`/etc faltavam em is_known_global_ident -> viravam captura ->
+// parallel.filter_bound nao resolvia o "local" `Set` -> erro de dispatch.
+const mixed: any[] = [1, "x", [2, 3], { k: 4 }];
+
+const arrays = mixed.filter((v) => Array.isArray(v));
+const arraysLen = arrays.length; // 1
+
+const nums = [1, 2, 3];
+const sizes = nums.map((v) => new Array(v).length).join(","); // 1,2,3
+
+// instanceof com classe global no callback (nao crasha).
+const things: any[] = [1, 2, 3];
+const sets = things.filter((v) => v instanceof Set);
+const setsLen = sets.length; // 0
+
+describe("callback_global_ident (#394)", () => {
+  test("filter Array.isArray", () => expect(arraysLen).toBe(1));
+  test("map new Array(v).length", () => expect(sizes).toBe("1,2,3"));
+  test("filter instanceof Set nao crasha", () => expect(setsLen).toBe(0));
+});


### PR DESCRIPTION
## Corrige crash em `arr.filter(v => v instanceof Set)` (avança #394)

`arr.filter(v => v instanceof Set)` / `.map(v => new Map())` crashava com `unknown namespace member parallel.filter_bound`.

**Causa:** `is_known_global_ident` (usado por `collect_free_captures` para excluir globais das capturas) listava Array/Object/Symbol mas **faltavam** Set/Map/WeakMap/WeakSet/Promise/Proxy/Reflect/BigInt/ArrayBuffer/typed-arrays/DataView/Function/URL/TextEncoder/errors extras. Então `Set` virava "captura" → lift como `__lifted_cap_` → `lower_parallel_bound_call` tentava `read_local("Set")` → None → bail → fallthrough para lookup ABI → erro.

### Fix
Adiciona as classes globais construtoras faltantes a `is_known_global_ident`. Callbacks que referenciam `Set`/`new Map()`/`instanceof X` agora liftam sem tratar o nome como variável capturada.

### Escopo honesto
Avança 394 (passa do erro `filter_bound` para um verifier error posterior — combinação destructuring/spread complexa, follow-up). **Não fecha 394.**

### Validação
- `tests/callback_global_ident.test.ts`: 3 casos, saída byte-idêntica a Bun
- Suite TS: **1663/1663** (+3, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)