### PR TITLE
chore: elimina warnings de build do rts-runtime

### DIFF
--- a/crates/rts-runtime/src/namespaces/collections/map.rs
+++ b/crates/rts-runtime/src/namespaces/collections/map.rs
@@ -1626,13 +1626,6 @@ pub(crate) fn mark_non_enumerable(handle: u64, key: &str) {
         .insert((handle, key.to_string()));
 }
 
-pub(crate) fn unmark_non_enumerable(handle: u64, key: &str) {
-    non_enumerable_set()
-        .lock()
-        .unwrap()
-        .remove(&(handle, key.to_string()));
-}
-
 /// (#208) `Object.defineProperty(obj, key, descriptor)`.
 /// Suporta `{ value: x }` e `{ enumerable: false }`. Demais
 /// (get/set/writable/configurable) caem em PR separada.

--- a/crates/rts-runtime/src/namespaces/gc/generator.rs
+++ b/crates/rts-runtime/src/namespaces/gc/generator.rs
@@ -911,7 +911,7 @@ pub extern "C" fn __RTS_FN_GL_ARRAY_VALUES_ITER(this_arr: i64) -> i64 {
 pub extern "C" fn __RTS_FN_GL_ARRAY_ITERATOR_FN() -> u64 {
     use crate::namespaces::gc::handles::FunctionData;
     alloc_entry(Entry::Function(Box::new(FunctionData {
-        fn_ptr: __RTS_FN_GL_ARRAY_VALUES_ITER as u64,
+        fn_ptr: __RTS_FN_GL_ARRAY_VALUES_ITER as *const () as u64,
         arity: 1,
         name: "[Symbol.iterator]".into(),
         bound_this: 0,

--- a/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/fetch/instance.rs
@@ -780,7 +780,7 @@ mod tests_response_then {
     #[test]
     fn then_wraps_string_result_in_promise() {
         let h = make_response("hello");
-        let cb = cb_returns_string as usize as u64;
+        let cb = cb_returns_string as *const () as u64;
         let result = __RTS_FN_GL_FETCH_RESPONSE_THEN(h, cb);
         let is_promise = with_entry(result, |entry| {
             matches!(entry, Some(Entry::PromiseAsync(_)))
@@ -797,7 +797,7 @@ mod tests_response_then {
     #[test]
     fn then_passthrough_when_callback_returns_promise() {
         let h = make_response("x");
-        let cb = cb_returns_promise as usize as u64;
+        let cb = cb_returns_promise as *const () as u64;
         let result = __RTS_FN_GL_FETCH_RESPONSE_THEN(h, cb);
         let is_promise = with_entry(result, |entry| {
             matches!(entry, Some(Entry::PromiseAsync(_)))

--- a/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
+++ b/crates/rts-runtime/src/namespaces/globals/text_encoding/instance.rs
@@ -412,7 +412,7 @@ pub fn mark_microtask_roots() {
         |s: &std::sync::Arc<crate::namespaces::gc::handles::PromiseSlot>| {
             mark_handle(promise_slot::current_value(s) as u64);
         };
-    let mut mark_task = |t: &Microtask| {
+    let mark_task = |t: &Microtask| {
             match t {
                 Microtask::Bare(fp) => mark_handle(*fp),
                 Microtask::SettledThen { fn_ptr, bound, value, result_slot, .. } => {

--- a/crates/rts-runtime/src/namespaces/promise/ops.rs
+++ b/crates/rts-runtime/src/namespaces/promise/ops.rs
@@ -57,22 +57,6 @@ fn resolve_callback_ptr(fp: u64) -> (u64, Vec<i64>, bool, i64) {
     resolved.unwrap_or((fp, Vec::new(), false, 0))
 }
 
-/// Invoca um ponteiro de fn extern "C" com 0 ou 1 arg, prepende
-/// bound_args. Retorna i64. Limite de aridade total = 8 (limite do
-/// trampolim em globals/function/ops).
-unsafe fn invoke_callback(fn_ptr: u64, bound: &[i64], extra: Option<i64>) -> i64 {
-    let mut args: Vec<i64> = bound.to_vec();
-    if let Some(v) = extra {
-        args.push(v);
-    }
-    // (cross-runtime closures) Consulta o registry de ABI: callbacks com param
-    // `number` agora compilam como `(f64)->...`; invocá-los via ABI i64 crua
-    // (transmute) segfaultava. invoke_fn_ptr_with_registry usa invoke_typed com
-    // os param_kinds reais (e normaliza args number-cru), ou invoke_n quando a
-    // fn é toda-i64 (comportamento idêntico ao transmute de antes).
-    crate::namespaces::globals::function::ops::invoke_fn_ptr_with_registry(fn_ptr, &args)
-}
-
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PROMISE_NEW_PENDING() -> u64 {
     let slot = promise_slot::new_pending();
@@ -688,8 +672,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CREATE(fn_handle: u64, args_vec_handle: u6
         // Combina bound (de bind) + extra_args do caller.
         let mut all: Vec<i64> = bound;
         all.extend(extra_args);
-        // invoke_callback aceita 0 ou 1 extra; aqui ja' temos tudo
-        // empacotado, entao desempacotamos manualmente.
+        // Tudo ja' empacotado em `all`, invocamos diretamente.
         let r = unsafe { invoke_callback_full(fn_ptr, &all) };
         // Checa error slot pra detectar throw dentro do body.
         let err = crate::namespaces::gc::error::__RTS_FN_RT_ERROR_GET();


### PR DESCRIPTION
## Resumo

Elimina todos os warnings de build do rts-runtime (eram 4 no build normal + 2 que so aparecem em --all-targets).

### Correcoes
- text_encoding/instance.rs: remove mut desnecessario de mark_task (unused_mut)
- gc/generator.rs: cast de fn item via as *const () as u64 (function_casts_as_integer)
- collections/map.rs: remove unmark_non_enumerable (dead code, nunca chamada; o par mark_non_enumerable permanece em uso)
- promise/ops.rs: remove invoke_callback (dead code; a fn em uso e invoke_callback_full)
- fetch/instance.rs (testes): 2 casts fn as usize as u64 para as *const () as u64

## Validacao
- cargo build --release (2 passos): 0 warnings, 0 erros
- TS suite: 637/637 arquivos, 1719/1719 testes verdes
- Varredura dead code (RUSTFLAGS + clippy --all-targets): nenhum codigo morto restante

## Nota (pre-existente, fora de escopo)
4 testes unitarios Rust falham na main antes destas mudancas (confirmado via git stash): inline_routing_caller_callee_e2e (rts-codegen), entries_returns_pairs_sorted, descriptor_synthesizes_default_flags, missing_property_returns_zero (rts-runtime).

Generated with Claude Code