### PR TITLE
fix(runtime): reduceRight passa o index ao callback (#345 follow-up)

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/vec.rs
+++ b/crates/rts-runtime/src/namespaces/collections/vec.rs
@@ -891,8 +891,18 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT(
 ) -> i64 {
     let items: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
     if fn_ptr == 0 { return init; }
-    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    items.into_iter().rev().fold(init, |a, b| f(a, b))
+    // (#345 follow-up) callback liftado de reduce tem 3 params (acc, val,
+    // index) — o lift do parallelism gera `__lifted_arr_method_reduce_N` com
+    // aridade 3. Sem passar o index como 3o arg, o param `i` lia lixo do
+    // registrador (`arr.reduceRight((a,x,i)=>a+x+i,0)` -> resultado errado).
+    // reduceRight visita da DIREITA p/ esquerda, mas o index eh a POSICAO
+    // ORIGINAL do elemento (JS spec): len-1, len-2, ..., 0.
+    let f: extern "C" fn(i64, i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let mut acc = init;
+    for (i, x) in items.into_iter().enumerate().rev() {
+        acc = f(acc, x, i as i64);
+    }
+    acc
 }
 
 /// (cross-runtime #202) `arr.reduceRight(fn)` sem initial value. JS spec:
@@ -904,11 +914,14 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_VEC_REDUCE_RIGHT_NO_INIT(
 ) -> i64 {
     let items: Vec<i64> = with_vec(handle, Vec::new(), |v| v.clone());
     if fn_ptr == 0 || items.is_empty() { return 0; }
-    let f: extern "C" fn(i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-    let mut iter = items.into_iter().rev();
-    let mut acc = iter.next().unwrap();
-    for x in iter {
-        acc = f(acc, x);
+    // (#345 follow-up) idem REDUCE_RIGHT: callback de 3 params (acc, val,
+    // index). Sem init, o ultimo elemento (items[len-1]) vira acc inicial e o
+    // loop comeca em len-2 descendo ate 0 (index = posicao original).
+    let f: extern "C" fn(i64, i64, i64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let last = items.len() - 1;
+    let mut acc = items[last];
+    for i in (0..last).rev() {
+        acc = f(acc, items[i], i as i64);
     }
     acc
 }

--- a/tests/reduce_index_arith.test.ts
+++ b/tests/reduce_index_arith.test.ts
@@ -28,6 +28,12 @@ const mapped = arr.map((x, i) => x + i).join(","); // 10,21,32
 let feSum = 0;
 arr.forEach((x, i) => { feSum = feSum + x + i; }); // 63
 
+// reduceRight com idx (visita 2,1,0 — index = posicao ORIGINAL)
+const rrIdx = arr.reduceRight((acc, x, i) => acc + x + i, 0); // 60 + (2+1+0) = 63
+const rrIdxOnly = arr.reduceRight((acc, x, i) => acc + i, 0); // 2+1+0 = 3
+const rrNoIdx = arr.reduceRight((acc, x) => acc + x, 0); // 60 (nao-regressao)
+const rrNoInit = arr.reduceRight((acc, x) => acc + x); // 60 (nao-regressao)
+
 describe("array method callback com idx em aritmetica (#345)", () => {
   test("reduce acc+x+i", () => expect(`${r3}`).toBe("63"));
   test("reduce so idx", () => expect(`${rIdxOnly}`).toBe("3"));
@@ -36,4 +42,8 @@ describe("array method callback com idx em aritmetica (#345)", () => {
   test("reduce idx nao usado (nao-regressao)", () => expect(`${rUnused}`).toBe("60"));
   test("map x+i", () => expect(mapped).toBe("10,21,32"));
   test("forEach acumulando x+i", () => expect(`${feSum}`).toBe("63"));
+  test("reduceRight acc+x+i", () => expect(`${rrIdx}`).toBe("63"));
+  test("reduceRight so idx (2+1+0)", () => expect(`${rrIdxOnly}`).toBe("3"));
+  test("reduceRight sem idx (nao-regressao)", () => expect(`${rrNoIdx}`).toBe("60"));
+  test("reduceRight sem init (nao-regressao)", () => expect(`${rrNoInit}`).toBe("60"));
 });


### PR DESCRIPTION
## #345 follow-up — reduceRight passa o index ao callback

Continuação do [#1327](https://github.com/UrubuCode/rts/pull/1327). Fecha o follow-up do reduceRight com idx.

### Problema
`arr.reduceRight((acc, x, i) => acc + x + i, 0)` dava `84` (esperado 63). Os índices passados eram lixo: `8, -1941359326289904151, ...`.

### Causa
`VEC_REDUCE_RIGHT` e `VEC_REDUCE_RIGHT_NO_INIT` transmutavam o callback como `fn(i64, i64) -> i64` e **nunca passavam o index** — o param `i` lia lixo do registrador.

### Solução
Passar o index como 3º arg, igual ao `PARALLEL_REDUCE`. reduceRight visita da direita pra esquerda, mas o index é a **posição original** do elemento (JS spec): `len-1, len-2, ..., 0`. Callbacks de 2 params ignoram o 3º arg pela calling convention.

### Validação (zero regressão)
- Suite TS: **1707 → 1711** (+4 casos reduceRight: acc+x+i, só-idx 2+1+0, sem-idx, sem-init)
- `cargo test --lib`: 12/12
- Verificado: `idxs = ,2,1,0` (posições corretas, right-to-left)

### Follow-up
Callback de string com idx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
