### PR TITLE
feat(codegen-new): Object.fromEntries(array)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -71,6 +71,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             "freeze" | "seal" | "preventExtensions" => self.object_freeze(module, args).map(Some),
             "is" => self.object_is(module, args).map(Some),
             "hasOwn" => self.object_has_own(module, args).map(Some),
+            "fromEntries" => self.object_from_entries(module, args).map(Some),
             other => unsupported!("Object.{other}(...) static method (later increment)"),
         }
     }
@@ -256,6 +257,34 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
     /// `Object.is(a, b)` — JS SameValue (`===` but NaN is NaN, +0 is not -0). Box
     /// both args and call the `__rtsadp_same_value` trampoline; result is a Bool.
+    /// `Object.fromEntries(entries)` — build an object from an array of `[k, v]`
+    /// pairs via `__rtsadp_obj_from_entries`. Requires a PROVEN-array source (a Map
+    /// source needs iteration — a later increment — so it BAILS honestly rather than
+    /// building an empty/wrong object).
+    fn object_from_entries(
+        &mut self,
+        module: &mut dyn Module,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        if args.len() != 1 {
+            return unsupported!("Object.fromEntries expects 1 arg, got {}", args.len());
+        }
+        // A proven array source: an array-valued expr OR an `Object.entries(...)`
+        // call (whose result is always a freshly-built array of pairs — the common
+        // round-trip `fromEntries(entries(o))`).
+        if !self.is_array_valued(&args[0]) && !self.is_object_static_array_expr(&args[0]) {
+            return unsupported!(
+                "Object.fromEntries with a non-array source (Map/iterator is a later increment)"
+            );
+        }
+        let v = self.lower_expr(module, &args[0])?;
+        let entries = self.box_value(v);
+        let res = self
+            .call_runtime(module, "__rtsadp_obj_from_entries", &[entries])?
+            .expect("__rtsadp_obj_from_entries returns an object word");
+        Ok(Val::tagged_kind(res, super::lower::JsKind::Object))
+    }
+
     /// `Object.hasOwn(obj, key)` — own-property membership (ES2022). Same runtime
     /// path as the `in` operator / `engine.obj_has`: box obj + key and call
     /// `__rtsadp_obj_has`, returning a Bool.

--- a/crates/rts-codegen-new/src/front/run/tests/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/objstatic.rs
@@ -106,7 +106,19 @@ fn object_assign_adding_key_bails() {
 }
 
 #[test]
-fn object_from_entries_bails() {
-    // fromEntries is unimplemented — explicit bail.
-    assert_bails("let e = [[\"a\", 1]]; let o = Object.fromEntries(e); console.log(o.a);");
+fn object_from_entries_array_source() {
+    // fromEntries now builds an object from an array of [k, v] pairs (was a bail).
+    assert_stdout(
+        "let e = [[\"a\", 1], [\"b\", 2]]; let o = Object.fromEntries(e); console.log(o.a, o.b);",
+        "1 2\n",
+    );
+}
+
+#[test]
+fn object_from_entries_non_array_bails() {
+    // A non-array source (a Map/iterator) still needs iteration — explicit bail
+    // (honesty floor: no empty/wrong object). `m` is an `any` param of unknown shape.
+    assert_bails(
+        "function f(m: any): any { return Object.fromEntries(m); } console.log(f([[\"a\", 1]]));",
+    );
 }

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -617,6 +617,10 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
         sym("__rtsadp_obj_has", objops::__rtsadp_obj_has as *const u8),
         sym("__rtsadp_obj_values", objops::__rtsadp_obj_values as *const u8),
         sym("__rtsadp_obj_entries", objops::__rtsadp_obj_entries as *const u8),
+        sym(
+            "__rtsadp_obj_from_entries",
+            objops::__rtsadp_obj_from_entries as *const u8,
+        ),
         // NOTE: the wrapper ctors (`__rtsadp_w_{boolean,number,string}_new`) and the
         // Error-family trampolines are GONE — Boolean/Number/String/Error all
         // construct via their `.ts` prelude class (the user-class path). ToString for

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -763,7 +763,7 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         },
         // obj_keys/values/entries(obj_word) -> fresh array PolyValue word (dynamic
         // Object.keys/values/entries; Object is primordial → engine-direct).
-        "__rtsadp_obj_values" | "__rtsadp_obj_entries" => SymSig {
+        "__rtsadp_obj_values" | "__rtsadp_obj_entries" | "__rtsadp_obj_from_entries" => SymSig {
             params: &[U64],
             ret: U64,
         },

--- a/crates/rts-codegen-new/src/value/objops.rs
+++ b/crates/rts-codegen-new/src/value/objops.rs
@@ -121,6 +121,47 @@ pub extern "C" fn __rtsadp_obj_set(obj_word: u64, key_str_handle: u64, val_word:
     val_word
 }
 
+/// `Object.fromEntries(entries)` — build a keyed object from an array of `[k, v]`
+/// pairs. `entries_word` is an array word; each element is itself a 2-element array
+/// `[key, value]`. The object starts empty (the `{}` shape header) and each pair is
+/// applied via `__rtsadp_obj_set` (shape transition per new key; a repeated key
+/// overwrites). The key is ToString'd to a property key (numbers/bools coerce like
+/// JS). Returns the new object word. A non-array entry (or non-array source) is
+/// skipped defensively — the lowering only routes a proven-array source here.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_obj_from_entries(entries_word: u64) -> u64 {
+    // Empty keyed object (slot 0 = empty-shape id, like a `{}` literal).
+    let obj_handle = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
+    let empty_shape = crate::shape::intern_global_shape(&[]);
+    let slot0 = PolyValue::from_i32(empty_shape as i32).raw() as i64;
+    rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(obj_handle, slot0);
+    let obj_word =
+        PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(obj_handle)).raw();
+
+    let entries = PolyValue::from_raw(entries_word);
+    if entries.is_object() {
+        let eh = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(entries.as_handle());
+        let n = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(eh).max(0);
+        for i in 0..n {
+            let pair_word = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(eh, i) as u64;
+            let pair = PolyValue::from_raw(pair_word);
+            if !pair.is_object() {
+                continue;
+            }
+            let ph = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(pair.as_handle());
+            if rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(ph) < 2 {
+                continue;
+            }
+            let k_word = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(ph, 0) as u64;
+            let v_word = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(ph, 1) as u64;
+            // Key → a string PolyValue (obj_set's key channel); numbers/bools ToString.
+            let key_str = super::genops::__rtsadp_to_string(k_word);
+            __rtsadp_obj_set(obj_word, key_str, v_word);
+        }
+    }
+    obj_word
+}
+
 /// `__rtsadp_obj_has(obj_word, key_str_handle)` — `key in obj` for a keyed object:
 /// `1` when the object has the property, `0` otherwise (incl. a non-object
 /// receiver). Returns an unboxed i64 (the `Bool` ABI) for a direct `brif`/`select`.


### PR DESCRIPTION
fromEntries de array de [k,v] via novo trampolim. Round-trip com Object.entries funciona. Map source baila honesto. Teste de bail atualizado (regressão intencional). 736/736 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)