### PR TITLE
feat(async): event loop cooperativo via state-machine, await cede a microtask (#207 fatia 1)

### DIFF
--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -202,6 +202,11 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
     add_fn!("__RTS_FN_NS_GC_GENERATOR_THROW", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GENERATOR_THROW);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_IS", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_IS);
     add_fn!("__RTS_FN_NS_GC_GEN_SM_DRAIN", crate::namespaces::gc::generator::__RTS_FN_NS_GC_GEN_SM_DRAIN);
+    add_fn!("__RTS_FN_NS_GC_ASYNC_SM_NEW", crate::namespaces::gc::generator::__RTS_FN_NS_GC_ASYNC_SM_NEW);
+    add_fn!("__RTS_FN_NS_GC_ASYNC_SM_START", crate::namespaces::gc::generator::__RTS_FN_NS_GC_ASYNC_SM_START);
+    add_fn!("__RTS_FN_NS_GC_ASYNC_SM_SUSPEND", crate::namespaces::gc::generator::__RTS_FN_NS_GC_ASYNC_SM_SUSPEND);
+    add_fn!("__RTS_FN_NS_GC_ASYNC_SM_AWAITED", crate::namespaces::gc::generator::__RTS_FN_NS_GC_ASYNC_SM_AWAITED);
+    add_fn!("__RTS_FN_NS_GC_ASYNC_SM_RESOLVE", crate::namespaces::gc::generator::__RTS_FN_NS_GC_ASYNC_SM_RESOLVE);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_GET", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_GET);
     add_fn!("__RTS_FN_NS_GC_TAGGED_RAW_REGISTER", crate::namespaces::gc::tagged_raw::__RTS_FN_NS_GC_TAGGED_RAW_REGISTER);
     add_fn!("__RTS_FN_NS_GC_STRING_NEW", __RTS_FN_NS_GC_STRING_NEW);

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -213,7 +213,10 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 let mut argv: Vec<_> = Vec::with_capacity(call.args.len());
                 let sig: Vec<cl::Type> = vec![cl::I64; call.args.len()];
                 for (i, a) in call.args.iter().enumerate() {
-                    if i == 0 && sym == "__RTS_FN_NS_GC_GEN_SM_NEW" {
+                    if i == 0
+                        && (sym == "__RTS_FN_NS_GC_GEN_SM_NEW"
+                            || sym == "__RTS_FN_NS_GC_ASYNC_SM_NEW")
+                    {
                         if let Expr::Ident(fid) = a.expr.as_ref() {
                             let addr = emit_user_fn_addr(ctx, fid.sym.as_str())?;
                             argv.push(ctx.coerce_to_i64(addr).val);
@@ -227,7 +230,10 @@ pub(super) fn lower_call(ctx: &mut FnCtx, call: &CallExpr) -> Result<TypedVal> {
                 let inst = ctx.builder.ins().call(fref, &argv);
                 if ret.is_some() {
                     let r = ctx.builder.inst_results(inst)[0];
-                    let vt = if sym == "__RTS_FN_NS_GC_GEN_SM_NEW" {
+                    let vt = if sym == "__RTS_FN_NS_GC_GEN_SM_NEW"
+                        || sym == "__RTS_FN_NS_GC_ASYNC_SM_NEW"
+                        || sym == "__RTS_FN_NS_GC_ASYNC_SM_START"
+                    {
                         ValTy::Handle
                     } else {
                         // value yieldado/ret eh ambiguo i64/handle.
@@ -4213,6 +4219,12 @@ fn gen_sm_sentinel(
         ("__RTS_GEN_SM_DONE", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_DONE", Some(cl::I64))),
         ("__RTS_GEN_SM_ENTER_TRY", 2) => Some(("__RTS_FN_NS_GC_GEN_SM_ENTER_TRY", None)),
         ("__RTS_GEN_SM_END_FINALLY", 1) => Some(("__RTS_FN_NS_GC_GEN_SM_END_FINALLY", Some(cl::I64))),
+        // (#207 async-SM) Sentinelas da state-machine de async functions.
+        ("__RTS_ASYNC_SM_NEW", 2) => Some(("__RTS_FN_NS_GC_ASYNC_SM_NEW", Some(cl::I64))),
+        ("__RTS_ASYNC_SM_START", 1) => Some(("__RTS_FN_NS_GC_ASYNC_SM_START", Some(cl::I64))),
+        ("__RTS_ASYNC_SM_SUSPEND", 2) => Some(("__RTS_FN_NS_GC_ASYNC_SM_SUSPEND", Some(cl::I64))),
+        ("__RTS_ASYNC_SM_AWAITED", 1) => Some(("__RTS_FN_NS_GC_ASYNC_SM_AWAITED", Some(cl::I64))),
+        ("__RTS_ASYNC_SM_RESOLVE", 2) => Some(("__RTS_FN_NS_GC_ASYNC_SM_RESOLVE", Some(cl::I64))),
         _ => None,
     }
 }

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -89,6 +89,49 @@ pub fn try_build(name: &str, function: &Function) -> Option<(FnDecl, FnDecl)> {
     Some((ctor, state_fn))
 }
 
+/// (#207 async-SM) Tenta construir a state-machine de uma `async function`
+/// elegivel (corpo linear com `await` em statement/decl/assign; sem await
+/// aninhado em sub-expressao, sem loops/if com await nesta fatia). Em sucesso
+/// devolve `(constructor, state_fn)`; em qualquer construct inelegivel devolve
+/// `None` (caller cai no caminho thread-blocking de `expand_async_functions`).
+pub fn try_build_async(name: &str, function: &Function) -> Option<(FnDecl, FnDecl)> {
+    let body = function.body.as_ref()?;
+    SM_SPAN.with(|c| c.set(body.span));
+
+    let mut params: Vec<String> = Vec::new();
+    for p in &function.params {
+        match &p.pat {
+            Pat::Ident(id) => params.push(id.id.sym.to_string()),
+            _ => return None, // destructuring em params => inelegivel
+        }
+    }
+
+    // So' aplica a SM async se o corpo REALMENTE tem await (senao deixa o
+    // caminho atual cuidar — uma async fn sem await e' so' uma fn que devolve
+    // promise resolvida).
+    if !body.stmts.iter().any(stmt_has_await) {
+        return None;
+    }
+
+    let mut builder = SmBuilder::new();
+    builder.is_async = true;
+    for p in &params {
+        builder.intern_local(p);
+    }
+
+    let entry = builder.new_state();
+    let exit = builder.lower_seq(&body.stmts, entry)?;
+    builder.set_done(exit, None);
+
+    let state_fn_name = format!("__async_state_{}", name);
+    let nslots = builder.locals.len() as f64;
+
+    let ctor = build_async_ctor(name, &params, &state_fn_name, nslots);
+    let state_fn = build_state_fn(&state_fn_name, &builder)?;
+
+    Some((ctor, state_fn))
+}
+
 const G: &str = "__g";
 
 fn ident(s: &str) -> Ident {
@@ -160,6 +203,10 @@ enum Trans {
     /// pendente, marcando done + state=-2) e, se nada pendente, segue para
     /// `normal_next`. (#477 fatia 2)
     EndFinally { normal_next: usize },
+    /// (#207 async-SM) `await <promise>`: salva locais, SETSTATE(next) e
+    /// suspende devolvendo `ASYNC_SM_SUSPEND(__g, <promise>)`. O estado `next`
+    /// comeca lendo o valor injetado via `ASYNC_SM_AWAITED(__g)`.
+    Await { promise: Expr, next: usize },
     /// placeholder ate ser preenchido.
     Unset,
 }
@@ -174,11 +221,14 @@ struct SmBuilder {
     states: Vec<StateBlock>,
     /// Locais (params + lets) -> slot index, em ordem de criacao.
     locals: Vec<String>,
+    /// (#207) True quando construindo a SM de uma `async function` (await=
+    /// suspensao); muda os terminais (SUSPEND/RESOLVE em vez de YIELD/DONE).
+    is_async: bool,
 }
 
 impl SmBuilder {
     fn new() -> Self {
-        SmBuilder { states: Vec::new(), locals: Vec::new() }
+        SmBuilder { states: Vec::new(), locals: Vec::new(), is_async: false }
     }
 
     fn intern_local(&mut self, name: &str) -> usize {
@@ -212,6 +262,9 @@ impl SmBuilder {
     fn set_end_finally(&mut self, state: usize, normal_next: usize) {
         self.states[state].trans = Trans::EndFinally { normal_next };
     }
+    fn set_await(&mut self, state: usize, promise: Expr, next: usize) {
+        self.states[state].trans = Trans::Await { promise, next };
+    }
 
     /// Lower uma sequencia de statements comecando em `cur`. Devolve o estado
     /// "depois" (que ainda nao tem transicao). `None` => construct inelegivel.
@@ -223,6 +276,13 @@ impl SmBuilder {
     }
 
     fn lower_stmt(&mut self, stmt: &Stmt, cur: usize) -> Option<usize> {
+        // (#207 async-SM) Pontos de suspensao `await` em statement/decl/assign.
+        // `await` aninhado em sub-expressao => inelegivel (fallback).
+        if self.is_async {
+            if let Some(next) = self.try_lower_await_stmt(stmt, cur)? {
+                return Some(next);
+            }
+        }
         match stmt {
             // `yield expr;`
             Stmt::Expr(es) => {
@@ -402,6 +462,126 @@ impl SmBuilder {
         }
     }
 
+    /// (#207) Tenta lower de um statement com `await`. Contrato:
+    /// - `Ok(Some(next))` => era um await elegivel, lowered (proximo estado `next`).
+    /// - `Ok(None)` => NAO contem await; segue para o match generico.
+    /// - `Err`(via `?` retornando None) => contem await em posicao inelegivel
+    ///   (sub-expressao aninhada) => aborta o build (fallback thread-blocking).
+    ///
+    /// Elegiveis fatia 1: `await x` (statement), `const/let v = await x`,
+    /// `v = await x`. O RHS do await NAO pode conter outro await aninhado.
+    fn try_lower_await_stmt(&mut self, stmt: &Stmt, cur: usize) -> Option<Option<usize>> {
+        match stmt {
+            Stmt::Expr(es) => {
+                match es.expr.as_ref() {
+                    // `await x;` (valor descartado, mas AWAITED roda p/ propagar
+                    // rejection ao error slot).
+                    Expr::Await(aw) => {
+                        if expr_has_await(&aw.arg) {
+                            return None; // await aninhado no RHS => inelegivel
+                        }
+                        let next = self.new_state();
+                        self.set_await(cur, (*aw.arg).clone(), next);
+                        // estado `next`: chama AWAITED(__g) (descarta valor).
+                        self.push_stmt(
+                            next,
+                            call_stmt(call("__RTS_ASYNC_SM_AWAITED", vec![ident_expr(G)])),
+                        );
+                        Some(Some(next))
+                    }
+                    // `v = await x;`
+                    Expr::Assign(a) => {
+                        if let Expr::Await(aw) = a.right.as_ref() {
+                            if expr_has_await(&aw.arg) {
+                                return None;
+                            }
+                            // alvo precisa ser ident simples.
+                            let AssignTarget::Simple(SimpleAssignTarget::Ident(id)) = &a.left
+                            else {
+                                return None;
+                            };
+                            let name = id.id.sym.to_string();
+                            self.intern_local(&name);
+                            let next = self.new_state();
+                            self.set_await(cur, (*aw.arg).clone(), next);
+                            // estado `next`: v = AWAITED(__g)
+                            self.push_stmt(
+                                next,
+                                assign_stmt(
+                                    &name,
+                                    call("__RTS_ASYNC_SM_AWAITED", vec![ident_expr(G)]),
+                                ),
+                            );
+                            Some(Some(next))
+                        } else if expr_has_await(es.expr.as_ref()) {
+                            None // await aninhado em assign complexo => inelegivel
+                        } else {
+                            Some(None)
+                        }
+                    }
+                    other => {
+                        if expr_has_await(other) {
+                            None // await aninhado em call/etc => inelegivel
+                        } else {
+                            Some(None)
+                        }
+                    }
+                }
+            }
+            // `const/let v = await x;`
+            Stmt::Decl(Decl::Var(vd)) => {
+                // So' trata o caso de UM declarator com init = await direto.
+                if vd.decls.len() == 1 {
+                    let d = &vd.decls[0];
+                    if let (Pat::Ident(id), Some(init)) = (&d.name, d.init.as_deref()) {
+                        if let Expr::Await(aw) = init {
+                            if expr_has_await(&aw.arg) {
+                                return None;
+                            }
+                            let name = id.id.sym.to_string();
+                            self.intern_local(&name);
+                            let next = self.new_state();
+                            self.set_await(cur, (*aw.arg).clone(), next);
+                            self.push_stmt(
+                                next,
+                                assign_stmt(
+                                    &name,
+                                    call("__RTS_ASYNC_SM_AWAITED", vec![ident_expr(G)]),
+                                ),
+                            );
+                            return Some(Some(next));
+                        }
+                    }
+                }
+                // contem await em init mas nao no formato simples => inelegivel
+                if vd.decls.iter().any(|d| d.init.as_deref().map(expr_has_await).unwrap_or(false)) {
+                    return None;
+                }
+                Some(None)
+            }
+            // `return await x;`
+            Stmt::Return(r) => {
+                if let Some(Expr::Await(aw)) = r.arg.as_deref() {
+                    if expr_has_await(&aw.arg) {
+                        return None;
+                    }
+                    let next = self.new_state();
+                    self.set_await(cur, (*aw.arg).clone(), next);
+                    // estado `next`: return AWAITED(__g)  (Done)
+                    self.set_done(next, Some(call("__RTS_ASYNC_SM_AWAITED", vec![ident_expr(G)])));
+                    return Some(Some(self.new_state()));
+                }
+                if r.arg.as_deref().map(expr_has_await).unwrap_or(false) {
+                    return None;
+                }
+                Some(None)
+            }
+            // Qualquer outro statement que contenha await => inelegivel fatia 1.
+            other if stmt_has_await(other) => None,
+            _ => Some(None),
+        }
+    }
+
     fn register_assign_target(&mut self, t: &AssignTarget) {
         if let AssignTarget::Simple(SimpleAssignTarget::Ident(id)) = t {
             self.intern_local(&id.id.sym.to_string());
@@ -444,6 +624,60 @@ fn expr_has_yield(e: &Expr) -> bool {
             .elems
             .iter()
             .any(|el| el.as_ref().map(|x| expr_has_yield(&x.expr)).unwrap_or(false)),
+        _ => false,
+    }
+}
+
+// ── Deteccao de await (#207 async-SM) ────────────────────────────────────────
+
+fn expr_has_await(e: &Expr) -> bool {
+    match e {
+        Expr::Await(_) => true,
+        Expr::Assign(a) => expr_has_await(&a.right),
+        Expr::Bin(b) => expr_has_await(&b.left) || expr_has_await(&b.right),
+        Expr::Unary(u) => expr_has_await(&u.arg),
+        Expr::Paren(p) => expr_has_await(&p.expr),
+        Expr::Cond(c) => {
+            expr_has_await(&c.test) || expr_has_await(&c.cons) || expr_has_await(&c.alt)
+        }
+        Expr::Seq(s) => s.exprs.iter().any(|x| expr_has_await(x)),
+        Expr::Call(c) => c.args.iter().any(|a| expr_has_await(&a.expr)),
+        Expr::Member(m) => expr_has_await(&m.obj),
+        Expr::Array(a) => a
+            .elems
+            .iter()
+            .any(|el| el.as_ref().map(|x| expr_has_await(&x.expr)).unwrap_or(false)),
+        _ => false,
+    }
+}
+
+fn stmt_has_await(s: &Stmt) -> bool {
+    match s {
+        Stmt::Expr(e) => expr_has_await(&e.expr),
+        Stmt::Block(b) => b.stmts.iter().any(stmt_has_await),
+        Stmt::If(i) => {
+            expr_has_await(&i.test)
+                || stmt_has_await(&i.cons)
+                || i.alt.as_deref().map(stmt_has_await).unwrap_or(false)
+        }
+        Stmt::While(w) => expr_has_await(&w.test) || stmt_has_await(&w.body),
+        Stmt::DoWhile(d) => expr_has_await(&d.test) || stmt_has_await(&d.body),
+        Stmt::For(f) => {
+            f.test.as_deref().map(expr_has_await).unwrap_or(false)
+                || f.update.as_deref().map(expr_has_await).unwrap_or(false)
+                || stmt_has_await(&f.body)
+        }
+        Stmt::ForOf(fo) => stmt_has_await(&fo.body),
+        Stmt::Decl(Decl::Var(vd)) => vd
+            .decls
+            .iter()
+            .any(|d| d.init.as_deref().map(expr_has_await).unwrap_or(false)),
+        Stmt::Return(r) => r.arg.as_deref().map(expr_has_await).unwrap_or(false),
+        Stmt::Try(t) => {
+            t.block.stmts.iter().any(stmt_has_await)
+                || t.handler.as_ref().map(|h| h.body.stmts.iter().any(stmt_has_await)).unwrap_or(false)
+                || t.finalizer.as_ref().map(|f| f.stmts.iter().any(stmt_has_await)).unwrap_or(false)
+        }
         _ => false,
     }
 }
@@ -539,6 +773,37 @@ fn build_ctor(
     stmts.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
         span: sp(),
         arg: Some(Box::new(ident_expr(G))),
+    }));
+
+    make_fn_decl(name, params, stmts, true)
+}
+
+/// (#207 async-SM) Ctor da async fn: aloca o GenState async, escreve params no
+/// frame e devolve `__RTS_ASYNC_SM_START(__g)` — que roda o corpo ate o 1o
+/// await e devolve o HANDLE da promise-resultado (preserva ABI `f(args) ->
+/// Promise`).
+fn build_async_ctor(
+    name: &str,
+    params: &[String],
+    state_fn_name: &str,
+    nslots: f64,
+) -> FnDecl {
+    let mut stmts: Vec<Stmt> = Vec::new();
+    // const __g = __RTS_ASYNC_SM_NEW(<state_fn>, nslots);
+    stmts.push(let_decl(
+        G,
+        call("__RTS_ASYNC_SM_NEW", vec![ident_expr(state_fn_name), num_expr(nslots)]),
+    ));
+    for (i, p) in params.iter().enumerate() {
+        stmts.push(call_stmt(call(
+            "__RTS_GEN_SM_FSET",
+            vec![ident_expr(G), num_expr(i as f64), ident_expr(p)],
+        )));
+    }
+    // return __RTS_ASYNC_SM_START(__g);
+    stmts.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
+        span: sp(),
+        arg: Some(Box::new(call("__RTS_ASYNC_SM_START", vec![ident_expr(G)]))),
     }));
 
     make_fn_decl(name, params, stmts, true)
@@ -644,11 +909,30 @@ fn build_state_fn(state_fn_name: &str, builder: &SmBuilder) -> Option<FnDecl> {
             }
             Trans::Done(ret) => {
                 let ret_expr = ret.clone().unwrap_or_else(undef_expr);
+                let term = if builder.is_async {
+                    "__RTS_ASYNC_SM_RESOLVE"
+                } else {
+                    "__RTS_GEN_SM_DONE"
+                };
+                blk.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
+                    span: sp(),
+                    arg: Some(Box::new(call(term, vec![ident_expr(G), ret_expr]))),
+                }));
+            }
+            // (#207 async-SM) `await <promise>`: salva locais, SETSTATE(next),
+            // suspende devolvendo SUSPEND(__g, <promise>). O drain retoma quando
+            // a promise settla, injetando o valor no estado `next`.
+            Trans::Await { promise, next } => {
+                blk.extend(store_all_locals(builder));
+                blk.push(call_stmt(call(
+                    "__RTS_GEN_SM_SETSTATE",
+                    vec![ident_expr(G), num_expr(*next as f64)],
+                )));
                 blk.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
                     span: sp(),
                     arg: Some(Box::new(call(
-                        "__RTS_GEN_SM_DONE",
-                        vec![ident_expr(G), ret_expr],
+                        "__RTS_ASYNC_SM_SUSPEND",
+                        vec![ident_expr(G), promise.clone()],
                     ))),
                 }));
             }
@@ -674,10 +958,15 @@ fn build_state_fn(state_fn_name: &str, builder: &SmBuilder) -> Option<FnDecl> {
         }));
     }
 
-    // else final: done(undefined)
+    // else final: done(undefined) / resolve(undefined) p/ async.
+    let final_term = if builder.is_async {
+        "__RTS_ASYNC_SM_RESOLVE"
+    } else {
+        "__RTS_GEN_SM_DONE"
+    };
     let final_else = Stmt::Return(swc_ecma_ast::ReturnStmt {
         span: sp(),
-        arg: Some(Box::new(call("__RTS_GEN_SM_DONE", vec![ident_expr(G), undef_expr()]))),
+        arg: Some(Box::new(call(final_term, vec![ident_expr(G), undef_expr()]))),
     });
     let chain = match chain {
         Some(Stmt::If(mut i)) => {

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -159,6 +159,15 @@ fn lower_stmt(cm: &Lrc<SourceMap>, stmt: &Stmt, out: &mut Vec<Item>) {
     }
 }
 
+/// (#207) Flag `RTS_ASYNC_SM`: on quando `1`/`on`/`true` (default OFF na fatia
+/// 1 — caminho thread-blocking permanece o default ate o flip da fatia 3).
+fn async_sm_enabled() -> bool {
+    matches!(
+        std::env::var("RTS_ASYNC_SM").ok().as_deref(),
+        Some("1") | Some("on") | Some("true") | Some("all")
+    )
+}
+
 fn lower_decl(cm: &Lrc<SourceMap>, decl: &Decl, out: &mut Vec<Item>) {
     match decl {
         Decl::Class(class_decl) => {
@@ -183,6 +192,27 @@ fn lower_decl(cm: &Lrc<SourceMap>, decl: &Decl, out: &mut Vec<Item>) {
                     &fn_decl.function,
                 ) {
                     // Ambas as fns sinteticas retornam i64 (handle/valor).
+                    let mut sf = lower_fn_decl(cm, &state_fn);
+                    sf.return_type = Some("i64".to_string());
+                    let mut cf = lower_fn_decl(cm, &ctor);
+                    cf.return_type = Some("i64".to_string());
+                    out.push(Item::Function(sf));
+                    out.push(Item::Function(cf));
+                    return;
+                }
+            }
+            // (#207 async-SM, flag RTS_ASYNC_SM) async fn elegivel -> state-
+            // machine cooperativa (await=suspensao que cede a microtask queue).
+            // Inelegivel ou flag off => caminho thread-blocking de
+            // expand_async_functions (intacto).
+            if fn_decl.function.is_async
+                && !fn_decl.function.is_generator
+                && async_sm_enabled()
+            {
+                if let Some((ctor, state_fn)) = crate::generator_sm::try_build_async(
+                    &fn_decl.ident.sym.to_string(),
+                    &fn_decl.function,
+                ) {
                     let mut sf = lower_fn_decl(cm, &state_fn);
                     sf.return_type = Some("i64".to_string());
                     let mut cf = lower_fn_decl(cm, &ctor);

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -168,6 +168,11 @@ pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_NEW(fn_ptr: u64, nslots: i64) -> u64 {
         finally_state: -1,
         pending_kind: 0,
         pending_val: UNDEFINED,
+        is_async: false,
+        result_promise: None,
+        pending_await: None,
+        awaited_val: UNDEFINED,
+        awaited_rejected: false,
     })))
 }
 
@@ -422,6 +427,159 @@ pub extern "C" fn __RTS_FN_NS_GC_GEN_SM_DRAIN(h: u64) -> u64 {
         }
     }
     alloc_entry(Entry::Vec(Box::new(out)))
+}
+
+// ── Async state-machine (#207 fatia 1) ──────────────────────────────────────
+// Uma `async function` elegivel vira a MESMA state-machine de generators, mas
+// `await x` eh um ponto de suspensao que CEDE a microtask queue (em vez de
+// `yield` que devolve ao .next() do caller). O START roda o corpo ate o 1o
+// await, suspende, enfileira um AsyncResume sobre a promise awaited e devolve a
+// promise-resultado. Quando a awaited settla, o drain injeta o valor e re-step.
+// Isso produz o interleaving cooperativo (393): duas async fns concorrentes
+// alternam a cada await.
+
+/// `__RTS_GEN_SM_ASYNC_START(fn_ptr, nslots)` — aloca o GenState async (igual a
+/// GEN_SM_NEW mas com `is_async=true`). Os params sao escritos via FSET pelo
+/// ctor sintetico; depois o ctor chama ASYNC_STEP_INIT para rodar o 1o trecho.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_ASYNC_SM_NEW(fn_ptr: u64, nslots: i64) -> u64 {
+    let n = if nslots < 0 { 0 } else { nslots as usize };
+    alloc_entry(Entry::GenState(Box::new(GenStateData {
+        fn_ptr,
+        state: 0,
+        frame: vec![0i64; n],
+        ret: UNDEFINED,
+        done: false,
+        finally_state: -1,
+        pending_kind: 0,
+        pending_val: UNDEFINED,
+        is_async: true,
+        result_promise: None,
+        pending_await: None,
+        awaited_val: UNDEFINED,
+        awaited_rejected: false,
+    })))
+}
+
+/// `__RTS_GEN_SM_ASYNC_START(h)` — aloca a promise-resultado pendente, guarda no
+/// GenState, roda o 1o passo (ate o 1o await ou ate terminar) e devolve o HANDLE
+/// da promise-resultado (preserva ABI `f(args) -> Promise`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_ASYNC_SM_START(h: u64) -> u64 {
+    use crate::namespaces::gc::promise_slot;
+    let result = promise_slot::new_pending();
+    let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.result_promise = Some(result.clone());
+        }
+    });
+    async_sm_step(h);
+    result_handle
+}
+
+/// Roda um passo da async SM: invoca a state-fn (avanca ate o proximo await ou
+/// ate `return`). Apos retornar: se suspendeu (pending_await setado), enfileira
+/// um AsyncResume sobre a awaited; se terminou (done), settla a result_promise.
+fn async_sm_step(h: u64) {
+    use crate::namespaces::gc::promise_slot;
+    let fn_ptr = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => g.fn_ptr,
+        _ => 0,
+    });
+    if fn_ptr == 0 {
+        return;
+    }
+    let state_fn: extern "C" fn(u64) -> i64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+    let ret = state_fn(h);
+    // Le o estado pos-step.
+    let (done, pending, result) = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => {
+            (g.done, g.pending_await.clone(), g.result_promise.clone())
+        }
+        _ => (true, None, None),
+    });
+    if done {
+        // Corpo terminou (RESOLVE chamado). Settla a promise-resultado: se o
+        // error slot esta setado (throw), rejeita; senao resolve com ret.
+        if let Some(rp) = result {
+            let err = crate::namespaces::gc::error::__RTS_FN_RT_ERROR_GET();
+            if err != 0 {
+                crate::namespaces::gc::error::__RTS_FN_RT_ERROR_CLEAR();
+                promise_slot::reject(&rp, err as i64);
+            } else {
+                promise_slot::resolve(&rp, ret);
+            }
+        }
+        return;
+    }
+    // Suspendeu em await: enfileira AsyncResume sobre a promise awaited.
+    if let Some(src) = pending {
+        crate::namespaces::globals::text_encoding::instance::enqueue_microtask_async_resume(h, src);
+    }
+}
+
+/// `__RTS_GEN_SM_ASYNC_SUSPEND(h, promise_handle)` — chamado pela state-fn ao
+/// atingir `await x`. Extrai o Arc<PromiseSlot> do handle (ou cria um ja settled
+/// se o valor awaited NAO eh uma Promise) e guarda em pending_await. Devolve um
+/// valor dummy (a state-fn ja vai retornar logo apos).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_ASYNC_SM_SUSPEND(h: u64, promise_handle: i64) -> i64 {
+    use crate::namespaces::gc::promise_slot;
+    // Extrai o slot da promise awaited. Se o handle nao eh PromiseAsync,
+    // trata o valor como ja-resolvido (await de nao-Promise).
+    let slot = with_entry(promise_handle as u64, |e| match e {
+        Some(Entry::PromiseAsync(p)) => Some(p.clone()),
+        _ => None,
+    });
+    let src = slot.unwrap_or_else(|| promise_slot::new_fulfilled(promise_handle));
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.pending_await = Some(src);
+        }
+    });
+    0
+}
+
+/// `__RTS_GEN_SM_ASYNC_AWAITED(h)` — devolve o valor injetado pela retomada do
+/// await. Se a promise awaited rejeitou, seta o error slot (await relanca).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_ASYNC_SM_AWAITED(h: u64) -> i64 {
+    let (val, rejected) = with_entry(h, |e| match e {
+        Some(Entry::GenState(g)) => (g.awaited_val, g.awaited_rejected),
+        _ => (UNDEFINED, false),
+    });
+    if rejected {
+        crate::namespaces::gc::error::__RTS_FN_RT_ERROR_SET(val as u64);
+    }
+    val
+}
+
+/// `__RTS_GEN_SM_ASYNC_RESOLVE(h, val)` — chamado pela state-fn no `return val`
+/// (ou fim do corpo). Marca done e guarda ret; o async_sm_step settla a
+/// result_promise apos a state-fn retornar.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GC_ASYNC_SM_RESOLVE(h: u64, val: i64) -> i64 {
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.done = true;
+            g.ret = val;
+        }
+    });
+    val
+}
+
+/// Chamado pelo drain quando a promise awaited settla: injeta o valor/erro no
+/// GenState e roda o proximo passo da async SM. Publico para `instance.rs`.
+pub fn async_sm_resume(h: u64, value: i64, rejected: bool) {
+    with_entry_mut(h, |e| {
+        if let Some(Entry::GenState(g)) = e {
+            g.awaited_val = value;
+            g.awaited_rejected = rejected;
+            g.pending_await = None;
+        }
+    });
+    async_sm_step(h);
 }
 
 /// `__RTS_GEN_SM_IS(h)` — 1 se o handle eh um generator lazy (GenState), 0 senao.

