### PR TITLE
perf(codegen): inline de user-fn pequena no call-site (RTS_INLINE_AST)

### DIFF
--- a/bench/callonly.ts
+++ b/bench/callonly.ts
@@ -1,0 +1,5 @@
+function pure(x: number): number { return (x * 16807) % 2147483647; }
+let acc = 0; let s = 123456789;
+const t0 = Date.now();
+for (let i = 0; i < 25000000; i++) { s = pure(s); acc = acc + (s % 7); }
+console.log("ms=" + (Date.now() - t0) + " acc=" + acc);

--- a/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/main_fn.rs
@@ -13,7 +13,7 @@ use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{Linkage, Module};
 use swc_ecma_ast::Stmt;
 
-use super::super::ctx::{ClassMeta, FnCtx, GlobalVar, UserFnAbi, ValTy};
+use super::super::ctx::{ClassMeta, FnCtx, GlobalVar, InlineCandidate, UserFnAbi, ValTy};
 use super::super::statements::lower_stmt;
 use super::util::collect_var_decls;
 
@@ -32,6 +32,7 @@ pub(crate) fn compile_main(
     fn_class_returns: &HashMap<String, String>,
     node_import_map: &HashMap<String, String>,
     local_alias_map: &HashMap<String, String>,
+    inline_bodies: &HashMap<String, InlineCandidate>,
     stmts: &[&Stmt],
     warnings: &mut Vec<String>,
 ) -> Result<()> {
@@ -66,6 +67,7 @@ pub(crate) fn compile_main(
             fn_class_returns,
             node_import_map,
             local_alias_map,
+            inline_bodies,
             true,
         );
 

--- a/crates/rts-codegen/src/codegen/lower/compile/program.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/program.rs
@@ -468,6 +468,30 @@ pub fn compile_program(
         }
     }
 
+    // (RTS_INLINE_AST) Coleta os corpos de user fns pequenas elegiveis a inline
+    // no call-site (so' fns numericas, prelude de const + return, conservador —
+    // ver `passes::userfn_inline`). Gate por env: `RTS_INLINE_AST=0` desliga
+    // (kill-switch) deixando o mapa vazio -> nenhum call-site inlina. Mesma
+    // fonte (`fn_decls` + `user_fn_abis`) que o codegen usa para a call normal,
+    // entao tipos e nomes batem 1:1.
+    let inline_enabled = std::env::var("RTS_INLINE_AST").as_deref() != Ok("0");
+    let mut inline_bodies: HashMap<String, crate::codegen::lower::ctx::InlineCandidate> =
+        HashMap::new();
+    if inline_enabled {
+        for fn_decl in &fn_decls {
+            let Some(abi) = user_fn_abis.get(&fn_decl.name) else {
+                continue;
+            };
+            if let Some(cand) = crate::codegen::lower::passes::userfn_inline::inline_eligible(
+                fn_decl,
+                &abi.params,
+                abi.ret,
+            ) {
+                inline_bodies.insert(fn_decl.name.clone(), cand);
+            }
+        }
+    }
+
     // Mapeia globais module-scope cuja anotacao bate com classe
     // registrada. Permite funcoes top-level acessarem globais como
     // instancias e participarem de overload.
