### PR TITLE
feat(streams): ReadableStream basico — fecha 64_readable_stream (#225)

### DIFF
--- a/crates/rts-codegen/src/abi/mod.rs
+++ b/crates/rts-codegen/src/abi/mod.rs
@@ -46,6 +46,12 @@ pub const GLOBAL_CLASS_SPECS: &[&GlobalClassSpec] = &[
     &crate::namespaces::globals::intl::abi::PLURAL_RULES_CLASS_SPEC,
     &crate::namespaces::globals::intl::abi::LIST_FORMAT_CLASS_SPEC,
     &crate::namespaces::globals::intl::abi::RELATIVE_TIME_FORMAT_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::READABLE_STREAM_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::READER_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::CONTROLLER_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::TRANSFORM_STREAM_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::WRITABLE_STREAM_CLASS_SPEC,
+    &crate::namespaces::globals::readable_stream::abi::WRITER_CLASS_SPEC,
 ];
 
 pub fn global_class_lookup(name: &str) -> Option<&'static GlobalClassSpec> {

--- a/crates/rts-codegen/src/codegen/jit.rs
+++ b/crates/rts-codegen/src/codegen/jit.rs
@@ -400,6 +400,20 @@ fn runtime_symbol_table() -> Vec<(&'static str, *const u8)> {
         add_fn!("__RTS_FN_GL_INTL_RELATIVE_TIME_FORMAT_FORMAT", __RTS_FN_GL_INTL_RELATIVE_TIME_FORMAT_FORMAT);
     }
 
+    // ── namespaces::globals::readable_stream (Web Streams) ────────────
+    {
+        use crate::namespaces::globals::readable_stream::instance::*;
+        add_fn!("__RTS_FN_GL_READABLE_STREAM_NEW", __RTS_FN_GL_READABLE_STREAM_NEW);
+        add_fn!("__RTS_FN_GL_READABLE_STREAM_GET_READER", __RTS_FN_GL_READABLE_STREAM_GET_READER);
+        add_fn!("__RTS_FN_GL_READABLE_STREAM_READER_READ", __RTS_FN_GL_READABLE_STREAM_READER_READ);
+        add_fn!("__RTS_FN_GL_READABLE_STREAM_CONTROLLER_ENQUEUE", __RTS_FN_GL_READABLE_STREAM_CONTROLLER_ENQUEUE);
+        add_fn!("__RTS_FN_GL_READABLE_STREAM_CONTROLLER_CLOSE", __RTS_FN_GL_READABLE_STREAM_CONTROLLER_CLOSE);
+        add_fn!("__RTS_FN_GL_TRANSFORM_STREAM_NEW", __RTS_FN_GL_TRANSFORM_STREAM_NEW);
+        add_fn!("__RTS_FN_GL_WRITABLE_STREAM_GET_WRITER", __RTS_FN_GL_WRITABLE_STREAM_GET_WRITER);
+        add_fn!("__RTS_FN_GL_WRITABLE_STREAM_WRITER_WRITE", __RTS_FN_GL_WRITABLE_STREAM_WRITER_WRITE);
+        add_fn!("__RTS_FN_GL_WRITABLE_STREAM_WRITER_CLOSE", __RTS_FN_GL_WRITABLE_STREAM_WRITER_CLOSE);
+    }
+
     // ── namespaces::globals::date (Date global class) ─────────────────
     use crate::namespaces::globals::date::instance::*;
     add_fn!("__RTS_FN_GL_DATE_NEW_NOW", __RTS_FN_GL_DATE_NEW_NOW);

--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -497,6 +497,16 @@ pub fn compile_program(
                             if matches!(cn, "WeakMap" | "WeakSet" | "Map" | "Set") {
                                 global_class_ty.insert(name.clone(), cn.to_string());
                             }
+                            // (Web Streams) Globais `const s = new ReadableStream/
+                            // TransformStream(...)` referenciadas de dentro de uma
+                            // async fn precisam carregar a classe para que
+                            // `s.getReader()/getWriter()` rotem ao instance method
+                            // global (e propaguem a classe do reader/writer).
+                            if !global_class_ty.contains_key(&name)
+                                && crate::abi::global_class_lookup(cn).is_some()
+                            {
+                                global_class_ty.insert(name.clone(), cn.to_string());
+                            }
                         }
                     }
                 }

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/indirect.rs
@@ -17,6 +17,30 @@ use super::builtins::{
     lower_array_builtin, lower_map_set_builtin, lower_number_builtin, lower_string_builtin,
 };
 
