### PR TITLE
URL via Registry (ctor + getters) + property-read genérico

### DIFF
--- a/crates/rts-codegen-new/src/front/run/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/globalclass.rs
@@ -227,6 +227,27 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let Some(class) = self.global_instance_class(object) else {
             return Ok(None);
         };
+        // GENERIC: a property READ on a PURE Registry-class instance (`u.hostname`,
+        // `u.pathname`) resolves to a 0-explicit-arg instance member — a getter — via
+        // the Registry, exactly like a method call but with no `()`. Data-driven, no
+        // per-class literal (the `RegExp` arms below are the primitive `/re/`
+        // exception, kept hardcoded). Today this serves `URL`'s getters; any Registry
+        // class with a 0-arg instance member gets its property read for free.
+        if self.is_pure_registry_class(&class) {
+            if let Some(call) = super::registry::class_member(&class, prop, 0) {
+                let recv = self.lower_expr(module, object)?;
+                let result_kind = match call.ret {
+                    rts_engine::abi::AbiType::Handle => JsKind::Str,
+                    rts_engine::abi::AbiType::Bool => JsKind::Bool,
+                    _ => JsKind::Number,
+                };
+                let v = self.emit_registry_call(module, &call, Some(recv), &[], result_kind)?;
+                return Ok(Some(v));
+            }
+            return Err(crate::front::error::Unsupported::new(format!(
+                "`{class}.{prop}` — no such property on runtime class `{class}`"
+            )));
+        }
         let symbol = match (class.as_str(), prop) {
             ("RegExp", "source") => "__rtsadp_re_source",
             ("RegExp", "flags") => "__rtsadp_re_flags",

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -100,6 +100,11 @@ pub(super) static REGISTER: &[Register] = &[
     Register { label: "Boolean class", run: ns::globals::boolean::register_boolean_class_spec, why: "Boolean wrapper ctor" },
     Register { label: "Number class", run: ns::globals::number::register_number_class_spec, why: "Number wrapper ctor" },
     Register { label: "String class", run: ns::globals::string::register_string_class_spec, why: "String wrapper ctor" },
+    // `URL` — backend/Registry class (WHATWG parser, no native syntax): `new URL(s)`
+    // + getters (href/hostname/pathname/…) resolve generically via registryclass.
+    Register { label: "URL class", run: ns::globals::url::register_url_class_spec, why: "URL ctor + getters" },
+    // URLSearchParams: follow-up — needs its own symbols installed + `u.searchParams`
+    // tagged RETURNS_OBJECT (it returns a URLSearchParams instance, not a string).
 ];
 
 /// One `.ts` prelude include, in DEPENDENCY ORDER (base before dependent).

--- a/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
@@ -287,3 +287,14 @@ fn bail_unknown_map_method() {
     // `values`/`entries`/`clear` are now real members; `groupInto` is not.
     assert_bails(r#"let m = new Map(); m.groupInto(() => {}); console.log(m.size);"#);
 }
+
+#[test]
+fn url_ctor_and_getters() {
+    // `URL` — a backend/Registry class (WHATWG parser, no native syntax): `new
+    // URL(s)` + its getters resolve generically via registryclass + the Registry
+    // 0-arg-member property read, with NO `"URL"` literal in codegen control flow.
+    assert_stdout(
+        r#"const u = new URL("https://a.com/p?x=1"); console.log(u.hostname, u.pathname);"#,
+        "a.com /p\n",
+    );
+}

--- a/crates/rts-codegen-new/src/registry_link.rs
+++ b/crates/rts-codegen-new/src/registry_link.rs
@@ -15,6 +15,7 @@
 
 use rts_runtime::namespaces::date as rt_date;
 use rts_runtime::namespaces::globals::date::instance as rt_gl_date;
+use rts_runtime::namespaces::globals::url::instance as rt_gl_url;
 
 use crate::runtime_link::JitSymbol;
 
@@ -210,5 +211,35 @@ pub fn date_symbols() -> Vec<JitSymbol> {
             "__RTS_FN_NS_GC_IS_DATE",
             rts_runtime::namespaces::gc::string_pool::__RTS_FN_NS_GC_IS_DATE
         ),
+    ]
+}
+
+/// Real `URL` class symbols (WHATWG parser): the `[StrPtr]`/`[StrPtr,StrPtr]` ctors
+/// + the string getters (href/protocol/host/hostname/port/pathname/search/hash/
+/// origin/username/password) the Registry `URL` members reference by symbol. The
+/// class-spec Members carry null `fn_ptr` (the harvest skips them), so the real
+/// extern addresses are installed here, like [`date_symbols`].
+pub fn url_symbols() -> Vec<JitSymbol> {
+    macro_rules! s {
+        ($name:literal, $f:path) => {
+            JitSymbol { name: $name, ptr: $f as *const u8 }
+        };
+    }
+    vec![
+        s!("__RTS_FN_GL_URL_NEW", rt_gl_url::__RTS_FN_GL_URL_NEW),
+        s!("__RTS_FN_GL_URL_NEW_WITH_BASE", rt_gl_url::__RTS_FN_GL_URL_NEW_WITH_BASE),
+        s!("__RTS_FN_GL_URL_HREF", rt_gl_url::__RTS_FN_GL_URL_HREF),
+        s!("__RTS_FN_GL_URL_PROTOCOL", rt_gl_url::__RTS_FN_GL_URL_PROTOCOL),
+        s!("__RTS_FN_GL_URL_HOST", rt_gl_url::__RTS_FN_GL_URL_HOST),
+        s!("__RTS_FN_GL_URL_HOSTNAME", rt_gl_url::__RTS_FN_GL_URL_HOSTNAME),
+        s!("__RTS_FN_GL_URL_PORT", rt_gl_url::__RTS_FN_GL_URL_PORT),
+        s!("__RTS_FN_GL_URL_PATHNAME", rt_gl_url::__RTS_FN_GL_URL_PATHNAME),
+        s!("__RTS_FN_GL_URL_SEARCH", rt_gl_url::__RTS_FN_GL_URL_SEARCH),
+        s!("__RTS_FN_GL_URL_HASH", rt_gl_url::__RTS_FN_GL_URL_HASH),
+        s!("__RTS_FN_GL_URL_ORIGIN", rt_gl_url::__RTS_FN_GL_URL_ORIGIN),
+        s!("__RTS_FN_GL_URL_USERNAME", rt_gl_url::__RTS_FN_GL_URL_USERNAME),
+        s!("__RTS_FN_GL_URL_PASSWORD", rt_gl_url::__RTS_FN_GL_URL_PASSWORD),
+        s!("__RTS_FN_GL_URL_TO_STRING", rt_gl_url::__RTS_FN_GL_URL_TO_STRING),
+        s!("__RTS_FN_GL_URL_FREE", rt_gl_url::__RTS_FN_GL_URL_FREE),
     ]
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -657,6 +657,7 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
     // directly — replacing the `__rtsadp_date_*` trampolines that used to forward
     // to them.
     syms.extend(crate::registry_link::date_symbols());
+    syms.extend(crate::registry_link::url_symbols());
     syms
 }
 


