### PR TITLE
fix(int32) + perf(array inline): conformidade bitwise + storage nativo de array

### DIFF
--- a/bench/multiuser_sim.ts
+++ b/bench/multiuser_sim.ts
@@ -1,0 +1,83 @@
+// Simulação multi-usuário: N usuários, cada um gera eventos (ações) que mutam
+// estado agregado. Mede throughput de processamento de eventos.
+// Portável: roda igual em RTS, Node e Bun (sem APIs específicas de runtime).
+//
+// Modelo:
+//  - USERS usuários, cada um com saldo (balance) e contador de ações.
+//  - cada usuário gera EVENTS_PER_USER eventos; tipo do evento via PRNG.
+//  - tipos: 0=deposit (+), 1=withdraw (-), 2=transfer (move p/ outro user),
+//           3=action (incrementa contador global de ações processadas).
+//  - estado mantido em arrays paralelos (balances[], actions[]) — o padrão
+//    que o RTS otimiza (VEC_GET/SET/RMW).
+
+const USERS = 5000;
+const EVENTS_PER_USER = 2000;
+
+// PRNG determinístico (LCG) — sem depender de wrap de 32-bit (que diverge
+// entre runtimes p/ shift sobre variável). Usa só * + % com valores que
+// cabem em f64 exato (< 2^53). Mesma sequência nos 3 runtimes.
+let seed = 123456789;
+function rnd(): number {
+  // Park-Miller minimal standard: seed = (seed * 16807) % 2147483647
+  seed = (seed * 16807) % 2147483647;
+  return seed % 1000000;
+}
+
+const balances: number[] = [];
+const actions: number[] = [];
+for (let i = 0; i < USERS; i++) {
+  balances[i] = 1000;
+  actions[i] = 0;
+}
+
+let totalActions = 0;
+let totalDeposits = 0;
+let totalWithdraws = 0;
+let totalTransfers = 0;
+
+const t0 = Date.now();
+
+for (let u = 0; u < USERS; u++) {
+  for (let e = 0; e < EVENTS_PER_USER; e++) {
+    const kind = rnd() % 4;
+    if (kind === 0) {
+      const amt = rnd() % 100;
+      balances[u] = balances[u] + amt;
+      totalDeposits = totalDeposits + 1;
+    } else if (kind === 1) {
+      const amt = rnd() % 100;
+      if (balances[u] >= amt) {
+        balances[u] = balances[u] - amt;
+        totalWithdraws = totalWithdraws + 1;
+      }
+    } else if (kind === 2) {
+      const target = rnd() % USERS;
+      const amt = rnd() % 50;
+      if (balances[u] >= amt) {
+        balances[u] = balances[u] - amt;
+        balances[target] = balances[target] + amt;
+        totalTransfers = totalTransfers + 1;
+      }
+    } else {
+      actions[u] = actions[u] + 1;
+      totalActions = totalActions + 1;
+    }
+  }
+}
+
+const t1 = Date.now();
+
+// Checksum: soma de todos os saldos (deve ser determinístico e idêntico nos 3).
+let sumBalances = 0;
+for (let i = 0; i < USERS; i++) {
+  sumBalances = sumBalances + balances[i];
+}
+
+const totalEvents = USERS * EVENTS_PER_USER;
+const ms = t1 - t0;
+
+console.log("users=" + USERS + " events/user=" + EVENTS_PER_USER + " total_events=" + totalEvents);
+console.log("deposits=" + totalDeposits + " withdraws=" + totalWithdraws + " transfers=" + totalTransfers + " actions=" + totalActions);
+console.log("sum_balances=" + sumBalances);
+console.log("time_ms=" + ms);
+console.log("events_per_sec=" + Math.floor(totalEvents / (ms / 1000)));

