### PR TITLE
docs: estudo sobre suporte a .node (Node native addons) no RTS

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -32,6 +32,12 @@ narrow storage real.
 - [Como criar um namespace](namespace-creation-guide.md) — Processo atual
   baseado em `crates/rts-abi/` (SPECS centralizado, simbolos `__RTS_FN_NS_*`,
   `AbiType`). Reflete a branch `feat/remake-namespaces`.
+- [Suporte a `.node` (Node native addons)](node-format/README.md) — Estudo
+  multi-fonte (8 docs) sobre o formato `.node`, a ABI N-API e as divergencias
+  para o RTS dar suporte a addons nativos do npm. Veredito: viavel so via N-API
+  (`napi_value`/`napi_env` opacos -> mapeaveis a HandleTable sem V8),
+  JIT-first, nunca V8-direto/NAN. Verificado por 2 runs adversariais (115
+  afirmacoes, 0 refutadas). Ponto de integracao: `resolve_node_modules_import`.
 - [Silent parallelism (Level-1)](silent-parallelism.md) — Como o codegen
   detecta padroes `for...of`, reduces, e `arr.map/forEach/reduce` e
   reescreve transparentemente para `parallel.*`. Pipeline dos 3 passes,

--- a/docs/specs/node-format/01-formato-binario.md
+++ b/docs/specs/node-format/01-formato-binario.md
@@ -1,0 +1,228 @@
+# 01 — O que é fisicamente um `.node` e como o Node o carrega
+
+> Verificado contra fontes primárias: `nodejs.org/api/addons.html`,
+> `nodejs.org/api/n-api.html`, e o código-fonte do Node
+> (`src/node.h`, `src/node_api.h`, `src/node_version.h`, `src/node_binding.cc`).
+
+## 1.1 Um `.node` é uma biblioteca dinâmica nativa — só a extensão muda
+
+Não existe formato de container próprio. Um `.node` é literalmente a shared
+library nativa do SO, apenas com a extensão renomeada:
+
+| Plataforma | Formato real | Magic | Observação |
+|---|---|---|---|
+| Linux | ELF shared object (`.so`) | `0x7F 45 4C 46` (`\x7FELF`) | `readelf -h foo.node` funciona |
+| Windows | PE/COFF DLL | `MZ` (`0x4D5A`) → `PE\0\0` | é literalmente um `.dll` |
+| macOS | Mach-O dylib | `0xFEEDFACF` (64-bit) / `0xCAFEBABE` (fat) | é literalmente um `.dylib` |
+
+A doc oficial confirma textualmente:
+
+> "The filename extension of the compiled addon binary is `.node` (as opposed to
+> `.dll` or `.so`). The `require()` function is written to look for files with
+> the `.node` file extension and initialize those as dynamically-linked
+> libraries."
+> — `nodejs.org/api/addons.html`
+
+> "*Addons* are dynamically-linked shared objects that can be loaded via the
+> `require()` function as ordinary Node.js modules."
+
+**Implicação para o RTS:** para *produzir* um `.node`, o RTS precisa emitir o
+formato nativo do alvo (ELF `.so` / PE DLL / Mach-O dylib) como **shared
+object**, não como executável — reusando o pipeline AOT (`cranelift_object` +
+linker), mas linkando em modo *shared library* com tabela de exportação. Para
+*consumir*, o loader é o do runtime host (o próprio RTS).
+
+## 1.2 O fluxo de carregamento
+
+```
+require('./addon.node')
+  → Module._extensions['.node']
+  → process.dlopen(module, path.toNamespacedPath(filename))
+  → internalBinding (src/node_binding.cc)
+  → DLib::Open
+      • POSIX:   dlopen(filename, RTLD_LAZY)        [flags configuráveis via os.constants.dlopen]
+      • Windows: uv_dlopen(filename, &lib)
+  → DLib::GetSymbolAddress(name)  → dlsym / uv_dlsym
+  → invoca o símbolo de inicialização
+  → o objeto `exports` populado vira o module.exports retornado ao JS
+```
+
+`DLib::Close` chama `dlclose`. O addon **não tem `main`**: ele só preenche e
+devolve `exports`.
+
+## 1.3 Os DOIS símbolos de entrada (confirmados no código)
+
+`src/node_binding.cc` tem duas funções de descoberta. Verificado literalmente
+contra o fonte:
+
+**N-API (alvo do RTS):**
+```c
+inline napi_addon_register_func GetNapiInitializerCallback(DLib* dlib) {
+  const char* name =
+      STRINGIFY(NAPI_MODULE_INITIALIZER_BASE) STRINGIFY(NAPI_MODULE_VERSION);
+  // NAPI_MODULE_INITIALIZER_BASE = "napi_register_module_v", NAPI_MODULE_VERSION = 1
+  // → símbolo exato: napi_register_module_v1
+```
+Assinatura (extern "C", **sem mangling** — qualquer mangling impede o `dlsym`):
+`napi_value napi_register_module_v1(napi_env env, napi_value exports)`. O Node
+resolve via `dlib->GetSymbolAddress(name)` + `reinterpret_cast` e o invoca via
+`napi_module_register_by_symbol(exports, module, context, init, module_api_version)`
+— **cinco argumentos** no Node atual (o `module_api_version` foi adicionado; a
+forma de 4 args vale só em versões antigas).
+
+**Legado / raw-V8 (fora do alcance do RTS):**
+```c
+inline InitializerCallback GetInitializerCallback(DLib* dlib) {
+  const char* name = "node_register_module_v" STRINGIFY(NODE_MODULE_VERSION);
+  // → ex.: node_register_module_v147 (NODE_MODULE_VERSION 147 = ABI do Node 26;
+  //   o branch main está em NODE_MAJOR_VERSION 27 em desenvolvimento)
+```
+
+A prova empírica de que runtimes alternativos procuram **exatamente**
+`napi_register_module_v1` é a mensagem de erro real do Bun (issues
+`oven-sh/bun#5578`, `#23136`, `#21432`):
+
+> `TypeError: symbol napi_register_module_v1 not found in native module. Is this a Node API (napi) module?`
+
+## 1.4 Auto-registro legado por constructor (caminho que o RTS ignora)
+
+Addons legados (`NODE_MODULE`, NAN) se auto-registram via constructor estático
+**antes** de qualquer símbolo ser procurado. `src/node.h`:
+
+```c
+#define NODE_MODULE_X(modname, regfunc, priv, flags)                  \
+  static node::node_module _module = {                                \
+      NODE_MODULE_VERSION, flags, NULL, __FILE__,                     \
+      (node::addon_register_func)(regfunc), NULL,                     \
+      NODE_STRINGIFY(modname), priv, NULL };                          \
+  NODE_C_CTOR(_register_##modname) { node_module_register(&_module); }
+```
+
+`node_module_register` grava o módulo numa thread-local
+(`thread_local node_module* thread_local_modpending;`), que o `DLOpen` lê após
+o `dlopen`:
+
+```c
+CHECK_NULL(thread_local_modpending);
+// ...
+node_module* mp = thread_local_modpending;
+thread_local_modpending = nullptr;
+```
+
+> **Correção verificada (detalhe MSVC):** `NODE_C_CTOR` expande para
+> `__attribute__((constructor))` no GCC/POSIX, mas no MSVC **não** usa a seção
+> `.CRT$XCU` — usa um construtor de struct estática em namespace anônimo
+> (`struct fn##_ { fn##_(){ fn(); }; } fn##_v_;`), inicialização estática C++
+> comum. (Apontado pela verificação adversarial.)
+
+## 1.5 A struct `node_module` (legado) é acoplada a V8 → inviável no RTS
+
+`src/node.h`:
+```c
+struct node_module {
+  int nm_version;
+  unsigned int nm_flags;
+  void* nm_dso_handle;
+  const char* nm_filename;
+  node::addon_register_func nm_register_func;
+  node::addon_context_register_func nm_context_register_func;
+  const char* nm_modname;
+  void* nm_priv;
+  struct node_module* nm_link;
+};
+typedef void (*addon_register_func)(
+    v8::Local<v8::Object> exports,   // ← tipos V8 no boundary
+    v8::Local<v8::Value> module, void* priv);
+```
+
+O register legado recebe `v8::Local<v8::Object>` — **acoplamento direto ao V8**.
+O RTS não tem V8, então o caminho legado é inviável de implementar fielmente.
+
+## 1.6 A struct `napi_module` (N-API) é independente de V8 → viável
+
+`src/node_api.h`:
+```c
+typedef struct napi_module {
+  int nm_version;
+  unsigned int nm_flags;
+  const char* nm_filename;
+  napi_addon_register_func nm_register_func;   // napi_value(*)(napi_env, napi_value)
+  const char* nm_modname;
+  void* nm_priv;
+  void* reserved[4];
+} napi_module;
+```
+
+`napi_env` e `napi_value` são **ponteiros opacos** — nenhum tipo V8 no boundary.
+Isto é o que torna o suporte viável sem V8 (ver [`02-napi-abi.md`](02-napi-abi.md)).
+
+A macro `NAPI_MODULE_INIT()` exporta dois símbolos com visibilidade default
+(`__declspec(dllexport)` no Windows / `visibility("default")` no POSIX):
+- `napi_register_module_v1(napi_env, napi_value) -> napi_value` (obrigatório)
+- `node_api_module_get_api_version_v1(void) -> int32_t` (negociação de versão)
+
+## 1.7 `NODE_MODULE_VERSION` — trava de ABI do caminho **legado** apenas
+
+`src/node_version.h`: `#define NODE_MODULE_VERSION 147`. Pelo
+`doc/abi_version_registry.json` oficial, **147 corresponde ao Node 26** (variant
+v8_14.6); o valor aparece no `node_version.h` do branch `main` enquanto
+`NODE_MAJOR_VERSION` está em 27 (desenvolvimento), mas a ABI foi registrada para
+o Node 26. O Node recusa addons legados compilados contra ABI diferente:
+
+```
+"The module '%s' was compiled against a different Node.js version using
+NODE_MODULE_VERSION %d. This version of Node.js requires NODE_MODULE_VERSION %d."
+```
+
+Valores confirmados: Node 16=93, 18=108, 20=115, 21=120, 22=127, 23=131, 24=137,
+**26=147**. Registro canônico: `doc/abi_version_registry.json`. Exposto em JS como
+`process.versions.modules`.
+
+**Ponto decisivo:** addons **N-API pulam essa checagem** (a struct `napi_module`
+carrega o seu próprio `NAPI_MODULE_VERSION` fixo e a verificação é diferente).
+Confirmado empiricamente: o Bun reporta `NODE_MODULE_VERSION 127` e a checagem
+só morde addons **não-N-API** (issue `oven-sh/bun#14105`, módulo `webgl`
+V8-direto rejeitado; addons N-API carregam sem reclamar de versão).
+
+## 1.8 Três níveis de addon (acoplamento decrescente)
+
+A doc oficial lista exatamente 3 opções (`addons.html`, confirmado verbatim):
+
+1. **Node-API** (recomendado) — interface C opaca, **ABI-estável**
+2. **`nan`** (Native Abstractions for Node.js) — wrapper C++ **sobre o V8 cru**,
+   sem garantia de ABI (recompila a cada major)
+3. **uso direto** de V8/libuv/internals — acoplamento máximo
+
+`node-addon-api` (≠ `nan`) é um wrapper C++ header-only **sobre o C N-API** —
+herda a estabilidade ABI. A doc confirma verbatim:
+
+> "Binaries built with `node-addon-api` will depend on the symbols of the
+> Node-API C-based functions exported by Node.js." … "Even though the addon is
+> written in C++, it still gets the benefits of the ABI stability provided by
+> the C Node-API."
+
+Ex.: `obj["foo"] = String::New(env, "bar")` (node-addon-api) compila para
+`napi_create_string_utf8` + `napi_set_named_property`.
+
+## Conclusão do capítulo
+
+- Um `.node` é uma DLL/`.so`/`.dylib` comum; o ponto de entrada é uma **função**
+  (`napi_register_module_v1`), não dados estáticos.
+- Há dois caminhos de registro: **N-API** (símbolo direto, ABI-estável, sem V8) e
+  **legado** (constructor + struct `node_module` acoplada a V8, travado por
+  `NODE_MODULE_VERSION`).
+- **O único alvo viável para o RTS é N-API.** O caminho legado/V8-direto exige
+  reproduzir o ABI binário do V8 — fora de escopo (ver
+  [`03-acoplamento-v8-libuv.md`](03-acoplamento-v8-libuv.md)).
+
+## Fontes
+
+- https://nodejs.org/api/addons.html
+- https://nodejs.org/api/n-api.html
+- https://raw.githubusercontent.com/nodejs/node/main/src/node.h
+- https://raw.githubusercontent.com/nodejs/node/main/src/node_api.h
+- https://raw.githubusercontent.com/nodejs/node/main/src/node_version.h
+- https://raw.githubusercontent.com/nodejs/node/main/src/node_binding.cc
+- https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
+- https://github.com/oven-sh/bun/issues/5578 · /issues/23136 · /issues/21432 · /issues/14105
+- https://blog.s1h.org/inside-node-loading-native-addons/

