### PR TITLE
perf(codegen): array inline — tamanho via const + arrays top-level

### DIFF
--- a/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
@@ -217,6 +217,34 @@ pub(crate) fn compile_main(
             }
         }
 
+        // (RTS_ARRAY_INLINE — top-level) Escape analysis sobre os statements
+        // TOP-LEVEL (__RTS_MAIN). Arrays locais ao modulo, nao-escapantes, de
+        // tamanho fixo (`new Array(N)` / `new Array(CONST)` / `[lit,...]`)
+        // qualificam pra StackSlot nativo — IGUAL a user fns, agora cobrindo o
+        // escopo do modulo. Gate por env; OFF = caminho atual bit-identico.
+        //
+        // SEGURANCA (impede o race do #1556): so' inlina arrays que NAO sao
+        // globais. Um array top-level referenciado de DENTRO de qualquer user
+        // fn / class method foi promovido a GLOBAL (data segment) por
+        // `collect_module_globals` — `fn_ctx.has_global(name)` e' true. Esses
+        // sao filtrados aqui e NUNCA viram nativo (continuam no caminho VEC/
+        // global com atom-RMW). Arrays compartilhados entre async fns sempre
+        // caem nesse caso (sao referenciados de dentro da fn => globais). O
+        // decl-site (decls.rs) re-checa `!has_global` antes de alocar o slot.
+        if std::env::var("RTS_ARRAY_INLINE").as_deref() == Ok("1") {
+            let cands =
+                crate::codegen::lower::passes::escape::non_escaping_fixed_arrays_from_stmts(stmts);
+            for (name, info) in cands {
+                // Default-DENY: array compartilhado cross-fn (global) escapa.
+                if fn_ctx.has_global(&name) {
+                    continue;
+                }
+                fn_ctx
+                    .native_array_candidates
+                    .insert(name, (info.len, info.elem_is_float));
+            }
+        }
+
         for stmt in stmts {
             match lower_stmt(&mut fn_ctx, stmt) {
                 Ok(_) => {}

--- a/crates/rts-codegen/src/codegen/lower/passes/escape.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/escape.rs
@@ -37,19 +37,52 @@ pub(crate) struct NativeArrayInfo {
     pub elem_is_float: bool,
 }
 
-/// Resultado da analise: nome do array -> metadata. So' contem arrays que
-/// passaram em TODOS os filtros (candidato valido + nao-escapante).
+/// Resultado da analise (entrada para user fns — `&[Statement]` wrapper Raw):
+/// nome do array -> metadata. So' contem arrays que passaram em TODOS os
+/// filtros (candidato valido + nao-escapante).
 pub(crate) fn non_escaping_fixed_arrays(
     body: &[Statement],
 ) -> HashMap<String, NativeArrayInfo> {
+    // Destrincha o wrapper `Statement::Raw` em `&Stmt` cru e delega ao nucleo
+    // comum (que tambem serve o top-level / __RTS_MAIN).
+    let stmts: Vec<&Stmt> = body
+        .iter()
+        .filter_map(|s| {
+            let Statement::Raw(raw) = s;
+            raw.stmt.as_ref()
+        })
+        .collect();
+    non_escaping_fixed_arrays_from_stmts(&stmts)
+}
+
+/// Resultado da analise (entrada para o top-level / __RTS_MAIN — `&[&Stmt]`
+/// cru do SWC, sem o wrapper `Statement::Raw`). Mesmo nucleo da entrada de
+/// user fns.
+///
+/// NOTA DE SEGURANCA (top-level): a escape analysis aqui so' enxerga os
+/// statements TOP-LEVEL. Arrays referenciados de DENTRO de uma user fn / class
+/// method NAO aparecem neste walk (corpos de fn sao `Item::Function`, fora de
+/// `stmts`), entao a escape walk sozinha NAO os marcaria. Esses arrays ja' sao
+/// promovidos a GLOBAL (data segment) por `collect_module_globals` justamente
+/// por serem referenciados cross-fn; o decl-site (`decls.rs`) so' aplica o
+/// caminho nativo quando `!ctx.has_global(name)`, e `compile_main` filtra os
+/// globais ANTES de popular `native_array_candidates`. Resultado: um array
+/// top-level compartilhado com qualquer fn (incl. async) NUNCA inlina —
+/// continua no caminho VEC/global, preservando o atom-RMW que impede o race
+/// do #1556. Ver `docs/specs/native-array-storage.md`.
+pub(crate) fn non_escaping_fixed_arrays_from_stmts(
+    stmts: &[&Stmt],
+) -> HashMap<String, NativeArrayInfo> {
+    // 0) Const-propagation: coleta `const NAME = <int literal>` (>= 0) no MESMO
+    //    body. So' `const` (imutavel por definicao) com init literal inteiro.
+    //    Permite `const N = 5000; new Array(N)` qualificar como `new Array(5000)`.
+    let consts = collect_const_ints(stmts);
+
     // 1) Coleta candidatos: vars com init `new Array(N)` / `[lit,...]` (N
-    //    literal). Tamanho registrado. Sem este passo nada qualifica.
+    //    literal OU const-int conhecida). Sem este passo nada qualifica.
     let mut candidates: HashMap<String, NativeArrayInfo> = HashMap::new();
-    for s in body {
-        let Statement::Raw(raw) = s;
-        if let Some(stmt) = raw.stmt.as_ref() {
-            collect_candidates_in_stmt(stmt, &mut candidates);
-        }
+    for stmt in stmts {
+        collect_candidates_in_stmt(stmt, &consts, &mut candidates);
     }
     if candidates.is_empty() {
         return candidates;
@@ -59,11 +92,8 @@ pub(crate) fn non_escaping_fixed_arrays(
     //    posicao nao-segura. Default-DENY: na menor duvida, escapa.
     let mut escaped: HashSet<String> = HashSet::new();
     let cand_names: HashSet<String> = candidates.keys().cloned().collect();
-    for s in body {
-        let Statement::Raw(raw) = s;
-        if let Some(stmt) = raw.stmt.as_ref() {
-            walk_stmt(stmt, &cand_names, &mut escaped);
-        }
+    for stmt in stmts {
+        walk_stmt(stmt, &cand_names, &mut escaped);
     }
     for name in &escaped {
         candidates.remove(name);
@@ -71,11 +101,136 @@ pub(crate) fn non_escaping_fixed_arrays(
     candidates
 }
 
+/// Coleta `const NAME = <int literal>` (inteiro >= 0, cabe em u32) declarado em
+/// QUALQUER nivel do body (top-level do escopo + aninhado em blocos/if/for).
+/// CONSERVADOR (default-DENY):
+///   - So' `VarDeclKind::Const` (imutavel — nunca reatribuido).
+///   - So' init `Lit::Num` inteiro, >= 0, <= u32::MAX (mesmo limite de tamanho
+///     que `candidate_info` aceita para `new Array(N)`).
+///   - Se o MESMO nome aparece em DOIS `const` com valores diferentes (shadow
+///     em escopos distintos => ambiguo), remove do mapa (nao resolve).
+/// Esse mapa so' habilita a resolucao de `new Array(NAME)`; um `let`/`var` ou
+/// uma const com init nao-literal NAO entra, mantendo o default-DENY.
+fn collect_const_ints(stmts: &[&Stmt]) -> HashMap<String, usize> {
+    let mut out: HashMap<String, usize> = HashMap::new();
+    let mut ambiguous: HashSet<String> = HashSet::new();
+    for stmt in stmts {
+        collect_const_ints_in_stmt(stmt, &mut out, &mut ambiguous);
+    }
+    for name in &ambiguous {
+        out.remove(name);
+    }
+    out
+}
+
+fn collect_const_ints_in_stmt(
+    stmt: &Stmt,
+    out: &mut HashMap<String, usize>,
+    ambiguous: &mut HashSet<String>,
+) {
+    use swc_ecma_ast::Stmt::*;
+    match stmt {
+        Decl(swc_ecma_ast::Decl::Var(v)) => {
+            if !matches!(v.kind, swc_ecma_ast::VarDeclKind::Const) {
+                return;
+            }
+            for d in &v.decls {
+                let Pat::Ident(id) = &d.name else { continue };
+                let name = id.id.sym.to_string();
+                let Some(init) = d.init.as_deref() else { continue };
+                if let swc_ecma_ast::Expr::Lit(Lit::Num(num)) = peel(init) {
+                    let val = num.value;
+                    if val.fract() == 0.0 && val >= 0.0 && val <= (u32::MAX as f64) {
+                        let usize_val = val as usize;
+                        match out.get(&name) {
+                            Some(&prev) if prev != usize_val => {
+                                ambiguous.insert(name);
+                            }
+                            _ => {
+                                out.insert(name, usize_val);
+                            }
+                        }
+                        continue;
+                    }
+                }
+                // const com init nao-literal-int: ambiguo (poderia ser usado
+                // como tamanho mas nao sabemos o valor). Marca para nao resolver.
+                ambiguous.insert(name);
+            }
+        }
+        If(i) => {
+            collect_const_ints_in_stmt(&i.cons, out, ambiguous);
+            if let Some(alt) = i.alt.as_deref() {
+                collect_const_ints_in_stmt(alt, out, ambiguous);
+            }
+        }
+        Block(b) => {
+            for s in &b.stmts {
+                collect_const_ints_in_stmt(s, out, ambiguous);
+            }
+        }
+        While(w) => collect_const_ints_in_stmt(&w.body, out, ambiguous),
+        DoWhile(w) => collect_const_ints_in_stmt(&w.body, out, ambiguous),
+        For(f) => {
+            if let Some(swc_ecma_ast::VarDeclOrExpr::VarDecl(vd)) = f.init.as_ref() {
+                if matches!(vd.kind, swc_ecma_ast::VarDeclKind::Const) {
+                    for d in &vd.decls {
+                        let Pat::Ident(id) = &d.name else { continue };
+                        let name = id.id.sym.to_string();
+                        if let Some(init) = d.init.as_deref() {
+                            if let swc_ecma_ast::Expr::Lit(Lit::Num(num)) = peel(init) {
+                                let val = num.value;
+                                if val.fract() == 0.0
+                                    && val >= 0.0
+                                    && val <= (u32::MAX as f64)
+                                {
+                                    let usize_val = val as usize;
+                                    match out.get(&name) {
+                                        Some(&prev) if prev != usize_val => {
+                                            ambiguous.insert(name);
+                                        }
+                                        _ => {
+                                            out.insert(name, usize_val);
+                                        }
+                                    }
+                                    continue;
+                                }
+                            }
+                            ambiguous.insert(name);
+                        }
+                    }
+                }
+            }
+            collect_const_ints_in_stmt(&f.body, out, ambiguous);
+        }
+        ForOf(f) => collect_const_ints_in_stmt(&f.body, out, ambiguous),
+        ForIn(f) => collect_const_ints_in_stmt(&f.body, out, ambiguous),
+        Try(t) => {
+            for s in &t.block.stmts {
+                collect_const_ints_in_stmt(s, out, ambiguous);
+            }
+            if let Some(h) = &t.handler {
+                for s in &h.body.stmts {
+                    collect_const_ints_in_stmt(s, out, ambiguous);
+                }
+            }
+            if let Some(f) = &t.finalizer {
+                for s in &f.stmts {
+                    collect_const_ints_in_stmt(s, out, ambiguous);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Coleta candidatos (var-decl com init array-literal / `new Array(N)`).
 /// Tambem desce em statements aninhados (if/for/while/block) — vars declaradas
 /// la' dentro tambem qualificam (escopo de bloco; o codegen lowera no ponto).
+/// `consts` resolve `new Array(NAME)` quando NAME e' uma const-int conhecida.
 fn collect_candidates_in_stmt(
     stmt: &Stmt,
+    consts: &HashMap<String, usize>,
     out: &mut HashMap<String, NativeArrayInfo>,
 ) {
     use swc_ecma_ast::Stmt::*;
@@ -85,7 +240,7 @@ fn collect_candidates_in_stmt(
                 let Pat::Ident(id) = &d.name else { continue };
                 let name = id.id.sym.to_string();
                 let Some(init) = d.init.as_deref() else { continue };
-                if let Some(info) = candidate_info(init) {
+                if let Some(info) = candidate_info(init, consts) {
                     // Nome duplicado (shadow em escopo diferente) — conservador:
                     // se ja' existe, remove (ambiguo qual slot). Default-DENY.
                     if out.contains_key(&name) {
@@ -97,25 +252,25 @@ fn collect_candidates_in_stmt(
             }
         }
         If(i) => {
-            collect_candidates_in_stmt(&i.cons, out);
+            collect_candidates_in_stmt(&i.cons, consts, out);
             if let Some(alt) = i.alt.as_deref() {
-                collect_candidates_in_stmt(alt, out);
+                collect_candidates_in_stmt(alt, consts, out);
             }
         }
         Block(b) => {
             for s in &b.stmts {
-                collect_candidates_in_stmt(s, out);
+                collect_candidates_in_stmt(s, consts, out);
             }
         }
-        While(w) => collect_candidates_in_stmt(&w.body, out),
-        DoWhile(w) => collect_candidates_in_stmt(&w.body, out),
+        While(w) => collect_candidates_in_stmt(&w.body, consts, out),
+        DoWhile(w) => collect_candidates_in_stmt(&w.body, consts, out),
         For(f) => {
             if let Some(swc_ecma_ast::VarDeclOrExpr::VarDecl(vd)) = f.init.as_ref() {
                 for d in &vd.decls {
                     let Pat::Ident(id) = &d.name else { continue };
                     let name = id.id.sym.to_string();
                     let Some(init) = d.init.as_deref() else { continue };
-                    if let Some(info) = candidate_info(init) {
+                    if let Some(info) = candidate_info(init, consts) {
                         if out.contains_key(&name) {
                             out.remove(&name);
                         } else {
@@ -124,22 +279,22 @@ fn collect_candidates_in_stmt(
                     }
                 }
             }
-            collect_candidates_in_stmt(&f.body, out);
+            collect_candidates_in_stmt(&f.body, consts, out);
         }
-        ForOf(f) => collect_candidates_in_stmt(&f.body, out),
-        ForIn(f) => collect_candidates_in_stmt(&f.body, out),
+        ForOf(f) => collect_candidates_in_stmt(&f.body, consts, out),
+        ForIn(f) => collect_candidates_in_stmt(&f.body, consts, out),
         Try(t) => {
             for s in &t.block.stmts {
-                collect_candidates_in_stmt(s, out);
+                collect_candidates_in_stmt(s, consts, out);
             }
             if let Some(h) = &t.handler {
                 for s in &h.body.stmts {
-                    collect_candidates_in_stmt(s, out);
+                    collect_candidates_in_stmt(s, consts, out);
                 }
             }
             if let Some(f) = &t.finalizer {
                 for s in &f.stmts {
-                    collect_candidates_in_stmt(s, out);
+                    collect_candidates_in_stmt(s, consts, out);
                 }
             }
         }
@@ -163,17 +318,40 @@ fn peel<'a>(e: &'a Expr) -> &'a Expr {
 /// Retorna `NativeArrayInfo` se `init` for um candidato a array nativo:
 ///   - `[lit, lit, ...]` — todos elementos presentes (sem holes / sem spread),
 ///     tamanho = elems.len().
-///   - `new Array(N)` — N literal inteiro >= 0.
+///   - `new Array(N)` — N literal inteiro >= 0, OU `new Array(NAME)` onde NAME
+///     e' uma const-int conhecida (`consts`).
 /// Caso contrario `None` (cai no caminho atual).
-fn candidate_info(init: &Expr) -> Option<NativeArrayInfo> {
+fn candidate_info(init: &Expr, consts: &HashMap<String, usize>) -> Option<NativeArrayInfo> {
     match peel(init) {
         Expr::Array(arr) => {
+            // Array literal VAZIO (`[]`) NAO qualifica: e' o padrao "cria e
+            // cresce por indice" (`const a = []; a[i] = v` num loop, i ate' N).
+            // Um slot de tamanho 0 faria todas as escritas saírem dos bounds
+            // (no-op) e as leituras devolverem o default (0) — corrompendo o
+            // resultado (visto em bench/multiuser_sim.ts: sum_balances=0). So'
+            // arrays literais NAO-vazios tem tamanho fixo confiavel; o padrao de
+            // crescimento cai no caminho VEC (que realoca corretamente).
+            if arr.elems.is_empty() {
+                return None;
+            }
             // Sem holes (`[1,,3]`) nem spread — tamanho ambiguo / nao-flat.
-            let mut all_float = !arr.elems.is_empty();
+            // TODOS os elementos precisam ser LITERAIS NUMERICOS (int ou float).
+            // Um literal de string (`["a","b"]`) guarda HANDLES de string; o
+            // storage nativo os armazena como i64 cru e a leitura devolve um
+            // TypedVal I64/F64 fixo — perdendo a tag ambigua que o caminho VEC
+            // carrega, o que quebra o dispatch de `+` (concat vs soma) e, pior,
+            // corrompe leituras cruzadas entre arrays (visto em
+            // array_str_index_concat.test.ts: `xs[0]` lia o slot de outro
+            // array). So' arrays numericos sao seguros pro fast-path; arrays de
+            // string/bool/misto caem no caminho VEC (com tag ambigua correta).
+            let mut all_float = true;
             for el in &arr.elems {
                 let Some(e) = el else { return None }; // hole
                 if e.spread.is_some() {
                     return None;
+                }
+                if !expr_is_numeric_lit(&e.expr) {
+                    return None; // elemento nao-numerico => nao qualifica.
                 }
                 if !expr_is_float_lit(&e.expr) {
                     all_float = false;
@@ -185,7 +363,7 @@ fn candidate_info(init: &Expr) -> Option<NativeArrayInfo> {
             })
         }
         Expr::New(n) => {
-            // `new Array(N)` com N literal inteiro.
+            // `new Array(N)` com N literal inteiro OU const-int conhecida.
             let Expr::Ident(callee) = peel(&n.callee) else { return None };
             if callee.sym.as_str() != "Array" {
                 return None;
@@ -197,18 +375,74 @@ fn candidate_info(init: &Expr) -> Option<NativeArrayInfo> {
             if args[0].spread.is_some() {
                 return None;
             }
-            if let Expr::Lit(Lit::Num(num)) = peel(&args[0].expr) {
-                let v = num.value;
-                if v.fract() == 0.0 && v >= 0.0 && v <= (u32::MAX as f64) {
-                    return Some(NativeArrayInfo {
-                        len: v as usize,
-                        elem_is_float: false,
-                    });
+            match peel(&args[0].expr) {
+                Expr::Lit(Lit::Num(num)) => {
+                    let v = num.value;
+                    if v.fract() == 0.0 && v >= 0.0 && v <= (u32::MAX as f64) {
+                        return Some(NativeArrayInfo {
+                            len: v as usize,
+                            elem_is_float: false,
+                        });
+                    }
+                    None
                 }
+                // `new Array(NAME)` — NAME e' uma const-int inequivoca no MESMO
+                // body (const, init literal int, nao-reatribuida). Const-propaga
+                // o valor. Se NAME nao esta no mapa, default-DENY (None).
+                Expr::Ident(id) => consts.get(id.sym.as_str()).map(|&len| NativeArrayInfo {
+                    len,
+                    elem_is_float: false,
+                }),
+                _ => None,
             }
-            None
         }
         _ => None,
+    }
+}
+
+/// True quando `idx` (a expressao do indice em `arr[idx]`) e' plausivelmente um
+/// INTEIRO — i.e. o fast-path nativo pode tratar como offset numerico. Rejeita
+/// (=> escape, caminho VEC) chaves que poderiam ser nao-inteiras:
+///   - `Member` (`arr[Symbol.iterator]`, `arr[obj.k]`) — chave simbolo/string;
+///   - `Lit::Str` (`arr["len"]`) — chave string;
+///   - `Tpl` (`arr[`${k}`]`) — chave string;
+///   - `Call`/`New` — pode devolver Symbol/string (`arr[Symbol()]`).
+/// Aceita (inteiro-seguro): literal numerico, ident (var de loop), binario
+/// aritmetico, unario, paren, ternario com ambos ramos seguros, `as`/`!`. O
+/// fast-path ja' faz bounds-check JS-correto sobre o valor inteiro resolvido.
+///
+/// CONSERVADOR: na duvida estrutural, `false` (escape). So' precisamos garantir
+/// que NENHUMA chave nao-inteira chegue ao fast-path (que leria um slot errado /
+/// garbage) — visto em array_symbol_iterator.test.ts (`a[Symbol.iterator]`).
+fn index_is_integer_safe(idx: &Expr) -> bool {
+    match peel(idx) {
+        Expr::Lit(Lit::Num(_)) => true,
+        Expr::Lit(_) => false, // string/bool/null/regex/bigint key.
+        Expr::Ident(_) => true, // var de loop (i, j, u, ...).
+        Expr::Bin(b) => index_is_integer_safe(&b.left) && index_is_integer_safe(&b.right),
+        Expr::Unary(u) => index_is_integer_safe(&u.arg),
+        Expr::Paren(p) => index_is_integer_safe(&p.expr),
+        Expr::Cond(c) => index_is_integer_safe(&c.cons) && index_is_integer_safe(&c.alt),
+        // Member / Call / New / Tpl / Object / Array / Arrow / etc. => chave
+        // potencialmente nao-inteira (Symbol/string) => escape.
+        _ => false,
+    }
+}
+
+/// True quando `e` e' um LITERAL NUMERICO (int ou float — swc representa todo
+/// number JS como `Lit::Num`). Aceita negacao/positivacao unaria de literal
+/// (`-1.5`, `+3`). Rejeita string/bool/null/expressoes. Usado para garantir
+/// que um array literal so' qualifica pro storage nativo quando TODOS os
+/// elementos sao numeros (handles de string nao podem virar i64 cru).
+fn expr_is_numeric_lit(e: &Expr) -> bool {
+    match peel(e) {
+        Expr::Lit(Lit::Num(_)) => true,
+        Expr::Unary(u)
+            if matches!(u.op, swc_ecma_ast::UnaryOp::Minus | swc_ecma_ast::UnaryOp::Plus) =>
+        {
+            matches!(peel(&u.arg), Expr::Lit(Lit::Num(_)))
+        }
+        _ => false,
     }
 }
 
@@ -341,6 +575,22 @@ fn walk_stmt(stmt: &Stmt, cands: &HashSet<String>, escaped: &mut HashSet<String>
     }
 }
 
+/// True quando `init` tem a FORMA estrutural de uma alocacao de array
+/// (`[...]` ou `new Array(...)`), independente do tamanho ser literal/const.
+/// Usado por `walk_decl_init` so' para distinguir "este decl e' a alocacao do
+/// candidato" de "uso normal" — nao re-valida tamanho (ja' validado em
+/// `candidate_info` quando o nome entrou em `cands`).
+fn is_array_alloc_form(init: &Expr) -> bool {
+    match peel(init) {
+        Expr::Array(_) => true,
+        Expr::New(n) => matches!(
+            peel(&n.callee),
+            Expr::Ident(callee) if callee.sym.as_str() == "Array"
+        ),
+        _ => false,
+    }
+}
+
 /// Trata o init de uma var-decl. Se o `name` declarado for um candidato e o
 /// `init` for exatamente a sua alocacao (array-literal / new Array), NAO
 /// contamos como escape (eh a criacao). Mas ainda precisamos varrer os
@@ -358,8 +608,11 @@ fn walk_decl_init(
     };
     // Se este decl e' a alocacao de um candidato, varre os elementos do
     // literal (que podem mencionar OUTROS candidatos), sem marcar o proprio.
+    // Usa `is_array_alloc_form` (estrutural, sem depender de consts): basta o
+    // init ser `[...]` ou `new Array(...)` — o `dn` so' esta em `cands` se ja'
+    // qualificou, entao a forma e' a sua alocacao.
     if let Some(dn) = &declared_name {
-        if cands.contains(dn) && candidate_info(init).is_some() {
+        if cands.contains(dn) && is_array_alloc_form(init) {
             // Varre sub-exprs do literal (elementos) sem tratar a alocacao
             // como uso do proprio `dn`.
             if let Expr::Array(arr) = peel(init) {
@@ -391,12 +644,17 @@ fn walk_expr(expr: &Expr, cands: &HashSet<String>, escaped: &mut HashSet<String>
             if let (Expr::Ident(obj_id), MemberProp::Computed(c)) =
                 (m.obj.as_ref(), &m.prop)
             {
-                if cands.contains(obj_id.sym.as_str()) {
+                if cands.contains(obj_id.sym.as_str()) && index_is_integer_safe(&c.expr) {
                     // Indice e' uma posicao de USO — se o indice for o proprio
                     // array (`arr[arr]`), o walk do indice o marca escapado.
                     walk_expr(&c.expr, cands, escaped);
                     return;
                 }
+                // Se o indice NAO e' inteiro-seguro (`arr[Symbol.iterator]`,
+                // `arr["key"]`, etc.), NAO e' um acesso indexado do fast-path:
+                // cai no walk generico abaixo, que varre `m.obj` como bare
+                // Ident => marca o array escapado (correto: precisa do caminho
+                // VEC que conhece chaves nao-inteiras).
             }
             // Qualquer outro Member: `arr.length`, `arr.push`, `arr[idx].x`,
             // `obj.arr`, etc. Varre obj + prop computed normalmente — uma
@@ -562,13 +820,15 @@ fn walk_assign(
         if let (Expr::Ident(obj_id), MemberProp::Computed(c)) =
             (m.obj.as_ref(), &m.prop)
         {
-            if cands.contains(obj_id.sym.as_str()) {
+            if cands.contains(obj_id.sym.as_str()) && index_is_integer_safe(&c.expr) {
                 // `arr[idx] = rhs` ou `arr[idx] OP= rhs` — posicao segura.
                 // O proprio `arr` NAO escapa; varre indice + RHS.
                 walk_expr(&c.expr, cands, escaped);
                 walk_expr(&a.right, cands, escaped);
                 return;
             }
+            // Indice nao inteiro-seguro no LHS (`arr[Symbol.x] = v`): cai no
+            // walk generico abaixo => o array escapa (caminho VEC).
         }
         // LHS member que nao e' `cand[idx]`: varre obj (bare ident de cand
         // escaparia) + indice computed.

--- a/crates/rts-codegen/src/codegen/lower/statements/decls.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/decls.rs
@@ -1004,10 +1004,16 @@ pub(super) fn lower_var_decl(ctx: &mut FnCtx, var_decl: &VarDecl) -> Result<bool
         // var como array local nao-escapante de tamanho fixo. Em vez de
         // VEC_NEW + declare_local(Handle), aloca um StackSlot e inicializa os
         // slots direto. `arr[i]` (read/write/RMW) e' interceptado pelos fast
-        // paths em members.rs/mod.rs via `ctx.native_arrays`. So' fora de
-        // module_scope (top-level e' follow-up) e quando o init e' EXATAMENTE
-        // a alocacao candidata (re-checa aqui — defensivo).
-        if !ctx.module_scope {
+        // paths em members.rs/mod.rs via `ctx.native_arrays`. Cobre tanto user
+        // fns quanto top-level (__RTS_MAIN, module_scope) — mas em module_scope
+        // SO' quando a var NAO e' global: um array top-level referenciado por
+        // qualquer user fn vira global (data segment) e DEVE permanecer no
+        // caminho VEC/global (atom-RMW), nunca num StackSlot local a __RTS_MAIN
+        // (invisivel a outras fns + reintroduziria o race do #1556). O
+        // `compile_main` ja' filtra globais antes de popular os candidatos;
+        // re-checamos `has_global` aqui defensivamente.
+        let native_ok = !ctx.module_scope || !ctx.has_global(name.as_str());
+        if native_ok {
             if let Some(&(len, elem_is_float)) =
                 ctx.native_array_candidates.get(name.as_str())
             {

--- a/docs/specs/native-array-storage.md
+++ b/docs/specs/native-array-storage.md
@@ -90,8 +90,35 @@ IR confirma: com ON, o loop tem 0 calls de coleção (só `stack_addr`/`load`/
 `store`); com OFF, tem `VEC_GET`/`VEC_SET`/`VEC_RMW`.
 
 **Cobertura da v1:** só arrays LOCAIS a uma fn, tamanho literal (`new Array(N)`/
-`[...]`), não-escapantes, sem push. O `bench/multiuser_sim.ts` tem ganho mínimo
-(5085→4898ms) porque seus arrays são **top-level** — coberto no follow-up.
+`[...]`), não-escapantes, sem push.
+
+## v2 (2026-06-13): const-size + top-level
+
+Duas restrições da v1 removidas:
+- **Tamanho via const:** `const N = 5000; new Array(N)` agora qualifica
+  (const-propagation de `const NAME = <int literal>` no mesmo body). Antes só
+  literal cru `new Array(5000)`.
+- **Arrays top-level (`__RTS_MAIN`):** a escape analysis agora roda no top-level
+  também, filtrando `has_global` (array referenciado de dentro de qualquer user
+  fn vira global → não inlina, fica no caminho atual).
+
+Medições v2:
+- `mu_local` (const-size, array local): OFF 998ms → ON 439ms (**2.3×**).
+- `mu_real2` (top-level pré-dimensionado, sem user-fn no loop): OFF 392ms → ON
+  173ms (**2.3×**), 5004 stack_addr no `__RTS_MAIN`.
+
+**3 bugs de corretude corrigidos** (a expansão os expôs; a análise ficou MAIS
+conservadora): (A) literal vazio `[]` (padrão grow) não qualifica — inliná-lo
+corrompia escritas além do tamanho; (B) literal só qualifica se TODOS os
+elementos forem literais NUMÉRICOS (string/handle perdia a tag ambígua); (C)
+índice não-inteiro (`a[Symbol.iterator]`) força escape.
+
+**Limite descoberto (v2):** arrays `const x = []` + grow (`x[i]=v` além do
+tamanho — o padrão do `bench/multiuser_sim.ts` original) corretamente NÃO inlinam
+(precisaria de tamanho conhecido). E quando o loop chama uma user-fn por
+iteração (ex. `rnd()`), o gargalo migra do array para o **overhead de call de
+user-fn + acesso a global** — outro eixo, fora deste fix (ver issue de
+seguimento).
 
 **Segurança validada:** o race-test do #1556 com flag ON dá 4000000
 determinístico (arrays async-compartilhados escapam → caminho atom-RMW, não

--- a/tests/claude-native-array-expand.test.ts
+++ b/tests/claude-native-array-expand.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "rts:test";
+
+// Expansão do storage nativo de array: tamanho via const + arrays top-level.
+// Corretude flag-independente (ON==OFF). O ganho de perf é medido em bench.
+
+// const-size: new Array(CONST) onde CONST é const-int → qualifica.
+const N = 8;
+function constSized(): number {
+  const a: number[] = new Array(N);
+  for (let i = 0; i < N; i++) a[i] = i + 1;
+  let s = 0;
+  for (let i = 0; i < N; i++) s = s + a[i];
+  return s; // 1+2+...+8 = 36
+}
+
+// const-size com RMW.
+function constRmw(): number {
+  const SIZE = 4;
+  const a: number[] = new Array(SIZE);
+  for (let i = 0; i < SIZE; i++) a[i] = 0;
+  for (let k = 0; k < 100; k++) a[k % SIZE] += 1;
+  return a[0] + a[1] + a[2] + a[3]; // 100
+}
+
+const r1 = constSized();
+const r2 = constRmw();
+
+describe("native array expand (const-size + top-level)", () => {
+  test("new Array(CONST) qualifica", () => {
+    expect(r1).toBe(36);
+  });
+  test("RMW em array const-dimensionado", () => {
+    expect(r2).toBe(100);
+  });
+});


### PR DESCRIPTION
Expande o storage nativo de array (PR #1558) removendo duas restrições que o
impediam de disparar em código realista.

## O que muda
1. **Tamanho via const:** `const N=5000; new Array(N)` agora qualifica
   (const-propagation). Antes só `new Array(5000)` literal cru — mas ninguém
   escreve assim; todo mundo usa uma const.
2. **Arrays top-level:** a escape analysis roda no `__RTS_MAIN` também (não só
   user fns). Filtra `has_global` — array usado de dentro de qualquer fn vira
   global e fica no caminho atual (preserva segurança async).

## Medições
- `mu_local` (const-size, local): OFF 998ms → **ON 439ms (2.3×)**.
- `mu_real2` (top-level pré-dimensionado): OFF 392ms → **ON 173ms (2.3×)**.

## 3 bugs de corretude corrigidos (a expansão expôs; análise mais conservadora)
- (A) `[]` vazio (grow) não qualifica — inliná-lo corrompia escritas além do tamanho.
- (B) literal só qualifica se TODOS elementos forem literais numéricos.
- (C) índice não-inteiro (`a[Symbol.iterator]`) força escape.

## Segurança
- Race do #1556 com flag ON = **4000000 determinístico (5/5 e 10/10)** — arrays
  async-compartilhados viram global → filtrados → caminho atom-RMW.
- Suite **1724/1724 ON e OFF**. Monte Carlo intocado. Corretude ON==OFF.

## Limite descoberto (issue de seguimento)
Quando o loop chama uma user-fn por iteração (ex. `rnd()`), o array inline
funciona mas o gargalo **migra** para overhead de call de user-fn + acesso a
global — outro eixo de otimização.

Tudo atrás de `RTS_ARRAY_INLINE=1` (default OFF). docs/specs/native-array-storage.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)