### PR TITLE
Class expressions via hoisting — fecha o arco classe-como-valor (globalThis.Map = class Map)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/class_as_value.rs
@@ -137,3 +137,49 @@ fn globalthis_poisoned_key_not_dispatched_as_class() {
         "caught\n",
     );
 }
+
+/// A CLASS EXPRESSION (`const D = class {…}`) is hoisted to a named top-level class
+/// (`__classexpr_N`), so `new D().method()` constructs + dispatches like any class.
+#[test]
+fn class_expression_anonymous() {
+    assert_stdout(
+        "const D = class { x: number = 5; getX(): number { return this.x; } }; \
+         console.log(new D().getX());",
+        "5\n",
+    );
+}
+
+/// A class expression with a CONSTRUCTOR.
+#[test]
+fn class_expression_with_ctor() {
+    assert_stdout(
+        "const D = class { v: number = 0; constructor(n: number) { this.v = n; } \
+         get(): number { return this.v; } }; \
+         console.log(new D(7).get());",
+        "7\n",
+    );
+}
+
+/// A NAMED class expression (`class Box {…}` in value position) is hoisted by the
+/// synthesized name; `new D()` still constructs it.
+#[test]
+fn class_expression_named() {
+    assert_stdout(
+        "const D = class Box { v: number = 3; get(): number { return this.v; } }; \
+         console.log(new D().get());",
+        "3\n",
+    );
+}
+
+/// END-TO-END: a class-EXPRESSION assigned to `globalThis` (`globalThis.Map =
+/// class M {…}`) hoists to `globalThis.Map = __classexpr_N` (a known class), the
+/// caminho-A pre-pass tracks it, and `const G = globalThis.Map; new G().m()`
+/// dispatches — the full `globalThis.Map = class Map {…}` literal pattern.
+#[test]
+fn class_expression_to_globalthis_end_to_end() {
+    assert_stdout(
+        "globalThis.Coll = class M { has(): boolean { return true; } }; \
+         const G = globalThis.Coll; console.log(new G().has());",
+        "true\n",
+    );
+}

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -113,6 +113,53 @@ impl swc_ecma_visit::VisitMut for MemberAssignFnHoister {
     }
 }
 
