### PR TITLE
Callback-from-runtime bridge + AbiType::PolyValue (EventEmitter) — suíte 343→346

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -493,6 +493,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 // already) — keep as-is, repr Bool.
                 Ok(Val::new(v, Repr::Bool))
             }
+            // A raw PolyValue word returned verbatim → keep it Tagged.
+            AbiType::PolyValue => {
+                Ok(Val::new(value.expect("PolyValue-returning symbol yields a value"), Repr::Tagged))
+            }
             AbiType::Void => {
                 let v = self
                     .builder

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -109,6 +109,10 @@ pub(super) static REGISTER: &[Register] = &[
     // syntax): `new TextEncoder().encode(s)` → Uint8Array handle, `decode(h)` → str.
     Register { label: "TextEncoder class", run: ns::globals::text_encoding::register_text_encoder_class_spec, why: "TextEncoder ctor + encode" },
     Register { label: "TextDecoder class", run: ns::globals::text_encoding::register_text_decoder_class_spec, why: "TextDecoder ctor + decode" },
+    // `EventEmitter` — backend/Registry class: `new EventEmitter([async])` + on/once/
+    // off/emit. The listener arg is a function-VALUE the backend invokes via the
+    // codegen `__rtsadp_fn_invoke` callback bridge (JIT-installed).
+    Register { label: "EventEmitter class", run: ns::globals::events::register_class_spec, why: "EventEmitter ctor + on/emit" },
 ];
 
 /// One `.ts` prelude include, in DEPENDENCY ORDER (base before dependent).

--- a/crates/rts-codegen-new/src/front/run/registry_call.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_call.rs
@@ -105,6 +105,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 // of an arbitrary value at a typed boundary is a later increment).
                 out.push(self.coerce(val, Repr::Bool)?);
             }
+            AbiType::PolyValue => {
+                // Raw NaN-boxed word, verbatim — a function-VALUE listener / any
+                // value the backend stores + invokes via the callback bridge keeps
+                // its tag (no coerce, no table-load).
+                out.push(self.box_value(val));
+            }
             AbiType::Void => return unsupported!("Void is not a valid argument type"),
         }
         Ok(())
@@ -161,6 +167,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 Val::new(v, Repr::Int64)
             }
             AbiType::Bool => Val::new(res.expect("bool return"), Repr::Bool),
+            AbiType::PolyValue => {
+                // The runtime returned a raw PolyValue word verbatim — keep it Tagged.
+                Val::new(res.expect("PolyValue return"), Repr::Tagged)
+            }
             AbiType::StrPtr => {
                 // No runtime symbol RETURNS a StrPtr (it is not `is_returnable`);
                 // a string result always comes back as a `Handle`.

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -299,6 +299,8 @@ fn abi_accepts_kind(abi: AbiType, kind: JsKind) -> bool {
         AbiType::Handle => matches!(kind, JsKind::Str | JsKind::Object),
         AbiType::F64 | AbiType::I64 | AbiType::U64 | AbiType::I32 => matches!(kind, JsKind::Number),
         AbiType::Bool => matches!(kind, JsKind::Bool),
+        // A raw PolyValue param carries any value verbatim — accepts any kind.
+        AbiType::PolyValue => true,
         AbiType::Void => false,
     }
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -469,6 +469,15 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
             rts_runtime::namespaces::globals::text_encoding::instance::__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE
                 as *const u8,
         ),
