### PR TITLE
new sobre classe-valor de runtime (slice 2: construct + sound)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -557,6 +557,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         let func_ref = module.declare_func_in_func(thunk_id, self.builder.func);
         let addr = self.builder.ins().func_addr(types::I64, func_ref);
+        // Register this class NEW-THUNK address as a valid `new <value>()` target,
+        // so a later dynamic `new` through this class-value constructs (and a
+        // non-constructor value throws). Idempotent: the address is stable.
+        self.call_runtime(module, "__rtsadp_register_ctor_thunk", &[addr])?;
         let nparams_v = self.builder.ins().iconst(types::I64, nparams);
         let has_rest_v = self.builder.ins().iconst(types::I64, 0);
         let env_word = self.builder.ins().iconst(types::I64, 0);
@@ -598,6 +602,53 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             emit_marshal::emit_vec_push(module, self.builder, arr, word);
         }
         Ok(arr)
+    }
+
+    /// Lower `new <local>(args)` where `<local>` holds a runtime VALUE (a class
+    /// reified into a local / `globalThis` field — `const G = globalThis.Box; new
+    /// G(5)`). The value is invoked through [`__rtsadp_new_invoke`]: if its stored
+    /// thunk is a registered class NEW-THUNK it constructs (allocates + runs the
+    /// ctor + returns the instance); otherwise a TypeError is thrown (the value is
+    /// not a constructor — never mis-constructed). The result is an opaque
+    /// PolyValue word (kind Unknown), so a `let c = new G()` records no static class.
+    pub(super) fn lower_new_value(
+        &mut self,
+        module: &mut dyn Module,
+        name: &str,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        let local = self
+            .local(name)
+            .expect("caller proved `name` is an in-scope local value");
+        let fn_word = self.builder.use_var(local.var);
+        // Box the first four positional args; overflow (5th+) into a rest array.
+        let undef = || value::PolyValue::undefined().raw() as i64;
+        let mut slots: [Value; 4] = [self.builder.ins().iconst(types::I64, undef()); 4];
+        for (i, a) in args.iter().take(4).enumerate() {
+            let v = self.lower_expr(module, a)?;
+            slots[i] = self.box_value(v);
+        }
+        let rest = if args.len() > 4 {
+            let arr = emit_marshal::emit_new_vec_object(module, self.builder);
+            for a in &args[4..] {
+                let v = self.lower_expr(module, a)?;
+                let word = self.box_value(v);
+                emit_marshal::emit_vec_push(module, self.builder, arr, word);
+            }
+            arr
+        } else {
+            self.builder.ins().iconst(types::I64, undef())
+        };
+        let res = self
+            .call_runtime(
+                module,
+                "__rtsadp_new_invoke",
+                &[fn_word, slots[0], slots[1], slots[2], slots[3], rest],
+            )?
+            .expect("__rtsadp_new_invoke returns a value");
+        // A non-constructor value left a pending TypeError — unwind it here.
+        self.emit_post_call_error_check(module)?;
+        Ok(Val::new(res, Repr::Tagged))
     }
 
     /// Lower a call through a function VALUE held in a local (`g(args)` where `g`

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -66,6 +66,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 if self.is_fn_ctor(class) {
                     return self.lower_new_fn_ctor(module, class, args);
                 }
+                // `new G(args)` where `G` is a LOCAL holding a runtime class-VALUE
+                // (`const G = globalThis.Box; new G(5)`) — NOT a static class name,
+                // NOT a `const C = Box` static alias (those go to `lower_new`). The
+                // value is invoked through its new-thunk; a non-constructor throws.
+                if self.local(class).is_some()
+                    && self.local_class_refs.get(class).is_none()
+                    && self.classes.get(class).is_none()
+                {
+                    return self.lower_new_value(module, class, args);
+                }
                 // A `new C(args)` used as a bare expression (not bound to a local
                 // whose class/shape we record) still builds the instance (a valid
                 // TAG_OBJECT PolyValue, so `console.log(new C())` / method chaining

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -200,6 +200,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.bind_tagged_local(name, val);
                 return Ok(());
             }
