### PR TITLE
fix(codegen-new): métodos de String despacham em variáveis (não só literais)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -148,9 +148,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     fn lower_ident(&mut self, module: &mut dyn Module, name: &str) -> FrontResult<Val> {
         if let Some(local) = self.local(name) {
             let v = self.builder.use_var(local.var);
-            // A local's static kind is its repr-implied kind; a Tagged local
-            // carries `Unknown` (we do not flow string-ness through vars yet),
-            // which makes strict-eq over it conservatively bail.
+            // A Tagged local recorded as a PROVEN STRING (`let s = "x"`, a param
+            // typed `string`) carries `JsKind::Str`, so `s.method(...)` dispatches
+            // on `class String` and `s === t` runs the string path — not just the
+            // handful of dynamic-table methods. Other locals' static kind is their
+            // repr-implied kind (a plain Tagged local is `Unknown`).
+            if self.string_locals.contains(name) {
+                return Ok(Val::tagged_kind(v, JsKind::Str));
+            }
             return Ok(Val::new(v, local.repr));
         }
         // MODULE-LEVEL MUTABLE GLOBAL (epic #195): a top-level `let` written from a

--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -169,7 +169,26 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 if let Some(val) = self.try_array_callback_dynamic(module, recv, method, args)? {
                     return Ok(Some(val));
                 }
-                return self.try_method_dispatch_dynamic(module, recv, method, args);
+                if let Some(val) = self.try_method_dispatch_dynamic(module, recv, method, args)? {
+                    return Ok(Some(val));
+                }
+                // FALLBACK: the dynamic table (`DYN_METHODS`) only covers the
+                // high-frequency string/array methods at fixed arity. For a method
+                // it lacks (`padStart`/`concat`/`includes` with a position arg/…) on
+                // a Tagged receiver that is a STRING, route to the ambient prelude
+                // `class String` (the `.ts` primitive-method library) — the SAME
+                // path a PROVEN-string literal uses, just over the dynamic word. The
+                // `.ts` `__str_val(this)` reads the string from the boxed receiver;
+                // a non-string Tagged word would mis-dispatch, so gate on a proven
+                // string kind. `Ok(None)` ⇒ no such String method (caller bails).
+                if matches!(recv.kind, JsKind::Str) {
+                    if let Some(val) =
+                        self.try_primitive_class_method(module, recv, "String", method, args)?
+                    {
+                        return Ok(Some(val));
+                    }
+                }
+                return Ok(None);
             }
             return Ok(None);
         };

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -290,6 +290,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(());
         }
 
+        // A STRING-valued initializer (`let s = "x"`, `let s = a + b` over strings,
+        // a string-returning method): record `name` as a proven string so a later
+        // `s.method(...)` dispatches on `class String` (the `.ts` primitive-method
+        // library) exactly like a string literal — not just the handful of methods
+        // in the dynamic table. The local rides Tagged (the boxed string word); only
+        // the proven-string FACT is recorded. (Mirrors the array-shape branch above.)
+        if matches!(val.kind, super::lower::JsKind::Str) {
+            self.bind_tagged_local(name, val);
+            self.string_locals.insert(name.to_string());
+            return Ok(());
+        }
+
         // The local's repr is the numeric annotation when the INITIALIZER ITSELF is
         // unboxed-numeric; a Tagged initializer keeps its `Tagged` repr even under a
         // numeric annotation. This is the soundness seam: `let a: number = null`