--- a/crates/rts-runtime/src/namespaces/gc/handles.rs
+++ b/crates/rts-runtime/src/namespaces/gc/handles.rs
@@ -511,6 +511,21 @@ pub struct GenStateData {
     pub pending_kind: i64,
     /// Valor da completion abrupta pendente (ret value ou erro).
     pub pending_val: i64,
+    /// (#207 async-SM) Este GenState eh uma `async function` (await=suspensao
+    /// que cede a microtask queue), nao um generator (yield). Roteia
+    /// SUSPEND/RESOLVE/AWAITED em vez de YIELD/DONE.
+    pub is_async: bool,
+    /// (#207) Promise resultado da async fn (resolvida quando o corpo termina
+    /// ou rejeitada em throw). `None` ate ASYNC_SM_START alocar.
+    pub result_promise: Option<std::sync::Arc<PromiseSlot>>,
+    /// (#207) Promise que o `await` corrente esta esperando (setado por
+    /// ASYNC_SM_SUSPEND). O drain enfileira AsyncResume sobre essa source.
+    pub pending_await: Option<std::sync::Arc<PromiseSlot>>,
+    /// (#207) Valor injetado pela retomada do await (settle da pending_await).
+    pub awaited_val: i64,
+    /// (#207) True se a promise awaited rejeitou (await deve relancar via
+    /// error slot na retomada).
+    pub awaited_rejected: bool,
 }
 
 /// State enum dos algoritmos suportados em `Entry::Hasher`. Wrap em Box

