### PR TITLE
Classe de usuário como valor + new-thunk (slice 1)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -535,6 +535,45 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(Val::tagged_kind(word, JsKind::Function))
     }
 
+    /// Reify a USER CLASS named `name` as a first-class VALUE (`const C = Box`): a
+    /// `TAG_FUNCTION` PolyValue whose code address is the class NEW-THUNK
+    /// (`<class>__rtsn_newthunk`) — invoking it (`new C(args)` / a plain call)
+    /// allocates an instance and runs the constructor. `nparams` is the ctor arity
+    /// (no `this` in the value ABI; the thunk synthesizes `this`). A class without a
+    /// real synthesized ctor (a literal-shape placeholder) has no new-thunk → bail.
+    /// `typeof` of the result is "function" (JS: `typeof Box === "function"`).
+    pub(super) fn reify_class(&mut self, module: &mut dyn Module, name: &str) -> FrontResult<Val> {
+        let desc = self
+            .classes
+            .get(name)
+            .ok_or_else(|| Unsupported::new(format!("reify of unknown class `{name}`")))?;
+        let nparams = desc.ctor_arity as i64;
+        let thunk_key = super::thunk::new_thunk_name(name);
+        let Some(&thunk_id) = self.thunks.get(&thunk_key) else {
+            return unsupported!(
+                "class `{name}` as a VALUE — no synthesized constructor (a literal-shape \
+                 / `extends`-only class as a value is a later increment)"
+            );
+        };
+        let func_ref = module.declare_func_in_func(thunk_id, self.builder.func);
+        let addr = self.builder.ins().func_addr(types::I64, func_ref);
+        let nparams_v = self.builder.ins().iconst(types::I64, nparams);
+        let has_rest_v = self.builder.ins().iconst(types::I64, 0);
+        let env_word = self.builder.ins().iconst(types::I64, 0);
+        let payload = self
+            .call_runtime(module, "__rtsadp_fn_reify", &[addr, nparams_v, has_rest_v, env_word])?
+            .expect("__rtsadp_fn_reify returns a value");
+        let header = value::encode(value::TAG_FUNCTION, 0) as i64;
+        let mask = self
+            .builder
+            .ins()
+            .iconst(types::I64, value::PAYLOAD_MASK as i64);
+        let masked = self.builder.ins().band(payload, mask);
+        let header_v = self.builder.ins().iconst(types::I64, header);
+        let word = self.builder.ins().bor(masked, header_v);
+        Ok(Val::tagged_kind(word, JsKind::Function))
+    }
+
     /// Build a closure's env array (P5.7): a fresh `Entry::Vec` (a `TAG_OBJECT`
     /// PolyValue) holding a SNAPSHOT of each captured outer-local's CURRENT value
     /// (boxed), in the recorded capture order. Returns the env's `TAG_OBJECT` word.

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -30,7 +30,17 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// guess a class).
     pub(in crate::front::run) fn static_instance_class(&self, object: &HirExpr) -> Option<String> {
         match &object.kind {
-            HirExprKind::New { class, .. } => self.classes.get(class).map(|_| class.clone()),
+            HirExprKind::New { class, .. } => {
+                // `new Box()` → `Box`; `new C()` where `C` is a class-reference local
+                // (`const C = Box`) → the referenced class, so a chained
+                // `new C().method()` dispatches statically.
+                let class = self
+                    .local_class_refs
+                    .get(class)
+                    .cloned()
+                    .unwrap_or_else(|| class.clone());
+                self.classes.get(&class).map(|_| class)
+            }
             HirExprKind::Ident(name) => self
                 .local_classes
                 .get(name)

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -173,6 +173,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 .expect("__rtsadp_globalthis returns a word");
             return Ok(Val::new_with_kind(w, Repr::Tagged, JsKind::Object));
         }
+        // A bare identifier naming a user CLASS in value position is a class VALUE
+        // reference (`const C = Box`, `globalThis.Box = Box`, `typeof Box`): reify
+        // it to a `TAG_FUNCTION` whose code address is the class new-thunk. `new
+        // C(..)` by name is intercepted on the static path, so this only fires in
+        // value position.
+        if self.classes.get(name).is_some() {
+            return self.reify_class(module, name);
+        }
         unsupported!("unbound identifier `{name}`")
     }
 

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -183,6 +183,12 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// (a `new C()` result, a `: C`-annotated param, or `this` inside a method).
     /// Drives static `instance.method(args)` dispatch; absent ⇒ method calls bail.
     pub local_classes: HashMap<String, String>,
