### PR TITLE
TextEncoder/TextDecoder via Registry (suíte 316→318)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -105,6 +105,10 @@ pub(super) static REGISTER: &[Register] = &[
     Register { label: "URL class", run: ns::globals::url::register_url_class_spec, why: "URL ctor + getters" },
     // URLSearchParams: follow-up — needs its own symbols installed + `u.searchParams`
     // tagged RETURNS_OBJECT (it returns a URLSearchParams instance, not a string).
+    // `TextEncoder`/`TextDecoder` — backend/Registry classes (UTF-8, no native
+    // syntax): `new TextEncoder().encode(s)` → Uint8Array handle, `decode(h)` → str.
+    Register { label: "TextEncoder class", run: ns::globals::text_encoding::register_text_encoder_class_spec, why: "TextEncoder ctor + encode" },
+    Register { label: "TextDecoder class", run: ns::globals::text_encoding::register_text_decoder_class_spec, why: "TextDecoder ctor + decode" },
 ];
 
 /// One `.ts` prelude include, in DEPENDENCY ORDER (base before dependent).

--- a/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
@@ -298,3 +298,15 @@ fn url_ctor_and_getters() {
         "a.com /p\n",
     );
 }
+
+#[test]
+fn text_encoder_decoder_roundtrip() {
+    // `TextEncoder`/`TextDecoder` — backend/Registry classes (UTF-8, no native
+    // syntax) wired via the Date template. `new TextDecoder()` is the 0-arg
+    // optional-label ctor (Sig default_args). Round-trip through a Uint8Array
+    // handle, no `"TextEncoder"` literal in codegen.
+    assert_stdout(
+        r#"const e = new TextEncoder(); const d = new TextDecoder(); console.log(d.decode(e.encode("hello")));"#,
+        "hello\n",
+    );
+}

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -420,6 +420,27 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTENC_ATOB
                 as *const u8,
         ),
+        // TextEncoder/TextDecoder class ctor + instance methods (Registry class).
+        sym(
+            "__RTS_FN_GL_TEXTENC_NEW",
+            rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTENC_NEW
+                as *const u8,
+        ),
+        sym(
+            "__RTS_FN_GL_TEXTENC_ENCODE_INSTANCE",
+            rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTENC_ENCODE_INSTANCE
+                as *const u8,
+        ),
+        sym(
+            "__RTS_FN_GL_TEXTDEC_NEW",
+            rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTDEC_NEW
+                as *const u8,
+        ),
+        sym(
+            "__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE",
+            rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE
+                as *const u8,
+        ),
         // ---- codegen-owned FUNCTION-value trampolines (__rtsadp_fn_*, P4.6) ----
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym(

--- a/crates/rts-std/src/globals/text_encoding/mod.rs
+++ b/crates/rts-std/src/globals/text_encoding/mod.rs
@@ -10,7 +10,7 @@
 
 pub mod instance;
 
-use rts_engine::{AbiType, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
+use rts_engine::{AbiType, DefaultArg, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
 
 /// Membro de namespace/classe global (helper hand-written, espelha a macro).
 #[allow(clippy::too_many_arguments)]
@@ -144,7 +144,10 @@ pub fn register_text_decoder_class_spec(e: &mut Engine) {
         .member(m(
             "new",
             MemberKind::Constructor,
-            Sig::new(vec![AbiType::StrPtr], AbiType::Handle),
+            // `label` is OPTIONAL (`new TextDecoder()` valid); default it to
+            // `undefined` so the generic ctor resolver admits a 0-arg call. UTF-8
+            // only, label ignored, so the runtime never reads a missing label.
+            Sig::with_defaults(vec![AbiType::StrPtr], AbiType::Handle, vec![DefaultArg::Undefined]),
             "__RTS_FN_GL_TEXTDEC_NEW",
             "new TextDecoder(label?: string)",
             "new TextDecoder(label?) — label opcional (so' UTF-8 suportado, label ignorado).",


### PR DESCRIPTION
## `new TextEncoder()` / `new TextDecoder()` via Registry

Bailavam `not a user class`. São backend/Registry (UTF-8, sem sintaxe nativa) → wirados pelo template Date/URL, **não** `.ts`. `register_text_{encoder,decoder}_class_spec` já existiam; faltava plugar + instalar os símbolos no JIT.

## Mudança
- `registry_build.rs`: Register rows → `is_pure_registry_class` → `registryclass.rs` genérico. Sem literal no codegen.
- `runtime_link.rs`: instala `__RTS_FN_GL_TEXTENC_NEW`/`ENCODE_INSTANCE`/`TEXTDEC_NEW`/`DECODE_INSTANCE` no JIT (faltavam — só BTOA/ATOB estavam).
- `rts-std/text_encoding/mod.rs`: ctor do TextDecoder → `Sig::with_defaults([StrPtr], Handle, [Undefined])` — `label` é **opcional** (`new TextDecoder()` válido); required=0 admite o 0-arg.

## Validação
- Repro = Bun: `new TextDecoder().decode(new TextEncoder().encode("hello"))` → `hello`.
- **2 fixtures** (text_encoding_class round-trip + buffer_indexing) FAIL → OK.
- suíte `measure_new`: **316 → 318** (+2).
- `cargo test -p rts-codegen-new`: **729 → 730**; gate sem HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)