--- a/bench/multiuser_sim_RESULTS.md
+++ b/bench/multiuser_sim_RESULTS.md
@@ -1,0 +1,55 @@
+# Benchmark: simulação multi-usuário (multiuser_sim.ts)
+
+Simula 5000 usuários × 2000 eventos = **10M eventos**. Cada evento muta estado
+agregado (saldos/ações) em arrays paralelos. PRNG determinístico (Park-Miller
+LCG, portável — não depende de wrap int32). Mesma corretude nos 3 runtimes
+(`sum_balances=28927970` idêntico).
+
+## Resultados (2026-06-13)
+
+| Runtime | Tempo  | Eventos/seg | vs Node |
+|---------|--------|-------------|---------|
+| Node 22 | 546 ms | 18.3M       | 1.0×    |
+| Bun 1.3 | 622 ms | 16.1M       | 0.88×   |
+| **RTS** | 3182 ms| 3.1M        | **0.17× (6× mais lento)** |
+
+## Por que o RTS perde AQUI (e ganha no Monte Carlo)
+
+- **Monte Carlo (RTS ganha ~5×):** workload de CPU puro, variáveis f64 em
+  registradores Cranelift, zero acesso a heap no loop quente.
+- **multiuser_sim (RTS perde ~6×):** workload **array-heavy**. Cada
+  `balances[u]`, `actions[u]`, `balances[target]` é uma **chamada extern**
+  (`VEC_GET`/`VEC_SET`) com lock de shard. O loop interno tem ~muitas dessas por
+  evento. V8/JSC têm arrays inline (acesso direto à memória, sem call, sem lock).
+
+**Conclusão honesta:** o RTS é mais rápido em CPU-bound aritmético, mas mais
+lento em código dominado por acesso a array/objeto, por causa do overhead de
+chamada extern + lock por acesso. Esse é o gargalo a atacar para workloads
+realistas (gateways de evento, simulações, processamento de coleções).
+
+## Caminhos de otimização identificados
+
+1. **Inline de array access no codegen** — `arr[i]` sobre Vec conhecido poderia
+   emitir load/store direto no ptr do Vec em vez de `call VEC_GET`, eliminando o
+   overhead de call + lock para o caso single-thread comum. Maior ganho.
+2. **Escape analysis** (Phase 4 pendente) — arrays locais que não escapam podem
+   virar memória nativa sem HandleTable.
+3. O `apply_rmw` (PR #1556) já provou o ganho: colapsar calls reduziu
+   `arr[i]+=1` de 6020ms→973ms (6×). Estender o princípio a get/set puro.
+
+## Bug de conformidade descoberto (separado)
+
+Shift bitwise sobre VARIÁVEL não trunca para int32 como o JS exige:
+`s << 13` com `s` number dá resultado 64-bit no RTS (`1011358015488`) vs int32
+no Node (`2040700928`). Literais const-folded (`1 << 31`) funcionam. Precisa de
+ToInt32 antes de bitwise/shift sobre operando dinâmico no codegen. (O
+`apply_rmw` do PR #1556 já faz `as i32` corretamente; o caminho normal de `<<`
+não.) Tracking: relacionado a #305.
+
+## Como rodar
+
+```bash
+target/release/rts.exe run bench/multiuser_sim.ts
+node bench/multiuser_sim.ts
+bun bench/multiuser_sim.ts
+```

--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -426,6 +426,22 @@ pub(crate) fn compile_user_fn(
             fn_ctx.emit_trace_push(fn_line, fn_col)?;
         }
 
+        // (RTS_ARRAY_INLINE) Escape analysis: arrays locais nao-escapantes de
+        // tamanho fixo (`new Array(N)` / `[lit,...]`, sem push) qualificam pra
+        // storage nativo em StackSlot. Gate por env var; OFF = caminho atual
+        // bit-identico. O decl-site (decls.rs) consulta `native_array_candidates`
+        // e aloca o slot + inicializa, em vez de VEC_NEW. So' user fns (top-level
+        // / __RTS_MAIN sao follow-up — ver docs/specs/native-array-storage.md).
+        if std::env::var("RTS_ARRAY_INLINE").as_deref() == Ok("1") {
+            let cands =
+                crate::codegen::lower::passes::escape::non_escaping_fixed_arrays(&fn_decl.body);
+            for (name, info) in cands {
+                fn_ctx
+                    .native_array_candidates
+                    .insert(name, (info.len, info.elem_is_float));
+            }
+        }
+
         // (#301) Var hoisting: coletar todos os nomes `var x` no body
         // (incluindo nested em if/for/while/try mas ignorando function/
         // arrow/class boundaries) e pre-declarar como I64=0. Isso

--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -181,6 +181,26 @@ pub struct LocalVar {
     pub is_const: bool,
 }
 
+/// (RTS_ARRAY_INLINE) Storage nativo de um array local nao-escapante de
+/// tamanho fixo. Em vez de um handle do HandleTable, o array vive num
+/// `StackSlot` Cranelift de `len * 8` bytes; `arr[i]` vira load/store direto
+/// (`[stack_addr + i*8]`), sem call extern nem lock. GC-safe porque o scanner
+/// de GC e' conservador e varre toda a stack (handles num slot sao marcados
+/// como qualquer local). Ver `docs/specs/native-array-storage.md`.
+#[derive(Debug, Clone, Copy)]
+pub struct NativeArrayStorage {
+    /// StackSlot Cranelift de `len * 8` bytes.
+    pub slot: StackSlot,
+    /// Numero de elementos (tamanho fixo).
+    pub len: i64,
+    /// Tipo Cranelift de cada elemento (I64 hoje; I64 com bits-f64 quando
+    /// `elem_ty == F64`).
+    pub elem_clty: cranelift_codegen::ir::Type,
+    /// Tipo logico do elemento. F64 => o slot guarda BITS de um f64 (bitcast
+    /// na leitura/escrita), espelhando `local_array_elem_ty`/`local_ta_view`.
+    pub elem_ty: ValTy,
+}
+
 /// Module-scope global lowered to a data symbol.
 #[derive(Debug, Clone)]
 pub struct GlobalVar {
@@ -554,6 +574,19 @@ pub struct FnCtx<'m, 'fb> {
     /// Sem isso, `arr.indexOf(x)` em `let arr: number[] = [...]` cai em
     /// string builtin (`__RTS_FN_GL_STRING_INDEX_OF`) e retorna lixo.
     pub local_array_vars: std::collections::HashSet<String>,
+    /// (RTS_ARRAY_INLINE) Arrays locais nao-escapantes de tamanho fixo que
+    /// vivem num StackSlot Cranelift em vez do HandleTable. `arr[i]` vira
+    /// load/store direto (zero call extern). Populado em `compile_user_fn`
+    /// quando a env `RTS_ARRAY_INLINE=1` esta ativa e a escape analysis
+    /// (`passes::escape`) qualifica o array. Vazio por padrao (flag OFF =
+    /// caminho atual bit-identico).
+    pub native_arrays: std::collections::HashMap<String, NativeArrayStorage>,
+    /// (RTS_ARRAY_INLINE) Nomes de arrays que a escape analysis qualificou
+    /// como nativos (nao-escapantes, tamanho fixo), com (len, elem_is_float).
+    /// Populado UMA vez no inicio de `compile_user_fn`. O decl-site (decls.rs)
+    /// consulta este set: se o nome esta aqui, aloca o StackSlot + registra em
+    /// `native_arrays` + inicializa, em vez de VEC_NEW. Vazio com flag OFF.
+    pub native_array_candidates: std::collections::HashMap<String, (usize, bool)>,
     /// (cross-runtime) Vars cujo valor eh Map/Set/WeakMap/WeakSet (anotacao
     /// `: Map<...>`, init `new Map/Set`, ou retorno de fn que devolve Map/Set).
     /// Usado por `.size` para rotear ao UNIVERSAL_LENGTH (detecta Entry::Map em
@@ -670,6 +703,8 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             str_handle_cache: HashMap::new(),
             num_val_cache: HashMap::new(),
             local_array_vars: std::collections::HashSet::new(),
+            native_arrays: std::collections::HashMap::new(),
+            native_array_candidates: std::collections::HashMap::new(),
             local_map_vars: std::collections::HashSet::new(),
             local_string_vars: std::collections::HashSet::new(),
             generator_vars: std::collections::HashSet::new(),
@@ -752,6 +787,114 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         let ptr_ty = self.module.isa().pointer_type();
         let addr = self.builder.ins().stack_addr(ptr_ty, slot, 0);
         (slot, addr)
+    }
+
+    /// (RTS_ARRAY_INLINE) Aloca o StackSlot de um array nativo de `len`
+    /// elementos (8 bytes cada, align 8) e registra em `native_arrays`.
+    /// Os slots NAO sao inicializados aqui — o chamador (decl site) emite os
+    /// stores iniciais (literal) ou zera (`new Array(N)`).
+    pub fn alloc_native_array(&mut self, name: &str, len: i64, elem_ty: ValTy) -> StackSlot {
+        use cranelift_codegen::ir::types as cl;
+        let bytes = (len.max(0) as u32).saturating_mul(8).max(8);
+        let slot = self.builder.create_sized_stack_slot(StackSlotData::new(
+            StackSlotKind::ExplicitSlot,
+            bytes,
+            3, // log2(8) = align 8
+        ));
+        self.native_arrays.insert(
+            name.to_string(),
+            NativeArrayStorage { slot, len, elem_clty: cl::I64, elem_ty },
+        );
+        slot
+    }
+
+    /// (RTS_ARRAY_INLINE) Emite leitura `arr[idx]` de um array nativo com
+    /// bounds-check JS-correto: fora de `[0, len)` devolve `default` (0 /
+    /// undefined-ish), nunca trap. Devolve o valor ja tipado conforme
+    /// `elem_ty` (bitcast pra F64 quando o slot guarda bits de f64).
+    pub fn emit_native_array_read(
+        &mut self,
+        store: NativeArrayStorage,
+        idx: Value,
+    ) -> TypedVal {
+        use cranelift_codegen::ir::condcodes::IntCC;
+        let ptr_ty = self.module.isa().pointer_type();
+        // idx em i64 (ja coerced pelo chamador).
+        let len_v = self.builder.ins().iconst(cl::I64, store.len);
+        let zero = self.builder.ins().iconst(cl::I64, 0);
+        // in_bounds = idx >= 0 && idx < len  (unsigned compare cobre ambos:
+        // idx < len como unsigned trata negativos como enormes => false).
+        let in_bounds = self
+            .builder
+            .ins()
+            .icmp(IntCC::UnsignedLessThan, idx, len_v);
+        // Endereco do slot: base + idx*8. Clamp idx a 0 quando fora de bounds
+        // pra que o `load` nunca toque memoria invalida (mesmo que descartemos
+        // o valor via select). Endereco sempre dentro do slot.
+        let safe_idx = self.builder.ins().select(in_bounds, idx, zero);
+        let base = self.builder.ins().stack_addr(ptr_ty, store.slot, 0);
+        let off = self.builder.ins().imul_imm(safe_idx, 8);
+        let off = if ptr_ty == cl::I32 {
+            self.builder.ins().ireduce(cl::I32, off)
+        } else {
+            off
+        };
+        let addr = self.builder.ins().iadd(base, off);
+        let raw = self
+            .builder
+            .ins()
+            .load(store.elem_clty, MemFlags::trusted(), addr, 0);
+        // Fora de bounds => 0 (default). JS daria undefined; 0 e' o sentinel
+        // numerico usado no resto do codegen para slots ausentes.
+        let val = self.builder.ins().select(in_bounds, raw, zero);
+        if matches!(store.elem_ty, ValTy::F64) {
+            let f = self
+                .builder
+                .ins()
+                .bitcast(cl::F64, MemFlags::new(), val);
+            TypedVal::new(f, ValTy::F64)
+        } else {
+            TypedVal::new(val, ValTy::I64)
+        }
+    }
+
+    /// (RTS_ARRAY_INLINE) Emite escrita `arr[idx] = val_i64` num array nativo.
+    /// `val_i64` ja deve carregar a representacao final (bits-f64 quando
+    /// `elem_ty == F64`). Bounds-check: fora de range NAO escreve (no-op via
+    /// endereco clamped + guard) — JS expandiria o array, mas para a fatia
+    /// segura (tamanho fixo) escritas fora de range sao descartadas.
+    pub fn emit_native_array_write(&mut self, store: NativeArrayStorage, idx: Value, val_i64: Value) {
+        use cranelift_codegen::ir::condcodes::IntCC;
+        let ptr_ty = self.module.isa().pointer_type();
+        let len_v = self.builder.ins().iconst(cl::I64, store.len);
+        let zero = self.builder.ins().iconst(cl::I64, 0);
+        let in_bounds = self
+            .builder
+            .ins()
+            .icmp(IntCC::UnsignedLessThan, idx, len_v);
+        // Clamp idx a 0 quando fora de bounds — o store sempre toca o slot 0
+        // (dentro do array), mas so' grava o valor real quando in_bounds; fora
+        // de bounds re-grava o valor atual do slot 0 (no-op observavel).
+        let safe_idx = self.builder.ins().select(in_bounds, idx, zero);
+        let base = self.builder.ins().stack_addr(ptr_ty, store.slot, 0);
+        let off = self.builder.ins().imul_imm(safe_idx, 8);
+        let off = if ptr_ty == cl::I32 {
+            self.builder.ins().ireduce(cl::I32, off)
+        } else {
+            off
+        };
+        let addr = self.builder.ins().iadd(base, off);
+        // Quando fora de bounds, preserva o conteudo atual do slot-0: carrega
+        // o valor existente e usa-o no lugar de `val_i64`. Assim o store nunca
+        // corrompe um slot valido com escrita fora de range.
+        let cur = self
+            .builder
+            .ins()
+            .load(store.elem_clty, MemFlags::trusted(), addr, 0);
+        let to_store = self.builder.ins().select(in_bounds, val_i64, cur);
+        self.builder
+            .ins()
+            .store(MemFlags::trusted(), to_store, addr, 0);
     }
 
     /// Pushes a new block scope. Variables declared with `let`/`const` go here.

--- a/crates/rts-codegen/src/codegen/lower/expressions/members.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/members.rs
@@ -807,6 +807,18 @@ pub(super) fn lower_member_expr(ctx: &mut FnCtx, m: &swc_ecma_ast::MemberExpr) -
             }
         }
     }
+    // (RTS_ARRAY_INLINE) `arr[idx]` (read) onde `arr` e' um array nativo
+    // (escape analysis qualificou -> StackSlot). Load direto com bounds-check,
+    // zero call extern. Interceptado ANTES de `lower_expr(m.obj)` porque o
+    // array nativo nao tem handle valido pra ler como Ident. Devolve TypedVal
+    // com elem_ty exato (I64 ou F64). Ver docs/specs/native-array-storage.md.
+    if let (Expr::Ident(obj_id), MemberProp::Computed(c)) = (m.obj.as_ref(), &m.prop) {
+        if let Some(&storage) = ctx.native_arrays.get(obj_id.sym.as_str()) {
+            let idx_tv = lower_expr(ctx, &c.expr)?;
+            let idx = ctx.coerce_to_i64(idx_tv).val;
+            return Ok(ctx.emit_native_array_read(storage, idx));
+        }
+    }
     // (cross-runtime #1052) `obj[<StringLit>]` ou `obj[k[N]]` (k const array
     // de strings) quando key resolve estaticamente para "length"/"name"
     // (propriedade comum) — reescreve como `obj.<prop>` para usar path direto

--- a/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/mod.rs
@@ -514,6 +514,126 @@ fn rmw_expr_reads_slot(e: &Expr, arr: &Expr, idx: &Expr) -> bool {
     }
 }
 
