### PR TITLE
feat(generators): yield em try/finally + .return/.throw na state-machine (#477 fatia 2)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -196,6 +196,10 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_GC_GEN_SM_DONE", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_DONE);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_NEXT", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_NEXT);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_RETURN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_RETURN);
+    add_fn!("__RTS_FN_NS_GC_GEN_SM_THROW", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_THROW);
+    add_fn!("__RTS_FN_NS_GC_GEN_SM_ENTER_TRY", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_ENTER_TRY);
+    add_fn!("__RTS_FN_NS_GC_GEN_SM_END_FINALLY", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_END_FINALLY);
+    add_fn!("__RTS_FN_NS_GC_GENERATOR_THROW", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_THROW);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_IS", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_IS);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_DRAIN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_DRAIN);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -327,6 +327,28 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                         }
                     }
                 }
+                // (#477 fatia 2) `<genVar>.throw(e)` — injeta excecao no ponto
+                // suspenso; se ha' finally ativo, roda o finally (yield absorve).
+                if prop.sym.as_str() == "throw" && call.args.len() == 1 {
+                    if let Expr::Ident(obj_id) = m.obj.as_ref() {
+                        if ctx.generator_vars.contains(obj_id.sym.as_str()) {
+                            use cranelift_codegen::ir::types as cl;
+                            let recv_tv = lower_expr(ctx, &m.obj)?;
+                            let recv = ctx.coerce_to_i64(recv_tv).val;
+                            let val_tv = lower_expr(ctx, &call.args[0].expr)?;
+                            let val = ctx.coerce_to_i64(val_tv).val;
+                            let throw_fn = ctx.get_extern(
+                                "__RTS_FN_NS_GC_GENERATOR_THROW",
+                                &[cl::I64, cl::I64],
+                                Some(cl::I64),
+                            )?;
+                            let inst = ctx.builder.ins().call(throw_fn, &[recv, val]);
+                            let h = ctx.builder.inst_results(inst)[0];
+                            ctx.declare_gc_handle(h);
+                            return Ok(TypedVal::new(h, ValTy::Handle));
+                        }
+                    }
+                }
             }
         }
         if let Expr::SuperProp(sp) = callee.as_ref() {
@@ -4189,6 +4211,8 @@ fn gen_sm_sentinel(
         ("__RTS_GEN_SM_SETSTATE", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_SETSTATE", None)),
         ("__RTS_GEN_SM_YIELD", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_YIELD", Some(cl::I64))),
         ("__RTS_GEN_SM_DONE", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_DONE", Some(cl::I64))),
+        ("__RTS_GEN_SM_ENTER_TRY", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_ENTER_TRY", None)),
+        ("__RTS_GEN_SM_END_FINALLY", 1) => Some(("__RTS_FN_NS_GC_GEN_SM_END_FINALLY", Some(cl::I64))),
         _ => None,
     }
 }

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -62,7 +62,7 @@ pub fn try_build(name: &str, function: &Function) -> Option<(FnDecl, FnDecl)> {
     // precisam de lazy: corpo contem um loop (`while`/`for`) com `yield` dentro.
     // Generators lineares finitos (`yield 1; yield 2;`) continuam no eager-buffer
     // — caminho provado que ja' serve for-of/spread/.next sem regressao.
-    if !body_has_loop_with_yield(&body.stmts) {
+    if !body_needs_lazy(&body.stmts) {
         return None;
     }
 
@@ -156,6 +156,10 @@ enum Trans {
     Done(Option<Expr>),
     /// if (<test>) goto then else goto els.
     Cond { test: Expr, then_s: usize, els: usize },
+    /// Fim do bloco `finally`: chama END_FINALLY (que honra return/throw
+    /// pendente, marcando done + state=-2) e, se nada pendente, segue para
+    /// `normal_next`. (#477 fatia 2)
+    EndFinally { normal_next: usize },
     /// placeholder ate ser preenchido.
     Unset,
 }
@@ -204,6 +208,9 @@ impl SmBuilder {
     }
     fn set_cond(&mut self, state: usize, test: Expr, then_s: usize, els: usize) {
         self.states[state].trans = Trans::Cond { test, then_s, els };
+    }
+    fn set_end_finally(&mut self, state: usize, normal_next: usize) {
+        self.states[state].trans = Trans::EndFinally { normal_next };
     }
 
     /// Lower uma sequencia de statements comecando em `cur`. Devolve o estado
@@ -338,6 +345,47 @@ impl SmBuilder {
                 // codigo apos return eh inalcancavel; novo estado morto p/ seq.
                 Some(self.new_state())
             }
+            // `try { ... } finally { ... }` (#477 fatia 2)
+            Stmt::Try(t) => {
+                // catch com yield => fora de escopo desta fatia.
+                if let Some(h) = &t.handler {
+                    if h.body.stmts.iter().any(stmt_has_yield) {
+                        return None;
+                    }
+                }
+                let Some(finalizer) = &t.finalizer else {
+                    // try sem finally: so' tem sentido aqui se o body tem yield.
+                    // Achata o body como sequencia (sem semantica de catch real).
+                    if t.handler.is_some() {
+                        return None;
+                    }
+                    return self.lower_seq(&t.block.stmts, cur);
+                };
+                // Estado de entrada do finally (alvo de ENTER_TRY e da saida
+                // normal do try body). Reservamos o indice antes de lower o body
+                // para que ENTER_TRY aponte para ele.
+                let finally_entry = self.new_state();
+                // ENTER_TRY(__g, finally_entry) no estado atual, antes do body.
+                self.push_stmt(
+                    cur,
+                    call_stmt(call(
+                        "__RTS_GEN_SM_ENTER_TRY",
+                        vec![ident_expr(G), num_expr(finally_entry as f64)],
+                    )),
+                );
+                // try body: comeca num estado novo logo apos `cur`.
+                let body_entry = self.new_state();
+                self.set_goto(cur, body_entry);
+                let body_exit = self.lower_seq(&t.block.stmts, body_entry)?;
+                // saida normal do body -> finally_entry
+                self.set_goto(body_exit, finally_entry);
+                // finally body
+                let fin_exit = self.lower_seq(&finalizer.stmts, finally_entry)?;
+                // ao fim do finally: END_FINALLY; se nada pendente, segue p/ after.
+                let after = self.new_state();
+                self.set_end_finally(fin_exit, after);
+                Some(after)
+            }
             // bloco aninhado simples: achata
             Stmt::Block(b) => self.lower_seq(&b.stmts, cur),
             // `if` sem yield no corpo: mantemos verbatim (efeito colateral puro).
@@ -400,23 +448,30 @@ fn expr_has_yield(e: &Expr) -> bool {
     }
 }
 
-/// True se ha' um loop (`while`/`do-while`/`for`/`for-of`/`for-in`) com `yield`
-/// no corpo — sinal de que o generator precisa de suspensao lazy real.
-fn body_has_loop_with_yield(stmts: &[Stmt]) -> bool {
-    stmts.iter().any(stmt_is_loop_with_yield)
+/// True se o corpo precisa de suspensao lazy real: contem um loop com `yield`
+/// (`while`/`for`/...) OU um `try`/`finally` envolvendo `yield` (#477 fatia 2).
+/// Generators lineares finitos continuam no eager-buffer.
+fn body_needs_lazy(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(stmt_needs_lazy)
 }
 
-fn stmt_is_loop_with_yield(s: &Stmt) -> bool {
+fn stmt_needs_lazy(s: &Stmt) -> bool {
     match s {
         Stmt::While(w) => stmt_has_yield(&w.body),
         Stmt::DoWhile(d) => stmt_has_yield(&d.body),
         Stmt::For(f) => stmt_has_yield(&f.body),
         Stmt::ForOf(fo) => stmt_has_yield(&fo.body),
         Stmt::ForIn(fi) => stmt_has_yield(&fi.body),
-        Stmt::Block(b) => body_has_loop_with_yield(&b.stmts),
+        // try/finally com yield em qualquer parte exige state-machine.
+        Stmt::Try(t) => {
+            t.block.stmts.iter().any(stmt_has_yield)
+                || t.handler.as_ref().map(|h| h.body.stmts.iter().any(stmt_has_yield)).unwrap_or(false)
+                || t.finalizer.as_ref().map(|f| f.stmts.iter().any(stmt_has_yield)).unwrap_or(false)
+        }
+        Stmt::Block(b) => body_needs_lazy(&b.stmts),
         Stmt::If(i) => {
-            stmt_is_loop_with_yield(&i.cons)
-                || i.alt.as_deref().map(stmt_is_loop_with_yield).unwrap_or(false)
+            stmt_needs_lazy(&i.cons)
+                || i.alt.as_deref().map(stmt_needs_lazy).unwrap_or(false)
         }
         _ => false,
     }
@@ -549,6 +604,42 @@ fn build_state_fn(state_fn_name: &str, builder: &SmBuilder) -> Option<FnDecl> {
                     test: Box::new(test.clone()),
                     cons: Box::new(then_blk),
                     alt: Some(Box::new(else_blk)),
+                }));
+            }
+            Trans::EndFinally { normal_next } => {
+                blk.extend(store_all_locals(builder));
+                // const __ef = END_FINALLY(__g);
+                blk.push(let_decl(
+                    "__ef",
+                    call("__RTS_GEN_SM_END_FINALLY", vec![ident_expr(G)]),
+                ));
+                // if (STATE(__g) === -2) { return __ef; }  -- completion honrada
+                blk.push(Stmt::If(swc_ecma_ast::IfStmt {
+                    span: sp(),
+                    test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                        span: sp(),
+                        op: swc_ecma_ast::BinaryOp::EqEqEq,
+                        left: Box::new(call("__RTS_GEN_SM_STATE", vec![ident_expr(G)])),
+                        right: Box::new(num_expr(-2.0)),
+                    })),
+                    cons: Box::new(Stmt::Block(BlockStmt {
+                        span: sp(),
+                        ctxt: Default::default(),
+                        stmts: vec![Stmt::Return(swc_ecma_ast::ReturnStmt {
+                            span: sp(),
+                            arg: Some(Box::new(ident_expr("__ef"))),
+                        })],
+                    })),
+                    alt: None,
+                }));
+                // senao: segue para o estado normal apos a try/finally.
+                blk.push(call_stmt(call(
+                    "__RTS_GEN_SM_SETSTATE",
+                    vec![ident_expr(G), num_expr(*normal_next as f64)],
+                )));
+                blk.push(Stmt::Continue(swc_ecma_ast::ContinueStmt {
+                    span: sp(),
+                    label: None,
                 }));
             }
             Trans::Done(ret) => {

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -111,6 +111,28 @@ pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_RETURN(vec_handle: u64, value: i64) -
     make_result(value, true)
 }
 
+/// `gen.throw(e)` — dispatcher: para generators lazy (GenState) delega a
+/// `GEN_SM_THROW` (roda finally / absorve). Para o eager-buffer (Vec) nao ha'
+/// try-region modelada; marca esgotado e propaga via error slot.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GENERATOR_THROW(vec_handle: u64, err: i64) -> u64 {
+    let is_sm = with_entry(vec_handle, |e| matches!(e, Some(Entry::GenState(_))));
+    if is_sm {
+        return __RTS_FN_NS_GC_GEN_SM_THROW(vec_handle, err);
+    }
+    let len = with_entry(vec_handle, |e| match e {
+        Some(Entry::Vec(v)) => Some(v.len()),
+        _ => None,
+    });
+    if let Some(len) = len {
+        GEN_CURSORS.with(|c| {
+            c.borrow_mut().insert(vec_handle, len + 1);
+        });
+    }
+    crate::namespaces::gc::error::__RTS_FN_RT_ERROR_SET(err as u64);
+    make_result(err, true)
+}
+
 /// `__RTS_GEN_GET_RET(vec)` — devolve o ret_value (`return X`) registrado
 /// por uma generator fn finita, ou undefined se ausente. Usado por
 /// `const r = yield* gen()` (#275/#379): o desugar empurra os elementos do
@@ -143,6 +165,9 @@ pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_NEW(fn_ptr: u64, nslots: i64) -> u64 {
         frame: vec![0i64; n],
         ret: UNDEFINED,
         done: false,
+        finally_state: -1,
+        pending_kind: 0,
+        pending_val: UNDEFINED,
     })))
 }
 
