### PR TITLE
Resultado de concat de string é string provada (.length/métodos)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -307,6 +307,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             HirBinOp::Exp => "__rtsadp_pow",
             _ => return unsupported!("generic arithmetic op {op:?}"),
         };
+        let (lk, rk) = (l.kind, r.kind);
         let ba = self.box_value(l);
         let bb = self.box_value(r);
         let res = self
@@ -316,8 +317,19 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // (only `+` can yield a string via concatenation). Recording the proven
         // `Number` kind lets a following `x%2 === 0` see same-kind operands and
         // lower the strict-eq soundly instead of bailing on Unknown.
+        //
+        // For `+`: if EITHER operand is a PROVEN string, the result is PROVEN a
+        // string — JS `string + x` ToString-concats `x` (and `x + string` too), so
+        // the concat result is a string regardless of the other operand. Recording
+        // `Str` lets `(v + "\n").length` / string methods on the concat result
+        // dispatch instead of bailing "unproven shape". Otherwise (number-add vs
+        // concat depends on runtime types) it stays Unknown.
         let kind = if matches!(op, HirBinOp::Add) {
-            JsKind::Unknown
+            if matches!(lk, JsKind::Str) || matches!(rk, JsKind::Str) {
+                JsKind::Str
+            } else {
+                JsKind::Unknown
+            }
         } else {
             JsKind::Number
         };
@@ -504,7 +516,7 @@ pub(super) fn is_int_repr(r: Repr) -> bool {
 /// concatenation). Used to allow `string + array/object` (pure concatenation via
 /// `String(...)`), which is well-defined, while still bailing the true ToPrimitive
 /// `array + array` case.
-fn is_proven_string_expr(e: &HirExpr) -> bool {
+pub(super) fn is_proven_string_expr(e: &HirExpr) -> bool {
     use rts_hir::ir::{HirExprKind, HirLit};
     if matches!(e.ty, rts_hir::HirType::Str) {
         return true;

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -604,6 +604,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// A `true` here lets `lower_member`/`lower_index` take the native string
     /// fast-path; everything else falls through to the heap-shape path UNCHANGED.
     fn receiver_is_proven_string(&self, object: &HirExpr) -> bool {
+        // A string LITERAL, a `+`-concat chain with a proven-string operand
+        // (`v + "\n"`), or an expr the HIR already typed `Str` — all yield a string
+        // (JS `string + x` ToString-concats), so `.length` / string methods on the
+        // result dispatch. Reuses the binop string-proof.
+        if super::binop::is_proven_string_expr(object) {
+            return true;
+        }
         match &object.kind {
             HirExprKind::Lit(rts_hir::ir::HirLit::Str(_)) => true,
             HirExprKind::Ident(name) => self.string_locals.contains(name),

--- a/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
@@ -310,3 +310,14 @@ fn text_encoder_decoder_roundtrip() {
         "hello\n",
     );
 }
+
+#[test]
+fn concat_result_is_proven_string() {
+    // JS `string + x` ToString-concats → the result is a proven string, so
+    // `.length` / string methods on a `+`-concat chain dispatch (was "unproven
+    // shape"). Either operand being a proven string proves the whole concat.
+    assert_stdout(
+        r#"function p(v: string): void { console.log((v + "!").length); } p("hi");"#,
+        "3\n",
+    );
+}


### PR DESCRIPTION
## Bug mascarado como "expression arrow"

`(v + "\n").length` / métodos de string num `+`-concat bailavam `receiver of unproven shape`. JS: `string + x` ToString-concatena → o resultado é **sempre** string se **qualquer** operando é string provada. O padrão ubíquo `print(v){ out += v + "\n"; }` do harness sofria disso (aparecia como "expression arrow" no cluster).

## Fix
- `binop.rs::lower_arith`: o kind do `+` genérico era sempre `Unknown`; agora se `l.kind` ou `r.kind == Str` → resultado `JsKind::Str` (captura os kinds antes do `box_value` que move l/r). Número-add vs concat continua `Unknown` quando nenhum operando é string provada.
- `obj.rs::receiver_is_proven_string`: reusa `is_proven_string_expr` (binop, agora `pub(super)`) que já prova literal / `HirType::Str` / `+`-concat-chain → `.length`/métodos de string no resultado de concat despacham.

## Validação
- Repro = Bun: `(v + "!").length` (v: string) → 3.
- suíte `measure_new`: **318 → 319** (+1).
- `cargo test -p rts-codegen-new`: **730 → 731** (+1).
- gate sem HARD; static byte-idêntico.

## Nota
Diagnóstico mais amplo: o **#195 (mutable captures) está em grande parte JÁ implementado** (captura read-only, gcells, closures inline/nested provados). Os bails "expression arrow" do cluster são **bugs narrow separados** mislabeled — este fix resolve um (concat-result→Str). Outros (ex. `.length` num gcell, arrows específicos) seguem como follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)