### PR TITLE
refactor(codegen-new): console data-driven — remove os 3 hardcodes do front

### DIFF
--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -45,16 +45,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 .local_classes
                 .get(name)
                 .cloned()
-                // A PRELUDE SINGLETON (`console`) is a force-promoted gcell (so it
-                // reaches inside functions), which erases the static `new Console()`
-                // class that a plain local would carry. Recover it from the fixed
-                // singleton→class allow-list so `console.log(..)` dispatches
-                // statically on `Console` in any scope. The name appears ONLY in this
-                // allow-list, not in dispatch logic.
+                // A top-level SINGLETON INSTANCE (`const x = new C()`) force-promoted
+                // to a gcell (so it reaches inside functions) loses the `local_classes`
+                // entry a plain `new C()` local would carry. Recover its class from the
+                // data-driven `gcell_classes` map (`name → C`, built by SHAPE from the
+                // HIR — no hardcoded name) so `x.method(..)` dispatches on `C` in any
+                // scope. Gated on `name` being an actual gcell (a same-named local
+                // shadows it via `local_classes` above, checked first).
                 .or_else(|| {
-                    prelude_singleton_class(name)
+                    self.gcell_classes
+                        .get(name)
                         .filter(|_| self.gcells.contains_key(name))
-                        .map(str::to_string)
+                        .cloned()
                 }),
             // A CALL whose callee is a user function with a provable return class
             // (`expect(x)` → `Matcher`): lets a chained method dispatch statically on
@@ -260,17 +262,5 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             Some(this_word),
             std::slice::from_ref(value),
         )
-    }
-}
-
-/// The user-class name a PRELUDE SINGLETON global maps to, or `None`. A prelude
-/// singleton (`const console = new Console()`) is force-promoted to a gcell to be
-/// reachable inside user functions, which erases the static `new`-class a plain
-/// local would carry; this fixed allow-list restores it so the singleton's methods
-/// dispatch statically. Keep in sync with `funcval::prelude_singleton_globals`.
-fn prelude_singleton_class(name: &str) -> Option<&'static str> {
-    match name {
-        "console" => Some("Console"),
-        _ => None,
     }
 }

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -111,30 +111,56 @@ pub fn module_globals(
     map
 }
 
-/// PRELUDE SINGLETON globals (`console`) that must be promoted to runtime CELLs so
-/// they are reachable from INSIDE user functions, not only at the top level.
+/// Top-level singleton-instance globals — every `const X = new Y()` at the top
+/// level — mapped to their class `Y`. DATA-DRIVEN: the engine NAMES nothing (no
+/// `"console"` allow-list); it matches the SHAPE `const = new`, so any prelude OR
+/// user singleton (`const console = new Console()`, `const app = new App()`) is
+/// covered uniformly.
 ///
