### PR TITLE
async/await síncrono no motor novo (desativa SM antigo) — suíte 333→343

### DIFF
--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -47,6 +47,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             } => self.lower_method_call(module, object, method, args),
             HirExprKind::Member { object, prop } => self.lower_member(module, object, prop),
             HirExprKind::Index { object, index } => self.lower_index(module, object, index),
+            // `await <expr>` — SYNCHRONOUS model (the new engine has no event loop /
+            // parallel async yet; the real-suspension state-machine is disabled, to be
+            // redesigned cleanly). An `async` fn body runs synchronously and returns
+            // its value directly (not a Promise wrapper), so `await x` is the value of
+            // `x`: await on a non-thenable yields the value, and a resolved-sync result
+            // needs no suspension. Real pending Promises (timers/IO) are a follow-up.
+            HirExprKind::Await(inner) => self.lower_expr(module, inner),
             HirExprKind::New { class, args } => {
                 // `new Array(n)` is the built-in Array constructor (not a user
                 // class) → a sized array value (P5.2).

--- a/crates/rts-codegen-new/src/front/run/tests/closure.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/closure.rs
@@ -143,3 +143,17 @@ fn top_level_runtime_const_read_in_function() {
         "8\n",
     );
 }
+
+#[test]
+fn async_await_synchronous_model() {
+    // SYNCHRONOUS async (no event loop / parallel yet — the suspension SM is
+    // disabled, to be redesigned). An `async` fn runs its body synchronously and
+    // returns the value; `await x` is the value of `x`. Covers the common
+    // resolved/sequential case.
+    assert_stdout(
+        "async function add(a: number, b: number): Promise<number> { return a + b; } \
+         async function run(): Promise<number> { const x = await add(2, 3); return await add(x, 10); } \
+         async function main(): Promise<void> { console.log(await run()); } main();",
+        "15\n",
+    );
+}

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -157,6 +157,13 @@ pub fn try_build_async_gen(name: &str, function: &Function) -> Option<(FnDecl, F
 /// devolve `(constructor, state_fn)`; em qualquer construct inelegivel devolve
 /// `None` (caller cai no caminho thread-blocking de `expand_async_functions`).
 pub fn try_build_async(name: &str, function: &Function) -> Option<(FnDecl, FnDecl)> {
+    // (motor novo) A state-machine async emite `__RTS_ASYNC_SM_SUSPEND`, que o motor
+    // novo NAO instala (a SM e' acoplada ao modelo de valor antigo). Desabilitada
+    // aqui: toda async fn cai no caminho `expand_async_functions` (promise.create/
+    // wait, `ns::promise` registrado). Async paralelo/suspensao real fica p/ um
+    // redesign limpo (latitude @drysius — desativar paralelo agora, refazer depois).
+    return None;
+    #[allow(unreachable_code)]
     let body = function.body.as_ref()?;
     SM_SPAN.with(|c| c.set(body.span));
 


### PR DESCRIPTION
## async/await redesenhado limpo pro motor novo

`async`/`await` bailava (`unknown function __RTS_ASYNC_SM_SUSPEND` / `expression await`): o motor novo não instala a state-machine async antiga (acoplada ao modelo i64 + precisa de event loop). **Latitude @drysius**: refazer async limpo, desativando o paralelo agora (recriado depois com o motor correto).

## Modelo SÍNCRONO (sem Promise-wrapper, sem event loop, sem threads)
- `generator_sm.rs::try_build_async` → `None`: desativa a SM async; o corpo da async fn roda **síncrono** (não emite SUSPEND).
- `expr.rs`: `Await(inner)` lowera como **identidade** — `await x` é o valor de `x` (await de não-thenable rende o valor; resolvido-síncrono não precisa de suspensão).

Cobre o caso comum (resolvido/sequencial). Repro = Bun: chain de awaits → 15.

## Validação
- **6/8 fixtures async básicas** OK (async_function/await_basic/async_multi_arg/async_try_catch_no_throw/...); as 2 que falham são edge (await em loop / promise real).
- suíte `measure_new`: **333 → 343** (+10).
- `cargo test -p rts-codegen-new`: **734 → 735**; gate sem HARD; zero regressão.

## Disabled (follow-up — redesign limpo)
Suspensão real / event loop / `Promise.all` / `.then` chains / `setTimeout`-driven async / async paralelo. A serem reconstruídos sobre o motor novo (PolyValue), conforme combinado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)