+/// (RTS_ARRAY_INLINE) Emite `arr[idx] OP= operand` num array nativo: load do
+/// slot; aplica `binop` em Cranelift IR (sem call apply_rmw); store; devolve o
+/// NOVO valor. Suporta as ops i64 (add/sub/mul/sdiv/srem/and/or/xor/shl/shr/
+/// ushr) e f64 (add/sub/mul/div) quando o array eh float. Retorna `Ok(None)`
+/// quando a op nao eh suportada (fall-through ao caminho atual).
+fn try_emit_native_array_rmw(
+    ctx: &mut FnCtx,
+    storage: crate::codegen::lower::ctx::NativeArrayStorage,
+    idx_expr: &Expr,
+    operand_expr: &Expr,
+    binop: BinaryOp,
+) -> Result<Option<TypedVal>> {
+    use cranelift_codegen::ir::condcodes::IntCC;
+    use cranelift_codegen::ir::{MemFlags, types as cl};
+
+    let float_mode = matches!(storage.elem_ty, ValTy::F64);
+    // Confirma op suportada (reusa o gate do VEC_RMW: codes 0..=10 int, 16..=19 float).
+    if rmw_op_code(binop, float_mode).is_none() {
+        return Ok(None);
+    }
+
+    let idx_tv = lower_expr(ctx, idx_expr)?;
+    let idx = ctx.coerce_to_i64(idx_tv).val;
+
+    let ptr_ty = ctx.module.isa().pointer_type();
+    let len_v = ctx.builder.ins().iconst(cl::I64, storage.len);
+    let zero = ctx.builder.ins().iconst(cl::I64, 0);
+    let in_bounds = ctx
+        .builder
+        .ins()
+        .icmp(IntCC::UnsignedLessThan, idx, len_v);
+    let safe_idx = ctx.builder.ins().select(in_bounds, idx, zero);
+    let base = ctx.builder.ins().stack_addr(ptr_ty, storage.slot, 0);
+    let off = ctx.builder.ins().imul_imm(safe_idx, 8);
+    let off = if ptr_ty == cl::I32 {
+        ctx.builder.ins().ireduce(cl::I32, off)
+    } else {
+        off
+    };
+    let addr = ctx.builder.ins().iadd(base, off);
+    let cur_raw = ctx
+        .builder
+        .ins()
+        .load(cl::I64, MemFlags::trusted(), addr, 0);
+
+    // operand.
+    let operand_tv = lower_expr(ctx, operand_expr)?;
+
+    let new_i64 = if float_mode {
+        // cur_raw guarda bits de f64.
+        let cur_f = ctx
+            .builder
+            .ins()
+            .bitcast(cl::F64, MemFlags::new(), cur_raw);
+        let op_f = to_f64(ctx, operand_tv);
+        let res_f = match binop {
+            BinaryOp::Add => ctx.builder.ins().fadd(cur_f, op_f),
+            BinaryOp::Sub => ctx.builder.ins().fsub(cur_f, op_f),
+            BinaryOp::Mul => ctx.builder.ins().fmul(cur_f, op_f),
+            BinaryOp::Div => ctx.builder.ins().fdiv(cur_f, op_f),
+            _ => return Ok(None),
+        };
+        ctx.builder.ins().bitcast(cl::I64, MemFlags::new(), res_f)
+    } else {
+        let op_i = ctx.coerce_to_i64(operand_tv).val;
+        match binop {
+            BinaryOp::Add => ctx.builder.ins().iadd(cur_raw, op_i),
+            BinaryOp::Sub => ctx.builder.ins().isub(cur_raw, op_i),
+            BinaryOp::Mul => ctx.builder.ins().imul(cur_raw, op_i),
+            BinaryOp::Div => {
+                // Divisao por zero em JS = Infinity/NaN; em RTS o slot eh i64.
+                // Guarda contra trap: divisor 0 -> resultado 0 (mantem caminho
+                // sem crash). Raro em arrays de inteiros.
+                let dz = ctx.builder.ins().icmp_imm(IntCC::Equal, op_i, 0);
+                let safe_div = ctx.builder.ins().select(dz, len_v, op_i); // !=0
+                let q = ctx.builder.ins().sdiv(cur_raw, safe_div);
+                ctx.builder.ins().select(dz, zero, q)
+            }
+            BinaryOp::Mod => {
+                let dz = ctx.builder.ins().icmp_imm(IntCC::Equal, op_i, 0);
+                let safe_div = ctx.builder.ins().select(dz, len_v, op_i);
+                let r = ctx.builder.ins().srem(cur_raw, safe_div);
+                ctx.builder.ins().select(dz, zero, r)
+            }
+            BinaryOp::BitAnd => ctx.builder.ins().band(cur_raw, op_i),
+            BinaryOp::BitOr => ctx.builder.ins().bor(cur_raw, op_i),
+            BinaryOp::BitXor => ctx.builder.ins().bxor(cur_raw, op_i),
+            BinaryOp::LShift => {
+                let sh = ctx.builder.ins().band_imm(op_i, 63);
+                ctx.builder.ins().ishl(cur_raw, sh)
+            }
+            BinaryOp::RShift => {
+                let sh = ctx.builder.ins().band_imm(op_i, 63);
+                ctx.builder.ins().sshr(cur_raw, sh)
+            }
+            BinaryOp::ZeroFillRShift => {
+                let sh = ctx.builder.ins().band_imm(op_i, 63);
+                ctx.builder.ins().ushr(cur_raw, sh)
+            }
+            _ => return Ok(None),
+        }
+    };
+
+    // Store de volta — so' quando in_bounds (preserva slot 0 fora de range).
+    let to_store = ctx.builder.ins().select(in_bounds, new_i64, cur_raw);
+    ctx.builder
+        .ins()
+        .store(MemFlags::trusted(), to_store, addr, 0);
+
+    if float_mode {
+        let f = ctx
+            .builder
+            .ins()
+            .bitcast(cl::F64, MemFlags::new(), new_i64);
+        Ok(Some(TypedVal::new(f, ValTy::F64)))
+    } else {
+        Ok(Some(TypedVal::new(new_i64, ValTy::I64)))
+    }
+}
+
 fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<TypedVal> {
     use swc_ecma_ast::{AssignOp, AssignTarget};
 
@@ -1059,6 +1179,68 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
         };
 
         // ─────────────────────────────────────────────────────────────────