-/// These are read-only `const` objects declared by the embedded prelude (e.g.
-/// `const console = new Console()` in `CONSOLE_TS`). Resolved as a plain top-level
-/// local, such a name is invisible inside a user `function f() { console.log(..) }`
-/// (a function reads only locals/params, gcells, and global constants) — it bails
-/// "unbound identifier `console`". Forcing it to a cell makes every scope read the
-/// one shared value. It is the ONLY place the engine references the prelude
-/// singleton names; the names are a fixed allow-list, not dispatch logic. Promotion
-/// is unconditional when the name is a top-level global (a cell is cheap; the
-/// `const` init writes it once via the normal `lower_let` gcell-set path).
-pub fn prelude_singleton_globals(main: &HirFunc) -> HashSet<String> {
-    /// Read-only object singletons the prelude declares at top level.
-    const PRELUDE_SINGLETONS: &[&str] = &["console"];
-    let mut out = HashSet::new();
+/// Why this exists: such a `const` resolved as a plain top-level local is INVISIBLE
+/// inside a user `function f() { console.log(..) }` (a function reads only
+/// locals/params, gcells, and global constants) → "unbound identifier". Two facts
+/// must survive into every scope: (a) the VALUE — fixed by promoting the name to a
+/// runtime CELL (gcell #195), so every scope reads the one shared instance; (b) the
+/// static CLASS — a plain `new Y()` local records `Y` in `local_classes`, but the
+/// gcell erases that, so we carry `name → Y` here for `static_instance_class` to
+/// recover (the receiver class for `console.log`-style dispatch in any scope).
+///
+/// ONLY singletons actually REFERENCED from inside a function (or arrow) are
+/// promoted — a `const x = new C()` used purely at the top level stays an ordinary
+/// local (promoting every singleton would needlessly route plain top-level method
+/// calls through a cell and mis-dispatch user singletons, e.g. `const p = new
+/// Point(); p.parseValue()`). Returns `name → class` for the promoted set.
+pub fn singleton_instance_globals(
+    funcs: &[HirFunc],
+    main: &HirFunc,
+) -> std::collections::HashMap<String, String> {
+    // Candidate singletons: top-level `const x = new C()`.
+    let mut candidates: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for s in &main.body {
-        if let HirStmt::Const { name, .. } = s {
-            if PRELUDE_SINGLETONS.contains(&name.as_str()) {
-                out.insert(name.clone());
+        if let HirStmt::Const { name, init, .. } = s {
+            if let rts_hir::ir::HirExprKind::New { class, .. } = &init.kind {
+                candidates.insert(name.clone(), class.clone());
             }
         }
     }
-    out
+    if candidates.is_empty() {
+        return candidates;
+    }
+    // Names READ FREE inside some function body OR some arrow in main (the actual
+    // reachability condition that needs a shared cell). A function's own params /
+    // locals shadow an outer singleton of the same name and don't count.
+    let mut referenced: HashSet<String> = HashSet::new();
+    for f in funcs {
+        let mut bound: HashSet<String> = f.params.iter().map(|p| p.name.clone()).collect();
+        bound.extend(declared_names(&f.body));
+        for s in &f.body {
+            collect_free_stmt(s, &mut bound, &mut referenced);
+        }
+    }
+    referenced.extend(arrow_free_idents(&main.body));
+    candidates.retain(|name, _| referenced.contains(name));
+    candidates
 }
 
 /// Top-level `let`s that must be promoted to runtime CELLs because a closure
@@ -170,8 +196,10 @@ pub fn captured_mutated_top_lets(funcs: &[HirFunc], main: &HirFunc) -> HashSet<S
         .collect()
 }
 
-/// Names always considered "not a capture" (engine globals the lowering knows).
-const GLOBALS: &[&str] = &["console", "undefined", "Infinity", "NaN"];
+/// Language singletons always considered "not a capture". These are genuine
+/// PRIMORDIAL value globals (not a non-primordial name like `console` — that is a
+/// gcell singleton, already treated as non-capture via `ctx.module_globals`).
+const GLOBALS: &[&str] = &["undefined", "Infinity", "NaN"];
 
 /// The result of the arrow-extraction pre-pass: the synthesized top-level
 /// functions to append, plus the ordered capture list of each CLOSURE (synthesized

--- a/crates/rts-codegen-new/src/front/run/funcval/scan.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/scan.rs
@@ -284,9 +284,81 @@ pub(super) fn collect_free_stmt(
                 collect_free_stmt(st, bound, free);
             }
         }
-        // A statement kind outside the subset: be conservative and treat any
-        // identifier it would reference as free (forces a bail). We approximate by
-        // not descending — the lowering will bail on the construct itself anyway.
+        HirStmt::Throw(e) => collect_free_expr(e, bound, free),
+        HirStmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            for st in body {
+                collect_free_stmt(st, bound, free);
+            }
+            if let Some(c) = catch {
+                // The catch param binds inside the handler only; snapshot/restore
+                // `bound` so it doesn't leak out (a `console` AFTER the try still
+                // counts as free).
+                let had = c.binding.as_ref().map(|b| bound.contains(b));
+                if let Some(b) = &c.binding {
+                    bound.insert(b.clone());
+                }
+                for st in &c.body {
+                    collect_free_stmt(st, bound, free);
+                }
+                if let (Some(b), Some(false)) = (&c.binding, had) {
+                    bound.remove(b);
+                }
+            }
+            if let Some(fin) = finally {
+                for st in fin {
+                    collect_free_stmt(st, bound, free);
+                }
+            }
+        }
+        HirStmt::For {
+            init,
+            cond,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                collect_free_stmt(i, bound, free);
+            }
+            if let Some(c) = cond {
+                collect_free_expr(c, bound, free);
+            }
+            if let Some(u) = update {
+                collect_free_expr(u, bound, free);
+            }
+            for st in body {
+                collect_free_stmt(st, bound, free);
+            }
+        }
+        HirStmt::ForOf {
+            binding,
+            iterable,
+            body,
+            ..
+        } => {
+            collect_free_expr(iterable, bound, free);
+            bound.insert(binding.clone());
+            for st in body {
+                collect_free_stmt(st, bound, free);
+            }
+        }
+        HirStmt::ForIn {
+            binding,
+            object,
+            body,
+        } => {
+            collect_free_expr(object, bound, free);
+            bound.insert(binding.clone());
+            for st in body {
+                collect_free_stmt(st, bound, free);
+            }
+        }
+        // Remaining kinds (Switch/Labeled/Break/Continue/Raw) carry no singleton
+        // reference the promotion cares about; not descending is safe (the lowering
+        // bails on an unsupported construct itself).
         _ => {}
     }
 }

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -238,6 +238,10 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// by its id, NOT a Cranelift Variable — checked AFTER `self.local` so a
     /// same-named param/local in the current function still shadows it.
     pub gcells: &'c HashMap<String, u32>,
