### PR TITLE
feat(codegen-new): #195 captura de local mutável via cell por-invocação

### DIFF
--- a/crates/rts-codegen-new/src/front/run/assign.rs
+++ b/crates/rts-codegen-new/src/front/run/assign.rs
@@ -83,6 +83,24 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             self.emit_gcell_set(module, id, word)?;
             return Ok(Val::new(word, Repr::Tagged));
         }
+        // FUNCTION-LOCAL CELL (#195): `x <op>= e` through the cell — read live,
+        // apply the arithmetic generically (Tagged), store back.
+        if self.is_cell_local(&name) {
+            let handle = {
+                let local = self.local(&name).expect("cell-local is a bound local");
+                self.builder.use_var(local.var)
+            };
+            let cur = self.emit_cell_get(module, handle);
+            let rhs = self.lower_expr(module, value)?;
+            let result = if op.is_arithmetic() || matches!(op, HirBinOp::Exp) {
+                self.lower_arith(module, op, cur, rhs)?
+            } else {
+                return unsupported!("compound-assign operator {op:?} on a local cell");
+            };
+            let word = self.box_value(result);
+            self.emit_cell_set(module, handle, word);
+            return Ok(Val::new(word, Repr::Tagged));
+        }
         let local = self
             .local(&name)
             .ok_or_else(|| Unsupported::new(format!("compound-assign to unbound `{name}`")))?;
