### PR TITLE
feat(async): vira RTS_ASYNC_SM ON por padrao (#207 fatia 3)

### DIFF
--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -159,12 +159,14 @@ fn lower_stmt(cm: &Lrc<SourceMap>, stmt: &Stmt, out: &mut Vec<Item>) {
     }
 }
 
-/// (#207) Flag `RTS_ASYNC_SM`: on quando `1`/`on`/`true` (default OFF na fatia
-/// 1 — caminho thread-blocking permanece o default ate o flip da fatia 3).
+/// (#207 fatia 3) Flag `RTS_ASYNC_SM`: agora default ON (async via state-machine
+/// cooperativo). So' desliga com `0`/`off`/`false`/`none` — volta ao caminho
+/// thread-blocking de fallback. Inelegiveis (try/catch em volta de await, await
+/// aninhado) caem no fallback automaticamente, entao o flip e' seguro.
 fn async_sm_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("RTS_ASYNC_SM").ok().as_deref(),
-        Some("1") | Some("on") | Some("true") | Some("all")
+        Some("0") | Some("off") | Some("false") | Some("none")
     )
 }
 


### PR DESCRIPTION
async via state-machine cooperativo agora e' o default (inverte async_sm_enabled: ON exceto 0/off/false/none). Inelegiveis caem no fallback -> flip seguro. 393 sem flag da o interleaving cooperativo correto. Zero regressao: default(ON) 1719/1719, off(fallback) 1719/1719. Converte a fatia 1 (#1337) em comportamento padrao.

🤖 Generated with [Claude Code](https://claude.com/claude-code)