### PR TITLE
feat(engine+napi): Entry::ArrayBuffer ptr estável + 15 fns N-API (ArrayBuffer/TypedArray)

### DIFF
--- a/crates/rts-engine/src/heap/handles.rs
+++ b/crates/rts-engine/src/heap/handles.rs
@@ -512,10 +512,84 @@ pub enum Entry {
     /// finalize (nunca o chama sob o lock do shard — ver `cleanup_entry`). Ver
     /// docs/specs/napi-implementation.md.
     NapiExternal(Box<NapiExternalData>),
+    /// (N-API) ArrayBuffer com **ponteiro de bytes ESTÁVEL** enquanto o handle
+    /// viver — o addon pega `data: *mut u8` via `arraybuffer_ptr` e escreve
+    /// direto na memória (hash/crypto/compressão). Diferente de `Buffer(Vec<u8>)`,
+    /// cujo `Vec` pode realocar e invalidar o ptr; aqui o backing é `Box<[u8]>`
+    /// (owned, nunca realoca) ou um ptr externo emprestado (borrowed). Ver
+    /// docs/specs/napi-implementation.md (#1548).
+    ArrayBuffer(Box<ArrayBufferData>),
     /// Tombstone left by `free`. Reused on next `alloc` with a bumped
     /// generation so dangling handles fail validation.
     Free,
 }
+
+/// Payload de `Entry::ArrayBuffer`. O backing é owned (Box, ptr estável) ou
+/// borrowed (ptr externo do addon + finalizer chamado na coleta).
+pub enum ArrayBufferBacking {
+    /// Bytes possuídos pelo engine. `Box<[u8]>` nunca realoca → ptr estável.
+    Owned(Box<[u8]>),
+    /// Ptr externo emprestado (`napi_create_external_arraybuffer`). O engine
+    /// NÃO possui os bytes; ao coletar, enfileira o `finalize(data, hint)`.
+    Borrowed {
+        ptr: *mut u8,
+        len: usize,
+        finalize: Option<
+            unsafe extern "C" fn(
+                env: *mut std::ffi::c_void,
+                data: *mut std::ffi::c_void,
+                hint: *mut std::ffi::c_void,
+            ),
+        >,
+        finalize_hint: *mut std::ffi::c_void,
+    },
+}
+
+pub struct ArrayBufferData {
+    pub backing: ArrayBufferBacking,
+    /// `true` após `napi_detach_arraybuffer` — leituras devolvem ptr nulo/len 0.
+    pub detached: bool,
+}
+
+impl ArrayBufferData {
+    /// Ponteiro mutável estável para os bytes (nulo se detached).
+    pub fn data_ptr(&mut self) -> *mut u8 {
+        if self.detached {
+            return std::ptr::null_mut();
+        }
+        match &mut self.backing {
+            ArrayBufferBacking::Owned(b) => b.as_mut_ptr(),
+            ArrayBufferBacking::Borrowed { ptr, .. } => *ptr,
+        }
+    }
+    pub fn byte_len(&self) -> usize {
+        if self.detached {
+            return 0;
+        }
+        match &self.backing {
+            ArrayBufferBacking::Owned(b) => b.len(),
+            ArrayBufferBacking::Borrowed { len, .. } => *len,
+        }
+    }
+}
+
+impl std::fmt::Debug for ArrayBufferData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let kind = match &self.backing {
+            ArrayBufferBacking::Owned(b) => format!("Owned({})", b.len()),
+            ArrayBufferBacking::Borrowed { len, .. } => format!("Borrowed({len})"),
+        };
+        f.debug_struct("ArrayBufferData")
+            .field("backing", &kind)
+            .field("detached", &self.detached)
+            .finish()
+    }
+}
+
+// SAFETY: o ptr borrowed é opaco ao engine (nunca dereferenciado por ele); o
+// finalize só roda na thread JS via a fila de finalizers. Owned é Box<[u8]>
+// (Send). Mesmo racional de NapiExternalData.
+unsafe impl Send for ArrayBufferData {}
 
 /// Payload de `Entry::NapiExternal`. Campos opacos ao engine.
 pub struct NapiExternalData {
@@ -759,6 +833,26 @@ fn cleanup_entry(entry: &mut Entry) {
                         data: ext.data,
                         finalize,
                         finalize_hint: ext.finalize_hint,
+                    });
+                }
+            }
+        }
+        // (N-API) ArrayBuffer borrowed: enfileira o finalizer do ptr externo (o
+        // engine não possui os bytes). Owned libera via Drop do Box. NUNCA chama
+        // finalize sob o lock do shard (mesmo racional do NapiExternal).
+        Entry::ArrayBuffer(ab) => {
+            if let ArrayBufferBacking::Borrowed {
+                ptr,
+                finalize: Some(finalize),
+                finalize_hint,
+                ..
+            } = &ab.backing
+            {
+                if let Ok(mut q) = PENDING_NAPI_FINALIZERS.lock() {
+                    q.push(PendingNapiFinalizer {
+                        data: *ptr as *mut std::ffi::c_void,
+                        finalize: *finalize,
+                        finalize_hint: *finalize_hint,
                     });
                 }
             }
@@ -1271,6 +1365,81 @@ pub fn read_string_handle(handle: u64) -> Option<String> {
     })
 }
 