@@ -239,16 +264,129 @@ pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_NEXT(h: u64) -> u64 {
     make_result(value, done)
 }
 
-/// `gen.return(v)` para generators lazy — encerra antecipadamente: marca done e
-/// devolve `{value:v, done:true}`.
+/// `gen.return(v)` para generators lazy (#477 fatia 2). Se ha' uma try-region
+/// ativa com `finally`, redireciona a execucao para o finally (registra a
+/// completion `return` pendente e re-invoca a fn de estado a partir do finally).
+/// O `yield` dentro do finally INTERCEPTA o return -> devolve `{value:yield,
+/// done:false}`. Sem finally ativo, encerra como antes: `{value:v, done:true}`.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_RETURN(h: u64, value: i64) -> u64 {
+    gen_sm_abrupt(h, value, 1)
+}
+
+/// `gen.throw(e)` para generators lazy (#477 fatia 2). Se ha' uma try-region
+/// ativa com `finally`, redireciona para o finally (completion `throw`
+/// pendente). O `yield` no finally ABSORVE o throw -> suspende devolvendo
+/// `{value:yield, done:false}` SEM propagar a excecao. Sem finally ativo,
+/// propaga: marca done e seta o error slot (caller re-lanca).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_THROW(h: u64, err: i64) -> u64 {
+    let has_finally = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => g.finally_state >= 0 && !g.done,
+        _ => false,
+    });
+    if has_finally {
+        return gen_sm_abrupt(h, err, 2);
+    }
+    // Sem finally: propaga a excecao via error slot global (caller re-lanca).
     with_entry_mut(h, |e| {
         if let Some(Entry::GenState(g)) = e {
             g.done = true;
         }
     });
