### PR TITLE
fix(codegen): Set storage preserva identidade de objetos (#394)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -1438,6 +1438,22 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
             map::__RTS_FN_NS_COLLECTIONS_SET_FROM_VEC
         );
         add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_SET_ADD",
+            map::__RTS_FN_NS_COLLECTIONS_SET_ADD
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_HAS",
+            map::__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_HAS
+        );
+        add_fn!(
+            "__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_DELETE",
+            map::__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_DELETE
+        );
+        add_fn!(
+            "__RTS_FN_RT_FOR_OF_NORMALIZE",
+            map::__RTS_FN_RT_FOR_OF_NORMALIZE
+        );
+        add_fn!(
             "__RTS_FN_NS_COLLECTIONS_VEC_NEW",
             vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW
         );

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/builtins.rs
@@ -666,6 +666,41 @@ pub(super) fn lower_map_set_builtin(
         Ok((p, l))
     }
 
+    // (#394) Como `arg_strptr`, mas lowera o arg UMA vez e devolve tambem o
+    // valor i64 cru do elemento (`raw`). Necessario p/ has()/delete() unificados
+    // Map/Set: Map usa (p,l) key-string, Set usa `raw` p/ a key estavel de
+    // identidade. Evita lowerar o arg duas vezes (efeitos colaterais / handles
+    // duplicados em `set.has(f())` ou `set.has({...})`).
+    fn arg_strptr_and_raw(
+        ctx: &mut FnCtx,
+        call: &CallExpr,
+        idx: usize,
+    ) -> Result<(
+        cranelift_codegen::ir::Value,
+        cranelift_codegen::ir::Value,
+        cranelift_codegen::ir::Value,
+    )> {
+        let arg = call
+            .args
+            .get(idx)
+            .ok_or_else(|| anyhow!("missing arg #{idx}"))?;
+        if arg.spread.is_some() {
+            return Err(anyhow!("spread not supported"));
+        }
+        let tv = lower_expr(ctx, &arg.expr)?;
+        let raw = ctx.coerce_to_i64(tv).val;
+        let h = ctx.coerce_to_handle(tv)?.val;
+        let ptr_fref =
+            ctx.get_extern("__RTS_FN_NS_GC_STRING_PTR", &[cl::I64], Some(cl::I64))?;
+        let len_fref =
+            ctx.get_extern("__RTS_FN_NS_GC_STRING_LEN", &[cl::I64], Some(cl::I64))?;
+        let pi = ctx.builder.ins().call(ptr_fref, &[h]);
+        let p = ctx.builder.inst_results(pi)[0];
+        let li = ctx.builder.ins().call(len_fref, &[h]);
+        let l = ctx.builder.inst_results(li)[0];
+        Ok((p, l, raw))
+    }
+
     // Arity check: a heuristica so' deve disparar quando o nº de args
     // bate com a assinatura JS de Map/Set. Sem isso, qualquer obj literal
     // com chave `add`/`set`/`get`/`has`/`delete` que carregue uma fn de