+            // `let c = new G(args)` where `G` is a LOCAL holding a runtime
+            // class-VALUE (`const G = globalThis.Box; const c = new G(5)`): invoke
+            // through the new-thunk. The result is opaque (no static class/shape).
+            HirExprKind::New { class, args }
+                if self.local(class).is_some()
+                    && self.local_class_refs.get(class).is_none()
+                    && self.classes.get(class).is_none() =>
+            {
+                let val = self.lower_new_value(module, class, args)?;
+                self.bind_tagged_local(name, val);
+                return Ok(());
+            }
             // `let c = new C(args)`: build the instance, record the local's CLASS
             // (for static `c.method()` dispatch) and OBJECT shape (for `c.field`).
             HirExprKind::New { class, args } => {

--- a/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
@@ -3,9 +3,13 @@
 //! class-value (a `TAG_FUNCTION` new-thunk), and `new C(args)` on the const-bound
 //! reference constructs the class. Proven against the reference runtime.
 //!
-//! SCOPE: the dynamic `new` resolves the class statically through the `const C =
-//! Box` reference. `new <runtime-value>()` (a class read back from globalThis at
-//! runtime) and class EXPRESSIONS (`class {…}`) are a deferred follow-up.
+//! SCOPE: `const C = Box; new C(..)` resolves the class statically through the
+//! reference. `new <runtime-value>()` (a class read back from `globalThis` at
+//! runtime) CONSTRUCTS the instance soundly (slice 2) — but the result has no
+//! static class, so calling a METHOD on it (`new G().get()`) needs static
+//! `globalThis`-key→class tracking or shape-keyed dispatch (a deferred follow-up;
+//! field access on the result works). Class EXPRESSIONS (`class {…}`) are also
+//! deferred (HIR does not model them).
 
 use super::assert_stdout;
 
@@ -50,5 +54,43 @@ fn class_value_through_globalthis() {
         "class Widget { } globalThis.Widget = Widget; \
          console.log(typeof globalThis.Widget);",
         "function\n",
+    );
+}
+
+/// (slice 2) `new <runtime-value>()`: a class read back from `globalThis` at
+/// runtime CONSTRUCTS a real instance — field access on the result works (the
+/// instance carries the class's fields). The result has no static class, so a
+/// METHOD call on it is a deferred follow-up.
+#[test]
+fn new_on_runtime_class_value_constructs() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } } \
+         globalThis.Box = Box; const G = globalThis.Box; \
+         const b = new G(5); console.log(b.v);",
+        "5\n",
+    );
+}
+
+/// Two constructions through a runtime class-value read from `globalThis`.
+#[test]
+fn new_on_runtime_class_value_multiple() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } } \
+         globalThis.Box = Box; const G = globalThis.Box; \
+         const x = new G(2); const y = new G(8); console.log(x.v + y.v);",
+        "10\n",
+    );
+}
+
+/// SOUNDNESS: `new <value>()` where the value is NOT a constructor (a number held
+/// in a local) throws a TypeError at runtime — it never mis-constructs. The throw
+/// is catchable, exactly like the reference runtime.
+#[test]
+fn new_on_non_constructor_throws() {
+    assert_stdout(
+        "class Box { } globalThis.x = 5; const G = globalThis.x; \
+         try { const b = new G(); console.log(\"no-throw\"); } \
+         catch (e) { console.log(\"caught\"); }",
+        "caught\n",
     );
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -44,8 +44,8 @@ use rts_runtime::namespaces::io as rt_io;
 use rts_runtime::namespaces::math as rt_math;
 
 use crate::value::{
-    abi_adapter, arraycb, arrayops, dyndispatch, errslot, funcops, genops, genops_arith, globalops,
-    globalthis, inspect, iterops, objops, regexops,
+    abi_adapter, arraycb, arrayops, ctorval, dyndispatch, errslot, funcops, genops, genops_arith,
+    globalops, globalthis, inspect, iterops, objops, regexops,
 };
 
 /// One installable JIT symbol: an extern "C" name and its function pointer. The
@@ -425,6 +425,15 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
         sym(
             "__rtsadp_fn_invoke",
             funcops::__rtsadp_fn_invoke as *const u8,
+        ),
+        // ---- new <value>() through a class VALUE (slice 2) ----
+        sym(
+            "__rtsadp_register_ctor_thunk",
+            ctorval::__rtsadp_register_ctor_thunk as *const u8,
+        ),
+        sym(
+            "__rtsadp_new_invoke",
+            ctorval::__rtsadp_new_invoke as *const u8,
         ),
         // ---- function-as-constructor side-table (new F() / x instanceof F) ----
         sym("__rtsadp_fn_ptr", funcops::__rtsadp_fn_ptr as *const u8),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -356,6 +356,18 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64, U64, U64, U64, U64],
             ret: U64,
         },
