### PR TITLE
feat(codegen-new): String.prototype.normalize

### DIFF
--- a/crates/rts-codegen-new/src/front/run/engineobj.rs
+++ b/crates/rts-codegen-new/src/front/run/engineobj.rs
@@ -507,6 +507,7 @@ fn engine_str_member(method: &str) -> Option<EngineStr> {
         "str_concat" => row("__RTS_FN_NS_ENGINE_STR_CONCAT", &[Str], StrRet::Str),
         "str_replace" => row("__RTS_FN_NS_ENGINE_STR_REPLACE", &[Str, Str], StrRet::Str),
         "str_replace_all" => row("__RTS_FN_NS_ENGINE_STR_REPLACE_ALL", &[Str, Str], StrRet::Str),
+        "str_normalize" => row("__RTS_FN_NS_ENGINE_STR_NORMALIZE", &[Str], StrRet::Str),
         _ => return None,
     })
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -1060,6 +1060,10 @@ fn engine_symbols() -> Vec<JitSymbol> {
             "__RTS_FN_NS_ENGINE_STR_REPLACE_ALL",
             rt_engine::__RTS_FN_NS_ENGINE_STR_REPLACE_ALL as *const u8,
         ),
+        sym(
+            "__RTS_FN_NS_ENGINE_STR_NORMALIZE",
+            rt_engine::__RTS_FN_NS_ENGINE_STR_NORMALIZE as *const u8,
+        ),
     ]
 }
 

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -248,8 +248,8 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[Handle, I64, Handle],
             ret: Handle,
         },
-        // (s, other: string) -> string.
-        "__RTS_FN_NS_ENGINE_STR_CONCAT" => SymSig {
+        // (s, other/form: string) -> string.
+        "__RTS_FN_NS_ENGINE_STR_CONCAT" | "__RTS_FN_NS_ENGINE_STR_NORMALIZE" => SymSig {
             params: &[Handle, Handle],
             ret: Handle,
         },

--- a/crates/rts-primitives/src/string.ts
+++ b/crates/rts-primitives/src/string.ts
@@ -198,4 +198,8 @@ class String {
   replaceAll(from: string, to: string): string {
     return engine.str_replace_all(__str_val(this), from, to);
   }
+  // Unicode normalization (NFC/NFD/NFKC/NFKD); `form` defaults to "NFC".
+  normalize(form: string = "NFC"): string {
+    return engine.str_normalize(__str_val(this), form);
+  }
 }

--- a/crates/rts-std/src/engine/string.rs
+++ b/crates/rts-std/src/engine/string.rs
@@ -42,6 +42,14 @@ unsafe extern "C" {
     fn __RTS_FN_GL_STRING_CONCAT(recv: u64, other: u64) -> u64;
     fn __RTS_FN_GL_STRING_REPLACE(recv: u64, from: u64, to: u64) -> u64;
     fn __RTS_FN_GL_STRING_REPLACE_ALL(recv: u64, from: u64, to: u64) -> u64;
+    fn __RTS_FN_GL_STRING_NORMALIZE(recv: u64, form_h: u64) -> u64;
+}
+
+/// `s.normalize(form?)` — Unicode normalization (NFC/NFD/NFKC/NFKD). Wraps
+/// GL_STRING_NORMALIZE; `form_h` is the form string handle (0 ⇒ NFC default).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_ENGINE_STR_NORMALIZE(s: u64, form_h: u64) -> Handle {
+    unsafe { __RTS_FN_GL_STRING_NORMALIZE(s, form_h) }
 }
 
 /// `s.toUpperCase()`. Wraps GL_STRING_TO_UPPER_CASE.
@@ -341,5 +349,13 @@ pub(super) fn register_members(b: ModuleBuilder<'_>) -> ModuleBuilder<'_> {
         "str_replace_all(s: string, from: string, to: string): string",
         "s.replaceAll(from, to). Wraps GL_STRING_REPLACE_ALL.",
         __RTS_FN_NS_ENGINE_STR_REPLACE_ALL as *const u8,
+    ))
+    .member(func(
+        "str_normalize",
+        "__RTS_FN_NS_ENGINE_STR_NORMALIZE",
+        sig!(Handle, Handle => Handle),
+        "str_normalize(s: string, form: string): string",
+        "s.normalize(form). Wraps GL_STRING_NORMALIZE.",
+        __RTS_FN_NS_ENGINE_STR_NORMALIZE as *const u8,
     ))
 }


### PR DESCRIPTION
`s.normalize(form?)` linkado ao impl Unicode real do runtime (`unicode_normalization`). Padrão dos demais bridges String. Destrava 194_string_normalize + outras.

733/733 unit verdes. (Nota: engine_str_member match é a tabela canônica dos bridges str_*, não duplicação — derivar de SPECS é follow-up amplo separado.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)