+        // EventEmitter class ctor + on/once/off/emit (the listener is a function
+        // VALUE the backend invokes via the `__rtsadp_fn_invoke` callback bridge).
+        sym("__RTS_FN_GL_EE_NEW", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_NEW as *const u8),
+        sym("__RTS_FN_GL_EE_NEW_ASYNC", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_NEW_ASYNC as *const u8),
+        sym("__RTS_FN_GL_EE_ON", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_ON as *const u8),
+        sym("__RTS_FN_GL_EE_ONCE", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_ONCE as *const u8),
+        sym("__RTS_FN_GL_EE_OFF", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_OFF as *const u8),
+        sym("__RTS_FN_GL_EE_EMIT", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_EMIT as *const u8),
+        sym("__RTS_FN_GL_EE_FREE", rts_runtime::namespaces::globals::events::__RTS_FN_GL_EE_FREE as *const u8),
         // ---- codegen-owned FUNCTION-value trampolines (__rtsadp_fn_*, P4.6) ----
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym(

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -33,8 +33,10 @@ fn scalar_to_cl(ty: AbiType) -> types::Type {
     match ty {
         AbiType::F64 => types::F64,
         AbiType::I32 => types::I32,
-        // Bool/I64/U64/Handle all ride an i64 register at the boundary.
-        AbiType::Bool | AbiType::I64 | AbiType::U64 | AbiType::Handle => types::I64,
+        // Bool/I64/U64/Handle/PolyValue all ride an i64 register at the boundary.
+        AbiType::Bool | AbiType::I64 | AbiType::U64 | AbiType::Handle | AbiType::PolyValue => {
+            types::I64
+        }
         AbiType::StrPtr => unreachable!("StrPtr must be expanded before scalar_to_cl"),
         AbiType::Void => unreachable!("Void has no Cranelift slot"),
     }

--- a/crates/rts-engine/src/abi/types.rs
+++ b/crates/rts-engine/src/abi/types.rs
@@ -29,6 +29,12 @@ pub enum AbiType {
     StrPtr,
     /// Opaque runtime handle (`u64`) produced by the GC namespace.
     Handle,
+    /// A raw 64-bit PolyValue word (NaN-boxed) carried across the ABI UNCHANGED —
+    /// no coercion, no unbox. Distinct from `Handle` (table-loads to a slot) and
+    /// `U64` (coerces to an integer): a `PolyValue` arg is the boxed word as-is.
+    /// Lets a backend receive a function-VALUE listener / an arbitrary value (the
+    /// EventEmitter/Proxy callback bridge) without losing its tag.
+    PolyValue,
 }
 
 impl AbiType {

--- a/crates/rts-engine/src/heap/poly.rs
+++ b/crates/rts-engine/src/heap/poly.rs
@@ -80,6 +80,11 @@ pub const POLY_TAG_OBJECT: u64 = 4;
 /// `crates/rts-codegen-new/src/value/layout.rs`; do not change without changing
 /// both.
 pub const POLY_TAG_FUNCTION: u64 = 5;
+/// Singleton tag (undefined/null/bool/hole/empty select via payload).
+pub const POLY_TAG_SINGLETON: u64 = 2;
+/// The `undefined` singleton word (`TAG_SINGLETON`, payload 0) — used to pad
+/// unread callback-arg slots in the `__rtsadp_fn_invoke` bridge.
+pub const POLY_UNDEFINED: u64 = POLY_BOX_BASE | (POLY_TAG_SINGLETON << POLY_TAG_SHIFT);
 
 /// If `c` is a NaN-boxed heap-handle word (boxed discriminator set AND tag ∈
 /// {STR, OBJECT, FUNCTION}), reconstruct the full real runtime handle for its

--- a/crates/rts-std/src/gc_surface.rs
+++ b/crates/rts-std/src/gc_surface.rs
@@ -22,4 +22,18 @@ unsafe extern "C" {
     pub safe fn __RTS_FN_NS_GC_GEN_SM_DRAIN(h: u64) -> u64;
     /// Truthiness JS de um valor i64/handle (0 = falsy). (`gc::string_pool`)
     pub safe fn __RTS_FN_RT_TRUTHY(value: i64) -> i64;
+    /// (callback-from-runtime bridge) Invoca uma FUNCAO-VALOR JS (palavra PolyValue
+    /// TAG_FUNCTION) com 4 args PolyValue + rest, retornando uma palavra PolyValue.
+    /// Codegen-owned (`value::funcops`), instalado no JIT symbol table. Permite a um
+    /// backend (EventEmitter/Proxy/…) chamar de volta um callback armazenado, sem
+    /// transmutar a palavra como ponteiro de codigo (que crashava). JIT-only por ora
+    /// (o simbolo nao esta no archive AOT — async/paralelo real e' redesign limpo).
+    pub safe fn __rtsadp_fn_invoke(
+        fn_word: u64,
+        a0: u64,
+        a1: u64,
+        a2: u64,
+        a3: u64,
+        rest: u64,
+    ) -> u64;
 }

--- a/crates/rts-std/src/globals/events/mod.rs
+++ b/crates/rts-std/src/globals/events/mod.rs
@@ -145,6 +145,27 @@ pub extern "C" fn __RTS_FN_GL_EE_OFF(
 /// ACCESS_VIOLATION. Fn nomeada / arrow sem captura = raw ptr → fast path.
 #[inline]
 fn invoke_listener(fn_ptr: u64, arg_f64: f64) {
+    use rts_engine::heap::poly::{POLY_BOX_BASE, POLY_TAG_FUNCTION, POLY_TAG_SHIFT, POLY_UNDEFINED};
+    // (callback-from-runtime bridge) The new engine passes a listener as a
+    // PolyValue FUNCTION word (`(w & BOX_BASE)==BOX_BASE && tag==FUNCTION`), not a
+    // raw code ptr nor an `Entry::Function` handle. Invoke it through the codegen
+    // `__rtsadp_fn_invoke` thunk (JIT-installed) — boxing the numeric arg as an
+    // inline-double PolyValue. Transmuting the word as a `fn(f64)` here was the
+    // ACCESS_VIOLATION. Older raw-ptr / handle listeners keep the paths below.
+    let is_poly_fn = (fn_ptr & POLY_BOX_BASE) == POLY_BOX_BASE
+        && ((fn_ptr >> POLY_TAG_SHIFT) & 0x7) == POLY_TAG_FUNCTION;
+    if is_poly_fn {
+        let arg_word = arg_f64.to_bits();
+        crate::gc_surface::__rtsadp_fn_invoke(
+            fn_ptr,
+            arg_word,
+            POLY_UNDEFINED,
+            POLY_UNDEFINED,
+            POLY_UNDEFINED,
+            POLY_UNDEFINED,
+        );
+        return;
+    }
     let is_handle = rts_engine::heap::handles::with_entry(fn_ptr, |e| {
         matches!(e, Some(rts_engine::heap::handles::Entry::Function(_)))
     });
@@ -361,7 +382,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "on",
             MemberKind::InstanceMethod,
             Sig::new(
-                vec![AbiType::Handle, AbiType::StrPtr, AbiType::U64],
+                vec![AbiType::Handle, AbiType::StrPtr, AbiType::PolyValue],
                 AbiType::Handle,
             ),
             "__RTS_FN_GL_EE_ON",
@@ -374,7 +395,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "once",
             MemberKind::InstanceMethod,
             Sig::new(
-                vec![AbiType::Handle, AbiType::StrPtr, AbiType::U64],
+                vec![AbiType::Handle, AbiType::StrPtr, AbiType::PolyValue],
                 AbiType::Handle,
             ),
             "__RTS_FN_GL_EE_ONCE",
@@ -387,7 +408,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "off",
             MemberKind::InstanceMethod,
             Sig::new(
-                vec![AbiType::Handle, AbiType::StrPtr, AbiType::U64],
+                vec![AbiType::Handle, AbiType::StrPtr, AbiType::PolyValue],
                 AbiType::Handle,
             ),
             "__RTS_FN_GL_EE_OFF",


### PR DESCRIPTION
## Ponte callback-from-runtime (foundation p/ Proxy/forEach/Promise.then)

Um backend que **guarda** um callback JS e o invoca depois crashava (ACCESS_VIOLATION): o listener é uma palavra PolyValue **TAG_FUNCTION** (modelo novo), não um raw fn-ptr nem `Entry::Function`; o `invoke_listener` transmutava a palavra como endereço de código. rts-shared/std **não pode** chamar `__rtsadp_fn_invoke` (codegen-owned). **Ponte JIT-first** (aval @drysius — AOT/paralelo real é redesign limpo).

## Mudança
- **`AbiType::PolyValue`** (re-adicionado, rts-engine): palavra crua, sem coerce/unbox — distinta de `Handle` (table-load→slot) e `U64` (coage int). Passa a função-VALOR ao backend sem perder o tag. + arms nos 4 matches.
- `poly.rs`: `POLY_TAG_SINGLETON` + `POLY_UNDEFINED`.
- `rts-std/gc_surface.rs`: declara `__rtsadp_fn_invoke` (JIT-provided, igual ASYNC_SM_RESUME). `events`: `invoke_listener` detecta TAG_FUNCTION + invoca via a ponte; on/once/off passam o listener como `PolyValue`.
- codegen: EventEmitter Register row + símbolos `__RTS_FN_GL_EE_*` no JIT.

## Validação
- Repro: `ee.on("x", onX); ee.emit("x", 7)` → `onX` dispara (`got 7`); fixture eventemitter_global **OK** (era SIGILL).
- suíte `measure_new`: **343 → 346** (+3).
- `cargo test -p rts-codegen-new`: **735/735**; gate sem HARD.

## Notas
- Listener **arrow** (`.on(ev, (v)=>…)`) ainda bail "expression arrow" (arrow-como-arg-de-método-Registry não lifted — issue separada); named-fn funciona.
- **JIT-only** (a ponte não está no archive AOT — async/paralelo real reconstruídos limpos depois). Foundation p/ Proxy traps / Map.forEach / Promise.then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)