### PR TITLE
ci: extract shared setup/build into composite actions (DRY)

### DIFF
--- a/.github/actions/build-rts/action.yml
+++ b/.github/actions/build-rts/action.yml
@@ -13,7 +13,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build rts-runtime staticlib + rts
+    # On Windows we MUST NOT use git-bash: it puts `C:\Program Files\Git\usr\bin`
+    # ahead on PATH, so rustc picks up MSYS `link.exe` instead of the MSVC linker
+    # and the build script fails to link. pwsh keeps the MSVC env (msvc-dev-cmd)
+    # intact.
+    - name: Build (Unix)
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         if [ "${{ inputs.profile }}" = "release" ]; then
@@ -23,3 +28,19 @@ runs:
           cargo build -p rts-runtime
           cargo build
         fi
+
+    - name: Build (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if ('${{ inputs.profile }}' -eq 'release') {
+          cargo build --release -p rts-runtime
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo build --release
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        } else {
+          cargo build -p rts-runtime
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        }

--- a/.github/actions/build-rts/action.yml
+++ b/.github/actions/build-rts/action.yml
@@ -1,0 +1,25 @@
+name: Build RTS
+description: >
+  Build the `rts` binary. The AOT runtime archive is a two-step build: Cargo only
+  emits rts-runtime's `staticlib` output (which build.rs embeds) when rts-runtime
+  is a direct target, so it is built first, then the `rts` bin picks it up.
+
+inputs:
+  profile:
+    description: "release | dev"
+    required: false
+    default: release
+
+runs:
+  using: composite
+  steps:
+    - name: Build rts-runtime staticlib + rts
+      shell: bash
+      run: |
+        if [ "${{ inputs.profile }}" = "release" ]; then
+          cargo build --release -p rts-runtime
+          cargo build --release
+        else
+          cargo build -p rts-runtime
+          cargo build
+        fi

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,3 +24,12 @@ runs:
 
     - name: Cache cargo build
       uses: Swatinem/rust-cache@v2
+      with:
+        # Share ONE cache across every job/workflow on the same OS (the default
+        # keys per job, fragmenting the cache). One job warms it, the rest reuse.
+        shared-key: rts-${{ runner.os }}
+        # Only `main` writes the canonical cache; PRs restore it read-only.
+        # GitHub scopes caches by branch — a PR can read the base/default branch
+        # cache but not another PR's, so keeping main warm is what lets every PR
+        # skip recompiling the heavy deps (cranelift, swc, actix, fltk).
+        save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,8 +1,10 @@
 name: Setup Rust
 description: >
-  Shared toolchain setup for every RTS job — stable Rust, platform build deps
-  (FLTK on Linux, MSVC env on Windows) and the cargo build cache. Run it right
-  after `actions/checkout`.
+  Shared toolchain setup for every RTS job — stable Rust, FLTK build deps on
+  Linux, and the cargo build cache. Run it right after `actions/checkout`.
+  NOTE: Windows MSVC env (ilammy/msvc-dev-cmd) is intentionally NOT here — the
+  env vars it exports via GITHUB_ENV do not propagate out of a composite action
+  reliably, so the only job that builds on Windows sets it up directly.
 
 runs:
   using: composite
@@ -19,10 +21,6 @@ runs:
           libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev \
           libxrender-dev libxfixes-dev libpango1.0-dev libgl1-mesa-dev \
           libglu1-mesa-dev libfontconfig1-dev libcairo2-dev jq
-
-    - name: Setup MSVC env (Windows)
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Cache cargo build
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,28 @@
+name: Setup Rust
+description: >
+  Shared toolchain setup for every RTS job — stable Rust, platform build deps
+  (FLTK on Linux, MSVC env on Windows) and the cargo build cache. Run it right
+  after `actions/checkout`.
+
+runs:
+  using: composite
+  steps:
+    - name: Install stable toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install FLTK system deps (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libx11-dev libxext-dev libxft-dev libxinerama-dev libxcursor-dev \
+          libxrender-dev libxfixes-dev libpango1.0-dev libgl1-mesa-dev \
+          libglu1-mesa-dev libfontconfig1-dev libcairo2-dev jq
+
+    - name: Setup MSVC env (Windows)
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Cache cargo build
+      uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -33,38 +33,22 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
+    # Job-level so the build composite's cargo invocation sees it (step-level env
+    # on a `uses:` step is not forwarded into composite action steps).
+    env:
+      RTS_BUILD_VERSION: ${{ needs.version.outputs.version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install FLTK system deps (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev libxext-dev libxft-dev libxinerama-dev \
-            libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libgl1-mesa-dev \
-            libglu1-mesa-dev libfontconfig1-dev libcairo2-dev
-
-      - name: Setup MSVC env (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-rust
 
       - name: Build release
-        env:
-          RTS_BUILD_VERSION: ${{ needs.version.outputs.version }}
-        # Two-step: Cargo only emits rts-runtime's `staticlib` output (the AOT
-        # runtime archive that build.rs embeds) when rts-runtime is a direct
-        # target, so build it first; then the `rts` build.rs picks it up.
-        run: |
-          cargo build --release -p rts-runtime
-          cargo build --release
+        uses: ./.github/actions/build-rts
+        with:
+          profile: release
 
       - name: Smoke test — rts run (JIT)
         run: target/release/rts run bench/pi_machin.ts

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 
+      # MSVC env must be a job step: env it exports via GITHUB_ENV does not
+      # propagate out of a composite action, so the bundled link.exe stays off
+      # PATH and build.rs fails to link.
+      - name: Setup MSVC env (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build release
         uses: ./.github/actions/build-rts
         with:

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -27,17 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install FLTK system deps (Linux)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev libxext-dev libxft-dev libxinerama-dev \
-            libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libgl1-mesa-dev \
-            libglu1-mesa-dev libfontconfig1-dev libcairo2-dev jq
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-rust
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -48,7 +38,9 @@ jobs:
           node-version: "22"
 
       - name: Build RTS (release)
-        run: cargo build --release
+        uses: ./.github/actions/build-rts
+        with:
+          profile: release
 
       - name: Run cross-runtime check
         id: cross

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -19,31 +19,20 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/setup-rust
 
-      - name: Install FLTK system deps (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev libxext-dev libxft-dev libxinerama-dev \
-            libxcursor-dev libxrender-dev libxfixes-dev libpango1.0-dev libgl1-mesa-dev \
-            libglu1-mesa-dev libfontconfig1-dev libcairo2-dev
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      # Build the rts-runtime staticlib + the debug bin in one go so build.rs
+      # embeds the real AOT archive (needed by the `rts compile` smoke below);
+      # the subsequent `cargo run` reuses this build instead of recompiling.
+      - name: Build RTS (debug)
+        uses: ./.github/actions/build-rts
+        with:
+          profile: dev
 
       - name: Run RTS test runner
         run: cargo run -- test
 
-      - name: Smoke test rts compile (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          echo 'import { io } from "rts"; io.print("smoke ok");' > /tmp/smoke.ts
-          cargo run --quiet -- compile /tmp/smoke.ts /tmp/smoke_bin
-          /tmp/smoke_bin
-
-      - name: Smoke test rts compile (macOS)
-        if: runner.os == 'macOS'
+      - name: Smoke test rts compile
         run: |
           echo 'import { io } from "rts"; io.print("smoke ok");' > /tmp/smoke.ts
           cargo run --quiet -- compile /tmp/smoke.ts /tmp/smoke_bin


### PR DESCRIPTION
Setup (Rust+FLTK/MSVC+cache) e build two-step estavam duplicados em 3 workflows. Extraí pra composite actions:
- `.github/actions/setup-rust`
- `.github/actions/build-rts` (input profile release/dev)

build-artifacts, rust-test, cross-runtime agora usam os composites. rust-test passa a buildar o staticlib (debug) antes do smoke `rts compile` (requisito do two-step).

Parte 1/2 — a seguir, cross-runtime/ts-suite reusam o artefato em vez de recompilar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)