+/// Hoists a class EXPRESSION (`const D = class {…}` / `globalThis.X = class M {…}`)
+/// into a named top-level class declaration (`__classexpr_N`), rewriting the
+/// expression site to an identifier. Once the site is an `Ident` naming a
+/// top-level class, the existing class-as-value machinery takes over: `const D =
+/// __classexpr_N` reifies the class VALUE, `new D()` constructs, and methods
+/// dispatch on the result (D is a static class reference). `globalThis.X = class
+/// M {…}` becomes `globalThis.X = __classexpr_N` — a known-class ident — so the
+/// caminho-A pre-pass tracks it and `const G = globalThis.X; new G().m()` works
+/// end-to-end. `visit_mut_function` is a no-op so we never descend into a
+/// function/method body: only TRUE top-level class-exprs are hoisted (one nested
+/// inside a body could capture outer locals; left in place it still bails
+/// downstream — the honesty floor). A named class-expr's inner self-reference
+/// (`class Foo { m() { return Foo; } }`) resolves to the original name, which is
+/// not the hoisted decl's name, so it bails downstream (an accepted edge).
+#[derive(Default)]
+struct ClassExprHoister {
+    hoisted: Vec<swc_ecma_ast::ClassDecl>,
+    counter: usize,
+}
+
+impl swc_ecma_visit::VisitMut for ClassExprHoister {
+    fn visit_mut_function(&mut self, _f: &mut SwcFunction) {
+        // no-op: do not descend into function/method bodies (avoid capturing hoists).
+    }
+
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        use swc_ecma_visit::VisitMutWith;
+        e.visit_mut_children_with(self);
+        if let Expr::Class(ce) = e {
+            let name = format!("__classexpr_{}", self.counter);
+            self.counter += 1;
+            let ident = swc_ecma_ast::Ident {
+                span: Default::default(),
+                ctxt: Default::default(),
+                sym: name.as_str().into(),
+                optional: false,
+            };
+            self.hoisted.push(swc_ecma_ast::ClassDecl {
+                ident: ident.clone(),
+                declare: false,
+                class: ce.class.clone(),
+            });
+            *e = Expr::Ident(ident);
+        }
+    }
+}
+
 fn lower_program(cm: &Lrc<SourceMap>, source: &SwcProgram) -> Program {
     let mut program = Program::default();
 
@@ -156,6 +203,29 @@ fn lower_program(cm: &Lrc<SourceMap>, source: &SwcProgram) -> Program {
                 SwcProgram::Script(s) => {
                     for (i, fd) in hoister.hoisted.into_iter().enumerate() {
                         s.body.insert(i, Stmt::Decl(Decl::Fn(fd)));
+                    }
+                }
+            }
+        }
+    }
+    // Hoist class EXPRESSIONS (`const D = class {…}` / `globalThis.X = class M {…}`)
+    // to named top-level class decls so the class-as-value machinery (reify +
+    // new-thunk, caminho A) takes over via the rewritten ident.
+    {
+        use swc_ecma_visit::VisitMutWith;
+        let mut hoister = ClassExprHoister::default();
+        owned.visit_mut_with(&mut hoister);
+        if !hoister.hoisted.is_empty() {
+            match &mut owned {
+                SwcProgram::Module(m) => {
+                    for (i, cd) in hoister.hoisted.into_iter().enumerate() {
+                        m.body
+                            .insert(i, ModuleItem::Stmt(Stmt::Decl(Decl::Class(cd))));
+                    }
+                }
+                SwcProgram::Script(s) => {
+                    for (i, cd) in hoister.hoisted.into_iter().enumerate() {
+                        s.body.insert(i, Stmt::Decl(Decl::Class(cd)));
                     }
                 }
             }


### PR DESCRIPTION
## Última peça do arco

`const D = class {…}` e `globalThis.Map = class Map {…}` bailavam `expression raw/unrecognized` (o expr-lowering não trata SWC `Expr::Class`). Agora funcionam, incl. o **padrão literal end-to-end**. = Bun.

## Como (espelha código existente)
`ClassExprHoister` em `rts-parser/lowering_items.rs` — espelho exato do `GenExprHoister` (que já hoista `function*(){}` → top-level `FnDecl`). `VisitMut`: em `visit_mut_expr`, se `Expr::Class(ce)` → gera nome fresco `__classexpr_N`, empurra `ClassDecl { ident, class: ce.class.clone() }`, reescreve o site p/ `Expr::Ident`. `visit_mut_function` no-op → não desce em corpos (só hoista class-exprs **top-level**; uma aninhada que capturaria fica no lugar e bail downstream — honesty floor). Wired no `lower_program` após os 2 hoisters de fn.

## Zero codegen changes
`const D = class {…}` vira `const D = __classexpr_0` (ident de classe top-level) → a maquinaria **classe-como-valor existente** assume (reify slice-1 + new-thunk + caminho A). `globalThis.Map = class M{}` vira `globalThis.Map = __classexpr_0` (ident de classe conhecida) → o pré-passe do **caminho A** rastreia → `new (globalThis.Map)().método()` end-to-end.

## Repros = Bun
| Caso | RTS |
|---|---|
| anon `class {…}; new D().getX()` | 5 |
| com ctor `new D(7).get()` | 7 |
| named `class Box {…}` em valor | 3 |
| **end-to-end** `globalThis.Map = class M{has(){…}}; const G=globalThis.Map; new G().has()` | **true** |

## Validação
- `cargo test -p rts-codegen-new`: **724 → 728** (+4).
- suíte `measure_new`: **309 → 309** (zero regressão).
- `cargo build --release` limpo (toca rts-parser; workspace compila); gate sem HARD.
- static `new Box()` + slices 1/2 + caminho A byte-idênticos.

## Edge (bail, não unsound)
Self-ref de class-expr nomeada (`class Foo{m(){return Foo}}`) → resolve ao nome original, não ao `__classexpr_N` → bail. Class-expr aninhada em corpo de função (capturaria) não é hoistada → bail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)