--- a/crates/rts-codegen-new/src/front/run/tests/arr_cb_dyn.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/arr_cb_dyn.rs
@@ -67,11 +67,25 @@ fn find_some_every_findindex_on_param() {
 
 #[test]
 fn map_on_any_non_array_is_safe_empty() {
-    // SAFETY: `.map` on a NON-array Tagged receiver must not fault — the trampoline
-    // does a HandleTable lookup and sees length 0, so the result is an empty array.
+    // SAFETY: `.map` on a genuinely UNKNOWN-kind Tagged receiver (a param whose
+    // value the engine cannot prove array/string/number) must not fault — the
+    // trampoline does a HandleTable lookup and sees length 0, so the result is an
+    // empty array. (A receiver PROVEN string/number routes to its prelude class and
+    // bails on the missing `.map`, which is JS-correct — see `map_on_proven_string_bails`.)
     assert_stdout(
-        r#"let s: any = "not an array";
-           console.log(s.map((x: number) => x * 2).join(","));"#,
+        r#"function f(s: any): string { return s.map((x: number) => x * 2).join(","); }
+           console.log(f("not an array"));"#,
         "\n",
+    );
+}
+
+#[test]
+fn map_on_proven_string_bails() {
+    // A var initialized with a string is PROVEN a string (string_locals), so
+    // `s.map(...)` dispatches on `class String` — which has no `.map`. JS throws a
+    // TypeError here; the engine BAILS (honesty floor: no wrong-but-safe empty).
+    super::assert_bails(
+        r#"let s = "not an array";
+           console.log(s.map((x: number) => x * 2).join(","));"#,
     );
 }

--- a/crates/rts-primitives/src/string.ts
+++ b/crates/rts-primitives/src/string.ts
@@ -35,6 +35,13 @@
 // `dispatch.rs`/`try_string_*` paths (array/regex marshaling is not a clean single
 // string→string engine helper).
 
+// NOTE on the repeated `2147483647` default below: it is the sentinel "to the end
+// of the string" (a large i32 the Rust impl clamps to length). A shared top-level
+// `const __STR_END` does NOT work here — the new engine does not yet resolve a
+// prelude module-level const inside a class METHOD body (only top-level functions
+// like `__str_val` reach method scope), so it would bail "unbound identifier". The
+// literal is therefore the pragmatic single form until that scope gap is closed.
+
 // Unwrap the primitive string from either an autoboxed primitive `self` (the
 // string itself) or a wrapper-object `self` (its `__prim` slot).
 function __str_val(self: any): string {
@@ -130,13 +137,26 @@ class String {
   lastIndexOf(needle: string): number {
     return engine.str_last_index_of(__str_val(this), needle);
   }
-  includes(needle: string): boolean {
+  // includes/startsWith take an optional `position` (search start); endsWith an
+  // optional `endPosition`. The irreducible search stays in the `engine.str_*`
+  // bridge over the WHOLE string; the position is applied by composing with
+  // `slice` (`s.includes(x, p) === s.slice(p).includes(x)`) — no new bridge.
+  includes(needle: string, position: number = 0): boolean {
+    if (position > 0) {
+      return engine.str_includes(__str_val(this.slice(position)), needle);
+    }
     return engine.str_includes(__str_val(this), needle);
   }
-  startsWith(prefix: string): boolean {
+  startsWith(prefix: string, position: number = 0): boolean {
+    if (position > 0) {
+      return engine.str_starts_with(__str_val(this.slice(position)), prefix);
+    }
     return engine.str_starts_with(__str_val(this), prefix);
   }
-  endsWith(suffix: string): boolean {
+  endsWith(suffix: string, endPosition: number = 2147483647): boolean {
+    if (endPosition < 2147483647) {
+      return engine.str_ends_with(__str_val(this.slice(0, endPosition)), suffix);
+    }
     return engine.str_ends_with(__str_val(this), suffix);
   }
   // padStart/padEnd: the pad string defaults to a single space (JS spec).


### PR DESCRIPTION
## Problema (pré-existente)
Métodos de String que a tabela dinâmica (`DYN_METHODS`) não cobre exatamente — `padStart`, `concat`, `includes`/`startsWith` com `position` — BAILAVAM quando o receiver era uma VARIÁVEL (`let s = "x"; s.padStart(8)`), mas funcionavam num LITERAL. Causa: o motor não propagava string-ness por variáveis, então o receiver caía no dispatch dinâmico (que só cobre poucos métodos a aridade fixa).

## Fix — data-driven (String é PRIMORDIAL)
- `lower_let`: init string-valued (`JsKind::Str`) registra a var em `string_locals`.
- `lower_ident`: var em `string_locals` lê como `JsKind::Str` (fechou o gap "we do not flow string-ness through vars").
- `try_method_dispatch`: receiver Tagged provado-string que o dyn não cobre → fallback p/ `class String` (`.ts` prelude), o mesmo path do literal. **Sem nome de método hardcoded.**
- `string.ts`: includes/startsWith/endsWith ganham o param de posição (compondo via slice).

## Regressão intencional
`map_on_any_non_array_is_safe_empty` agora usa receiver genuinamente Unknown (param `any`); `.map` numa string provada BAILA (JS = TypeError; mais correto que o retorno-vazio antigo) — novo teste `map_on_proven_string_bails`.

## Testes
730/730 unit verdes. Fixtures string com receiver-variável destravadas. `125_array_includes` não crasha mais (segue divergindo só em NaN/fromIndex-negativo do Array.includes — bug separado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)