### PR TITLE
feat(codegen-new): Array.splice(start, deleteCount?, ...items)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method_array.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array.rs
@@ -147,6 +147,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return self.array_concat_variadic(module, object, args);
         }
 
+        // `splice(start, deleteCount?, ...items)` (MUTATING, variadic): pack the
+        // args into an array word `[start, deleteCount?, ...items]` and delegate to
+        // `__rtsadp_arr_splice` (→ runtime VEC_SPLICE_AUTO). Returns the removed
+        // elements as a NEW array. Any arity (1+) routes here.
+        if method == "splice" && argc >= 1 {
+            return self.array_splice(module, object, args);
+        }
+
         let Some(spec) = resolve_method(RecvClass::Array, method, argc) else {
             return Err(crate::front::error::Unsupported::new(format!(
                 "no Registry entry for `Array.{method}({argc} args)` \
@@ -248,6 +256,43 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
         // The final accumulator is a TAG_OBJECT array word.
         Ok(Val::tagged_kind(acc_word, super::lower::JsKind::Array))
+    }
+
+    /// `arr.splice(start, deleteCount?, ...items)` (MUTATING). Build an args array
+    /// `[start, deleteCount?, ...items]` (each boxed to a PolyValue word), then call
+    /// `__rtsadp_arr_splice(receiver_handle, args_array)`. Returns the removed
+    /// elements as a NEW array.
+    fn array_splice(
+        &mut self,
+        module: &mut dyn Module,
+        object: &HirExpr,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        // Build the args array. The runtime `VEC_SPLICE_AUTO` reads each slot as a
+        // raw `i64`: slots 0/1 (start, deleteCount) are INDICES → coerce to Int64
+        // (the raw integer, not a boxed PolyValue, or the index would be garbage);
+        // slots 2+ (items) are ELEMENTS → boxed PolyValue words (the array element
+        // convention).
+        let args_arr = emit_marshal::emit_new_vec_object(module, self.builder);
+        for (i, a) in args.iter().enumerate() {
+            let v = self.lower_expr(module, a)?;
+            let w = if i < 2 {
+                self.coerce(v, Repr::Int64)?
+            } else {
+                self.box_value(v)
+            };
+            emit_marshal::emit_vec_push(module, self.builder, args_arr, w);
+        }
+        // Receiver → its real Vec handle. The args array (a TAG_OBJECT word) is also
+        // table-loaded to its real Vec handle (the trampoline takes two handles).
+        let args_handle = emit_marshal::emit_table_load(module, self.builder, args_arr);
+        let recv = self.lower_expr(module, object)?;
+        let recv_word = self.box_value(recv);
+        let handle = emit_marshal::emit_table_load(module, self.builder, recv_word);
+        let removed = self
+            .call_runtime(module, "__rtsadp_arr_splice", &[handle, args_handle])?
+            .expect("__rtsadp_arr_splice returns an array word");
+        Ok(Val::tagged_kind(removed, super::lower::JsKind::Array))
     }
 
     /// Lower an Array CALLBACK method (`map`/`filter`/`forEach`/`find`/`findIndex`/

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -275,6 +275,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             arrayops::__rtsadp_arr_concat as *const u8,
         ),
         sym(
+            "__rtsadp_arr_splice",
+            arrayops::__rtsadp_arr_splice as *const u8,
+        ),
+        sym(
             "__rtsadp_arr_flat",
             arrayops::__rtsadp_arr_flat as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -481,7 +481,7 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, I64, U64],
             ret: U64,
         },
-        "__rtsadp_arr_fill" | "__rtsadp_arr_concat" => SymSig {
+        "__rtsadp_arr_fill" | "__rtsadp_arr_concat" | "__rtsadp_arr_splice" => SymSig {
             params: &[U64, U64],
             ret: U64,
         },

--- a/crates/rts-codegen-new/src/value/arrayops.rs
+++ b/crates/rts-codegen-new/src/value/arrayops.rs
@@ -500,6 +500,20 @@ pub extern "C" fn __rtsadp_arr_to_spliced(vec_handle: u64, start: i64, delete_co
     PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(new_vec)).raw()
 }
 
+/// `arr.splice(start, deleteCount?, ...items)` (MUTATING) — remove `deleteCount`
+/// elements at `start` and insert `items`, returning a NEW array of the removed
+/// elements. `args_word` is a TAG_OBJECT array word holding `[start, deleteCount?,
+/// ...items]` (the lowering packs the variadic args). Delegates to the runtime
+/// `VEC_SPLICE_AUTO` (both the receiver and the args ride real Vec handles; the
+/// element words are raw `i64` PolyValue words on both sides).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_splice(vec_handle: u64, args_handle: u64) -> u64 {
+    // Both `vec_handle` and `args_handle` are REAL Vec handles (the lowering
+    // table-loads the receiver and the packed args array before the call).
+    let removed = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SPLICE_AUTO(vec_handle, args_handle);
+    PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(removed)).raw()
+}
+
 /// `arr.copyWithin(target, start, end)` — copy the slice `[start, end)` to `target`,
 /// IN PLACE, returning the receiver word (JS clamps all three; the copy is shift-
 /// safe via a snapshot of the source range). Arity-2 (`copyWithin(target, start)`)


### PR DESCRIPTION
splice variádico (mutante) via novo trampolim que delega ao VEC_SPLICE_AUTO. Índices crus (start/count) + items boxeados. Remove/insert/replace corretos. Destrava 150/151.

734/734 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)