### PR TITLE
fix(codegen-new): Array.join() 0-arg + String.indexOf fromIndex

### DIFF
--- a/crates/rts-codegen-new/src/dispatch.rs
+++ b/crates/rts-codegen-new/src/dispatch.rs
@@ -209,6 +209,7 @@ const ARRAY_ROWS: &[(&str, usize, MethodSpec)] = &[
     ("indexOf", 1, am("__rtsadp_arr_index_of", &[U64], I64)),
     ("includes", 1, am("__rtsadp_arr_includes", &[U64], Bool)),
     ("at", 1, am("__rtsadp_arr_at", &[I64], U64)),
+    ("join", 0, am("__rtsadp_arr_join0", &[], Handle)),
     ("join", 1, am("__rtsadp_arr_join", &[Handle], Handle)),
     ("push", 1, am("__rtsadp_arr_push", &[U64], I64)),
     ("pop", 0, am("__rtsadp_arr_pop", &[], U64)),

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -234,6 +234,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             arrayops::__rtsadp_arr_join as *const u8,
         ),
         sym(
+            "__rtsadp_arr_join0",
+            arrayops::__rtsadp_arr_join0 as *const u8,
+        ),
+        sym(
             "__rtsadp_arr_push",
             arrayops::__rtsadp_arr_push as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -418,6 +418,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, Handle],
             ret: Handle,
         },
+        "__rtsadp_arr_join0" => SymSig {
+            params: &[U64],
+            ret: Handle,
+        },
         "__rtsadp_arr_push" => SymSig {
             params: &[U64, U64],
             ret: I64,

--- a/crates/rts-codegen-new/src/value/arrayops.rs
+++ b/crates/rts-codegen-new/src/value/arrayops.rs
@@ -79,6 +79,13 @@ pub extern "C" fn __rtsadp_arr_at(vec_handle: u64, i: i64) -> u64 {
 /// `console.log`/`__rtsadp_to_string`), join with `sep` (a real string handle),
 /// and intern the result in the REAL string pool, returning its handle. An empty
 /// array yields the interned empty string.
+/// `arr.join()` with no argument — `arr.join(",")` (the JS default separator).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_join0(vec_handle: u64) -> u64 {
+    let comma = abi_adapter::intern_poly(",").as_handle_real();
+    __rtsadp_arr_join(vec_handle, comma)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_arr_join(vec_handle: u64, sep_str_handle: u64) -> u64 {
     let sep = abi_adapter::real_handle_to_string(sep_str_handle);

--- a/crates/rts-primitives/src/string.ts
+++ b/crates/rts-primitives/src/string.ts
@@ -131,7 +131,14 @@ class String {
   substring(start: number, end: number = 2147483647): string {
     return engine.str_substring(__str_val(this), start, end);
   }
-  indexOf(needle: string): number {
+  // indexOf takes an optional `position` (search start). Compose via slice: search
+  // the tail from `position`, then offset the found index back to absolute (or keep
+  // -1). `s.indexOf(x, p)` over the whole string when `p <= 0`.
+  indexOf(needle: string, position: number = 0): number {
+    if (position > 0) {
+      const found = engine.str_index_of(__str_val(this.slice(position)), needle);
+      return found < 0 ? -1 : found + position;
+    }
     return engine.str_index_of(__str_val(this), needle);
   }
   lastIndexOf(needle: string): number {


### PR DESCRIPTION
Duas variantes de aridade faltando:
- `arr.join()` (0 args) → default "," via novo trampolim `__rtsadp_arr_join0` (delega ao join existente).
- `s.indexOf(needle, pos)` → param opcional composto via slice no string.ts.

Destrava 142_array_join_edge_cases e 135_array_indexof_lastindexof (não crasham mais).

731/731 unit verdes. (Os 2 `global_this_*` têm flakiness transitória pré-existente do singleton compartilhado — passam isolados/re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)