### PR TITLE
fix(codegen): limitar array nativo a 1024 elems (evita stack overflow/segfault)

### DIFF
--- a/bench/company_sim.ts
+++ b/bench/company_sim.ts
@@ -1,0 +1,82 @@
+// Simulação de empresa: N funcionários, M departamentos, processando eventos
+// (vendas, despesas, transferências entre deptos, contratações). Estado
+// agregado em arrays paralelos pré-dimensionados (padrão otimizável pelo RTS).
+// Portável: roda igual em RTS, Node e Bun.
+
+const EMPLOYEES = 10000;
+const DEPARTMENTS = 50;
+const EVENTS = 20000000;
+
+// Estado por funcionário (arrays paralelos, pré-dimensionados).
+const salary: number[] = new Array(EMPLOYEES);
+const performance: number[] = new Array(EMPLOYEES);
+const deptOf: number[] = new Array(EMPLOYEES);
+for (let i = 0; i < EMPLOYEES; i++) {
+  salary[i] = 50000;
+  performance[i] = 100;
+  deptOf[i] = i % DEPARTMENTS;
+}
+
+// Orçamento por departamento.
+const deptBudget: number[] = new Array(DEPARTMENTS);
+for (let d = 0; d < DEPARTMENTS; d++) deptBudget[d] = 1000000;
+
+// PRNG determinístico (Park-Miller LCG).
+let seed = 123456789;
+function rnd(): number { seed = (seed * 16807) % 2147483647; return seed % 1000000; }
+
+let totalSales = 0;
+let totalRaises = 0;
+let totalTransfers = 0;
+
+const t0 = Date.now();
+
+for (let ev = 0; ev < EVENTS; ev++) {
+  const emp = rnd() % EMPLOYEES;
+  const kind = rnd() % 4;
+
+  if (kind === 0) {
+    // venda: adiciona ao orçamento do depto do funcionário + bump performance
+    const amount = rnd() % 5000;
+    const dept = deptOf[emp];
+    deptBudget[dept] = deptBudget[dept] + amount;
+    performance[emp] = performance[emp] + 1;
+    totalSales = totalSales + 1;
+  } else if (kind === 1) {
+    // aumento: se performance alta e orçamento do depto cobre
+    const dept = deptOf[emp];
+    const raise = rnd() % 2000;
+    if (performance[emp] > 105 && deptBudget[dept] >= raise) {
+      salary[emp] = salary[emp] + raise;
+      deptBudget[dept] = deptBudget[dept] - raise;
+      totalRaises = totalRaises + 1;
+    }
+  } else if (kind === 2) {
+    // transferência entre departamentos
+    const toDept = rnd() % DEPARTMENTS;
+    const fromDept = deptOf[emp];
+    const amount = rnd() % 1000;
+    if (deptBudget[fromDept] >= amount) {
+      deptBudget[fromDept] = deptBudget[fromDept] - amount;
+      deptBudget[toDept] = deptBudget[toDept] + amount;
+      deptOf[emp] = toDept;
+      totalTransfers = totalTransfers + 1;
+    }
+  } else {
+    // penalidade de performance
+    if (performance[emp] > 50) performance[emp] = performance[emp] - 1;
+  }
+}
+
+const t1 = Date.now();
+
+// Checksums determinísticos.
+let totalSalary = 0;
+let totalBudget = 0;
+let totalPerf = 0;
+for (let i = 0; i < EMPLOYEES; i++) { totalSalary = totalSalary + salary[i]; totalPerf = totalPerf + performance[i]; }
+for (let d = 0; d < DEPARTMENTS; d++) totalBudget = totalBudget + deptBudget[d];
+
+console.log("events=" + EVENTS + " sales=" + totalSales + " raises=" + totalRaises + " transfers=" + totalTransfers);
+console.log("total_salary=" + totalSalary + " total_budget=" + totalBudget + " total_perf=" + totalPerf);
+console.log("time_ms=" + (t1 - t0) + " events_per_sec=" + Math.floor(EVENTS / ((t1 - t0) / 1000)));