+// ── ArrayBuffer (N-API, #1548) ───────────────────────────────────────────────
+
+/// Aloca um `Entry::ArrayBuffer` owned de `len` bytes (zerados) e devolve o
+/// handle. Os bytes têm endereço estável (não realocam) — use [`arraybuffer_ptr`]
+/// para escrever direto neles.
+pub fn alloc_arraybuffer(len: usize) -> u64 {
+    alloc_entry(Entry::ArrayBuffer(Box::new(ArrayBufferData {
+        backing: ArrayBufferBacking::Owned(vec![0u8; len].into_boxed_slice()),
+        detached: false,
+    })))
+}
+
+/// Aloca um `Entry::ArrayBuffer` borrowed (ptr externo + finalizer). O engine
+/// não copia nem possui os bytes; ao coletar, enfileira o finalizer.
+pub fn alloc_external_arraybuffer(
+    ptr: *mut u8,
+    len: usize,
+    finalize: Option<
+        unsafe extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void, *mut std::ffi::c_void),
+    >,
+    finalize_hint: *mut std::ffi::c_void,
+) -> u64 {
+    alloc_entry(Entry::ArrayBuffer(Box::new(ArrayBufferData {
+        backing: ArrayBufferBacking::Borrowed {
+            ptr,
+            len,
+            finalize,
+            finalize_hint,
+        },
+        detached: false,
+    })))
+}
+
+/// Ponteiro mutável **estável** para os bytes do ArrayBuffer (nulo se o handle
+/// não for ArrayBuffer ou estiver detached). Válido enquanto o handle viver.
+pub fn arraybuffer_ptr(handle: u64) -> *mut u8 {
+    with_entry_mut(handle, |e| match e {
+        Some(Entry::ArrayBuffer(ab)) => ab.data_ptr(),
+        _ => std::ptr::null_mut(),
+    })
+}
+
+/// Comprimento em bytes (0 se não for ArrayBuffer ou estiver detached).
+pub fn arraybuffer_len(handle: u64) -> usize {
+    with_entry(handle, |e| match e {
+        Some(Entry::ArrayBuffer(ab)) => ab.byte_len(),
+        _ => 0,
+    })
+}
+
+/// `true` se o handle é um `Entry::ArrayBuffer`.
+pub fn is_arraybuffer(handle: u64) -> bool {
+    with_entry(handle, |e| matches!(e, Some(Entry::ArrayBuffer(_))))
+}
+
+/// Marca o ArrayBuffer como detached (`napi_detach_arraybuffer`). Leituras
+/// subsequentes devolvem ptr nulo / len 0. Retorna `true` se era um ArrayBuffer.
+pub fn arraybuffer_detach(handle: u64) -> bool {
+    with_entry_mut(handle, |e| match e {
+        Some(Entry::ArrayBuffer(ab)) => {
+            ab.detached = true;
+            true
+        }
+        _ => false,
+    })
+}
+
+/// `true` se o ArrayBuffer está detached.
+pub fn arraybuffer_is_detached(handle: u64) -> bool {
+    with_entry(handle, |e| match e {
+        Some(Entry::ArrayBuffer(ab)) => ab.detached,
+        _ => false,
+    })
+}
+
 /// Mutable access to an entry. `f` receives `None` for invalid handles.
 pub fn with_entry_mut<R>(handle: u64, f: impl FnOnce(Option<&mut Entry>) -> R) -> R {
     if handle == 0 {
@@ -1418,6 +1587,62 @@ mod tests {
         })));
         assert!(free_handle(h2));
         assert!(drain_pending_napi_finalizers().is_empty());