@@ -710,16 +745,22 @@ pub(super) fn lower_map_set_builtin(
             Ok(Some(TypedVal::new(recv_h, ValTy::Handle)))
         }
         "add" => {
-            // Set.add(value) → map_set(h, value, 1).
-            let (kp, kl) = arg_strptr(ctx, call, 0)?;
-            let one = ctx.builder.ins().iconst(cl::I64, 1);
+            // (#394) Set.add(value) → SET_ADD(h, elemRaw). O runtime deriva a
+            // KEY estavel (set_stable_key): conteudo p/ string, "\0obj#<h>" p/
+            // objeto/Set (dedup por IDENTIDADE), decimal p/ numero. Armazena o
+            // VALOR i64 original como value, de modo que values()/[...set]/for-of
+            // recuperem a identidade do elemento (handle de objeto/Set aninhado).
+            // Antes objetos viravam key vazia e colidiam todos numa entrada.
+            let val_tv = lower_expr(ctx, &call.args[0].expr)?;
+            let elem_raw = ctx.coerce_to_i64(val_tv).val;
             let fref = ctx.get_extern(
-                "__RTS_FN_NS_COLLECTIONS_MAP_SET",
-                &[cl::I64, cl::I64, cl::I64, cl::I64],
-                None,
+                "__RTS_FN_NS_COLLECTIONS_SET_ADD",
+                &[cl::I64, cl::I64],
+                Some(cl::I64),
             )?;
-            ctx.builder.ins().call(fref, &[recv_h, kp, kl, one]);
-            Ok(Some(TypedVal::new(recv_h, ValTy::Handle)))
+            let inst = ctx.builder.ins().call(fref, &[recv_h, elem_raw]);
+            let h = ctx.builder.inst_results(inst)[0];
+            Ok(Some(TypedVal::new(h, ValTy::Handle)))
         }
         "get" => {
             let (kp, kl) = arg_strptr(ctx, call, 0)?;
@@ -744,24 +785,28 @@ pub(super) fn lower_map_set_builtin(
             Ok(Some(TypedVal::new(v, ValTy::I64)))
         }
         "has" => {
-            let (kp, kl) = arg_strptr(ctx, call, 0)?;
+            // (#394) Unificado Map/Set. Passa key-string (kp/kl) E elemento cru
+            // (elem_raw); o runtime escolhe por handle_is_set_kind: Set usa key
+            // estavel (identidade p/ objetos), Map usa key-string (inalterado).
+            let (kp, kl, elem_raw) = arg_strptr_and_raw(ctx, call, 0)?;
             let fref = ctx.get_extern(
-                "__RTS_FN_NS_COLLECTIONS_MAP_HAS",
-                &[cl::I64, cl::I64, cl::I64],
+                "__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_HAS",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
                 Some(cl::I64),
             )?;
-            let inst = ctx.builder.ins().call(fref, &[recv_h, kp, kl]);
+            let inst = ctx.builder.ins().call(fref, &[recv_h, kp, kl, elem_raw]);
             let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::Bool)))
         }
         "delete" => {
-            let (kp, kl) = arg_strptr(ctx, call, 0)?;
+            // (#394) Unificado Map/Set (ver `has`).
+            let (kp, kl, elem_raw) = arg_strptr_and_raw(ctx, call, 0)?;
             let fref = ctx.get_extern(
-                "__RTS_FN_NS_COLLECTIONS_MAP_DELETE",
-                &[cl::I64, cl::I64, cl::I64],
+                "__RTS_FN_NS_COLLECTIONS_SET_OR_MAP_DELETE",
+                &[cl::I64, cl::I64, cl::I64, cl::I64],
                 Some(cl::I64),
             )?;
-            let inst = ctx.builder.ins().call(fref, &[recv_h, kp, kl]);
+            let inst = ctx.builder.ins().call(fref, &[recv_h, kp, kl, elem_raw]);
             let v = ctx.builder.inst_results(inst)[0];
             Ok(Some(TypedVal::new(v, ValTy::Bool)))
         }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/new_expr.rs
