### PR TITLE
fix(codegen): add/sub inteiro nao overflowa em i32 (#305 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,9 +573,8 @@ de escopo de PR pequena):
 - **#223** dynamic import
 - **#301** var hoisting em fn user (top-level ja' funciona)
 - **#304** toString/valueOf em coercao implicita
-- **#305** integer overflow — multiplicacao promovida a i64 (cobre ~3e18);
-  acima disso ainda satura (f64 completo seria refator maior). add/sub i32 idem
-  pendente
+- **#305** integer overflow — mul/add/sub promovidos a i64 (cobre ~9e18);
+  acima disso ainda satura (f64 completo seria refator maior)
 - **#477** generator infinito (vec push estoura — refator state machine)
 - **#211/#219/#225** generators / BigInt / Intl (candidate-discard)
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1993,21 +1993,34 @@ pub(super) fn lower_add(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result
         return Ok(TypedVal::new(result, ValTy::Handle));
     }
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
-    let val = match ty {
-        ValTy::F64 => ctx.builder.ins().fadd(lv, rv),
-        ValTy::I32 => ctx.builder.ins().iadd(lv, rv),
-        _ => ctx.builder.ins().iadd(lv, rv),
-    };
-    Ok(TypedVal::new(val, ty))
+    match ty {
+        ValTy::F64 => Ok(TypedVal::new(ctx.builder.ins().fadd(lv, rv), ValTy::F64)),
+        // (#305) `i32 + i32` overflowa a 32 bits (`2e9 + 2e9` virava
+        // -294967296). Em JS `number` eh f64; promovemos a soma inteira para
+        // i64 (cobre ate ~9*10^18). Acumuladores de loop sem anotacao ja' viram
+        // f64 (promote_to_f64); este caso cobre i32+i32 puro (literais/vars i32).
+        ValTy::I32 => {
+            let lv64 = ctx.builder.ins().sextend(cl::I64, lv);
+            let rv64 = ctx.builder.ins().sextend(cl::I64, rv);
+            Ok(TypedVal::new(ctx.builder.ins().iadd(lv64, rv64), ValTy::I64))
+        }
+        _ => Ok(TypedVal::new(ctx.builder.ins().iadd(lv, rv), ty)),
+    }
 }
 
 pub(super) fn lower_sub(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {
     let (lv, rv, ty) = promote_numeric(ctx, lhs, rhs)?;
-    let val = match ty {
-        ValTy::F64 => ctx.builder.ins().fsub(lv, rv),
-        _ => ctx.builder.ins().isub(lv, rv),
-    };
-    Ok(TypedVal::new(val, ty))
+    match ty {
+        ValTy::F64 => Ok(TypedVal::new(ctx.builder.ins().fsub(lv, rv), ValTy::F64)),
+        // (#305) idem add: `i32 - i32` pode underflowar (ex: 0 - (-2e9) -> 2e9
+        // cabe, mas -2e9 - 2e9 = -4e9 estoura). Promove a i64.
+        ValTy::I32 => {
+            let lv64 = ctx.builder.ins().sextend(cl::I64, lv);
+            let rv64 = ctx.builder.ins().sextend(cl::I64, rv);
+            Ok(TypedVal::new(ctx.builder.ins().isub(lv64, rv64), ValTy::I64))
+        }
+        _ => Ok(TypedVal::new(ctx.builder.ins().isub(lv, rv), ty)),
+    }
 }
 
 fn lower_mul(ctx: &mut FnCtx, lhs: TypedVal, rhs: TypedVal) -> Result<TypedVal> {

--- a/crates/rts-codegen/src/mir_codegen/lower.rs
+++ b/crates/rts-codegen/src/mir_codegen/lower.rs
@@ -426,15 +426,25 @@ fn lower_inst(
 
         // Integer arithmetic
         IAdd { dst, lhs, rhs } => {
-            let v = builder.ins().iadd(val(vmap, *lhs)?, val(vmap, *rhs)?);
+            // (#305) `i32 + i32` overflowa a 32 bits (`2e9 + 2e9` -> -294967296).
+            // Promove a i64 (espelha lower_add do AST). sextend_to_i64 passa i64
+            // direto, entao operandos ja-i64 ou mistos seguem corretos.
+            let lv = sextend_to_i64(builder, val(vmap, *lhs)?);
+            let rv = sextend_to_i64(builder, val(vmap, *rhs)?);
+            let v = builder.ins().iadd(lv, rv);
             bind!(dst, v);
         }
         IAddImm { dst, lhs, imm } => {
-            let v = builder.ins().iadd_imm(val(vmap, *lhs)?, *imm);
+            // (#305) idem; cobre `x + N` (ex: acumulador `s = s + 100000`).
+            let lv = sextend_to_i64(builder, val(vmap, *lhs)?);
+            let v = builder.ins().iadd_imm(lv, *imm);
             bind!(dst, v);
         }
         ISub { dst, lhs, rhs } => {
-            let v = builder.ins().isub(val(vmap, *lhs)?, val(vmap, *rhs)?);
+            // (#305) idem add: promove i32 a i64 antes do isub.
+            let lv = sextend_to_i64(builder, val(vmap, *lhs)?);
+            let rv = sextend_to_i64(builder, val(vmap, *rhs)?);
+            let v = builder.ins().isub(lv, rv);
             bind!(dst, v);
         }
         IMul { dst, lhs, rhs } => {

--- a/tests/int_mul_overflow.test.ts
+++ b/tests/int_mul_overflow.test.ts
@@ -33,6 +33,18 @@ function area(w: number, h: number): number {
 }
 const big = area(1000000, 1000000); // 10^12
 
+// (#305 follow-up) add/sub tambem promovem i32 -> i64.
+const addLit = 2000000000 + 2000000000; // 4*10^9 (> i32::MAX)
+const c = 2000000000;
+const d = 2000000000;
+const addVar = c + d; // 4*10^9
+const subNeg = 1000000000 - 3000000000; // -2*10^9
+const mixed = (100000 * 100000) + (2000000000 + 2000000000); // 10^10 + 4*10^9
+let counter = 2000000000;
+counter = counter + 1;
+counter = counter + 1; // 2000000002
+const addSmall = 1000 + 2000; // 3000 (nao-regressao)
+
 describe("multiplicacao inteira nao overflowa em i32 (#305)", () => {
   test("literal * literal 10^12", () => expect(`${litMul}`).toBe("1000000000000"));
   test("var * var 10^10", () => expect(`${varMul}`).toBe("10000000000"));
@@ -40,4 +52,11 @@ describe("multiplicacao inteira nao overflowa em i32 (#305)", () => {
   test("acumulador em loop", () => expect(`${acc}`).toBe("20000000000"));
   test("produto pequeno continua exato", () => expect(`${small}`).toBe("1000000"));
   test("fn area 10^12", () => expect(`${big}`).toBe("1000000000000"));
+
+  test("add literal > 2^31", () => expect(`${addLit}`).toBe("4000000000"));
+  test("add var > 2^31", () => expect(`${addVar}`).toBe("4000000000"));
+  test("sub negativo > -2^31", () => expect(`${subNeg}`).toBe("-2000000000"));
+  test("mul + add aninhado", () => expect(`${mixed}`).toBe("14000000000"));
+  test("contador cruza 2^31", () => expect(`${counter}`).toBe("2000000002"));
+  test("add pequeno continua exato", () => expect(`${addSmall}`).toBe("3000"));
 });


### PR DESCRIPTION
## #305 follow-up — add/sub inteiro não overflowa em i32

Continuação do [#1325](https://github.com/UrubuCode/rts/pull/1325) (multiplicação). Fecha o follow-up de add/sub que ficou explicitamente aberto.

### Problema
`2000000000 + 2000000000` dava `-294967296` (overflow i32). Mesma raiz da multiplicação: operação inteira em 32 bits estourando antes de promover.

### Solução
Mesma via i64 já provada no mul:
- **AST `lower_add`/`lower_sub`**: `i32 +/- i32` → `sextend`→`iadd`/`isub` i64.
- **MIR codegen `IAdd`/`IAddImm`/`ISub`**: `sextend_to_i64` antes da op.

O acumulador de loop sem anotação já virava f64 (`promote_to_f64` do #305); este fix cobre o caso **i32+i32 puro** (literais e vars i32). Vars `: i64` anotadas (Monte Carlo) e f64 não passam pelo caminho i32 → hot path intacto.

### Benchmark guard
best-of-3-min, interleaved: Monte Carlo CLEAN 79.6ms vs FIX 78.0ms (**-2%**, dentro do ruído). add/sub i32 é comum em loops, mas o índice/acumulador idiomático já não usa i32 puro após o #305.

### Validação (zero regressão)
- Suite TS: **1694 → 1700** (+6 casos: add literal/var > 2^31, sub negativo, mul+add aninhado, contador cruzando 2^31, add pequeno exato)
- `cargo test --lib`: 12/12, rts-mir: 64/64

### Limite consciente
Acima de i64 (raro) ainda satura; f64 completo seria refator maior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
