### PR TITLE
feat(codegen-new): #218 Proxy fase-1 — traps get/set via callback bridge

### DIFF
--- a/crates/rts-codegen-new/src/front/run/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/globalclass.rs
@@ -244,9 +244,20 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let v = self.emit_registry_call(module, &call, Some(recv), &[], result_kind)?;
                 return Ok(Some(v));
             }
-            return Err(crate::front::error::Unsupported::new(format!(
-                "`{class}.{prop}` — no such property on runtime class `{class}`"
-            )));
+            // No registered getter for `prop` → DYNAMIC property read. This serves an
+            // EXOTIC instance whose properties are not fixed members (a `Proxy`, whose
+            // `get` trap fires inside `__rtsadp_obj_get`); for an ordinary Registry
+            // instance with no such key the dynamic read returns `undefined` — the
+            // JS-correct value (`new Date().foo` is `undefined`), not a bail. Generic
+            // (no per-class name): the proxy trap dispatch lives entirely in the
+            // runtime trampoline.
+            let recv = self.lower_expr(module, object)?;
+            let recv_word = self.box_value(recv);
+            let key = self.intern_key_word(prop);
+            let v = self
+                .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key])?
+                .expect("__rtsadp_obj_get returns a value");
+            return Ok(Some(Val::new(v, crate::repr::Repr::Tagged)));
         }
         let symbol = match (class.as_str(), prop) {
             ("RegExp", "source") => "__rtsadp_re_source",

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -936,7 +936,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// Intern a STATIC property name as a string-PolyValue key word (an i64
     /// constant — the literal is interned in the real pool at lowering time, like
     /// every string literal).
-    fn intern_key_word(&mut self, prop: &str) -> Value {
+    pub(super) fn intern_key_word(&mut self, prop: &str) -> Value {
         let pv = abi_adapter::intern_poly(prop);
         self.builder.ins().iconst(types::I64, pv.raw() as i64)
     }

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -113,6 +113,12 @@ pub(super) static REGISTER: &[Register] = &[
     // off/emit. The listener arg is a function-VALUE the backend invokes via the
     // codegen `__rtsadp_fn_invoke` callback bridge (JIT-installed).
     Register { label: "EventEmitter class", run: ns::globals::events::register_class_spec, why: "EventEmitter ctor + on/emit" },
+    // `Proxy` — backend/Registry class (#218): `new Proxy(target, handler)` →
+    // `__RTS_FN_GL_PROXY_NEW` (Entry::Proxy). The get/set TRAPS are resolved at
+    // runtime in the dynamic property trampolines (`__rtsadp_obj_get`/`_set` detect
+    // a Proxy receiver via `resolve_proxy` and invoke `handler.get`/`.set` through
+    // the `__rtsadp_fn_invoke` callback bridge), not by a codegen arm.
+    Register { label: "Proxy class", run: ns::globals::proxy::register_proxy_class_spec, why: "Proxy ctor → PROXY_NEW; traps in obj_get/set" },
 ];
 
 /// One `.ts` prelude include, in DEPENDENCY ORDER (base before dependent).

--- a/crates/rts-codegen-new/src/front/run/tests/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/mod.rs
@@ -77,6 +77,7 @@ mod error_cause;
 mod json_parse;
 mod numeric_coercion;
 mod object_static;
+mod proxy;
 mod string_methods;
 mod url;
 mod logical;

--- a/crates/rts-codegen-new/src/front/run/tests/proxy.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/proxy.rs
@@ -1,0 +1,59 @@
+//! PROXY (#218) — `new Proxy(target, handler)` + the `get`/`set` traps.
+//!
+//! A proxy is an `Entry::Proxy { target, handler }` (built by the Registry ctor
+//! `__RTS_FN_GL_PROXY_NEW`). Property access on a proxy routes through the dynamic
+//! property trampolines (`__rtsadp_obj_get`/`_set`), which detect the proxy
+//! receiver via `resolve_proxy` and invoke `handler.get`/`.set` through the
+//! `__rtsadp_fn_invoke` callback bridge — falling through to the target when the
+//! handler defines no trap. The other traps (has/deleteProperty/apply/construct)
+//! and `Reflect.*` are later increments.
+
+use super::assert_stdout;
+
+#[test]
+fn get_trap_intercepts_every_key() {
+    // `handler.get` fires for ANY property — present or absent on the target.
+    assert_stdout(
+        "const t: any = { x: 10, y: 20 }; \
+         const h: any = { get: (_t: any, _k: any) => 42 }; \
+         const p: any = new Proxy(t, h); \
+         console.log(p.x, p.anything, p.y);",
+        "42 42 42\n",
+    );
+}
+
+#[test]
+fn no_get_trap_reads_through_to_target() {
+    // A handler WITHOUT a `get` trap reads the property straight off the target
+    // (present → its value, absent → `undefined`).
+    assert_stdout(
+        "const t: any = { foo: 100 }; const p: any = new Proxy(t, {}); \
+         console.log(p.foo, p.missing);",
+        "100 undefined\n",
+    );
+}
+
+#[test]
+fn set_trap_intercepts_writes() {
+    // `handler.set` fires on every write; the underlying target is NOT mutated by
+    // the trap (it only counts), so the side effect is observable via the counter.
+    assert_stdout(
+        "let count = 0; const t: any = { x: 0 }; \
+         const h: any = { set: (_t: any, _k: any, _v: any) => { count = count + 1; return true; } }; \
+         const p: any = new Proxy(t, h); \
+         p.a = 1; p.b = 2; p.c = 3; console.log(count);",
+        "3\n",
+    );
+}
+
+#[test]
+fn get_trap_can_read_the_target() {
+    // A `get` trap that forwards to the target (`target[key]`) — the common
+    // logging-proxy shape — reads the real value through the proxy.
+    assert_stdout(
+        "const t: any = { n: 7 }; \
+         const h: any = { get: (target: any, key: any) => target[key] }; \
+         const p: any = new Proxy(t, h); console.log(p.n);",
+        "7\n",
+    );
+}

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -38,6 +38,7 @@ use rts_runtime::namespaces::engine as rt_engine;
 use rts_runtime::namespaces::gc::collector as rt_gcoll;
 use rts_runtime::namespaces::gc::handles as rt_handles;
 use rts_runtime::namespaces::gc::string_pool as rt_str;
+use rts_runtime::namespaces::globals::proxy::ops as rt_proxy;
 use rts_runtime::namespaces::globals::number as rt_num;
 use rts_runtime::namespaces::globals::string::rt as rt_gl_str;
 use rts_runtime::namespaces::io as rt_io;
@@ -938,6 +939,13 @@ fn gl_method_symbols() -> Vec<JitSymbol> {
         sym(
             "__RTS_FN_GL_NUMBER_TO_STRING_RADIX",
             rt_num::__RTS_FN_GL_NUMBER_TO_STRING_RADIX as *const u8,
+        ),
+        // Proxy ctor (#218): `new Proxy(target, handler)` → `Entry::Proxy`. The
+        // get/set TRAPS run inside `__rtsadp_obj_get`/`_set` (engine trampolines,
+        // already installed); only the ctor symbol needs installing here.
+        sym(
+            "__RTS_FN_GL_PROXY_NEW",
+            rt_proxy::__RTS_FN_GL_PROXY_NEW as *const u8,
         ),
     ]
 }

--- a/crates/rts-codegen-new/src/value/objops.rs
+++ b/crates/rts-codegen-new/src/value/objops.rs
@@ -38,11 +38,66 @@
 
 use rts_runtime::namespaces::collections::vec as rt_vec;
 use rts_runtime::namespaces::gc::handles as rt_handles;
+use rts_runtime::namespaces::globals::proxy as rt_proxy;
 
 use crate::shape::global_shape_keys;
 
 use super::inspect::looks_like_object;
 use super::{PolyValue, abi_adapter};
+
+/// PROXY (#218) — when `obj_word` wraps an `Entry::Proxy`, return its
+/// `(target, handler)` reboxed as `TAG_OBJECT` PolyValue words (the stored values
+/// are real GC handles; `& PAYLOAD_MASK` drops the generation to the 48-bit slot
+/// the box expects). `None` for any non-proxy receiver — the cost is one extra
+/// HandleTable lookup on the DYNAMIC property path (never the proven-shape fast
+/// path), accepted for the trap semantics.
+fn proxy_parts(obj_word: u64) -> Option<(u64, u64)> {
+    let obj = PolyValue::from_raw(obj_word);
+    if !obj.is_object() {
+        return None;
+    }
+    let handle = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(obj.as_handle());
+    let (target, handler) = rt_proxy::ops::resolve_proxy(handle)?;
+    // The stored target/handler are full GC handles; `POLY_FROM_HANDLE` drops the
+    // generation to the 48-bit slot the `TAG_OBJECT` box expects (NOT a raw mask —
+    // the handle layout is not slot-in-low-48).
+    let t_slot = rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(target);
+    let h_slot = rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(handler);
+    let t_word = PolyValue::from_object_handle(t_slot).raw();
+    let h_word = PolyValue::from_object_handle(h_slot).raw();
+    Some((t_word, h_word))
+}
+
+/// Proxy `get` trap: `handler.get(target, key)` when the handler defines a `get`
+/// FUNCTION; otherwise read the property straight off the target (the default
+/// behavior of a trap-less handler). The trap is invoked through the
+/// `__rtsadp_fn_invoke` callback bridge with `(target, key)` — the same bridge the
+/// EventEmitter listeners use.
+fn proxy_get(target_word: u64, handler_word: u64, key_str_handle: u64) -> u64 {
+    let get_key = abi_adapter::intern_poly("get").raw();
+    let trap = __rtsadp_obj_get(handler_word, get_key);
+    if PolyValue::from_raw(trap).is_function() {
+        let undef = PolyValue::undefined().raw();
+        super::funcops::__rtsadp_fn_invoke(trap, target_word, key_str_handle, undef, undef, 0)
+    } else {
+        __rtsadp_obj_get(target_word, key_str_handle)
+    }
+}
+
+/// Proxy `set` trap: `handler.set(target, key, value)` when the handler defines a
+/// `set` FUNCTION; otherwise write straight to the target. JS assignment evaluates
+/// to the assigned `value` regardless of the trap's own return.
+fn proxy_set(target_word: u64, handler_word: u64, key_str_handle: u64, val_word: u64) -> u64 {
+    let set_key = abi_adapter::intern_poly("set").raw();
+    let trap = __rtsadp_obj_get(handler_word, set_key);
+    if PolyValue::from_raw(trap).is_function() {
+        let undef = PolyValue::undefined().raw();
+        super::funcops::__rtsadp_fn_invoke(trap, target_word, key_str_handle, val_word, undef, 0);
+        val_word
+    } else {
+        __rtsadp_obj_set(target_word, key_str_handle, val_word)
+    }
+}
 
 /// Resolve `(real_vec_handle, key_index)` for `obj_word`.`key`: `Some((handle, i))`
 /// when `obj_word` is a keyed object whose shape contains `key` (value lives at
@@ -87,6 +142,11 @@ fn key_text(key_str_handle: u64) -> String {
 /// array / primitive). The lowering routes here only proven-object receivers.
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_obj_get(obj_word: u64, key_str_handle: u64) -> u64 {
+    // PROXY (#218): a proxy receiver routes through its `get` trap. Checked first —
+    // a proxy is not a keyed Vec object, so `resolve_slot` would read `undefined`.
+    if let Some((target, handler)) = proxy_parts(obj_word) {
+        return proxy_get(target, handler, key_str_handle);
+    }
     match resolve_slot(obj_word, key_str_handle) {
         Some((handle, idx)) => rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, 1 + idx) as u64,
         None => PolyValue::undefined().raw(),
@@ -103,6 +163,10 @@ pub extern "C" fn __rtsadp_obj_get(obj_word: u64, key_str_handle: u64) -> u64 {
 /// PRIMORDIAL → property addition is engine-direct.)
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_obj_set(obj_word: u64, key_str_handle: u64, val_word: u64) -> u64 {
+    // PROXY (#218): a proxy receiver routes through its `set` trap.
+    if let Some((target, handler)) = proxy_parts(obj_word) {
+        return proxy_set(target, handler, key_str_handle, val_word);
+    }
     if let Some((handle, idx)) = resolve_slot(obj_word, key_str_handle) {
         rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(handle, 1 + idx, val_word as i64);
         return val_word;

--- a/crates/rts-shared/src/globals/proxy/ops.rs
+++ b/crates/rts-shared/src/globals/proxy/ops.rs
@@ -46,15 +46,14 @@ unsafe extern "C" {
 }
 
 /// Construtor Proxy: aloca Entry::Proxy { target, handler }.
-/// Retorna 0 se o handler nao for Map (validacao minima — JS lanca
-/// TypeError, mas v0 retorna 0 pra evitar throw desnecessario).
+///
+/// `target` e `handler` sao words/handles de objeto opacos — no motor novo
+/// objetos sao keyed `Entry::Vec` (NAO `Entry::Map` como no motor velho), entao
+/// NAO se valida o tipo do handler aqui: as traps leem `handler.get`/`.set` pela
+/// via dinamica de propriedade do proprio motor (`__rtsadp_obj_get`), que aceita
+/// qualquer objeto. A GC mantem target+handler vivos enquanto o Proxy viver.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_GL_PROXY_NEW(target: u64, handler: u64) -> u64 {
-    // Validacao basica: handler precisa ser Map.
-    let handler_ok = with_entry(handler, |e| matches!(e, Some(Entry::Map(_))));
-    if !handler_ok {
-        return 0;
-    }
     alloc_entry(Entry::Proxy { target, handler })
 }
 


### PR DESCRIPTION
## #218 — Proxy get/set traps

`new Proxy(target, handler)` + os traps `get`/`set` funcionam no motor novo, reusando o callback-from-runtime bridge (`__rtsadp_fn_invoke`, o mesmo dos listeners de EventEmitter).

**Mecanismo:**
- `new Proxy(t, h)` resolve genericamente pelo Registry (ctor `__RTS_FN_GL_PROXY_NEW` registrado em registry_build, como Date/Map/EventEmitter) → `Entry::Proxy { target, handler }`, GC-traced.
- Property access num proxy → trampolins dinâmicos `__rtsadp_obj_get`/`_set` detectam via `resolve_proxy`, leem `handler.get`/`.set`, invocam pelo bridge ou caem no target.
- **Front-end genérico**: property-miss numa classe-registry pura roteia ao `__rtsadp_obj_get` dinâmico (proxy → trap; não-proxy → undefined JS-correto) — **sem literal "Proxy" no control flow** do motor.

**Fix no caminho**: `__RTS_FN_GL_PROXY_NEW` exigia `handler` ser `Entry::Map` (motor velho) → falhava no motor novo (objetos são `Entry::Vec`) e retornava 0. Removida a validação.

## Validação (vs Bun)

| Caso | Saída |
|---|---|
| get trap toda chave (`p.x p.anything p.y`) | 42 42 42 |
| sem get trap → lê target (`p.foo p.missing`) | 100 undefined |
| set trap conta escritas | 3 |
| get trap lê `target[key]` | 7 |

+4 testes unitários. cargo test rts-codegen-new **778→782**, zero regressão. Suíte rts:test 360→361. Gate sem hard violation.

## Pendente (fora desta fase)
Reflect.* (proxy_phase1), traps has/deleteProperty/apply/construct, e arrow INLINE em object-literal passado direto a `new Proxy` (gap de extração de arrow separado — proxy_phase2/3 bailam nele).

🤖 Generated with [Claude Code](https://claude.com/claude-code)