### PR TITLE
fix(codegen-new): Array slice()/toString()/toLocaleString() + String.lastIndexOf fromIndex

### DIFF
--- a/crates/rts-codegen-new/src/dispatch.rs
+++ b/crates/rts-codegen-new/src/dispatch.rs
@@ -237,6 +237,10 @@ const ARRAY_ROWS: &[(&str, usize, MethodSpec)] = &[
         am("__rtsadp_arr_last_index_of_from", &[U64, I64], I64),
     ),
     ("slice", 1, am("__rtsadp_arr_slice1", &[I64], U64)),
+    ("slice", 0, am("__rtsadp_arr_slice0", &[], U64)),
+    ("toString", 0, am("__rtsadp_arr_to_string", &[], Handle)),
+    // toLocaleString without locale data == toString (the runtime has no Intl).
+    ("toLocaleString", 0, am("__rtsadp_arr_to_string", &[], Handle)),
     ("toReversed", 0, am("__rtsadp_arr_to_reversed", &[], U64)),
     ("with", 2, am("__rtsadp_arr_with", &[I64, U64], U64)),
     ("sort", 0, am("__rtsadp_arr_sort", &[], U64)),

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -238,6 +238,14 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             arrayops::__rtsadp_arr_join0 as *const u8,
         ),
         sym(
+            "__rtsadp_arr_slice0",
+            arrayops::__rtsadp_arr_slice0 as *const u8,
+        ),
+        sym(
+            "__rtsadp_arr_to_string",
+            arrayops::__rtsadp_arr_to_string as *const u8,
+        ),
+        sym(
             "__rtsadp_arr_push",
             arrayops::__rtsadp_arr_push as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -422,6 +422,14 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64],
             ret: Handle,
         },
+        "__rtsadp_arr_slice0" => SymSig {
+            params: &[U64],
+            ret: U64,
+        },
+        "__rtsadp_arr_to_string" => SymSig {
+            params: &[U64],
+            ret: Handle,
+        },
         "__rtsadp_arr_push" => SymSig {
             params: &[U64, U64],
             ret: I64,

--- a/crates/rts-codegen-new/src/value/arrayops.rs
+++ b/crates/rts-codegen-new/src/value/arrayops.rs
@@ -298,6 +298,18 @@ pub extern "C" fn __rtsadp_arr_slice1(vec_handle: u64, start: i64) -> u64 {
     __rtsadp_arr_slice(vec_handle, start, vec_len(vec_handle))
 }
 
+/// `arr.slice()` (no args) — a shallow COPY of the whole array (`slice(0, len)`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_slice0(vec_handle: u64) -> u64 {
+    __rtsadp_arr_slice(vec_handle, 0, vec_len(vec_handle))
+}
+
+/// `arr.toString()` — JS defines it as `arr.join(",")`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_to_string(vec_handle: u64) -> u64 {
+    __rtsadp_arr_join0(vec_handle)
+}
+
 /// `arr.indexOf(needle, fromIndex)` — first index `>= fromIndex` whose element
 /// `=== needle`, or `-1`. Negative `from` counts from the end (`len + from`,
 /// clamped to `0`).

--- a/crates/rts-primitives/src/string.ts
+++ b/crates/rts-primitives/src/string.ts
@@ -141,7 +141,15 @@ class String {
     }
     return engine.str_index_of(__str_val(this), needle);
   }
-  lastIndexOf(needle: string): number {
+  // lastIndexOf takes an optional `fromIndex` — the LAST match that STARTS at index
+  // <= fromIndex. Compose via slice: a match starting at <= fromIndex lies wholly
+  // within `this.slice(0, fromIndex + needle.length)`, so lastIndexOf over that
+  // prefix gives the same (absolute) index.
+  lastIndexOf(needle: string, fromIndex: number = 2147483647): number {
+    if (fromIndex < 2147483647) {
+      const prefix = this.slice(0, fromIndex + needle.length);
+      return engine.str_last_index_of(__str_val(prefix), needle);
+    }
     return engine.str_last_index_of(__str_val(this), needle);
   }
   // includes/startsWith take an optional `position` (search start); endsWith an


### PR DESCRIPTION
Mais variantes de aridade (todas linkam fn já existente no runtime):
- `arr.slice()` 0-arg → cópia. `arr.toString()`/`toLocaleString()` → join(','). `s.lastIndexOf(x, from)` → composto via slice.

Destrava 157_array_tostring_tolocalestring. 731/731 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)