+    /// Top-level SINGLETON-INSTANCE globals (`const X = new Y()`) → class `Y`. Lets
+    /// `static_instance_class` recover the receiver class of a gcell-promoted
+    /// singleton in any scope (the gcell erases the `local_classes` entry).
+    pub gcell_classes: &'c HashMap<String, String>,
     /// The program's user classes (descriptors: fields → shape slots, methods →
     /// functions). Read-only, shared across all functions. Drives `new C(args)`,
     /// `this.field`, and static `instance.method(args)`.
@@ -269,6 +273,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         classes: &'c super::class::ClassTable,
         captures: &'c HashMap<String, Vec<String>>,
         gcells: &'c HashMap<String, u32>,
+        gcell_classes: &'c HashMap<String, String>,
         this_class: Option<&str>,
         is_prelude: bool,
         builtins: &'c HashMap<String, (String, String)>,
@@ -298,6 +303,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             ids,
             captures,
             gcells,
+            gcell_classes,
             classes,
             is_prelude,
             builtins,

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -105,13 +105,26 @@ fn build_with_includes(src: &str) -> FrontResult<LoweredProgram> {
     }
 }
 
-/// The set of top-level function names a `prelude` exposes — the AMBIENT functions
-/// a user program may reference (the `rts:test` `describe`/`test`/`expect`, the
-/// primordial `.ts` helpers). Seeded into the user build's arrow extraction so a
-/// callback arrow naming one is not misjudged a capture (see [`build_from_program`]
-/// → [`funcval::extract_arrows`]).
+/// The set of AMBIENT names a `prelude` exposes to a user program — its top-level
+/// FUNCTIONS (`rts:test` describe/test/expect, primordial `.ts` helpers) AND its
+/// top-level SINGLETON INSTANCES (`const console = new Console()`). Seeded into the
+/// user build's arrow extraction so a callback arrow naming one (`x =>
+/// console.log(x)`) is NOT misjudged a capture (the singleton resolves as a shared
+/// gcell after the merge, not a captured outer local). See [`build_from_program`]
+/// → [`funcval::extract_arrows`].
 fn prelude_fn_names(prelude: &LoweredProgram) -> std::collections::HashSet<String> {
-    prelude.funcs.iter().map(|f| f.name.clone()).collect()
+    let mut names: std::collections::HashSet<String> =
+        prelude.funcs.iter().map(|f| f.name.clone()).collect();
+    // Top-level `const x = new C()` singletons in the prelude main (`console`) are
+    // ambient non-captures for the user side too — matched by SHAPE, no name list.
+    for s in &prelude.main.body {
+        if let rts_hir::ir::HirStmt::Const { name, init, .. } = s {
+            if matches!(&init.kind, rts_hir::ir::HirExprKind::New { .. }) {
+                names.insert(name.clone());
+            }
+        }
+    }
+    names
 }
 
 /// Parse, lower, JIT, and run `src` with `console.log` output CAPTURED into a
