### PR TITLE
feat(codegen-new): Array.toSpliced variádico (insert form)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method_array.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array.rs
@@ -152,7 +152,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // `__rtsadp_arr_splice` (→ runtime VEC_SPLICE_AUTO). Returns the removed
         // elements as a NEW array. Any arity (1+) routes here.
         if method == "splice" && argc >= 1 {
-            return self.array_splice(module, object, args);
+            return self.array_splice(module, object, args, "__rtsadp_arr_splice");
+        }
+        // `toSpliced(start, deleteCount?, ...items)` (NON-mutating): same packed-args
+        // path as splice, different trampoline. The 2-arg no-items form keeps its own
+        // dedicated row below; the variadic (items) form routes here.
+        if method == "toSpliced" && argc > 2 {
+            return self.array_splice(module, object, args, "__rtsadp_arr_to_spliced_var");
         }
 
         let Some(spec) = resolve_method(RecvClass::Array, method, argc) else {
@@ -267,6 +273,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         module: &mut dyn Module,
         object: &HirExpr,
         args: &[HirExpr],
+        trampoline: &str,
     ) -> FrontResult<Val> {
         // Build the args array. The runtime `VEC_SPLICE_AUTO` reads each slot as a
         // raw `i64`: slots 0/1 (start, deleteCount) are INDICES → coerce to Int64
@@ -290,8 +297,8 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let recv_word = self.box_value(recv);
         let handle = emit_marshal::emit_table_load(module, self.builder, recv_word);
         let removed = self
-            .call_runtime(module, "__rtsadp_arr_splice", &[handle, args_handle])?
-            .expect("__rtsadp_arr_splice returns an array word");
+            .call_runtime(module, trampoline, &[handle, args_handle])?
+            .expect("array splice trampoline returns an array word");
         Ok(Val::tagged_kind(removed, super::lower::JsKind::Array))
     }
 

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -279,6 +279,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             arrayops::__rtsadp_arr_splice as *const u8,
         ),
         sym(
+            "__rtsadp_arr_to_spliced_var",
+            arrayops::__rtsadp_arr_to_spliced_var as *const u8,
+        ),
+        sym(
             "__rtsadp_arr_flat",
             arrayops::__rtsadp_arr_flat as *const u8,
         ),

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -481,7 +481,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, I64, U64],
             ret: U64,
         },
-        "__rtsadp_arr_fill" | "__rtsadp_arr_concat" | "__rtsadp_arr_splice" => SymSig {
+        "__rtsadp_arr_fill"
+        | "__rtsadp_arr_concat"
+        | "__rtsadp_arr_splice"
+        | "__rtsadp_arr_to_spliced_var" => SymSig {
             params: &[U64, U64],
             ret: U64,
         },

--- a/crates/rts-codegen-new/src/value/arrayops.rs
+++ b/crates/rts-codegen-new/src/value/arrayops.rs
@@ -514,6 +514,16 @@ pub extern "C" fn __rtsadp_arr_splice(vec_handle: u64, args_handle: u64) -> u64 
     PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(removed)).raw()
 }
 
+/// `arr.toSpliced(start, deleteCount?, ...items)` (ES2023, NON-mutating, variadic)
+/// — like `splice` but returns a NEW array with the splice applied and leaves the
+/// receiver unchanged. Same packed-args convention; delegates to the runtime
+/// `VEC_TO_SPLICED_AUTO`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_arr_to_spliced_var(vec_handle: u64, args_handle: u64) -> u64 {
+    let result = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_TO_SPLICED_AUTO(vec_handle, args_handle);
+    PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(result)).raw()
+}
+
 /// `arr.copyWithin(target, start, end)` — copy the slice `[start, end)` to `target`,
 /// IN PLACE, returning the receiver word (JS clamps all three; the copy is shift-
 /// safe via a snapshot of the source range). Arity-2 (`copyWithin(target, start)`)


### PR DESCRIPTION
toSpliced com items via novo trampolim (delega VEC_TO_SPLICED_AUTO). Reusa empacotamento do splice. Não-mutante. 734/734 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)