@@ -353,14 +353,16 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
             if let Some(arg) = init_arg {
                 if let Expr::Array(arr) = arg.expr.as_ref() {
                     if class_name == "Set" {
-                        // add(elem) para cada item. Para F64 (number), usa
-                        // STRING_FROM_F64 que preserva NaN/Infinity/-0
-                        // como keys distintas (#669/95).
-                        let from_i64 = ctx.get_extern(
-                            "__RTS_FN_NS_GC_STRING_FROM_I64",
-                            &[cl::I64],
-                            Some(cl::I64),
-                        )?;
+                        // (#394) add(elem) para cada item.
+                        // - F64 (number): STRING_FROM_F64 preserva NaN/Infinity/-0
+                        //   como keys distintas (#669/95); value = `one` (caminho
+                        //   float tem repr propria, fora deste escopo).
+                        // - resto (string/objeto/Set/int): SET_ADD deriva a KEY
+                        //   estavel (conteudo p/ string, identidade p/ objeto,
+                        //   decimal p/ int) e grava o VALOR original como value,
+                        //   de modo que values()/[...set]/for-of recuperem a
+                        //   identidade do elemento. Antes objetos viravam key
+                        //   vazia (STRING_PTR de nao-string) e colidiam todos.
                         let from_f64 = ctx.get_extern(
                             "__RTS_FN_NS_GC_STRING_FROM_F64",
                             &[cl::F64],
@@ -381,30 +383,27 @@ pub(crate) fn lower_new(ctx: &mut FnCtx, new_expr: &swc_ecma_ast::NewExpr) -> Re
                             &[cl::I64, cl::I64, cl::I64, cl::I64],
                             None,
                         )?;
+                        let set_add = ctx.get_extern(
+                            "__RTS_FN_NS_COLLECTIONS_SET_ADD",
+                            &[cl::I64, cl::I64],
+                            Some(cl::I64),
+                        )?;
                         let one = ctx.builder.ins().iconst(cl::I64, 1);
                         for elem in arr.elems.iter().flatten() {
                             if elem.spread.is_some() { continue; }
                             let tv = lower_expr(ctx, &elem.expr)?;
-                            let key_h = if matches!(tv.ty, ValTy::F64) {
+                            if matches!(tv.ty, ValTy::F64) {
                                 let inst_s = ctx.builder.ins().call(from_f64, &[tv.val]);
-                                ctx.builder.inst_results(inst_s)[0]
-                            } else if matches!(tv.ty, ValTy::Handle) {
-                                // (cross-runtime #316) Elemento string/handle: a
-                                // KEY do Set eh o CONTEUDO da string, nao o numero
-                                // do handle. Sem isto `new Set(["a","b","a"])` nao
-                                // deduplicava (cada "a" tinha handle distinto) e
-                                // has("a") falhava. Usa o proprio handle string.
-                                tv.val
+                                let key_h = ctx.builder.inst_results(inst_s)[0];
+                                let inst_p = ctx.builder.ins().call(str_ptr, &[key_h]);
+                                let kp = ctx.builder.inst_results(inst_p)[0];
+                                let inst_l = ctx.builder.ins().call(str_len, &[key_h]);
+                                let kl = ctx.builder.inst_results(inst_l)[0];
+                                ctx.builder.ins().call(map_set, &[h, kp, kl, one]);
                             } else {
-                                let i = ctx.coerce_to_i64(tv).val;
-                                let inst_s = ctx.builder.ins().call(from_i64, &[i]);
-                                ctx.builder.inst_results(inst_s)[0]
-                            };
-                            let inst_p = ctx.builder.ins().call(str_ptr, &[key_h]);
-                            let kp = ctx.builder.inst_results(inst_p)[0];
-                            let inst_l = ctx.builder.ins().call(str_len, &[key_h]);
-                            let kl = ctx.builder.inst_results(inst_l)[0];
-                            ctx.builder.ins().call(map_set, &[h, kp, kl, one]);
+                                let elem_raw = ctx.coerce_to_i64(tv).val;
+                                ctx.builder.ins().call(set_add, &[h, elem_raw]);
+                            }
                         }
                     } else {
                         // Map: cada elem e' [key, value].

--- a/crates/rts-codegen/src/codegen/lower/statements/loops.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/loops.rs
@@ -298,6 +298,19 @@ pub(super) fn lower_for_of(ctx: &mut FnCtx, for_of: &swc_ecma_ast::ForOfStmt) ->
         )?;
         ctx.builder.ins().call(spread_fn, &[char_vec, handle]);
         handle = char_vec;
+    } else if iter_class.is_none() {
+        // (#394) Classe estatica desconhecida (ex: bind de outro for-of, como
+        // `for (const s of setOfSets) for (const n of s)`). Normaliza em
+        // runtime: Set->elementos, Map->entries, resto inalterado. So' altera
+        // handles que seriam mal-iterados (Set/Map sem classe conhecida); Vec
+        // passa direto.
+        let norm_fn = ctx.get_extern(
+            "__RTS_FN_RT_FOR_OF_NORMALIZE",
+            &[cl::I64],
+            Some(cl::I64),
+        )?;
+        let inst = ctx.builder.ins().call(norm_fn, &[handle]);
+        handle = ctx.builder.inst_results(inst)[0];
     }
 
     let len_fref = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_LEN", &[cl::I64], Some(cl::I64))?;

--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -567,10 +567,9 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FOR_EACH(handle: u64, fn_ptr: u64)
     // Para Map, mantem transmute fn(i64,i64,i64) — callbacks de Map sao
     // normalmente arrows lifted (windows_fastcall) que aceitam essa sig.
     if is_set {
-        for (k, _v) in &pairs {
-            let key_for_set: i64 = k.parse::<i64>().unwrap_or_else(|_| {
-                alloc_entry(Entry::String(k.clone().into_bytes())) as i64
-            });
+        for (k, v) in &pairs {
+            // (#394) elemento via value preservado (identidade), nao parse da key.
+            let key_for_set: i64 = set_element_from_pair(k, *v);
             let args_vec = alloc_entry(Entry::Vec(Box::new(vec![key_for_set, key_for_set, handle as i64])));
             crate::namespaces::globals::function::ops::__RTS_FN_RT_INVOKE_AUTO(
                 fn_ptr as i64,
@@ -934,6 +933,11 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
     if let Some((target, handler)) = crate::namespaces::globals::proxy::ops::resolve_proxy(handle) {
         return crate::namespaces::globals::proxy::ops::dispatch_own_keys(target, handler);
     }
+    // (#394) Set.keys() eh alias de Set.values() em JS — retorna os ELEMENTOS
+    // (com identidade preservada), nao as keys-string internas.
+    if handle_is_set_kind(handle) {
+        return __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle);
+    }
     let keys: Vec<String> = with_map(handle, Vec::new(), |m| {
         // (#208) Filtra `__proto__` e nao-enumeraveis (defineProperty) —
         // JS spec: Object.keys retorna so own enumeravel.
@@ -989,18 +993,13 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_KEYS(handle: u64) -> u64 {
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle: u64) -> u64 {
     if handle_is_set_kind(handle) {
-        // Set.values() retorna os elementos (= keys do storage Map).
-        // Cada key foi armazenada como string — se parseia como int,
-        // converte de volta, senao retorna handle string.
+        // Set.values() retorna os elementos. (#394) Recupera a IDENTIDADE do
+        // elemento a partir do value preservado (set_element_from_pair); cai
+        // no parse da key apenas no fallback legado/float.
         let elems: Vec<i64> = with_map(handle, Vec::new(), |m| {
-            m.keys()
-                .filter(|k| k.as_str() != "__proto__")
-                .map(|k| match k.parse::<i64>() {
-                    Ok(n) => n,
-                    Err(_) => crate::namespaces::gc::handles::alloc_entry(
-                        crate::namespaces::gc::handles::Entry::String(k.clone().into_bytes()),
-                    ) as i64,
-                })
+            m.iter()
+                .filter(|(k, _)| k.as_str() != "__proto__")
+                .map(|(k, &v)| set_element_from_pair(k, v))
                 .collect()
         });
         return crate::namespaces::gc::handles::alloc_entry(
@@ -1088,6 +1087,26 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES(handle: u64) -> u64 {
 /// e `for (const [k, v] of m)`.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES_INSERTION(handle: u64) -> u64 {
+    // (#394) Set.entries() em JS retorna pares [elem, elem] (cada elemento
+    // duplicado). Usa o elemento com identidade preservada, nao a key-string.
+    if handle_is_set_kind(handle) {
+        let elems: Vec<i64> = with_map(handle, Vec::new(), |m| {
+            m.iter()
+                .filter(|(k, _)| k.as_str() != "__proto__")
+                .map(|(k, &v)| set_element_from_pair(k, v))
+                .collect()
+        });
+        let mut outer: Vec<i64> = Vec::with_capacity(elems.len());
+        for e in elems {
+            let inner = crate::namespaces::gc::handles::alloc_entry(
+                crate::namespaces::gc::handles::Entry::Vec(Box::new(vec![e, e])),
+            );
+            outer.push(inner as i64);
+        }
+        return crate::namespaces::gc::handles::alloc_entry(
+            crate::namespaces::gc::handles::Entry::Vec(Box::new(outer)),
+        );
+    }
     let pairs: Vec<(String, i64)> = with_map(handle, Vec::new(), |m| {
         m.iter()
             .filter(|(k, _)| k.as_str() != "__proto__")
@@ -1409,6 +1428,29 @@ pub(crate) fn handle_is_map_kind(handle: u64) -> bool {
 
 pub(crate) fn handle_is_set_kind(handle: u64) -> bool {
     set_kind_set().lock().unwrap().contains(&handle)
+}
+
+/// (#394) Recupera o ELEMENTO de um Set a partir do par (key, value) do Map
+/// interno. Os escritores (Set.add, new Set([...]), SET_FROM_VEC) gravam o
+/// VALOR original do elemento como value, preservando a identidade (handle de
+/// objeto/Set aninhado/string). A leitura prefere esse value.
+///
+/// Fallback (value sentinel legado `1` E a key nao parseia como `1`): Sets
+/// criados pelo caminho float (que mantem value=`1`) ou por estados antigos —
+/// reconstroi o elemento parseando a key (int) ou alocando string handle.
+/// Quando key=="1" o value=1 eh o numero genuino, entao usa o value direto.
+pub(crate) fn set_element_from_pair(key: &str, value: i64) -> i64 {
+    if value == 1 && key != "1" {
+        // value sentinel legado / float: reconstroi da key.
+        match key.parse::<i64>() {
+            Ok(n) => n,
+            Err(_) => crate::namespaces::gc::handles::alloc_entry(
+                crate::namespaces::gc::handles::Entry::String(key.as_bytes().to_vec()),
+            ) as i64,
+        }
+    } else {
+        value
+    }
 }
 
 /// (#316) Helper interno para estruturas que clonam (structuredClone)
@@ -1963,6 +2005,98 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_FROM_ENTRIES(arr: u64) -> u64 {
 /// Cria um Map marcado como Set e adiciona cada elemento como key (value=1).
 /// Espelha a conversao do caminho de array literal: elemento handle-string usa
 /// o conteudo; inteiro usa a representacao decimal. Dedup natural (HashMap).
+/// (#394) Deriva a KEY ESTAVEL de um elemento de Set a partir do seu valor i64
+/// cru. A key serve para dedup (has/add/delete); o VALUE armazenado preserva a
+/// identidade. Regras:
+/// - `Entry::String` -> conteudo da string (dedup por valor: `"a"` == `"a"`).
+/// - outro Entry (objeto/Map/Set/Vec/etc) -> `"\0obj#<handle>"`: dedup por
+///   IDENTIDADE (handle unico). Antes objetos viravam key vazia (STRING_PTR de
+///   nao-string = ptr nulo) e colidiam todos numa unica entrada.
+/// - sem Entry valido (numero/bool/sentinel) -> representacao decimal.
+pub(crate) fn set_stable_key(elem_raw: i64) -> String {
+    use crate::namespaces::gc::handles::{Entry, with_entry};
+    with_entry(elem_raw as u64, |e| match e {
+        Some(Entry::String(b)) => String::from_utf8_lossy(b).into_owned(),
+        Some(_) => format!("\0obj#{elem_raw}"),
+        None => elem_raw.to_string(),
+    })
+}
+
+/// (#394) `set.add(elem)` — insere preservando identidade. A KEY vem de
+/// `set_stable_key` (dedup correto p/ objetos), o VALUE eh o elemento cru
+/// (leitura recupera a identidade via `set_element_from_pair`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_ADD(set_h: u64, elem_raw: i64) -> u64 {
+    if set_h == 0 || elem_raw == i64::MIN + 4 {
+        return set_h;
+    }
+    let key = set_stable_key(elem_raw);
+    let sealed = is_map_sealed(set_h);
+    with_map_mut(set_h, (), |m| {
+        if sealed && !m.contains_key(&key) {
+            return;
+        }
+        m.insert(key, elem_raw);
+    });
+    set_h
+}
+
+/// (#394) `coll.has(arg)` unificado Map/Set. Para Set usa a key estavel
+/// derivada do elemento cru (`elem_raw`) — identidade p/ objetos. Para Map (e
+/// qualquer handle nao-Set) usa a key-string (`key_ptr`/`key_len`), preservando
+/// 100% o comportamento de `MAP_HAS`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_OR_MAP_HAS(
+    handle: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+    elem_raw: i64,
+) -> i64 {
+    if handle_is_set_kind(handle) {
+        let key = set_stable_key(elem_raw);
+        return with_map(handle, false, |m| m.contains_key(&key)) as i64;
+    }
+    __RTS_FN_NS_COLLECTIONS_MAP_HAS(handle, key_ptr, key_len)
+}
+
+/// (#394) `coll.delete(arg)` unificado Map/Set. Mesma logica de
+/// `SET_OR_MAP_HAS`: Set por identidade (elem_raw), Map por key-string.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_OR_MAP_DELETE(
+    handle: u64,
+    key_ptr: *const u8,
+    key_len: i64,
+    elem_raw: i64,
+) -> i64 {
+    if handle_is_set_kind(handle) {
+        if is_map_frozen(handle) {
+            return 0;
+        }
+        let key = set_stable_key(elem_raw);
+        return with_map_mut(handle, false, |m| m.shift_remove(&key).is_some()) as i64;
+    }
+    __RTS_FN_NS_COLLECTIONS_MAP_DELETE(handle, key_ptr, key_len)
+}
+
+/// (#394) Normaliza um iteravel de for-of quando o codegen NAO conhece a
+/// classe estatica (ex: o bind eh elemento de outro for-of, como em
+/// `for (const s of setOfSets) for (const n of s)`). Decide em runtime:
+/// - Set  -> Vec dos ELEMENTOS (MAP_VALUES, identidade preservada);
+/// - Map  -> Vec de pares [k,v] (ENTRIES_INSERTION);
+/// - resto (Vec/Buffer/string/etc) -> o proprio handle inalterado.
+/// So' eh chamado no ramo "classe desconhecida"; o caminho tipado comum
+/// (Vec anotado) nao passa por aqui.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_FOR_OF_NORMALIZE(handle: u64) -> u64 {
+    if handle_is_set_kind(handle) {
+        return __RTS_FN_NS_COLLECTIONS_MAP_VALUES(handle);
+    }
+    if handle_is_map_kind(handle) {
+        return __RTS_FN_NS_COLLECTIONS_MAP_ENTRIES_INSERTION(handle);
+    }
+    handle
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_FROM_VEC(src: u64) -> u64 {
     use crate::namespaces::gc::handles::{Entry, with_entry};
@@ -1975,13 +2109,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_SET_FROM_VEC(src: u64) -> u64 {
     for raw in elems {
         // hole sentinel: ignora.
         if raw == i64::MIN + 4 { continue; }
-        let key_str: Option<String> = with_entry(raw as u64, |ke| match ke {
-            Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
-            _ => None,
-        });
-        let key = key_str.unwrap_or_else(|| raw.to_string());
+        // (#394) key estavel (identidade p/ objetos) + value = elemento cru.
+        let key = set_stable_key(raw);
         with_map_mut(m, (), |mm| {
-            mm.insert(key, 1);
+            mm.insert(key, raw);
         });
     }
     m

--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -824,8 +824,12 @@ pub extern "C" fn __RTS_FN_GL_ARRAY_FROM_VEC(src: u64, fn_ptr: u64) -> u64 {
         Some(Entry::Buffer(b)) => b.iter().map(|&x| x as i64).collect(),
         Some(Entry::Map(m)) => {
             if is_set {
-                m.keys()
-                    .filter_map(|k| k.parse::<i64>().ok())
+                // (#394) Recupera identidade do elemento via value preservado
+                // (set_element_from_pair) em vez de descartar nao-numericos.
+                m.iter()
+                    .map(|(k, &v)| {
+                        crate::namespaces::collections::map::set_element_from_pair(k, v)
+                    })
                     .collect()
             } else if is_map {
                 // JS Map: Array.from(map) retorna pares [key, value].
@@ -1026,12 +1030,12 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_VALUES(handle: u64) -> u64 {
     // (#61) Set armazena value=1 marker no Map<String,i64>; values reais
     // sao as keys. Detecta via handle_is_set_kind antes do match Map.
     let is_set = crate::namespaces::collections::map::handle_is_set_kind(handle);
-    enum Kind { Vec(Vec<i64>), MapVals(Vec<i64>), SetKeys(Vec<String>), Other }
+    enum Kind { Vec(Vec<i64>), MapVals(Vec<i64>), SetPairs(Vec<(String, i64)>), Other }
     let kind = with_entry(handle, |e| match e {
         Some(Entry::Vec(v)) => Kind::Vec((**v).clone()),
         Some(Entry::Map(m)) => {
             if is_set {
-                Kind::SetKeys(m.keys().cloned().collect())
+                Kind::SetPairs(m.iter().map(|(k, &v)| (k.clone(), v)).collect())
             } else {
                 Kind::MapVals(m.values().copied().collect())
             }
@@ -1040,16 +1044,11 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_VALUES(handle: u64) -> u64 {
     });
     let out: Vec<i64> = match kind {
         Kind::Vec(v) | Kind::MapVals(v) => v,
-        Kind::SetKeys(keys) => keys
+        // (#394) Recupera identidade do elemento via value preservado.
+        Kind::SetPairs(pairs) => pairs
             .into_iter()
-            .map(|k| {
-                // Tenta interpretar key como inteiro (Set de numeros) — JS Set
-                // mantem o tipo original. Fallback: aloca como string.
-                if let Ok(n) = k.parse::<i64>() {
-                    n
-                } else {
-                    alloc_entry(Entry::String(k.into_bytes())) as i64
-                }
+            .map(|(k, v)| {
+                crate::namespaces::collections::map::set_element_from_pair(&k, v)
             })
             .collect(),
         Kind::Other => Vec::new(),

--- a/tests/set_identity_storage.test.ts
+++ b/tests/set_identity_storage.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "rts:test";
+
+// (#394) Set storage preserva a IDENTIDADE do elemento.
+//
+// Antes o Set armazenava `1` como value interno e a key de objetos virava
+// vazia (STRING_PTR de nao-string = ptr nulo), entao todos os objetos
+// colidiam numa unica entrada e a leitura (values/spread/for-of) re-parseava
+// a key perdendo o handle. Agora:
+// - a KEY estavel: conteudo p/ string, "\0obj#<h>" p/ objeto/Set (identidade),
+//   decimal p/ number;
+// - o VALUE eh o elemento original -> leitura recupera a identidade.
+
+// --- Set de Sets aninhados via add() + for-of aninhado ---
+const inner1 = new Set<number>([1, 2]);
+const inner2 = new Set<number>([3, 4]);
+const outer = new Set<Set<number>>();
+outer.add(inner1);
+outer.add(inner2);
+let nestedTotal = 0;
+for (const s of outer) {
+  for (const n of s) {
+    nestedTotal += n;
+  }
+}
+
+// --- Set de Sets via construtor literal ---
+const a = new Set<number>([10, 20]);
+const b = new Set<number>([30]);
+const lit = new Set<Set<number>>([a, b]);
+let litTotal = 0;
+for (const s of lit) {
+  for (const n of s) {
+    litTotal += n;
+  }
+}
+const litSize = lit.size;
+
+// --- has/delete por identidade de objeto ---
+const obj1 = new Set<number>([1]);
+const obj2 = new Set<number>([2]);
+const holder = new Set<Set<number>>();
+holder.add(obj1);
+const hasObj1 = holder.has(obj1);
+const hasObj2 = holder.has(obj2); // identidade distinta -> false
+holder.delete(obj1);
+const afterDelete = holder.size;
+
+// --- primitivos continuam corretos (nao-regressao) ---
+const nums = new Set<number>();
+nums.add(5);
+nums.add(7);
+nums.add(5); // dedup
+const numsArr = [...nums].join(",");
+const numsHas = nums.has(7);
+const numsHasMissing = nums.has(99);
+
+const strs = new Set<string>(["x", "y", "x"]);
+const strsArr = Array.from(strs.values()).join(",");
+const strsHas = strs.has("y");
+
+// --- Map nao-regrediu (has/delete por key-string) ---
+const m = new Map<string, number>();
+m.set("k", 42);
+const mapHas = m.has("k");
+const mapGet = m.get("k");
+m.delete("k");
+const mapAfter = m.has("k");
+
+describe("Set storage preserva identidade (#394)", () => {
+  test("Sets aninhados via add + for-of", () => expect(`${nestedTotal}`).toBe("10"));
+  test("Sets aninhados via literal", () => expect(`${litTotal}`).toBe("60"));
+  test("size do Set de Sets literal", () => expect(`${litSize}`).toBe("2"));
+  test("has por identidade (mesmo obj)", () => expect(hasObj1).toBe(true));
+  test("has por identidade (obj distinto)", () => expect(hasObj2).toBe(false));
+  test("delete por identidade", () => expect(`${afterDelete}`).toBe("0"));
+
+  test("Set numerico spread", () => expect(numsArr).toBe("5,7"));
+  test("Set numerico has", () => expect(numsHas).toBe(true));
+  test("Set numerico has ausente", () => expect(numsHasMissing).toBe(false));
+  test("Set string values", () => expect(strsArr).toBe("x,y"));
+  test("Set string has", () => expect(strsHas).toBe(true));
+
+  test("Map has nao-regrediu", () => expect(mapHas).toBe(true));
+  test("Map get nao-regrediu", () => expect(`${mapGet}`).toBe("42"));
+  test("Map delete nao-regrediu", () => expect(mapAfter).toBe(false));
+});


### PR DESCRIPTION
## #394 — Set storage preserva identidade de objetos

Fecha o último sub-bug do #394 (design de Set storage), mencionado no commit `d5245004`.

### Problema
Set de objetos/Sets aninhados não preservava a **identidade** do elemento. O storage interno `Map<string, i64>` gravava `1` como value e a key de objetos virava **vazia** (`STRING_PTR` de não-string = ptr nulo), então todos os objetos colidiam numa única entrada. A leitura re-parseava a key, perdendo o handle.

Sintoma: `for (const s of setOfSets) for (const n of s)` somava `0`; `new Set([o1, o2])` ficava com size errado; `set.has(obj)` não distinguia identidades.

### Solução
**Escritores** (`Set.add`, construtor literal `new Set([...])`, `SET_FROM_VEC`) gravam o **valor original** como value do Map interno. A **key estável** vem de `set_stable_key`:
- conteúdo p/ string (dedup por valor)
- `"\0obj#<handle>"` p/ objeto/Set (dedup por **identidade**)
- decimal p/ number

**Leitores** (`MAP_VALUES`, `VEC_VALUES`, `ARRAY_FROM_VEC`, `forEach`, `keys`, `entries`) recuperam o elemento via `set_element_from_pair` (value preservado; fallback parse-da-key p/ Sets legados/float).

`has`/`delete` unificados Map/Set (`SET_OR_MAP_HAS`/`DELETE`) decidem por `handle_is_set_kind`: Set por identidade (elemento cru), Map por key-string (**inalterado**).

for-of aninhado resolvido via `FOR_OF_NORMALIZE`: quando a classe estática do bind é desconhecida (ex: bind de outro for-of), o runtime detecta Set/Map e normaliza (Set→elementos, Map→entries, Vec inalterado).

### Validação (zero regressão)
- Suite TS: **1674 → 1688** (novo `tests/set_identity_storage.test.ts`, 14 casos: identidade aninhada, has/delete por identidade, primitivos e Map sem regressão)
- `cargo test --release --lib`: 12/12
- `cargo build --release`: limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
