### PR TITLE
Rastreio estático de globalThis.X = Class (caminho A — fecha new(globalThis.X)().método())

### DIFF
--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -242,6 +242,13 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// `static_instance_class` recover the receiver class of a gcell-promoted
     /// singleton in any scope (the gcell erases the `local_classes` entry).
     pub gcell_classes: &'c HashMap<String, String>,
+    /// `globalThis.<key>` → the user CLASS statically held there, when EVERY
+    /// assignment `globalThis.<key> = <Class>` in the whole program agrees on one
+    /// known class (the all-agree pre-pass `infer_globalthis_classes`). Lets
+    /// `const G = globalThis.X` record `G` as a class reference so `new G(args)`
+    /// constructs on the static path and the result is method-dispatchable.
+    /// Program-wide read-only (shared across all function lowerings).
+    pub globalthis_class_refs: &'c HashMap<String, String>,
     /// The program's user classes (descriptors: fields → shape slots, methods →
     /// functions). Read-only, shared across all functions. Drives `new C(args)`,
     /// `this.field`, and static `instance.method(args)`.
@@ -274,6 +281,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         captures: &'c HashMap<String, Vec<String>>,
         gcells: &'c HashMap<String, u32>,
         gcell_classes: &'c HashMap<String, String>,
+        globalthis_class_refs: &'c HashMap<String, String>,
         this_class: Option<&str>,
         is_prelude: bool,
         builtins: &'c HashMap<String, (String, String)>,
@@ -304,6 +312,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             captures,
             gcells,
             gcell_classes,
+            globalthis_class_refs,
             classes,
             is_prelude,
             builtins,

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -135,6 +135,11 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
             break;
         }
     }
+    // Program-wide `globalThis.<key>` → class, by the all-agree pre-pass: a key is
+    // a static class only if EVERY `globalThis.key = <Class>` across all functions
+    // + main agrees on one known class (a single non-class / disagreeing write
+    // poisons it). Lets `const G = globalThis.X; new G().m()` dispatch statically.
+    let globalthis_class_refs = infer_globalthis_classes(funcs, main, classes);
     let main_sig = FnSig::main_sig();
 
     // 2. Declare every function up front so cross-calls resolve to a FuncId.
@@ -193,6 +198,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
             captures,
             gcells,
             gcell_classes,
+            &globalthis_class_refs,
             this_class,
             is_prelude,
             builtins,
@@ -212,6 +218,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
         captures,
         gcells,
         gcell_classes,
+        &globalthis_class_refs,
         None,
         false,
         builtins,