+    /// Name → the user CLASS a local holds as a VALUE (`const C = Box` → `C`→`Box`).
+    /// Distinct from `local_classes` (which holds an INSTANCE's class): here the
+    /// local IS the class/constructor itself, so `new C(args)` constructs `Box`
+    /// statically. Same insert/remove lifecycle as `local_classes` (cleared on any
+    /// rebind of the name). Absent ⇒ `new <local>()` is not a static class value.
+    pub local_class_refs: HashMap<String, String>,
     /// GENERATOR locals: `const it = g()` where `g` is a generator. `true` = LAZY
     /// (GenState handle, `Int64`); `false` = EAGER (`__gen_buf` ARRAY word).
     /// `it.next()`/`.return()`/`.throw()` route to `GENERATOR_*` by this kind.
@@ -279,6 +285,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             object_locals: std::collections::HashSet::new(),
             string_locals: std::collections::HashSet::new(),
             local_classes: HashMap::new(),
+            local_class_refs: HashMap::new(),
             generator_locals: HashMap::new(),
             global_instance_classes: HashMap::new(),
             shapes: ShapeTable::new(),

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -160,6 +160,18 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
         let id = thunk::declare_thunk(&mut module, &f.name)?;
         thunks.insert(f.name.clone(), id);
     }
+    // 2c. Declare a per-class NEW-THUNK (`<class>__rtsn_newthunk`) for every user
+    //     class with a REAL synthesized constructor (a literal-shape class has a
+    //     `__rtsl_noctor_*` placeholder not in `ids` — skip it; it is never `new`ed
+    //     through a value). A class used as a VALUE (`const C = Box`) reifies to
+    //     this thunk's address, so `new C(args)` allocates + constructs uniformly.
+    //     Keyed in the same `thunks` map under the distinct `__rtsn_newthunk` name.
+    for desc in classes.iter() {
+        if ids.contains_key(&desc.ctor) {
+            let id = thunk::declare_new_thunk(&mut module, &desc.name)?;
+            thunks.insert(thunk::new_thunk_name(&desc.name), id);
+        }
+    }
 
     // 3. Define each user function body.
     for f in funcs {
@@ -214,6 +226,21 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
             &sigs[&f.name],
             capture_count,
         )?;
+    }
+    // 4c. Define every class NEW-THUNK: allocate the instance + run the ctor +
+    //     return the instance word (the constructor's `this` is synthesized in the
+    //     allocation, sidestepping the `reify_function` `has_this` bail).
+    for desc in classes.iter() {
+        if let Some(&ctor_id) = ids.get(&desc.ctor) {
+            thunk::define_new_thunk(
+                &mut module,
+                thunks[&thunk::new_thunk_name(&desc.name)],
+                ctor_id,
+                &sigs[&desc.ctor],
+                desc.global_shape,
+                desc.fields.len(),
+            )?;
+        }
     }
 
     module