+    }
+
+    /// (N-API #1548) ArrayBuffer owned: ptr estável + escrita direta + detach.
+    #[test]
+    fn arraybuffer_owned_stable_ptr() {
+        let h = alloc_arraybuffer(8);
+        assert!(is_arraybuffer(h));
+        assert_eq!(arraybuffer_len(h), 8);
+        let p1 = arraybuffer_ptr(h);
+        assert!(!p1.is_null());
+        // Escreve direto nos bytes.
+        unsafe {
+            *p1 = 0xAB;
+            *p1.add(7) = 0xCD;
+        }
+        // Ptr é estável entre chamadas (Box<[u8]> não realoca).
+        let p2 = arraybuffer_ptr(h);
+        assert_eq!(p1, p2);
+        unsafe {
+            assert_eq!(*p2, 0xAB);
+            assert_eq!(*p2.add(7), 0xCD);
+        }
+        // Detach → ptr nulo, len 0.
+        assert!(arraybuffer_detach(h));
+        assert!(arraybuffer_is_detached(h));
+        assert!(arraybuffer_ptr(h).is_null());
+        assert_eq!(arraybuffer_len(h), 0);
+        free_handle(h);
+    }
+
+    /// (N-API #1548) ArrayBuffer borrowed: enfileira o finalizer no free.
+    #[test]
+    fn arraybuffer_borrowed_finalizer_queued() {
+        use std::ffi::c_void;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let _ = drain_pending_napi_finalizers();
+        static CALLS: AtomicUsize = AtomicUsize::new(0);
+        unsafe extern "C" fn fin(_e: *mut c_void, _d: *mut c_void, _h: *mut c_void) {
+            CALLS.fetch_add(1, Ordering::SeqCst);
+        }
+        let mut bytes = [1u8, 2, 3, 4];
+        let h = alloc_external_arraybuffer(
+            bytes.as_mut_ptr(),
+            4,
+            Some(fin),
+            0x99 as *mut c_void,
+        );
+        assert_eq!(arraybuffer_len(h), 4);
+        // O ptr é o externo (não copiado).
+        assert_eq!(arraybuffer_ptr(h), bytes.as_mut_ptr());
+        // Free enfileira (não chama sob lock).
+        assert!(free_handle(h));
+        assert_eq!(CALLS.load(Ordering::SeqCst), 0);
+        let pending = drain_pending_napi_finalizers();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].finalize_hint, 0x99 as *mut c_void);
     }
 
     #[test]