--- a/bench/logic_sim.ts
+++ b/bench/logic_sim.ts
@@ -1,0 +1,56 @@
+// Simulação SEM arrays: lógica de negócio pura com aritmética intensa,
+// funções, branches e acumuladores escalares. Mede o codegen de
+// call/branch/arith — não acesso a coleção.
+// Portável: roda igual em RTS, Node, Bun.
+
+// PRNG determinístico (Park-Miller LCG).
+let seed = 123456789;
+function rnd(): number { seed = (seed * 16807) % 2147483647; return seed % 1000000; }
+
+// "Regras de negócio" — funções pequenas (candidatas a inline).
+function tax(income: number): number {
+  if (income < 1000) return 0;
+  if (income < 5000) return (income * 10) / 100;
+  if (income < 20000) return (income * 20) / 100;
+  return (income * 35) / 100;
+}
+
+function bonus(perf: number, base: number): number {
+  if (perf > 90) return (base * 20) / 100;
+  if (perf > 70) return (base * 10) / 100;
+  return 0;
+}
+
+function score(a: number, b: number, c: number): number {
+  return (a * 3 + b * 2 + c) % 1000;
+}
+
+const ITER = 30000000;
+
+let totalTax = 0;
+let totalBonus = 0;
+let totalScore = 0;
+let highEarners = 0;
+
+const t0 = Date.now();
+
+for (let i = 0; i < ITER; i++) {
+  const income = rnd() % 50000;
+  const perf = rnd() % 100;
+  const base = rnd() % 10000;
+
+  const t = tax(income);
+  const b = bonus(perf, base);
+  const s = score(income, perf, base);
+
+  totalTax = (totalTax + t) % 1000000007;
+  totalBonus = (totalBonus + b) % 1000000007;
+  totalScore = (totalScore + s) % 1000000007;
+  if (income > 20000) highEarners = highEarners + 1;
+}
+
+const t1 = Date.now();
+
+console.log("iters=" + ITER + " high_earners=" + highEarners);
+console.log("total_tax=" + totalTax + " total_bonus=" + totalBonus + " total_score=" + totalScore);
+console.log("time_ms=" + (t1 - t0) + " iters_per_sec=" + Math.floor(ITER / ((t1 - t0) / 1000)));

--- a/crates/rts-codegen/src/codegen/lower/passes/escape.rs
+++ b/crates/rts-codegen/src/codegen/lower/passes/escape.rs
@@ -27,6 +27,13 @@ use swc_ecma_ast::{Expr, Lit, MemberProp, Pat, Stmt};
 
 use crate::parser::ast::Statement;
 
+/// Limite de elementos para um array ir pro stack slot. Cada elemento ocupa 8
+/// bytes; o slot vive na stack da fn. Arrays grandes (ou varios arrays grandes
+/// na mesma fn) estouram a stack -> SEGFAULT. 1024 elems = 8 KiB por array, com
+/// margem confortavel para multiplos arrays + as outras stack vars da fn.
+/// Acima disso o array fica no HandleTable (caminho atual, heap, sem limite).
+pub(crate) const MAX_NATIVE_ARRAY_LEN: usize = 1024;
+
 /// Metadata de um array local qualificado para storage nativo (stack slot).
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct NativeArrayInfo {
@@ -321,7 +328,19 @@ fn peel<'a>(e: &'a Expr) -> &'a Expr {
 ///   - `new Array(N)` — N literal inteiro >= 0, OU `new Array(NAME)` onde NAME
 ///     e' uma const-int conhecida (`consts`).
 /// Caso contrario `None` (cai no caminho atual).