--- a/crates/rts-codegen-new/src/front/run/newexpr.rs
+++ b/crates/rts-codegen-new/src/front/run/newexpr.rs
@@ -40,6 +40,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         class: &str,
         args: &[HirExpr],
     ) -> FrontResult<(Val, String, ShapeId)> {
+        // A local that REFERENCES a class as a value (`const C = Box; new C(..)`):
+        // resolve `C` to the real class `Box` and construct it on the static path.
+        // A local SHADOWS the bare class name, so this ref map is checked first.
+        // Owned so the name outlives the later `&mut self` lowering calls.
+        let class_owned: String = self
+            .local_class_refs
+            .get(class)
+            .cloned()
+            .unwrap_or_else(|| class.to_string());
+        let class: &str = &class_owned;
         let Some(desc) = self.classes.get(class).cloned() else {
             return unsupported!(
                 "`new {class}(..)` — class `{class}` is not a user class in this program \

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -465,6 +465,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if self.is_globalthis_receiver(object) {
             return self.lower_dynamic_set_expr(module, object, prop, value);
         }
+        // ---- a bare class NAME target (`C.n = 5`) is a STATIC FIELD WRITE, a later
+        // increment. Bail BEFORE the function-value-property path: `C` now reifies
+        // to a `TAG_FUNCTION` class-value, so without this guard the write would be
+        // silently recorded as a data property on the class-value instead. ----
+        if self.class_name_receiver(object).is_some() {
+            return unsupported!(
+                "static field write `.{prop}` (read-only static getter synthesis — a later increment)"
+            );
+        }
         // ---- accessor SET `obj.x = v` where x is a setter on the receiver class ----
         if let Some(class) = self.instance_class_of(object) {
             if self

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -226,6 +226,19 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.local_classes.insert(name.to_string(), class);
                 return Ok(());
             }
+            // `const C = Box`: bind the local to the reified class VALUE (a
+            // `TAG_FUNCTION` new-thunk word) AND record that `C` REFERENCES class
+            // `Box`, so a later `new C(args)` constructs `Box` on the static path.
+            // Guarded so a local of the same name shadows the class (then it is not
+            // a class reference). Reassignment clears the ref (the removes below).
+            HirExprKind::Ident(c)
+                if self.local(c).is_none() && self.classes.get(c).is_some() =>
+            {
+                let val = self.lower_expr(module, init)?;
+                self.bind_tagged_local(name, val);
+                self.local_class_refs.insert(name.to_string(), c.clone());
+                return Ok(());
+            }
             _ => None,
         };
         if let Some(shape) = shape {
@@ -282,6 +295,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // local being re-`let`, drop the stale shape/class (its value is now opaque).
         self.local_shapes.remove(name);
         self.local_classes.remove(name);
+        self.local_class_refs.remove(name);
         self.global_instance_classes.remove(name);
         self.object_locals.remove(name);
         Ok(())

--- a/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
@@ -1,0 +1,54 @@
+//! A USER class used as a first-class VALUE: a bare class name in value position
+//! (`const C = Box`, `typeof Box`, `globalThis.X = Box`) reifies to a callable
+//! class-value (a `TAG_FUNCTION` new-thunk), and `new C(args)` on the const-bound
+//! reference constructs the class. Proven against the reference runtime.
+//!
+//! SCOPE: the dynamic `new` resolves the class statically through the `const C =
+//! Box` reference. `new <runtime-value>()` (a class read back from globalThis at
+//! runtime) and class EXPRESSIONS (`class {…}`) are a deferred follow-up.
+
+use super::assert_stdout;
+
+/// `const C = Box; new C(7)` — the class name reifies to a value, the const binds
+/// the reference, and `new C(..)` constructs `Box` on the static path.
+#[test]
+fn const_ref_dynamic_new() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } \
+         get(): number { return this.v; } } \
+         const C = Box; console.log(new C(7).get());",
+        "7\n",
+    );
+}
+
+/// Multiple constructions through the same class-reference local.
+#[test]
+fn const_ref_multiple_new() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } \
+         get(): number { return this.v; } } \
+         const C = Box; const x = new C(3); const y = new C(9); \
+         console.log(x.get() + y.get());",
+        "12\n",
+    );
+}
+
+/// `typeof Box` is "function" (a class value is callable, like JS).
+#[test]
+fn typeof_class_is_function() {
+    assert_stdout(
+        "class Box { v: number = 0; } console.log(typeof Box);",
+        "function\n",
+    );
+}
+
+/// A class VALUE survives a round-trip through `globalThis`: stored as a property
+/// and read back, it is still a callable function value.
+#[test]
+fn class_value_through_globalthis() {
+    assert_stdout(
+        "class Widget { } globalThis.Widget = Widget; \
+         console.log(typeof globalThis.Widget);",
+        "function\n",
+    );
+}

--- a/crates/rts-codegen-new/src/front/run/tests/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/mod.rs
@@ -53,6 +53,7 @@ mod arraycb;
 mod boolean_class;
 mod builtin_import;
 mod class;
+mod class_as_value;
 mod class_inherit;
 mod console_methods;
 mod closure;

