### PR TITLE
feat(codegen-new): extração de arrow desce em new(args) e await

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -548,6 +548,16 @@ impl Ctx {
                     self.rewrite_expr(v, scope, mutated);
                 }
             }
+            // `new C(args)` — descend into the CTOR ARGS so an inline arrow there
+            // (`new Proxy(t, { get: (_t, _k) => 42 })`, a callback passed to a ctor)
+            // is lifted, not left to bail. The class is a NAME, never an arrow.
+            HirExprKind::New { args, .. } => {
+                for a in args.iter_mut() {
+                    self.rewrite_expr(a, scope, mutated);
+                }
+            }
+            // `await <expr>` — descend so an arrow inside an awaited expression lifts.
+            HirExprKind::Await(inner) => self.rewrite_expr(inner, scope, mutated),
             HirExprKind::Arrow { .. } => {
                 // Try to extract this arrow into a top-level function or closure. On
                 // success, replace the node with an Ident of the synthesized name.

--- a/crates/rts-codegen-new/src/front/run/tests/proxy.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/proxy.rs
@@ -47,6 +47,18 @@ fn set_trap_intercepts_writes() {
 }
 
 #[test]
+fn inline_handler_arrow_in_new_ctor_arg() {
+    // The handler object literal — with its `get` ARROW — is passed INLINE as a
+    // ctor arg to `new Proxy(...)` (not a named `const`). The arrow extraction must
+    // descend into `new`'s args to lift it, else "expression arrow".
+    assert_stdout(
+        "const p: any = new Proxy({ y: 2 }, { get: (_t: any, _k: any) => 99 }); \
+         console.log(p.y);",
+        "99\n",
+    );
+}
+
+#[test]
 fn get_trap_can_read_the_target() {
     // A `get` trap that forwards to the target (`target[key]`) — the common
     // logging-proxy shape — reads the real value through the proxy.


### PR DESCRIPTION
Arrow extraction (`funcval::rewrite_expr`) não descia em `new C(args)` nem `await` → arrow INLINE num arg de ctor (`new Proxy(t, { get: arrow })`) bailava "expression arrow". Adicionados arms `New { args }` + `Await(inner)`.

Geral: qualquer callback inline passado a um ctor agora lifta. Destrava handler inline de Proxy; proxy_phase2/3 avançam p/ Reflect.

Validação: `new Proxy({y:2}, { get: (_t,_k)=>99 }).y` → 99. +1 teste. cargo test 782/782, zero regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)