### PR DESCRIPTION
## `new URL()` via Registry (template Date)

`new URL("…")` bailava `class URL is not a user class` (cluster top da suíte). URL é backend/Registry (parser WHATWG, sem sintaxe nativa) → wirado pelo template Date, **não** `.ts`. `register_url_class_spec` já existia, só faltava plugar.

## Mudança
- `registry_build.rs`: Register row → `is_pure_registry_class("URL")` true → `new URL()` roteia pelo `registryclass.rs` genérico (`emit_registry_ctor`). **Sem literal "URL" no codegen.**
- `globalclass.rs`: path **GENÉRICO** de property-READ em instância de classe-Registry (`u.hostname`/`u.pathname` → membro de instância 0-arg = getter, via Registry). Data-driven, sem literal por-classe — serve **qualquer** classe Registry com getter 0-arg.
- `runtime_link.rs`: símbolos `__RTS_FN_GL_URL_*` no JIT.

## Validação
- Repro = Bun: `new URL("https://a.com/p?x=1").hostname/.pathname` → `a.com /p`.
- `cargo test -p rts-codegen-new`: **728 → 729** (+1 `url_ctor_and_getters`).
- gate sem HARD (sem literal URL no codegen; mentions em registry_build = labels de dado).

## Follow-up
**URLSearchParams** (`u.searchParams.get(...)`) — precisa `register_urlsp_class_spec` + `.searchParams` tagged `RETURNS_OBJECT` + rastrear a classe do resultado pro `.get()` encadeado. As 4 fixtures URL dependem disso (suíte inalterada até lá); URL básico já é capability real + o mecanismo genérico de getter ajuda outras classes Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)