--- a/crates/rts-codegen-new/src/front/run/thunk.rs
+++ b/crates/rts-codegen-new/src/front/run/thunk.rs
@@ -180,6 +180,122 @@ fn build_thunk_body(
     Ok(())
 }
 
+/// Declare a per-class NEW-THUNK symbol (`<class>__rtsn_newthunk`) and return its
+/// [`FuncId`]. The new-thunk is a uniform-ABI value that, when invoked, ALLOCATES
+/// a fresh instance and runs the class constructor — so a class used as a VALUE
+/// (`const C = Box; new C(7)`) reifies to this thunk's address. Sidesteps the
+/// `reify_function` `has_this` bail: the ctor's `this` is synthesized HERE (the
+/// allocation), never filled from a positional arg.
+pub fn declare_new_thunk(module: &mut JITModule, class_name: &str) -> FrontResult<FuncId> {
+    let sig = uniform_signature(module);
+    let name = new_thunk_name(class_name);
+    module
+        .declare_function(&name, Linkage::Local, &sig)
+        .map_err(|e| Unsupported::new(format!("declare new-thunk `{name}`: {e}")))
+}
+
+/// The synthesized new-thunk symbol name for a user class `class`.
+pub fn new_thunk_name(class: &str) -> String {
+    format!("{class}__rtsn_newthunk")
+}
+
+/// Define a class NEW-THUNK body: allocate the instance (a `VEC` whose slot 0 is
+/// `global_shape`, one `undefined` per field — exactly what `lower_new` emits),
+/// run the constructor `ctor_id` with `this` = the instance and the explicit args
+/// unpacked from `a0..a3` (+ `rest`), and RETURN the instance word (`TAG_OBJECT`),
+/// NOT the ctor's own return. `ctor_sig.params[0]` is the `this` receiver; the
+/// remaining params are the declared ctor args. A `...rest`/non-coercible param is
+/// rejected the same way [`build_thunk_body`] does.
+pub fn define_new_thunk(
+    module: &mut JITModule,
+    new_thunk_id: FuncId,
+    ctor_id: FuncId,
+    ctor_sig: &FnSig,
+    global_shape: u32,
+    n_fields: usize,
+) -> FrontResult<()> {
+    let mut ctx = module.make_context();
+    ctx.func.signature = uniform_signature(module);
+    {
+        let mut fb_ctx = FunctionBuilderContext::new();
+        let mut fb = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
+        let res =
+            build_new_thunk_body(module, &mut fb, ctor_id, ctor_sig, global_shape, n_fields);
+        match res {
+            Ok(()) => fb.finalize(),
+            Err(e) => {
+                module.clear_context(&mut ctx);
+                return Err(e);
+            }
+        }
+    }
+    module
+        .define_function(new_thunk_id, &mut ctx)
+        .map_err(|e| Unsupported::new(format!("define new-thunk: {e}")))?;
+    module.clear_context(&mut ctx);
+    Ok(())
+}
+
+/// Emit the new-thunk body: allocate the instance, fill `this` + ctor args, call
+/// the ctor, return the instance word.
+fn build_new_thunk_body(
+    module: &mut JITModule,
+    fb: &mut FunctionBuilder,
+    ctor_id: FuncId,
+    ctor_sig: &FnSig,
+    global_shape: u32,
+    n_fields: usize,
+) -> FrontResult<()> {
+    let entry = fb.create_block();
+    fb.append_block_params_for_function_params(entry);
+    fb.switch_to_block(entry);
+    fb.seal_block(entry);
+    let block_params: Vec<Value> = fb.block_params(entry).to_vec();
+    // uniform params: env, a0..a3, rest. `env` is unused (a class-value never
+    // captures); the positional/rest carry the ctor's explicit args.
+    let positional = &block_params[1..1 + POSITIONAL];
+    let rest_word = block_params[1 + POSITIONAL];
+
+    // ---- allocate the instance: VEC + slot0 shape-id + one `undefined` per field
+    let obj_word = emit_marshal::emit_new_vec_object(module, fb);
+    let id_word = fb.ins().iconst(
+        types::I64,
+        value::PolyValue::from_i32(global_shape as i32).raw() as i64,
+    );
+    emit_marshal::emit_vec_push(module, fb, obj_word, id_word);
+    let undef = fb
+        .ins()
+        .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
+    for _ in 0..n_fields {
+        emit_marshal::emit_vec_push(module, fb, obj_word, undef);
+    }
+
+    // ---- ctor call args: params[0] = `this` (the instance), params[1..] from
+    //      a0.. (the explicit ctor args), unboxed to each param's repr.
+    let mut call_args: Vec<Value> = Vec::with_capacity(ctor_sig.params.len());
+    for (i, &repr) in ctor_sig.params.iter().enumerate() {
+        if i == 0 {
+            // `this` is the freshly allocated instance (a Tagged object word).
+            call_args.push(obj_word);
+            continue;
+        }
+        let pos = i - 1; // arg position (param 1 → a0)
+        let word = if pos < POSITIONAL {
+            positional[pos]
+        } else {
+            let idx = fb.ins().iconst(types::I64, (pos - POSITIONAL) as i64);
+            emit_marshal::emit_vec_get(module, fb, rest_word, idx)
+        };
+        call_args.push(unbox_word_to_repr(fb, word, repr)?);
+    }
+    let ctor_ref = module.declare_func_in_func(ctor_id, fb.func);
+    fb.ins().call(ctor_ref, &call_args);
+
+    // The instance word IS the result of `new` (the ctor's own return is ignored).
+    fb.ins().return_(&[obj_word]);
+    Ok(())
+}
+
 /// Unbox a uniform-ABI PolyValue `word` into a value of native `repr` for the
 /// real call (the inverse of [`box_repr_to_word`]). A `Tagged` param keeps the
 /// word verbatim. Pure IR (the egraph folds a box/unbox round-trip).