-    make_result(value, true)
+    crate::namespaces::gc::error::__RTS_FN_RT_ERROR_SET(err as u64);
+    make_result(err, true)
+}
+
+/// Logica comum de `.return`/`.throw`: redireciona para o finally se ativo,
+/// senao encerra. `kind`: 1=return, 2=throw.
+fn gen_sm_abrupt(h: u64, value: i64, kind: i64) -> u64 {
+    let (fn_ptr, finally_state, already_done) = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => (g.fn_ptr, g.finally_state, g.done),
+        _ => (0u64, -1, true),
+    });
+    if already_done || finally_state < 0 || fn_ptr == 0 {
+        // Sem try-region ativa: encerra (semantica simples).
+        with_entry_mut(h, |e| {
+            if let Some(Entry::GenState(g)) = e {
+                g.done = true;
+            }
+        });
+        return make_result(value, true);
+    }
+    // Redireciona para o finally: registra a completion pendente e re-invoca.
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.pending_kind = kind;
+            g.pending_val = value;
+            g.state = finally_state;
+            g.finally_state = -1; // nao re-disparar a mesma try-region
+        }
+    });
+    let state_fn: extern "C" fn(u64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let yielded = state_fn(h);
+    let done = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => g.done,
+        _ => true,
+    });
+    make_result(yielded, done)
+}
+
+/// `__RTS_GEN_SM_ENTER_TRY(h, finally_state)` — registra o estado de entrada do
+/// finally da try-region que estamos comecando. `.return`/`.throw` redirecionam
+/// para esse estado se a suspensao ocorrer dentro da try.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_ENTER_TRY(h: u64, finally_state: i64) {
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.finally_state = finally_state;
+        }
+    });
+}
+
+/// `__RTS_GEN_SM_END_FINALLY(h)` — chamado ao fim do bloco finally. Limpa a
+/// try-region ativa e honra a completion pendente: para `return`, retorna
+/// `DONE(pending_val)`; para `throw`, seta o error slot e marca done. Devolve o
+/// valor que a fn de estado deve retornar (e que NEXT empacotara em {value,done}).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_END_FINALLY(h: u64) -> i64 {
+    let (kind, val) = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => (g.pending_kind, g.pending_val),
+        _ => (0, UNDEFINED),
+    });
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.finally_state = -1;
+            g.pending_kind = 0;
+        }
+    });
+    match kind {
+        1 => {
+            // return pendente: completion. state=-2 sinaliza ao desugar que a fn
+            // de estado deve retornar `val` imediatamente (done) sem seguir p/ o
+            // estado normal apos a try/finally.
+            with_entry_mut(h, |e| {
+                if let Some(Entry::GenState(g)) = e {
+                    g.done = true;
+                    g.ret = val;
+                    g.state = -2;
+                }
+            });
+            val
+        }
+        2 => {
+            // throw pendente nao absorvido: propaga via error slot.
+            with_entry_mut(h, |e| {
+                if let Some(Entry::GenState(g)) = e {
+                    g.done = true;
+                    g.state = -2;
+                }
+            });
+            crate::namespaces::gc::error::__RTS_FN_RT_ERROR_SET(val as u64);
+            val
+        }
+        _ => UNDEFINED, // sem completion pendente: caller segue p/ estado normal.
+    }
 }
 
 /// `__RTS_GEN_SM_DRAIN(h)` — consome o generator lazy ate `done`, coletando os

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -502,6 +502,15 @@ pub struct GenStateData {
     pub ret: i64,
     /// Generator esgotado (proximo `.next()` => `{value:undefined,done:true}`).
     pub done: bool,
+    /// (#477 fatia 2) Estado de entrada do `finally` da try-region ativa, ou
+    /// -1 se nenhuma. Setado por `ENTER_TRY`, limpo por `END_FINALLY`. Permite
+    /// `.return(v)`/`.throw(e)` redirecionarem para o finally em vez de so'
+    /// terminar — o `yield` no finally intercepta/absorve a completion abrupta.
+    pub finally_state: i64,
+    /// Tipo de completion abrupta pendente: 0=nenhuma, 1=return, 2=throw.
+    pub pending_kind: i64,
+    /// Valor da completion abrupta pendente (ret value ou erro).
+    pub pending_val: i64,
 }
 
 /// State enum dos algoritmos suportados em `Entry::Hasher`. Wrap em Box


