### PR TITLE
fix(codegen-new): Array.sort(cmp) — ordena in-place com comparador JS

### DIFF
--- a/crates/rts-codegen-new/src/dispatch.rs
+++ b/crates/rts-codegen-new/src/dispatch.rs
@@ -244,6 +244,10 @@ const ARRAY_ROWS: &[(&str, usize, MethodSpec)] = &[
     ("toReversed", 0, am("__rtsadp_arr_to_reversed", &[], U64)),
     ("with", 2, am("__rtsadp_arr_with", &[I64, U64], U64)),
     ("sort", 0, am("__rtsadp_arr_sort", &[], U64)),
+    // sort(cmp): a 1-callback method. The CbShape is Predicate only to satisfy the
+    // "exactly one callback arg" marshaling; the `__rtsadp_arr_sort_cmp` trampoline
+    // invokes the cb as a 2-arg comparator `(a, b)`, not as `(elem, i, arr)`.
+    ("sort", 1, cm("__rtsadp_arr_sort_cmp", U64, CbShape::Predicate)),
     ("toSorted", 0, am("__rtsadp_arr_to_sorted", &[], U64)),
     ("toSpliced", 2, am("__rtsadp_arr_to_spliced", &[I64, I64], U64)),
     ("copyWithin", 2, am("__rtsadp_arr_copy_within2", &[I64, I64], U64)),

--- a/crates/rts-codegen-new/src/front/run/tests/arraycb.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/arraycb.rs
@@ -8,7 +8,7 @@
 //! Capturing callbacks + `.sort(comparator)` BAIL explicitly (the soundness
 //! floor) — never a wrong value.
 
-use super::{assert_bails, assert_stdout};
+use super::assert_stdout;
 
 #[test]
 fn map_doubles() {
@@ -118,8 +118,15 @@ fn capturing_callback_now_works() {
 }
 
 #[test]
-fn sort_with_comparator_bails() {
-    // `.sort(cmp)` is not in the implemented Array surface → BAIL (no Registry
-    // row for `Array.sort`).
-    assert_bails("let a=[3,1,2]; a.sort((x:number,y:number)=>x-y); console.log(a.join(\",\"));");
+fn sort_with_comparator() {
+    // `.sort(cmp)` sorts in place using the JS comparator (a 1-callback method via
+    // `__rtsadp_arr_sort_cmp`): `x - y` ascending, `y - x` descending.
+    assert_stdout(
+        "let a=[3,1,2]; a.sort((x:number,y:number)=>x-y); console.log(a.join(\",\"));",
+        "1,2,3\n",
+    );
+    assert_stdout(
+        "let a=[1,3,2]; a.sort((x:number,y:number)=>y-x); console.log(a.join(\",\"));",
+        "3,2,1\n",
+    );
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -307,6 +307,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
         ),
         sym("__rtsadp_arr_sort", arrayops::__rtsadp_arr_sort as *const u8),
         sym(
+            "__rtsadp_arr_sort_cmp",
+            arrayops::__rtsadp_arr_sort_cmp as *const u8,
+        ),
+        sym(
             "__rtsadp_arr_to_sorted",
             arrayops::__rtsadp_arr_to_sorted as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -774,7 +774,8 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         | "__rtsadp_arr_for_each"
         | "__rtsadp_arr_find"
         | "__rtsadp_arr_find_last"
-        | "__rtsadp_arr_flat_map" => SymSig {
+        | "__rtsadp_arr_flat_map"
+        | "__rtsadp_arr_sort_cmp" => SymSig {
             params: &[U64, U64],
             ret: U64,
         },

--- a/crates/rts-codegen-new/src/value/arrayops.rs
+++ b/crates/rts-codegen-new/src/value/arrayops.rs
@@ -24,7 +24,7 @@ use rts_runtime::namespaces::collections::vec as rt_vec;
 use rts_runtime::namespaces::gc::handles as rt_handles;
 use rts_runtime::namespaces::gc::string_pool as rt_str;
 
-use super::{PolyValue, abi_adapter, genops};
+use super::{PolyValue, abi_adapter, funcops, genops};
 
 /// Element count of the real Vec behind `vec_handle` (clamped to `>= 0`).
 fn vec_len(vec_handle: u64) -> i64 {
@@ -429,6 +429,34 @@ pub extern "C" fn __rtsadp_arr_sort(vec_handle: u64) -> u64 {
     let len = vec_len(vec_handle);
     let mut words: Vec<u64> = (0..len).map(|i| vec_word(vec_handle, i)).collect();
     words.sort_by(|&a, &b| default_sort_cmp(a, b));
+    for (i, w) in words.into_iter().enumerate() {
+        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(vec_handle, i as i64, w as i64);
+    }
+    box_self(vec_handle)
+}
+
+/// `arr.sort(cmp)` — sort IN PLACE using the JS comparator `cmp(a, b)`: a returned
+/// number < 0 keeps `a` before `b`, > 0 puts `b` first, 0 (or NaN) treats them as
+/// equal. The comparator is a `TAG_FUNCTION` word invoked through the uniform
+/// indirect-call ABI. Returns the (mutated) receiver. Mirrors `__rtsadp_arr_sort`
+/// but with the user comparator instead of `default_sort_cmp`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_sort_cmp(vec_handle: u64, cb: u64) -> u64 {
+    let len = vec_len(vec_handle);
+    let mut words: Vec<u64> = (0..len).map(|i| vec_word(vec_handle, i)).collect();
+    let u = PolyValue::undefined().raw();
+    words.sort_by(|&a, &b| {
+        // `cmp(a, b)` → a PolyValue word; ToNumber it (JS coercion). A NaN/0 result
+        // is `Equal` (a stable no-swap), matching the spec's "treat as equal".
+        let r = genops::dyn_to_number(funcops::__rtsadp_fn_invoke(cb, a, b, u, u, u));
+        if r < 0.0 {
+            std::cmp::Ordering::Less
+        } else if r > 0.0 {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
     for (i, w) in words.into_iter().enumerate() {
         rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(vec_handle, i as i64, w as i64);
     }


### PR DESCRIPTION
`arr.sort((a,b)=>...)` bailava; agora ordena in-place chamando o comparador (método de 1-callback, novo trampolim `__rtsadp_arr_sort_cmp`). Destrava 217_array_sort_stability + sort com comparador em geral.

731/731 unit verdes (regressão intencional: sort_with_comparator_bails → sort_with_comparator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)