### PR TITLE
fix(codegen): structuredClone preserva tipo do valor clonado (#394 parcial)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -743,17 +743,25 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                             if fname == "fetch" {
                                 ctx.local_class_ty.insert(name.clone(), "Response".to_string());
                             } else if fname == "structuredClone" {
-                                // (#68) structuredClone(buf) de (Shared)ArrayBuffer
-                                // devolve outro buffer (clone byte-a-byte). Propaga
-                                // ArrayBuffer p/ que `new Uint8Array(moved)` use o
-                                // path view-viva (sem isso vira Vec vazio).
+                                // (#68/#394) structuredClone preserva o tipo do
+                                // valor clonado. Propaga local_class_ty/local_map_vars
+                                // do arg (ident) pro receptor — sem isso o clone
+                                // (Date/RegExp/Map/Set/ArrayBuffer) chega sem tipo e
+                                // metodos (.getUTCFullYear/.has/view) mis-despacham.
                                 if let Some(a) = call.args.first() {
                                     if let swc_ecma_ast::Expr::Ident(aid) = a.expr.as_ref() {
-                                        if ctx.local_class_ty.get(aid.sym.as_str())
-                                            .map(|c| c == "ArrayBuffer" || c == "SharedArrayBuffer")
-                                            .unwrap_or(false)
-                                        {
-                                            ctx.local_class_ty.insert(name.clone(), "ArrayBuffer".to_string());
+                                        let src = aid.sym.as_str();
+                                        if let Some(src_cls) = ctx.local_class_ty.get(src).cloned() {
+                                            // SharedArrayBuffer clona como ArrayBuffer.
+                                            let cls = if src_cls == "SharedArrayBuffer" {
+                                                "ArrayBuffer".to_string()
+                                            } else {
+                                                src_cls
+                                            };
+                                            ctx.local_class_ty.insert(name.clone(), cls);
+                                        }
+                                        if ctx.local_map_vars.contains(src) {
+                                            ctx.local_map_vars.insert(name.clone());
                                         }
                                     }
                                 }

--- a/tests/structuredclone_type_preserve.test.ts
+++ b/tests/structuredclone_type_preserve.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "rts:test";
+
+// (#394) structuredClone preserva o TIPO do valor clonado. Antes o clone
+// de Date/Map/Set/RegExp chegava sem local_class_ty no receptor -> metodos
+// (.getUTCFullYear/.has/.size) mis-despachavam (SIGILL). Agora decls.rs
+// propaga o tipo do arg ident para o var receptor do structuredClone.
+const d = new Date("2026-06-15T00:00:00Z");
+const dc = structuredClone(d);
+const dcYear = dc.getUTCFullYear();      // 2026
+const dcIsDate = dc instanceof Date;     // true
+
+const m = new Map<string, number>([["a", 1], ["b", 2]]);
+const mc = structuredClone(m);
+const mcGet = mc.get("a");               // 1
+const mcSize = mc.size;                  // 2
+
+const s = new Set<number>([10, 20]);
+const sc = structuredClone(s);
+const scHas = sc.has(20);                // true
+const scSize = sc.size;                  // 2
+
+describe("structuredclone_type_preserve (#394)", () => {
+  test("Date clone getUTCFullYear", () => expect(dcYear).toBe(2026));
+  test("Date clone instanceof", () => expect(dcIsDate).toBe(true));
+  test("Map clone get", () => expect(mcGet).toBe(1));
+  test("Map clone size", () => expect(mcSize).toBe(2));
+  test("Set clone has", () => expect(scHas).toBe(true));
+  test("Set clone size", () => expect(scSize).toBe(2));
+});


### PR DESCRIPTION
## structuredClone preserva tipo (Date/Map/Set/RegExp) — avança #394

`structuredClone(x)` de Date/Map/Set/RegExp/(Shared)ArrayBuffer devolvia um clone correto, mas o var receptor (`const dc = structuredClone(d)`) **não herdava** o `local_class_ty`/`local_map_vars` do arg → métodos no clone (`.getUTCFullYear`/`.has`/`.size`/view) mis-despachavam → SIGILL.

### Fix
`decls.rs`: quando o init é `structuredClone(<ident>)`, propaga o `local_class_ty` do arg para o receptor (SharedArrayBuffer → ArrayBuffer) e o `local_map_vars`. Generaliza o caso ArrayBuffer-only do #1319.

### Escopo honesto
Avança 394 de SIGILL (parava no bloco Date) para **rodar inteiro** — restam 2 linhas erradas (deep-clone de inner Set via spread+filter+destructuring + isolação de mutação), sub-bugs separados. **Não fecha 394.**

### Validação
- `tests/structuredclone_type_preserve.test.ts`: 6 casos (Date, Map, Set), byte-idêntico a Bun
- Suite TS: **1674/1674** (+6, zero regressão)
- `cargo test --release --lib`: 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)