@@ -273,6 +280,7 @@ fn define_one(
     captures: &HashMap<String, Vec<String>>,
     gcells: &HashMap<String, u32>,
     gcell_classes: &HashMap<String, String>,
+    globalthis_class_refs: &HashMap<String, String>,
     this_class: Option<&str>,
     is_prelude: bool,
     builtins: &HashMap<String, (String, String)>,
@@ -285,7 +293,7 @@ fn define_one(
         let mut fb = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
         let res = Lowerer::lower_function(
             module, &mut fb, func, sig, sigs, thunks, ids, classes, captures, gcells, gcell_classes,
-            this_class, is_prelude, builtins,
+            globalthis_class_refs, this_class, is_prelude, builtins,
         );
         match res {
             Ok(()) => fb.finalize(),
@@ -302,6 +310,193 @@ fn define_one(
         .map_err(|e| Unsupported::new(format!("define `{}`: {e}", func.name)))?;
     module.clear_context(&mut ctx);
     Ok(())
+}
+
+/// Program-wide `globalThis.<key>` → user class, by the ALL-AGREE rule: a key maps
+/// to class `C` iff EVERY assignment `globalThis.key = <Class>` across the whole
+/// program (every function body + `main`, every nested expression) names the SAME
+/// class `C` known to the table, with no non-class / disagreeing write. A single
+/// poisoning write (a non-class value, or a different class) drops the key; zero
+/// assignments → absent. Sound regardless of branches/loops, because ALL writes
+/// agree ⇒ the runtime value of `globalThis.key` is always `C`. Lets
+/// `const G = globalThis.X; new G().m()` dispatch `m` on the static path.
+fn infer_globalthis_classes(
+    funcs: &[HirFunc],
+    main: &HirFunc,
+    classes: &super::class::ClassTable,
+) -> HashMap<String, String> {
+    use rts_hir::HirStmt;
+    use rts_hir::ir::{HirArrowBody, HirExpr, HirExprKind};
+
+    // key → `Some(class)` while still agreeing on one class; `None` once poisoned.
+    let mut acc: HashMap<String, Option<String>> = HashMap::new();
+
+    fn record(key: &str, class: Option<String>, acc: &mut HashMap<String, Option<String>>) {
+        match acc.get(key) {
+            None => {
+                acc.insert(key.to_string(), class);
+            }
+            Some(None) => {} // already poisoned — stays poisoned
+            Some(Some(prev)) => {
+                if class.as_deref() != Some(prev.as_str()) {
+                    acc.insert(key.to_string(), None); // disagree / non-class → poison
+                }
+            }
+        }
+    }
+
+    fn scan_expr(
+        e: &HirExpr,
+        classes: &super::class::ClassTable,
+        acc: &mut HashMap<String, Option<String>>,
+    ) {
+        // `globalThis.<key> = <rhs>`: a known-class rhs is a class candidate;
+        // anything else poisons the key (a reassignment to a non-class).
+        if let HirExprKind::Assign { target, value } = &e.kind {
+            if let HirExprKind::Member { object, prop } = &target.kind {
+                if matches!(&object.kind, HirExprKind::Ident(n) if n == "globalThis") {
+                    let class = match &value.kind {
+                        HirExprKind::Ident(name) if classes.get(name).is_some() => {
+                            Some(name.clone())
+                        }
+                        _ => None,
+                    };
+                    record(prop, class, acc);
+                }
+            }
+        }
+        // Descend into EVERY child expression so a nested write is never missed
+        // (missing a poisoning write would be unsound).
+        match &e.kind {
+            HirExprKind::Lit(_) | HirExprKind::Ident(_) | HirExprKind::Raw(_) => {}
+            HirExprKind::Bin { lhs, rhs, .. } => {
+                scan_expr(lhs, classes, acc);
+                scan_expr(rhs, classes, acc);
+            }
+            HirExprKind::Unary { operand, .. }
+            | HirExprKind::Await(operand)
+            | HirExprKind::Spread(operand)
+            | HirExprKind::PreInc(operand)
+            | HirExprKind::PreDec(operand)
+            | HirExprKind::PostInc(operand)
+            | HirExprKind::PostDec(operand)
+            | HirExprKind::Cast { expr: operand, .. } => scan_expr(operand, classes, acc),
+            HirExprKind::Assign { target, value }
+            | HirExprKind::AssignOp { target, value, .. } => {
+                scan_expr(target, classes, acc);
+                scan_expr(value, classes, acc);
+            }
+            HirExprKind::Call { callee, args } => {
+                scan_expr(callee, classes, acc);
+                for a in args {
+                    scan_expr(a, classes, acc);
+                }
+            }
+            HirExprKind::MethodCall { object, args, .. } => {
+                scan_expr(object, classes, acc);
+                for a in args {
+                    scan_expr(a, classes, acc);
+                }
+            }
+            HirExprKind::New { args, .. } => {
+                for a in args {
+                    scan_expr(a, classes, acc);
+                }
+            }
+            HirExprKind::Member { object, .. } => scan_expr(object, classes, acc),
+            HirExprKind::Index { object, index } => {
+                scan_expr(object, classes, acc);
+                scan_expr(index, classes, acc);
+            }
+            HirExprKind::Array(xs) | HirExprKind::Seq(xs) => {
+                for x in xs {
+                    scan_expr(x, classes, acc);
+                }
+            }
+            HirExprKind::Object(props) => {
+                for (_, x) in props {
+                    scan_expr(x, classes, acc);
+                }
+            }
+            HirExprKind::Ternary { cond, then, else_ } => {
+                scan_expr(cond, classes, acc);
+                scan_expr(then, classes, acc);
+                scan_expr(else_, classes, acc);
+            }
+            HirExprKind::Arrow { body, .. } => match body {
+                HirArrowBody::Expr(e) => scan_expr(e, classes, acc),
+                HirArrowBody::Block(b) => walk(b, classes, acc),
+            },
+        }
+    }
+
+    fn walk(
+        stmts: &[HirStmt],
+        classes: &super::class::ClassTable,
+        acc: &mut HashMap<String, Option<String>>,
+    ) {
+        for s in stmts {
+            match s {
+                HirStmt::Expr(e) | HirStmt::Throw(e) | HirStmt::Const { init: e, .. } => {
+                    scan_expr(e, classes, acc)
+                }
+                HirStmt::Return(Some(e)) | HirStmt::Let { init: Some(e), .. } => {
+                    scan_expr(e, classes, acc)
+                }
+                HirStmt::If { cond, then, else_ } => {
+                    scan_expr(cond, classes, acc);
+                    walk(then, classes, acc);
+                    if let Some(e) = else_ {
+                        walk(e, classes, acc);
+                    }
+                }
+                HirStmt::While { cond, body } | HirStmt::DoWhile { body, cond } => {
+                    scan_expr(cond, classes, acc);
+                    walk(body, classes, acc);
+                }
+                HirStmt::For { init, cond, update, body } => {
+                    if let Some(i) = init {
+                        walk(std::slice::from_ref(i), classes, acc);
+                    }
+                    if let Some(c) = cond {
+                        scan_expr(c, classes, acc);
+                    }
+                    if let Some(u) = update {
+                        scan_expr(u, classes, acc);
+                    }
+                    walk(body, classes, acc);
+                }
+                HirStmt::ForOf { iterable: e, body, .. } | HirStmt::ForIn { object: e, body, .. } => {
+                    scan_expr(e, classes, acc);
+                    walk(body, classes, acc);
+                }
+                HirStmt::Block(body) => walk(body, classes, acc),
+                HirStmt::Try { body, catch, finally } => {
+                    walk(body, classes, acc);
+                    if let Some(c) = catch {
+                        walk(&c.body, classes, acc);
+                    }
+                    if let Some(f) = finally {
+                        walk(f, classes, acc);
+                    }
+                }
+                HirStmt::Switch { discriminant, cases } => {
+                    scan_expr(discriminant, classes, acc);
+                    for c in cases {
+                        walk(&c.body, classes, acc);
+                    }
+                }
+                HirStmt::Labeled { body, .. } => walk(std::slice::from_ref(body), classes, acc),
+                _ => {}
+            }
+        }
+    }
+
+    for f in funcs {
+        walk(&f.body, classes, &mut acc);
+    }
+    walk(&main.body, classes, &mut acc);
+    acc.into_iter().filter_map(|(k, v)| v.map(|c| (k, c))).collect()
 }
 
 /// Infer the user-CLASS a function provably RETURNS: `Some(C)` iff EVERY value

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -251,6 +251,22 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.local_class_refs.insert(name.to_string(), c.clone());
                 return Ok(());
             }
+            // `const G = globalThis.X` where `globalThis.X` is a statically-tracked
+            // class (every `globalThis.X = <Class>` agrees, via the all-agree
+            // pre-pass): bind the read value AND record `G` as a class reference, so
+            // `new G(args)` constructs `<Class>` on the static path → the result is
+            // method-dispatchable. Reuses the slice-1 `local_class_refs` machinery;
+            // a poisoned/untracked key falls through to the dynamic slice-2 path.
+            HirExprKind::Member { object, prop }
+                if self.is_globalthis_receiver(object)
+                    && self.globalthis_class_refs.contains_key(prop) =>
+            {
+                let class = self.globalthis_class_refs[prop].clone();
+                let val = self.lower_expr(module, init)?;
+                self.bind_tagged_local(name, val);
+                self.local_class_refs.insert(name.to_string(), class);
+                return Ok(());
+            }
             _ => None,
         };
         if let Some(shape) = shape {

--- a/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
@@ -94,3 +94,46 @@ fn new_on_non_constructor_throws() {
         "caught\n",
     );
 }
+
+/// (caminho A) `globalThis.X = Box` (the only write, a known class) is tracked
+/// statically, so `const G = globalThis.X; new G(5)` constructs on the STATIC path
+/// and a METHOD on the result dispatches — the end-to-end `globalThis`-class
+/// pattern.
+#[test]
+fn globalthis_tracked_class_dispatches_method() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } \
+         get(): number { return this.v; } } \
+         globalThis.Box = Box; const G = globalThis.Box; \
+         console.log(new G(5).get());",
+        "5\n",
+    );
+}
+
+/// Two constructions + method dispatch through a statically-tracked globalThis key.
+#[test]
+fn globalthis_tracked_class_multiple() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } \
+         get(): number { return this.v; } } \
+         globalThis.Box = Box; const G = globalThis.Box; \
+         const a = new G(2); const b = new G(8); console.log(a.get() + b.get());",
+        "10\n",
+    );
+}
+
+/// SOUNDNESS: a key with a DISAGREEING write (`globalThis.X = Box` then
+/// `globalThis.X = 5`) is POISONED — it is NOT tracked as `Box`, so `new G()`
+/// falls to the dynamic path where the runtime value (5) is not a constructor and
+/// THROWS, never mis-dispatching as `Box`. (If the poison rule failed, `new G(7)`
+/// would wrongly construct a `Box` and print "constructed".)
+#[test]
+fn globalthis_poisoned_key_not_dispatched_as_class() {
+    assert_stdout(
+        "class Box { v: number = 0; constructor(n: number) { this.v = n; } } \
+         globalThis.X = Box; globalThis.X = 5; const G = globalThis.X; \
+         try { const b = new G(7); console.log(\"constructed\"); } \
+         catch (e) { console.log(\"caught\"); }",
+        "caught\n",
+    );
+}