+        // ---- new <value>() through a class VALUE (slice 2) ----
+        // register_ctor_thunk(addr) -> void: mark a class NEW-THUNK address valid.
+        "__rtsadp_register_ctor_thunk" => SymSig {
+            params: &[U64],
+            ret: Void,
+        },
+        // new_invoke(fn_word, a0, a1, a2, a3, rest) -> instance PolyValue word (U64);
+        // throws (pending error) when the value is not a registered constructor.
+        "__rtsadp_new_invoke" => SymSig {
+            params: &[U64, U64, U64, U64, U64, U64],
+            ret: U64,
+        },
         // ---- function-as-constructor side-table (new F() / x instanceof F) ----
         // fn_ptr(fn_word) -> ctor identity (U64, 0 = not a fn).
         "__rtsadp_fn_ptr" => SymSig {

--- a/crates/rts-codegen-new/src/value/ctorval.rs
+++ b/crates/rts-codegen-new/src/value/ctorval.rs
@@ -1,0 +1,75 @@
+//! Runtime support for `new <value>()` — constructing through a class VALUE (a
+//! reified user class held in a local / `globalThis` / a field), slice 2 of
+//! class-as-value.
+//!
+//! A class-value is a `TAG_FUNCTION` word whose stored thunk is the class's
+//! NEW-THUNK (it allocates `this`, runs the typed constructor, returns the
+//! `TAG_OBJECT` instance — see [`super::super::front::run::thunk`]). A plain
+//! function value's thunk is an ordinary body thunk. The two are indistinguishable
+//! by tag, so to keep `new` SOUND — a non-constructor must THROW, never
+//! mis-construct — every class NEW-THUNK address is registered here at reify time
+//! ([`__rtsadp_register_ctor_thunk`], emitted by `reify_class`). `new <value>()`
+//! lowers to [`__rtsadp_new_invoke`], which invokes the value ONLY when its stored
+//! thunk address is a registered constructor; otherwise it raises a
+//! TypeError-style throw.
+//!
+//! Code addresses are stable for the whole program run and never reused, so the
+//! address-set membership is EXACT — no slot/generation-reuse hazard (unlike a
+//! handle-keyed marker would have).
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use super::PolyValue;
+use super::abi_adapter::intern_poly;
+use super::errslot::__rtsadp_throw_set;
+use super::funcops::{__rtsadp_fn_invoke, __rtsadp_fn_ptr};
+
+/// The set of class NEW-THUNK code addresses — the only thunk targets `new` may
+/// invoke as a constructor.
+static CTOR_THUNKS: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
+
+fn ctor_set() -> &'static Mutex<HashSet<u64>> {
+    CTOR_THUNKS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Register `addr` (a class NEW-THUNK code address) as a valid `new` target.
+/// Emitted by `reify_class` whenever a class is reified as a value (idempotent —
+/// the same class registers the same stable address every time).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_register_ctor_thunk(addr: u64) {
+    if addr != 0 {
+        ctor_set()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(addr);
+    }
+}
+
+/// `new <value>(a0..a3, rest)` — construct through a class VALUE. When `fn_word`'s
+/// stored thunk address is a registered class NEW-THUNK, invoke it (the thunk
+/// allocates the instance, runs the constructor, and returns the `TAG_OBJECT`
+/// instance word). Otherwise the value is NOT a constructor: set a pending
+/// TypeError and return `undefined` (the caller's post-call error check unwinds).
+/// Never mis-constructs a non-constructor.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_new_invoke(
+    fn_word: u64,
+    a0: u64,
+    a1: u64,
+    a2: u64,
+    a3: u64,
+    rest: u64,
+) -> u64 {
+    let addr = __rtsadp_fn_ptr(fn_word);
+    let is_ctor = addr != 0
+        && ctor_set()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(&addr);
+    if !is_ctor {
+        __rtsadp_throw_set(intern_poly("TypeError: value is not a constructor").raw());
+        return PolyValue::undefined().raw();
+    }
+    __rtsadp_fn_invoke(fn_word, a0, a1, a2, a3, rest)
+}