### PR DESCRIPTION
## Resumo

Estende a state-machine de generators (fatia 1, #1334) para suportar `yield` dentro de `try/finally` e os protocolos `.return(v)`/`.throw(e)` com semantica de finally. Fecha o teste real `tests/cross-runtime/generators/276_generator_return_throw.ts` **byte-identico ao Node**:

```
return=1,false,99,false   # .return(7) dispara finally; yield 99 INTERCEPTA -> {99,false}
throw=                    # .throw(boom) dispara finally; yield 99 ABSORVE -> nao propaga
```

Antes: `error: unsupported expression: yield`.

## Mudancas

- **handles.rs** `GenStateData`: +`finally_state`/`pending_kind`/`pending_val` (rastreia try-region ativa + completion abrupta pendente).
- **generator.rs**: `GEN_SM_RETURN` delega a `gen_sm_abrupt`; `GEN_SM_THROW` (nova) injeta no ponto suspenso; `gen_sm_abrupt` roda o finally (yield no finally intercepta/absorve); `ENTER_TRY`/`END_FINALLY` (novas) modelam a try-region; `GENERATOR_THROW` dispatcher `.throw()`.
- **generator_sm.rs**: elegibilidade aceita `try/finally`-com-yield; `Stmt::Try` vira estados. Catch-com-yield/try-catch ficam inelegiveis (fallback eager).
- **calls/mod.rs + jit.rs**: handler `.throw()` + 5 simbolos novos no JIT.

## Zero regressao

329 (fatia 1) intacto, 15 `tests/generator_*.test.ts` verdes, suite **1719/1719**. Verify adversarial rodou no worktree certo (corrigido apos o falso-negativo da fatia 1) + validei 276/329/suite na main manualmente.

## Follow-up

Fatias seguintes: 379/275/368 (yield*), 109/392 (async generators — dep. event loop #207).

🤖 Generated with [Claude Code](https://claude.com/claude-code)