### PR TITLE
Builtins globais não são captura de closure (template em arrow) — suíte 319→333

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -196,10 +196,21 @@ pub fn captured_mutated_top_lets(funcs: &[HirFunc], main: &HirFunc) -> HashSet<S
         .collect()
 }
 
-/// Language singletons always considered "not a capture". These are genuine
-/// PRIMORDIAL value globals (not a non-primordial name like `console` — that is a
-/// gcell singleton, already treated as non-capture via `ctx.module_globals`).
-const GLOBALS: &[&str] = &["undefined", "Infinity", "NaN"];
+/// Language globals always considered "not a capture" — value singletons plus the
+/// PRIMORDIAL/builtin global NAMES an arrow body may reference (resolved at
+/// lowering, never a capturable outer local). Critically includes `String`: the
+/// template-literal desugar wraps each `${expr}` in `String(expr)`, so an arrow
+/// containing a template (`() => `${x}``) reads `String` as a free ident — without
+/// it here the arrow would be misjudged a capture of an unknown name and BAIL
+/// (`expression arrow`). (A non-primordial like `console` is a gcell singleton,
+/// already non-capture via `ctx.module_globals`.)
+const GLOBALS: &[&str] = &[
+    "undefined", "Infinity", "NaN", "globalThis",
+    // Primordial wrapper/constructor + utility globals callable from an arrow.
+    "String", "Number", "Boolean", "Object", "Array", "Function", "Symbol",
+    "Math", "JSON", "Date", "RegExp", "Promise", "Error",
+    "parseInt", "parseFloat", "isNaN", "isFinite",
+];
 
 /// The result of the arrow-extraction pre-pass: the synthesized top-level
 /// functions to append, plus the ordered capture list of each CLOSURE (synthesized

--- a/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/globalclass.rs
@@ -321,3 +321,16 @@ fn concat_result_is_proven_string() {
         "3\n",
     );
 }
+
+#[test]
+fn arrow_capturing_var_in_template_literal() {
+    // A template literal desugars `${x}` to `String(x)`, so an arrow containing a
+    // template reads `String` as a free ident. `String` (and the other primordial
+    // globals) must be treated as NON-captures, else the capturing arrow bailed
+    // "expression arrow". The arrow here captures `s` AND references `String` via
+    // the template — both must resolve.
+    assert_stdout(
+        r#"const s = 3; function call(g: () => string): string { return g(); } console.log(call(() => `v=${s}`));"#,
+        "v=3\n",
+    );
+}


### PR DESCRIPTION
## Bug: arrow capturante com template literal bailava "expression arrow"

Padrão **ubíquo** do harness: `test("...", () => expect(`${x}`).toBe(...))`. O desugar P5.8 envolve cada `${expr}` em `String(expr)`, então o arrow lê **`String`** como free-ident. `String` não era reconhecido como global → a análise de captura o tratava como local-capturável-desconhecido → bail.

## Fix
`GLOBALS` (funcval) passa a incluir os nomes **PRIMORDIAIS/builtin** globais que um corpo de arrow pode referenciar sem ser captura (resolvidos no lowering): `String`/`Number`/`Boolean`/`Object`/`Array`/`Function`/`Symbol`/`Math`/`JSON`/`Date`/`RegExp`/`Promise`/`Error` + `parseInt`/`parseFloat`/`isNaN`/`isFinite` + `globalThis`, além dos value-singletons `undefined`/`Infinity`/`NaN`. Vale geral (qualquer builtin em arrow, ex. `() => Math.max(a,b)` capturando `a`).

## Validação
- Repro = Bun: `const s=3; call(() => `v=${s}`)` → `v=3` (inline + hoisted).
- suíte `measure_new`: **319 → 333** (+14 — o template em test-arrow é ubíquo).
- `cargo test -p rts-codegen-new`: **732 → 733**.
- gate sem HARD; static byte-idêntico.

## Contexto
Parte da investigação #195: o #195 (mutable captures) está em grande parte já implementado; os bails "expression arrow" do cluster eram **bugs narrow mislabeled**. Este é o segundo fix da leva (após concat-result→string, #1670) e o de maior alavanca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)