### PR TITLE
feat(codegen-new): ToNumber de boolean em aritmética/unários

### DIFF
--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -250,9 +250,19 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return self.lower_generic_arith(module, op, l, r);
         }
 
-        if matches!(l.repr, Repr::Bool) || matches!(r.repr, Repr::Bool) {
-            return unsupported!("arithmetic on a boolean operand");
-        }
+        // A boolean operand ToNumbers to 0/1 (JS: `true + 1 === 2`). Bool is already
+        // an i64 0/1 in our repr, so coercing to Int32 is a pure reinterpret — then
+        // the normal integer/float arithmetic below applies.
+        let l = if matches!(l.repr, Repr::Bool) {
+            Val::new(self.coerce(l, Repr::Int32)?, Repr::Int32)
+        } else {
+            l
+        };
+        let r = if matches!(r.repr, Repr::Bool) {
+            Val::new(self.coerce(r, Repr::Int32)?, Repr::Int32)
+        } else {
+            r
+        };
         let both_int = is_int_repr(l.repr) && is_int_repr(r.repr);
         match op {
             HirBinOp::Div => {

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -241,6 +241,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
         let val = self.lower_expr(module, operand)?;
         match op {
+            // A Bool operand ToNumbers to 0/1 first (`-true === -1`): coerce to Int32
+            // (a pure reinterpret — Bool is already i64 0/1), then `ineg`.
+            HirUnOp::Neg if matches!(val.repr, Repr::Bool) => {
+                let iv = self.coerce(val, Repr::Int32)?;
+                let v = self.builder.ins().ineg(iv);
+                Ok(Val::new(v, Repr::Int32))
+            }
             HirUnOp::Neg => match val.repr {
                 Repr::Float64 => {
                     let v = self.builder.ins().fneg(val.v);
@@ -262,6 +269,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             },
             // `~` (ToInt32 then bitwise NOT). Native for proven ints; generic for
             // Tagged. swc maps `~` to `BitNot` UNAMBIGUOUSLY, so this is sound.
+            // `~` is ToInt32-then-bitwise-NOT: a Bool (0/1) or Float64 operand first
+            // coerces to Int32 (`~true === -2`, `~1.5 === -2` via truncation), then
+            // `bnot`.
+            HirUnOp::BitNot if matches!(val.repr, Repr::Bool | Repr::Float64) => {
+                let iv = self.coerce(val, Repr::Int32)?;
+                let v = self.builder.ins().bnot(iv);
+                Ok(Val::new(v, Repr::Int32))
+            }
             HirUnOp::BitNot => match val.repr {
                 Repr::Int32 | Repr::Int64 => {
                     let v = self.builder.ins().bnot(val.v);

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -507,6 +507,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
             // int relabel (same register)
             (Repr::Int32, Repr::Int64) | (Repr::Int64, Repr::Int32) => Ok(val.v),
+            // Bool ToNumber: a Bool is already an i64 0/1, so → Int is a pure relabel
+            // (same register) and → Float64 is a signed-int convert. (`true + 1`,
+            // `-true`, `~true`, `true * 2.0`.)
+            (Repr::Bool, Repr::Int32) | (Repr::Bool, Repr::Int64) => Ok(val.v),
+            (Repr::Bool, Repr::Float64) => {
+                Ok(self.builder.ins().fcvt_from_sint(types::F64, val.v))
+            }
             // native double → native int: truncate toward zero (JS `ToInteger` /
             // array-index / `i64`-typed binding from a `number` expression). Uses the
             // saturating conversion so an out-of-range / NaN double yields a defined


### PR DESCRIPTION
true+1, -true, ~true, ~1.5 etc. Bool ToNumbers a 0/1. coerce + lower_arith + lower_unary. Todos JS-corretos. 736/736 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)