### PR TITLE
fix(codegen): multiplicacao inteira nao overflowa em i32 (#305)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,7 +573,9 @@ de escopo de PR pequena):
 - **#223** dynamic import
 - **#301** var hoisting em fn user (top-level ja' funciona)
 - **#304** toString/valueOf em coercao implicita
-- **#305** integer overflow JS spec (i64 wraparound vs f64 promotion)
+- **#305** integer overflow — multiplicacao promovida a i64 (cobre ~3e18);
+  acima disso ainda satura (f64 completo seria refator maior). add/sub i32 idem
+  pendente
 - **#477** generator infinito (vec push estoura — refator state machine)
 - **#211/#219/#225** generators / BigInt / Intl (candidate-discard)
 

--- a/crates/rts-codegen/src/codegen/lower/analysis/module_globals.rs
+++ b/crates/rts-codegen/src/codegen/lower/analysis/module_globals.rs
@@ -66,7 +66,25 @@ pub(crate) fn collect_module_globals(
                     .and_then(|ann| ts_type_to_val_ty(&ann.type_ann)),
                 _ => None,
             };
-            let ty = ann_ty.unwrap_or_else(|| infer_expr_ty(decl.init.as_deref()));
+            let inferred = infer_expr_ty(decl.init.as_deref());
+            // (#305) Espelha o `promote_to_f64` de lower_var_decl: var MUTAVEL
+            // (`let`/`var`) sem anotacao, inicializada com LITERAL inteiro, vira
+            // F64. Sem isto o global ficava i32/i64 e `acc = acc * 10` num loop
+            // top-level (referenciado por user fn -> vira global) truncava em 32
+            // bits (`20000000000` virava -1474836480). JS: number eh f64.
+            let is_mutable_kind = matches!(
+                var_decl.kind,
+                swc_ecma_ast::VarDeclKind::Let | swc_ecma_ast::VarDeclKind::Var
+            );
+            let init_is_int_lit = matches!(
+                decl.init.as_deref(),
+                Some(swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Num(_)))
+            ) && matches!(inferred, ValTy::I32 | ValTy::I64);
+            let ty = if ann_ty.is_none() && is_mutable_kind && init_is_int_lit {
+                ValTy::F64
+            } else {
+                ann_ty.unwrap_or(inferred)
+            };
 
             let symbol = format!("__rts_global_{}_{}", sanitize_symbol(&name), counter);
             counter += 1;

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -2012,11 +2012,22 @@ pub(super) fn lower_sub(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result
 
 fn lower_mul(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
-    let val = match ty {
-        ValTy::F64 => ctx.builder.ins().fmul(lv, rv),
-        _ => ctx.builder.ins().imul(lv, rv),
-    };
-    Ok(TypedVal::new(val, ty))
+    match ty {
+        ValTy::F64 => Ok(TypedVal::new(ctx.builder.ins().fmul(lv, rv), ValTy::F64)),
+        // (#305) `i32 * i32` overflowa a 32 bits (`1000000 * 1000000` virava
+        // -727379968 / 1410065408 em vez de 10^12). Em JS `number` eh f64
+        // (exato ate 2^53). Promovemos a multiplicacao i32 para i64 (cobre ate
+        // ~3*10^18), evitando o overflow no caso cotidiano sem o custo de f64.
+        // add/sub/peephole `x*2^k` ficam inalterados (nao sao o gargalo de
+        // overflow rapido). Acima de i64 (raro) ainda satura — full f64 seria
+        // refator maior com risco em loops hot.
+        ValTy::I32 => {
+            let lv64 = ctx.builder.ins().sextend(cl::I64, lv);
+            let rv64 = ctx.builder.ins().sextend(cl::I64, rv);
+            Ok(TypedVal::new(ctx.builder.ins().imul(lv64, rv64), ValTy::I64))
+        }
+        _ => Ok(TypedVal::new(ctx.builder.ins().imul(lv, rv), ty)),
+    }
 }
 
 fn lower_div(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {

--- a/crates/rts-codegen/src/mir_codegen/lower.rs
+++ b/crates/rts-codegen/src/mir_codegen/lower.rs
@@ -382,6 +382,17 @@ fn val(vmap: &HashMap<ValueId, Value>, vid: ValueId) -> Result<Value> {
         .ok_or_else(|| anyhow!("MIR value v{} referenced before being defined", vid))
 }
 
+/// (#305) Promove um valor inteiro a i64 (sextend se i32, passthrough se ja'
+/// i64). Usado antes de `imul` para que a multiplicacao inteira nao overflowe
+/// em 32 bits — `number` em JS eh f64 (exato ate 2^53).
+fn sextend_to_i64(builder: &mut FunctionBuilder, v: Value) -> Value {
+    if builder.func.dfg.value_type(v) == cl::I32 {
+        builder.ins().sextend(cl::I64, v)
+    } else {
+        v
+    }
+}
+
 fn lower_inst(
     builder: &mut FunctionBuilder,
     inst: &Inst,
@@ -427,11 +438,18 @@ fn lower_inst(
             bind!(dst, v);
         }
         IMul { dst, lhs, rhs } => {
-            let v = builder.ins().imul(val(vmap, *lhs)?, val(vmap, *rhs)?);
+            // (#305) `i32 * i32` overflowa a 32 bits. Em JS `number` eh f64
+            // (exato ate 2^53); promovemos a multiplicacao inteira para i64
+            // (cobre ate ~3*10^18). Espelha o fix do caminho AST (lower_mul).
+            let lv = sextend_to_i64(builder, val(vmap, *lhs)?);
+            let rv = sextend_to_i64(builder, val(vmap, *rhs)?);
+            let v = builder.ins().imul(lv, rv);
             bind!(dst, v);
         }
         IMulImm { dst, lhs, imm } => {
-            let v = builder.ins().imul_imm(val(vmap, *lhs)?, *imm);
+            // (#305) idem: promove o operando a i64 antes do imul_imm.
+            let lv = sextend_to_i64(builder, val(vmap, *lhs)?);
+            let v = builder.ins().imul_imm(lv, *imm);
             bind!(dst, v);
         }
         SDiv { dst, lhs, rhs } => {

--- a/tests/int_mul_overflow.test.ts
+++ b/tests/int_mul_overflow.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "rts:test";
+
+// (#305) `1000000 * 1000000` dava -727379968 (overflow i32): literais inteiros
+// que cabem em i32 eram classificados I32 e o `imul` operava em 32 bits,
+// estourando antes de promover. Em JS `number` eh f64 (exato ate 2^53). Fix:
+// `lower_mul` promove `i32 * i32` para i64 (cobre ate ~3*10^18) sem o custo de
+// f64 em loops hot. add/sub/peephole `x*2^k` ficam inalterados.
+
+// literal * literal
+const litMul = 1000000 * 1000000; // 10^12
+
+// var * var
+const a = 100000;
+const b = 100000;
+const varMul = a * b; // 10^10
+
+// literais com produto > 2^31
+const wide = 123456 * 654321; // 80779853376
+
+// acumulador em loop ultrapassando i32
+let acc = 2;
+for (let i = 0; i < 10; i++) {
+  acc = acc * 10;
+}
+// 2 * 10^10 = 20000000000
+
+// produto que ainda cabe em i32 (nao-regressao: continua exato)
+const small = 1000 * 1000; // 1000000
+
+// area-like (caso cotidiano: medida * medida)
+function area(w: number, h: number): number {
+  return w * h;
+}
+const big = area(1000000, 1000000); // 10^12
+
+describe("multiplicacao inteira nao overflowa em i32 (#305)", () => {
+  test("literal * literal 10^12", () => expect(`${litMul}`).toBe("1000000000000"));
+  test("var * var 10^10", () => expect(`${varMul}`).toBe("10000000000"));
+  test("produto largo > 2^31", () => expect(`${wide}`).toBe("80779853376"));
+  test("acumulador em loop", () => expect(`${acc}`).toBe("20000000000"));
+  test("produto pequeno continua exato", () => expect(`${small}`).toBe("1000000"));
+  test("fn area 10^12", () => expect(`${big}`).toBe("1000000000000"));
+});


### PR DESCRIPTION
## #305 — Multiplicação inteira não overflowa em i32

### Problema
`1000000 * 1000000` dava `-727379968` (overflow i32). Literais inteiros que cabem em i32 eram classificados `I32` e o `imul` operava em 32 bits, estourando antes de promover. Em JS `number` é f64 (exato até 2^53).

### Solução
Escolhida a via **i64** (cabe ~3×10^18) em vez de f64 — cobre o caso cotidiano (10^10, 10^12, medidas/preços) sem o custo de f64 em loops hot. Três frentes:

1. **AST `lower_mul`**: `i32 * i32` faz `sextend`→`imul` i64→retorna I64.
2. **MIR codegen `IMul`/`IMulImm`**: `sextend_to_i64` antes do `imul`. O top-level `__RTS_MAIN` passa pelo MIR (não só o AST), então o fix precisava dos dois caminhos.
3. **Globais mutáveis**: `let acc = 2` referenciado por user fn vira global tipado i32, então `acc = acc * 10` num loop truncava em 32 bits. `collect_module_globals` agora promove var **mutável** sem anotação + init int-literal a **F64** (espelha `promote_to_f64` de `lower_var_decl`). Vars `: i64` anotadas (Monte Carlo) **não** são promovidas → hot path intacto.

### Benchmark guard (exigido pelo roadmap)
Warmup + 15 amostras, mediana:
- **Monte Carlo**: CLEAN 79.1ms vs FIX 78.8ms — **delta -0.4%** (dentro do ruído)
- pi_machin: sem loop/int-mul, não afetado

### Validação (zero regressão)
- Suite TS: **1688 → 1694** (novo `tests/int_mul_overflow.test.ts`, 6 casos: literal*literal, var*var, produto largo >2^31, acumulador em loop, produto pequeno exato, fn area)
- `cargo test --release --lib`: 12/12
- rts-mir: 64/64

### Limites conscientes (follow-up)
Acima de i64 (raro) ainda satura; f64 completo + promoção de add/sub i32 ficam como follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
