### PR TITLE
globalThis como objeto global singleton (foundation: valores)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -163,6 +163,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if self.sigs.contains_key(name) {
             return self.reify_function(module, name);
         }
+        // `globalThis` — the singleton global OBJECT (foundation: value get/set).
+        // A local/gcell of the same name would have shadowed it above; here it is
+        // the language global, resolved to the singleton TAG_OBJECT word so
+        // `globalThis.prop` get/set route through the dynamic-object trampolines.
+        if name == "globalThis" {
+            let w = self
+                .call_runtime(module, "__rtsadp_globalthis", &[])?
+                .expect("__rtsadp_globalthis returns a word");
+            return Ok(Val::new_with_kind(w, Repr::Tagged, JsKind::Object));
+        }
         unsupported!("unbound identifier `{name}`")
     }
 

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -205,6 +205,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         object: &HirExpr,
         prop: &str,
     ) -> FrontResult<Val> {
+        // ---- `globalThis.prop` read: the singleton global object is a keyed
+        // OBJECT of runtime-only shape, so resolve the property dynamically (a
+        // missing key reads `undefined`, JS-correct). ----
+        if self.is_globalthis_receiver(object) {
+            return self.lower_dynamic_get_expr(module, object, prop);
+        }
         // ---- NAMESPACE-OBJECT constant read (`math.PI`, `math.E`): `math` was
         // imported from bare `"rts"` (bound as a namespace object, member empty).
         // The constant is a zero-arg `MemberKind::Constant` getter in the Registry
@@ -453,6 +459,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         prop: &str,
         value: &HirExpr,
     ) -> FrontResult<Val> {
+        // ---- `globalThis.prop = v` write: the singleton global object's dynamic
+        // property. `__rtsadp_obj_set` writes an existing slot or appends a new key
+        // (shape transition), so a brand-new global property works. ----
+        if self.is_globalthis_receiver(object) {
+            return self.lower_dynamic_set_expr(module, object, prop, value);
+        }
         // ---- accessor SET `obj.x = v` where x is a setter on the receiver class ----
         if let Some(class) = self.instance_class_of(object) {
             if self
@@ -841,6 +853,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// stored slot for a keyed object and `undefined` for an absent key OR a
     /// non-object receiver (the trampoline never faults; see `value/objops.rs`).
     /// The result is a Tagged `Val` of kind `Unknown`.
+    /// Whether `object` is the bare `globalThis` language global (not shadowed by a
+    /// local/param or a module-level cell of the same name). Its `.prop` get/set
+    /// routes to the dynamic-object trampolines on the singleton object word.
+    pub(super) fn is_globalthis_receiver(&self, object: &HirExpr) -> bool {
+        matches!(&object.kind, HirExprKind::Ident(n)
+            if n == "globalThis" && self.local(n).is_none() && self.gcell_id(n).is_none())
+    }
+
     fn lower_dynamic_get_expr(
         &mut self,
         module: &mut dyn Module,

--- a/crates/rts-codegen-new/src/front/run/tests/globals.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/globals.rs
@@ -116,9 +116,33 @@ fn coerce_in_concat() {
 // ---- bails for genuinely-unsupported forms (honesty floor) ----
 
 #[test]
-fn global_this_bails() {
-    // globalThis has no value model here → still an unbound-identifier bail.
-    assert_bails("console.log(globalThis);");
+fn global_this_value_props() {
+    // `globalThis` is now the singleton global object (foundation: value get/set).
+    // The instance is a process-global singleton, so these assertions are written
+    // SELF-CONTAINED (set-then-read / a unique absent key) to stay order-independent
+    // of other tests sharing it; a real `rts run` is one program = one fresh global.
+    // Set-then-read a value property.
+    assert_stdout(
+        "globalThis.gtSetGet = 42; console.log(globalThis.gtSetGet);",
+        "42\n",
+    );
+    // An absent property reads `undefined` (a key no other test sets).
+    assert_stdout("console.log(globalThis.gtNeverSetKeyXyz);", "undefined\n");
+    // `typeof globalThis` → "object" (matches bun).
+    assert_stdout("console.log(typeof globalThis);", "object\n");
+}
+
+#[test]
+fn global_this_persists_across_functions() {
+    // A write from inside a function is visible after it returns — the singleton
+    // object is shared by reference. Reset at the top so it is order-independent.
+    assert_stdout(
+        "globalThis.gtCounter = 0;\n\
+         function inc() { globalThis.gtCounter = globalThis.gtCounter + 1; }\n\
+         inc(); inc(); inc();\n\
+         console.log(globalThis.gtCounter);",
+        "3\n",
+    );
 }
 
 #[test]

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -45,7 +45,7 @@ use rts_runtime::namespaces::math as rt_math;
 
 use crate::value::{
     abi_adapter, arraycb, arrayops, dyndispatch, errslot, funcops, genops, genops_arith, globalops,
-    inspect, iterops, objops, regexops,
+    globalthis, inspect, iterops, objops, regexops,
 };
 
 /// One installable JIT symbol: an extern "C" name and its function pointer. The
@@ -535,6 +535,8 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             "__rtsadp_re_str_search",
             regexops::__rtsadp_re_str_search as *const u8,
         ),
+        // ---- the `globalThis` singleton object (value get/set foundation) ----
+        sym("__rtsadp_globalthis", globalthis::__rtsadp_globalthis as *const u8),
         // ---- codegen-owned DYNAMIC property access (objops, P5.5) ----
         sym("__rtsadp_obj_get", objops::__rtsadp_obj_get as *const u8),
         sym("__rtsadp_obj_set", objops::__rtsadp_obj_set as *const u8),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -705,6 +705,12 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         // value-word param and returns the value word; obj_has returns a Bool
         // (i64 0/1). The key is a string PolyValue word (U64) — a literal interned
         // at lowering or a computed key's ToString.
+        // The `globalThis` singleton object word (no args; returns a TAG_OBJECT
+        // PolyValue). `globalThis.prop` get/set then reuse __rtsadp_obj_get/_set.
+        "__rtsadp_globalthis" => SymSig {
+            params: &[],
+            ret: U64,
+        },
         "__rtsadp_obj_get" => SymSig {
             params: &[U64, U64],
             ret: U64,

--- a/crates/rts-codegen-new/src/value/globalthis.rs
+++ b/crates/rts-codegen-new/src/value/globalthis.rs
@@ -1,0 +1,50 @@
+//! `globalThis` — the singleton global object (foundation: VALUE properties).
+//!
+//! `globalThis` is a process-wide dynamic object: an arbitrary string→PolyValue
+//! property bag readable/writable from anywhere (`globalThis.x = 5; globalThis.x`).
+//! It is backed by the SAME keyed-object representation as an object literal (a
+//! `VEC` whose slot 0 is a global shape-id, values at `1 + index`), so
+//! `globalThis.prop` get/set route through the ordinary dynamic-object trampolines
+//! ([`super::objops`]) — no new property machinery.
+//!
+//! The single instance is created lazily on first reference and pinned as a
+//! permanent GC root: it lives only in a `OnceLock`, off every stack, so without
+//! the root the conservative sweep would collect it (and any heap value it solely
+//! holds). The root marks the boxed object word; `Entry::Vec`'s child tracing then
+//! keeps the stored property values alive.
+//!
+//! SCOPE — VALUE properties only. `globalThis.X = class X {…}` (class-as-value) and
+//! `new (globalThis.X)()` (dynamic construct) are a deferred follow-up: they need
+//! HIR class-expressions, which the front-end does not model yet.
+
+use std::sync::OnceLock;
+
+use rts_engine::collector::global_roots;
+use rts_runtime::namespaces::collections::vec as rt_vec;
+use rts_runtime::namespaces::gc::handles as rt_handles;
+
+use super::PolyValue;
+
+/// The singleton `globalThis` object word (`TAG_OBJECT`), set once on first access.
+static GLOBALTHIS: OnceLock<u64> = OnceLock::new();
+
+/// Return the singleton `globalThis` object word, creating it on first call. The
+/// instance is an EMPTY keyed object (slot 0 = the empty-keys global shape-id,
+/// exactly like an object literal `{}`), and is registered as a permanent GC root
+/// so it — and every heap value it holds — survives collection.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_globalthis() -> u64 {
+    let word = *GLOBALTHIS.get_or_init(|| {
+        let handle = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
+        // slot 0 = the empty-shape id, the same header a `{}` literal carries.
+        let empty_shape = crate::shape::intern_global_shape(&[]);
+        let slot0 = PolyValue::from_i32(empty_shape as i32).raw() as i64;
+        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle, slot0);
+        let poly48 = rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(handle);
+        PolyValue::from_object_handle(poly48).raw()
+    });
+    // Pin as a permanent root (idempotent — `add` dedups by address). Done AFTER
+    // init so the address read is the stable `OnceLock` slot holding the word.
+    global_roots::add(GLOBALTHIS.get().expect("just initialised") as *const u64 as usize);
+    word
+}

--- a/crates/rts-codegen-new/src/value/mod.rs
+++ b/crates/rts-codegen-new/src/value/mod.rs
@@ -128,6 +128,9 @@ pub mod regexops;
 // `_set`/`_has` for `obj.key`/`obj[k]` whose shape is known only at RUNTIME,
 // reading the slot-0 global shape-id + the global shape registry.
 pub mod objops;
+// The `globalThis` singleton object (foundation: VALUE get/set), backed by the
+// same keyed-object repr so `globalThis.prop` reuses the `objops` trampolines.
+pub mod globalthis;
 // Codegen-owned thread-local pending-error slot for `throw` / `try-catch` (P5.13):
 // `__rtsadp_throw_set` / `__rtsadp_err_pending` / `__rtsadp_err_take` /
 // `__rtsadp_err_clear` — the manual-unwind exception model.

--- a/docs/specs/rts-codegen-new-design.md
+++ b/docs/specs/rts-codegen-new-design.md
@@ -343,6 +343,37 @@ da doutrina "no front só referência". Agora:
   ressurge após; um throw no próprio finally tem precedência). `io.print` direto não
   expunha o bug (1 extern, sem post-call check).
 
+#### 3.2.4 `globalThis` — objeto global singleton (foundation: VALUES) — FEITO
+
+`globalThis` deixou de ser bail "unbound identifier" e virou um OBJETO global
+singleton com get/set dinâmico de VALORES (`globalThis.x = 5; globalThis.x`,
+write-de-dentro-de-função visível depois, `typeof globalThis === "object"` — bate
+com bun). Reusa a representação de objeto keyed existente (Vec com shape-id no slot
+0), então `globalThis.prop` get/set roteia pelos mesmos trampolins dinâmicos
+`__rtsadp_obj_get`/`__rtsadp_obj_set` (incl. append de chave nova via shape
+transition) — sem maquinaria de propriedade nova.
+
+- O singleton é o extern codegen-owned `__rtsadp_globalthis()` (`value/globalthis.rs`):
+  `OnceLock<u64>` criando uma vez um objeto keyed vazio (slot 0 = shape vazio,
+  igual a `{}`), retornando a palavra `TAG_OBJECT`.
+- **GC**: o objeto vive só no `OnceLock` (fora de toda stack), então é registrado
+  como root permanente via `global_roots::add` (o mesmo pin usado por globals
+  top-level/N-API). O mark normaliza a palavra NaN-boxed e o tracing de `Entry::Vec`
+  mantém vivos os valores guardados.
+- `globalThis` resolve como identificador bare em `lower_ident` (após local/gcell,
+  como `NaN`/`undefined`) → palavra do singleton; `lower_member`/`lower_member_assign`
+  detectam o receiver `globalThis` (`is_globalthis_receiver`) e roteiam ao path
+  dinâmico. É um GLOBAL DE LINGUAGEM (não classe não-primordial) — o motor pode
+  nomeá-lo, como `NaN`.
+- Singleton process-global: um `rts run` é 1 programa = 1 globalThis fresco
+  (correto). O harness de unit-test compartilha o processo → testes são
+  self-contained (set-then-get / chave única absent) p/ serem order-independent.
+
+**Follow-up deferido (NÃO neste increment):** `globalThis.X = class X {…}`
+(classe-como-valor) + `new (globalThis.X)()` (construção dinâmica) precisam de
+class-EXPRESSIONS no HIR (hoje `: C`/`class` expr degradam) + `new` sobre um valor
+dinâmico. É o que destrava o padrão `globalThis.Map = class Map` por completo.
+
 #### 3.2.1 Number migrado p/ `.ts` (mesmo padrão de Boolean)
 
 `number` é um PRIMITIVO (sintaxe literal `123`), então o VALOR continua unboxed


### PR DESCRIPTION
## Gap geral: `globalThis`

Provado vs Bun: `globalThis` era um **unbound-identifier bail** ("globalThis has no value model here"). Bun faz `globalThis.x = 5; globalThis.x`. Esta foundation torna `globalThis` um objeto global dinâmico real — bag `string→PolyValue` legível/gravável de qualquer lugar.

**Escopo travado — só VALORES.** `globalThis.X = class X {…}` (classe-como-valor) + `new (globalThis.X)()` (construção dinâmica) ficam de **follow-up** (precisam de class-expressions/class-as-value no HIR, que o front-end ainda não modela).

## Implementação
- `value/globalthis.rs` (novo): `__rtsadp_globalthis()` — `OnceLock<u64>` cria 1× um objeto keyed vazio (slot0 = shape vazio, igual `{}`), retorna palavra `TAG_OBJECT`. Vive só no OnceLock (fora de stack) → **root GC permanente** (`global_roots::add`): o mark marca a palavra boxed, `Entry::Vec` traça os valores → um valor que só o globalThis segura sobrevive ao sweep.
- `expr.rs`: `globalThis` resolve em `lower_ident` (após local/gcell, como `NaN`/`undefined`) → palavra singleton. `typeof globalThis` → `"object"`. É global de LINGUAGEM (não classe), o motor pode nomear.
- `obj.rs`: member read/write detectam o receiver via `is_globalthis_receiver` → reusa os trampolins dinâmicos `__rtsadp_obj_get/_set` (incl. append de chave nova via shape transition). Zero maquinaria nova. Ausente → `undefined` (`globalThis.count ?? 0` funciona).
- `tests/globals.rs`: `global_this_bails` → `global_this_value_props` + `global_this_persists_across_functions` (comportamento mudou bail→funciona; asserts order-independent pois o singleton é process-global).
- design doc §3.2.4.

## Validação
- repro = Bun: `5 hi 1` / `3` / `object`.
- `cargo test -p rts-codegen-new`: **709 → 714**.
- suíte TS (`measure_new`): **309 → 310**.
- gate sem HARD; nada >500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)