+///
+/// Aplica o limite [`MAX_NATIVE_ARRAY_LEN`]: arrays maiores ficam no HandleTable
+/// (heap) em vez de virar um stack slot — senao varios/grandes arrays estouram a
+/// stack da fn (SEGFAULT, visto em bench/company_sim.ts com 5 arrays de 10000).
 fn candidate_info(init: &Expr, consts: &HashMap<String, usize>) -> Option<NativeArrayInfo> {
+    let info = candidate_info_inner(init, consts)?;
+    if info.len > MAX_NATIVE_ARRAY_LEN {
+        return None;
+    }
+    Some(info)
+}
+
+fn candidate_info_inner(init: &Expr, consts: &HashMap<String, usize>) -> Option<NativeArrayInfo> {
     match peel(init) {
         Expr::Array(arr) => {
             // Array literal VAZIO (`[]`) NAO qualifica: e' o padrao "cria e

--- a/tests/claude-native-array-stack-limit.test.ts
+++ b/tests/claude-native-array-stack-limit.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "rts:test";
+
+// Limite de tamanho do storage nativo (MAX_NATIVE_ARRAY_LEN=1024): arrays
+// grandes ficam no heap (caminho atual) em vez de virar stack slot, senão
+// vários/grandes arrays estouram a stack (SEGFAULT — visto em company_sim com
+// 5 arrays de 10000). Corretude flag-independente; o teste garante que arrays
+// grandes não crasham e produzem o resultado certo.
+
+function bigArray(): number {
+  const a: number[] = new Array(5000); // > 1024 → heap, não stack slot
+  for (let i = 0; i < 5000; i++) a[i] = i;
+  let s = 0;
+  for (let i = 0; i < 5000; i++) s = s + a[i];
+  return s; // 0+1+...+4999 = 12497500
+}
+
+function smallArray(): number {
+  const a: number[] = new Array(64); // <= 1024 → stack slot (inline)
+  for (let i = 0; i < 64; i++) a[i] = i;
+  let s = 0;
+  for (let i = 0; i < 64; i++) s = s + a[i];
+  return s; // 0+...+63 = 2016
+}
+
+// Vários arrays grandes na mesma fn (o caso que segfaultava).
+function manyBig(): number {
+  const a: number[] = new Array(3000);
+  const b: number[] = new Array(3000);
+  const c: number[] = new Array(3000);
+  for (let i = 0; i < 3000; i++) { a[i] = 1; b[i] = 2; c[i] = 3; }
+  let s = 0;
+  for (let i = 0; i < 3000; i++) s = s + a[i] + b[i] + c[i];
+  return s; // 3000 * 6 = 18000
+}
+
+const r1 = bigArray();
+const r2 = smallArray();
+const r3 = manyBig();
+
+describe("native array stack limit", () => {
+  test("array grande (>1024) funciona (heap, sem segfault)", () => {
+    expect(r1).toBe(12497500);
+  });
+  test("array pequeno (<=1024) funciona (stack slot)", () => {
+    expect(r2).toBe(2016);
+  });
+  test("vários arrays grandes na mesma fn não estouram a stack", () => {
+    expect(r3).toBe(18000);
+  });
+});


### PR DESCRIPTION
## Bug

O storage nativo de array (`RTS_ARRAY_INLINE`) alocava um StackSlot de `len*8`
bytes **sem limite de tamanho**. Arrays grandes — ou vários arrays grandes na
mesma fn — estouravam a stack: **SEGFAULT** (exit 139).

Reproduzido em `bench/company_sim.ts` (5 arrays de 10000 = 5×80KB = 400KB de
stack slots). Confirmado: 1 array de 16384 (128KB) já falha; 4096 (32KB) ok.

## Fix

`MAX_NATIVE_ARRAY_LEN = 1024` (8 KiB/array, margem p/ múltiplos arrays + stack
vars). Arrays maiores ficam no HandleTable (heap, caminho atual). `candidate_info`
vira wrapper que filtra o tamanho.

## Validação
- company_sim (arrays 10000): **não crasha mais** (vão pro heap, checksums batem
  com Node).
- company_sim 1000 funcionários (arrays ≤1024): mantém o inline, **RTS ganha do
  Node** (841ms vs 1475ms, 20M eventos).
- Suite **1732/1732 ON e OFF**. Fixture `claude-native-array-stack-limit`.

Também adiciona `bench/company_sim.ts` e `bench/logic_sim.ts` (benchmarks de
simulação de empresa, com e sem arrays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)