### PR DESCRIPTION
## Gap geral: classe-como-valor

Provado vs Bun: `const C = Box` (nome de classe em posição de valor) bailava `unbound identifier \`Box\``; Bun reifica a classe como valor-construtor (`typeof Box === "function"`). Primeiro slice rumo a `globalThis.Map = class Map`.

## Achado decisivo
O ctor sintetizado `__rtsn_ctor_C(this, args…)` tem `this`, então `reify_function` bail (o caminho uniforme de função-valor não invoca ctor). **Solução: um NEW-THUNK por classe** — variante ABI-uniforme que ALOCA o `this` internamente, chama o ctor tipado, retorna a instância. Contorna o bail sintetizando `this` na alocação.

## Implementação
- **new-thunk** (`thunk.rs`/`module_jit.rs`): gerado por classe com ctor real (`<class>__rtsn_newthunk`); litshape sem ctor é pulada.
- **reify** (`expr.rs`/`call.rs`): nome de classe em posição de valor → classe-valor = `TAG_FUNCTION` apontando pro new-thunk (via `__rtsadp_fn_reify`, GC-safe, heap handle atrás do tag). `typeof` → `"function"`.
- **new via alias** (`stmt.rs`/`newexpr.rs`/`class/dispatch.rs`): `const C = Box` registra `local_class_refs["C"]="Box"` (mesmo ciclo de `local_classes`); `lower_new`/`static_instance_class` resolvem `C`→`Box` → constrói no caminho ESTÁTICO. `new Box()` por nome **byte-idêntico** (alias no-op).
- **guard** (`obj.rs`): `class_name_receiver` antes do caminho função-valor — `C.n = 5` (static-field write) volta a bailar.

## Validação
- Repro = Bun: `const C = Box; new C(7).get()` → 7; multi-new → 12; `typeof Box` → function; round-trip globalThis (`globalThis.Widget = Widget; typeof globalThis.Widget`) → function.
- `cargo test -p rts-codegen-new`: **714 → 718** (+4 `class_as_value`).
- suíte `measure_new`: **310 → 310** (sem regressão); `static_field_write_bails` de volta verde.
- gate sem HARD; nada >500.

## Deferido (não tentado)
1. **new-on-runtime-value** (`const G = globalThis.Box; new G(5)` — G de read dinâmico) — invocar o new-thunk em RUNTIME (caminho fn-valor com `new`). É o que fecha `new (globalThis.Map)()`.
2. **Class expressions** (`const D = class {…}`) — HIR não modela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)