--- a/docs/specs/node-format/02-napi-abi.md
+++ b/docs/specs/node-format/02-napi-abi.md
@@ -1,0 +1,247 @@
+# 02 — A ABI N-API / Node-API (a interface C estável dos addons)
+
+> Verificado contra `nodejs.org/api/n-api.html` e os headers
+> `src/js_native_api_types.h`, `src/js_native_api_v8.h`, `src/node_api.h`.
+> A N-API é a **única** superfície que um runtime não-V8 (RTS, Bun) pode
+> implementar — ver [`01-formato-binario.md`](01-formato-binario.md).
+
+## 2.1 `napi_value` — ponteiro opaco
+
+```c
+typedef struct napi_value__* napi_value;   // struct incompleto, nunca definido
+```
+
+Doc oficial (confirmado verbatim):
+> "All JavaScript values are abstracted behind an opaque type named
+> `napi_value`. This is an opaque pointer that is used to represent a JavaScript
+> value."
+
+O addon **nunca** dereferencia `napi_value` — só o passa de volta às funções
+`napi_*`. No Node real, `napi_value` é binariamente igual a um
+`v8::Local<v8::Value>` (8 bytes):
+
+```c
+// src/js_native_api_v8.h
+static_assert(sizeof(v8::Local<v8::Value>) == sizeof(napi_value), ...);
+inline napi_value JsValueFromV8LocalValue(v8::Local<v8::Value> local) {
+  return reinterpret_cast<napi_value>(*local);
+}
+```
+
+**Ponto-chave para o RTS:** como o addon trata `napi_value` como opaco, o RTS é
+**livre para escolher o que ele encapsula** — um handle `u64` da `HandleTable`
+ou um ponteiro para um `RuntimeValue` interno. É isto que torna o suporte viável
+sem V8 (o Bun mapeia para `JSC::JSValue`, igualmente 8 bytes).
+
+## 2.2 `napi_env` — contexto opaco passado a toda função
+
+```c
+typedef struct napi_env__* napi_env;
+```
+
+No Node carrega `v8::Isolate*` + `v8impl::Persistent<v8::Context>`. Regras de ABI:
+- o **mesmo** `napi_env` da função inicial deve ser repassado a toda chamada
+  N-API aninhada;
+- **não** pode ser cacheado para reuso geral nem compartilhado entre Worker
+  threads;
+- torna-se inválido quando a instância do addon é descarregada.
+
+**No RTS:** `napi_env` = ponteiro para uma `RtsNapiEnv` contendo: a `HandleTable`,
+a pilha de handle scopes, o slot de exceção pendente, instance-data, e o ponteiro
+para o event loop (ponte tokio). Um `napi_env` **por instância de addon**.
+
+## 2.3 Convenção uniforme: retorna `napi_status`, escreve em out-param
+
+Toda função N-API segue:
+```c
+napi_status napi_create_double(napi_env env, double value, napi_value* result);
+```
+
+`napi_status` (enum ABI-estável, ~24 valores, ordem fixa): `napi_ok=0`,
+`napi_invalid_arg`, `napi_object_expected`, `napi_string_expected`,
+`napi_number_expected`, `napi_function_expected`, `napi_pending_exception`,
+`napi_generic_failure`, `napi_escape_called_twice`, `napi_handle_scope_mismatch`,
+`napi_bigint_expected`, `napi_date_expected`, `napi_arraybuffer_expected`,
+`napi_cannot_run_js`, etc. Detalhe via `napi_get_last_error_info`.
+
+**No RTS:** cada shim `extern "C" __rts_napi_*` retorna `i32` (status) e recebe
+ponteiros de saída — **alinhado ao modelo ABI tipado do RTS**. A ordem do enum é
+ABI-estável e não pode ser reordenada.
+
+## 2.4 Callbacks: como JS chama uma função nativa
+
+```c
+typedef napi_value (NAPI_CDECL* napi_callback)(napi_env env, napi_callback_info info);
+napi_status napi_get_cb_info(napi_env env, napi_callback_info cbinfo,
+                             size_t* argc, napi_value* argv,
+                             napi_value* this_arg, void** data);
+```
+
+`argc` é in/out (capacidade na entrada, nº real na saída); `this_arg` recebe o
+receiver; `data` recebe o `void*` registrado em `napi_create_function`.
+
+**Divergência de convenção de chamada:** o RTS usa `CallConv::Tail` para fns de
+usuário, mas `napi_callback` exige `extern "C"`/CDECL nativo. O trampolim
+RTS→addon→RTS precisa **trocar de convenção** — já há precedente no RTS
+(`invoke_all_i64` com asm win64).
+
+## 2.5 O núcleo de funções (o "80/20" que quase todo addon usa)
+
+A superfície total é de **~150-160 funções** (`napi_*`/`node_api_*`) — a contagem
+varia por fonte: `node-api-headers` v10 lista ~111 (89 `js_native_api` + 22
+`node_api`), os headers do Node têm ~161 declarações `NAPI_EXTERN`, o Bun rastreia
+"156/156" (issue #158) e o `symbol_exports.json` do Deno lista 163 (parte deles
+de libuv/loop). O núcleo de um addon típico são ~30-40:
+
+**Registro:** `napi_register_module_v1`, struct `napi_module`.
+
+**Criação de valores** (`env`, dados nativos…, `out napi_value*`):
+`napi_create_double/int32/uint32/int64/bigint_*`,
+`napi_create_string_utf8` (length pode ser `NAPI_AUTO_LENGTH`),
+`napi_create_object`, `napi_create_array`, `napi_create_array_with_length`,
+`napi_get_boolean`, `napi_get_undefined`, `napi_get_null`, `napi_get_global`.
+
+**Extração** (`env`, `napi_value`, `out C-type*`):
+`napi_get_value_double/int32/uint32/int64/bool`,
+`napi_get_value_string_utf8(env, val, char* buf, size_t bufsize, size_t* result)`
+— **protocolo de duas passagens**: `buf=NULL` mede o comprimento, depois copia.
+Implementar isso fielmente é crítico (addons pré-alocam buffers).
+
+**Propriedades:**
+`napi_get_property`/`napi_set_property` (chave `napi_value`),
+`napi_get_named_property`/`napi_set_named_property` (string C),
+`napi_has_property`, `napi_delete_property`,
+`napi_get_element`/`napi_set_element` (índice `uint32_t`),
+`napi_is_array`, `napi_define_properties(…, const napi_property_descriptor*)`.
+
+**Funções e chamadas:**
+`napi_create_function(env, name, len, napi_callback, void* data, out)`,
+`napi_call_function(env, recv, func, argc, argv, out)`,
+`napi_new_instance`, `napi_define_class`.
+
+**Tipos e coerção:**
+`napi_typeof` → `napi_valuetype` { `napi_undefined`, `napi_null`,
+`napi_boolean`, `napi_number`, `napi_string`, `napi_symbol`, `napi_object`,
+`napi_function`, `napi_external`, `napi_bigint` };
+`napi_coerce_to_string/number/bool/object`;
+`napi_create_external(env, void* data, finalize_cb, hint, out)` — embrulha um
+ponteiro nativo cru visível ao JS só como handle.
+
+**Erros/exceções:**
+`napi_throw`, `napi_throw_error/type_error/range_error`,
+`napi_is_exception_pending`, `napi_get_and_clear_last_exception`.
+
+## 2.6 Handle scopes — lifetime dos `napi_value`
+
+```c
+napi_open_handle_scope(env, napi_handle_scope*);
+napi_close_handle_scope(env, napi_handle_scope);
+napi_open_escapable_handle_scope(env, napi_escapable_handle_scope*);
+napi_close_escapable_handle_scope(env, scope);
+napi_escape_handle(env, scope, napi_value escapable, napi_value* result);
+```
+
+Doc (confirmada verbatim):
+> "Closing the scope can indicate to the GC that all `napi_value`s created
+> during the lifetime of the handle scope are no longer referenced from the
+> current stack frame."
+
+Regras: scopes fecham em ordem inversa; já existe um *default scope* na entrada
+de um método nativo; `napi_escape_handle` só pode ser chamado **uma vez** por
+scope (senão `napi_escape_called_twice`).
+
+**Divergência fundamental de GC (não bloqueador):** no V8 (GC móvel) o handle
+scope é *obrigatório*. No RTS (mark+sweep **não-móvel**, stack maps Cranelift) a
+semântica pode ser simplificada — **mas o RTS DEVE implementar as 5 funções**
+porque addons reais as chamam em loops para não acumular handles. Mínimo viável:
+cada handle scope é um vetor de handles registrado como **root extra** no
+scanner do GC do RTS; fechar o scope desregistra; `napi_escape_handle` promove
+um handle ao scope pai. (É exatamente o que o Bun faz: array de slots
+escaneável.)
+
+## 2.7 Referências e finalizers — integração com o GC
+
+```c
+napi_create_reference(env, value, uint32_t initial_refcount, napi_ref*);  // 0=weak, >0=strong
+napi_reference_ref/unref(env, ref, uint32_t* result);
+napi_get_reference_value(env, ref, napi_value*);  // null se já coletado (weak)
+napi_delete_reference(env, ref);
+
+napi_wrap(env, js_object, void* native, napi_finalize cb, void* hint, napi_ref*);
+napi_unwrap(env, js_object, void** result);
+napi_add_finalizer(env, js_object, void* native, napi_finalize cb, void* hint, napi_ref*);
+
+typedef void (NAPI_CDECL* napi_finalize)(napi_env env, void* data, void* hint);
+```
+
+`napi_ref` mantém valores vivos **além** do handle scope (ex.: um constructor
+guardado entre chamadas). `napi_wrap` associa um objeto nativo C++ a um objeto
+JS com finalizer na coleta — base de quase todo addon que expõe um recurso
+nativo (DB handle, socket).
+
+**No RTS:** tabela de refs com refcount que conta como **GC root** quando strong
+(>0) e **não** conta quando weak (0); o `sweep_all_shards()` precisa, ao liberar
+um `Entry` com finalizer N-API associado, **enfileirar** a chamada do
+`napi_finalize` — **fora** da fase de marcação (timing "second-pass": chamar o
+motor durante o weak callback é inseguro). Liga-se à issue **#217** do RTS
+(WeakMap/WeakSet hoje com semântica forte).
+
+## 2.8 Promises e async
+
+```c
+napi_create_promise(env, napi_deferred* deferred, napi_value* promise);
+napi_resolve_deferred(env, deferred, napi_value resolution);
+napi_reject_deferred(env, deferred, napi_value rejection);
+```
+
+**No RTS:** mapeia quase 1:1 ao subsistema `promise.create`/`PromiseAsync` do
+RTS (#437) — o `deferred` é o lado de resolução que o RTS já modela. Ponto de
+integração quase pronto.
+
+## 2.9 Threadsafe functions e async work (o degrau difícil)
+
+```c
+napi_create_async_work / napi_queue_async_work / napi_cancel_async_work
+napi_create_threadsafe_function / napi_call_threadsafe_function
+napi_acquire/release/ref/unref_threadsafe_function
+napi_get_uv_event_loop(env, uv_loop_t**)
+```
+
+Assumem o **event loop libuv**. Detalhado em
+[`03-acoplamento-v8-libuv.md`](03-acoplamento-v8-libuv.md) e
+[`05-divergencias-rts.md`](05-divergencias-rts.md) (divergência 4) — é a área de
+maior risco de incompatibilidade de cauda longa (até o Bun tem gaps aqui).
+
+## 2.10 Estabilidade ABI e versionamento
+
+Doc oficial (confirmada verbatim):
+> "Node-API … is independent from the underlying JavaScript runtime (for
+> example, V8) … This API will be Application Binary Interface (ABI) stable
+> across versions of Node.js."
+
+Versionamento **cumulativo** (cada versão = retrocompatível):
+N-API 8 → Node 12.22+/14.17+/16+; 9 → 18.17+/20.3+/21+; 10 → 22.14+/23.6+.
+`#define NAPI_VERSION X` antes do include "baka" a versão no addon.
+`napi_get_version(env, uint32_t*)` retorna a versão N-API suportada em runtime.
+
+**No RTS:** implementar uma versão alvo inteira (ex.: começar em N-API 8 ou 9);
+`napi_get_version` anuncia o nível implementado.
+
+## Conclusão do capítulo
+
+- `napi_value`/`napi_env` opacos = o RTS controla 100% da representação → suporte
+  sem V8 é viável (Bun é a prova de existência sobre JSC).
+- A convenção `napi_status` + out-params casa com a ABI tipada `extern "C"` do
+  RTS.
+- Os pontos de integração de GC (handle scopes, refs, finalizers) são reais mas
+  conhecidos — mapeiam à `HandleTable`/mark+sweep do RTS.
+- async/threadsafe é o degrau difícil (event loop libuv vs tokio).
+
+## Fontes
+
+- https://nodejs.org/api/n-api.html
+- https://raw.githubusercontent.com/nodejs/node/main/src/js_native_api_types.h
+- https://raw.githubusercontent.com/nodejs/node/main/src/js_native_api_v8.h
+- https://github.com/nodejs/node-addon-api/blob/main/doc/handle_scope.md
+- https://bun.com/blog/how-bun-supports-v8-apis-without-using-v8-part-1
+- https://nodejs.org/en/learn/modules/abi-stability