+        // (RTS_ARRAY_INLINE) RMW nativo `arr[i] OP= x` / `arr[i] = arr[i] OP x`
+        // num array nativo (StackSlot). load; op em Cranelift IR; store. Zero
+        // call extern, zero lock. ANTES do colapso VEC_RMW (que chama extern).
+        // So' quando `arr` e' Ident registrado em native_arrays. Reusa as
+        // formas A/B e os op-codes do caminho VEC_RMW. Ver spec.
+        if let MemberProp::Computed(idx_cp) = &m.prop {
+            if let Expr::Ident(arr_id) = rmw_peel(m.obj.as_ref()) {
+                if let Some(&storage) = ctx.native_arrays.get(arr_id.sym.as_str()) {
+                    // Detecta (operand, binop) nas duas formas (igual VEC_RMW).
+                    let rmw_match: Option<(&Expr, BinaryOp)> =
+                        if !matches!(a.op, AssignOp::Assign) {
+                            if let Expr::Bin(b) = final_rhs_expr.as_ref() {
+                                Some((b.right.as_ref(), b.op))
+                            } else {
+                                None
+                            }
+                        } else if let Expr::Bin(b) = rmw_peel(a.right.as_ref()) {
+                            if let Expr::Member(lm) = rmw_peel(&b.left) {
+                                if let MemberProp::Computed(lc) = &lm.prop {
+                                    if rmw_same_array(&lm.obj, &m.obj)
+                                        && rmw_same_index(&lc.expr, &idx_cp.expr)
+                                    {
+                                        Some((b.right.as_ref(), b.op))
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+                    if let Some((operand_expr, binop)) = rmw_match {
+                        let idx_trivial = rmw_index_is_trivial(&idx_cp.expr);
+                        let operand_safe = !rmw_expr_reads_slot(
+                            operand_expr,
+                            m.obj.as_ref(),
+                            &idx_cp.expr,
+                        );
+                        if idx_trivial && operand_safe {
+                            if let Some(tv) = try_emit_native_array_rmw(
+                                ctx,
+                                storage,
+                                &idx_cp.expr,
+                                operand_expr,
+                                binop,
+                            )? {
+                                return Ok(tv);
+                            }
+                        }
+                    }
+                    // Qualquer outra forma de assign a `arr[i]` num array nativo
+                    // (incl. `arr[i] = expr` simples) cai no write fast-path
+                    // abaixo (nao no VEC_SET). Fall-through.
+                }
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────
         // (data-race fix) Atomic RMW de slot de array/objeto. Reconhece DUAS
         // formas e colapsa GET+OP+SET num único VEC_RMW/MAP_RMW_KH (um só lock
         // do shard, sem janela entre read e write) — fecha o race com
@@ -1402,6 +1584,35 @@ fn lower_assign_expr(ctx: &mut FnCtx, a: &swc_ecma_ast::AssignExpr) -> Result<Ty
                     )?;
                     return Ok(TypedVal::new(rhs_i64, ValTy::I64));
                 }
+            }
+        }
+
+        // (RTS_ARRAY_INLINE) `arr[i] = v` num array nativo (StackSlot): store
+        // direto com bounds-check, zero call extern. Para array float, guarda
+        // os BITS de f64 (simetrico com a leitura). ANTES do VEC_SET/MAP_SET.
+        if let (Expr::Ident(obj_id), MemberProp::Computed(c)) = (m.obj.as_ref(), &m.prop) {
+            if let Some(&storage) = ctx.native_arrays.get(obj_id.sym.as_str()) {
+                use cranelift_codegen::ir::types as cl;
+                let idx_tv = lower_expr(ctx, &c.expr)?;
+                let idx = ctx.coerce_to_i64(idx_tv).val;
+                let store_val = if matches!(storage.elem_ty, ValTy::F64) {
+                    if rhs_i64_is_f64_bits {
+                        // ja' carrega bits de f64 (literal float ou destino f64).
+                        rhs_i64
+                    } else {
+                        // RHS inteiro/ambiguo: converte pra f64 e guarda os bits.
+                        let f = to_f64(ctx, TypedVal::new(rhs_i64, ValTy::I64));
+                        ctx.builder.ins().bitcast(
+                            cl::I64,
+                            cranelift_codegen::ir::MemFlags::new(),
+                            f,
+                        )
+                    }
+                } else {
+                    rhs_i64
+                };
+                ctx.emit_native_array_write(storage, idx, store_val);
+                return Ok(TypedVal::new(rhs_i64, ValTy::I64));
             }
         }
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/operators.rs
@@ -1367,28 +1367,55 @@ pub(super) fn lower_bin(ctx: &mut FnCtx, bin: &BinExpr) -> Result<TypedVal> {
         BinaryOp::GtEq => Ok(lower_icmp(ctx, IntCC::SignedGreaterThanOrEqual, lhs_p, rhs_p)),
         BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd
         | BinaryOp::LShift | BinaryOp::RShift => {
-            // (#1066) JS bitops aplicam ToInt32 nos operandos. Quando
-            // promote_numeric resultou em F64 (operando >= 2^31, ex:
-            // 0xDEADBEEF), Cranelift bitops nao aceitam F64 — converte
-            // via fcvt_to_sint para I64 (ToInt32 semantics aprox.).
+            // (#1066) JS spec para &, |, ^, <<, >>: ToInt32 em cada operando,
+            // executa a op sobre int32 com sinal, e re-interpreta o resultado
+            // como int32 (wrap de 32 bits, podendo virar negativo). O RTS
+            // carrega numbers inteiros em i64, entao o caminho correto e':
+            //   1. normalizar cada operando para i64 (F64 via fcvt, I32 via
+            //      sextend, I64 passthrough);
+            //   2. ireduce I32 = ToInt32 (low 32 bits, com sinal ao operar/
+            //      sextend de volta);
+            //   3. operar em I32 nativo (ishl/sshr/band/bor/bxor);
+            //   4. sextend I64 do resultado I32 → wrap de 32 bits correto.
+            // Shifts: o count usa apenas os 5 low bits (band_imm 0x1F).
             use cranelift_codegen::ir::types as cl;
-            let (lv_i, rv_i) = if matches!(ty, ValTy::F64) {
-                let l = ctx.builder.ins().fcvt_to_sint_sat(cl::I64, lv);
-                let r = ctx.builder.ins().fcvt_to_sint_sat(cl::I64, rv);
-                (l, r)
-            } else {
-                (lv, rv)
+            // Passo 1: normaliza ambos os operandos para um Value i64.
+            let to_i64 = |ctx: &mut FnCtx, v: cranelift_codegen::ir::Value| {
+                let vt = ctx.builder.func.dfg.value_type(v);
+                if matches!(ty, ValTy::F64) {
+                    ctx.builder.ins().fcvt_to_sint_sat(cl::I64, v)
+                } else if vt == cl::I32 {
+                    ctx.builder.ins().sextend(cl::I64, v)
+                } else if vt == cl::I64 {
+                    v
+                } else {
+                    // qualquer outro tipo inteiro estreito: estende com sinal.
+                    ctx.builder.ins().sextend(cl::I64, v)
+                }
             };
-            let res_ty = if matches!(ty, ValTy::F64) { ValTy::I64 } else { ty };
-            let v = match bin.op {
-                BinaryOp::BitOr => ctx.builder.ins().bor(lv_i, rv_i),
-                BinaryOp::BitXor => ctx.builder.ins().bxor(lv_i, rv_i),
-                BinaryOp::BitAnd => ctx.builder.ins().band(lv_i, rv_i),
-                BinaryOp::LShift => ctx.builder.ins().ishl(lv_i, rv_i),
-                BinaryOp::RShift => ctx.builder.ins().sshr(lv_i, rv_i),
+            let lv64 = to_i64(ctx, lv);
+            let rv64 = to_i64(ctx, rv);
+            // Passo 2: ToInt32 = low 32 bits com sinal.
+            let l32 = ctx.builder.ins().ireduce(cl::I32, lv64);
+            let r32 = ctx.builder.ins().ireduce(cl::I32, rv64);
+            // Passo 3: opera em I32 nativo. Shifts mascaram o count com 0x1F.
+            let res32 = match bin.op {
+                BinaryOp::BitOr => ctx.builder.ins().bor(l32, r32),
+                BinaryOp::BitXor => ctx.builder.ins().bxor(l32, r32),
+                BinaryOp::BitAnd => ctx.builder.ins().band(l32, r32),
+                BinaryOp::LShift => {
+                    let cnt = ctx.builder.ins().band_imm(r32, 0x1F);
+                    ctx.builder.ins().ishl(l32, cnt)
+                }
+                BinaryOp::RShift => {
+                    let cnt = ctx.builder.ins().band_imm(r32, 0x1F);
+                    ctx.builder.ins().sshr(l32, cnt)
+                }
                 _ => unreachable!(),
             };
-            Ok(TypedVal::new(v, res_ty))
+            // Passo 4: sextend de volta para i64 (wrap de 32 bits + sinal).
+            let v = ctx.builder.ins().sextend(cl::I64, res32);
+            Ok(TypedVal::new(v, ValTy::I64))
         }
         BinaryOp::ZeroFillRShift => {
             // JS spec: ToUint32(lhs) >>> (rhs & 0x1F). Promove para i64,

--- a/crates/rts-codegen/src/codegen/lower/passes/escape.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/escape.rs
@@ -1,0 +1,594 @@
+//! Escape analysis intraprocedural para arrays locais de tamanho fixo.
+//!
+//! Habilita `RTS_ARRAY_INLINE`: arrays LOCAIS, com tamanho estatico conhecido
+//! (`new Array(N)` com N literal, ou `[lit, lit, ...]`), SEM push, e que NAO
+//! escapam — sao candidatos a viver num `StackSlot` Cranelift em vez do
+//! HandleTable. `arr[i]` vira load/store direto (zero call extern, zero lock).
+//!
+//! **Default-DENY (conservador).** Um array-var so' qualifica se TODA aparicao
+//! do seu identificador no corpo da fn estiver numa posicao segura:
+//!   - `arr[idx]`            (leitura indexada)
+//!   - `arr[idx] = ...`      (escrita indexada, LHS de assign)
+//!   - `arr[idx] OP= ...`    (RMW indexado)
+//! Qualquer outra mencao (arg de call, return, atribuicao do proprio ident,
+//! captura por arrow/fn, `.length`/`.push`/`.map`/..., spread, membro nao-
+//! computed, indice que e' o proprio array, etc.) marca o array como ESCAPADO
+//! — cai no caminho atual (VEC_NEW/GET/SET/RMW), bit-identico.
+//!
+//! GC-safety: o scanner do GC e' conservador e varre toda a stack, entao
+//! handles guardados num stack slot sao marcados automaticamente (igual a
+//! qualquer local). Tamanho fixo + sem push => nunca realoca. Nao-escapante =>
+//! nunca compartilhado entre threads (sem race async). Ver
+//! `docs/specs/native-array-storage.md`.
+
+use std::collections::{HashMap, HashSet};
+
+use swc_ecma_ast::{Expr, Lit, MemberProp, Pat, Stmt};
+
+use crate::parser::ast::Statement;
+
+/// Metadata de um array local qualificado para storage nativo (stack slot).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NativeArrayInfo {
+    /// Numero de slots (elementos) — tamanho estatico conhecido.
+    pub len: usize,
+    /// True quando o init e' um array literal comprovadamente todo-float
+    /// (`[0.0, 1.5]`). Nesse caso cada slot guarda os BITS de um f64.
+    pub elem_is_float: bool,
+}
+
+/// Resultado da analise: nome do array -> metadata. So' contem arrays que
+/// passaram em TODOS os filtros (candidato valido + nao-escapante).
+pub(crate) fn non_escaping_fixed_arrays(
+    body: &[Statement],
+) -> HashMap<String, NativeArrayInfo> {
+    // 1) Coleta candidatos: vars com init `new Array(N)` / `[lit,...]` (N
+    //    literal). Tamanho registrado. Sem este passo nada qualifica.
+    let mut candidates: HashMap<String, NativeArrayInfo> = HashMap::new();
+    for s in body {
+        let Statement::Raw(raw) = s;
+        if let Some(stmt) = raw.stmt.as_ref() {
+            collect_candidates_in_stmt(stmt, &mut candidates);
+        }
+    }
+    if candidates.is_empty() {
+        return candidates;
+    }
+
+    // 2) Escape walk: remove do conjunto qualquer candidato que apareca numa
+    //    posicao nao-segura. Default-DENY: na menor duvida, escapa.
+    let mut escaped: HashSet<String> = HashSet::new();
+    let cand_names: HashSet<String> = candidates.keys().cloned().collect();
+    for s in body {
+        let Statement::Raw(raw) = s;
+        if let Some(stmt) = raw.stmt.as_ref() {
+            walk_stmt(stmt, &cand_names, &mut escaped);
+        }
+    }
+    for name in &escaped {
+        candidates.remove(name);
+    }
+    candidates
+}
+
+/// Coleta candidatos (var-decl com init array-literal / `new Array(N)`).
+/// Tambem desce em statements aninhados (if/for/while/block) — vars declaradas
+/// la' dentro tambem qualificam (escopo de bloco; o codegen lowera no ponto).
+fn collect_candidates_in_stmt(
+    stmt: &Stmt,
+    out: &mut HashMap<String, NativeArrayInfo>,
+) {
+    use swc_ecma_ast::Stmt::*;
+    match stmt {
+        Decl(swc_ecma_ast::Decl::Var(v)) => {
+            for d in &v.decls {
+                let Pat::Ident(id) = &d.name else { continue };
+                let name = id.id.sym.to_string();
+                let Some(init) = d.init.as_deref() else { continue };
+                if let Some(info) = candidate_info(init) {
+                    // Nome duplicado (shadow em escopo diferente) — conservador:
+                    // se ja' existe, remove (ambiguo qual slot). Default-DENY.
+                    if out.contains_key(&name) {
+                        out.remove(&name);
+                    } else {
+                        out.insert(name, info);
+                    }
+                }
+            }
+        }
+        If(i) => {
+            collect_candidates_in_stmt(&i.cons, out);
+            if let Some(alt) = i.alt.as_deref() {
+                collect_candidates_in_stmt(alt, out);
+            }
+        }
+        Block(b) => {
+            for s in &b.stmts {
+                collect_candidates_in_stmt(s, out);
+            }
+        }
+        While(w) => collect_candidates_in_stmt(&w.body, out),
+        DoWhile(w) => collect_candidates_in_stmt(&w.body, out),
+        For(f) => {
+            if let Some(swc_ecma_ast::VarDeclOrExpr::VarDecl(vd)) = f.init.as_ref() {
+                for d in &vd.decls {
+                    let Pat::Ident(id) = &d.name else { continue };
+                    let name = id.id.sym.to_string();
+                    let Some(init) = d.init.as_deref() else { continue };
+                    if let Some(info) = candidate_info(init) {
+                        if out.contains_key(&name) {
+                            out.remove(&name);
+                        } else {
+                            out.insert(name, info);
+                        }
+                    }
+                }
+            }
+            collect_candidates_in_stmt(&f.body, out);
+        }
+        ForOf(f) => collect_candidates_in_stmt(&f.body, out),
+        ForIn(f) => collect_candidates_in_stmt(&f.body, out),
+        Try(t) => {
+            for s in &t.block.stmts {
+                collect_candidates_in_stmt(s, out);
+            }
+            if let Some(h) = &t.handler {
+                for s in &h.body.stmts {
+                    collect_candidates_in_stmt(s, out);
+                }
+            }
+            if let Some(f) = &t.finalizer {
+                for s in &f.stmts {
+                    collect_candidates_in_stmt(s, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Peel wrappers TS-only (`as`/`!`/`(...)`) para inspecionar o init real.
+fn peel<'a>(e: &'a Expr) -> &'a Expr {
+    match e {
+        Expr::Paren(p) => peel(&p.expr),
+        Expr::TsAs(a) => peel(&a.expr),
+        Expr::TsConstAssertion(a) => peel(&a.expr),
+        Expr::TsNonNull(a) => peel(&a.expr),
+        Expr::TsTypeAssertion(a) => peel(&a.expr),
+        Expr::TsSatisfies(a) => peel(&a.expr),
+        _ => e,
+    }
+}
+
+/// Retorna `NativeArrayInfo` se `init` for um candidato a array nativo:
+///   - `[lit, lit, ...]` — todos elementos presentes (sem holes / sem spread),
+///     tamanho = elems.len().
+///   - `new Array(N)` — N literal inteiro >= 0.
+/// Caso contrario `None` (cai no caminho atual).
+fn candidate_info(init: &Expr) -> Option<NativeArrayInfo> {
+    match peel(init) {
+        Expr::Array(arr) => {
+            // Sem holes (`[1,,3]`) nem spread — tamanho ambiguo / nao-flat.
+            let mut all_float = !arr.elems.is_empty();
+            for el in &arr.elems {
+                let Some(e) = el else { return None }; // hole
+                if e.spread.is_some() {
+                    return None;
+                }
+                if !expr_is_float_lit(&e.expr) {
+                    all_float = false;
+                }
+            }
+            Some(NativeArrayInfo {
+                len: arr.elems.len(),
+                elem_is_float: all_float,
+            })
+        }
+        Expr::New(n) => {
+            // `new Array(N)` com N literal inteiro.
+            let Expr::Ident(callee) = peel(&n.callee) else { return None };
+            if callee.sym.as_str() != "Array" {
+                return None;
+            }
+            let args = n.args.as_ref()?;
+            if args.len() != 1 {
+                return None;
+            }
+            if args[0].spread.is_some() {
+                return None;
+            }
+            if let Expr::Lit(Lit::Num(num)) = peel(&args[0].expr) {
+                let v = num.value;
+                if v.fract() == 0.0 && v >= 0.0 && v <= (u32::MAX as f64) {
+                    return Some(NativeArrayInfo {
+                        len: v as usize,
+                        elem_is_float: false,
+                    });
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// True quando `e` e' um literal float (numerico). Aceita negacao unaria de
+/// literal numerico (`-1.5`). Usado pra detectar arrays todo-float.
+fn expr_is_float_lit(e: &Expr) -> bool {
+    match peel(e) {
+        Expr::Lit(Lit::Num(_)) => true,
+        Expr::Unary(u)
+            if matches!(u.op, swc_ecma_ast::UnaryOp::Minus | swc_ecma_ast::UnaryOp::Plus) =>
+        {
+            matches!(peel(&u.arg), Expr::Lit(Lit::Num(_)))
+        }
+        _ => false,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Escape walk — default-DENY. Qualquer mencao de um candidato fora de
+// `arr[idx]` (read/write/RMW) marca como escapado.
+// ─────────────────────────────────────────────────────────────────────────
+
+fn walk_stmt(stmt: &Stmt, cands: &HashSet<String>, escaped: &mut HashSet<String>) {
+    use swc_ecma_ast::Stmt::*;
+    match stmt {
+        Expr(e) => walk_expr(&e.expr, cands, escaped),
+        Return(r) => {
+            if let Some(a) = r.arg.as_deref() {
+                walk_expr(a, cands, escaped);
+            }
+        }
+        If(i) => {
+            walk_expr(&i.test, cands, escaped);
+            walk_stmt(&i.cons, cands, escaped);
+            if let Some(alt) = i.alt.as_deref() {
+                walk_stmt(alt, cands, escaped);
+            }
+        }
+        Block(b) => {
+            for s in &b.stmts {
+                walk_stmt(s, cands, escaped);
+            }
+        }
+        While(w) => {
+            walk_expr(&w.test, cands, escaped);
+            walk_stmt(&w.body, cands, escaped);
+        }
+        DoWhile(w) => {
+            walk_expr(&w.test, cands, escaped);
+            walk_stmt(&w.body, cands, escaped);
+        }
+        For(f) => {
+            if let Some(init) = f.init.as_ref() {
+                match init {
+                    swc_ecma_ast::VarDeclOrExpr::VarDecl(vd) => {
+                        for d in &vd.decls {
+                            if let Some(e) = d.init.as_deref() {
+                                // O init de uma var-decl candidato (`[...]` /
+                                // `new Array(N)`) NAO conta como escape — eh a
+                                // alocacao. Walk so' o que NAO for a propria init.
+                                walk_decl_init(&d.name, e, cands, escaped);
+                            }
+                        }
+                    }
+                    swc_ecma_ast::VarDeclOrExpr::Expr(e) => walk_expr(e, cands, escaped),
+                }
+            }
+            if let Some(t) = f.test.as_deref() {
+                walk_expr(t, cands, escaped);
+            }
+            if let Some(u) = f.update.as_deref() {
+                walk_expr(u, cands, escaped);
+            }
+            walk_stmt(&f.body, cands, escaped);
+        }
+        ForOf(f) => {
+            // `for (const x of <arr>)` — o array no RHS escapa (iteracao
+            // chama Symbol.iterator / itera o Vec). Walk normal o marca.
+            walk_expr(&f.right, cands, escaped);
+            walk_stmt(&f.body, cands, escaped);
+        }
+        ForIn(f) => {
+            walk_expr(&f.right, cands, escaped);
+            walk_stmt(&f.body, cands, escaped);
+        }
+        Decl(swc_ecma_ast::Decl::Var(v)) => {
+            for d in &v.decls {
+                if let Some(e) = d.init.as_deref() {
+                    walk_decl_init(&d.name, e, cands, escaped);
+                }
+            }
+        }
+        Throw(t) => walk_expr(&t.arg, cands, escaped),
+        Try(t) => {
+            for s in &t.block.stmts {
+                walk_stmt(s, cands, escaped);
+            }
+            if let Some(h) = &t.handler {
+                for s in &h.body.stmts {
+                    walk_stmt(s, cands, escaped);
+                }
+            }
+            if let Some(f) = &t.finalizer {
+                for s in &f.stmts {
+                    walk_stmt(s, cands, escaped);
+                }
+            }
+        }
+        Switch(sw) => {
+            walk_expr(&sw.discriminant, cands, escaped);
+            for case in &sw.cases {
+                if let Some(t) = case.test.as_deref() {
+                    walk_expr(t, cands, escaped);
+                }
+                for s in &case.cons {
+                    walk_stmt(s, cands, escaped);
+                }
+            }
+        }
+        Labeled(l) => walk_stmt(&l.body, cands, escaped),
+        // Decl::Fn / Decl::Class etc — nested fn declarations: conservador,
+        // qualquer candidato referenciado dentro escapa. Mas declaracoes
+        // aninhadas sao raras no body (o lifter ja' as extraiu); por seguranca
+        // marcamos TODOS os candidatos como escapados se houver uma fn-decl
+        // nested que referencie algum (nao temos visibilidade barata aqui).
+        // Como o caminho seguro e' nao-inline, simplesmente nao descemos —
+        // mas qualquer USO via expr ja' foi coberto. Fn-decls nested nao
+        // expressam uso direto de var local aqui (params proprios).
+        _ => {}
+    }
+}
+
+/// Trata o init de uma var-decl. Se o `name` declarado for um candidato e o
+/// `init` for exatamente a sua alocacao (array-literal / new Array), NAO
+/// contamos como escape (eh a criacao). Mas ainda precisamos varrer os
+/// SUB-exprs do init (ex: `[foo()]` — `foo()` pode usar outro candidato).
+fn walk_decl_init(
+    name: &Pat,
+    init: &Expr,
+    cands: &HashSet<String>,
+    escaped: &mut HashSet<String>,
+) {
+    let declared_name = if let Pat::Ident(id) = name {
+        Some(id.id.sym.to_string())
+    } else {
+        None
+    };
+    // Se este decl e' a alocacao de um candidato, varre os elementos do
+    // literal (que podem mencionar OUTROS candidatos), sem marcar o proprio.
+    if let Some(dn) = &declared_name {
+        if cands.contains(dn) && candidate_info(init).is_some() {
+            // Varre sub-exprs do literal (elementos) sem tratar a alocacao
+            // como uso do proprio `dn`.
+            if let Expr::Array(arr) = peel(init) {
+                for el in arr.elems.iter().flatten() {
+                    walk_expr(&el.expr, cands, escaped);
+                }
+            }
+            if let Expr::New(n) = peel(init) {
+                if let Some(args) = &n.args {
+                    for a in args {
+                        walk_expr(&a.expr, cands, escaped);
+                    }
+                }
+            }
+            return;
+        }
+    }
+    // Caso geral: o init e' um uso normal — varre tudo.
+    walk_expr(init, cands, escaped);
+}
+
+fn walk_expr(expr: &Expr, cands: &HashSet<String>, escaped: &mut HashSet<String>) {
+    match expr {
+        // ── Acesso indexado `arr[idx]` (read) — posicao SEGURA. ──────────
+        // Se obj e' Ident candidato e prop e' Computed, o `arr` NAO escapa
+        // por esta ocorrencia. So' varremos o INDICE (que pode usar outro
+        // candidato, ou mesmo `arr` de novo — la' sim escaparia).
+        Expr::Member(m) => {
+            if let (Expr::Ident(obj_id), MemberProp::Computed(c)) =
+                (m.obj.as_ref(), &m.prop)
+            {
+                if cands.contains(obj_id.sym.as_str()) {
+                    // Indice e' uma posicao de USO — se o indice for o proprio
+                    // array (`arr[arr]`), o walk do indice o marca escapado.
+                    walk_expr(&c.expr, cands, escaped);
+                    return;
+                }
+            }
+            // Qualquer outro Member: `arr.length`, `arr.push`, `arr[idx].x`,
+            // `obj.arr`, etc. Varre obj + prop computed normalmente — uma
+            // referencia bare a `arr` em `m.obj` sera' marcada escapada.
+            walk_expr(&m.obj, cands, escaped);
+            if let MemberProp::Computed(c) = &m.prop {
+                walk_expr(&c.expr, cands, escaped);
+            }
+        }
+
+        // ── Assign — LHS `arr[idx] = ...` / `arr[idx] OP= ...` SEGURO. ────
+        Expr::Assign(a) => {
+            walk_assign(a, cands, escaped);
+        }
+
+        // ── Identificador bare — ESCAPE. ─────────────────────────────────
+        // Qualquer mencao do candidato que chegue aqui (nao filtrada pelo
+        // caso Member/Assign acima) e' uso fora de `arr[idx]` => escapa.
+        Expr::Ident(id) => {
+            if cands.contains(id.sym.as_str()) {
+                escaped.insert(id.sym.to_string());
+            }
+        }
+
+        // ── Recursao estrutural. ─────────────────────────────────────────
+        Expr::Call(c) => {
+            if let swc_ecma_ast::Callee::Expr(e) = &c.callee {
+                walk_expr(e, cands, escaped);
+            }
+            for a in &c.args {
+                walk_expr(&a.expr, cands, escaped);
+            }
+        }
+        Expr::New(n) => {
+            walk_expr(&n.callee, cands, escaped);
+            if let Some(args) = &n.args {
+                for a in args {
+                    walk_expr(&a.expr, cands, escaped);
+                }
+            }
+        }
+        Expr::Bin(b) => {
+            walk_expr(&b.left, cands, escaped);
+            walk_expr(&b.right, cands, escaped);
+        }
+        Expr::Unary(u) => walk_expr(&u.arg, cands, escaped),
+        Expr::Update(u) => walk_expr(&u.arg, cands, escaped),
+        Expr::Cond(c) => {
+            walk_expr(&c.test, cands, escaped);
+            walk_expr(&c.cons, cands, escaped);
+            walk_expr(&c.alt, cands, escaped);
+        }
+        Expr::Paren(p) => walk_expr(&p.expr, cands, escaped),
+        Expr::Seq(s) => {
+            for e in &s.exprs {
+                walk_expr(e, cands, escaped);
+            }
+        }
+        Expr::Tpl(t) => {
+            for e in &t.exprs {
+                walk_expr(e, cands, escaped);
+            }
+        }
+        Expr::TaggedTpl(t) => {
+            walk_expr(&t.tag, cands, escaped);
+            for e in &t.tpl.exprs {
+                walk_expr(e, cands, escaped);
+            }
+        }
+        Expr::Array(a) => {
+            for el in a.elems.iter().flatten() {
+                walk_expr(&el.expr, cands, escaped);
+            }
+        }
+        Expr::Object(o) => {
+            for p in &o.props {
+                match p {
+                    swc_ecma_ast::PropOrSpread::Spread(s) => {
+                        walk_expr(&s.expr, cands, escaped)
+                    }
+                    swc_ecma_ast::PropOrSpread::Prop(prop) => {
+                        if let swc_ecma_ast::Prop::KeyValue(kv) = prop.as_ref() {
+                            walk_expr(&kv.value, cands, escaped);
+                        }
+                        // Computed key tambem e' uso.
+                        if let swc_ecma_ast::Prop::KeyValue(kv) = prop.as_ref() {
+                            if let swc_ecma_ast::PropName::Computed(c) = &kv.key {
+                                walk_expr(&c.expr, cands, escaped);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Expr::Await(a) => walk_expr(&a.arg, cands, escaped),
+        Expr::Yield(y) => {
+            if let Some(a) = y.arg.as_deref() {
+                walk_expr(a, cands, escaped);
+            }
+        }
+        Expr::OptChain(o) => {
+            // `arr?.[idx]` / `arr?.x` — conservador: trata como uso (escape).
+            // O fast-path nativo nao cobre optional chain; varre a base como
+            // expressao generica (marcando bare idents).
+            match o.base.as_ref() {
+                swc_ecma_ast::OptChainBase::Member(m) => {
+                    walk_expr(&m.obj, cands, escaped);
+                    if let MemberProp::Computed(c) = &m.prop {
+                        walk_expr(&c.expr, cands, escaped);
+                    }
+                }
+                swc_ecma_ast::OptChainBase::Call(c) => {
+                    walk_expr(&c.callee, cands, escaped);
+                    for a in &c.args {
+                        walk_expr(&a.expr, cands, escaped);
+                    }
+                }
+            }
+        }
+        Expr::TsAs(a) => walk_expr(&a.expr, cands, escaped),
+        Expr::TsConstAssertion(a) => walk_expr(&a.expr, cands, escaped),
+        Expr::TsNonNull(a) => walk_expr(&a.expr, cands, escaped),
+        Expr::TsTypeAssertion(a) => walk_expr(&a.expr, cands, escaped),
+        Expr::TsSatisfies(a) => walk_expr(&a.expr, cands, escaped),
+        // Arrow / Fn expressions: qualquer candidato capturado escapa. Como
+        // nao temos o set de free-vars barato aqui, descemos no corpo e
+        // qualquer bare-ident de candidato sera' marcado escapado (correto:
+        // captura por closure = compartilhamento => escape).
+        Expr::Arrow(arrow) => {
+            match arrow.body.as_ref() {
+                swc_ecma_ast::BlockStmtOrExpr::BlockStmt(b) => {
+                    for s in &b.stmts {
+                        walk_stmt(s, cands, escaped);
+                    }
+                }
+                swc_ecma_ast::BlockStmtOrExpr::Expr(e) => walk_expr(e, cands, escaped),
+            }
+        }
+        Expr::Fn(fn_expr) => {
+            if let Some(b) = fn_expr.function.body.as_ref() {
+                for s in &b.stmts {
+                    walk_stmt(s, cands, escaped);
+                }
+            }
+        }
+        // Literais, this, super, idents nao-candidatos via outros ramos: nada.
+        _ => {}
+    }
+}
+
+/// Walk de um assignment. O LHS `arr[idx]` (Computed Member com obj Ident
+/// candidato) e' SEGURO — so' o INDICE e o RHS sao usos. Qualquer outra forma
+/// de LHS que mencione o candidato => escape (via walk generico).
+fn walk_assign(
+    a: &swc_ecma_ast::AssignExpr,
+    cands: &HashSet<String>,
+    escaped: &mut HashSet<String>,
+) {
+    use swc_ecma_ast::{AssignTarget, SimpleAssignTarget};
+    // RHS sempre e' uso.
+    // (avaliamos o LHS primeiro pra detectar a forma segura.)
+    if let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &a.left {
+        if let (Expr::Ident(obj_id), MemberProp::Computed(c)) =
+            (m.obj.as_ref(), &m.prop)
+        {
+            if cands.contains(obj_id.sym.as_str()) {
+                // `arr[idx] = rhs` ou `arr[idx] OP= rhs` — posicao segura.
+                // O proprio `arr` NAO escapa; varre indice + RHS.
+                walk_expr(&c.expr, cands, escaped);
+                walk_expr(&a.right, cands, escaped);
+                return;
+            }
+        }
+        // LHS member que nao e' `cand[idx]`: varre obj (bare ident de cand
+        // escaparia) + indice computed.
+        walk_expr(&m.obj, cands, escaped);
+        if let MemberProp::Computed(c) = &m.prop {
+            walk_expr(&c.expr, cands, escaped);
+        }
+        walk_expr(&a.right, cands, escaped);
+        return;
+    }
+    // LHS Ident (`x = ...`): se `x` for candidato, reassign => escape (o
+    // slot perderia a identidade). Conservador.
+    if let AssignTarget::Simple(SimpleAssignTarget::Ident(id)) = &a.left {
+        if cands.contains(id.id.sym.as_str()) {
+            escaped.insert(id.id.sym.to_string());
+        }
+    }
+    // LHS de destructuring / pattern: trata o RHS normal; padroes que
+    // referenciem candidatos no LHS sao raros e o walk generico do RHS cobre
+    // o uso. Por seguranca, qualquer AssignTarget::Pat marca nada extra aqui
+    // (o RHS abaixo cobre usos).
+    walk_expr(&a.right, cands, escaped);
+}

--- a/crates/rts-codegen/src/codegen/lower/passes/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/mod.rs
@@ -10,6 +10,7 @@ pub mod async_expand;
 pub mod box_captures;
 pub mod custom_iterator;
 pub mod destructuring;
+pub mod escape;
 pub mod hoist_fn;
 pub mod native_addon;
 pub mod object_methods;

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -1000,6 +1000,43 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
             }
         }
 
+        // (RTS_ARRAY_INLINE) Array nativo: a escape analysis qualificou esta
+        // var como array local nao-escapante de tamanho fixo. Em vez de
+        // VEC_NEW + declare_local(Handle), aloca um StackSlot e inicializa os
+        // slots direto. `arr[i]` (read/write/RMW) e' interceptado pelos fast
+        // paths em members.rs/mod.rs via `ctx.native_arrays`. So' fora de
+        // module_scope (top-level e' follow-up) e quando o init e' EXATAMENTE
+        // a alocacao candidata (re-checa aqui — defensivo).
+        if !ctx.module_scope {
+            if let Some(&(len, elem_is_float)) =
+                ctx.native_array_candidates.get(name.as_str())
+            {
+                if let Some(init) = decl.init.as_ref() {
+                    if try_lower_native_array_decl(ctx, &name, init, len, elem_is_float)? {
+                        // Registra um local sentinela (I64) com o nome do array
+                        // pra que `var_ty`/`find_local` nao retornem None caso
+                        // algo consulte o nome fora do fast-path (a escape
+                        // analysis garante que nao ha leitura-de-valor, mas
+                        // mantemos a invariante de que vars declaradas existem).
+                        let sentinel = ctx.builder.ins().iconst(
+                            cranelift_codegen::ir::types::I64,
+                            0,
+                        );
+                        let is_const = matches!(var_decl.kind, VarDeclKind::Const);
+                        let function_scope = matches!(var_decl.kind, VarDeclKind::Var);
+                        ctx.declare_local_kind(
+                            &name,
+                            ValTy::I64,
+                            sentinel,
+                            is_const,
+                            function_scope,
+                        );
+                        continue;
+                    }
+                }
+            }
+        }
+
         let (init_val, inferred_ty) = if let Some(init) = &decl.init {
             let tv = lower_expr(ctx, init)?;
             (tv.val, tv.ty)
@@ -1136,6 +1173,83 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         }
     }
     Ok(false)
+}
+
+/// (RTS_ARRAY_INLINE) Aloca o StackSlot do array nativo `name` e inicializa.
+/// Retorna `Ok(true)` quando tratou (init era literal/new Array reconhecido);
+/// `Ok(false)` quando o init nao casou (fall-through ao caminho atual — nao
+/// deveria acontecer pois `candidate_info` ja validou, mas defensivo).
+fn try_lower_native_array_decl(
+    ctx: &mut FnCtx,
+    name: &str,
+    init: &swc_ecma_ast::Expr,
+    len: usize,
+    elem_is_float: bool,
+) -> Result<bool> {
+    use cranelift_codegen::ir::MemFlags;
+    fn peel(e: &swc_ecma_ast::Expr) -> &swc_ecma_ast::Expr {
+        match e {
+            swc_ecma_ast::Expr::Paren(p) => peel(&p.expr),
+            swc_ecma_ast::Expr::TsAs(a) => peel(&a.expr),
+            swc_ecma_ast::Expr::TsConstAssertion(a) => peel(&a.expr),
+            swc_ecma_ast::Expr::TsNonNull(a) => peel(&a.expr),
+            swc_ecma_ast::Expr::TsTypeAssertion(a) => peel(&a.expr),
+            swc_ecma_ast::Expr::TsSatisfies(a) => peel(&a.expr),
+            _ => e,
+        }
+    }
+    let elem_ty = if elem_is_float { ValTy::F64 } else { ValTy::I64 };
+    let _slot = ctx.alloc_native_array(name, len as i64, elem_ty);
+    let storage = *ctx
+        .native_arrays
+        .get(name)
+        .ok_or_else(|| anyhow!("native array `{name}` nao registrado"))?;
+    let ptr_ty = ctx.module.isa().pointer_type();
+
+    match peel(init) {
+        swc_ecma_ast::Expr::Array(arr) => {
+            // Store cada elemento literal. Float => bits-f64. O conjunto de
+            // elementos foi validado por `candidate_info` (sem holes/spread).
+            for (i, el) in arr.elems.iter().enumerate() {
+                let Some(el) = el else { return Ok(false) };
+                let tv = lower_expr(ctx, &el.expr)?;
+                let store_val = if elem_is_float {
+                    let f = ctx.coerce_to_f64(tv).val;
+                    ctx.builder
+                        .ins()
+                        .bitcast(cl::I64, MemFlags::new(), f)
+                } else {
+                    ctx.coerce_to_i64(tv).val
+                };
+                let base = ctx.builder.ins().stack_addr(ptr_ty, storage.slot, 0);
+                let off_v = ctx.builder.ins().iconst(ptr_ty, (i * 8) as i64);
+                let addr = ctx.builder.ins().iadd(base, off_v);
+                ctx.builder
+                    .ins()
+                    .store(MemFlags::trusted(), store_val, addr, 0);
+            }
+            Ok(true)
+        }
+        swc_ecma_ast::Expr::New(_) => {
+            // `new Array(N)` — JS deixa holes (=undefined). Para a fatia
+            // numerica, zeramos os slots (0 = default lido pelo read fast path).
+            let zero = ctx.builder.ins().iconst(cl::I64, 0);
+            for i in 0..len {
+                let base = ctx.builder.ins().stack_addr(ptr_ty, storage.slot, 0);
+                let off_v = ctx.builder.ins().iconst(ptr_ty, (i * 8) as i64);
+                let addr = ctx.builder.ins().iadd(base, off_v);
+                ctx.builder
+                    .ins()
+                    .store(MemFlags::trusted(), zero, addr, 0);
+            }
+            Ok(true)
+        }
+        _ => {
+            // Init nao reconhecido — remove o registro (volta ao caminho atual).
+            ctx.native_arrays.remove(name);
+            Ok(false)
+        }
+    }
 }
 
 pub(super) fn ts_type_to_val_ty(ty: &swc_ecma_ast::TsType) -> Option<ValTy> {

--- a/docs/specs/native-array-storage.md
+++ b/docs/specs/native-array-storage.md
@@ -1,0 +1,118 @@
+# Storage nativo de array (stack-slot inline) — RTS_ARRAY_INLINE
+
+> Plano de implementação (PR-1, fatia segura). Decidido por painel de design.
+> Objetivo: eliminar o overhead de call extern + lock em `arr[i]` para arrays
+> locais não-escapantes de tamanho fixo, fechando a maior parte do gap de 6× vs
+> V8 medido em `bench/multiuser_sim.ts`.
+
+## Diagnóstico (verificado no IR real)
+
+O gap de array access (RTS 6× mais lento que Node no `multiuser_sim`) é
+~100% **overhead de chamada extern** — não o lock. Cada `arr[i]` (read/RMW) é
+uma `call __RTS_FN_NS_COLLECTIONS_VEC_*` com decode de handle + lock do shard +
+bounds. O PR #1556 já fundiu o RMW em 1 lock; o que resta é a call. A única
+forma de matar a call é **não chamar** = inline em memória.
+
+## A fatia segura: stack slot
+
+Arrays **locais, tamanho estático conhecido, sem push, não-escapantes** vão para
+um `StackSlot` Cranelift de `len*8` bytes. `arr[i]` vira `load/store
+[stack_addr + i*8]` puro. Zero call, zero lock, zero handle.
+
+**Por que é safe-by-construction (os 4 constraints caem):**
+| Constraint | Por que cai |
+|---|---|
+| realloc | tamanho fixo, sem push → nunca realoca |
+| race async | array não-escapante → nunca compartilhado entre threads |
+| deadlock GC | nenhum lock de shard; nem está no HandleTable |
+| UAF de handle no array | o scanner de GC é **conservador** e varre toda a stack (`collector/scan.rs:84-110`) → handles num stack slot são marcados automaticamente, igual a qualquer local |
+
+O caminho `Box<[i64]>` heap foi **descartado**: `trace_children`
+(handles.rs:957) não alcança buffer fora do HandleTable → UAF de handles
+internos. Só o stack slot é seguro sem um registry escaneável novo.
+
+## Plano de implementação
+
+1. **Escape analysis intraprocedural** — novo
+   `crates/rts-codegen/src/codegen/lower/passes/escape.rs`.
+   `non_escaping_local_arrays(body) -> HashSet<String>`, **default-DENY**: o
+   array escapa se aparecer em: arg de call, return, assign a target não-local,
+   captura por arrow/fn (incl. async), ou método que vaza
+   (`.map/.reduce/.forEach/.slice/.concat/.push/...`). Conservador: na dúvida,
+   escapa (fica no caminho atual).
+
+2. **Qualificação para stack slot** — `non_escaping` ∧ sem
+   `push/pop/splice/unshift` ∧ tamanho estático conhecido (`new Array(N)` com N
+   literal, ou `[lit, lit, ...]`). O padrão `for i<N { arr[i]=v }` de
+   pré-dimensionamento é follow-up (mais análise).
+
+3. **Estado no FnCtx** (`ctx.rs`, junto de `local_array_vars`):
+   `native_arrays: HashMap<String, NativeArrayStorage>` com
+   `{ slot: StackSlot, len: i64, elem_clty: cl::Type, elem_ty: ValTy }`.
+
+4. **Alocação** (`statements/decls.rs`, onde hoje faz `VEC_NEW`): se qualifica,
+   `create_sized_stack_slot(ExplicitSlot, len*8, 3)` + registra em
+   `native_arrays`, em vez de `VEC_NEW`.
+
+5. **Read inline** (`members.rs:~1827`, antes de `INDEX_GET_AUTO`): se `m.obj` é
+   Ident ∈ `native_arrays`, emite `stack_addr` + `imul_imm(idx,8)` + `iadd` +
+   `load(elem_clty, MemFlags::trusted())` com bounds-check
+   (`idx<len && idx>=0 ? load : default`). Devolve `TypedVal` com `elem_ty`
+   exato (sem ambiguidade).
+
+6. **Write inline** (`mod.rs:~1456`, ramo `arr[i]=v`): Ident ∈ `native_arrays`
+   → `store` direto.
+
+7. **RMW inline** (`mod.rs:~1063`, colapso VEC_RMW): Ident ∈ `native_arrays` →
+   `load; op; store` em registrador. **Este é o ponto que fecha o gap** (mata os
+   VEC_RMW/iteração).
+
+8. **Bounds-check**: `idx<len && idx>=0 ? acesso : default` (JS-correto). Elision
+   via range analysis é follow-up.
+
+## Gate
+
+Tudo atrás de `RTS_ARRAY_INLINE=1` (env var). Default OFF (caminho atual,
+bit-idêntico). Quando provado em produção, vira default.
+
+## Resultados medidos (v1, 2026-06-13)
+
+Micro-bench `arr[k%16] += 1` em loop de 50M (100% array access, pior caso):
+
+| | Tempo | vs OFF |
+|---|---|---|
+| RTS OFF (caminho atual) | 21548 ms | 1× |
+| **RTS ON (inline)** | **199 ms** | **108× mais rápido** |
+| Node 22 | 112 ms | — |
+
+O RTS sai de 192× mais lento que o Node para **1.8× mais lento** neste workload.
+IR confirma: com ON, o loop tem 0 calls de coleção (só `stack_addr`/`load`/
+`store`); com OFF, tem `VEC_GET`/`VEC_SET`/`VEC_RMW`.
+
+**Cobertura da v1:** só arrays LOCAIS a uma fn, tamanho literal (`new Array(N)`/
+`[...]`), não-escapantes, sem push. O `bench/multiuser_sim.ts` tem ganho mínimo
+(5085→4898ms) porque seus arrays são **top-level** — coberto no follow-up.
+
+**Segurança validada:** o race-test do #1556 com flag ON dá 4000000
+determinístico (arrays async-compartilhados escapam → caminho atom-RMW, não
+inline). Suite 1720/1720 com flag ON e OFF.
+
+## Verificação obrigatória
+
+- `target/release/rts.exe test` 1712/1712 (com flag ON e OFF).
+- Monte Carlo não regride.
+- **Stress do race-test do #1556 sob carga async** — garantir que nenhum array
+  async-compartilhado caiu no caminho nativo (a escape analysis DEVE forçá-los
+  ao caminho atual).
+- Micro-bench: `arr[i]+=1` em loop (array local fixo) com flag ON vs OFF —
+  medir o ganho real.
+- `bench/multiuser_sim.ts` — medir (o ganho aqui depende do top-level +
+  loop-init, que é follow-up; o micro-bench valida o mecanismo).
+
+## Follow-up (épico)
+
+- Top-level arrays (`__RTS_MAIN`) + tamanho-via-loop-init (`for i<N{arr[i]=v}`).
+- `Box<[i64]>` heap para tamanho dinâmico (precisa registry escaneável pelo GC).
+- Arrays com push (cap variável).
+- Escape analysis interprocedural (call-graph).
+- Bounds-check elision (range analysis).

--- a/tests/claude-int32-bitwise.test.ts
+++ b/tests/claude-int32-bitwise.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "rts:test";
+
+// Conformidade JS: bitwise/shift sobre VARIÁVEL aplicam ToInt32 (32-bit wrap
+// com sinal) no resultado, como o JS exige. Antes, `s << 13` sobre variável
+// dava resultado 64-bit em vez do int32 envolvido (literais const-folded já
+// funcionavam; o bug era só sobre operandos dinâmicos).
+//
+// Pré-computado no top-level (valores em const) — ver nota CLAUDE.md sobre GC
+// em test() closures.
+
+let s: number = 123456789;
+const shl13 = s << 13;        // 2040700928
+const shl5 = s << 5;          // -344350048 (wrap de sinal!)
+
+let big: number = 3000000000; // > 2^31
+const bigShl1 = big << 1;     // 1705032704 (ToInt32(big) primeiro)
+const bigOr0 = big | 0;       // -1294967296 (ToInt32)
+
+let x: number = 1;
+const x31 = x << 31;          // -2147483648 (bit de sinal)
+
+let neg: number = -5;
+const negShr = neg >> 1;      // -3 (arithmetic, preserva sinal)
+
+const andMask = s & 0xFFFF;   // 52501
+
+// xorshift32 — a sequência completa deve casar com o JS real.
+let seed: number = 123456789;
+function rnd(): number {
+  seed = seed ^ (seed << 13);
+  seed = seed ^ (seed >>> 17);
+  seed = seed ^ (seed << 5);
+  return (seed >>> 0) % 1000000;
+}
+const r0 = rnd(); // 967881
+const r1 = rnd(); // 813396
+const r2 = rnd(); // 77441
+
+describe("bitwise/shift int32 conformance", () => {
+  test("<< trunca para int32", () => {
+    expect(shl13).toBe(2040700928);
+  });
+  test("<< envolve para negativo (wrap de sinal)", () => {
+    expect(shl5).toBe(-344350048);
+  });
+  test("ToInt32 de operando > 2^31 antes do shift", () => {
+    expect(bigShl1).toBe(1705032704);
+  });
+  test("| 0 aplica ToInt32", () => {
+    expect(bigOr0).toBe(-1294967296);
+  });
+  test("1 << 31 = bit de sinal", () => {
+    expect(x31).toBe(-2147483648);
+  });
+  test(">> arithmetic preserva sinal de negativo", () => {
+    expect(negShr).toBe(-3);
+  });
+  test("& de valor pequeno inalterado", () => {
+    expect(andMask).toBe(52501);
+  });
+  test("xorshift32 sequência casa com JS", () => {
+    expect(r0).toBe(967881);
+    expect(r1).toBe(813396);
+    expect(r2).toBe(77441);
+  });
+});

--- a/tests/claude-native-array-inline.test.ts
+++ b/tests/claude-native-array-inline.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "rts:test";
+
+// Storage nativo de array (stack-slot inline) — corretude.
+// Sob RTS_ARRAY_INLINE=1, arrays locais de tamanho fixo, não-escapantes, viram
+// stack slot (load/store direto, sem call extern). Este teste valida que o
+// resultado é IDÊNTICO ao caminho atual (HandleTable), com ou sem a flag —
+// corretude não depende da flag. (O ganho de perf é medido em micro-bench, não
+// aqui.)
+//
+// Pré-computado no top-level (ver nota CLAUDE.md sobre GC em test closures).
+
+// Array local fixo via new Array(N) — qualifica para inline quando flag ON.
+function sumIndexed(): number {
+  const a: number[] = new Array(8);
+  for (let i = 0; i < 8; i++) a[i] = i * 10;
+  let s = 0;
+  for (let i = 0; i < 8; i++) s = s + a[i];
+  return s; // 0+10+...+70 = 280
+}
+
+// RMW inline: arr[i] += x e arr[i] = arr[i] + x.
+function rmwIndexed(): number {
+  const a: number[] = new Array(4);
+  for (let i = 0; i < 4; i++) a[i] = 0;
+  for (let k = 0; k < 1000; k++) {
+    a[k % 4] = a[k % 4] + 1;
+    a[(k + 1) % 4] += 2;
+  }
+  let s = 0;
+  for (let i = 0; i < 4; i++) s = s + a[i];
+  return s; // 1000*1 + 1000*2 = 3000
+}
+
+// Array literal fixo.
+function literalArray(): number {
+  const a: number[] = [5, 10, 15, 20];
+  return a[0] + a[1] + a[2] + a[3]; // 50
+}
+
+// OOB read → 0 (JS: undefined, coage a 0 em soma). Bounds-check correto.
+function oobRead(): number {
+  const a: number[] = new Array(3);
+  a[0] = 7;
+  a[1] = 8;
+  a[2] = 9;
+  return a[0] + a[5] + a[2]; // 7 + 0 + 9 = 16 (a[5] OOB)
+}
+
+const r1 = sumIndexed();
+const r2 = rmwIndexed();
+const r3 = literalArray();
+const r4 = oobRead();
+
+describe("native array inline (corretude, flag-independente)", () => {
+  test("array indexado fixo soma corretamente", () => {
+    expect(r1).toBe(280);
+  });
+  test("RMW inline (+= e = self +) em array local", () => {
+    expect(r2).toBe(3000);
+  });
+  test("array literal fixo", () => {
+    expect(r3).toBe(50);
+  });
+  test("leitura fora de bounds devolve 0 (bounds-check)", () => {
+    expect(r4).toBe(16);
+  });
+});


### PR DESCRIPTION
Dois trabalhos descobertos via `bench/multiuser_sim.ts` (simulação multi-usuário,
10M eventos), onde o RTS estava 6× mais lento que o Node em workload array-heavy.

## 1. fix(codegen): bitwise/shift int32 (`cb818fe5`)

Operadores `<<`, `>>`, `&`, `|`, `^` sobre **variável** não aplicavam ToInt32
(32-bit wrap com sinal) no resultado — operavam em i64. `s << 13` dava
1011358015488 em vez de 2040700928; `s << 5` não virava negativo. Literais
const-folded já funcionavam. Fix: o arm normaliza operandos, `ireduce` I32
(ToInt32), opera em I32, `sextend` I64. Descoberto porque o xorshift32 PRNG do
bench divergia do Node. Fixture `claude-int32-bitwise` (8 casos).

## 2. perf(codegen): storage nativo de array (`a7cc18f8`)

O gap de 6× era overhead de **call extern por acesso a array** (o IR provou — o
PR #1556 já fundiu o RMW em 1 lock; o que resta é a call). A única forma de matar
a call é não chamar = **inline em memória**.

Arrays locais a uma fn, tamanho literal, não-escapantes, sem push → vão para um
**StackSlot Cranelift**; `arr[i]` vira load/store direto. Atrás de
`RTS_ARRAY_INLINE=1` (default OFF = idêntico ao atual).

**Safe-by-construction:** o GC scanner é conservador e varre toda a stack, então
handles num stack slot são marcados automaticamente. Tamanho fixo (sem realloc),
não-escapante (sem race async — escape analysis default-DENY força arrays
async-compartilhados ao caminho atual), sem lock de shard (sem deadlock com GC).

### Medições (micro-bench `arr[k%16]+=1`, 50M — pior caso)
| | Tempo | vs OFF |
|---|---|---|
| RTS OFF | 21548 ms | 1× |
| **RTS ON** | **199 ms** | **108× mais rápido** |
| Node 22 | 112 ms | — |

RTS sai de 192× mais lento para **1.8× mais lento** que o Node. IR: 0 calls de
coleção no loop com ON.

### Segurança validada
- Race-test do #1556 com flag ON = **4000000 determinístico** (arrays
  async-compartilhados escapam → não inline, sem reintroduzir o race).
- Array passado a fn não inlina (escape analysis funciona).
- Suite **1720/1720 com flag ON E OFF**. Monte Carlo intocado. Corretude ON==OFF.

### Cobertura v1 (honesto)
Só arrays locais a fn. Top-level (caso do `multiuser_sim`, ganho mínimo
5085→4898ms), `Box<[]>` heap, push, escape interprocedural, bounds-elision =
follow-up documentado em `docs/specs/native-array-storage.md`.

Suite final: **1720/1720** (1712 + int32 fixture + array fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)