--- a/crates/rts-napi/src/arraybuffer.rs
+++ b/crates/rts-napi/src/arraybuffer.rs
@@ -1,0 +1,446 @@
+//! ArrayBuffer / TypedArray / DataView N-API (#1548 item 1). Usa o
+//! `Entry::ArrayBuffer` do engine (ptr estável). Views (typedarray/dataview)
+//! são modeladas como `Entry::Map` com chaves reservadas apontando o buffer +
+//! offset + length + tipo (o RTS não tem TypedArray nativo). Ver
+//! docs/specs/napi-implementation.md.
+
+use std::ffi::{c_char, c_void};
+
+use rts_engine::heap::handles::{
+    alloc_arraybuffer, alloc_entry, alloc_external_arraybuffer, arraybuffer_detach,
+    arraybuffer_is_detached, arraybuffer_len, arraybuffer_ptr, is_arraybuffer, with_entry,
+    with_entry_mut, Entry,
+};
+
+use crate::env::{handle_from_value, value_from_handle};
+use crate::types::{napi_env, napi_status, napi_value};
+
+use napi_status::{napi_invalid_arg, napi_ok};
+
+// Chaves reservadas que descrevem uma view (typedarray/dataview) sobre um buffer.
+const VIEW_BUF: &str = "__napi_view_buf__";
+const VIEW_OFFSET: &str = "__napi_view_offset__";
+const VIEW_LEN: &str = "__napi_view_len__"; // nº de elementos
+const VIEW_TYPE: &str = "__napi_view_type__"; // napi_typedarray_type (i32), -1 = dataview
+
+// ── ArrayBuffer ──────────────────────────────────────────────────────────────
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_create_arraybuffer(
+    _env: napi_env,
+    byte_length: usize,
+    data: *mut *mut c_void,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let h = alloc_arraybuffer(byte_length);
+    if !data.is_null() {
+        unsafe { *data = arraybuffer_ptr(h) as *mut c_void };
+    }
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_create_external_arraybuffer(
+    _env: napi_env,
+    external_data: *mut c_void,
+    byte_length: usize,
+    finalize_cb: *mut c_void,
+    finalize_hint: *mut c_void,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let finalize = if finalize_cb.is_null() {
+        None
+    } else {
+        Some(unsafe {
+            std::mem::transmute::<
+                *mut c_void,
+                unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+            >(finalize_cb)
+        })
+    };
+    let h = alloc_external_arraybuffer(
+        external_data as *mut u8,
+        byte_length,
+        finalize,
+        finalize_hint,
+    );
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_get_arraybuffer_info(
+    _env: napi_env,
+    arraybuffer: napi_value,
+    data: *mut *mut c_void,
+    byte_length: *mut usize,
+) -> napi_status {
+    let h = handle_from_value(arraybuffer);
+    if !is_arraybuffer(h) {
+        return napi_status::napi_arraybuffer_expected;
+    }
+    if !data.is_null() {
+        unsafe { *data = arraybuffer_ptr(h) as *mut c_void };
+    }
+    if !byte_length.is_null() {
+        unsafe { *byte_length = arraybuffer_len(h) };
+    }
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_is_arraybuffer(
+    _env: napi_env,
+    value: napi_value,
+    result: *mut bool,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    unsafe { *result = is_arraybuffer(handle_from_value(value)) };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_detach_arraybuffer(
+    _env: napi_env,
+    arraybuffer: napi_value,
+) -> napi_status {
+    if arraybuffer_detach(handle_from_value(arraybuffer)) {
+        napi_ok
+    } else {
+        napi_status::napi_arraybuffer_expected
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_is_detached_arraybuffer(
+    _env: napi_env,
+    value: napi_value,
+    result: *mut bool,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    unsafe { *result = arraybuffer_is_detached(handle_from_value(value)) };
+    napi_ok
+}
+
+// ── TypedArray / DataView (views via Map) ────────────────────────────────────
+
+fn make_view(buf: u64, ty: i32, length: usize, byte_offset: usize) -> u64 {
+    let mut m = indexmap::IndexMap::new();
+    m.insert(VIEW_BUF.to_string(), buf as i64);
+    m.insert(VIEW_OFFSET.to_string(), byte_offset as i64);
+    m.insert(VIEW_LEN.to_string(), length as i64);
+    m.insert(VIEW_TYPE.to_string(), ty as i64);
+    alloc_entry(Entry::Map(Box::new(m)))
+}
+
+fn read_view(h: u64) -> Option<(u64, i32, usize, usize)> {
+    with_entry(h, |e| match e {
+        Some(Entry::Map(m)) => {
+            let buf = *m.get(VIEW_BUF)? as u64;
+            let ty = *m.get(VIEW_TYPE)? as i32;
+            let len = *m.get(VIEW_LEN)? as usize;
+            let off = *m.get(VIEW_OFFSET)? as usize;
+            Some((buf, ty, len, off))
+        }
+        _ => None,
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_create_typedarray(
+    _env: napi_env,
+    type_: i32,
+    length: usize,
+    arraybuffer: napi_value,
+    byte_offset: usize,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let buf = handle_from_value(arraybuffer);
+    if !is_arraybuffer(buf) {
+        return napi_status::napi_arraybuffer_expected;
+    }
+    let h = make_view(buf, type_, length, byte_offset);
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_get_typedarray_info(
+    _env: napi_env,
+    typedarray: napi_value,
+    type_: *mut i32,
+    length: *mut usize,
+    data: *mut *mut c_void,
+    arraybuffer: *mut napi_value,
+    byte_offset: *mut usize,
+) -> napi_status {
+    let Some((buf, ty, len, off)) = read_view(handle_from_value(typedarray)) else {
+        return napi_invalid_arg;
+    };
+    if ty < 0 {
+        return napi_invalid_arg; // é um dataview, não typedarray
+    }
+    if !type_.is_null() {
+        unsafe { *type_ = ty };
+    }
+    if !length.is_null() {
+        unsafe { *length = len };
+    }
+    if !data.is_null() {
+        let base = arraybuffer_ptr(buf);
+        unsafe { *data = if base.is_null() { base } else { base.add(off) } as *mut c_void };
+    }
+    if !arraybuffer.is_null() {
+        unsafe { *arraybuffer = value_from_handle(buf) };
+    }
+    if !byte_offset.is_null() {
+        unsafe { *byte_offset = off };
+    }
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_create_dataview(
+    _env: napi_env,
+    byte_length: usize,
+    arraybuffer: napi_value,
+    byte_offset: usize,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let buf = handle_from_value(arraybuffer);
+    if !is_arraybuffer(buf) {
+        return napi_status::napi_arraybuffer_expected;
+    }
+    let h = make_view(buf, -1, byte_length, byte_offset); // ty=-1 → dataview
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_get_dataview_info(
+    _env: napi_env,
+    dataview: napi_value,
+    byte_length: *mut usize,
+    data: *mut *mut c_void,
+    arraybuffer: *mut napi_value,
+    byte_offset: *mut usize,
+) -> napi_status {
+    let Some((buf, ty, len, off)) = read_view(handle_from_value(dataview)) else {
+        return napi_invalid_arg;
+    };
+    if ty != -1 {
+        return napi_invalid_arg; // não é dataview
+    }
+    if !byte_length.is_null() {
+        unsafe { *byte_length = len };
+    }
+    if !data.is_null() {
+        let base = arraybuffer_ptr(buf);
+        unsafe { *data = if base.is_null() { base } else { base.add(off) } as *mut c_void };
+    }
+    if !arraybuffer.is_null() {
+        unsafe { *arraybuffer = value_from_handle(buf) };
+    }
+    if !byte_offset.is_null() {
+        unsafe { *byte_offset = off };
+    }
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_is_typedarray(
+    _env: napi_env,
+    value: napi_value,
+    result: *mut bool,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let is = read_view(handle_from_value(value)).map(|(_, ty, ..)| ty >= 0).unwrap_or(false);
+    unsafe { *result = is };
+    napi_ok
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_is_dataview(
+    _env: napi_env,
+    value: napi_value,
+    result: *mut bool,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let is = read_view(handle_from_value(value)).map(|(_, ty, ..)| ty == -1).unwrap_or(false);
+    unsafe { *result = is };
+    napi_ok
+}
+
+// ── external_buffer + buffer_from_arraybuffer ────────────────────────────────
+
+/// `napi_create_external_buffer`: como o RTS não tem Buffer com ptr externo
+/// emprestado, criamos um ArrayBuffer borrowed (mesma semântica: ptr + len +
+/// finalizer). Addons tratam o resultado como Buffer-like.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn napi_create_external_buffer(
+    _env: napi_env,
+    length: usize,
+    data: *mut c_void,
+    finalize_cb: *mut c_void,
+    finalize_hint: *mut c_void,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let finalize = if finalize_cb.is_null() {
+        None
+    } else {
+        Some(unsafe {
+            std::mem::transmute::<
+                *mut c_void,
+                unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+            >(finalize_cb)
+        })
+    };
+    let h = alloc_external_arraybuffer(data as *mut u8, length, finalize, finalize_hint);
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+/// `node_api_create_buffer_from_arraybuffer`: cria um Buffer (Entry::Buffer)
+/// copiando os bytes do arraybuffer no range [offset, offset+len).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn node_api_create_buffer_from_arraybuffer(
+    _env: napi_env,
+    arraybuffer: napi_value,
+    byte_offset: usize,
+    byte_length: usize,
+    result: *mut napi_value,
+) -> napi_status {
+    if result.is_null() {
+        return napi_invalid_arg;
+    }
+    let buf = handle_from_value(arraybuffer);
+    if !is_arraybuffer(buf) {
+        return napi_status::napi_arraybuffer_expected;
+    }
+    let bytes = {
+        let base = arraybuffer_ptr(buf);
+        let total = arraybuffer_len(buf);
+        if base.is_null() || byte_offset + byte_length > total {
+            Vec::new()
+        } else {
+            unsafe { std::slice::from_raw_parts(base.add(byte_offset), byte_length).to_vec() }
+        }
+    };
+    let h = alloc_entry(Entry::Buffer(bytes));
+    unsafe { *result = value_from_handle(h) };
+    napi_ok
+}
+
+/// `node_api_create_sharedarraybuffer`: o RTS não tem memória compartilhada
+/// entre threads via SAB; cria um ArrayBuffer normal (backing igual). Atomics
+/// sobre ele funcionam single-process.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn node_api_create_sharedarraybuffer(
+    env: napi_env,
+    byte_length: usize,
+    data: *mut *mut c_void,
+    result: *mut napi_value,
+) -> napi_status {
+    unsafe { napi_create_arraybuffer(env, byte_length, data, result) }
+}
+
+// suprime warning de import não-usado em alguns paths
+#[allow(unused_imports)]
+use with_entry_mut as _wem;
+#[allow(unused_imports)]
+use c_char as _cc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    fn env() -> napi_env {
+        napi_env(ptr::null_mut())
+    }
+
+    #[test]
+    fn arraybuffer_create_write_read() {
+        let mut data: *mut c_void = ptr::null_mut();
+        let mut ab = napi_value(ptr::null_mut());
+        unsafe { napi_create_arraybuffer(env(), 16, &mut data, &mut ab) };
+        assert!(!data.is_null());
+        unsafe {
+            *(data as *mut u8) = 0x42;
+        }
+        // is_arraybuffer
+        let mut is = false;
+        unsafe { napi_is_arraybuffer(env(), ab, &mut is) };
+        assert!(is);
+        // get_info devolve o mesmo ptr + len
+        let mut d2: *mut c_void = ptr::null_mut();
+        let mut len = 0usize;
+        unsafe { napi_get_arraybuffer_info(env(), ab, &mut d2, &mut len) };
+        assert_eq!(len, 16);
+        assert_eq!(d2, data);
+        unsafe {
+            assert_eq!(*(d2 as *const u8), 0x42);
+        }
+    }
+
+    #[test]
+    fn typedarray_view_over_buffer() {
+        let mut data: *mut c_void = ptr::null_mut();
+        let mut ab = napi_value(ptr::null_mut());
+        unsafe { napi_create_arraybuffer(env(), 32, &mut data, &mut ab) };
+        // Uint8Array (type 1, p.ex.) de 10 elementos com offset 4.
+        let mut ta = napi_value(ptr::null_mut());
+        unsafe { napi_create_typedarray(env(), 1, 10, ab, 4, &mut ta) };
+        let mut is = false;
+        unsafe { napi_is_typedarray(env(), ta, &mut is) };
+        assert!(is);
+        let mut ty = 0i32;
+        let mut len = 0usize;
+        let mut tdata: *mut c_void = ptr::null_mut();
+        let mut off = 0usize;
+        unsafe {
+            napi_get_typedarray_info(env(), ta, &mut ty, &mut len, &mut tdata, ptr::null_mut(), &mut off)
+        };
+        assert_eq!(ty, 1);
+        assert_eq!(len, 10);
+        assert_eq!(off, 4);
+        // data aponta para base+4
+        assert_eq!(tdata as usize, data as usize + 4);
+    }
+
+    #[test]
+    fn detach_arraybuffer() {
+        let mut ab = napi_value(ptr::null_mut());
+        unsafe { napi_create_arraybuffer(env(), 8, ptr::null_mut(), &mut ab) };
+        let mut det = true;
+        unsafe { napi_is_detached_arraybuffer(env(), ab, &mut det) };
+        assert!(!det);
+        unsafe { napi_detach_arraybuffer(env(), ab) };
+        unsafe { napi_is_detached_arraybuffer(env(), ab, &mut det) };
+        assert!(det);
+    }
+}

--- a/crates/rts-napi/src/lib.rs
+++ b/crates/rts-napi/src/lib.rs
@@ -18,6 +18,7 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::missing_safety_doc)]
 
+pub mod arraybuffer;
 pub mod classes;
 pub mod env;
 pub mod errors;
@@ -181,10 +182,22 @@ pub fn force_link() -> usize {
         crate::phase2c::napi_create_promise as *const (),
         crate::phase2c::napi_fatal_exception as *const (),
         crate::phase2c::napi_get_prototype as *const (),
-        crate::phase2c::napi_is_arraybuffer as *const (),
-        crate::phase2c::napi_is_dataview as *const (),
-        crate::phase2c::napi_is_detached_arraybuffer as *const (),
-        crate::phase2c::napi_is_typedarray as *const (),
+        // ArrayBuffer/TypedArray/DataView (arraybuffer.rs, engine #1548)
+        crate::arraybuffer::napi_create_arraybuffer as *const (),
+        crate::arraybuffer::napi_create_external_arraybuffer as *const (),
+        crate::arraybuffer::napi_get_arraybuffer_info as *const (),
+        crate::arraybuffer::napi_is_arraybuffer as *const (),
+        crate::arraybuffer::napi_detach_arraybuffer as *const (),
+        crate::arraybuffer::napi_is_detached_arraybuffer as *const (),
+        crate::arraybuffer::napi_create_typedarray as *const (),
+        crate::arraybuffer::napi_get_typedarray_info as *const (),
+        crate::arraybuffer::napi_is_typedarray as *const (),
+        crate::arraybuffer::napi_create_dataview as *const (),
+        crate::arraybuffer::napi_get_dataview_info as *const (),
+        crate::arraybuffer::napi_is_dataview as *const (),
+        crate::arraybuffer::napi_create_external_buffer as *const (),
+        crate::arraybuffer::node_api_create_buffer_from_arraybuffer as *const (),
+        crate::arraybuffer::node_api_create_sharedarraybuffer as *const (),
         crate::phase2c::napi_reject_deferred as *const (),
         crate::phase2c::napi_remove_env_cleanup_hook as *const (),
         crate::phase2c::napi_resolve_deferred as *const (),

--- a/crates/rts-napi/src/phase2c.rs
+++ b/crates/rts-napi/src/phase2c.rs
@@ -153,30 +153,8 @@ fn fmt_num(f: f64) -> String {
 
 // ── type checks que faltavam (sem suporte real → false) ──────────────────────
 
-macro_rules! always_false_check {
-    ($name:ident) => {
-        #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn $name(
-            _env: napi_env,
-            _value: napi_value,
-            result: *mut bool,
-        ) -> napi_status {
-            if result.is_null() {
-                return napi_invalid_arg;
-            }
-            // RTS não tem ArrayBuffer/TypedArray/DataView distintos ainda
-            // (follow-up engine). Reportar false é seguro: addons checam e usam
-            // o caminho alternativo (ex.: Buffer).
-            unsafe { *result = false };
-            napi_ok
-        }
-    };
-}
-
-always_false_check!(napi_is_arraybuffer);
-always_false_check!(napi_is_typedarray);
-always_false_check!(napi_is_dataview);
-always_false_check!(napi_is_detached_arraybuffer);
+// napi_is_arraybuffer/typedarray/dataview/detached migraram para arraybuffer.rs
+// (impl real sobre Entry::ArrayBuffer, #1548).
 
 // ── type tags (object branding) ──────────────────────────────────────────────
 // Um type tag é um par u64 (lower, upper). Guardamos numa chave reservada do Map.
@@ -452,14 +430,6 @@ mod tests {
         let other = napi_type_tag { lower: 1, upper: 2 };
         unsafe { napi_check_object_type_tag(env(), obj, &other, &mut matches) };
         assert!(!matches);
-    }
-
-    #[test]
-    fn is_arraybuffer_false() {
-        let mut b = true;
-        let buf = value_from_handle(alloc_entry(Entry::Buffer(vec![1, 2])));
-        unsafe { napi_is_arraybuffer(env(), buf, &mut b) };
-        assert!(!b);
     }
 
     #[test]

--- a/crates/rts-napi/src/surface.rs
+++ b/crates/rts-napi/src/surface.rs
@@ -1,7 +1,6 @@
-//! Superfície N-API restante — dependem do engine (arraybuffer/typedarray
-//! ptr estável; async/threadsafe event loop #207; bigint real #219;
-//! registro legado). Stubs `napi_generic_failure` p/ o load_all() do
-//! napi-sys completar. Ver docs/specs/napi-implementation.md.
+//! Superfície N-API restante (bloqueada pelo engine: async/threadsafe event
+//! loop #207; bigint real #219; registro legado) — stubs `napi_generic_failure`
+//! p/ o load_all() do napi-sys completar. Ver docs/specs/napi-implementation.md.
 
 #![allow(clippy::too_many_arguments)]
 use crate::types::napi_status;
@@ -23,21 +22,12 @@ surface_stub!(napi_async_init);
 surface_stub!(napi_call_threadsafe_function);
 surface_stub!(napi_cancel_async_work);
 surface_stub!(napi_close_callback_scope);
-surface_stub!(napi_create_arraybuffer);
 surface_stub!(napi_create_async_work);
 surface_stub!(napi_create_bigint_uint64);
 surface_stub!(napi_create_bigint_words);
-surface_stub!(napi_create_dataview);
-surface_stub!(napi_create_external_arraybuffer);
-surface_stub!(napi_create_external_buffer);
 surface_stub!(napi_create_threadsafe_function);
-surface_stub!(napi_create_typedarray);
 surface_stub!(napi_delete_async_work);
-surface_stub!(napi_detach_arraybuffer);
-surface_stub!(napi_get_arraybuffer_info);
-surface_stub!(napi_get_dataview_info);
 surface_stub!(napi_get_threadsafe_function_context);
-surface_stub!(napi_get_typedarray_info);
 surface_stub!(napi_get_uv_event_loop);
 surface_stub!(napi_get_value_bigint_uint64);
 surface_stub!(napi_get_value_bigint_words);
@@ -48,8 +38,6 @@ surface_stub!(napi_ref_threadsafe_function);
 surface_stub!(napi_release_threadsafe_function);
 surface_stub!(napi_remove_async_cleanup_hook);
 surface_stub!(napi_unref_threadsafe_function);
-surface_stub!(node_api_create_buffer_from_arraybuffer);
-surface_stub!(node_api_create_sharedarraybuffer);
 surface_stub!(node_api_post_finalizer);
 
 pub fn force_link_surface() -> usize {
@@ -61,21 +49,12 @@ pub fn force_link_surface() -> usize {
         napi_call_threadsafe_function as *const (),
         napi_cancel_async_work as *const (),
         napi_close_callback_scope as *const (),
-        napi_create_arraybuffer as *const (),
         napi_create_async_work as *const (),
         napi_create_bigint_uint64 as *const (),
         napi_create_bigint_words as *const (),
-        napi_create_dataview as *const (),
-        napi_create_external_arraybuffer as *const (),
-        napi_create_external_buffer as *const (),
         napi_create_threadsafe_function as *const (),
-        napi_create_typedarray as *const (),
         napi_delete_async_work as *const (),
-        napi_detach_arraybuffer as *const (),
-        napi_get_arraybuffer_info as *const (),
-        napi_get_dataview_info as *const (),
         napi_get_threadsafe_function_context as *const (),
-        napi_get_typedarray_info as *const (),
         napi_get_uv_event_loop as *const (),
         napi_get_value_bigint_uint64 as *const (),
         napi_get_value_bigint_words as *const (),
@@ -86,8 +65,6 @@ pub fn force_link_surface() -> usize {
         napi_release_threadsafe_function as *const (),
         napi_remove_async_cleanup_hook as *const (),
         napi_unref_threadsafe_function as *const (),
-        node_api_create_buffer_from_arraybuffer as *const (),
-        node_api_create_sharedarraybuffer as *const (),
         node_api_post_finalizer as *const (),
     ];
     std::hint::black_box(fns.iter().map(|p| *p as usize).fold(0usize, usize::wrapping_add))

--- a/docs/specs/napi-implementation.md
+++ b/docs/specs/napi-implementation.md
@@ -1,7 +1,8 @@
 # N-API — Plano de implementação (doc vivo de acompanhamento)
 
-> **Status:** Fase 0 + 1 + 2 + classes nativas ✅ — **124/159 fns implementadas**,
-> paridade Node v22 em addons npm reais (crc32, xxhash+classe, uuid).
+> **Status:** Fase 0 + 1 + 2 + classes + **ArrayBuffer/TypedArray** ✅ —
+> **135/159 fns implementadas**, paridade Node v22 em addons npm reais (crc32,
+> xxhash+classe, uuid) e ArrayBuffer (escrita direta `fill(100)`=22532 idêntico).
 >
 > **Issues de rastreamento:**
 > - [#1547](https://github.com/UrubuCode/rts/issues/1547) — tracking geral do N-API
@@ -16,12 +17,13 @@
 | type checks, coerce, Buffer, Date, Symbol, BigInt(i64), wrap/unwrap | ✅ Fase 2 |
 | Promise/deferred, type tags, finalizer, syntax errors, make_callback | ✅ Fase 2c/2d |
 | **classes nativas** (`napi_define_class` + `new addon.X()` + `inst.method()`) | ✅ |
+| **ArrayBuffer/TypedArray/DataView** (`Entry::ArrayBuffer` ptr estável, #1548) | ✅ |
 
-### 35 stubs restantes — **bloqueados pelo engine** (retornam `napi_generic_failure`)
+### 24 stubs restantes — **bloqueados pelo engine** (retornam `napi_generic_failure`)
 
 | Bloco | Qtd | Depende de |
 |---|---|---|
-| arraybuffer/typedarray/dataview create+info | 11 | `Entry::ArrayBuffer` com **ptr estável** (follow-up Drysius) |
+| ~~arraybuffer/typedarray/dataview~~ | ~~11~~ | ✅ **FEITO** (`Entry::ArrayBuffer` ptr estável, #1548 item 1) |
 | async_work/threadsafe_function/uv_event_loop | 19 | **event loop real** (#207) |
 | bigint uint64/words real | 4 | BigInt real (#219) |
 | module_register (registro legado) | 1 | fora de escopo (não-N-API) |
@@ -50,6 +52,7 @@ Os stubs degradam graciosamente (falha, não crash). Tudo na export table para o
 | `phase2b.rs` | strings latin1/utf16, wrap/unwrap, instance-data, version, property keys |
 | `phase2c.rs` | Promise/deferred, type tags, finalizer, coerce_to_string, syntax errors, cleanup hooks |
 | `phase2d.rs` | external strings, make_callback, is_sharedarraybuffer |
+| `arraybuffer.rs` | ArrayBuffer/TypedArray/DataView sobre `Entry::ArrayBuffer` (engine, #1548) — ptr estável, views via Map |
 | `surface.rs` | os 35 stubs restantes (`napi_generic_failure`) — gerados a partir da lista |
 | `napi_symbols.list` | **fonte única** dos nomes exportados (consumida por `symbols.rs` e pelo `build.rs` raiz) |
 


### PR DESCRIPTION
## Parte do engine (#1548 item 1) + N-API por cima

Implementa a API do motor que o N-API precisava — **`Entry::ArrayBuffer` com ponteiro de bytes estável** — e plota 15 fns N-API de ArrayBuffer/TypedArray/DataView por cima. Destrava addons de hash/crypto/compressão que escrevem direto na memória.

**Issue #1548 segue ABERTA** (item 1 feito; itens 3/4 — event loop, bigint real — dependem do motor novo do @drysius). Refs #1548, #1547.

### Validação — paridade Node v22
Addon que cria ArrayBuffer, escreve `byte[i]=i*3` **direto no ptr estável** + relê via `get_arraybuffer_info`: `fill(100)` = **22532** no RTS e no Node (idêntico).

### Engine (`rts-engine`)
- `Entry::ArrayBuffer` com backing `Owned(Box<[u8]>)` (ptr estável, não realoca) ou `Borrowed{ptr,len,finalize}` (externo).
- fns: `alloc_arraybuffer`/`alloc_external_arraybuffer`, `arraybuffer_ptr`/`_len`/`_detach`, `is_arraybuffer`.
- `cleanup_entry` enfileira o finalizer do borrowed (fora do lock).

### N-API (`rts-napi/arraybuffer.rs`, 15 fns)
create/get_info/is/detach para arraybuffer; typedarray + dataview (views via Map: buffer+offset+len+tipo); external_buffer, buffer_from_arraybuffer, sharedarraybuffer.

### Testes
- `rts-engine` 53 (+2), `rts-napi` 48 (+3)
- addons npm reais (crc32, xxhash classe) sem regressão
- Suite TS **1710/1710**

🤖 Generated with [Claude Code](https://claude.com/claude-code)