### PR TITLE
fix(codegen): param number em arrow liftada funciona ponta-a-ponta (#1281 A+C+D)

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -477,6 +477,33 @@ pub(super) fn lower_curry_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &CallE
     let callee = lower_expr(ctx, callee_expr)?;
     let callee_val = ctx.coerce_to_i64(callee).val;
 
+    // (A+D — #1281) Decide a convencao de empacotamento dos args proprios do
+    // curry: bits-f64 (callee e' arrow liftada TYPED com param number) vs i64
+    // raw (callee e' fn_ptr i64 cru — function expression hoisted como `nested`,
+    // que captura via global e retorna func_addr). Resolve a raiz da cadeia de
+    // calls (`add3(1)(2)` -> `add3`) e consulta o registro do pass de lift.
+    let root_is_typed = {
+        let mut cur = callee_expr;
+        loop {
+            match cur {
+                Expr::Call(c) => {
+                    if let swc_ecma_ast::Callee::Expr(inner) = &c.callee {
+                        cur = inner.as_ref();
+                    } else {
+                        break false;
+                    }
+                }
+                Expr::Paren(p) => cur = p.expr.as_ref(),
+                Expr::Ident(id) => {
+                    break crate::codegen::lower::passes::this_arrow::fn_returns_typed_arrow(
+                        id.sym.as_str(),
+                    );
+                }
+                _ => break false,
+            }
+        }
+    };
+
     let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
     let vec_push = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[cl::I64, cl::I64], None)?;
     let vec_extend = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_EXTEND_FROM", &[cl::I64, cl::I64], None)?;
@@ -490,9 +517,37 @@ pub(super) fn lower_curry_call(ctx: &mut FnCtx, callee_expr: &Expr, call: &CallE
             ctx.builder.ins().call(vec_extend, &[args_vec, src]);
             continue;
         }
