### PR TITLE
fix(codegen): reduce/map/forEach com idx em aritmetica (#345)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -1321,6 +1321,21 @@ impl LiftAcc {
                     continue;
                 }
 
+                // (#345) Nao re-liftar idents que JA' sao fns liftadas
+                // internamente pelo `lift_inline_arrows` (`__lifted_arr_method_*`
+                // / `__lifted_cap_*`). Essas ja' tem a signature correta do
+                // parallel.* (3 params: acc/val/idx) e devem ser chamadas
+                // DIRETO. Re-liftar criava um trampolim `__lifted_arrow_N(acc,x)`
+                // que so' passava 2 args ao target (perdendo o idx -> undefined
+                // sentinel) e ainda fazia recursao mutua tanglada. Era a causa
+                // de `reduce((acc,x,i)=>acc+x+i,0)` -> lixo (-3.26e-322).
+                if let Expr::Ident(id) = peel_ts(arg.expr.as_ref()) {
+                    let n = id.sym.as_str();
+                    if n.starts_with("__lifted_arr_method_") || n.starts_with("__lifted_cap_") {
+                        continue;
+                    }
+                }
+
                 // Decide qual variante:
                 //  (a) Arrow capturando `this` dentro de classe → trampolim
                 //      com slot global.

--- a/tests/reduce_index_arith.test.ts
+++ b/tests/reduce_index_arith.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "rts:test";
+
+// (#345) Callback de array method com o parametro INDICE usado em aritmetica
+// dava lixo (-3.26e-322). Causa: double-lifting — a arrow de 3 params era
+// liftada por lift_inline_arrows (__lifted_arr_method_reduce_N, 3 params) E
+// re-liftada por this_arrow (__lifted_arrow_N, 2 params), que passava o idx
+// como undefined sentinel (i64::MIN+2) e criava recursao mutua tanglada. Fix:
+// this_arrow nao re-lifta idents ja' liftados internamente (__lifted_arr_method_*
+// / __lifted_cap_*); parallel.* os chama direto com a aridade correta.
+
+const arr = [10, 20, 30];
+
+// reduce com idx usado em aritmetica
+const r3 = arr.reduce((acc, x, i) => acc + x + i, 0); // 60 + (0+1+2) = 63
+const rIdxOnly = arr.reduce((acc, x, i) => acc + i, 0); // 0+1+2 = 3
+const rIdxMul = arr.reduce((acc, x, i) => acc + i * 2, 0); // 0+2+4 = 6
+
+// reduce sem idx continua funcionando (nao-regressao)
+const r2 = arr.reduce((acc, x) => acc + x, 0); // 60
+
+// idx declarado mas nao usado (nao-regressao)
+const rUnused = arr.reduce((acc, x, i) => acc + x, 0); // 60
+
+// map com idx em aritmetica
+const mapped = arr.map((x, i) => x + i).join(","); // 10,21,32
+
+// forEach com idx acumulando
+let feSum = 0;
+arr.forEach((x, i) => { feSum = feSum + x + i; }); // 63
+
+describe("array method callback com idx em aritmetica (#345)", () => {
+  test("reduce acc+x+i", () => expect(`${r3}`).toBe("63"));
+  test("reduce so idx", () => expect(`${rIdxOnly}`).toBe("3"));
+  test("reduce idx*2", () => expect(`${rIdxMul}`).toBe("6"));
+  test("reduce sem idx (nao-regressao)", () => expect(`${r2}`).toBe("60"));
+  test("reduce idx nao usado (nao-regressao)", () => expect(`${rUnused}`).toBe("60"));
+  test("map x+i", () => expect(mapped).toBe("10,21,32"));
+  test("forEach acumulando x+i", () => expect(`${feSum}`).toBe("63"));
+});


### PR DESCRIPTION
## #345 — reduce/map/forEach com índice em aritmética

Primeiro fix concreto da família **invoke dinâmico / param_kinds** (maior alavanca do roadmap). A causa-raiz aqui era mais simples que o esperado.

### Problema
`arr.reduce((acc, x, i) => acc + x + i, 0)` dava lixo (`-3.26e-322`).

### Causa-raiz (não era tipos mistos — era double-lifting)
O roadmap supunha "tipos mistos f64/i64 no body liftado". Investigando o IR, a causa real é **DOUBLE-LIFTING**:

A arrow de 3 params é liftada por `lift_inline_arrows` → `__lifted_arr_method_reduce_N` (3 params, signature correta). Mas `this_arrow` (`lift_arrow_callbacks`) a **re-lifta**, criando um trampolim `__lifted_arrow_N` de **2 params** que:
1. passa `i` como undefined sentinel (`i64::MIN+2`) ao target;
2. cria recursão mútua tanglada (arrow chama wrapper, wrapper chama arrow de volta com idx=undefined).

### Solução
`this_arrow` não re-lifta idents que **já são** fns liftadas internamente (`__lifted_arr_method_*` / `__lifted_cap_*`). Essas têm a signature correta do `parallel.*` (acc/val/idx) e são chamadas direto. Beneficiou também map/forEach com idx (mesma raiz).

### Validação (zero regressão)
- Suite TS: **1700 → 1707** (novo `tests/reduce_index_arith.test.ts`, 7 casos: reduce acc+x+i / só-idx / idx*2 / sem-idx / idx-não-usado / map x+i / forEach acumulando)
- `cargo test --lib`: 12/12

### Follow-up (pré-existente, não regressão)
`reduceRight` com idx passa índice errado (84 vs 63) — confirmado que já dava 84 no HEAD limpo. Callback de string com idx também fica como follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