@@ -245,10 +258,12 @@ fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<
     // resolving to the cell rather than an unbound ident.
     let mut forced_globals = prelude.forced_globals;
     forced_globals.extend(user.forced_globals);
-    // Prelude read-only singletons (`console`) over the COMBINED main — the
-    // singleton's `const` lives in the merged prelude side, so re-promote here too
-    // (cell ids are recomputed over prelude+user; this keeps `console` a cell).
-    forced_globals.extend(funcval::prelude_singleton_globals(&main));
+    // Top-level singleton-instance globals (`const X = new Y()`) over the COMBINED
+    // main — data-driven, no name allow-list. Force-promote each to a cell (so it
+    // reaches inside functions) and carry `name → class` so `static_instance_class`
+    // recovers the receiver class the gcell erases.
+    let gcell_classes = funcval::singleton_instance_globals(&funcs, &main);
+    forced_globals.extend(gcell_classes.keys().cloned());
     let gcells = funcval::module_globals(&funcs, &main, &forced_globals);
 
     Ok(LoweredProgram {
@@ -258,6 +273,7 @@ fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<
         fn_this_class,
         captures,
         gcells,
+        gcell_classes,
         forced_globals,
         prelude_fns,
         builtins,
@@ -282,6 +298,12 @@ pub(crate) struct LoweredProgram {
     /// access goes through `__RTS_FN_NS_GC_GCELL_GET/SET` by this id. Computed by
     /// [`funcval::module_globals`] over the final funcs+main.
     pub gcells: std::collections::HashMap<String, u32>,
+    /// Top-level SINGLETON-INSTANCE globals (`const X = new Y()`) → their class `Y`.
+    /// Data-driven (matched by SHAPE, no name allow-list). Carried so the lowerer's
+    /// `static_instance_class` recovers the receiver class for a gcell-promoted
+    /// singleton (`console.log` dispatches on `Console` inside any function) — the
+    /// gcell promotion erases the `local_classes` entry a plain `new Y()` would set.
+    pub gcell_classes: std::collections::HashMap<String, String>,
     /// CELL-promotion set (#195): top-level `let`s force-promoted to runtime cells
     /// because a closure captures them AND they are mutated (a by-value snapshot
     /// would be stale). Carried so the multi-file merge re-promotes the same names
@@ -464,9 +486,11 @@ fn build_from_program(
     // the live cell) instead of bailing. Stored on the program so the multi-file merge
     // re-promotes the same names over the combined main (arrows are gone by then).
     let mut forced_globals = funcval::captured_mutated_top_lets(&funcs, &main);
-    // Prelude read-only singletons (`console`) — force-promoted so they reach
-    // inside user functions (a plain top-level `const` does not).
-    forced_globals.extend(funcval::prelude_singleton_globals(&main));
+    // Top-level singleton-instance globals (`const X = new Y()`) — data-driven,
+    // force-promoted to cells so they reach inside user functions (a plain
+    // top-level `const` does not); `name → class` carried for `static_instance_class`.
+    let gcell_classes = funcval::singleton_instance_globals(&funcs, &main);
+    forced_globals.extend(gcell_classes.keys().cloned());
     let pre_globals: std::collections::HashSet<String> =
         funcval::module_globals(&funcs, &main, &forced_globals)
             .into_keys()
@@ -485,6 +509,7 @@ fn build_from_program(
         fn_this_class,
         captures: extracted.captures,
         gcells,
+        gcell_classes,
         forced_globals,
         // A single `build_program` has no prelude/user split — every fn is "user"
         // here. When `merge_programs` combines a prelude + user program it computes

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -77,6 +77,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
     let fn_this_class = &prog.fn_this_class;
     let captures = &prog.captures;
     let gcells = &prog.gcells;
+    let gcell_classes = &prog.gcell_classes;
     let prelude_fns = &prog.prelude_fns;
     let builtins = &prog.builtins;
     let mut module = make_module();
@@ -191,6 +192,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
             classes,
             captures,
             gcells,
+            gcell_classes,
             this_class,
             is_prelude,
             builtins,
@@ -209,6 +211,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
         classes,
         captures,
         gcells,
+        gcell_classes,
         None,
         false,
         builtins,
@@ -269,6 +272,7 @@ fn define_one(
     classes: &super::class::ClassTable,
     captures: &HashMap<String, Vec<String>>,
     gcells: &HashMap<String, u32>,
+    gcell_classes: &HashMap<String, String>,
     this_class: Option<&str>,
     is_prelude: bool,
     builtins: &HashMap<String, (String, String)>,
@@ -280,8 +284,8 @@ fn define_one(
         let mut fb_ctx = FunctionBuilderContext::new();
         let mut fb = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
         let res = Lowerer::lower_function(
-            module, &mut fb, func, sig, sigs, thunks, ids, classes, captures, gcells, this_class,
-            is_prelude, builtins,
+            module, &mut fb, func, sig, sigs, thunks, ids, classes, captures, gcells, gcell_classes,
+            this_class, is_prelude, builtins,
         );
         match res {
             Ok(()) => fb.finalize(),

--- a/crates/rts-codegen-new/src/front/run/trycatch.rs
+++ b/crates/rts-codegen-new/src/front/run/trycatch.rs
@@ -243,23 +243,6 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(())
     }
 
-    /// In a `try`/`finally` with no `catch`: after the finalizer ran, re-check the
-    /// pending flag and route a still-pending error (the body threw and nothing
-    /// caught it) — to the enclosing catch, or a sentinel-return — else fall to
-    /// `after`.
-    fn emit_finally_propagate(&mut self, module: &mut dyn Module, after: Block) -> FrontResult<()> {
-        let pending = self
-            .call_runtime(module, "__rtsadp_err_pending", &[])?
-            .expect("__rtsadp_err_pending returns a value");
-        let err_block = self.builder.create_block();
-        self.builder.ins().brif(pending, err_block, &[], after, &[]);
-        self.builder.switch_to_block(err_block);
-        self.builder.seal_block(err_block);
-        self.block_terminated = false;
-        self.unwind(module)?;
-        Ok(())
-    }
-
     /// After a finalizer that ran with a SAVED (cleared) pending error: decide what
     /// propagates. Precedence (JS): a NEW error thrown by the finalizer itself wins
     /// — its `throw` re-set the slot, so if a pending error exists NOW, unwind it.

--- a/docs/specs/rts-codegen-new-design.md
+++ b/docs/specs/rts-codegen-new-design.md
@@ -324,16 +324,28 @@ da doutrina "no front só referência". Agora:
   front não faz mais o split estático objeto-vs-escalar), `engine.print_line(s)` /
   `engine.eprint_line(s)` (sink capture-aware → `__rtsadp_print_line(ptr,len,to_stderr)`,
   stdout/stderr). O join variádico com espaços é `.ts` puro (itera `...args`).
-- **Globais singleton read-only alcançam funções de usuário (mecanismo novo):** um
-  `const console` top-level é, por padrão, INVISÍVEL dentro de `function f() {
-  console.log(..) }` (uma função resolve ident livre só por local/param, gcell #195,
-  ou constante global). Fix: `funcval::prelude_singleton_globals` FORÇA `console` a
-  virar gcell #195 (acessível em qualquer escopo, via o set `force`); `module_globals`
-  passou a considerar `HirStmt::Const` (não só `Let`); e `static_instance_class`
-  recupera a classe `Console` da gcell via uma allow-list singleton→classe em
-  `class/dispatch.rs` (`"console" => "Console"`). Essa allow-list de NOME (não lógica
-  de dispatch) é a ÚNICA menção a console no front — o equivalente do que já existia
-  p/ `undefined`/`NaN`/`Infinity` no set `GLOBALS`.
+- **Arquivo:** `crates/rts-shared/src/stdlib/console.ts` — `console` é uma backend
+  class NÃO-primordial, então o `.ts` vive em `rts-shared/stdlib` (ao lado de
+  `json.ts`/`map_set.ts`), NÃO em `rts-primitives` (lá só primordiais: error/object/
+  boolean/number/string). Exposto via `rts_runtime::stdlib::CONSOLE_TS`.
+- **Globais singleton read-only alcançam funções de usuário — DATA-DRIVEN, sem
+  nomear console:** um `const console = new Console()` top-level é, por padrão,
+  INVISÍVEL dentro de `function f() { console.log(..) }` (uma função resolve ident
+  livre só por local/param, gcell #195, ou constante global). A solução NÃO nomeia
+  console em lugar nenhum do front — ela casa o PADRÃO `const X = new Y()`:
+  `funcval::singleton_instance_globals(funcs, main)` detecta todo `const X = new Y()`
+  top-level REFERENCIADO de dentro de função/arrow (a condição real de
+  reachability), promove a gcell #195 e carrega `name → class` num mapa
+  `gcell_classes` (threaded pelo `LoweredProgram`→`module_jit`→`Lowerer`, paralelo a
+  `gcells`); `static_instance_class` recupera a classe da gcell desse mapa. Só os
+  referenciados em função são promovidos (um singleton só-top-level fica local
+  normal — promover todos mis-dispatcharia `const p = new Point(); p.parseValue()`).
+  `prelude_fn_names` inclui os singletons do prelude como ambient não-captura no user
+  build (uma arrow `x => console.log(x)` não vira captura). Bug latente fechado no
+  caminho: `collect_free_stmt` não descia em `Try`/`Throw`/`For*` (scan de free-ident
+  incompleto). NENHUMA allow-list de nome — o equivalente data-driven do que
+  @drysius fez p/ classes Registry (`is_pure_registry_class`, nunca `if class ==
+  "Date"`).
 - **`finally` com chamada e erro pendente (correção de unwind exposta):** como
   `console.log` virou chamada de método (várias sub-chamadas com
   `emit_post_call_error_check`), um `finally { console.log(..) }` alcançado no unwind


### PR DESCRIPTION
## Resumo

Endereça o feedback do @drysius na revisão do #1566: `console`/`Console` apareciam **hardcoded no front** em 3 lugares (antipadrão — o motor não pode nomear não-primordial). Agora é **data-driven por shape**, o front não nomeia console.

Rebaseado sobre a main atual (que já mergeou #1566 + moveu console.ts p/ rts-shared/stdlib).

## Mudanças

- `singleton_instance_globals(funcs, main)`: detecta `const X = new Y()` top-level **referenciado de dentro de função/arrow** → promove a gcell + carrega `name → class`. Genérico (qualquer singleton, prelude ou user). Só promove os referenciados em função (um singleton só-top-level fica local — senão mis-dispatcha `const p = new Point(); p.parseValue()`).
- `dispatch.rs::static_instance_class`: recupera a classe via `gcell_classes` (mapa threaded pelo Lowerer), não `prelude_singleton_class("console")`. Função hardcoded **deletada**.
- `GLOBALS` perde `console` (fica só undefined/Infinity/NaN).
- `prelude_fn_names` inclui singletons do prelude → ambient não-captura no user build.

## Bug latente corrigido no caminho
`collect_free_stmt` (scan.rs) NÃO descia em `Try`/`Throw`/`For`/`ForOf`/`ForIn` (`_ => {}`) — `console` dentro de try/catch/loop numa função não era detectado → unbound. Arms adicionados (free-ident scan completo, respeitando catch param / loop var binding).

## Testes
- **713/713 unit verdes**. Zero hardcode de console no front (só comentários).

🤖 Generated with [Claude Code](https://claude.com/claude-code)