-        // INTEIRO (coerce_to_i64): casa com a convencao i64-ABI da arrow
-        // liftada (fcvt_from_sint no body) e com as capturas (REIFY).
-        let v = ctx.coerce_to_i64(tv).val;
+        // (A+C+D — #1281) Args NUMERICOS viajam como bits-f64 (bitcast); o
+        // runtime faz from_bits quando o param_kind do callee e' 1 (arrow
+        // liftada agora reificada TYPED com params number=f64). Como o callee
+        // dinamico nao expoe kinds aqui, usamos o tipo do ARGUMENTO: F64 OU
+        // literal numerico (incl. inteiro `2`, que o param number le como f64).
+        // Handles/strings/idents-ambiguos seguem coerce_to_i64 (callee i64,
+        // le raw — curry-i64/add3(1)(2)(3) byte-identico, pois nesse caso o
+        // param e' i64/kind=0 e o arg inteiro casa).
+        //
+        // NB: add3(1)(2)(3) — os params (a,b,c) sao number, logo kind=1, e o
+        // arg inteiro literal vai como bits-f64 -> from_bits casa. curry-i64
+        // (adder com number) idem. Quando o param fosse i64 puro (sem number),
+        // o arg inteiro literal cairia em coerce_to_i64; ver match abaixo.
+        let arg_is_num_lit = matches!(
+            &*arg.expr,
+            Expr::Lit(swc_ecma_ast::Lit::Num(_))
+        ) || matches!(
+            &*arg.expr,
+            Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus)
+                && matches!(&*u.arg, Expr::Lit(swc_ecma_ast::Lit::Num(_)))
+        );
+        let v = if root_is_typed && (matches!(tv.ty, ValTy::F64) || arg_is_num_lit) {
+            let f = ctx.coerce_to_f64(tv).val;
+            ctx.builder.ins().bitcast(
+                cl::I64,
+                cranelift_codegen::ir::MemFlags::new(),
+                f,
+            )
+        } else {
+            ctx.coerce_to_i64(tv).val
+        };
         ctx.builder.ins().call(vec_push, &[args_vec, v]);
     }
     let zero = ctx.builder.ins().iconst(cl::I64, 0);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -3410,7 +3410,68 @@ pub(super) fn emit_hoisted_arrow_handle(
     let is_arrow_v = ctx.builder.ins().iconst(cl::I32, 1);
     let has_this_v = ctx.builder.ins().iconst(cl::I32, 0);
 
-    let handle = if let Some(this_val) = bound_this {
+    // (A+C — #1281) Deriva param_kinds + return_kind da UserFnAbi. Quando ha
+    // algum kind!=0 (param/ret number/bool, ex arrow `(i:number)=>i+100`), o
+    // handle precisa carregar os kinds p/ invoke_typed fazer from_bits — senao
+    // o raw fn_ptr `(f64)->f64` e' invocado via invoke_all_i64 (ABI i64) e
+    // corrompe. SE todo-zero: caminho BYTE-IDENTICO ao de hoje (REIFY/REIFY_BOUND).
+    let (pks_bytes, rk_byte): (Vec<u8>, u8) = {
+        let info = ctx.user_fns.get(name);
+        let pks: Vec<u8> = info
+            .map(|f| {
+                f.params
+                    .iter()
+                    .map(|p| super::members::val_ty_to_kind(*p))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let rk: u8 = info
+            .and_then(|f| f.ret)
+            .map(super::members::val_ty_to_kind)
+            .unwrap_or(0);
+        (pks, rk)
+    };
+    let has_nonzero_kind = pks_bytes.iter().any(|&k| k != 0) || rk_byte != 0;
+
+    let handle = if has_nonzero_kind {
+        // TYPED: usa REIFY_BOUND_TYPED (cobre bound_this opcional + kinds).
+        let (kinds_ptr, kinds_len) = if pks_bytes.is_empty() {
+            (
+                ctx.builder.ins().iconst(cl::I64, 0),
+                ctx.builder.ins().iconst(cl::I64, 0),
+            )
+        } else {
+            let tv = ctx.emit_str_handle(&pks_bytes)?;
+            let h = ctx.coerce_to_i64(tv).val;
+            let p = ctx.builder.ins().call(str_ptr_fn, &[h]);
+            let l = ctx.builder.ins().call(str_len_fn, &[h]);
+            (ctx.builder.inst_results(p)[0], ctx.builder.inst_results(l)[0])
+        };
+        let (bound_this_v, has_bound_v) = match bound_this {
+            Some(this_val) => (this_val, ctx.builder.ins().iconst(cl::I32, 1)),
+            None => (
+                ctx.builder.ins().iconst(cl::I64, 0),
+                ctx.builder.ins().iconst(cl::I32, 0),
+            ),
+        };
+        let return_kind_v = ctx.builder.ins().iconst(cl::I32, rk_byte as i64);
+        let reify_fn = ctx.get_extern(
+            "__RTS_FN_GL_FUNCTION_REIFY_BOUND_TYPED",
+            &[
+                cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32,
+                cl::I64, cl::I32, cl::I64, cl::I64, cl::I32,
+            ],
+            Some(cl::I64),
+        )?;
+        let inst_r = ctx.builder.ins().call(
+            reify_fn,
+            &[
+                fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v,
+                bound_this_v, has_bound_v, kinds_ptr, kinds_len, return_kind_v,
+            ],
+        );
+        ctx.builder.inst_results(inst_r)[0]
+    } else if let Some(this_val) = bound_this {
         // Captura `this` do escopo envolvente no handle — arrow de longa duração.
         let has_bound_v = ctx.builder.ins().iconst(cl::I32, 1);
         let reify_fn = ctx.get_extern(
@@ -3470,18 +3531,47 @@ pub(crate) fn emit_lifted_arrow_handle_with_captures(
     // Empacota capturas num Vec<i64> (f64 -> bits). param_kinds reflete o
     // tipo de cada capture + zeros para os params proprios (codegen ja' passa
     // valores como i64; f64 reinterpretado via param_kinds[i]=1).
+    // (A+C+D — #1281) Deriva param_kinds + return_kind da UserFnAbi da fn
+    // liftada (mesmo padrao de lower_callable_target_h:3306-3321). A fn liftada
+    // tem params = [capturas..., params proprios]; com a anotacao number/boolean
+    // preservada (this_arrow.rs PARTE A), os kinds refletem o tipo real.
+    let (pks_bytes, rk_byte): (Vec<u8>, u8) = {
+        let info = ctx.user_fns.get(name);
+        let pks: Vec<u8> = info
+            .map(|f| {
+                f.params
+                    .iter()
+                    .map(|p| super::members::val_ty_to_kind(*p))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let rk: u8 = info
+            .and_then(|f| f.ret)
+            .map(super::members::val_ty_to_kind)
+            .unwrap_or(0);
+        (pks, rk)
+    };
+    // SE todo-zero (incl. ret): caminho BYTE-IDENTICO ao de hoje (curry-i64
+    // intacto). SE algum kind!=0: TYPED com kinds reais + capturas f64-bits.
+    let has_nonzero_kind = pks_bytes.iter().any(|&k| k != 0) || rk_byte != 0;
+
     let vec_new = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[], Some(cl::I64))?;
     let bound_h = {
         let i = ctx.builder.ins().call(vec_new, &[]);
         ctx.builder.inst_results(i)[0]
     };
     let vec_push = ctx.get_extern("__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[cl::I64, cl::I64], None)?;
-    // A fn liftada e' i64-only (params sem anotacao de tipo viram i64). Passa
-    // cada captura coergida pra i64 — `coerce_to_i64` converte f64 numerico
-    // (40.0 -> 40) e mantem handles. param_kinds vazio = caminho rapido
-    // invoke_all_i64. (Captura f64 FRACIONARIA perde precisao — follow-up.)
-    for cv in capture_vals {
-        let raw = ctx.coerce_to_i64(*cv).val;
+    // Empacota cada captura. As capturas ocupam os PRIMEIROS slots dos params
+    // (ver lift_arrow_to_ident). Quando o slot correspondente e' kind=1 (f64),
+    // empacota como bits-f64 (bitcast) p/ o runtime fazer from_bits; senao
+    // coerce_to_i64 como hoje (handle/i64/bool i64 cru).
+    for (i, cv) in capture_vals.iter().enumerate() {
+        let raw = if has_nonzero_kind && pks_bytes.get(i).copied() == Some(1) {
+            let f = ctx.coerce_to_f64(*cv).val;
+            ctx.builder.ins().bitcast(cl::I64, cranelift_codegen::ir::MemFlags::new(), f)
+        } else {
+            ctx.coerce_to_i64(*cv).val
+        };
         ctx.builder.ins().call(vec_push, &[bound_h, raw]);
     }
     // Mantem o Vec vivo durante a reificacao.
@@ -3492,11 +3582,25 @@ pub(crate) fn emit_lifted_arrow_handle_with_captures(
         &[cl::I64, cl::I64, cl::I64, cl::I64, cl::I32, cl::I32, cl::I64, cl::I64, cl::I64, cl::I32],
         Some(cl::I64),
     )?;
-    let zero = ctx.builder.ins().iconst(cl::I64, 0);
-    let return_kind_v = ctx.builder.ins().iconst(cl::I32, 0);
+    let (kinds_ptr, kinds_len) = if has_nonzero_kind && !pks_bytes.is_empty() {
+        let tv = ctx.emit_str_handle(&pks_bytes)?;
+        let h = ctx.coerce_to_i64(tv).val;
+        let p = ctx.builder.ins().call(str_ptr_fn, &[h]);
+        let l = ctx.builder.ins().call(str_len_fn, &[h]);
+        (ctx.builder.inst_results(p)[0], ctx.builder.inst_results(l)[0])
+    } else {
+        (
+            ctx.builder.ins().iconst(cl::I64, 0),
+            ctx.builder.ins().iconst(cl::I64, 0),
+        )
+    };
+    let return_kind_v = ctx
+        .builder
+        .ins()
+        .iconst(cl::I32, if has_nonzero_kind { rk_byte as i64 } else { 0 });
     let inst = ctx.builder.ins().call(
         reify_fn,
-        &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v, bound_h, zero, zero, return_kind_v],
+        &[fn_addr, arity_v, n_ptr, n_len, is_arrow_v, has_this_v, bound_h, kinds_ptr, kinds_len, return_kind_v],
     );
     let handle = ctx.builder.inst_results(inst)[0];
     ctx.declare_gc_handle(handle);

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -169,6 +169,23 @@ fn lower_ident_expr(ctx: &mut FnCtx, name: &str) -> Result<TypedVal> {
                 let bound_this = ctx.coerce_to_i64(tv).val;
                 return calls::emit_hoisted_arrow_handle(ctx, name, Some(bound_this));
             }
+            // (A+C — #1281) Arrow com param/ret number/bool (kind!=0): raw fn
+            // addr `(f64)->f64` nao pode ser invocado via INVOKE_AUTO (ABI i64).
+            // Reifica como handle TYPED p/ invoke_typed fazer from_bits.
+            // Arrow todo-i64 mantem raw fn addr (byte-identico ao de hoje).
+            let has_nonzero_kind = ctx
+                .user_fns
+                .get(name)
+                .map(|f| {
+                    f.params
+                        .iter()
+                        .any(|p| members::val_ty_to_kind(*p) != 0)
+                        || f.ret.map(members::val_ty_to_kind).unwrap_or(0) != 0
+                })
+                .unwrap_or(false);
+            if has_nonzero_kind {
+                return calls::emit_hoisted_arrow_handle(ctx, name, None);
+            }
             // Fora de escopo de classe — raw fn addr como antes.
             return emit_user_fn_addr(ctx, name);
         }

--- a/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/this_arrow.rs
@@ -429,6 +429,9 @@ pub(crate) fn lift_arrow_callbacks(program: &mut Program) -> HashSet<String> {
         alias_to_real,
         needs_c_callconv: HashSet::new(),
         scope_vars: HashSet::new(),
+        scope_var_types: HashMap::new(),
+        current_fn: None,
+        fn_returns_typed_arrow: HashSet::new(),
         lifted_captures: HashMap::new(),
         lifted_arrow_class: HashMap::new(),
     };
@@ -582,6 +585,7 @@ pub(crate) fn lift_arrow_callbacks(program: &mut Program) -> HashSet<String> {
     // os idents `__lifted_arrow_N` como handles Function com bound_args.
     set_lifted_captures(std::mem::take(&mut acc.lifted_captures));
     set_lifted_arrow_class(std::mem::take(&mut acc.lifted_arrow_class));
+    set_fn_returns_typed_arrow(std::mem::take(&mut acc.fn_returns_typed_arrow));
     acc.needs_c_callconv
 }
 
@@ -596,6 +600,20 @@ thread_local! {
     /// da arrow liftada.
     static LIFTED_ARROW_CLASS: std::cell::RefCell<HashMap<String, String>> =
         std::cell::RefCell::new(HashMap::new());
+    /// (A+D — #1281) user fns que retornam arrow liftada TYPED (param number).
+    static FN_RETURNS_TYPED_ARROW: std::cell::RefCell<HashSet<String>> =
+        std::cell::RefCell::new(HashSet::new());
+}
+
+/// (A+D — #1281) Registra o conjunto de fns que retornam arrow liftada TYPED.
+pub(crate) fn set_fn_returns_typed_arrow(set: HashSet<String>) {
+    FN_RETURNS_TYPED_ARROW.with(|c| *c.borrow_mut() = set);
+}
+
+/// (A+D — #1281) `f` retorna uma arrow liftada com param number (kind=1)?
+/// Consultado pelo curry call site p/ decidir bits-f64 vs i64 raw nos args.
+pub(crate) fn fn_returns_typed_arrow(name: &str) -> bool {
+    FN_RETURNS_TYPED_ARROW.with(|c| c.borrow().contains(name))
 }
 
 /// (#195) Registra o mapa `__lifted_arrow_N -> [capturas]` produzido pelo
@@ -676,6 +694,21 @@ struct LiftAcc {
     /// pra detectar capturas (free vars que sao desses, e nao user fns).
     /// Atualizado conforme desce em fns/arrows.
     scope_vars: HashSet<String>,
+    /// (A — #1281) Tipo conhecido (string da anotacao, ex: "number"/"boolean")
+    /// das vars em escopo. Usado por `lift_arrow_to_ident` p/ anotar a captura
+    /// com o mesmo tipo do param/var do escopo enclosing — sem isso a captura
+    /// f64 vira i64 (curry com captura fracionaria perde precisao). So' params
+    /// anotados number/boolean populam aqui; resto fica None.
+    scope_var_types: HashMap<String, Option<String>>,
+    /// (A+D — #1281) Nome da user fn sendo processada (p/ associar arrows
+    /// liftadas TYPED ao fn que as retorna).
+    current_fn: Option<String>,
+    /// (A+D — #1281) user fns cujo corpo retorna (direta ou via curry aninhado)
+    /// uma arrow liftada com param number (kind=1) — `adder`/`add3`/`partial`.
+    /// O curry call site empaca args como bits-f64 SO' p/ esses; fn que retorna
+    /// fn_ptr i64 cru (function expression hoisted, ex `nested`) fica de fora,
+    /// mantendo a convencao i64 raw (zero regressao do path antigo).
+    fn_returns_typed_arrow: HashSet<String>,
     /// (#195) Mapa `__lifted_arrow_N` -> nomes das vars capturadas (ordem
     /// estavel). O codegen consulta pra reificar via REIFY_CAPTURED, passando
     /// os valores das capturas como bound_args.
@@ -724,6 +757,24 @@ impl LiftAcc {
             .filter(|n| self.scope_vars.insert((*n).clone()))
             .cloned()
             .collect();
+        // (A — #1281) Registra o tipo conhecido dos params desta fn pra que a
+        // captura num arrow aninhado herde number/boolean (curry com captura
+        // f64 fracionaria). So' os tipos que mapeiam pra repr != i64.
+        let prev_var_types: Vec<(String, Option<Option<String>>)> = f
+            .parameters
+            .iter()
+            .filter_map(|p| {
+                let ty = match p.type_annotation.as_deref() {
+                    Some("number") | Some("f64") => Some("number".to_string()),
+                    Some("boolean") => Some("boolean".to_string()),
+                    _ => None,
+                };
+                ty.map(|t| {
+                    let prev = self.scope_var_types.insert(p.name.clone(), Some(t));
+                    (p.name.clone(), prev)
+                })
+            })
+            .collect();
 
         // Promove cada captura pra global e reescreve toda a fn.
         // Insere as syncs de parâmetros no topo (em ordem reversa para
@@ -760,11 +811,23 @@ impl LiftAcc {
         // Agora roda o lift normal — idents nos arrows são globais,
         // resolvem sem problema. (As capturas por-valor sao detectadas via
         // scope_vars e viram params do __lifted_arrow_N.)
+        let prev_fn = self.current_fn.replace(f.name.clone());
         self.lift_in_body("", &mut f.body, /*in_class=*/ false);
+        self.current_fn = prev_fn;
 
         // Restaura scope_vars (remove o que esta fn adicionou).
         for n in &prev_scope {
             self.scope_vars.remove(n);
+        }
+        for (name, prev) in prev_var_types {
+            match prev {
+                Some(v) => {
+                    self.scope_var_types.insert(name, v);
+                }
+                None => {
+                    self.scope_var_types.remove(&name);
+                }
+            }
         }
     }
 
@@ -777,6 +840,52 @@ impl LiftAcc {
     /// `hoist_fn::build_fn_decl`. Sem isso a arrow liftada perdia os proprios
     /// params (`(i) => values[i]` virava fn sem `i` -> "undefined variable i").
     /// Cobre rest (`...args`), destructuring (`[k,v]`/`{a}`) e filtra `this`.
+    /// (A — #1281) Mapeia a anotacao TS de um BindingIdent para o string de
+    /// tipo que o codegen reconhece em `UserFnAbi`. So' number->"number" e
+    /// boolean->"boolean" (tipos primitivos com representacao Cranelift
+    /// distinta de i64). Qualquer outro tipo (string/handle/object/ausente)
+    /// -> None, mantendo o i64 ambiguo de hoje (bail intencional). Le de
+    /// `b.type_ann` (BindingIdent.type_ann), nao de `b.id.type_ann`.
+    fn binding_keyword_type_ann(b: &swc_ecma_ast::BindingIdent) -> Option<String> {
+        let ann = b.type_ann.as_ref()?;
+        if let TsType::TsKeywordType(k) = ann.type_ann.as_ref() {
+            use swc_ecma_ast::TsKeywordTypeKind;
+            return match k.kind {
+                TsKeywordTypeKind::TsNumberKeyword => Some("number".to_string()),
+                TsKeywordTypeKind::TsBooleanKeyword => Some("boolean".to_string()),
+                _ => None,
+            };
+        }
+        None
+    }
+
+    /// (A — #1281) Inferencia ESTRITA: a expr e' f64 quando e' aritmetica
+    /// (+,-,*,/) cujos operandos sao idents number (do set), literais
+    /// numericos, ou subexpressoes f64. Comparacoes/logicos -> false (bool),
+    /// arrow/call/string/object -> false. Conservadora: na duvida, false.
+    fn arrow_expr_is_f64(
+        e: &swc_ecma_ast::Expr,
+        f64_idents: &std::collections::HashSet<String>,
+    ) -> bool {
+        use swc_ecma_ast::{BinaryOp, Expr, Lit};
+        match e {
+            Expr::Ident(id) => f64_idents.contains(id.sym.as_str()),
+            Expr::Lit(Lit::Num(_)) => true,
+            Expr::Paren(p) => Self::arrow_expr_is_f64(&p.expr, f64_idents),
+            Expr::Bin(b) => match b.op {
+                BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
+                    Self::arrow_expr_is_f64(&b.left, f64_idents)
+                        && Self::arrow_expr_is_f64(&b.right, f64_idents)
+                }
+                _ => false,
+            },
+            Expr::Unary(u) if matches!(u.op, swc_ecma_ast::UnaryOp::Minus | swc_ecma_ast::UnaryOp::Plus) => {
+                Self::arrow_expr_is_f64(&u.arg, f64_idents)
+            }
+            _ => false,
+        }
+    }
+
     fn arrow_params_to_parameters(
         arrow: &swc_ecma_ast::ArrowExpr,
         syn_name: &str,
@@ -837,7 +946,7 @@ impl LiftAcc {
                 }
                 parameters.push(Parameter {
                     name: n,
-                    type_annotation: None,
+                    type_annotation: Self::binding_keyword_type_ann(b),
                     modifiers: MemberModifiers::default(),
                     variadic: false,
                     default: None,
@@ -848,7 +957,7 @@ impl LiftAcc {
                 if let Pat::Ident(b) = a.left.as_ref() {
                     parameters.push(Parameter {
                         name: b.id.sym.to_string(),
-                        type_annotation: None,
+                        type_annotation: Self::binding_keyword_type_ann(b),
                         modifiers: MemberModifiers::default(),
                         variadic: false,
                         default: Some(a.right.clone()),
@@ -920,9 +1029,16 @@ impl LiftAcc {
 
         let mut parameters: Vec<Parameter> = Vec::with_capacity(captures.len() + own_parameters.len());
         for cap in &captures {
+            // (A — #1281) Herda o tipo da var capturada do escopo enclosing.
+            // `__captured_this` nunca tem tipo numerico (None).
+            let cap_ty = if cap == "__captured_this" {
+                None
+            } else {
+                self.scope_var_types.get(cap).cloned().flatten()
+            };
             parameters.push(Parameter {
                 name: cap.clone(),
-                type_annotation: None,
+                type_annotation: cap_ty,
                 modifiers: MemberModifiers::default(),
                 variadic: false,
                 default: None,
@@ -930,6 +1046,7 @@ impl LiftAcc {
             });
         }
         parameters.extend(own_parameters);
+        let has_captures = !captures.is_empty();
         if !captures.is_empty() {
             self.lifted_captures.insert(syn_name.clone(), captures);
         }
@@ -962,15 +1079,78 @@ impl LiftAcc {
             .filter_map(|p| if let Pat::Ident(id) = p { Some(id.id.sym.to_string()) } else { None })
             .filter(|n| self.scope_vars.insert(n.clone()))
             .collect();
+        // (A — #1281) Tambem registra o tipo dos params proprios pra que
+        // arrows aninhadas (curry `(a)=>(b)=>(c)=>...`) herdem number/boolean
+        // ao capturar `a`/`b`. Restaura depois.
+        let prev_inner_types: Vec<(String, Option<Option<String>>)> = arrow
+            .params
+            .iter()
+            .filter_map(|p| {
+                if let Pat::Ident(id) = p {
+                    let ty = Self::binding_keyword_type_ann(id)?;
+                    let name = id.id.sym.to_string();
+                    let prev = self.scope_var_types.insert(name.clone(), Some(ty));
+                    Some((name, prev))
+                } else {
+                    None
+                }
+            })
+            .collect();
         self.lift_in_body(class_name, &mut body_stmts, in_class);
         for n in &added_to_scope {
             self.scope_vars.remove(n);
+        }
+        for (name, prev) in prev_inner_types {
+            match prev {
+                Some(v) => {
+                    self.scope_var_types.insert(name, v);
+                }
+                None => {
+                    self.scope_var_types.remove(&name);
+                }
+            }
         }
 
         // Expression-body arrows always return a value; block-body arrows
         // with explicit `return` also do, but we can't easily detect that
         // here, so treat block-body as void (the common UI-callback case).
-        let ret_ty = if has_return_value { Some("i64".to_string()) } else { Some("void".to_string()) };
+        // (A — #1281) Quando o body e' uma expressao aritmetica f64 (algum
+        // param/captura number), o retorno e' "number" — senao o lower forca
+        // fcvt_to_sint_sat e trunca (curry_f -> 3 em vez de 3.75). Inferencia
+        // ESTRITA: so' marca number quando ha pelo menos um param number e a
+        // expr e' aritmetica f64; default mantem "i64".
+        let number_params: std::collections::HashSet<String> = parameters
+            .iter()
+            .filter(|p| p.type_annotation.as_deref() == Some("number"))
+            .map(|p| p.name.clone())
+            .collect();
+        let body_is_f64 = match arrow.body.as_ref() {
+            swc_ecma_ast::BlockStmtOrExpr::Expr(e) => {
+                !number_params.is_empty() && Self::arrow_expr_is_f64(e, &number_params)
+            }
+            _ => false,
+        };
+        let ret_ty = if !has_return_value {
+            Some("void".to_string())
+        } else if body_is_f64 {
+            Some("number".to_string())
+        } else {
+            Some("i64".to_string())
+        };
+
+        // (A+D — #1281) Se esta arrow tem param number (kind=1), o curry call
+        // site precisa empacotar args como bits-f64 quando o callee resolve a
+        // user fn que a RETORNA. Registra a fn enclosing. Cobre arrow COM
+        // captura (emit_lifted_arrow_handle_with_captures, TYPED) e SEM captura
+        // (func_addr direto p/ signature f64 — `mkInc`). function expressions
+        // (hoist_fn, ex `nested`) NAO passam por aqui, logo ficam de fora e
+        // mantem a convencao i64 raw (zero regressao).
+        let _ = has_captures;
+        if !number_params.is_empty() {
+            if let Some(fname) = &self.current_fn {
+                self.fn_returns_typed_arrow.insert(fname.clone());
+            }
+        }
 
         self.new_fns.push(Item::Function(FunctionDecl {
             name: syn_name.clone(),

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -38,6 +38,26 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                     }
                 }
             }
+            // (A — #1281) `const g = (i:number)=>i+100` — init eh ident de
+            // arrow liftada/hoistada cujo UserFnAbi.ret e' F64. Marca
+            // local_fn_ret_f64 p/ que `g(5)` use INVOKE_AUTO_AS_F64 + bitcast
+            // (senao o retorno f64 e' lido como int via fcvt_from_sint).
+            if let Some(init) = &decl.init {
+                if let swc_ecma_ast::Expr::Ident(fid) = init.as_ref() {
+                    let fname = fid.sym.as_str();
+                    if (fname.starts_with("__lifted_arrow_")
+                        || fname.starts_with("__hoisted_arrow_"))
+                        && ctx
+                            .user_fns
+                            .get(fname)
+                            .and_then(|f| f.ret)
+                            .map(|r| matches!(r, ValTy::F64))
+                            .unwrap_or(false)
+                    {
+                        ctx.local_fn_ret_f64.insert(name.clone());
+                    }
+                }
+            }
             if let Some(ann) = id.type_ann.as_ref() {
                 // (372) `f: () => number` — fn que retorna number. Marca pra
                 // que `f()` reinterprete o i64-bits do invoke como f64.


### PR DESCRIPTION
## Resumo

Fecha o cluster **invoke param_kinds** (#1281): arrows liftadas com param `number` (f64) agora funcionam ponta-a-ponta.

| caso | antes | depois |
|---|---|---|
| `adder(1.5)(2.25)` (curry_f) | 3 | **3.75** ✓ |
| `partial(mul,6)(7)` | 0 | **42** ✓ |
| `mkInc()(41)` | 41.0001 | **42** ✓ |
| `adder(40)(2)` (curry_i) | 42 | **42** (intacto) |
| `add3(1)(2)(3)` (curry3) | 6 | **6** (intacto) |
| HOF i64/f64 | 42/5 | **42/5** (intacto) |

## Mudanca atomica (A+C+D)

O refator falhou **4×** quando tentado por partes — as 3 partes sao acopladas. Esta PR faz tudo junto, **condicionado por `kind!=0`** (arrow all-i64 = caminho byte-identico ao atual):

- **(A) `this_arrow.rs`**: `arrow_params_to_parameters` preserva `number`/`boolean`; capturas herdam tipo via `scope_var_types`; `ret_ty` vira number quando o body e' f64 (inferencia estrita); registra `fn_returns_typed_arrow`.
- **(C) `calls/mod.rs`**: `emit_lifted_arrow_handle_with_captures`/`emit_hoisted_arrow_handle` derivam pks/rk de `UserFnAbi`; `kind!=0` → `REIFY_*_TYPED` + capturas como bits-f64; todo-zero → byte-identico.
- **(D) `indirect.rs`**: `lower_curry_call` empacota args numericos como bits-f64 quando a raiz da cadeia esta em `fn_returns_typed_arrow`; senao i64 raw (preserva `nested`/curry-i64). `mod.rs`: arrow sem captura `kind!=0` reifica handle TYPED. `decls.rs`: `const g=<arrow ret F64>` marca `local_fn_ret_f64`.

**Chave:** a captura f64 do curry tambem vira bits-f64 quando o param e' f64 — o que permite `curry_i=42` e `curry_f=3.75` simultaneos.

## Fundacao

Apoiado em #1330 (invoke_typed arity 0-8), #1331 (infer ret arrow→Handle), #1332 (reify arrow no return).

## Validacao

- `cargo build --release` verde.
- Suite TS: **1719/1719** (0 falhas), reproduzido na main.
- Implementado e verificado por workflow impl + verify adversarial (probe 7/7, suite conferida independentemente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)