### PR TITLE
feat(codegen-new): void operator + static overloads por aridade

### DIFF
--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -331,6 +331,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             HirUnOp::Delete => unsupported!(
                 "`delete` (slot removal needs the transition tree — a later increment)"
             ),
+            // `void x` — `x` is already lowered above (its side effects ran); the
+            // expression always evaluates to `undefined`.
+            HirUnOp::Void => {
+                let v = self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
+                Ok(Val::tagged_kind(v, JsKind::Undefined))
+            }
             other => unsupported!("unary operator {other:?}"),
         }
     }

--- a/crates/rts-codegen-new/src/front/run/registry.rs
+++ b/crates/rts-codegen-new/src/front/run/registry.rs
@@ -200,6 +200,25 @@ pub fn class_static_any(class: &str, method: &str) -> Option<ResolvedCall> {
     Some(flat_call(m))
 }
 
+/// EVERY static/function overload of `method` on `class`, in declaration order —
+/// lets the static-call lowering pick the overload whose arity window admits the
+/// caller's argc (e.g. `URL.canParse(href)` vs `URL.canParse(href, base)`, two
+/// same-named statics of arity 1 and 2). `class_static_any` returns only the FIRST
+/// match, which wrongly rejects the higher-arity overloads.
+pub fn class_statics(class: &str, method: &str) -> Vec<ResolvedCall> {
+    let Some(c) = registry().class(class) else {
+        return Vec::new();
+    };
+    c.members
+        .iter()
+        .filter(|m| {
+            matches!(m.kind, MemberKind::StaticMethod | MemberKind::Function)
+                && m.matches_name(method)
+        })
+        .map(|m| flat_call(m))
+        .collect()
+}
+
 /// Every constructor's argument-`AbiType` slice for `class`, in declaration
 /// order — lets the ctor lowering pick the overload by arg TYPE (Date's 1-arg
 /// ms-vs-ISO split: a `[I64]` ctor vs a `[StrPtr]` ctor of the same arity).

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -228,21 +228,25 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(None);
         }
         use super::registry;
-        let Some(call) = registry::class_static_any(name, method) else {
-            return unsupported!("`{name}.{method}()` — no such static on `{name}`");
-        };
-        // [required, total] arity window: `total` = declared params, `required` =
-        // leading non-default params (empty `default_args` = all required). An
-        // argc outside the window BAILS — this reproduces `Date.UTC`'s "< 2 args"
-        // refusal and any wrong-arity static, as DATA from the spec.
-        let total = call.arg_abis.len();
-        let required = required_args(&call.default_args, total);
         let argc = args.len();
-        if argc < required || argc > total {
-            return unsupported!(
-                "`{name}.{method}({argc} args)` — expects {required}..={total} arg(s)"
-            );
+        // ALL overloads of `name.method`, then pick the one whose [required, total]
+        // arity window admits `argc` (e.g. `URL.canParse(href)` vs `(href, base)`).
+        // `class_static_any` returned only the FIRST, wrongly rejecting a 2-arg call
+        // to a name whose 1-arg overload was declared first.
+        let overloads = registry::class_statics(name, method);
+        if overloads.is_empty() {
+            return unsupported!("`{name}.{method}()` — no such static on `{name}`");
         }
+        let Some(call) = overloads.into_iter().find(|c| {
+            let total = c.arg_abis.len();
+            let required = required_args(&c.default_args, total);
+            argc >= required && argc <= total
+        }) else {
+            return unsupported!(
+                "`{name}.{method}({argc} args)` — no overload accepts {argc} arg(s)"
+            );
+        };
+        let total = call.arg_abis.len();
         // Lower the provided args. A `StrPtr` param fed a non-proven-string BAILS
         // (the generic marshal would ToString-coerce instead — a behavior change
         // we refuse; preserves the old `Date.parse(non-string)` bail).

--- a/crates/rts-codegen-new/src/front/run/tests/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/mod.rs
@@ -101,3 +101,4 @@ mod toprimitive;
 mod trycatch;
 mod type_erasure;
 mod update_tagged;
+mod void_op;

--- a/crates/rts-codegen-new/src/front/run/tests/void_op.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/void_op.rs
@@ -1,0 +1,23 @@
+//! `void x` — evaluates the operand (side effects run) and yields `undefined`.
+
+use super::assert_stdout;
+
+#[test]
+fn void_yields_undefined() {
+    assert_stdout("console.log(void 0);", "undefined\n");
+    assert_stdout("console.log(void \"x\");", "undefined\n");
+}
+
+#[test]
+fn typeof_void_is_undefined() {
+    assert_stdout("console.log(typeof void 0);", "undefined\n");
+}
+
+#[test]
+fn void_evaluates_operand_side_effect() {
+    // The operand still runs (its side effect is observed); the value is dropped.
+    assert_stdout(
+        "let n = 0; function bump(): number { n = n + 1; return 9; } void bump(); console.log(n);",
+        "1\n",
+    );
+}

--- a/crates/rts-codegen-new/src/registry_link.rs
+++ b/crates/rts-codegen-new/src/registry_link.rs
@@ -241,5 +241,7 @@ pub fn url_symbols() -> Vec<JitSymbol> {
         s!("__RTS_FN_GL_URL_PASSWORD", rt_gl_url::__RTS_FN_GL_URL_PASSWORD),
         s!("__RTS_FN_GL_URL_TO_STRING", rt_gl_url::__RTS_FN_GL_URL_TO_STRING),
         s!("__RTS_FN_GL_URL_FREE", rt_gl_url::__RTS_FN_GL_URL_FREE),
+        s!("__RTS_FN_GL_URL_CAN_PARSE", rt_gl_url::__RTS_FN_GL_URL_CAN_PARSE),
+        s!("__RTS_FN_GL_URL_CAN_PARSE_BASE", rt_gl_url::__RTS_FN_GL_URL_CAN_PARSE_BASE),
     ]
 }


### PR DESCRIPTION
Lote de 3: (1) operador void→undefined; (2) static overloads por aridade genérico (class_statics); (3) URL.canParse símbolos JIT. URL.canParse(2 args) funciona. 749/749 unit verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)