@@ -638,6 +662,7 @@ pub fn compile_program(
             &fn_class_returns,
             &node_import_map,
             &local_alias_map,
+            &inline_bodies,
             fn_decl,
             info,
             owner_class,
@@ -685,6 +710,7 @@ pub fn compile_program(
         &fn_class_returns,
         &node_import_map,
         &local_alias_map,
+        &inline_bodies,
         &top_stmts,
         &mut warnings,
     )

--- a/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
+++ b/crates/rts-codegen/src/codegen/lower/compile/user_fn.rs
@@ -15,7 +15,7 @@ use cranelift_module::Module;
 
 use crate::parser::ast::{FunctionDecl, Statement};
 
-use super::super::ctx::{ClassMeta, FnCtx, GlobalVar, UserFnAbi, ValTy};
+use super::super::ctx::{ClassMeta, FnCtx, GlobalVar, InlineCandidate, UserFnAbi, ValTy};
 use super::super::statements::lower_stmt;
 use super::class::class_init_name;
 use super::mir_route::try_compile_via_mir;
@@ -47,6 +47,7 @@ pub(crate) fn compile_user_fn(
     fn_class_returns: &HashMap<String, String>,
     node_import_map: &HashMap<String, String>,
     local_alias_map: &HashMap<String, String>,
+    inline_bodies: &HashMap<String, InlineCandidate>,
     fn_decl: &FunctionDecl,
     info: &UserFn,
     current_class: Option<String>,
@@ -132,6 +133,7 @@ pub(crate) fn compile_user_fn(
             fn_class_returns,
             node_import_map,
             local_alias_map,
+            inline_bodies,
             false,
         );
         fn_ctx.return_ty = info.ret;

--- a/crates/rts-codegen/src/codegen/lower/ctx.rs
+++ b/crates/rts-codegen/src/codegen/lower/ctx.rs
@@ -159,6 +159,36 @@ impl ValTy {
     }
 }
 
+/// (RTS_INLINE_AST) Corpo elegivel de uma user fn pequena, pre-coletado em
+/// `compile_program` para inline no call-site. O `body` e' CLONADO do
+/// `FunctionDecl` (Statement e' Clone) para nao prender o emprestimo do AST
+/// no FnCtx. So' fns que passam em `inline_eligible` aparecem aqui.
+#[derive(Debug, Clone)]
+pub struct InlineCandidate {
+    /// (nome_param, tipo) na ordem declarada. Aridade <= MAX_INLINE_ARITY.
+    pub params: Vec<(String, ValTy)>,
+    /// Tipo de retorno (numerico) — usado pra criar a result_var.
+    pub ret: ValTy,
+    /// Corpo clonado da fn (statements). Re-lowered no call-site.
+    pub body: Vec<crate::parser::ast::Statement>,
+    /// Custo aproximado (nos AST) — usado no gate de budget (diagnostico).
+    pub cost: usize,
+}
+
+/// (RTS_INLINE_AST) Frame de um inline em andamento. Empilhado em
+/// `inline_stack` antes de lower o corpo clonado; `lower_return_stmt`
+/// consulta o topo para redirecionar `return` para um `def_var`+`jump` ao
+/// `join_block` em vez de emitir `return_`. Copy (tudo handle leve).
+#[derive(Debug, Clone, Copy)]
+pub struct InlineFrame {
+    /// Variable que recebe o valor de retorno do callee inlinado.
+    pub result_var: Variable,
+    /// Tipo de retorno do callee (coerce do `return <expr>` para ele).
+    pub ret_ty: ValTy,
+    /// Bloco de juncao para onde todos os `return` do callee saltam.
+    pub join_block: Block,
+}
+
 /// A typed Cranelift value.
 #[derive(Debug, Clone, Copy)]
 pub struct TypedVal {
@@ -630,6 +660,17 @@ pub struct FnCtx<'m, 'fb> {
     /// True quando codegen emitiu push_frame no entry — pop_frame deve ser
     /// emitido antes de cada `return_` nesta função.
     pub trace_instrumented: bool,
+
+    /// (RTS_INLINE_AST) Corpos de user fns pequenas elegiveis a inline no
+    /// call-site. Pre-coletado em `compile_program` (mesma fonte que
+    /// `user_fns`). Vazio quando o inline esta desligado (`RTS_INLINE_AST=0`).
+    pub inline_bodies: &'fb HashMap<String, InlineCandidate>,
+    /// (RTS_INLINE_AST) Pilha de frames de inline em andamento. `lower_return_
+    /// stmt` olha o topo para redirecionar `return` ao join_block do inline.
+    pub inline_stack: Vec<InlineFrame>,
+    /// (RTS_INLINE_AST) Profundidade de inline transitiva (a()->b()->c()).
+    /// Limitada por MAX_INLINE_DEPTH para conter code bloat / recursao mutua.
+    pub inline_depth: usize,
 }
 
 impl<'m, 'fb> FnCtx<'m, 'fb> {
@@ -650,6 +691,7 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
         fn_class_returns: &'fb HashMap<String, String>,
         node_import_map: &'fb HashMap<String, String>,
         local_alias_map: &'fb HashMap<String, String>,
+        inline_bodies: &'fb HashMap<String, InlineCandidate>,
         module_scope: bool,
     ) -> Self {
         Self {
@@ -715,6 +757,9 @@ impl<'m, 'fb> FnCtx<'m, 'fb> {
             current_fn_name: String::new(),
             current_file: String::new(),
             trace_instrumented: false,
+            inline_bodies,
+            inline_stack: Vec::new(),
+            inline_depth: 0,
         }
     }
 

--- a/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/expressions/calls/mod.rs
@@ -4458,6 +4458,23 @@ pub(crate) fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> R
         return Ok(TypedVal::new(placeholder, ty));
     }
 
+    // (RTS_INLINE_AST) Inline no call-site de user fns pequenas e numericas.
+    // Toma prioridade sobre a call normal (mas NAO sobre o tail-call acima —
+    // tail mantem a semantica de loop). So' inlina quando:
+    //   - a fn esta no mapa de candidatos (passou em `inline_eligible`);
+    //   - a profundidade transitiva (a()->b()->c()) cabe em MAX_INLINE_DEPTH;
+    //   - a aridade do call-site bate com a do corpo (`values.len()` == params).
+    // `values` ja' foi lowered 1× (args avaliados exatamente uma vez, com a
+    // coercao por param da ABI), entao o inline preserva a ordem/efeitos dos
+    // argumentos. Falha em qualquer condicao => call normal (zero regressao).
+    if ctx.inline_depth < crate::codegen::lower::passes::userfn_inline::MAX_INLINE_DEPTH {
+        if let Some(cand) = ctx.inline_bodies.get(name).cloned() {
+            if values.len() == cand.params.len() {
+                return try_inline_user_call(ctx, &cand, &values);
+            }
+        }
+    }
+
     let ret_ty = abi.ret.unwrap_or(ValTy::I64);
 
     // Stack depth guard: push → brif → call → pop.
@@ -4510,6 +4527,118 @@ pub(crate) fn lower_user_call(ctx: &mut FnCtx, name: &str, call: &CallExpr) -> R
     ctx.builder.switch_to_block(after_block);
     ctx.builder.seal_block(after_block);
     let result = ctx.builder.block_params(after_block)[0];
+    Ok(TypedVal::new(result, ret_ty))
+}
+
+/// (RTS_INLINE_AST) Inlina o corpo de uma user fn pequena no call-site, em vez
+/// de emitir `call`. `values` sao os args ja' lowered (1×, na ordem/tipo da
+/// ABI). Liga cada param a seu arg, empilha um `InlineFrame` para que os
+/// `return` do callee virem `def_var(result_var) + jump(join_block)`, lower o
+/// corpo clonado e devolve o `use_var(result_var)` apos o join.
+///
+/// **Control-flow (ponto fragil — ver `docs/specs/userfn-inline.md`):**
+/// - `result_var` recebe um DEFAULT antes do corpo, de modo que callee sem
+///   `return` explicito (ou caminho de fall-through) ainda deixa um valor
+///   valido em `use_var`.
+/// - `join_block` e' selado SO' no fim, apos TODOS os jumps (returns +
+///   fall-through). Selar cedo => panic do Cranelift.
+/// - O jump de fall-through e' guardado por `is_unreachable()`: quando o corpo
+///   termina por return em todos os ramos (ex: `if(c) return a; else return b`),
+///   o bloco apos o corpo fica unreachable e NAO deve emitir jump (panica).
+fn try_inline_user_call(
+    ctx: &mut FnCtx,
+    cand: &crate::codegen::lower::ctx::InlineCandidate,
+    values: &[cranelift_codegen::ir::Value],
+) -> Result<TypedVal> {
+    use crate::codegen::lower::ctx::InlineFrame;
+
+    let ret_ty = cand.ret;
+    let ret_clty = ret_ty.cl_type();
+
+    // result_var inicializado com default (0 / 0.0) — cobre callee sem return
+    // explicito e o caminho fall-through unreachable.
+    let result_var = ctx.new_var(ret_ty);
+    let default_val = match ret_ty {
+        ValTy::F64 => ctx.builder.ins().f64const(0.0),
+        ValTy::I32 => ctx.builder.ins().iconst(cl::I32, 0),
+        _ => ctx.builder.ins().iconst(ret_clty, 0),
+    };
+    ctx.builder.def_var(result_var, default_val);
+
+    let join_block = ctx.builder.create_block();
+
+    // Escopo proprio para os params/locals do callee (nao vazam pro caller).
+    ctx.push_scope();
+    for ((pname, pty), &argval) in cand.params.iter().zip(values.iter()) {
+        // declare_local normaliza o valor pro cl_type da Variable (ex: Bool i8
+        // -> i64). `argval` ja' veio coerced pela ABI do call-site.
+        ctx.declare_local(pname, *pty, argval);
+    }
+
+    // O caller deve preservar seu proprio `return_ty`/tail-state — o frame do
+    // inline redireciona `return` para o join. Empilha o frame e marca que
+    // estamos 1 nivel mais fundo (limita inline transitivo).
+    ctx.inline_stack.push(InlineFrame {
+        result_var,
+        ret_ty,
+        join_block,
+    });
+    ctx.inline_depth += 1;
+
+    // `in_tail_position` dentro do corpo inlinado nao faz sentido (o return e'
+    // interceptado, nao e' tail do CALLER). Desliga durante o lower do corpo.
+    let saved_tail = ctx.in_tail_position;
+    ctx.in_tail_position = false;
+
+    // Lower o corpo clonado statement a statement; para no primeiro terminator.
+    // `terminated` rastreia se o ULTIMO statement lowered fechou o bloco
+    // corrente (return/throw/jump) — espelha o loop de `compile_user_fn`. NAO
+    // basta `is_unreachable()`: apos um `return` interceptado o bloco corrente
+    // ja' tem terminator (jump pro join) mas nao e' "unreachable" no sentido do
+    // builder (tem predecessor), entao um jump de fall-through aqui violaria o
+    // verifier ("terminator before end of block").
+    let mut lower_err: Option<anyhow::Error> = None;
+    let mut terminated = false;
+    for stmt_raw in &cand.body {
+        if terminated || ctx.builder.is_unreachable() {
+            break;
+        }
+        let crate::parser::ast::Statement::Raw(raw) = stmt_raw;
+        if let Some(swc_stmt) = raw.stmt.as_ref() {
+            match crate::codegen::lower::statements::lower_stmt(ctx, swc_stmt) {
+                Ok(t) => {
+                    terminated = t;
+                }
+                Err(e) => {
+                    lower_err = Some(e);
+                    break;
+                }
+            }
+        }
+    }
+
+    ctx.in_tail_position = saved_tail;
+    ctx.inline_depth -= 1;
+    ctx.inline_stack.pop();
+    ctx.pop_scope();
+
+    if let Some(e) = lower_err {
+        return Err(e);
+    }
+
+    // Fall-through: se o corpo NAO terminou por return/terminator e o ponto
+    // corrente ainda e' alcancavel (callee sem return no final, ou um ramo que
+    // cai fora do `if`), salta pro join. Guardado por `terminated` E
+    // `is_unreachable()` — quando todo caminho ja' retornou, emitir um jump aqui
+    // faria o Cranelift panicar ("terminator before end of block").
+    if !terminated && !ctx.builder.is_unreachable() {
+        ctx.builder.ins().jump(join_block, &[]);
+    }
+
+    // Sela o join SO' agora (todos os predecessores ja' emitiram seus jumps).
+    ctx.builder.switch_to_block(join_block);
+    ctx.builder.seal_block(join_block);
+    let result = ctx.builder.use_var(result_var);
     Ok(TypedVal::new(result, ret_ty))
 }
 

--- a/crates/rts-codegen/src/codegen/lower/passes/mod.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/mod.rs
@@ -17,3 +17,4 @@ pub mod object_methods;
 pub mod parallelism;
 pub mod static_fields;
 pub mod this_arrow;
+pub mod userfn_inline;

--- a/crates/rts-codegen/src/codegen/lower/passes/userfn_inline.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/userfn_inline.rs
@@ -1,0 +1,364 @@
+//! (RTS_INLINE_AST) Elegibilidade de inline de user-fn no call-site.
+//!
+//! O inline do MIR (`rts-mir/passes/inline.rs`) NUNCA toca o `__RTS_MAIN`
+//! top-level (compilado 100% via AST). Loops quentes que chamam uma fn pequena
+//! (ex: `pure(x)=(x*16807)%N` 25M×) pagam o overhead de call inteiro. Esta
+//! analise marca fns pequenas e CONSERVADORAS para inline direto no lowering
+//! AST do call-site — eliminando a call (2 externs STACK_PUSH/POP + diamante de
+//! 4 blocos com phi).
+//!
+//! **Default-DENY.** Uma fn so' qualifica se TODAS as condicoes de
+//! `inline_eligible` valem. Na menor duvida, NAO inlina (cai na call normal,
+//! zero regressao por construcao). Gate por env `RTS_INLINE_AST` (default ON;
+//! `=0` desliga = kill-switch).
+//!
+//! Ver `docs/specs/userfn-inline.md`.
+
+use swc_ecma_ast::{Expr, Pat, Stmt};
+
+use crate::codegen::lower::ctx::{InlineCandidate, ValTy};
+use crate::parser::ast::{FunctionDecl, Statement};
+
+/// Profundidade maxima de inline transitivo (a()->b()->c()). Conter code bloat
+/// e recursao mutua. Lido em `lower_user_call`.
+pub(crate) const MAX_INLINE_DEPTH: usize = 3;
+/// Aridade maxima de uma fn elegivel.
+pub(crate) const MAX_INLINE_ARITY: usize = 6;
+/// Orcamento de custo (nos AST) do corpo. Acima disto nao inlina.
+pub(crate) const INLINE_AST_BUDGET: usize = 12;
+
+/// Tipo numerico aceito (param e ret). Sem Handle/string/U64 na v1 — strings
+/// exigem gestao de handle/GC que o inline simples nao modela.
+fn is_numeric(ty: ValTy) -> bool {
+    matches!(
+        ty,
+        ValTy::I8
+            | ValTy::I16
+            | ValTy::I32
+            | ValTy::I64
+            | ValTy::U8
+            | ValTy::U16
+            | ValTy::Bool
+            | ValTy::F64
+    )
+}
+
+/// True quando a anotacao textual e' um ESCALAR puro (number/int/float/bool).
+///
+/// CRUCIAL: o `ValTy` da ABI colapsa muitos tipos logicos distintos em I64
+/// (fn-type `(n)=>number`, `Map<...>`, sem-anotacao, `any`, etc.). O codegen de
+/// `compile_user_fn` faz tagging especial por param a partir da ANOTACAO crua
+/// (`local_fn_ret_f64`, `local_map_vars`, `local_string_vars`, `local_array_
+/// vars`, `var_member_call_values` para `any`/sem-anotacao, `generator_vars`).
+/// O inline simples NAO replica esse tagging — entao um param tagged como
+/// fn-type/Map/string/array/any inlinado vira um I64 cru e o corpo gera lixo
+/// (ex: `f(n)` indireto devolve bits-f64 sem normalizar). Por isso so' aceitamos
+/// params/ret cuja anotacao e' um escalar literal sem ambiguidade. Default-DENY:
+/// anotacao ausente, fn-type, generico, ou qualquer coisa nao listada => nao
+/// inlina (cai na call normal).
+fn is_scalar_annotation(ann: Option<&str>) -> bool {
+    let Some(a) = ann else {
+        // Sem anotacao => param vira I64 ambiguo (var_member_call_values).
+        // Inline perderia esse tagging. DENY.
+        return false;
+    };
+    let a = a.trim();
+    matches!(
+        a,
+        "number"
+            | "i8" | "I8" | "i16" | "I16" | "i32" | "I32" | "i64" | "I64"
+            | "u8" | "U8" | "u16" | "U16"
+            | "f32" | "F32" | "f64" | "F64"
+            | "boolean" | "bool"
+    )
+}
+
+/// Tenta produzir um `InlineCandidate` para `fn_decl`. Retorna `None` quando a
+/// fn nao e' elegivel (cai na call normal). CONSERVADORA — ver doc do modulo.
+///
+/// `params_ty` / `ret_ty` vem do `UserFnAbi` ja' resolvido (mesma fonte que o
+/// call-site usa para coercao de args), garantindo consistencia de tipos.
+pub(crate) fn inline_eligible(
+    fn_decl: &FunctionDecl,
+    params_ty: &[ValTy],
+    ret_ty: Option<ValTy>,
+) -> Option<InlineCandidate> {
+    // (1) Nao-async.
+    if fn_decl.is_async {
+        return None;
+    }
+
+    // Nomes sinteticos liftados/hoistados carregam semantica especial de ABI
+    // (capturas, handles ambiguos, this capturado) que o inline simples nao
+    // modela — exclui por nome. So' fns "normais" de usuario qualificam.
+    let n = fn_decl.name.as_str();
+    if n.starts_with("__lifted_")
+        || n.starts_with("__hoisted_")
+        || n.starts_with("__captured_")
+        || n.starts_with("__async_inner_")
+        || n.starts_with("__class_")
+    {
+        return None;
+    }
+
+    // (3) Aridade <= MAX_INLINE_ARITY; sem variadic/default/this.
+    if fn_decl.parameters.len() > MAX_INLINE_ARITY {
+        return None;
+    }
+    if fn_decl.parameters.len() != params_ty.len() {
+        return None;
+    }
+    for p in &fn_decl.parameters {
+        // (2) sem param `this`.
+        if p.name == "this" || p.name == "arguments" {
+            return None;
+        }
+        if p.variadic || p.default.is_some() {
+            return None;
+        }
+        // (4-strict) Anotacao crua DEVE ser um escalar puro. Sem isso o param
+        // recebe tagging especial em compile_user_fn (fn-type -> local_fn_ret_
+        // f64, Map -> local_map_vars, string -> local_string_vars, array ->
+        // local_array_vars, any/sem-anotacao -> var_member_call_values,
+        // Iterator -> generator_vars) que o inline NAO replica => lixo no corpo.
+        if !is_scalar_annotation(p.type_annotation.as_deref()) {
+            return None;
+        }
+    }
+
+    // (4) params e ret TODOS numericos (ABI) — redundante com a checagem de
+    // anotacao acima, mas defensivo (params_ty e' a fonte usada na coercao).
+    if !params_ty.iter().copied().all(is_numeric) {
+        return None;
+    }
+    let ret_ty = ret_ty?;
+    if !is_numeric(ret_ty) {
+        return None;
+    }
+    // (4-strict) Anotacao de retorno tambem escalar pura. Uma fn `: string` que
+    // o codegen infere como F64 (corpo `"x"+s`) passaria o teste de ValTy mas
+    // devolveria bits errados; exigir anotacao escalar fecha esse buraco.
+    if !is_scalar_annotation(fn_decl.return_type.as_deref()) {
+        return None;
+    }
+
+    // (5)+(6)+(7) Walk do corpo: so' constructs seguros, sem self-recursao,
+    // sem this/throw/loop/try/etc. Conta custo e exige >= 1 return.
+    let mut checker = BodyChecker {
+        self_name: fn_decl.name.as_str(),
+        cost: 0,
+        returns: 0,
+        ok: true,
+    };
+    for stmt_raw in &fn_decl.body {
+        let Statement::Raw(raw) = stmt_raw;
+        match raw.stmt.as_ref() {
+            Some(stmt) => checker.check_stmt(stmt),
+            None => {
+                // Statement sintetico sem AST SWC — nao da' pra inlinar com
+                // seguranca.
+                return None;
+            }
+        }
+        if !checker.ok {
+            return None;
+        }
+    }
+    if !checker.ok || checker.returns == 0 {
+        return None;
+    }
+    // (8) cost <= budget.
+    if checker.cost > INLINE_AST_BUDGET {
+        return None;
+    }
+
+    let params: Vec<(String, ValTy)> = fn_decl
+        .parameters
+        .iter()
+        .zip(params_ty.iter().copied())
+        .map(|(p, ty)| (p.name.clone(), ty))
+        .collect();
+
+    Some(InlineCandidate {
+        params,
+        ret: ret_ty,
+        body: fn_decl.body.clone(),
+        cost: checker.cost,
+    })
+}
+
+/// Walker conservador (default-DENY) sobre o corpo da fn candidata.
+struct BodyChecker<'a> {
+    self_name: &'a str,
+    cost: usize,
+    returns: usize,
+    ok: bool,
+}
+
+impl BodyChecker<'_> {
+    fn deny(&mut self) {
+        self.ok = false;
+    }
+
+    fn check_stmt(&mut self, stmt: &Stmt) {
+        if !self.ok {
+            return;
+        }
+        self.cost += 1;
+        match stmt {
+            // `const NAME = init` (binding simples). Nao aceita `let`/`var`
+            // (mutacao escaparia o modelo SSA do inline simples) nem
+            // destructuring.
+            Stmt::Decl(swc_ecma_ast::Decl::Var(v)) => {
+                if !matches!(v.kind, swc_ecma_ast::VarDeclKind::Const) {
+                    self.deny();
+                    return;
+                }
+                for d in &v.decls {
+                    if !matches!(&d.name, Pat::Ident(_)) {
+                        self.deny();
+                        return;
+                    }
+                    match d.init.as_deref() {
+                        Some(init) => self.check_expr(init),
+                        None => {
+                            self.deny();
+                            return;
+                        }
+                    }
+                }
+            }
+            // `return <expr>` — interceptado no inline. Exige arg (Some).
+            Stmt::Return(r) => match r.arg.as_deref() {
+                Some(arg) => {
+                    self.returns += 1;
+                    self.check_expr(arg);
+                }
+                None => self.deny(),
+            },
+            // `if (c) {...} else {...}` — ambos ramos walked. Necessario para
+            // os casos de control-flow (early-return, if/else ambos retornam).
+            Stmt::If(if_stmt) => {
+                self.check_expr(&if_stmt.test);
+                self.check_stmt(&if_stmt.cons);
+                if let Some(alt) = if_stmt.alt.as_deref() {
+                    self.check_stmt(alt);
+                }
+            }
+            // Bloco `{ ... }` — recursa nos statements internos.
+            Stmt::Block(b) => {
+                for s in &b.stmts {
+                    self.check_stmt(s);
+                    if !self.ok {
+                        return;
+                    }
+                }
+            }
+            // Statement de expressao puro: so' permitido se a expr for segura
+            // (sem side-effect proibido). Conservador: deny por padrao, pois
+            // expr-stmt sem efeito e' raro num corpo "single-return + const".
+            // Permite no maximo quando a expr passa o checker (ex: chamada a
+            // outra fn pura inline-avel nao deveria ser descartada — deny).
+            Stmt::Expr(_) => self.deny(),
+            // Empty/Debugger — inofensivos, custo zero adicional.
+            Stmt::Empty(_) => {
+                self.cost -= 1;
+            }
+            // Tudo o mais (loops, while, for, switch, try, throw, break,
+            // continue, labeled, with, fn-decl aninhada, class) => deny.
+            _ => self.deny(),
+        }
+    }
+
+    fn check_expr(&mut self, expr: &Expr) {
+        if !self.ok {
+            return;
+        }
+        self.cost += 1;
+        match expr {
+            Expr::Lit(_) => {}
+            // Ident permitido, EXCETO `arguments` (que o codegen sintetiza como
+            // Vec local em compile_user_fn — nao replicado no inline => crash).
+            Expr::Ident(id) => {
+                if id.sym.as_str() == "arguments" {
+                    self.deny();
+                }
+            }
+            // `this` proibido (2).
+            Expr::This(_) => self.deny(),
+            Expr::Paren(p) => self.check_expr(&p.expr),
+            Expr::Unary(u) => {
+                // delete/typeof/void sao seguros sobre numericos, mas para
+                // simplicidade so' permitimos os aritmeticos/logicos.
+                match u.op {
+                    swc_ecma_ast::UnaryOp::Minus
+                    | swc_ecma_ast::UnaryOp::Plus
+                    | swc_ecma_ast::UnaryOp::Bang
+                    | swc_ecma_ast::UnaryOp::Tilde => self.check_expr(&u.arg),
+                    _ => self.deny(),
+                }
+            }
+            Expr::Bin(b) => {
+                self.check_expr(&b.left);
+                self.check_expr(&b.right);
+            }
+            Expr::Cond(c) => {
+                self.check_expr(&c.test);
+                self.check_expr(&c.cons);
+                self.check_expr(&c.alt);
+            }
+            // Chamada a OUTRA user fn (por nome) e' permitida — habilita inline
+            // transitivo (depth-limitado no call-site). Self-recursao direta e'
+            // proibida (7). Chamadas a member (`x.y()`) / namespace sao
+            // permitidas se o callee for resolvido normalmente; mas para
+            // conservadorismo so' aceitamos call de Ident simples e member-call
+            // de namespace conhecido. Aqui aceitamos apenas Ident-callee que
+            // NAO seja a propria fn.
+            Expr::Call(call) => {
+                match &call.callee {
+                    swc_ecma_ast::Callee::Expr(e) => match e.as_ref() {
+                        Expr::Ident(id) => {
+                            if id.sym.as_str() == self.self_name {
+                                self.deny();
+                                return;
+                            }
+                        }
+                        // Member call (ns.fn() ou Math.x()) — permitido; o
+                        // lowering normal resolve. Conservador: aceita Member.
+                        Expr::Member(_) => {}
+                        _ => {
+                            self.deny();
+                            return;
+                        }
+                    },
+                    _ => {
+                        self.deny();
+                        return;
+                    }
+                }
+                if call.args.iter().any(|a| a.spread.is_some()) {
+                    self.deny();
+                    return;
+                }
+                for a in &call.args {
+                    self.check_expr(&a.expr);
+                    if !self.ok {
+                        return;
+                    }
+                }
+            }
+            // Member access `a.b` / `a[b]` — leitura simples permitida (ex:
+            // Math.PI). Computed index sobre numero raro mas inofensivo.
+            Expr::Member(m) => {
+                self.check_expr(&m.obj);
+                if let swc_ecma_ast::MemberProp::Computed(c) = &m.prop {
+                    self.check_expr(&c.expr);
+                }
+            }
+            // Tudo o mais proibido: new, arrow/fn aninhada, await, yield,
+            // assign (mutacao), seq, template, tagged, array/object literal,
+            // spread, optional-chain, etc. => deny.
+            _ => self.deny(),
+        }
+    }
+}