--- a/crates/rts-codegen-new/src/value/mod.rs
+++ b/crates/rts-codegen-new/src/value/mod.rs
@@ -131,6 +131,10 @@ pub mod objops;
 // The `globalThis` singleton object (foundation: VALUE get/set), backed by the
 // same keyed-object repr so `globalThis.prop` reuses the `objops` trampolines.
 pub mod globalthis;
+// `new <value>()` through a class VALUE (slice 2 of class-as-value): the
+// constructor-thunk registry + `__rtsadp_new_invoke` (sound — a non-constructor
+// value throws, never mis-constructs).
+pub mod ctorval;
 // Codegen-owned thread-local pending-error slot for `throw` / `try-catch` (P5.13):
 // `__rtsadp_throw_set` / `__rtsadp_err_pending` / `__rtsadp_err_take` /
 // `__rtsadp_err_clear` — the manual-unwind exception model.


### PR DESCRIPTION
## Closer parcial do `globalThis.Map = class Map`

`new G(args)` onde `G` é um local com um **classe-valor de runtime** (`const G = globalThis.Box; new G(5)`) — antes bailava `class \`G\` is not a user class`. Agora **constrói** pelo new-thunk via invoke uniforme. Provado vs Bun.

## Soundness (o piso)
Classe-valor e função-comum são ambos `TAG_FUNCTION`, indistinguíveis por tag. Pra `new` nunca mis-construir um não-construtor:
- `value/ctorval.rs` (novo): registry `CTOR_THUNKS` (HashSet de endereços de new-thunk), populado em `reify_class` via `__rtsadp_register_ctor_thunk`. `__rtsadp_new_invoke` só invoca se o thunk é um construtor REGISTRADO; senão lança **TypeError** (catchável). Endereços de código estáveis → membership exata.
- `call.rs::lower_new_value`: boxa args (4+rest), `new_invoke`, post-call error-check (unwind do throw), retorna Tagged.
- `expr.rs`/`stmt.rs`: roteia p/ `lower_new_value` só quando `G` é local && não class_ref estático && não classe. `new Box()` estático + alias slice-1 **byte-idênticos**.

## Escopo (parede honesta)
O resultado de `new <runtime-value>()` **não tem classe estática** (G veio de read dinâmico de globalThis), então um **método** no resultado (`new G().get()`) ainda bail — dispatch é estático-por-nome-de-classe. **Acesso a campo funciona** (`new G(5).v` → 5). Fechar o método-no-resultado = follow-up: **(A)** rastrear `globalThis.X = Box` estático, ou **(B)** dispatch por-shape.

## Validação
- Repro = Bun: `globalThis.Box = Box; const G = globalThis.Box; new G(5).v` → 5; multi-new → 10; `new <num>()` → throw TypeError catchável (`"caught"`).
- `cargo test -p rts-codegen-new`: **718 → 721** (+3).
- static `new Box()` byte-idêntico; gate sem HARD.

## Próximo
Caminho A: rastrear `globalThis.X = <classe>` estaticamente (bail em reassign) → `new (globalThis.X)().metodo()` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)