--- a/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
@@ -236,6 +236,14 @@ pub(crate) enum Microtask {
         fn_ptr: u64,
         result_slot: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
     },
+    /// (#207 async-SM) Retomada de uma `async function` suspensa em `await`.
+    /// `source` eh a promise awaited; enquanto pending, re-enfileira; quando
+    /// settla, injeta o valor/erro no GenState `gen_handle` e roda o proximo
+    /// passo da SM. Produz o interleaving cooperativo de 393.
+    AsyncResume {
+        gen_handle: u64,
+        source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+    },
 }
 thread_local! {
     static MICROTASK_QUEUE: RefCell<Vec<Microtask>> = const { RefCell::new(Vec::new()) };
@@ -318,6 +326,18 @@ pub fn enqueue_microtask_pending_finally(
     });
 }
 
+/// (#207 async-SM) Enfileira a retomada de uma async fn suspensa em `await`
+/// sobre a promise `source`. Quando `source` settla, o drain injeta o valor no
+/// GenState e roda o proximo passo da SM (interleaving cooperativo do 393).
+pub fn enqueue_microtask_async_resume(
+    gen_handle: u64,
+    source: std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>,
+) {
+    MICROTASK_QUEUE.with(|q| {
+        q.borrow_mut().push(Microtask::AsyncResume { gen_handle, source })
+    });
+}
+
 /// Drena microtasks pendentes. Chamada pelo pipeline pos-main e tambem
 /// pode ser chamada pelo codegen no fim de cada task (futuro).
 pub fn drain_microtasks() {
@@ -338,7 +358,8 @@ pub fn drain_microtasks() {
         // Detecta ciclo sem progresso: todos PendingThen ainda pending.
         let all_stalled_pending = queue.iter().all(|t| match t {
             Microtask::PendingThen { source, .. }
-            | Microtask::PendingFinally { source, .. } => {
+            | Microtask::PendingFinally { source, .. }
+            | Microtask::AsyncResume { source, .. } => {
                 promise_slot::current_state(source) == promise_slot::STATE_PENDING
             }
             _ => false,
@@ -484,6 +505,26 @@ pub fn drain_microtasks() {
                         } else {
                             promise_slot::reject(&result_slot, value);
                         }
+                    }
+                }
+                // (#207 async-SM) Retomada de async fn suspensa em await.
+                Microtask::AsyncResume { gen_handle, source } => {
+                    let st = promise_slot::current_state(&source);
+                    if st == promise_slot::STATE_PENDING {
+                        // awaited ainda nao settlou: re-enfileira no FIM da fila
+                        // para re-checar no proximo ciclo do drain.
+                        MICROTASK_QUEUE.with(|q| {
+                            q.borrow_mut().push(Microtask::AsyncResume { gen_handle, source })
+                        });
+                    } else {
+                        let value = promise_slot::current_value(&source);
+                        let rejected = st == promise_slot::STATE_REJECTED;
+                        // Injeta valor/erro e roda o proximo passo da SM. Se o
+                        // step suspender de novo, ele re-enfileira outro
+                        // AsyncResume internamente (interleaving).
+                        crate::namespaces::gc::generator::async_sm_resume(
+                            gen_handle, value, rejected,
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Resumo

`async function` via state-machine (reusa `generator_sm.rs`): `await` vira ponto de suspensao que **cede a microtask queue** em vez de bloquear a thread. Produz o interleaving cooperativo do JS. **SOB FLAG `RTS_ASYNC_SM`** (off = caminho thread-blocking atual intacto, zero regressao).

393 (flag ON) — nucleo byte-identico ao Node, deterministico:
```
caught:handled
A1,B1,A2,B2,A3,B3                          (era A1,A2,A3,B1,B2,B3)
micro1,micro2,queueMicrotask,micro3,timeout
```

## Modelo

async = generator com `await`=yield-to-microtask. `await x` salva o frame, SETSTATE, `return ASYNC_SM_SUSPEND(promise)`; quando a promise settla, a microtask `AsyncResume` injeta valor/erro e retoma a fn. Cooperativo single-thread, ordem determinista.

## Zero regressao

Suite flag OFF **1719/1719** (byte-identico HEAD); flag ON **1719/1719**. Validado na main em ambos os modos.

## Follow-up (fatias seguintes)

- `.then`-chains/`Promise.all` ainda thread-blocking (4a linha do 393 nao-deterministica) — Fatia 5 migra combinators ao drain.
- `try/catch` em volta de `await` cai no fallback — Fatia 2.
- async generators 109/392 — Fatia 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)