+/// (Web Streams) Despacha `controller.enqueue(x)` / `controller.close()` (e o
+/// `close` do writer) por nome de metodo via GLOBAL_CLASS_SPECS, mesmo quando o
+/// receiver eh um handle sem tipo estatico de classe (param do callback). O
+/// handle de runtime (Map de controller/writer) carrega o `__stream`, entao o
+/// extern fn correto opera sobre ele. Retorna None se o metodo nao for um
+/// metodo de stream conhecido.
+fn lower_stream_method(
+    ctx: &mut FnCtx,
+    prop: &str,
+    obj_h: cranelift_codegen::ir::Value,
+    call: &CallExpr,
+) -> Result<Option<TypedVal>> {
+    // enqueue -> controller; close -> controller (writer.close compartilha nome
+    // mas o controller spec ja cobre a aridade 1 (receiver only) corretamente).
+    let spec = crate::abi::global_class_lookup("ReadableStreamDefaultController");
+    if let Some(spec) = spec {
+        if let Some(member) = spec.instance_method(prop) {
+            let tv = super::ns_call::lower_global_instance_call(ctx, member, obj_h, call)?;
+            return Ok(Some(tv));
+        }
+    }
+    Ok(None)
+}
+
 pub(super) fn lower_var_member_call(
     ctx: &mut FnCtx,
     obj_name: &str,
@@ -27,6 +51,19 @@ pub(super) fn lower_var_member_call(
         .read_local(obj_name)
         .ok_or_else(|| anyhow!("var `{obj_name}` nao encontrada"))?;
     let obj_h = ctx.coerce_to_i64(obj_tv).val;
+
+    // (Web Streams) Metodos de controller/writer chamados em handle sem tipo
+    // estatico de classe (ex: `controller.enqueue(x)` onde `controller` eh
+    // param do callback `start`). Despacha via GLOBAL_CLASS_SPECS por nome de
+    // metodo. Restrito aos nomes especificos de streams para nao colidir com
+    // builtins de array/string/map (que tratam slice/concat/etc).
+    if matches!(obj_tv.ty, ValTy::Handle | ValTy::I64 | ValTy::U64)
+        && matches!(prop, "enqueue" | "close")
+    {
+        if let Some(tv) = lower_stream_method(ctx, prop, obj_h, call)? {
+            return Ok(tv);
+        }
+    }
 
     // (#208) Boolean.prototype methods em receiver Bool.
     if matches!(obj_tv.ty, ValTy::Bool) {

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -2202,7 +2202,7 @@ pub(super) fn assign_target_field_is_f64(ctx: &FnCtx, m: &swc_ecma_ast::MemberEx
     false
 }
 
-pub(super) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
+pub(crate) fn lhs_static_class(ctx: &FnCtx, expr: &Expr) -> Option<String> {
     match expr {
         Expr::This(_) => ctx.current_class.clone(),
         Expr::Ident(id) => ctx

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -2,7 +2,7 @@
 
 mod basics;
 mod calls;
-mod members;
+pub(crate) mod members;
 mod operators;
 
 use anyhow::{Result, anyhow};

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -911,6 +911,35 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
                                 }
                             }
                         }
+                        // (Web Streams) `const reader = stream.getReader()` /
+                        // `const w = ts.writable.getWriter()` — propaga a classe
+                        // de retorno declarada no ts_signature do instance_method
+                        // (ex: getReader(): ReadableStreamDefaultReader). Sem isso
+                        // `reader.read()` cairia no fallback Map -> SIGILL.
+                        if let swc_ecma_ast::Expr::Member(m) = cb.as_ref() {
+                            if let swc_ecma_ast::MemberProp::Ident(mid) = &m.prop {
+                                let prop_name = mid.sym.as_str();
+                                if let Some(recv_cls) =
+                                    crate::codegen::lower::expressions::members::lhs_static_class(ctx, &m.obj)
+                                {
+                                    if let Some(spec) = crate::abi::global_class_lookup(&recv_cls) {
+                                        if let Some(member) = spec.instance_method(prop_name) {
+                                            let sig = member.ts_signature;
+                                            if let Some(colon_pos) = sig.rfind(':') {
+                                                let ret_ty = sig[colon_pos + 1..]
+                                                    .trim()
+                                                    .trim_end_matches(';')
+                                                    .trim();
+                                                if crate::abi::global_class_lookup(ret_ty).is_some() {
+                                                    ctx.local_class_ty
+                                                        .insert(name.clone(), ret_ty.to_string());
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 let asserted_class = match init.as_ref() {

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -23,6 +23,7 @@ pub mod json;
 pub mod json5;
 pub mod performance;
 pub mod proxy;
+pub mod readable_stream;
 pub mod reflect;
 pub mod regexp;
 pub mod string;

--- a/crates/rts-runtime/src/namespaces/globals/readable_stream/abi.rs
+++ b/crates/rts-runtime/src/namespaces/globals/readable_stream/abi.rs
@@ -1,0 +1,175 @@
+//! Web Streams — ReadableStream / TransformStream family.
+//!
+//! Registered as composite/plain GlobalClassSpecs so codegen can resolve
+//! `new ReadableStream({...})` via `global_class_lookup("ReadableStream")`
+//! and dispatch instance methods (`getReader`, `read`, `enqueue`, `close`,
+//! `getWriter`, `write`) through the standard global-class path.
+//!
+//! Data model (all handles are GC `Entry::Map`):
+//! - stream:     `__buf` (Vec handle), `__closed` (0/1), `__transform` (Function|0)
+//! - controller: `__stream` (stream handle)
+//! - reader:     `__stream`, `__cursor` (i64)
+//! - writer:     `__stream`
+//!
+//! `reader.read()` returns a *resolved* Promise of `{value, done}`; the
+//! cooperative `await` (default) drains it. Data is synchronous (the producer
+//! enqueues into the buffer before `read()` runs).
+
+use crate::abi::{AbiType, GlobalClassSpec, MemberKind, NamespaceMember};
+
+const fn method(
+    name: &'static str,
+    symbol: &'static str,
+    args: &'static [AbiType],
+    returns: AbiType,
+    ts: &'static str,
+) -> NamespaceMember {
+    NamespaceMember {
+        name,
+        kind: MemberKind::InstanceMethod,
+        symbol,
+        args,
+        returns,
+        doc: "Web Streams instance method.",
+        ts_signature: ts,
+        intrinsic: None,
+        pure: false,
+    }
+}
+
+const fn ctor(symbol: &'static str, sig: &'static str) -> NamespaceMember {
+    NamespaceMember {
+        name: "new",
+        kind: MemberKind::Constructor,
+        symbol,
+        args: &[AbiType::Handle],
+        returns: AbiType::Handle,
+        doc: "Web Streams constructor.",
+        ts_signature: sig,
+        intrinsic: None,
+        pure: false,
+    }
+}
+
+// ── ReadableStream ────────────────────────────────────────────────────────────
+
+pub const READABLE_STREAM_MEMBERS: &[NamespaceMember] = &[
+    ctor(
+        "__RTS_FN_GL_READABLE_STREAM_NEW",
+        "new ReadableStream(underlyingSource?: object): ReadableStream",
+    ),
+    method(
+        "getReader",
+        "__RTS_FN_GL_READABLE_STREAM_GET_READER",
+        &[AbiType::Handle],
+        AbiType::Handle,
+        "getReader(): ReadableStreamDefaultReader",
+    ),
+];
+
+pub const READABLE_STREAM_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "ReadableStream",
+    doc: "ReadableStream (Web Streams, synchronous-buffer model).",
+    members: READABLE_STREAM_MEMBERS,
+};
+
+// ── ReadableStreamDefaultReader ────────────────────────────────────────────────
+
+pub const READER_MEMBERS: &[NamespaceMember] = &[
+    method(
+        "read",
+        "__RTS_FN_GL_READABLE_STREAM_READER_READ",
+        &[AbiType::Handle],
+        AbiType::Handle,
+        "read(): Promise<{value: any; done: boolean}>",
+    ),
+];
+
+pub const READER_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "ReadableStreamDefaultReader",
+    doc: "ReadableStreamDefaultReader.",
+    members: READER_MEMBERS,
+};
+
+// ── ReadableStreamDefaultController ─────────────────────────────────────────────
+
+pub const CONTROLLER_MEMBERS: &[NamespaceMember] = &[
+    method(
+        "enqueue",
+        "__RTS_FN_GL_READABLE_STREAM_CONTROLLER_ENQUEUE",
+        &[AbiType::Handle, AbiType::Handle],
+        AbiType::Void,
+        "enqueue(chunk: any): void",
+    ),
+    method(
+        "close",
+        "__RTS_FN_GL_READABLE_STREAM_CONTROLLER_CLOSE",
+        &[AbiType::Handle],
+        AbiType::Void,
+        "close(): void",
+    ),
+];
+
+pub const CONTROLLER_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "ReadableStreamDefaultController",
+    doc: "ReadableStreamDefaultController.",
+    members: CONTROLLER_MEMBERS,
+};
+
+// ── TransformStream ────────────────────────────────────────────────────────────
+
+pub const TRANSFORM_STREAM_MEMBERS: &[NamespaceMember] = &[
+    ctor(
+        "__RTS_FN_GL_TRANSFORM_STREAM_NEW",
+        "new TransformStream(transformer?: object): TransformStream",
+    ),
+];
+
+pub const TRANSFORM_STREAM_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "TransformStream",
+    doc: "TransformStream (Web Streams, synchronous-buffer model).",
+    members: TRANSFORM_STREAM_MEMBERS,
+};
+
+// ── WritableStream (the `.writable` side of a TransformStream) ──────────────────
+
+pub const WRITABLE_STREAM_MEMBERS: &[NamespaceMember] = &[
+    method(
+        "getWriter",
+        "__RTS_FN_GL_WRITABLE_STREAM_GET_WRITER",
+        &[AbiType::Handle],
+        AbiType::Handle,
+        "getWriter(): WritableStreamDefaultWriter",
+    ),
+];
+
+pub const WRITABLE_STREAM_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WritableStream",
+    doc: "WritableStream.",
+    members: WRITABLE_STREAM_MEMBERS,
+};
+
+// ── WritableStreamDefaultWriter ─────────────────────────────────────────────────
+
+pub const WRITER_MEMBERS: &[NamespaceMember] = &[
+    method(
+        "write",
+        "__RTS_FN_GL_WRITABLE_STREAM_WRITER_WRITE",
+        &[AbiType::Handle, AbiType::Handle],
+        AbiType::Handle,
+        "write(chunk: any): Promise<void>",
+    ),
+    method(
+        "close",
+        "__RTS_FN_GL_WRITABLE_STREAM_WRITER_CLOSE",
+        &[AbiType::Handle],
+        AbiType::Handle,
+        "close(): Promise<void>",
+    ),
+];
+
+pub const WRITER_CLASS_SPEC: GlobalClassSpec = GlobalClassSpec {
+    name: "WritableStreamDefaultWriter",
+    doc: "WritableStreamDefaultWriter.",
+    members: WRITER_MEMBERS,
+};

--- a/crates/rts-runtime/src/namespaces/globals/readable_stream/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/readable_stream/instance.rs
@@ -1,0 +1,259 @@
+//! Web Streams runtime — ReadableStream / TransformStream family.
+//!
+//! See `abi.rs` for the data model. Buffers are synchronous: the producer
+//! (`start` callback / `transform`) enqueues chunks before any `read()` runs,
+//! so `read()` can resolve a Promise immediately with the next buffered chunk.
+
+use crate::namespaces::gc::handles::{Entry, alloc_entry, with_entry, with_entry_mut};
+use crate::namespaces::gc::promise_slot;
+use indexmap::IndexMap;
+
+const UNDEFINED: i64 = i64::MIN + 2;
+const BOOL_FALSE: i64 = i64::MIN;
+const BOOL_TRUE: i64 = i64::MIN + 1;
+
+// ── Map helpers ─────────────────────────────────────────────────────────────
+
+fn map_get(map_h: u64, key: &str) -> i64 {
+    with_entry(map_h, |e| match e {
+        Some(Entry::Map(m)) => m.get(key).copied().unwrap_or(0),
+        _ => 0,
+    })
+}
+
+fn map_set(map_h: u64, key: &str, val: i64) {
+    with_entry_mut(map_h, |e| {
+        if let Some(Entry::Map(m)) = e {
+            m.insert(key.to_string(), val);
+        }
+    });
+}
+
+fn new_map() -> u64 {
+    alloc_entry(Entry::Map(Box::new(IndexMap::new())))
+}
+
+fn vec_push(vec_h: u64, val: i64) {
+    with_entry_mut(vec_h, |e| {
+        if let Some(Entry::Vec(v)) = e {
+            v.push(val);
+        }
+    });
+}
+
+fn vec_len(vec_h: u64) -> i64 {
+    with_entry(vec_h, |e| match e {
+        Some(Entry::Vec(v)) => v.len() as i64,
+        _ => 0,
+    })
+}
+
+fn vec_get(vec_h: u64, idx: i64) -> i64 {
+    with_entry(vec_h, |e| match e {
+        Some(Entry::Vec(v)) => v.get(idx as usize).copied().unwrap_or(UNDEFINED),
+        _ => UNDEFINED,
+    })
+}
+
+/// Resolves a callback value to its raw `extern "C"` fn pointer (+ bound args).
+///
+/// Object-literal methods (`{ start(c){...} }`) are stored either as an
+/// `Entry::Function` handle *or* as a raw `func_addr` i64 (the common case for
+/// method shorthand). Mirror `promise::resolve_callback_ptr`: when the handle
+/// is not a Function entry, treat the value itself as the raw fn pointer.
+fn fn_ptr_of(handle: i64) -> Option<(u64, Vec<i64>)> {
+    if handle == 0 {
+        return None;
+    }
+    let as_fn = with_entry(handle as u64, |e| match e {
+        Some(Entry::Function(fd)) => Some((fd.fn_ptr, fd.bound_args.clone())),
+        _ => None,
+    });
+    Some(as_fn.unwrap_or((handle as u64, Vec::new())))
+}
+
+/// Invokes an `extern "C" fn(i64...) -> i64` with the given args (arity 0..=4).
+unsafe fn invoke(fn_ptr: u64, args: &[i64]) -> i64 {
+    use std::mem::transmute;
+    unsafe {
+        match args.len() {
+            0 => transmute::<u64, extern "C" fn() -> i64>(fn_ptr)(),
+            1 => transmute::<u64, extern "C" fn(i64) -> i64>(fn_ptr)(args[0]),
+            2 => transmute::<u64, extern "C" fn(i64, i64) -> i64>(fn_ptr)(args[0], args[1]),
+            3 => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(fn_ptr)(
+                args[0], args[1], args[2],
+            ),
+            _ => transmute::<u64, extern "C" fn(i64, i64, i64, i64) -> i64>(fn_ptr)(
+                args[0], args[1], args[2], args[3],
+            ),
+        }
+    }
+}
+
+/// Calls `fn_handle(extra...)` (prepending bound args). No-op if not a fn.
+fn call_fn(fn_handle: i64, extra: &[i64]) {
+    if let Some((ptr, bound)) = fn_ptr_of(fn_handle) {
+        if ptr == 0 {
+            return;
+        }
+        let mut all = bound;
+        all.extend_from_slice(extra);
+        unsafe {
+            invoke(ptr, &all);
+        }
+    }
+}
+
+/// Builds a `{value, done}` result Map (same shape as the iterator protocol).
+fn make_result(value: i64, done: bool) -> u64 {
+    let mut m: IndexMap<String, i64> = IndexMap::new();
+    m.insert("value".to_string(), value);
+    m.insert("done".to_string(), if done { BOOL_TRUE } else { BOOL_FALSE });
+    alloc_entry(Entry::Map(Box::new(m)))
+}
+
+/// Wraps a value handle in a fulfilled Promise.
+fn fulfilled_promise(value: i64) -> u64 {
+    let slot = promise_slot::new_fulfilled(value);
+    alloc_entry(Entry::PromiseAsync(slot))
+}
+
+// ── Stream allocation ─────────────────────────────────────────────────────────
+
+/// Allocates a stream Map with an empty buffer + open state.
+fn new_stream() -> u64 {
+    let buf = alloc_entry(Entry::Vec(Box::new(Vec::new())));
+    let s = new_map();
+    map_set(s, "__buf", buf as i64);
+    map_set(s, "__closed", 0);
+    s
+}
+
+/// Allocates a controller bound to `stream_h`.
+fn new_controller(stream_h: u64) -> u64 {
+    let c = new_map();
+    map_set(c, "__stream", stream_h as i64);
+    c
+}
+
+fn stream_enqueue(stream_h: u64, val: i64) {
+    let buf = map_get(stream_h, "__buf") as u64;
+    if buf != 0 {
+        vec_push(buf, val);
+    }
+}
+
+fn stream_close(stream_h: u64) {
+    map_set(stream_h, "__closed", 1);
+}
+
+// ── ReadableStream ─────────────────────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_READABLE_STREAM_NEW(opts: u64) -> u64 {
+    let stream = new_stream();
+    let controller = new_controller(stream);
+    // Invoke `start(controller)` synchronously, if provided.
+    let start = map_get(opts, "start");
+    call_fn(start, &[controller as i64]);
+    stream
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_READABLE_STREAM_CONTROLLER_ENQUEUE(controller: u64, chunk: i64) {
+    let stream = map_get(controller, "__stream") as u64;
+    if stream != 0 {
+        stream_enqueue(stream, chunk);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_READABLE_STREAM_CONTROLLER_CLOSE(controller: u64) {
+    let stream = map_get(controller, "__stream") as u64;
+    if stream != 0 {
+        stream_close(stream);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_READABLE_STREAM_GET_READER(stream: u64) -> u64 {
+    let r = new_map();
+    map_set(r, "__stream", stream as i64);
+    map_set(r, "__cursor", 0);
+    r
+}
+
+/// `reader.read()` -> resolved Promise of `{value, done}`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_READABLE_STREAM_READER_READ(reader: u64) -> u64 {
+    let stream = map_get(reader, "__stream") as u64;
+    let cursor = map_get(reader, "__cursor");
+    let buf = map_get(stream, "__buf") as u64;
+    let len = vec_len(buf);
+    let result = if cursor < len {
+        let val = vec_get(buf, cursor);
+        map_set(reader, "__cursor", cursor + 1);
+        make_result(val, false)
+    } else {
+        // No more buffered data. With the synchronous model the producer has
+        // already closed (or there is nothing left) — signal done.
+        make_result(UNDEFINED, true)
+    };
+    fulfilled_promise(result as i64)
+}
+
+// ── TransformStream ────────────────────────────────────────────────────────────
+//
+// A TransformStream shares one buffer between its writable and readable sides.
+// The `transform(chunk, controller)` callback enqueues into that buffer; the
+// readable side reads from it. `.readable` / `.writable` are stored as fields
+// pointing at the shared stream (so member access returns the right handle).
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_TRANSFORM_STREAM_NEW(opts: u64) -> u64 {
+    let stream = new_stream();
+    // Store the transform callback for the writer side to invoke per chunk.
+    let transform = map_get(opts, "transform");
+    map_set(stream, "__transform", transform);
+    // readable / writable both refer to the same underlying stream.
+    let ts = new_map();
+    map_set(ts, "readable", stream as i64);
+    map_set(ts, "writable", stream as i64);
+    // Mark so codegen field access yields the correct sub-stream handles.
+    map_set(ts, "__stream", stream as i64);
+    ts
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WRITABLE_STREAM_GET_WRITER(stream: u64) -> u64 {
+    let w = new_map();
+    map_set(w, "__stream", stream as i64);
+    w
+}
+
+/// `writer.write(chunk)` -> resolved Promise<void>. Runs `transform(chunk, ctrl)`
+/// if the stream has a transformer; otherwise enqueues the chunk directly.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WRITABLE_STREAM_WRITER_WRITE(writer: u64, chunk: i64) -> u64 {
+    let stream = map_get(writer, "__stream") as u64;
+    if stream != 0 {
+        let transform = map_get(stream, "__transform");
+        if transform != 0 {
+            let controller = new_controller(stream);
+            call_fn(transform, &[chunk, controller as i64]);
+        } else {
+            stream_enqueue(stream, chunk);
+        }
+    }
+    fulfilled_promise(UNDEFINED)
+}
+
+/// `writer.close()` -> resolved Promise<void>. Closes the underlying stream.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_GL_WRITABLE_STREAM_WRITER_CLOSE(writer: u64) -> u64 {
+    let stream = map_get(writer, "__stream") as u64;
+    if stream != 0 {
+        stream_close(stream);
+    }
+    fulfilled_promise(UNDEFINED)
+}

--- a/crates/rts-runtime/src/namespaces/globals/readable_stream/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/readable_stream/mod.rs
@@ -1,0 +1,2 @@
+pub mod abi;
+pub mod instance;


### PR DESCRIPTION
new ReadableStream({start(controller){controller.enqueue(...)}}) + getReader() + await reader.read(). Fecha 64 byte-Node (out=a,b; antes ILLEGAL_INSTRUCTION). Classe global (modelo Intl #1340); reader.read() retorna Promise resolvida drenada pelo await cooperativo (#1337/#1338); NAO toca drain/timers core. Fix: metodos de obj-literal sao raw func_addr (espelha resolve_callback_ptr); getReader() em var nao roteia p/ MAP_GET_CHAIN. 96 follow-up. Suite 1719/1719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)