### PR DESCRIPTION
## Fecha o método-no-resultado de `new (globalThis.X)()`

A slice-2 (`new` sobre runtime-value) constrói, mas o resultado não tinha classe estática → `new G(5).get()` bailava. Agora `globalThis.Map = Map; const G = globalThis.Map; new G().método()` funciona **end-to-end** (= Bun). O padrão stdlib `globalThis.Map = class Map` está fechado para a forma de **classe nomeada**.

## Pré-passe program-wide ALL-AGREE (sound)
`infer_globalthis_classes` (ao lado de `infer_ret_class`): anda em TODAS as funções + main com **descida exaustiva em sub-exprs** (uma poisoning perdida seria unsound). Para cada `globalThis.X = rhs`: rhs = Ident de classe conhecida → candidato; senão **envenena** a key. `globalThis.X` → classe C **sse TODA** escrita concorda em C. Sound com branches/loops (todas concordam ⇒ runtime é sempre C).

## Wiring
- `globalthis_class_refs` program-wide (read-only, threaded igual `gcell_classes`).
- `stmt.rs`: `const G = globalThis.X` (X rastreado) → grava `local_class_refs["G"]=classe` (reusa slice-1) → `new G()` no caminho **estático** → resultado method-dispatchable. Cross-função (pré-passe program-wide).

## Soundness / poison
`globalThis.X=Box; globalThis.X=5; const G=globalThis.X; new G(7)` → key **envenenada** → caminho dinâmico slice-2 → throw TypeError catchável. **Nunca** mis-dispatcha Box.

## Validação
- Repro = Bun: `globalThis.Box=Box; const G=globalThis.Box; new G(5).get()` → 5; multi-new → 10.
- `cargo test -p rts-codegen-new`: **721 → 724** (+3: dispatches_method / multiple / poisoned).
- suíte `measure_new`: **309 → 309** (pass-list idêntica, zero regressão).
- static `new Box()` + slices 1/2 byte-idênticos; gate sem HARD.

## Falta no arco
**Class expressions** (`const D = class {…}`) — HIR não modela (vira `Raw`). Único pedaço restante pro `globalThis.Map = class Map {…}` literal; a forma nomeada está fechada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)