### PR TITLE
feat(codegen-new): Object.is (SameValue) static

### DIFF
--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -69,6 +69,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             "entries" => self.object_entries(module, args).map(Some),
             "assign" => self.object_assign(module, args).map(Some),
             "freeze" | "seal" | "preventExtensions" => self.object_freeze(module, args).map(Some),
+            "is" => self.object_is(module, args).map(Some),
             other => unsupported!("Object.{other}(...) static method (later increment)"),
         }
     }
@@ -250,6 +251,22 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     fn object_freeze(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
         let (word, _keys) = self.receiver(module, args)?;
         Ok(Val::new(word, Repr::Tagged))
+    }
+
+    /// `Object.is(a, b)` — JS SameValue (`===` but NaN is NaN, +0 is not -0). Box
+    /// both args and call the `__rtsadp_same_value` trampoline; result is a Bool.
+    fn object_is(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
+        if args.len() != 2 {
+            return unsupported!("Object.is expects 2 args, got {}", args.len());
+        }
+        let a = self.lower_expr(module, &args[0])?;
+        let aw = self.box_value(a);
+        let b = self.lower_expr(module, &args[1])?;
+        let bw = self.box_value(b);
+        let res = self
+            .call_runtime(module, "__rtsadp_same_value", &[aw, bw])?
+            .expect("__rtsadp_same_value returns a value");
+        Ok(Val::tagged_kind(res, super::lower::JsKind::Bool))
     }
 
     /// Whether `e` is an `Object.keys/values/entries/getOwnPropertyNames(o)` call

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -173,6 +173,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             genops::__rtsadp_strict_eq as *const u8,
         ),
         sym(
+            "__rtsadp_same_value",
+            genops::__rtsadp_same_value as *const u8,
+        ),
+        sym(
             "__rtsadp_strict_neq",
             genops::__rtsadp_strict_neq as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -299,7 +299,8 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         | "__rtsadp_strict_eq"
         | "__rtsadp_strict_neq"
         | "__rtsadp_loose_eq"
-        | "__rtsadp_loose_neq" => SymSig {
+        | "__rtsadp_loose_neq"
+        | "__rtsadp_same_value" => SymSig {
             params: &[U64, U64],
             ret: U64,
         },

--- a/crates/rts-codegen-new/src/value/genops.rs
+++ b/crates/rts-codegen-new/src/value/genops.rs
@@ -267,6 +267,32 @@ fn real_handle_for_concat(v: PolyValue) -> u64 {
 /// (`STRING_EQ`) — the indirection table means two equal strings may sit at
 /// different idxs, so a raw-word compare is NOT sufficient. Everything else
 /// compares by identical representation.
+/// `Object.is(a, b)` — JS SameValue. Like `===` EXCEPT: `Object.is(NaN, NaN)` is
+/// `true` and `Object.is(0, -0)` is `false`. Both differences live in the number
+/// branch (string/other identity match `===`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_same_value(a: u64, b: u64) -> u64 {
+    let av = PolyValue::from_raw(a);
+    let bv = PolyValue::from_raw(b);
+    let same = if is_number(av) && is_number(bv) {
+        let (x, y) = (av.number_as_f64(), bv.number_as_f64());
+        if x.is_nan() && y.is_nan() {
+            true // SameValue: NaN is NaN
+        } else if x == 0.0 && y == 0.0 {
+            x.is_sign_negative() == y.is_sign_negative() // +0 is NOT -0
+        } else {
+            x == y
+        }
+    } else if av.is_string() && bv.is_string() {
+        let ah = abi_adapter::real_handle_of(av);
+        let bh = abi_adapter::real_handle_of(bv);
+        rt_str::__RTS_FN_NS_GC_STRING_EQ(ah, bh) != 0
+    } else {
+        av.raw() == bv.raw()
+    };
+    PolyValue::bool(same).raw()
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_strict_eq(a: u64, b: u64) -> u64 {
     let av = PolyValue::from_raw(a);


### PR DESCRIPTION
`Object.is(a, b)` resolve via novo trampolim `__rtsadp_same_value` (SameValue: === mas NaN is NaN). Destrava ~8 fixtures.

Limitação conhecida (gap separado): -0 ainda não distinto de +0 na repr, então `Object.is(0,-0)` devolve true (deveria false). Resto JS-correto.

731/731 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)