### PR TITLE
fix(codegen): inferencia de retorno reconhece ident de arrow liftada como Handle (#1281)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -1059,6 +1059,18 @@ fn inspect_return_kind(
             // via fcvt_from_sint perdendo bits — chamada subsequente
             // `f(...)` falhava.
             Expr::Fn(_) | Expr::Arrow(_) => true,
+            // (#1281) Quando o pass de lift roda ANTES desta inferencia, o
+            // `return () => ...` ja' virou `return __lifted_arrow_N` (Ident).
+            // Sem reconhecer esses prefixos sinteticos de funcao, a fn que
+            // RETORNA uma arrow (curry/partial: `partial(f,a){ return (b)=>... }`)
+            // inferia Number/F64 e o handle da arrow voltava como f64-bits
+            // corrompido -> chamada subsequente dava 0.
+            Expr::Ident(id) => {
+                let n = id.sym.as_str();
+                n.starts_with("__lifted_arrow_")
+                    || n.starts_with("__hoisted_arrow_")
+                    || n.starts_with("__hoisted_fn_")
+            }
             Expr::Member(m) => {
                 if let swc_ecma_ast::MemberProp::Computed(_) = &m.prop {
                     if let Expr::Ident(id) = peel(m.obj.as_ref()) {


### PR DESCRIPTION
## Resumo

Fundacao do cluster invoke param_kinds (#1281). `inspect_return_kind` so' tratava `return () => ...` (`Expr::Arrow`) como Handle. Mas o **pass de lift roda ANTES** da inferencia: `return (b)=>f(a,b)` ja' virou `return __lifted_arrow_N` (Ident) quando `inspect_return_kind` roda. O Ident nao casava nenhum braco de `expr_yields_handle` -> caia em `ReturnKind::Number` -> a fn que **retorna** uma arrow (curry/partial: `partial(f,a){ return (b)=>... }`) era inferida como `-> f64` e o handle da arrow voltava como f64-bits corrompido.

## Fix

`expr_yields_handle` reconhece idents com prefixo `__lifted_arrow_`/`__hoisted_arrow_`/`__hoisted_fn_` como Handle. `partial`/`makeAdder` agora inferem `-> i64` (handle) corretamente.

## Escopo / honestidade

Corrige a inferencia de retorno espuria que tambem causava a regressao #1 da tentativa A+C+D. **Nao fecha curry/partial sozinho** (falta reificar arg-fn capturado com param_kinds — fatia a, follow-up). E' uma fundacao correta + nao-regressiva.

## Validacao

- `cargo build --release` verde.
- Suite TS: **1719/1719** (0 falhas), antes e depois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)