### PR TITLE
WeakMap/WeakSet como .ts stdlib (strong-ref, #217)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,15 +233,23 @@ syntactic form?**
   (`Function`), **regex literals `/re/` (`RegExp` — it HAS native syntax, so it is
   native/primitive, NOT Registry)**, template literals, and `Error`+subclasses
   (primordial). These interact directly with codegen.
-- **No native syntax ⇒ rts-shared UTILITY LIB ⇒ Registry, indirect.** The JS
-  utility libraries you reach via `new X()`/static calls with NO literal form:
-  `Date`, `Map`, `Set`, `WeakMap`/`WeakSet`, `JSON`, `URL`, `Math` (methods),
-  `Promise`, `Intl.*`, `Proxy`/`Reflect`, typed arrays, and all backend classes.
-  These resolve through the real `Registry` (`crates/rts-codegen-new/src/front/run/
-  registry.rs` builds it from `Engine::new()` + the `register`/`register_class_spec`
-  fns; `registry_call.rs` is the generic marshal-from-`AbiType` path) — the engine
-  NEVER reimplements them as codegen `__rtsadp_*` tables. `Date` is the reference
-  migration (done); `Map`/`Set` are the next to migrate.
+- **No native syntax ⇒ rts-shared UTILITY LIB, indirect.** The JS utility
+  libraries you reach via `new X()`/static calls with NO literal form: `Date`,
+  `Map`, `Set`, `WeakMap`/`WeakSet`, `JSON`, `URL`, `Math` (methods), `Promise`,
+  `Intl.*`, `Proxy`/`Reflect`, typed arrays, and all backend classes. The engine
+  NEVER names them / reimplements them as codegen `__rtsadp_*` tables. Two
+  sub-paths, both engine-name-free:
+  - **Registry (data dispatch):** `Date` is the reference (done) — ctor/statics/
+    methods resolve via `MethodSpec`/`Sig.default_args`/flags through
+    `is_pure_registry_class` + `registryclass.rs`. Target of `URL`/typed-arrays/
+    `TextEncoder`/backend (real Rust impl, no native syntax).
+  - **`.ts` stdlib (`rts-shared/src/stdlib/*.ts`):** **COLLECTIONS** (`Map`/`Set`
+    done; `WeakMap`/`WeakSet` done, strong-ref interim) are ambient `.ts` classes,
+    NOT Registry — they need arbitrary key/value types the i64 Rust backend can't
+    hold without the PolyValue containers (P2, deferred); the `.ts` (arrays of
+    PolyValue) covers it. `WeakMap`/`WeakSet` become REAL weak when the GC weak
+    phase lands (design doc §5.7, deferred until ~90% cross-runtime); until then
+    strong-ref, like the Rust v0 stubs.
 - **Reclassification vs the bullet above:** `RegExp` moves to the native/primitive
   side (it has `/re/` syntax). The "Registry only" list still holds for the
   no-native-syntax utilities. This refines, not contradicts, "no builtins in the

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -127,6 +127,7 @@ pub(super) static PRELUDE_TS: &[PreludeTs] = &[
     PreludeTs { label: "console", source: rts_runtime::CONSOLE_TS, why: "console.log/warn/… → engine bridges" },
     // Stdlib classes.
     PreludeTs { label: "Map/Set", source: rts_runtime::stdlib::MAP_SET_TS, why: "class Map/Set shadow native" },
+    PreludeTs { label: "WeakMap/WeakSet", source: rts_runtime::stdlib::WEAKMAP_SET_TS, why: "class WeakMap/WeakSet (strong-ref, #217)" },
     PreludeTs { label: "JSON", source: rts_runtime::stdlib::JSON_TS, why: "JSON.stringify/parse" },
     // The rts:test FRAMEWORK — LAST, so its Matcher/describe/test see every primordial.
     PreludeTs { label: "rts:test", source: rts_runtime::namespaces::test::BUNDLE_TS, why: "describe/test/expect/Matcher" },

--- a/crates/rts-shared/src/stdlib/mod.rs
+++ b/crates/rts-shared/src/stdlib/mod.rs
@@ -12,6 +12,12 @@ pub const MAP_SET_TS: &str = include_str!("map_set.ts");
 /// recursion); the engine names nothing JSON-specific, it just runs the generics.
 pub const JSON_TS: &str = include_str!("json.ts");
 
+/// `WeakMap`/`WeakSet` — STRONG-reference collections for now (#217 tracks the
+/// real weak path), backed by private arrays with `===` keys, like `MAP_SET_TS`.
+/// Non-iterable surface only (no `size`/`keys`/`values`/`forEach`). Ambient `.ts`
+/// classes so `new WeakMap()` is an ordinary user-class construction.
+pub const WEAKMAP_SET_TS: &str = include_str!("weakmap_set.ts");
+
 /// The global `console` object (`log`/`info`/`debug`/`dir` → stdout,
 /// `warn`/`error` → stderr) — a rts-shared backend utility, NOT a primordial: it
 /// has no native syntax and prints through the backend, so it lives here with the

--- a/crates/rts-shared/src/stdlib/weakmap_set.ts
+++ b/crates/rts-shared/src/stdlib/weakmap_set.ts
@@ -1,0 +1,84 @@
+// Faithful TypeScript `WeakMap`/`WeakSet` — the stdlib for the new engine.
+//
+// STRONG-reference semantics for now (no real weak collection / GC interaction —
+// #217 tracks the weak path): backed by private arrays with `===` (reference)
+// key/value compare, exactly like the `Map`/`Set` stdlib (`map_set.ts`). The Weak
+// variants expose ONLY the non-iterable surface JS allows (no `size`, no
+// `keys`/`values`/`entries`/`forEach`, no iteration) — keys/values are object
+// references compared by identity. Embedded as an engine `include`
+// (declarations-only): the ambient `class WeakMap`/`class WeakSet` make
+// `new WeakMap()` an ordinary user-class construction.
+
+class WeakMap<K, V> {
+  #keys: K[] = [];
+  #vals: V[] = [];
+  // `new WeakMap([[k, v], …])` — iterable of [key, value] pairs, like JS.
+  constructor(init: [K, V][] = []) {
+    for (const p of init) { this.set(p[0], p[1]); }
+  }
+  set(k: K, v: V): WeakMap<K, V> {
+    for (let i = 0; i < this.#keys.length; i++) {
+      if (this.#keys[i] === k) { this.#vals[i] = v; return this; }
+    }
+    this.#keys.push(k);
+    this.#vals.push(v);
+    return this;
+  }
+  get(k: K): V | undefined {
+    for (let i = 0; i < this.#keys.length; i++) {
+      if (this.#keys[i] === k) { return this.#vals[i]; }
+    }
+    return undefined;
+  }
+  has(k: K): boolean {
+    for (let i = 0; i < this.#keys.length; i++) {
+      if (this.#keys[i] === k) { return true; }
+    }
+    return false;
+  }
+  delete(k: K): boolean {
+    for (let i = 0; i < this.#keys.length; i++) {
+      if (this.#keys[i] === k) {
+        const last = this.#keys.length - 1;
+        this.#keys[i] = this.#keys[last];
+        this.#vals[i] = this.#vals[last];
+        this.#keys.pop();
+        this.#vals.pop();
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+class WeakSet<T> {
+  #items: T[] = [];
+  // `new WeakSet([v, …])` — iterable of values, like JS.
+  constructor(init: T[] = []) {
+    for (const v of init) { this.add(v); }
+  }
+  add(v: T): WeakSet<T> {
+    for (let i = 0; i < this.#items.length; i++) {
+      if (this.#items[i] === v) { return this; }
+    }
+    this.#items.push(v);
+    return this;
+  }
+  has(v: T): boolean {
+    for (let i = 0; i < this.#items.length; i++) {
+      if (this.#items[i] === v) { return true; }
+    }
+    return false;
+  }
+  delete(v: T): boolean {
+    for (let i = 0; i < this.#items.length; i++) {
+      if (this.#items[i] === v) {
+        const last = this.#items.length - 1;
+        this.#items[i] = this.#items[last];
+        this.#items.pop();
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/docs/specs/rts-codegen-new-design.md
+++ b/docs/specs/rts-codegen-new-design.md
@@ -189,11 +189,21 @@ genérico**. Correto e escalável.
   lowera a sintaxe direto; impl em `rts-primitives`. **`Error` migrou para `.ts`**
   (prelude include, §3.2.1): a impl de campos/métodos está em
   `rts-primitives/src/error.ts`, não mais hardcoded no codegen.
-- **Sem sintaxe nativa ⇒ lib utilitária rts-shared ⇒ Registry, indireto:**
-  `Date`/`Map`/`Set`/`WeakMap`/`JSON`/`URL`/`Math`/`Promise`/`Proxy`/typed-arrays/
-  backend — acessadas via `new X()`/estáticos, despachadas pela Registry, **nunca
-  reimplementadas como tabelas codegen `__rtsadp_*`**. `Date` é a migração
-  referência (feita); `Map`/`Set` são os próximos.
+- **Sem sintaxe nativa ⇒ lib utilitária rts-shared, indireto:** `Date`/`Map`/`Set`/
+  `WeakMap`/`WeakSet`/`JSON`/`URL`/`Math`/`Promise`/`Proxy`/typed-arrays/backend —
+  acessadas via `new X()`/estáticos, **nunca reimplementadas como tabelas codegen
+  `__rtsadp_*`**. Dois sub-caminhos, ambos sem o motor nomear a classe:
+  - **Registry (despacho de dados):** `Date` é a referência (feita) — ctor/
+    estáticos/métodos resolvem por `MethodSpec`/`Sig.default_args`/flags via
+    `is_pure_registry_class` + `registryclass.rs`. Alvo de `URL`/typed-arrays/
+    `TextEncoder`/backend (têm impl Rust real, sem sintaxe nativa).
+  - **`.ts` stdlib (rts-shared/stdlib):** **COLEÇÕES** (`Map`/`Set` — feito;
+    `WeakMap`/`WeakSet` — feito, strong-ref interim) são classes `.ts` ambient, NÃO
+    Registry. Motivo: chave/valor de tipo **arbitrário** que o backend Rust i64 não
+    guarda sem os containers PolyValue (P2, diferido); o `.ts` (arrays guardando
+    PolyValue) cobre isso. `WeakMap`/`WeakSet` viram weak **real** quando a fase
+    weak do GC existir (§5.7, diferido até ~90% cross-runtime); até lá são
+    strong-ref (igual aos stubs Rust v0).
 
 ### 3.2.1 `Error` migrado para `.ts` (prelude include) — FEITO
 
@@ -720,6 +730,57 @@ PolyValue boxed. A decisão de design:
   inline) e em containers de `PolyValue`.
 - O zoológico `__RTS_FN_RT_FLOAT_BOX/UNBOX/EQ_AMBIG/NUM_ARITH` — box/unbox são IR
   pura; igualdade e aritmética operam sobre tags, não sobre helpers de re-tag.
+
+### 5.7 GC futuro — geracional copying + fase weak (PLANO, diferido)
+
+> **Status: diferido.** Decisão (2026-06-20): o GC atual (mark-sweep preciso com
+> stack maps do Cranelift) fica como está; o upgrade geracional só será feito
+> **quando o cross-runtime estiver em ~90%**. Esta seção documenta o alvo para
+> não se perder. Até lá, novas features assumem o mark-sweep atual.
+
+**A vantagem que decide o design: handle indirection.** Como o PolyValue carrega
+um *índice de slot*, não um ponteiro cru (§5.4), **mover um objeto é barato** — o
+calcanhar-de-aquiles de todo GC móvel (achar + reescrever todo ponteiro pro
+objeto movido) não existe no RTS: o objeto move no backing store, atualiza-se só
+o `slot→endereço` no slab, e o índice nos PolyValues **não muda**. Isto posiciona
+o RTS unicamente para um GC **geracional copying**, que a maioria dos motores paga
+caro para ter.
+
+**Alvo: geracional copying (nursery).** A hipótese geracional é fortíssima em JS
+(a esmagadora maioria dos objetos morre jovem — temporários de loop, `{}`/`[]`
+intermediários):
+
+- **Young gen (nursery):** *bump-allocate* (alloc = incrementa ponteiro). Cheia →
+  **minor GC**: copia só os sobreviventes pro old gen; escaneia só o young + o
+  *remembered set*. A maioria dos temps morre aqui → nunca promovido → coleta
+  baratíssima. Mover = trivial (handle indirection).
+- **Old gen:** mark-sweep / mark-compact dos sobreviventes, roda **raro**.
+- **Write barrier:** registra refs old→young (remembered set) pro minor GC não
+  varrer o old gen — custo pequeno em property-write de objeto velho.
+- **Multi-thread:** nursery por-thread (TLAB) → alloc lock-free; casa com a
+  `HandleTable` shard-aware existente.
+- **Stack maps** (Cranelift `UserStackMap`, já existe) pras roots precisas.
+
+Ganho: alloc rápido (bump), minor GC barato (o caso comum), major GC raro,
+compactação (sem fragmentação) — e o custo de mover sai de graça. É o que V8/JSC
+fazem; no RTS a parte cara já está neutralizada.
+
+**Fase weak (#217) — NÃO precisa do geracional.** O mark-sweep atual já faz weak
+real com **uma fase nova entre mark e sweep**, e pode ser feita antes do upgrade
+geracional:
+
+1. Mark normal — mas **não** marca através das chaves do `WeakMap`/`WeakSet` nem
+   do target do `WeakRef` (ficam "candidatos a morrer").
+2. **Fase weak** (pós-mark, pré-sweep): pra cada `WeakMap`/`WeakSet`/`WeakRef`, se
+   o target **não foi marcado** → remove a entrada / `deref`→`undefined`;
+   `FinalizationRegistry` → enfileira o callback.
+3. Sweep normal.
+
+A handle indirection ajuda de novo: `WeakRef` guarda `(slot, generation)` completos
+(§5.5); se o slot foi liberado/reusado (geração bumpou), `deref` retorna
+`undefined` em O(1), sem scan. **Até a fase weak existir, `WeakMap`/`WeakSet` são
+um stdlib `.ts` strong-ref** (ver §10.x doutrina) — funcionalmente igual aos stubs
+Rust v0, sem coleta automática; o `.ts` cobre tipo de chave/valor arbitrário.
 
 ---
 


### PR DESCRIPTION
## Gap: `new WeakMap()` / `new WeakSet()` bailavam

`class WeakMap is not a user class` — o maior cluster da suíte (44 "not a user class"). Coleções ficam **`.ts`** (doutrina, igual Map/Set), então WeakMap/WeakSet são um prelude `.ts` ambient — **não** Registry.

## Mudança
- `rts-shared/stdlib/weakmap_set.ts` (novo): `WeakMap` (set/get/has/delete) + `WeakSet` (add/has/delete), backed por arrays privados + `===` (ref) keys, **espelho exato do `map_set.ts`**. STRONG-reference por ora (#217 trackeia o weak real); superfície **não-iterável** só (sem size/keys/values/forEach — Weak não itera em JS). Ctor com iterável.
- `stdlib/mod.rs`: `WEAKMAP_SET_TS` (re-exportado via facade).
- `registry_build.rs`: `PreludeTs` entry após Map/Set.

**Zero codegen**: as classes ambient `.ts` fazem `new WeakMap()` uma construção de user-class normal (reusa toda a maquinaria de classe).

## Validação
- Repro = Bun: `wm.set(k,42); wm.has(k)/wm.get(k)` → `true 42`; `ws.add(k); ws.has(k)` → `true`.
- **7 fixtures** WeakMap/WeakSet OK (eram FAIL).
- suíte `measure_new`: **309 → 316** (+7, zero regressão).
- `cargo test -p rts-codegen-new`: **728/728**; gate sem HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)