--- a/docs/specs/node-format/03-acoplamento-v8-libuv.md
+++ b/docs/specs/node-format/03-acoplamento-v8-libuv.md
@@ -1,0 +1,171 @@
+# 03 — Acoplamento com V8, libuv e o runtime host
+
+> O que um host precisa prover para um `.node` carregar e rodar. Verificado
+> contra `nodejs.org/api/addons.html`, `nodejs.org/api/n-api.html`,
+> `node-gyp/src/win_delay_load_hook.cc`, issues do Node/Bun e o blog técnico do
+> Bun.
+
+## 3.1 Um `.node` NÃO é self-contained — tem símbolos undefined
+
+Um addon é compilado deixando símbolos como `napi_*`, `uv_*`, `v8::*`, `node::*`
+como **undefined**; o linker dinâmico os resolve a partir do **binário host** já
+carregado em memória (node.exe / electron.exe / o próprio RTS.exe).
+
+Doc oficial (confirmada verbatim):
+> "Only the libuv, OpenSSL, V8, and zlib symbols are purposefully re-exported by
+> Node.js and may be used to various extents by addons."
+
+Issue `nodejs/node#52282`: quando o Node é compilado como shared library, um
+`node.def` lista todos os símbolos exportados, e qualquer host que embute a lib
+precisa linkar contra `node.def` para "re-exportar os símbolos necessários" que
+o `.node` espera.
+
+**Requisito central para o RTS:** para carregar um `.node`, o RTS **não** precisa
+parsear/relinkar nada — precisa apenas:
+1. `dlopen` do `.node`, e
+2. **exportar** do seu próprio executável a tabela de símbolos `napi_*` (e, p/
+   async, um subconjunto `uv_*`) que o `.node` referencia como undefined.
+
+Sem essa exportação, o `dlopen` falha com *undefined symbol*.
+
+## 3.2 Quanto um addon depende de V8 vs apenas N-API
+
+Três vias (acoplamento decrescente — ver
+[`01-formato-binario.md`](01-formato-binario.md) §1.8):
+
+| Via | Depende de | ABI estável? | Suportável no RTS? |
+|---|---|---|---|
+| **Node-API** (C) | só símbolos `napi_*` | ✅ sim | ✅ **sim** |
+| **node-addon-api** (C++ header-only) | reduz a símbolos `napi_*` | ✅ sim (herda) | ✅ **sim** |
+| **nan** (C++ sobre V8) | `v8::Local`, `v8::Isolate`, `v8::HandleScope`… | ❌ não | ❌ caro |
+| **V8 direto** (`v8.h`) | layout binário do V8 | ❌ não | ❌ inviável |
+
+A garantia de ABI vale **apenas** para `<node_api.h>`. A doc afirma que
+`<node.h>`, `<node_buffer.h>`, `<uv.h>`, `<v8.h>` **não** têm estabilidade ABI
+entre majors.
+
+## 3.3 Por que addons V8-diretos/NAN são o caso difícil
+
+O problema não é só "exportar símbolos V8". Funções **inline** dos headers do V8
+são **compiladas DENTRO do `.node`** e o host não pode interceptá-las.
+
+Blog do Bun (*how-bun-supports-v8-apis-without-using-v8*):
+- `v8::Object::GetInternalField` é inline; "performs some checks and then calls
+  `v8::Object::SlowGetInternalField` if they fail" — essas checagens
+  desreferenciam ponteiros usando o **esquema de tagged pointers do V8** (lower 2
+  bits = tipo);
+- esse código "gets compiled into each native module. **We can't change any of
+  it**";
+- JSC usa **NaN-boxing** (51 bits em NaN, 48-bit heap ptr / 32-bit int) — layout
+  incompatível com o tagged-pointer do V8.
+
+Para suportar esses addons, o host teria que **emular o layout de memória do
+V8** (tagged pointers, `HandleScope` com stack de slots que o GC varre, internal
+fields em offsets fixos, "Maps" falsos de tipo V8). O Bun documenta isso como
+trabalho **multi-parte e incompleto** (issue `oven-sh/bun#4290`).
+
+**Conclusão para o RTS:** suportar N-API é tratável e bem-definido (~150 fns,
+faixa ~110-160);
+emular o ABI binário do V8 é um projeto separado, enorme e frágil. **O RTS deve
+mirar SÓ N-API** e declarar addons v8-diretos/NAN como não-suportados — a mesma
+fronteira que Bun levou anos empurrando e que Deno (mesmo com V8 real) também não
+cruza (`better-sqlite3` falha nos dois).
+
+## 3.4 Trabalho assíncrono nativo via libuv
+
+Conjunto de funções:
+- **async simples:** `napi_create_async_work`, `napi_delete_async_work`,
+  `napi_queue_async_work`, `napi_cancel_async_work` — internamente
+  `uv_queue_work(loop, req, work_cb, after_work_cb)` (threadpool do libuv,
+  `after` roda na thread do loop);
+- **thread-safe:** `napi_create_threadsafe_function` + `call/acquire/release/
+  ref/unref` — usam um `uv_async_t` (`uv_async_send` acorda o loop de outra
+  thread);
+- **event loop:** `napi_get_uv_event_loop(env, uv_loop_t**)` — dá o loop cru.
+
+Addons NAN/diretos chamam `uv_default_loop()` para pegar o loop.
+
+**Divergência para o RTS:** o RTS roda **tokio**, não libuv. Para async N-API:
+- `napi_create_async_work` → `rt().spawn_blocking(execute_cb)`, `complete_cb`
+  postado de volta à "thread principal" RTS;
+- threadsafe function → fila MPSC drenada na thread que executa JS (casa com o
+  modelo `promise`/`spawn_blocking` do RTS, #437);
+- `napi_get_uv_event_loop` é o ponto **mais espinhoso** — addons que usam
+  `uv_async_t` no loop cru exigiriam um **shim `uv_loop_t` mínimo** sobre tokio.
+
+O Bun **não** roda sobre libuv (Linux/macOS): `uv_default_loop()` não é o loop do
+runtime, então addons que o usam direto quebram (issues `oven-sh/bun#14830`,
+`#20453`, `#25220`); só funcionam via `napi_get_uv_event_loop` + um shim libuv.
+Esta é a área onde **até o Bun ainda tem parity gaps**.
+
+## 3.5 Resolução de símbolos no Windows: delay-load
+
+`node-gyp` injeta `src/win_delay_load_hook.cc` em todo addon. O mecanismo:
+- registra `__pfnDliNotifyHook2 = load_exe_hook`;
+- quando o loader tenta carregar a DLL `HOST_BINARY` (ex.: `node.exe`), o hook
+  intercepta em `dliNotePreLoadLibrary`, compara via `_stricmp(info->szDll,
+  HOST_BINARY)`, e em vez de procurar o `.exe` no disco retorna
+  `GetModuleHandle(TEXT("libnode.dll"))` ou, se nulo, **`GetModuleHandle(NULL)`**
+  (handle do próprio processo);
+- assim os símbolos `napi_*`/`uv_*`/`v8` são resolvidos a partir do executável
+  host — **funciona mesmo se o host foi renomeado**.
+
+**Para o RTS no Windows:** basta (1) **exportar** `napi_*`/`uv_*` do seu próprio
+`.exe` (equivalente a um `node.def` / `/EXPORT`), e (2) o `win_delay_load_hook`
+já embutido no `.node` cairá no fallback `GetModuleHandle(NULL)` → buscará os
+símbolos **no RTS.exe**. O RTS só precisa garantir que esses símbolos estejam na
+export table do binário.
+
+## 3.6 Resolução de símbolos no Linux/macOS
+
+Node carrega via `dlopen` (padrão `RTLD_LAZY|RTLD_LOCAL`, configurável via
+`process.dlopen` flags + `os.constants.dlopen`). Em macOS `dlopen` age como
+`RTLD_GLOBAL` por padrão; Linux usa `RTLD_LOCAL`. Os símbolos `napi_*`/`uv_*`/
+`v8` undefined no `.node` são resolvidos contra o binário host já carregado.
+
+**Para o RTS no Linux/macOS:** o `RTS.exe` precisa ser linkado com os símbolos
+`napi_*`/`uv_*` **visíveis dinamicamente** — ou seja, **não** `-fvisibility=
+hidden` para eles; provavelmente um *version script* / `--dynamic-list` ou
+`--export-dynamic`. Sem isso, mesmo implementando `napi_*`, o `dlsym` dinâmico do
+`.node` não os acha. **Detalhe de link a observar no RTS.**
+
+## 3.7 Precedente: como Bun e Deno exportam os símbolos
+
+- **Bun** (JSC, não-V8): implementa N-API do zero. `napi.cpp` (bindings JSC) +
+  `napi.zig` (TSFN/async/loop) + `bindings/v8/` (shim V8 p/ NAN) +
+  **`src/symbols.txt`** (lista de símbolos exportados). 156/156 fns. `napi_value`
+  ↔ `JSC::JSValue`.
+- **Deno** (V8 via rusty_v8): `napi_value` **é** um `v8::Local` de verdade
+  (mapeamento direto). Crate `deno_napi`; símbolos declarados via macro
+  `#[napi_sym::napi_sym]`, nomes em
+  **`cli/napi_sym/symbol_exports.json`**, `.def` gerado por
+  `tools/napi/generate_symbols_lists.js`. Loader via `libloading`. Mesmo entry
+  point `napi_register_module_v1`.
+
+**Para o RTS:** o molde é claro — uma **lista declarativa de símbolos N-API**
+(análoga ao `symbol_exports.json` do Deno e à própria `abi::SPECS`/`symbols.rs`
+do RTS), com geração de `.def`/export table. A maquinaria que o RTS já tem para
+gerar `rts.d.ts` a partir de `SPECS` geraria os exports N-API.
+
+## Conclusão do capítulo
+
+- O host precisa **exportar `napi_*` (+ subset `uv_*`)** do seu binário e fazer
+  `dlopen` + `dlsym(napi_register_module_v1)`.
+- No Windows o delay-load hook cai em `GetModuleHandle(NULL)` → resolve no
+  RTS.exe; no Linux/macOS exige `--export-dynamic` dos símbolos N-API.
+- N-API é tratável; **V8-direto/NAN exige emular o layout binário do V8** —
+  fora de escopo.
+- async/libuv é o degrau difícil — ponte tokio + shim `uv_loop` mínimo (área
+  com gaps até no Bun).
+
+## Fontes
+
+- https://nodejs.org/api/addons.html · /api/n-api.html
+- https://github.com/nodejs/node-gyp/blob/main/src/win_delay_load_hook.cc
+- https://github.com/nodejs/node/issues/52282
+- https://github.com/oven-sh/bun/issues/158 · /4290 · /14830 · /20453 · /25220
+- https://bun.com/blog/how-bun-supports-v8-apis-without-using-v8-part-1 · part-2
+- https://docs.rs/deno_napi/latest/deno_napi/
+- https://github.com/denoland/deno/tree/main/ext/napi
+- https://docs.libuv.org/en/v1.x/async.html
+- https://man7.org/linux/man-pages/man3/dlopen.3.html

--- a/docs/specs/node-format/04-precedente-bun-deno.md
+++ b/docs/specs/node-format/04-precedente-bun-deno.md
@@ -1,0 +1,178 @@
+# 04 — Precedente: como Bun e Deno implementaram N-API
+
+> O roadmap que o RTS seguiria. Bun (sobre JavaScriptCore, **não**-V8) é o
+> precedente mais próximo do RTS; Deno (sobre V8 real) mostra o contraste.
+> Verificado contra blog/docs do Bun, `deno_napi`, e issues do GitHub.
+
+## 4.1 O contrato é idêntico para os dois: `napi_register_module_v1`
+
+Ambos carregam o `.node` via `dlopen`/`libloading`, resolvem
+`napi_register_module_v1(napi_env, napi_value exports) -> napi_value`, fabricam
+um `napi_env`, criam um `exports` vazio e chamam a init. O erro quando o símbolo
+falta (visto em runtimes não-Node):
+> `symbol napi_register_module_v1 not found in native module. Is this a Node API (napi) module?`
+
+## 4.2 Deno — o caminho "fácil" (engine V8)
+
+- Embute V8 via **rusty_v8**; logo `napi_value` **é** um `v8::Local` de verdade —
+  **sem tradução de engine**. `deno_napi` só faz transmute/abstração.
+- Estrutura: crate `deno_napi` com `Env`, `EnvShared`, `NapiModule`, `NapiState`,
+  `InstanceData`; módulos `js_native_api` (operações de valor), `node_api`,
+  `function`, `value`, `uv` (integração libuv).
+- Símbolos: macro `#[napi_sym::napi_sym]`, nomes em
+  `cli/napi_sym/symbol_exports.json`, `.def` gerado por
+  `tools/napi/generate_symbols_lists.js`. Loader via `libloading`
+  (`DenoRtNativeAddonLoader`).
+- **Modelo de permissão:** addons exigem `node_modules/` local + flag
+  **`--allow-ffi`** (mesma permissão do FFI cru, pois roda fora do sandbox;
+  aceita lista de paths `--allow-ffi=./libfoo.so`).
+- **`deno compile`:** historicamente falhava com addons (issue `#23266`,
+  `LoadLibraryExW failed`). PR `#28934` adicionou
+  `deno_rt_native_addon_loader` que **extrai** as shared libs / `.node` embutidos
+  **para um arquivo temp** e os abre dali (modelo self-extracting). Limitações
+  admitidas: não funciona em FS read-only nem se a lib precisa de outros arquivos
+  reais em disco.
+
+> **Nuance verificada (`napi_value` no Deno):** não é *literalmente* um
+> `v8::Local`. Em `ext/napi/value.rs` é um newtype
+> `#[repr(transparent)] NapiValue<'s>(Option<NonNull<v8::Value>>)` —
+> **nullable** (≠ o `Local` não-nullable do rusty_v8), conversível para/de
+> `v8::Local` via `From` e `Deref`/`transmute` **sem tradução de engine** (porque
+> o engine *é* V8). Ponte quase zero-custo, mais barata que a do Bun.
+> A flag `deno compile --self-extracting` (validada no Deno 2.3) é o mecanismo de
+> AOT.
+
+**Lição para o RTS:** Deno teve o caminho fácil para `napi_value` (tem V8). O RTS
+**não** está nesse caminho — segue o modelo **Bun** (mapear `napi_value` para
+handle próprio). Mas o **modelo de permissão** (`--allow-ffi`) e o **modelo
+self-extracting** para o AOT são diretamente reaproveitáveis.
+
+## 4.3 Bun — o caminho do RTS (engine não-V8)
+
+- Usa **JavaScriptCore**; trata `napi_value` como um `JSC::JSValue`
+  (`EncodedJSValue`, 8 bytes, **NaN-boxing**, ≠ tagged pointer do V8), via
+  `reinterpret_cast` + `JSValue::encode/decode`. O NaN-boxing do JSC usa uma
+  **tag de 16 bits superiores** (não "2 bits"): tag `0x0000` = ponteiro `JSCell`
+  de 48 bits (objetos no heap); tag `0xFFFE` = `int32` com sinal (ex.:
+  `0xfffe000000000000 | (uint32_t)input`).
+- **Cobertura COMPLETA de superfície:** issue `oven-sh/bun#158` reporta
+  **156/156** funções `napi_*`/`node_api_*` implementadas e exportadas. O
+  restante é **paridade comportamental (~95%)**, não API faltando.
+- Roda as suites oficiais do Node no CI: `js-native-api` (engine-agnóstico,
+  ~98-100%), `node-api` (específico-Node, ~48%), combinado ~76%.
+- Estrutura de código (caminhos **atuais** do repo — molde para o RTS):
+  - `src/jsc/bindings/napi.cpp` — funções `napi_*` + integração JSC (valor);
+  - `src/runtime/napi/napi.zig` — threadsafe functions, async work, event loop,
+    handle scopes;
+  - `src/jsc/bindings/v8/` — shim do ABI C++ do V8 (para addons NAN);
+  - `src/symbols.txt` — lista de símbolos exportados.
+  > (Caminhos antigos `src/bun.js/bindings/...` aparecem em material datado.)
+
+### Como Bun gerencia handle scopes (modelo direto p/ o RTS)
+
+`HandleScope` de 24 bytes stack-alocado { ptr Isolate, ptr scope anterior, ptr
+`HandleScopeBuffer` }; no construtor se marca como *current*, no destrutor
+restaura o anterior. O scope atual fica em
+`globalObject->V8GlobalInternals()->currentHandleScope()` (lazily pendurado no
+global object). Cada `Handle` = 24 bytes. `napi_value` retornado é ponteiro para
+o slot **estável** no buffer — **nunca** o ponteiro do objeto direto.
+
+**Lição crítica para o RTS:** `napi_value` deve ser uma **indireção estável**
+(slot na `HandleTable`/handle scope), nunca o ponteiro cru de um `RuntimeValue` —
+senão o mark+sweep do RTS pode coletar/invalidar o valor no meio da chamada
+nativa (a classe de bug "handle collected before use" que o RTS já documentou).
+
+> **Nuance verificada (por que a implementação ingênua do Bun falha):** o GC do
+> JSC é **non-moving** (Riptide, non-compacting — `JSCell`s ficam em endereço
+> fixo), então o problema **não** é ponteiro invalidado por coleta movente. A
+> implementação ingênua (partes 1-2 do blog) é "deeply broken" porque os
+> `Handle`s vivem num `HandleScopeBuffer` que o coletor do JSC **não rastreia** —
+> objetos referenciados só por handles podem ser coletados enquanto ainda vivos
+> (problema de **rooting/visibilidade ao GC**, não de movimento). É exatamente o
+> risco análogo no RTS: o handle scope precisa ser registrado como **root
+> escaneável** pelo `mark_stack_roots()`, senão o sweep coleta o que o addon
+> ainda usa. O GC não-móvel do RTS (como o do JSC) facilita a parte de
+> *estabilidade de endereço*, mas **não** dispensa o rooting.
+
+### O degrau difícil que o Bun não cruza por completo
+
+- **async_hooks** não integrado (Bun recomenda `AsyncLocalStorage`);
+- **libuv:** só um **subconjunto** de símbolos `uv_*` exportado;
+  `uv_default_loop()` ≠ loop do runtime → addons que o usam direto quebram;
+- ordenação de finalizers em *worker terminate* diverge;
+- `napi_adjust_external_memory` difere do V8.
+
+### O shim V8-C++ (NAN) — projeto separado, anos de trabalho
+
+Issue `oven-sh/bun#4290`: para NAN/V8-direto, Bun shimou (desde **v1.1.25**,
+ago/2024) `v8::Isolate::GetCurrent`, `HandleScope`, `EscapableHandleScope`,
+`Number/String/Boolean/Object/Array/External`, `FunctionTemplate`,
+`ObjectTemplate`, internal fields, `node_module_register`, cleanup hooks. **Ainda
+quebram:** operações avançadas de Array, `ObjectTemplate` com construtores, casos
+de `FunctionTemplate`, `ArrayBuffer`, strings UTF-16, persistent handles. A
+tentativa ingênua de reinterpretar `Local<T>` ↔ `JSValue` **falhou** porque
+funções inline do V8 dereferenciam assumindo o layout V8.
+
+## 4.4 Mapa de compatibilidade de addons reais (baseline de teste)
+
+| Addon | Bun | Deno | Por quê |
+|---|---|---|---|
+| `esbuild` | ✅ | ✅ | N-API puro |
+| `sqlite3` (npm) / `duckdb` | ✅ | ✅ | N-API |
+| `better-sqlite3` | ⚠️ contornado por `bun:sqlite` | ❌ (`#18444`, não acha bindings) | addon nativo; Deno usa `libsql`/`denodrivers` |
+| `sharp` | ✅ (libvips + fallback WASM, 2026) | parcial | N-API + binário |
+| `bcrypt` | ✅ (N-API desde v4.0.0; Bun v1.0.19+) | parcial | migrou de V8-C++ → N-API; `bcryptjs`/`Bun.password` ficam como conveniência |
+| `node-canvas` (v2) | ❌ | ❌ | V8-C++ |
+
+> **Nuance verificada (estado 2025-2026):** `bcrypt` **não** é mais "V8-C++ que
+> quebra" — migrou para N-API na v4.0.0 e o Bun v1.0.19 desbloqueou o suporte
+> oficial. O exemplo canônico de "quebra por V8-C++ direto" é o `node-canvas`
+> (v2). `better-sqlite3` é addon nativo mas o atrito no Deno é não achar o
+> arquivo de bindings, não V8-C++.
+
+**Padrão geral:** addons **N-API puros** tendem a funcionar; addons que usam
+**nan/v8.h direto** quebram nos dois runtimes — confirmando a fronteira que o RTS
+deve adotar.
+
+**Estratégia "API embutida em vez de addon":** o Bun oferece `bun:sqlite`
+(4-6× mais rápido que `better-sqlite3`, evita marshaling N-API). O RTS já tem
+namespaces nativos (`crypto`, `net`, `sqlite` futuro?) que podem servir de
+alternativa quando o addon N-API for inviável.
+
+## 4.5 Estimativa de esforço (do precedente)
+
+- **Bun:** superfície N-API "completa" (156/156 fns na contagem da issue #158),
+  mas **paridade comportamental +
+  shim V8-C++** consumiram releases desde v1.1.25 (ago/2024) até hoje, com **três
+  posts de blog** só explicando a emulação de layout. Combinado ainda **76%** nos
+  suites do Node.
+- **Deno:** macro `napi_sym` + lista JSON de símbolos; suporte **estável** no
+  Deno 2.0; organização limpa (`js_native_api.rs`/`node_api.rs`/`function.rs`/
+  `value.rs`/`uv.rs`).
+
+**Ordem de grandeza para o RTS:** a Estratégia A completa (toda a N-API) é
+**muitos meses**. Mas o **núcleo 80/20** (~40 fns síncronas) roda a maioria dos
+addons N-API simples e é bem menor — ver [`06-estrategia-roadmap.md`](06-estrategia-roadmap.md).
+
+## Conclusão do capítulo
+
+- O RTS segue o **molde Bun** (engine não-V8 → mapear `napi_value` a handle
+  próprio), com a organização de código do Deno (lista declarativa de símbolos).
+- `napi_value` = **indireção estável** (handle), nunca ponteiro cru — alinhado à
+  `HandleTable` do RTS.
+- Escopo realista = **N-API puro**; V8-C++/NAN fora (a fronteira que nem Bun nem
+  Deno cruzam por completo).
+- Baseline de teste pronto: `esbuild`, `sqlite3`, `sharp` (sim); `bcrypt`,
+  `better-sqlite3`, `canvas` (não) — serve para medir paridade, como o RTS já
+  faz com fixtures cross-runtime.
+
+## Fontes
+
+- https://bun.com/blog/how-bun-supports-v8-apis-without-using-v8-part-1 · part-2
+- https://bun.com/docs/runtime/node-api · /sqlite
+- https://github.com/oven-sh/bun/issues/158 · /4290 · /16050
+- https://docs.rs/deno_napi/latest/deno_napi/
+- https://github.com/denoland/deno/tree/main/ext/napi
+- https://github.com/denoland/deno/issues/18444 · /23266 · /pull/28934
+- https://docs.deno.com/runtime/fundamentals/ffi/ · /node/
+- https://www.alexcloudstar.com/blog/bun-compatibility-2026-npm-nodejs-nextjs/

--- a/docs/specs/node-format/05-divergencias-rts.md
+++ b/docs/specs/node-format/05-divergencias-rts.md
@@ -1,0 +1,218 @@
+# 05 — Divergências fundamentais: RTS × `.node`
+
+> O coração do estudo. Cada divergência classificada como **bloqueador
+> fundamental** ou **trabalho de engenharia**, ancorada na arquitetura real do
+> RTS (Cranelift, ABI `extern "C"` de tipos de máquina, `HandleTable`, GC
+> mark+sweep, tokio).
+
+## Resumo executivo das 5 divergências
+
+| # | Divergência | Natureza | Classificação |
+|---|---|---|---|
+| 1 | Representação de valor (`napi_value` vs bits/handles RTS) | camada de marshalling | 🟡 engenharia média |
+| 2 | ABI/loading (`napi_*` exportado + dlopen vs link estático) | volume + loader | 🟠 engenharia alta (volume) |
+| 3 | GC/finalizers (`napi_ref` V8 vs mark+sweep) | hooks de root/sweep | 🟡 engenharia média |
+| 4 | Event loop (libuv vs tokio) | ponte + shim uv | 🟠 média-alta, cauda longa |
+| 5 | JIT/AOT (dlopen runtime vs binário self-contained) | conflito filosófico | 🔴 bloqueador filosófico no AOT |
+| — | **(extra)** addons V8-diretos/NAN | emular layout V8 | 🔴 quase-bloqueador técnico → **fora de escopo** |
+
+**Veredito:** nenhuma das 5 é bloqueador **absoluto**. A barreira real é
+**volume** + a **cauda longa** de `v8::` cru/`uv_*`, e o **conflito filosófico**
+com o `.rtslib` estático no modo AOT.
+
+---
+
+## Divergência 1 — Representação de valor 🟡
+
+**O problema.** Addons N-API operam sobre `napi_value` (handle opaco). O RTS
+representa valores JS como **bits nativos** `i64`/`f64` ou **handles `u64`** numa
+`HandleTable`. Não há "objeto JS no heap" no sentido V8.
+
+**Por que NÃO é bloqueador.** O addon **nunca** dereferencia `napi_value` — só o
+passa de volta às funções `napi_*`. Logo o RTS controla 100% da representação.
+O Bun é a prova de existência (mapeia `napi_value` → `JSC::JSValue` sem V8).
+
+**O que o RTS constrói:** uma camada de marshalling — `napi_value` vira um
+**handle estável** (índice na `HandleTable`/handle scope), nunca um ponteiro cru
+para um `RuntimeValue` (senão o sweep coleta no meio da chamada — bug "handle
+collected before use" já documentado no RTS). Boxing/desboxing:
+- `number` → box `i64`/`f64`;
+- `string` → handle do pool GC (`gc::string_*`);
+- `object`/`array` → handle `collections.map_*`/`vec_*`;
+- ponteiro nativo → `napi_external` (handle `u64`).
+
+**Vantagem do RTS sobre o Bun aqui:** o GC do RTS é **não-móvel** (mark+sweep,
+não copia/realoca). No V8 (GC móvel) o handle scope é obrigatório para o GC
+atualizar ponteiros; no RTS um `napi_value` pode ser um handle estável sem
+realocação — simplifica a semântica.
+
+---
+
+## Divergência 2 — ABI e loading 🟠
+
+Duas partes.
+
+**(a) Implementar a superfície N-API.** O RTS teria que exportar **~150
+funções** `napi_*`/`node_api_*` como `extern "C"` reais do runtime (a contagem
+real é **~110-160**: `node-api-headers` v10 ~111, headers do Node ~161, Bun
+"156/156", Deno 163 incl. libuv). É o **maior volume de trabalho puro**, mas:
+- **não há bloqueador conceitual** — cada `napi_*` traduz para primitivas RTS
+  (`gc.*`, `collections.map_*`, `string.*`);
+- o RTS **já** tem o paradigma `extern "C"` tipado (40+ namespaces, símbolos
+  `__RTS_FN_*`), então +~150 símbolos `extern "C"` é **natural ao modelo**;
+- o esforço é **alto mas linear/incremental** (o Bun provou que dá, sem V8).
+
+**(b) Carregar dinamicamente.** O RTS precisa de `libloading` (dlopen/
+LoadLibrary) para abrir o `.node`, resolver `napi_register_module_v1`, e fabricar
+um `napi_env` (ponteiro para uma `RtsNapiEnv`: `HandleTable`, handle-scope stack,
+slot de exceção, ponte tokio). Trabalho direto.
+
+**Atrito com o modelo do RTS:** o `.rtslib` (proposta existente) é **link
+estático**, tipos de máquina, símbolo direto. O `.node` é **dlopen dinâmico** com
+indirect call. Suportar `.node` é **construir um SEGUNDO loader dinâmico ao lado
+do estático**, não estender o existente. Ver Divergência 5.
+
+**Ponto de integração concreto no código:**
+`crates/rts-codegen/src/module/import_resolver.rs::resolve_node_modules_import`
+hoje só aceita `.rts/.ts/.js` (a função `resolve_source_candidate` rejeita outras
+extensões). Um `.node` (ou um `package.json` cujo `main` aponta para `.node`)
+seria **interceptado ali** e roteado para o loader N-API em vez do pipeline de
+compilação TS.
+
+---
+
+## Divergência 3 — GC e finalizers 🟡
+
+**O problema.** `napi_ref`/`napi_wrap`/`napi_add_finalizer` atrelam lifetime e
+finalização ao GC do V8. O RTS tem mark+sweep com stack maps Cranelift.
+
+**Sub-problema crítico — handle scopes invisíveis ao stack map.** Um `napi_value`
+vivo dentro de um addon C **não aparece** no stack map Cranelift (o frame é do
+addon, código nativo opaco ao RTS). Logo `mark_stack_roots()` não o veria e o
+sweep o coletaria no meio da chamada.
+
+**O que o RTS constrói:**
+1. **Handle scopes como roots extras:** cada handle scope é um vetor de handles
+   registrado como raiz adicional no scanner do GC (igual ao Bun: array de slots
+   escaneável); fechar o scope desregistra.
+2. **`napi_ref` com refcount:** strong (refcount > 0) conta como GC root; weak
+   (0) **não** marca, mas guarda o handle para retornar `null` pós-coleta.
+3. **Finalizers no sweep:** ao liberar um `Entry` com finalizer N-API associado,
+   `sweep_all_shards()` **enfileira** a chamada do `napi_finalize` — executada
+   **fora** da fase de marcação (timing "second-pass": chamar o motor durante o
+   weak callback é inseguro).
+
+**Estado do RTS:** já reconhece a dificuldade de weak refs — issue **#217**
+(WeakMap/WeakSet hoje com semântica forte). A integração N-API é a mesma família
+de problema. É engenharia GC real e ordenada, mas **conhecida — não bloqueador**.
+
+---
+
+## Divergência 4 — Event loop / async 🟠
+
+**O problema.** `napi_create_async_work`/`napi_queue_async_work` e threadsafe
+functions assumem o **loop libuv**. `napi_get_uv_event_loop` devolve um
+`uv_loop_t*` cru. O RTS usa **tokio**.
+
+**O que o RTS constrói:**
+- `napi_create_async_work` → `rt().spawn_blocking(execute_cb)`; `complete_cb`
+  postado de volta à thread que executa JS (modelo `promise.create`/#437);
+- threadsafe function → fila MPSC drenada na thread JS;
+- `napi_get_uv_event_loop` → o ponto **mais espinhoso**: addons que linkam libuv
+  direto e usam `uv_async_t` no loop cru exigiriam um **shim `uv_loop_t` mínimo**
+  sobre tokio (o Bun exporta só um subset de `uv_*`).
+
+**Por que é a área de maior risco.** É **cauda longa**: o caminho síncrono
+(maioria dos addons utilitários) não toca nisso e funciona sem o loop. Mas o
+shim `uv_loop` cru é onde **o próprio Bun ainda tem gaps**. Liga-se à issue
+**#207** do RTS (real async event loop ainda aberta) — o gargalo.
+
+**Não bloqueador**, mas o item async deve ser **fase tardia** com mensagem de
+erro clara quando um símbolo `uv_*` não suportado for chamado (como o Bun faz).
+
+---
+
+## Divergência 5 — JIT vs AOT 🔴 (filosófico)
+
+**O problema.** No modo **AOT** (`rts compile`) o RTS produz um binário nativo
+**self-contained** (a promessa do `.rtslib`: "um binário, zero arquivos, sem
+carregamento dinâmico"). Mas um `.node` de terceiros é uma **shared lib
+relocável** que **não** pode ser linkada estaticamente como um `.o` — ela espera
+resolver `napi_*` do host em runtime via tabela de símbolos dinâmica.
+
+**A única saída (precedente Deno).** `deno compile` historicamente **falhava**
+com addons (`#23266`). A solução (`#28934`, `deno_rt_native_addon_loader`):
+**embutir** o `.node` no binário e, no startup, **extrair para um tempdir +
+dlopen**. Limitações admitidas: não funciona em FS **read-only** nem se a lib
+precisa de outros arquivos reais em disco.
+
+**Por que NÃO existe link estático de `.node`.** O SO precisa de um **arquivo em
+disco** para `mmap`+relocar a shared lib — não há `dlopen` de código que está só
+dentro do binário.
+
+**Conclusão por modo:**
+- **JIT (`rts run`):** já há memória executável e o processo já é dinâmico →
+  `dlopen` é **natural e sem fricção**. ✅
+- **AOT (`rts compile`):** ou **proibir** `.node` (preserva a pureza
+  self-contained), ou adotar o modelo **self-extracting** explícito do Deno
+  (quebra "um binário, zero arquivos"). ⚠️ Tradeoff arquitetural explícito que
+  **contradiz o `.rtslib` estático**.
+
+---
+
+## Divergência extra — addons V8-diretos / NAN 🔴 (fora de escopo)
+
+A **única candidata a bloqueador técnico** (parcial). Addons que linkam contra
+`v8::*` (ou usam `nan`/`node-addon-api` que expandem para **inline V8**)
+dependem do **layout binário do V8**: funções inline compiladas dentro do
+`.node` fazem *raw field reads* em offsets fixos (tagged pointers, internal
+fields) que o host **não pode interceptar** (ver
+[`03-acoplamento-v8-libuv.md`](03-acoplamento-v8-libuv.md) §3.3).
+
+Para suportá-los, o RTS teria que **sintetizar um ABI binário V8 fake** —
+esforço imenso e frágil (o Bun documenta como multi-parte e incompleto; o Deno
+nem com V8 real roda `better-sqlite3`).
+
+**Recomendação:** o RTS deve mirar **APENAS** `.node` compilados contra Node-API
+estável (a maioria moderna do npm via `napi-rs`/`node-addon-api` em modo N-API) e
+**declarar addons v8-diretos como não-suportados** — exatamente a postura do Bun
+e do Deno.
+
+---
+
+## Quadro de pontos de integração com o RTS existente
+
+| Peça N-API | Infra RTS que reaproveita | Issue/spec relacionada |
+|---|---|---|
+| `napi_value` ↔ handle | `HandleTable` (slab, gen+slot, 32 shards) | — |
+| `napi_create_string_utf8` | pool de strings GC (`gc::string_*`) | bug #235 (string com `\0`) |
+| `napi_create_object`/`set_named_property` | `collections.map_*` / `RuntimeValue::Object` | — |
+| handle scopes como roots | `mark_stack_roots()` / `thread_registry` | — |
+| `napi_ref` weak / finalizers | `sweep_all_shards()` + refcount | #217 (weak WeakMap/Set) |
+| `napi_create_promise` | `promise.create` / `PromiseAsync` | #437 (async/Promise) |
+| async work / TSFN | `async_rt::rt()` / `spawn_blocking` / `tokio_ctx` | #207 (event loop) |
+| `napi_callback` (CDECL) | trampolim de troca de callconv | precedente `invoke_all_i64` |
+| `napi_create_external` / buffers | namespace `buffer` / `Vec<u8>` na HandleTable | — |
+| `napi_define_class` (classe dinâmica em runtime) | classes RTS hoje só em compile-time | ⚠️ ponto que mais aperta |
+| `napi_throw` / exceção pendente | error slot thread-local (try/catch fase 1) | #128 |
+
+## Conclusão do capítulo
+
+- **Nenhum bloqueador absoluto.** As barreiras reais são **volume** (Div. 2),
+  **cauda longa async** (Div. 4) e **conflito filosófico AOT** (Div. 5).
+- O **único quase-bloqueador técnico** (V8-direto/NAN) se resolve **restringindo
+  o escopo a N-API puro** — postura validada por Bun e Deno.
+- A maioria das peças tem **infra RTS reaproveitável** (`HandleTable`, GC,
+  promise, tokio). O ponto que mais aperta é `napi_define_class` (classe dinâmica
+  em runtime, que o RTS hoje só faz em compile-time) — evitável na fase 1
+  mirando addons que **só exportam funções**.
+
+→ Estratégia e roadmap em [`06-estrategia-roadmap.md`](06-estrategia-roadmap.md).
+
+## Fontes
+
+- https://nodejs.org/api/n-api.html · https://nodejs.org/en/learn/modules/abi-stability
+- https://bun.com/docs/runtime/node-api · /blog/how-bun-supports-v8-apis-without-using-v8-part-1 · part-2
+- https://github.com/oven-sh/bun/issues/158 · /23136
+- https://github.com/denoland/deno/issues/23266 · /pull/28934
+- https://github.com/nodejs/node-addon-api/blob/main/doc/external_buffer.md

--- a/docs/specs/node-format/06-estrategia-roadmap.md
+++ b/docs/specs/node-format/06-estrategia-roadmap.md
@@ -1,0 +1,206 @@
+# 06 — Estratégias de implementação e roadmap
+
+> Como o RTS poderia carregar/usar `.node`. Estratégias avaliadas, o núcleo
+> 80/20, a questão dos prebuilts/`NODE_MODULE_VERSION`, e uma recomendação
+> faseada.
+
+## 6.1 As quatro estratégias
+
+### Estratégia A — N-API completa (espelhar Bun/Deno)
+
+RTS exporta **todos** os símbolos `napi_*`/`uv_*`, carrega `.node` via dlopen,
+traduz `napi_value` ↔ handle RTS.
+- **Prós:** máxima compatibilidade com o ecossistema N-API.
+- **Contras:** ~150 fns (faixa real ~110-160) + paridade comportamental + ponte
+  de event loop. Bun levou **anos** e ainda está em ~76% nos suites do Node.
+- **Veredito:** é o destino, não o ponto de partida.
+
+### Estratégia B — shim mínimo / núcleo 80/20 ✅ (ponto de partida)
+
+Implementar só o subconjunto que os addons mais usados precisam (~40 fns
+síncronas, §6.2). Roda a maioria dos addons N-API simples (parsers, hashing,
+compressão síncrona).
+- **Veredito:** **melhor primeiro passo** — entrega um addon real rodando cedo.
+
+### Estratégia C — só JIT, nunca AOT ✅ (coerente arquiteturalmente)
+
+Suportar `.node` apenas em `rts run` (JIT: já há memória executável + dlopen
+runtime é aceitável); **proibir** em `rts compile` (preserva o self-contained do
+`.rtslib`).
+- **Veredito:** **a mais coerente** com a arquitetura. Combina com B na fase
+  inicial. AOT fica para depois (modelo self-extracting do Deno, opcional).
+
+### Estratégia D — recompilar addon como `.rtslib` ❌ (não resolve compat)
+
+Só viável quando há **source** disponível **e** ele não usa N-API/V8 (a `.rtslib`
+usa tipos de máquina + símbolo direto, não `napi_env`/`napi_value`). Para a
+maioria dos addons binários do npm seria **reescrita**, não recompilação.
+- **Veredito:** a `.rtslib` **não** é rota de compatibilidade com o ecossistema
+  `.node` — é um formato nativo **paralelo** (first-party performante). Os dois
+  são **complementares**, não substitutos.
+
+## 6.2 O núcleo 80/20 (~40 funções da Estratégia B)
+
+Subconjunto realmente exercido por um addon CRUD/utilitário típico:
+
+- **Registro:** `napi_register_module_v1` + struct `napi_module`.
+- **Callbacks:** `napi_create_function`, `napi_get_cb_info`, `napi_call_function`.
+- **Criar valores:** `napi_create_double/int32/uint32/int64/bigint`,
+  `napi_create_string_utf8`, `napi_create_array`, `napi_create_object`,
+  `napi_get_boolean`, `napi_get_undefined`, `napi_get_null`, `napi_get_global`.
+- **Extrair:** `napi_get_value_double/int32/string_utf8/bool`,
+  `napi_get_array_length`, `napi_get_element`.
+- **Propriedades:** `napi_set_named_property`, `napi_get_named_property`,
+  `napi_set_property`, `napi_get_property`, `napi_define_properties`.
+- **Tipos:** `napi_typeof`, `napi_is_array`, `napi_instanceof`.
+- **Erros:** `napi_throw`, `napi_throw_error/type_error`, `napi_create_error`,
+  `napi_is_exception_pending`, `napi_get_and_clear_last_exception`.
+- **Handle scopes:** `napi_open/close_handle_scope`,
+  `napi_open_escapable_handle_scope`, `napi_escape_handle`.
+- **Referências:** `napi_create_reference`, `napi_get_reference_value`,
+  `napi_delete_reference`, `napi_reference_ref/unref`.
+- **Wrap (fase 2):** `napi_wrap`, `napi_unwrap`, `napi_define_class`,
+  `napi_add_finalizer`.
+- **Instance data:** `napi_set/get_instance_data`.
+
+**Fica para depois:** buffers/typedarrays/arraybuffers (`napi_create_buffer/
+external_buffer/typedarray/dataview/arraybuffer`), promises
+(`napi_create_promise`, `resolve/reject_deferred`), async work, threadsafe
+functions (estes exigem o event loop — degrau difícil).
+
+## 6.3 A questão dos prebuilts e `NODE_MODULE_VERSION`
+
+### Boa notícia: addons N-API pulam a checagem de versão no load
+
+A struct `napi_module` carrega o seu próprio `NAPI_MODULE_VERSION`; a verificação
+de `NODE_MODULE_VERSION` do Node **só morde addons não-N-API**. Confirmado
+empiricamente: o Bun reporta `NODE_MODULE_VERSION 127` (= Node 22) e addons
+N-API carregam sem reclamar de versão (issue `oven-sh/bun#14105`). **O RTS não
+precisa fingir um `NODE_MODULE_VERSION` no `dlopen` de um addon N-API.**
+
+### Mas precisa para a fase ANTERIOR: instalação/seleção do prebuilt
+
+`npm`/`prebuild-install`/`node-pre-gyp`/`node-gyp-build` escolhem qual `.node`
+baixar por `(platform, arch, abi)`. O RTS reportaria:
+- `process.platform` → `win32`/`linux`/`darwin`;
+- `process.arch` → `x64`/`arm64`;
+- `process.versions.node` → ex.: fingir Node 22;
+- `process.versions.modules` → o `NODE_MODULE_VERSION` (ex.: `127`).
+
+Fonte canônica do mapeamento: `doc/abi_version_registry.json` (repo do Node) e o
+pacote npm **`node-abi`**.
+
+### Melhor notícia: prebuilds N-API modernos são por (napi|abi)+platform+arch
+
+`prebuildify` nomeia `node.napi.node`, `electron.abi40.node`,
+`node.napi.uv1.armv8.node`; `napi-rs` publica `index.darwin-x64.node`,
+`snappy.linux-x64-gnu.node` (pacotes scoped por plataforma `@scope/pkg-linux-x64-
+gnu`). Pacotes **N-API** publicam **um binário por (plataforma, arch)** — **não**
+um por versão de Node (justamente pela estabilidade de ABI).
+
+**Implicação:** addons N-API com prebuild tag `napi` são selecionados por
+**platform+arch** e **não** exigem que o RTS finja uma versão de Node específica
+para a escolha do binário — só exigem `platform`/`arch` corretos. **Priorizar o
+ecossistema `napi-rs`/`prebuildify` minimiza o masquerading.** Pacotes que só
+publicam tag `abi<n>` (estilo `prebuild-install` antigo) forçariam o RTS a
+reportar um `process.versions.modules` específico.
+
+## 6.4 Modelo de permissão (lição do Deno)
+
+Carregar `.node` roda **código nativo fora do sandbox**. O Deno exige
+`--allow-ffi` (aceita lista de paths). **O RTS deveria exigir um flag explícito**
+(ex.: `--allow-native-addons` / `--allow-ffi`) para carregar `.node`,
+espelhando o Deno — segurança e intenção explícita.
+
+## 6.5 Recomendação faseada concreta
+
+> Cada fase entrega **valor verificável** (um addon real rodando) antes de pagar
+> o custo da próxima.
+
+### Fase 0 — Descoberta (loader mínimo, só JIT)
+- Interceptar `require('./x.node')` / `import` de `.node` em
+  `resolve_node_modules_import` → rotear para loader N-API.
+- `libloading` (dlopen/LoadLibrary) + resolver `napi_register_module_v1`.
+- `napi_env` mínimo (struct `RtsNapiEnv`) + tradução `napi_value` ↔ handle `u64`.
+- **Só** no caminho JIT (`rts run`) — Estratégia C.
+- **Garantir export-dynamic** dos símbolos `napi_*` do binário RTS (`.def`/`/EXPORT`
+  no Windows; `--export-dynamic`/version script no Linux/macOS).
+- **Critério de saída:** um addon N-API trivial (1 função que soma dois números)
+  carrega e roda.
+
+### Fase 1 — Núcleo 80/20 (Estratégia B)
+- As ~40 fns síncronas do §6.2: valores escalares, `string_utf8`, array, object,
+  named properties, `create_function`/`get_cb_info`/`call_function`, `typeof`,
+  throw/exceção, handle scopes, references.
+- **Critério de saída:** um addon N-API síncrono real roda (ex.: um hashing ou
+  compressão síncrona, ou `esbuild` no caminho síncrono).
+
+### Fase 2 — Objetos nativos e GC
+- Buffers/typedarrays/arraybuffer + `napi_wrap`/`unwrap`/`define_class`/
+  finalizer (integração com GC roots + sweep enfileirando finalizers).
+- **Critério de saída:** um addon que expõe uma classe nativa com recurso (ex.:
+  um wrapper de DB síncrono) roda e libera recursos corretamente.
+
+### Fase 3 — Async (o degrau difícil)
+- Promises (mapear a `promise.create`/#437), async work
+  (→ `rt().spawn_blocking`), threadsafe functions (fila MPSC drenada na thread
+  JS), `napi_get_uv_event_loop` + **mini-shim de libuv** (`uv_async_t`,
+  `uv_loop_t` opaco, `uv_queue_work`) sobre o tokio global.
+- Mensagem de erro clara para símbolos `uv_*` não suportados (como o Bun).
+- **Critério de saída:** um addon assíncrono (worker em background + callback)
+  roda.
+
+### Fase 4 — Distribuição / npm
+- Reportar `process.platform`/`arch`/`versions.node`/`versions.modules`
+  coerentes para que `npm`/`prebuild-install`/`node-gyp-build` baixem o prebuilt
+  certo. Priorizar `napi-rs`/`prebuildify` (selecionados por plataforma).
+- **Critério de saída:** `rts i <pacote-com-addon-napi>` baixa o `.node` certo e
+  ele carrega.
+
+### AOT — adiado / opcional
+- Manter **proibido** em `rts compile` (preserva self-contained), **ou** adotar
+  o modelo **self-extracting** do Deno (embutir + extrair para tempdir +
+  dlopen), documentado como exceção explícita ao `.rtslib`.
+
+### Nunca
+- Addons **V8-diretos / NAN** (fora de escopo, como Bun e Deno). Mensagem de erro
+  clara: "addon usa a API C++ do V8, não suportado — use a variante N-API".
+
+## 6.6 Organização de código sugerida (molde Bun/Deno)
+
+Espelhando a separação que funcionou no Bun (`napi.cpp` + `napi.zig`) e a lista
+declarativa do Deno (`symbol_exports.json`):
+
+```
+crates/rts-runtime/src/napi/
+  mod.rs            — RtsNapiEnv, loader (libloading), register handshake
+  values.rs         — napi_create_*/napi_get_value_* (↔ HandleTable/gc/collections)
+  props.rs          — propriedades, define_properties
+  functions.rs      — create_function, call_function, get_cb_info, trampolim callconv
+  scopes.rs         — handle scopes (roots extras p/ o GC), references, wrap/finalizers
+  errors.rs         — throw, exceção pendente (↔ error slot thread-local)
+  async.rs          — async work, threadsafe functions (↔ async_rt/tokio), uv shim
+  symbols.rs        — lista declarativa de símbolos N-API exportados (→ .def/export table)
+```
+
+A maquinaria que o RTS já tem (geração de `rts.d.ts` a partir de `abi::SPECS`,
+convenção `symbols.rs`) geraria a tabela de exports N-API.
+
+## Conclusão do capítulo
+
+- **Ponto de partida: B + C** (núcleo 80/20, só JIT). Destino: A (N-API
+  completa).
+- A `.rtslib` é **complementar** (first-party performante), não rota de compat.
+- Prebuilds N-API por **platform+arch** minimizam o masquerading de versão de
+  Node — priorizar `napi-rs`/`prebuildify`.
+- Roadmap em 5 fases, cada uma com um **addon real** como critério de saída.
+
+## Fontes
+
+- https://bun.com/docs/runtime/node-api · https://github.com/oven-sh/bun/issues/158 · /14105
+- https://nodejs.org/api/n-api.html · /api/addons.html
+- https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
+- https://www.npmjs.com/package/node-abi · /prebuildify · /prebuild-install
+- https://napi.rs/docs/cli/build · /deep-dive/native-module
+- https://docs.deno.com/runtime/fundamentals/node/ · /ffi/ · /reference/cli/compile/
+- https://github.com/denoland/deno/issues/23266 · /pull/28934

--- a/docs/specs/node-format/07-conclusao.md
+++ b/docs/specs/node-format/07-conclusao.md
@@ -1,0 +1,154 @@
+# 07 — Conclusão: viabilidade de suporte a `.node` no RTS
+
+> Síntese executiva. Veredito de viabilidade, as decisões-chave e os próximos
+> passos concretos.
+
+## TL;DR
+
+**Suportar `.node` no RTS é viável, mas só pela porta N-API, preferencialmente
+no modo JIT, e nunca para addons V8-diretos/NAN.** Não há bloqueador técnico
+absoluto — o Bun provou que dá para implementar N-API sobre um engine não-V8. As
+barreiras reais são **volume de trabalho** (~150 funções, faixa ~110-160), a **cauda longa do
+event loop** (libuv vs tokio) e um **conflito filosófico** entre o `dlopen`
+dinâmico do `.node` e a promessa self-contained do modo AOT (`.rtslib`).
+
+## Os 5 fatos que decidem tudo
+
+1. **Um `.node` é uma DLL/`.so`/`.dylib` comum**, com extensão trocada; o ponto
+   de entrada é a função exportada **`napi_register_module_v1(napi_env,
+   napi_value) -> napi_value`**. (Verificado no código: `node_binding.cc`.)
+
+2. **`napi_value` e `napi_env` são ponteiros opacos.** O addon nunca os
+   dereferencia — só os passa de volta às funções `napi_*`. Isso permite ao RTS
+   mapeá-los para sua **`HandleTable`/`RuntimeValue`** sem precisar de V8.
+   (Verificado: `napi_value` = "an opaque pointer".)
+
+3. **N-API é ABI-estável e independente do engine; o V8 cru NÃO é.** Addons
+   N-API/`node-addon-api` são suportáveis; addons `nan`/`v8.h`-direto exigem
+   **emular o layout binário do V8** (tagged pointers, internal fields inline no
+   `.node`) — inviável. **Escopo = N-API puro.** (Postura idêntica de Bun e
+   Deno; `better-sqlite3`/`bcrypt`/`canvas` falham nos dois.)
+
+4. **Addons N-API pulam a checagem de `NODE_MODULE_VERSION` no load** — o RTS não
+   precisa fingir uma versão de Node para o `dlopen`. Só precisa de
+   `platform`/`arch` corretos para a **seleção do prebuilt** (prebuilds N-API
+   modernos via `napi-rs`/`prebuildify` são por plataforma, não por versão de
+   Node).
+
+5. **O host precisa exportar `napi_*` (+ subset `uv_*`) do seu binário.** No
+   Windows o `win_delay_load_hook` embutido no `.node` cai em
+   `GetModuleHandle(NULL)` → resolve no RTS.exe; no Linux/macOS exige
+   `--export-dynamic`. **O RTS não relinka o `.node` — só faz dlopen + dlsym e
+   provê os símbolos.**
+
+## Veredito por divergência
+
+| Divergência | Veredito |
+|---|---|
+| 1. Representação de valor | 🟢 **Não bloqueador** — camada de marshalling `napi_value` ↔ handle (GC não-móvel do RTS até simplifica) |
+| 2. ABI/loading | 🟡 **Engenharia alta por volume** — ~150 `extern "C"` (faixa ~110-160) + libloading; conceitualmente alinhado ao RTS |
+| 3. GC/finalizers | 🟢 **Não bloqueador** — handle scopes como roots + finalizers no sweep; família do #217 |
+| 4. Event loop async | 🟡 **Média-alta, cauda longa** — ponte tokio fácil; shim `uv_loop` cru difícil (gaps até no Bun); família do #207 |
+| 5. JIT/AOT | 🔴 **Bloqueador filosófico no AOT** — natural no JIT; AOT exige self-extracting (quebra self-contained) |
+| extra. V8-direto/NAN | 🔴 **Fora de escopo** — resolve-se restringindo a N-API puro |
+
+## As decisões arquiteturais recomendadas
+
+1. **Mirar SÓ N-API.** Declarar addons V8-diretos/NAN não-suportados, com
+   mensagem de erro clara. (Validado por Bun e Deno.)
+2. **Começar por JIT (`rts run`).** É onde `dlopen` é natural. No AOT: proibir
+   inicialmente, ou self-extracting explícito depois.
+3. **`napi_value` = indireção estável** (handle na `HandleTable`/handle scope),
+   **nunca** ponteiro cru de `RuntimeValue` (evita "handle collected before
+   use").
+4. **Reaproveitar a infra existente:** `HandleTable`, GC mark+sweep, `promise`
+   (#437), `async_rt`/tokio, error slot thread-local, convenção `symbols.rs` +
+   geração a partir de `SPECS`.
+5. **Exigir um flag de permissão** (`--allow-native-addons`) — código nativo fora
+   do sandbox (lição do `--allow-ffi` do Deno).
+6. **`.rtslib` e `.node` são complementares**, não substitutos: `.rtslib` =
+   first-party performante (link estático, tipos de máquina); `.node` =
+   compatibilidade com o ecossistema npm (dlopen dinâmico, N-API shim).
+
+## Esforço realista
+
+- **Núcleo 80/20 (Fase 0+1, ~40 fns síncronas, só JIT):** o primeiro addon real
+  rodando é um marco **alcançável e bem-delimitado**.
+- **N-API completa (Estratégia A):** **muitos meses** — o Bun levou anos e ainda
+  está em ~76% nos suites do Node. É destino, não ponto de partida.
+- **O degrau caro:** event loop async (Fase 3) — onde o próprio Bun tem gaps.
+
+## Próximos passos concretos
+
+1. **Validar o ponto de integração:** confirmar que
+   `resolve_node_modules_import`
+   (`crates/rts-codegen/src/module/import_resolver.rs`) é o lugar para
+   interceptar `.node` (hoje rejeita extensões ≠ `.rts/.ts/.js`).
+2. **PoC Fase 0:** loader `libloading` + `napi_register_module_v1` + `napi_env`
+   mínimo + export-dynamic dos símbolos, rodando um addon N-API trivial em
+   `rts run`. Usar `esbuild` ou um addon `napi-rs` "hello world" como alvo.
+3. **Abrir um epic** com as 5 fases do [`06-estrategia-roadmap.md`](06-estrategia-roadmap.md),
+   cada fase com um addon real como critério de saída.
+4. **Definir a baseline de conformidade:** rodar as suites `js-native-api` e
+   `node-api` do Node (como o Bun faz no CI) para medir paridade — integra ao
+   sistema de fixtures cross-runtime que o RTS já tem.
+5. **Decidir a política AOT:** proibir `.node` em `rts compile` (preserva
+   `.rtslib`) ou planejar self-extracting — decisão de produto, não técnica.
+
+## Mapa dos documentos
+
+- [`01-formato-binario.md`](01-formato-binario.md) — o que é o `.node`, loader,
+  símbolos, `NODE_MODULE_VERSION`.
+- [`02-napi-abi.md`](02-napi-abi.md) — a ABI N-API: valores, env, scopes, refs,
+  o núcleo de funções.
+- [`03-acoplamento-v8-libuv.md`](03-acoplamento-v8-libuv.md) — símbolos que o
+  host exporta, delay-load, libuv.
+- [`04-precedente-bun-deno.md`](04-precedente-bun-deno.md) — como Bun e Deno
+  fizeram; o que quebra; custo.
+- [`05-divergencias-rts.md`](05-divergencias-rts.md) — as 5 divergências
+  classificadas, pontos de integração.
+- [`06-estrategia-roadmap.md`](06-estrategia-roadmap.md) — estratégias, 80/20,
+  prebuilds, roadmap faseado.
+
+## Nota de confiança e metodologia
+
+Este estudo foi produzido por uma pesquisa multi-agente (6 eixos paralelos com
+busca web) sobre fontes **primárias**: documentação oficial do Node
+(`n-api.html`, `addons.html`), código-fonte do Node (`node_binding.cc`,
+`node.h`, `node_api.h`, `node_version.h`, `js_native_api_*.h`), código e blog do
+Bun, e `deno_napi`/issues do Deno.
+
+**Verificação adversarial (dois runs independentes completos):** cada afirmação
+técnica estrutural passou por um verificador cético que tentou refutá-la contra
+fontes primárias. Resultado agregado dos dois runs:
+
+| Métrica | Run A | Run B |
+|---|---|---|
+| Achados de pesquisa | 60 | 76 |
+| Afirmações verificadas | 50 | 65 |
+| **Confirmadas** | 35 | 49 |
+| **Parciais** (nuance, não invalidação) | 15 | 16 |
+| **Refutadas** | **0** | **0** |
+| Não-verificadas (rate-limit/limite de sessão) | 4 | 4 |
+
+**Zero refutações em 115 verificações.** Os ~31 veredictos "parciais" foram todos
+**correções de nuance** já incorporadas aos documentos:
+
+- `NODE_MODULE_VERSION 147` = **Node 26** (não 27) — corrigido em §1.7.
+- A invocação N-API usa `napi_module_register_by_symbol` com **5 args**
+  (`+module_api_version`) no Node atual — §1.3.
+- `NODE_C_CTOR` no MSVC usa construtor de struct estática, **não** `.CRT$XCU` — §1.4.
+- Superfície N-API = **~110-160 funções** (não um "156" fixo) — §2.5, doc 05/06.
+- Caminhos atuais do Bun: `src/jsc/bindings/napi.cpp` + `src/runtime/napi/napi.zig`
+  + `src/jsc/bindings/v8/` (não `src/bun.js/bindings/...`) — doc 04.
+- `napi_value` no Deno = newtype `#[repr(transparent)]
+  NapiValue(Option<NonNull<v8::Value>>)`, nullable — doc 04.
+- O GC do JSC é **non-moving** (Riptide); a falha da impl. ingênua do Bun é
+  **rooting/visibilidade ao GC**, não movimento — doc 04.
+- `bcrypt` migrou para N-API (v4.0.0) e funciona no Bun — doc 04 §4.4.
+
+Os fatos centrais foram confirmados **verbatim contra o código-fonte do Node**:
+`napi_register_module_v1`, `node_register_module_v<N>`, a mensagem de mismatch de
+`NODE_MODULE_VERSION`, `thread_local_modpending`, e a checagem
+`if ((mp->nm_version != -1) && (mp->nm_version != NODE_MODULE_VERSION))` com o
+comentário `// -1 is used for Node-API modules` (que prova a isenção N-API).

--- a/docs/specs/node-format/README.md
+++ b/docs/specs/node-format/README.md
@@ -1,0 +1,55 @@
+# Estudo: Suporte a `.node` (Node.js native addons) no RTS
+
+> **Status:** pesquisa em andamento (iniciada 2026-06-11).
+> **Autor:** investigação técnica assistida (multi-agente + fontes web verificadas).
+> **Objetivo:** entender em profundidade o que é o formato `.node`, como ele
+> funciona no Node.js, e quais divergências fundamentais o RTS enfrenta caso
+> queira dar suporte a carregar/rodar addons nativos `.node` do ecossistema npm.
+
+## Por que este estudo existe
+
+O RTS compila TypeScript para binário nativo com runtime Rust mínimo e ABI de
+"tipos de máquina" (`extern "C"`, sem `JsValue`, sem boxing). Já existe uma
+proposta análoga e **estática** — o [`.rtslib`](../rtslib-external-namespaces.md)
+(objeto `.o` por triple, linkado em compile-time). O `.node` é o **oposto**:
+biblioteca dinâmica carregada em runtime via `dlopen`, acoplada à ABI N-API
+(que assume um host estilo V8). Suportar `.node` significa reconciliar dois
+modelos de execução muito diferentes.
+
+## Índice dos documentos
+
+| Documento | Conteúdo |
+|---|---|
+| [`01-formato-binario.md`](01-formato-binario.md) | O que é fisicamente um `.node` (PE/ELF/Mach-O), como o Node carrega, símbolo de entrada, struct `node_module`, `NODE_MODULE_VERSION` |
+| [`02-napi-abi.md`](02-napi-abi.md) | A ABI N-API/Node-API: `napi_value`, `napi_env`, handle scopes, ciclo de vida, callbacks, refs/finalizers, o núcleo de funções |
+| [`03-acoplamento-v8-libuv.md`](03-acoplamento-v8-libuv.md) | Quanto um addon depende de V8 vs N-API, libuv/event loop, símbolos que o host deve exportar, delay-load no Windows |
+| [`04-precedente-bun-deno.md`](04-precedente-bun-deno.md) | Como Bun (sobre JSC) e Deno (sobre V8) implementaram N-API; o que funciona/quebra; custo real |
+| [`05-divergencias-rts.md`](05-divergencias-rts.md) | As divergências fundamentais RTS × `.node`: valor, ABI, GC, event loop, JIT/AOT — bloqueador vs engenharia |
+| [`06-estrategia-roadmap.md`](06-estrategia-roadmap.md) | Estratégias de implementação, núcleo 80/20, `NODE_MODULE_VERSION`/prebuilds, recomendação faseada |
+| [`07-conclusao.md`](07-conclusao.md) | Síntese executiva, veredito de viabilidade e próximos passos |
+
+## TL;DR
+
+**Suportar `.node` é viável, mas só pela porta N-API, preferencialmente no modo
+JIT, e nunca para addons V8-diretos/NAN.** Não há bloqueador técnico absoluto
+(o Bun provou que dá para implementar N-API sobre engine não-V8). As barreiras
+reais são: **volume** (~150 funções `napi_*`, faixa ~110-160), a **cauda longa do event loop**
+(libuv vs tokio do RTS), e um **conflito filosófico** entre o `dlopen` dinâmico
+do `.node` e a promessa self-contained do AOT (`.rtslib`).
+
+**Os 5 fatos que decidem tudo:**
+1. Um `.node` é uma DLL/`.so`/`.dylib` comum; entry point = `napi_register_module_v1`.
+2. `napi_value`/`napi_env` são **opacos** → o RTS pode mapeá-los à sua `HandleTable` sem V8.
+3. N-API é ABI-estável e engine-independente; V8 cru/NAN não → **escopo = N-API puro**.
+4. Addons N-API **pulam** a checagem de `NODE_MODULE_VERSION` no load; prebuilds modernos são por platform+arch.
+5. O host só precisa **exportar `napi_*`** do seu binário + `dlopen` + `dlsym` — não relinka o `.node`.
+
+**Recomendação:** começar por **JIT + núcleo 80/20** (~40 fns síncronas);
+`.rtslib` e `.node` são **complementares** (first-party performante × compat npm).
+Detalhes em [`07-conclusao.md`](07-conclusao.md).
+
+**Metodologia:** pesquisa multi-agente (6 eixos, busca web) sobre fontes
+primárias (docs + código-fonte do Node, código de Bun/Deno), com **verificação
+adversarial em dois runs independentes completos** (115 afirmações verificadas,
+**0 refutadas**, ~31 nuances corrigidas e incorporadas). Detalhes e tabela de
+veredictos em [`07-conclusao.md`](07-conclusao.md).


### PR DESCRIPTION
## Resumo

Estudo multi-fonte (8 documentos em `docs/specs/node-format/`) sobre o formato `.node`, a ABI N-API e as divergencias para o RTS dar suporte a addons nativos do ecossistema npm.

## Veredito

**Viavel, mas so via N-API, JIT-first, nunca para addons V8-direto/NAN.**

- `napi_value`/`napi_env` sao ponteiros opacos -> mapeaveis a `HandleTable` do RTS sem V8 (Bun e a prova de existencia sobre JSC).
- Addons V8-direto/NAN exigiriam emular o layout binario do V8 -> fora de escopo (nem Bun nem Deno cruzam essa fronteira).
- AOT colide com o self-contained do `.rtslib` (dlopen exige arquivo em disco); JIT (`rts run`) e natural.
- Ponto de integracao concreto: `resolve_node_modules_import` (`crates/rts-codegen/src/module/import_resolver.rs`), que hoje rejeita extensoes != `.rts/.ts/.js`.
- `.rtslib` e `.node` sao **complementares** (link estatico/tipos de maquina vs dlopen dinamico/N-API), nao substitutos.

## Conteudo

| Doc | Tema |
|---|---|
| README | Indice + TL;DR + metodologia |
| 01 | Formato binario, loader, `napi_register_module_v1`, `NODE_MODULE_VERSION` |
| 02 | ABI N-API: valores, env, handle scopes, refs/finalizers, nucleo de funcoes |
| 03 | Acoplamento V8/libuv, simbolos que o host exporta, delay-load Windows |
| 04 | Precedente Bun (JSC) e Deno (V8); o que quebra; custo |
| 05 | As 5 divergencias RTS classificadas (valor/ABI/GC/async/JIT-AOT) |
| 06 | Estrategias, nucleo 80/20, prebuilds, roadmap em 5 fases |
| 07 | Conclusao + proximos passos + tabela de veredictos |

## Metodologia

Pesquisa multi-agente (6 eixos paralelos com busca web) sobre fontes primarias (codigo-fonte do Node, docs oficiais, codigo de Bun/Deno), com **verificacao adversarial em 2 runs independentes completos**: 115 afirmacoes verificadas, **0 refutadas**, ~31 nuances corrigidas e incorporadas. Fatos centrais confirmados verbatim contra `node_binding.cc`.

Apenas documentacao — nao toca runtime/codegen/GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)