@@ -111,6 +129,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         name: &str,
         value: &HirExpr,
     ) -> FrontResult<Val> {
+        // A FUNCTION-LOCAL CELL (#195) holds its value behind a handle, so the
+        // def_var-based conditional store below would clobber the handle. Bail
+        // honestly — logical-assign on a captured-mutated local is a later increment.
+        if self.is_cell_local(name) {
+            return unsupported!("logical-assign on a captured-mutated local `{name}`");
+        }
         let local = self
             .local(name)
             .ok_or_else(|| Unsupported::new(format!("logical-assign to unbound `{name}`")))?;

--- a/crates/rts-codegen-new/src/front/run/cell.rs
+++ b/crates/rts-codegen-new/src/front/run/cell.rs
@@ -1,0 +1,61 @@
+//! Function-local mutable CELLS (epic #195) — a function-scope `let` that a
+//! closure CAPTURES and MUTATES.
+//!
+//! Unlike a module-level gcell (a compile-time id in a process-global store), a
+//! function-local cell is a PER-INVOCATION runtime box: a 1-slot `Vec` allocated
+//! at the local's declaration. The local VAR holds the cell HANDLE (a `TAG_OBJECT`
+//! PolyValue word); the closure captures that HANDLE **by value** (the handle is
+//! stable) through the ordinary env mechanism ([`super::call::build_closure_env`]
+//! reads `use_var` → the raw handle, never the dereferenced value), so the
+//! declaring function and the closure share ONE mutable box.
+//!
+//! Every READ of the name → `VEC_GET(handle, 0)`; every WRITE → `VEC_SET(handle,
+//! 0, word)`. The cell (a `Vec` GC entry) stays reachable via the captured handle
+//! even after the declaring function returns (a returned counter closure
+//! `function mk(){ let c=0; return () => ++c; }`), so the value survives.
+//!
+//! Only locals PROVEN captured-and-mutated become cells (see
+//! [`super::funcval`] `try_extract`): a non-captured mutable local stays a plain
+//! Cranelift Variable (the fast path), and a read-only capture stays by-value.
+
+use cranelift_codegen::ir::{InstBuilder, Value, types};
+use cranelift_module::Module;
+
+use crate::repr::Repr;
+use crate::value::emit_marshal;
+
+use super::lower::{Lowerer, Val};
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// True when `name` is a function-local cell in the CURRENT function: its local
+    /// Variable holds the cell HANDLE, not the value directly, so a read/write must
+    /// route through [`Self::emit_cell_get`]/[`Self::emit_cell_set`].
+    pub(super) fn is_cell_local(&self, name: &str) -> bool {
+        self.cell_locals.contains(name)
+    }
+
+    /// Allocate a fresh 1-slot cell holding `init_word` and return its boxed HANDLE
+    /// word (a `TAG_OBJECT` PolyValue). Used at a cell-local's `let` declaration —
+    /// the handle is then bound to the local's Variable (a `Tagged` register).
+    pub(super) fn emit_cell_alloc(&mut self, module: &mut dyn Module, init_word: Value) -> Value {
+        let handle = emit_marshal::emit_new_vec_object(module, self.builder);
+        emit_marshal::emit_vec_push(module, self.builder, handle, init_word);
+        handle
+    }
+
+    /// Load the cell behind `handle_word` (slot 0) → a `Tagged` PolyValue word (the
+    /// stored value, kind unknown — same shape as a gcell read).
+    pub(super) fn emit_cell_get(&mut self, module: &mut dyn Module, handle_word: Value) -> Val {
+        let idx = self.builder.ins().iconst(types::I64, 0);
+        let w = emit_marshal::emit_vec_get(module, self.builder, handle_word, idx);
+        Val::new(w, Repr::Tagged)
+    }
+
+    /// Store `word` (an already-boxed PolyValue) into the cell behind `handle_word`
+    /// (slot 0). The cell was allocated with one slot at declaration, so index 0
+    /// always exists.
+    pub(super) fn emit_cell_set(&mut self, module: &mut dyn Module, handle_word: Value, word: Value) {
+        let idx = self.builder.ins().iconst(types::I64, 0);
+        emit_marshal::emit_vec_set(module, self.builder, handle_word, idx, word);
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -154,6 +154,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
     fn lower_ident(&mut self, module: &mut dyn Module, name: &str) -> FrontResult<Val> {
         if let Some(local) = self.local(name) {
+            // FUNCTION-LOCAL CELL (#195): the local Variable holds the cell HANDLE,
+            // not the value. Read the LIVE value through the cell (a closure may have
+            // mutated it). Checked FIRST — a raw `use_var` would yield the handle.
+            if self.is_cell_local(name) {
+                let handle = self.builder.use_var(local.var);
+                return Ok(self.emit_cell_get(module, handle));
+            }
             let v = self.builder.use_var(local.var);
             // A Tagged local recorded as a PROVEN STRING (`let s = "x"`, a param
             // typed `string`) carries `JsKind::Str`, so `s.method(...)` dispatches

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -244,6 +244,12 @@ const GLOBALS: &[&str] = &[
 pub struct ExtractResult {
     pub funcs: Vec<HirFunc>,
     pub captures: HashMap<String, Vec<String>>,
+    /// FUNCTION-LOCAL CELLS (#195): function name → the set of its LOCAL names that
+    /// became per-invocation cells (a closure in that function captures AND mutates
+    /// them). Keyed by BOTH the declaring function (where the `let` allocates the
+    /// cell) AND the synthesized closure (where the captured leading param holds the
+    /// handle), so each side routes reads/writes through the cell. See [`super::cell`].
+    pub cells: HashMap<String, HashSet<String>>,
 }
 
 /// Extract every inline arrow used as a value from `funcs` + `main` into fresh
@@ -272,6 +278,9 @@ pub fn extract_arrows(
         module_globals: module_globals.clone(),
         synthesized: Vec::new(),
         captures: HashMap::new(),
+        cells: HashMap::new(),
+        current_fn: String::new(),
+        current_fn_lets: HashSet::new(),
         counter: 0,
     };
 
@@ -281,10 +290,14 @@ pub fn extract_arrows(
     for f in funcs.iter_mut() {
         let params: HashSet<String> = f.params.iter().map(|p| p.name.clone()).collect();
         let mutated = mutated_names(&f.body);
+        ctx.current_fn = f.name.clone();
+        ctx.current_fn_lets = declared_locals(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
     }
     let main_params: HashSet<String> = main.params.iter().map(|p| p.name.clone()).collect();
     let main_mutated = mutated_names(&main.body);
+    ctx.current_fn = main.name.clone();
+    ctx.current_fn_lets = declared_locals(&main.body);
     ctx.rewrite_block(&mut main.body, &main_params, &main_mutated);
 
     // The synthesized arrow bodies may THEMSELVES contain arrows; rewrite those
@@ -295,6 +308,8 @@ pub fn extract_arrows(
         let mut f = ctx.synthesized[i].clone();
         let params: HashSet<String> = f.params.iter().map(|p| p.name.clone()).collect();
         let mutated = mutated_names(&f.body);
+        ctx.current_fn = f.name.clone();
+        ctx.current_fn_lets = declared_locals(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
         ctx.synthesized[i] = f;
         i += 1;
@@ -311,6 +326,7 @@ pub fn extract_arrows(
     ExtractResult {
         funcs: ctx.synthesized,
         captures: ctx.captures,
+        cells: ctx.cells,
     }
 }
 
@@ -414,6 +430,18 @@ struct Ctx {
     synthesized: Vec<HirFunc>,
     /// synthesized closure fn name → ordered captured outer-local names.
     captures: HashMap<String, Vec<String>>,
+    /// FUNCTION-LOCAL CELLS (#195): function name → its names that became cells.
+    /// Populated by [`Self::try_extract`] when it accepts a captured-AND-mutated
+    /// local as a cell instead of bailing — keyed under BOTH the declaring function
+    /// ([`Self::current_fn`]) and the synthesized closure.
+    cells: HashMap<String, HashSet<String>>,
+    /// The function whose body is currently being rewritten (the declaring scope of
+    /// any cell a closure here captures). Set before each `rewrite_block` for a fn.
+    current_fn: String,
+    /// The `let`/`const` names declared at the TOP LEVEL of [`Self::current_fn`]'s
+    /// body — the only locals a captured-mutated name may be a cell of this
+    /// increment (a deeper-block or param capture bails, kept sound).
+    current_fn_lets: HashSet<String>,
     /// Fresh-name counter.
     counter: usize,
 }
@@ -576,6 +604,10 @@ impl Ctx {
         // Partition the free idents: a param / global / top-level fn is NOT a
         // capture; anything else must be a CAPTURABLE outer local to be sound.
         let mut captures: Vec<String> = Vec::new();
+        // Captures that are MUTATED (by the closure or the enclosing fn) → CELLS:
+        // a by-value snapshot would be stale, but capturing the cell HANDLE by value
+        // shares the live box. Recorded after the synthesized name exists.
+        let mut cell_caps: Vec<String> = Vec::new();
         for id in &free {
             if param_names.contains(id)
                 || GLOBALS.contains(&id.as_str())
@@ -584,16 +616,23 @@ impl Ctx {
             {
                 continue;
             }
-            // A free ident outside those sets is a CAPTURE. It must be:
-            //   (1) a real outer local in scope (not an unknown name / `this`);
-            //   (2) NOT assigned by the closure body (mutable capture is unsound
-            //       by-value);
-            //   (3) NOT reassigned in the enclosing function (a stale snapshot).
+            // A free ident outside those sets is a CAPTURE. It must be a real outer
+            // local in scope (not an unknown name / `this`).
             if !scope.contains(id) {
                 return None; // unknown name / `this` — not a capturable local.
             }
+            // A MUTATED capture (assigned by the closure body OR reassigned in the
+            // enclosing function) is sound ONLY as a CELL (#195): the local must be a
+            // TOP-LEVEL `let` of THIS function (so its `let` can allocate the cell and
+            // the handle is captured by value). A mutated param / deeper-block local
+            // is outside this increment → bail (sound floor, never a stale snapshot).
             if body_assigns.contains(id) || mutated.contains(id) {
-                return None; // mutable / aliased capture — bail (sound floor).
+                if self.current_fn_lets.contains(id) {
+                    cell_caps.push(id.clone());
+                    captures.push(id.clone());
+                    continue;
+                }
+                return None; // mutable param / non-let-local capture — bail.
             }
             captures.push(id.clone());
         }
@@ -604,6 +643,20 @@ impl Ctx {
         let name = format!("__rtsn_arrow_{}", self.counter);
         self.counter += 1;
         self.top_level.insert(name.clone());
+
+        // Record each CELL capture under BOTH the declaring function (its `let`
+        // allocates the cell) and the synthesized closure (its captured leading param
+        // holds the handle) — both sides route reads/writes through the cell.
+        for c in &cell_caps {
+            self.cells
+                .entry(self.current_fn.clone())
+                .or_default()
+                .insert(c.clone());
+            self.cells
+                .entry(name.clone())
+                .or_default()
+                .insert(c.clone());
+        }
 
         // Prepend each captured var as a leading Tagged param (the thunk fills these
         // from the env array; the arrow's own params follow, filled from a0..a3).

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -179,6 +179,14 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// unknown shape. The local keeps its Tagged ABI/repr (the i64 register holds
     /// the boxed string word); only the proven-string fact is recorded here.
     pub string_locals: std::collections::HashSet<String>,
+    /// FUNCTION-LOCAL CELLS (#195): names in the CURRENT function whose local
+    /// Variable holds a 1-slot-`Vec` cell HANDLE because a closure CAPTURES and
+    /// MUTATES them. A read routes through `emit_cell_get`, a write through
+    /// `emit_cell_set`, and the declaration (`let`) allocates the cell. Owned (not
+    /// shared) — the per-function set computed by [`super::funcval`] and passed into
+    /// [`Self::lower_function`]. The closure thunk receives the same names as its
+    /// captured leading PARAMS (already holding the handle), so it shares the set.
+    pub cell_locals: std::collections::HashSet<String>,
     /// Name → the statically-known CLASS of a local/param holding a class instance
     /// (a `new C()` result, a `: C`-annotated param, or `this` inside a method).
     /// Drives static `instance.method(args)` dispatch; absent ⇒ method calls bail.
@@ -285,6 +293,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         this_class: Option<&str>,
         is_prelude: bool,
         builtins: &'c HashMap<String, (String, String)>,
+        cell_locals: std::collections::HashSet<String>,
     ) -> FrontResult<()> {
         let entry = builder.create_block();
         builder.append_block_params_for_function_params(entry);
@@ -297,6 +306,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             local_shapes: HashMap::new(),
             object_locals: std::collections::HashSet::new(),
             string_locals: std::collections::HashSet::new(),
+            cell_locals,
             local_classes: HashMap::new(),
             local_class_refs: HashMap::new(),
             generator_locals: HashMap::new(),

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -27,6 +27,7 @@ mod binop;
 mod call;
 mod call_shape;
 mod call_spread;
+mod cell;
 mod class;
 mod desugar;
 mod engineobj;
@@ -234,6 +235,10 @@ fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<
     fn_this_class.extend(user.fn_this_class);
     let mut captures = prelude.captures;
     captures.extend(user.captures);
+    // FUNCTION-LOCAL CELLS (#195): union (prelude then user). Keyed by function name;
+    // the two sides' synthesized-fn names never collide, so a plain extend is exact.
+    let mut cells = prelude.cells;
+    cells.extend(user.cells);
 
     // builtins: prelude then user (the prelude does not import `rts:<ns>` today, but
     // merging keeps the type total and user wins on a name clash).
@@ -273,6 +278,7 @@ fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<
         classes,
         fn_this_class,
         captures,
+        cells,
         gcells,
         gcell_classes,
         forced_globals,
@@ -294,6 +300,11 @@ pub(crate) struct LoweredProgram {
     /// synthesized CLOSURE fn name → ordered captured outer-local names (P5.7).
     /// Drives env construction at reify and the env-read split in the thunk.
     pub captures: std::collections::HashMap<String, Vec<String>>,
+    /// FUNCTION-LOCAL CELLS (#195): function name → its LOCAL names promoted to
+    /// per-invocation cells (a closure captures + mutates them). Keyed under both the
+    /// declaring function and the synthesized closure. Union of prelude + user on
+    /// merge. See [`funcval::extract_arrows`] / [`cell`].
+    pub cells: std::collections::HashMap<String, std::collections::HashSet<String>>,
     /// MODULE-LEVEL MUTABLE GLOBALS (epic #195): top-level `let` name → cell id.
     /// A top-level var written from inside a function is a runtime CELL; every
     /// access goes through `__RTS_FN_NS_GC_GCELL_GET/SET` by this id. Computed by
@@ -509,6 +520,7 @@ fn build_from_program(
         classes,
         fn_this_class,
         captures: extracted.captures,
+        cells: extracted.cells,
         gcells,
         gcell_classes,
         forced_globals,

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -76,6 +76,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
     let classes = &prog.classes;
     let fn_this_class = &prog.fn_this_class;
     let captures = &prog.captures;
+    let cells = &prog.cells;
     let gcells = &prog.gcells;
     let gcell_classes = &prog.gcell_classes;
     let prelude_fns = &prog.prelude_fns;
@@ -196,6 +197,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
             &ids,
             classes,
             captures,
+            cells,
             gcells,
             gcell_classes,
             &globalthis_class_refs,
@@ -216,6 +218,7 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
         &ids,
         classes,
         captures,
+        cells,
         gcells,
         gcell_classes,
         &globalthis_class_refs,
@@ -278,6 +281,7 @@ fn define_one(
     ids: &HashMap<String, FuncId>,
     classes: &super::class::ClassTable,
     captures: &HashMap<String, Vec<String>>,
+    cells: &HashMap<String, std::collections::HashSet<String>>,
     gcells: &HashMap<String, u32>,
     gcell_classes: &HashMap<String, String>,
     globalthis_class_refs: &HashMap<String, String>,
@@ -291,9 +295,10 @@ fn define_one(
     {
         let mut fb_ctx = FunctionBuilderContext::new();
         let mut fb = FunctionBuilder::new(&mut ctx.func, &mut fb_ctx);
+        let cell_locals = cells.get(&func.name).cloned().unwrap_or_default();
         let res = Lowerer::lower_function(
             module, &mut fb, func, sig, sigs, thunks, ids, classes, captures, gcells, gcell_classes,
-            globalthis_class_refs, this_class, is_prelude, builtins,
+            globalthis_class_refs, this_class, is_prelude, builtins, cell_locals,
         );
         match res {
             Ok(()) => fb.finalize(),

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -124,6 +124,20 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(());
         }
 
+        // FUNCTION-LOCAL CELL (#195): a function-scope `let` a closure captures AND
+        // mutates. Allocate a per-invocation 1-slot cell holding the boxed init and
+        // bind the HANDLE to a Tagged local — every later read/write of `name`
+        // routes through `emit_cell_get`/`emit_cell_set`, and a capturing closure
+        // snapshots the HANDLE by value (shared mutable box). Shape tracking is
+        // dropped (a captured-mutated var is opaque).
+        if self.is_cell_local(name) {
+            let val = self.lower_expr(module, init)?;
+            let word = self.box_value(val);
+            let handle = self.emit_cell_alloc(module, word);
+            self.bind_tagged_local(name, Val::new(handle, Repr::Tagged));
+            return Ok(());
+        }
+
         // GENERATOR-valued init: `const it = g()` where `g` is a generator. Mark
         // `it` so `it.next()`/`.return()`/`.throw()` route to `GENERATOR_*`. LAZY →
         // bind the raw `Int64` GenState handle; EAGER → bind the `__gen_buf` ARRAY
@@ -387,6 +401,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             self.emit_gcell_set(module, id, word)?;
             return Ok(Val::new(word, Repr::Tagged));
         }
+        // FUNCTION-LOCAL CELL (#195): write the value through the cell so a
+        // capturing closure (and later reads) see it live.
+        if self.is_cell_local(&name) {
+            let handle = {
+                let local = self.local(&name).expect("cell-local is a bound local");
+                self.builder.use_var(local.var)
+            };
+            let val = self.lower_expr(module, value)?;
+            let word = self.box_value(val);
+            self.emit_cell_set(module, handle, word);
+            return Ok(Val::new(word, Repr::Tagged));
+        }
         // Re-`x = {…}` to a DIFFERENT object literal: the local stays a proven
         // keyed OBJECT, but its exact shape may now differ from the old one. Lower
         // the new literal (recording its global shape-id in slot 0), bind it, and
@@ -492,6 +518,27 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 .call_runtime(module, sym, &[old_num, one_word])?
                 .expect("generic arithmetic returns a value");
             self.emit_gcell_set(module, id, new_num)?;
+            let produced = if prefix { new_num } else { old_num };
+            return Ok(Val::new(produced, Repr::Tagged));
+        }
+        // FUNCTION-LOCAL CELL (#195): `++`/`--` through the cell (mirrors the gcell
+        // path: read live, ToNumber, ±1 generically, store back).
+        if self.is_cell_local(&name) {
+            let handle = {
+                let local = self.local(&name).expect("cell-local is a bound local");
+                self.builder.use_var(local.var)
+            };
+            let old = self.emit_cell_get(module, handle);
+            let old_num = self
+                .call_runtime(module, "__rtsadp_pos", &[old.v])?
+                .expect("__rtsadp_pos returns a value");
+            let one_f64 = self.builder.ins().f64const(1.0);
+            let one_word = self.box_value(Val::new(one_f64, Repr::Float64));
+            let sym = if inc { "__rtsadp_add" } else { "__rtsadp_sub" };
+            let new_num = self
+                .call_runtime(module, sym, &[old_num, one_word])?
+                .expect("generic arithmetic returns a value");
+            self.emit_cell_set(module, handle, new_num);
             let produced = if prefix { new_num } else { old_num };
             return Ok(Val::new(produced, Repr::Tagged));
         }

--- a/crates/rts-codegen-new/src/front/run/tests/closure.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/closure.rs
@@ -158,6 +158,68 @@ fn async_await_synchronous_model() {
     );
 }
 
+// ===========================================================================
+// FUNCTION-LOCAL MUTABLE CAPTURE (#195) — a closure that CAPTURES and MUTATES a
+// function-scope `let`. The local is promoted to a per-invocation runtime CELL
+// (a 1-slot Vec); the closure captures the cell HANDLE by value, so both sides
+// share one mutable box. The headline gap behind the "expression arrow" cluster.
+// ===========================================================================
+
+#[test]
+fn closure_writes_captured_function_local() {
+    // `cb` (an inline arrow in `setup`) WRITES the captured local `count`; the
+    // enclosing function reads it back after three calls → the writes are visible
+    // (a by-value snapshot could not do this). `count` becomes a cell.
+    assert_stdout(
+        "function setup(): number { let count = 0; const cb = () => { count = count + 1; }; \
+         cb(); cb(); cb(); return count; } console.log(setup());",
+        "3\n",
+    );
+}
+
+#[test]
+fn returned_counter_closure_outlives_its_factory() {
+    // The closure `() => ++c` is RETURNED from `mk` and called after `mk` returned:
+    // the cell (held alive by the closure's captured handle) survives, so the three
+    // calls see 1, 2, 3 — independent state per `mk()` invocation.
+    assert_stdout(
+        "function mk(): () => number { let c = 0; return () => ++c; } \
+         const f = mk(); console.log(f(), f(), f());",
+        "1 2 3\n",
+    );
+}
+
+#[test]
+fn two_counters_have_independent_cells() {
+    // Each `mk()` allocates a FRESH cell, so two counters do not share state.
+    assert_stdout(
+        "function mk(): () => number { let c = 0; return () => ++c; } \
+         const a = mk(); const b = mk(); console.log(a(), a(), b());",
+        "1 2 1\n",
+    );
+}
+
+#[test]
+fn captured_mutated_local_compound_assign() {
+    // `+=` on a captured-mutated local routes through the cell (read-modify-write).
+    assert_stdout(
+        "function run(): number { let total = 0; const add = (n: number) => { total += n; }; \
+         add(10); add(5); return total; } console.log(run());",
+        "15\n",
+    );
+}
+
+#[test]
+fn readonly_capture_stays_by_value_not_a_cell() {
+    // A captured local that is NEVER mutated stays the by-value fast path (NOT a
+    // cell) — guards against over-promotion. `k` is read-only in the closure.
+    assert_stdout(
+        "function f(): number { let k = 3; const g = (x: number) => x * k; return g(4); } \
+         console.log(f());",
+        "12\n",
+    );
+}
+
 #[test]
 fn inline_arrow_callback_reading_console() {
     // An inline arrow CALLBACK that reads `console` (a prelude singleton) — the


### PR DESCRIPTION
## #195 — function-local mutable capture

Uma closure que **captura E muta** um `let` de função agora funciona (antes bailava `expression arrow`). O local vira uma **cell runtime por-invocação** (`Vec` de 1 slot); a closure captura o **HANDLE por valor** (estável) → função declarante e closure compartilham uma caixa mutável.

- Read → `VEC_GET(handle,0)`, write → `VEC_SET(handle,0)`, decl `let` aloca a cell.
- Diferente do gcell module-level (id estático): cell de função é **por-chamada**, sem tabela de id.
- Detecção em `funcval::try_extract`: captura mutável só vira cell quando é `let` top-level da função (param/bloco-fundo continuam bail — piso de solidez).
- Caminho da closure: param-líder capturado já recebe o handle; ambos roteiam via `cell_locals`.
- A cell (Vec, GC-traced) sobrevive à função via o handle capturado (contador retornado).

Novo `front/run/cell.rs`; campo `cell_locals` por-função; `cells` threaded de `ExtractResult` → `LoweredProgram` → `lower_function`.

## Validação (vs Bun)

| Caso | Saída |
|---|---|
| `setup()` (closure escreve `count`) | 3 |
| counter-factory `mk()` → `f(),f(),f()` | 1 2 3 |
| dois contadores independentes | 1 2 1 |
| `+=` via cell | 15 |
| captura read-only (não vira cell) | 12 |
| `count+10` / `typeof count` | 13 / number |

+5 testes unitários (closure.rs 17→22). **Suíte rts:test 356→360.** cargo test rts-codegen-new **773/773**, zero regressão. Gate sem hard violation.

## Nota
`closure_local_capture.test.ts` ainda falha, mas por bug **PRÉ-EXISTENTE e independente**: `gc.string_from_i64` retorna handle de string com ts_sig `: number`, então o motor reboxa o resultado como número cru (mesmo `gc.string_from_i64(3)` literal). Fix separado do modelamento de retorno gc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)