--- a/crates/rts-codegen/src/codegen/lower/statements/control.rs
+++ b/crates/rts-codegen/src/codegen/lower/statements/control.rs
@@ -107,8 +107,15 @@ fn try_lower_if_else_return_to_select(
     let cons_tv = lower_expr(ctx, cons_expr)?;
     let alt_tv = lower_expr(ctx, alt_expr)?;
 
-    // Coerce ambos pro mesmo tipo (igual ao caminho de return normal).
-    let ret_ty = ctx.return_ty.unwrap_or(crate::codegen::lower::ctx::ValTy::I64);
+    // (RTS_INLINE_AST) Dentro de um corpo inlinado, o "return" deste atalho de
+    // select tambem precisa virar `def_var(result_var) + jump(join)` em vez de
+    // `return_` (que sairia da fn do CALLER). Usa o tipo de retorno do CALLEE
+    // (frame.ret_ty), nao o do caller.
+    let inline_frame = ctx.inline_stack.last().copied();
+    let ret_ty = match inline_frame {
+        Some(f) => f.ret_ty,
+        None => ctx.return_ty.unwrap_or(crate::codegen::lower::ctx::ValTy::I64),
+    };
     let cons_v = match ret_ty {
         crate::codegen::lower::ctx::ValTy::I32 => ctx.coerce_to_i32(cons_tv).val,
         crate::codegen::lower::ctx::ValTy::F64 => ctx.coerce_to_f64(cons_tv).val,
@@ -121,7 +128,15 @@ fn try_lower_if_else_return_to_select(
     };
 
     let result = ctx.builder.ins().select(cond_val, cons_v, alt_v);
-    ctx.builder.ins().return_(&[result]);
+    match inline_frame {
+        Some(frame) => {
+            ctx.builder.def_var(frame.result_var, result);
+            ctx.builder.ins().jump(frame.join_block, &[]);
+        }
+        None => {
+            ctx.builder.ins().return_(&[result]);
+        }
+    }
     // Sinaliza que o block esta terminated (caller nao precisa emitir
     // jump pro merge nem fallthrough).
     Ok(Some(true))
@@ -384,6 +399,32 @@ pub(super) fn lower_return_stmt(
     ctx: &mut FnCtx,
     ret_stmt: &swc_ecma_ast::ReturnStmt,
 ) -> Result<bool> {
+    // (RTS_INLINE_AST) `return` DENTRO de um corpo inlinado: nao emite `return_`
+    // (que sairia da fn do CALLER). Em vez disso, avalia o arg, coerce pro tipo
+    // de retorno do callee, escreve em `result_var` e salta pro `join_block`.
+    // Tem prioridade sobre o caminho de finally/tail abaixo — o inline so'
+    // qualifica fns sem try/finally/throw (ver elegibilidade), entao nao ha
+    // interacao com finally_stack aqui. O jump e' guardado por is_unreachable()
+    // por seguranca (um return em ramo ja' terminado nao re-emite).
+    if let Some(frame) = ctx.inline_stack.last().copied() {
+        if let Some(arg) = &ret_stmt.arg {
+            let tv = lower_expr(ctx, arg)?;
+            let coerced = match frame.ret_ty {
+                ValTy::I32 => ctx.coerce_to_i32(tv).val,
+                ValTy::F64 => ctx.coerce_to_f64(tv).val,
+                // I64/Bool/I8/I16/U8/U16 — Variable backed por i64.
+                _ => ctx.coerce_to_i64(tv).val,
+            };
+            ctx.builder.def_var(frame.result_var, coerced);
+        }
+        // `return;` sem arg deixa o result_var no default (ja' setado no
+        // try_inline_user_call). Salta pro join, fechando este caminho.
+        if !ctx.builder.is_unreachable() {
+            ctx.builder.ins().jump(frame.join_block, &[]);
+        }
+        return Ok(true);
+    }
+
     // (#128 fase 2) `return` dentro de try-com-finally: avalia o valor de
     // retorno, roda os finally pendentes (mais interno primeiro) e so' entao
     // emite `return_`. Sem tail-call (o return nao eh mais o ultimo ato).

--- a/docs/specs/userfn-inline.md
+++ b/docs/specs/userfn-inline.md
@@ -1,0 +1,98 @@
+# Inline de user-fn no call-site (RTS_INLINE_AST) + stack-guard barato
+
+> Plano decidido por painel de design. Objetivo: eliminar o overhead de chamada
+> de função pequena no call-site quente. Medido: `pure(x)` chamada 25M× custa
+> 3494ms; o mesmo cálculo inline custa 189ms (18×). No Node call==inline (V8
+> inlina). Quando o RTS inlina, GANHA do Node (189 vs 292ms).
+
+## Causa
+- O inline só existe no MIR (`rts-mir/passes/inline.rs`). O top-level
+  `__RTS_MAIN` (onde o loop do bench vive) é compilado 100% via AST
+  (`main_fn.rs`→`lower_stmt`) → o inline MIR nunca o toca.
+- `lower_user_call` (`calls/mod.rs:4295`) emite `call`/`return_call` sem inline.
+- Cada call não-tail emite 2 externs (`STACK_PUSH`+`STACK_POP`) + diamante de 4
+  blocos com phi (`calls/mod.rs:4463-4513`) — metade do custo.
+
+## Fase 0 — stack-guard barato (separável, risco ~zero)
+Substituir os 2 externs `__RTS_FN_RT_STACK_PUSH`/`POP` (`calls/mod.rs:4464/4494`)
+por um contador thread-local lido/escrito inline em Cranelift (global data symbol
++ iadd_imm/store), mantendo o `brif` de overflow. Elimina 2 calls extern por
+user-call. Ganha em TODAS as chamadas. Medir callonly.ts antes/depois (calibra o
+ROI da Fase 1).
+
+## Fase 1 — inline no call-site
+4 toques:
+1. `ctx.rs`: `struct InlineCandidate { params, ret, body: Vec<Statement>, cost }`
+   + `struct InlineFrame { result_var, ret_ty, join_block }` + campos
+   `inline_bodies: &HashMap<String,InlineCandidate>`, `inline_stack`,
+   `inline_depth` no FnCtx + param em `FnCtx::new`.
+2. `program.rs:419`: coleta `inline_bodies` via `inline_eligible(fn_decl)`,
+   repassa a `compile_main` e `compile_user_fn`.
+3. `calls/mod.rs:4461` (após `values` montado, após o tail-call path): hook
+   `try_inline_user_call(ctx, cand, values)` — cria result_var + join_block,
+   push_scope, bind params via declare_local(name, ty, Value), push InlineFrame,
+   loop lower_stmt sobre o corpo clonado, pop, jump join, seal.
+4. `control.rs:383` (topo de lower_return_stmt, ANTES do finally_stack):
+   intercepta return quando `inline_stack` não-vazio → def_var(result_var) +
+   jump(join_block) + return Ok(true).
+
+Gate: `RTS_INLINE_AST` (default ON; =0 desliga, kill-switch p/ bisseção).
+
+## Elegibilidade EXATA (conservadora v1)
+Fn candidata SÓ se TODAS valem:
+1. não-async.
+2. sem `this` param e sem ThisExpr no corpo.
+3. aridade ≤6; sem variadic/default.
+4. params e ret TODOS numéricos (I8..I64/U8../Bool/F64). Sem Handle/string na v1.
+5. corpo = "single-return + prelude de `const` puros": zero+ `const NAME=init`
+   (binding simples) seguidos de EXATAMENTE 1 `return Some(expr)`.
+6. sem try/catch/throw, break/continue LABEL, yield/await, new, member em this,
+   fn/arrow aninhada com captura, arguments.
+7. não-recursiva direta (corpo não chama a si mesma por nome).
+8. cost(body) ≤ INLINE_AST_BUDGET (=12 nós).
+MAX_INLINE_DEPTH=3 (recursão transitiva), MAX_INLINE_ARITY=6.
+Args 1× garantido (values já lowered 1×). Não-elegível → call normal (0 regressão).
+
+## Medição
+bench/callonly.ts (`pure(x)=return (x*16807)%N`, 25M×):
+- baseline ~3494ms → Fase 0 (?) → Fase 1 alvo ~190ms.
+- `RTS_INLINE_AST=0` deve voltar ao baseline (prova que o ganho é o inline).
+
+## Resultado medido (Fase 1, 2026-06-14)
+
+| | Tempo | acc |
+|---|---|---|
+| RTS OFF (RTS_INLINE_AST=0) | 3578 ms | 75019643 |
+| **RTS ON (inline, default)** | **190 ms** | 75019643 |
+| Node 22 | 296 ms | 75019643 |
+
+**18.8× mais rápido — e o RTS GANHA do Node** (190 vs 296ms). Quando inlina, o
+codegen rápido do RTS vence o V8. Suite 1726/1726 ON e OFF. Race #1556 = 4000000
+(inline não corrompe async). Fase 0 (stack-guard barato) não foi necessária — o
+inline elimina a call inteira (logo o stack-guard junto) no caso do bench.
+
+**Bugs corrigidos durante a implementação:** (1) elegibilidade recuada para exigir
+anotação ESCALAR pura em todo param+ret (o ValTy da ABI colapsa tipos lógicos em
+I64; sem isso, fns com param fn/Map/`arguments` geravam lixo/ACCESS_VIOLATION);
+(2) `try_lower_if_else_return_to_select` (control.rs) emitia `return_` cru — agora
+roteia pelo inline frame; (3) tracking de `terminated` no loop de stmts +
+guarda dupla `!terminated && !is_unreachable()` no jump de fall-through (panic do
+verifier Cranelift "terminator before end of block").
+
+## Não-regressão (honesty floor)
+- Suite 1724/1724 (ON e OFF). Monte Carlo (toFloat() inlina — single-return f64).
+- Smoke `rts run` E suite (gap de cobertura JIT-symbol).
+- Bateria control-flow OBRIGATÓRIA: early-return único; if/else ambos retornam
+  (bloco unreachable — valida is_unreachable() antes do jump + seal do join);
+  return em if sem else; callee sem return (default); inline aninhado (depth);
+  callee em 2+ call-sites.
+- Fixture float: fn f64-ret inlinada vs RTS_INLINE_AST=0 byte-idêntica.
+
+## Riscos
+- Selagem do join_block: selar SÓ no fim após todos os jumps; is_unreachable()
+  antes do jump de fall-through (Cranelift panica se selar cedo).
+- Race async #1556: inline preserva ordem de loads/stores → não cria race. Sem
+  teste inline×async = risco; RTS_INLINE_AST=0 é kill-switch.
+- Code bloat: budget 12 + depth 3. Medir tempo de build.
+Regra de parada: se control-flow ou float não passar, recuar elegibilidade
+(v1 ainda mais restrita: single-return sem if interno cobre pure/toFloat).

--- a/tests/claude-userfn-inline.test.ts
+++ b/tests/claude-userfn-inline.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from "rts:test";
+
+// Inline de user-fn no call-site (RTS_INLINE_AST). Corretude flag-independente:
+// o resultado deve ser idêntico com inline ON (default) e OFF. Cobre os casos
+// de control-flow que o inline precisa redirecionar corretamente (return →
+// store+jump ao join block).
+//
+// Pré-computado no top-level (ver nota CLAUDE.md sobre GC em test closures).
+
+// (a) single-return — o caso elegível básico.
+function pure(x: number): number { return (x * 16807) % 2147483647; }
+
+// (b) if/else ambos retornam — os dois ramos fazem def_var+jump(join).
+function maxOf(a: number, b: number): number {
+  if (a > b) return a;
+  else return b;
+}
+
+// (c) return em if sem else (fall-through).
+function clamp(x: number): number {
+  if (x < 0) return 0;
+  return x;
+}
+
+// (e) inline aninhado: outer chama inner (depth).
+function inner(x: number): number { return x + 1; }
+function outer(x: number): number { return inner(x) * 2; }
+
+// chamadas (callee em múltiplos call-sites também).
+const r_pure1 = pure(123456789);
+const r_pure2 = pure(987654321);
+const r_max1 = maxOf(70, 1);
+const r_max2 = maxOf(4, 9);
+const r_clamp1 = clamp(-5);
+const r_clamp2 = clamp(100);
+const r_outer = outer(13); // (13+1)*2 = 28
+
+describe("user-fn inline (corretude, flag-independente)", () => {
+  test("single-return inlinado", () => {
+    expect(r_pure1).toBe((123456789 * 16807) % 2147483647);
+    expect(r_pure2).toBe((987654321 * 16807) % 2147483647);
+  });
+  test("if/else ambos retornam", () => {
+    expect(r_max1).toBe(70);
+    expect(r_max2).toBe(9);
+  });
+  test("if sem else (fall-through)", () => {
+    expect(r_clamp1).toBe(0);
+    expect(r_clamp2).toBe(100);
+  });
+  test("inline aninhado outer→inner", () => {
+    expect(r_outer).toBe(28);
+  });
+});


### PR DESCRIPTION
Funções pequenas (single-return, numéricas, não-recursivas) são inlinadas no
call-site durante o lowering AST, em vez de emitir `call`. Cobre o top-level
`__RTS_MAIN` (que é 100% AST — o inline do MIR nunca o tocava).

## Motivação (medido)
`pure(x)=(x*16807)%N` chamada 25M×:

| | Tempo |
|---|---|
| RTS OFF (RTS_INLINE_AST=0) | 3578 ms |
| **RTS ON (inline, default)** | **190 ms** |
| Node 22 | 296 ms |

**18.8× mais rápido — e o RTS GANHA do Node** (190 vs 296ms). No Node call==inline
(V8 inlina a fn trivial automaticamente); o RTS pagava a call. Resolvido o inline,
o codegen rápido do RTS vence o V8. Era 100% overhead de call — não a global.

## Implementação (gate RTS_INLINE_AST, default ON, =0 kill-switch)
4 toques + 1 pass novo:
- `ctx.rs`: InlineCandidate + InlineFrame + campos no FnCtx.
- `program.rs`: coleta inline_bodies via `inline_eligible`, repassa a
  compile_main E compile_user_fn.
- `passes/userfn_inline.rs` (NOVO): elegibilidade conservadora (default-DENY).
- `calls/mod.rs`: hook `try_inline_user_call` após o tail-call path.
- `control.rs`: `return` dentro de inline → store no result_var + jump ao join.

## Elegibilidade conservadora
Só param/ret ESCALAR puro (number/i8..i64/f64/bool), single-return + const-prelude,
não-recursiva, aridade ≤6, budget ≤12, depth ≤3, sem this/try/async/arguments.
Não-elegível → call normal (0 regressão por construção).

## Verificação
- callonly 190ms ON vs 3578ms OFF, acc idêntico, IR sem call de `pure` no loop.
- **Suite 1726/1726 ON e OFF.**
- Race #1556 = **4000000** (inline não corrompe async).
- Monte Carlo pi correto (`toFloat()` inlina). Control-flow sólido (if/else,
  if-sem-else, nested) — fixture `claude-userfn-inline` ON==OFF.

3 bugs corrigidos no caminho: elegibilidade recuada p/ escalar puro (ValTy da ABI
colapsa tipos em I64), atalho if/else→select roteado pelo inline frame, guarda
`terminated+unreachable` no fall-through (panic do verifier Cranelift).

docs/specs/userfn-inline.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)