### PR TITLE
fix(codegen): reifica handle ao retornar arrow liftada sem captura (#1281)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -16,6 +16,8 @@ use self::calls::{
     AccessorKind, emit_user_fn_addr, emit_virtual_accessor_dispatch, lower_call, lower_new,
     lower_super_prop_assign, lower_super_prop_read, resolve_setter_owner,
 };
+// (#1281) re-export p/ lower_return_stmt reificar arrow liftada que escapa.
+pub(crate) use self::calls::emit_lifted_arrow_handle_with_captures;
 use self::members::{
     assign_target_field_is_f64, class_field_uses_flat, emit_flat_field_write,
     field_is_readonly_in_hierarchy, lhs_static_class, lower_array_lit, lower_member_expr,

--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -428,6 +428,31 @@ pub(super) fn lower_return_stmt(
     }
 
     if let Some(arg) = &ret_stmt.arg {
+        // (#1281) `return () => ...` cuja arrow liftada NAO tem captura nem
+        // `this` escaparia como func_addr CRU (mod.rs:171) — o caller invoca
+        // via INVOKE_AUTO esperando handle e recebe ptr cru -> 0. Como o valor
+        // ESCAPA aqui (return), reifica um handle Function. Diferente do uso
+        // como callback sincrono (describe/test), que continua ptr cru porque
+        // nao passa por este caminho de return-de-arrow-sem-captura. So' atua
+        // quando o ident e' arrow liftada sem captura registrada (com captura
+        // ou `this` o lower_expr normal ja' reifica handle).
+        if let swc_ecma_ast::Expr::Ident(id) = arg.as_ref() {
+            let n = id.sym.as_str();
+            let is_lifted_arrow = (n.starts_with("__lifted_arrow_")
+                || n.starts_with("__hoisted_arrow_"))
+                && ctx.user_fns.contains_key(n)
+                && crate::codegen::lower::passes::this_arrow::lifted_arrow_captures(n).is_none()
+                && ctx.read_local("this").is_none();
+            if is_lifted_arrow {
+                let tv = crate::codegen::lower::expressions::emit_lifted_arrow_handle_with_captures(
+                    ctx, n, &[],
+                )?;
+                ctx.emit_trace_pop()?;
+                let coerced = ctx.pass_as_handle(tv)?;
+                ctx.builder.ins().return_(&[coerced.val]);
+                return Ok(true);
+            }
+        }
         let is_direct_tail_call = is_direct_call_expr(arg);
         let prev = ctx.in_tail_position;
         ctx.in_tail_position = is_direct_tail_call;


### PR DESCRIPTION
## Resumo

`mk(){ return () => 42 }; mk()()` dava **0**. Causa: arrow liftada **sem captura** e sem `this`, em posicao de valor, escapava como `func_addr` CRU (`expressions/mod.rs:171`); o caller invoca via `INVOKE_AUTO` esperando um handle Function e recebia ptr cru -> `read_function_data` falha/colide -> 0. Arrows **com** captura/`this` ja' reificavam handle.

## Fix contexto-sensivel

Em `lower_return_stmt`: quando o `return` devolve um ident de arrow liftada sem captura, reifica um handle Function (bound_args vazio) ANTES de retornar. So' atua no **return-de-arrow-que-escapa**; callbacks sincronos (`describe`/`test`) continuam recebendo `func_addr` cru pelo caminho normal.

> Uma tentativa anterior de "reificar handle sempre" em `mod.rs:171` regrediu **27 testes** por quebrar esses callbacks. Esta versao e' cirurgica — so' o contexto de return.

## Validacao

- `cargo build --release` verde.
- Suite TS: **1719/1719** (0 falhas).
- Casos novos OK: `mk(){return ()=>42}; mk()()`=42; arrow-id reusada (`id(7)`/`id(99)`); function-expr retornada (`mkFn()()`).
- Limitacao conhecida (follow-up, fatia a): arg f64 fracionario do callee dinamico (`mkInc()(41)` da 41.0000…1) — bug separado de empacotamento de arg, nao desta mudanca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)