### PR TITLE
feat(codegen-new): delete operator + Reflect.deleteProperty/ownKeys

### DIFF
--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -235,6 +235,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(Val::tagged_kind(res, JsKind::Str));
         }
 
+        // `delete obj.key` / `delete obj[k]` — remove the property via a shape
+        // transition (`__rtsadp_obj_delete` shifts the value slots + reshapes the
+        // object, the inverse of the key-append in `obj_set`). Intercepted BEFORE the
+        // operand is lowered (like `typeof`) — we need the object + key separately,
+        // not the property's value. Always evaluates `true` (own/configurable/absent
+        // deletes are all `true`). A non-property target keeps the prior bail.
+        if matches!(op, HirUnOp::Delete) {
+            return self.lower_delete(module, operand);
+        }
+
         // `-0` is the one negation whose result an integer slot CANNOT hold: JS `-0`
         // is the IEEE-754 negative zero (distinct from `+0` — `1/-0 === -Infinity`,
         // `Object.is(0,-0) === false`). The literal-0 operand would otherwise lower
@@ -335,9 +345,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // `delete o.absent` / discarding the result. We bail on a member/index
             // target (cannot actually remove) and only return `true` for the
             // never-removes cases is unsound — so bail uniformly rather than guess.
-            HirUnOp::Delete => unsupported!(
-                "`delete` (slot removal needs the transition tree — a later increment)"
-            ),
+            // `delete` is handled before the operand is lowered (see top of
+            // `lower_unary`); it never reaches this match.
+            HirUnOp::Delete => unreachable!("delete intercepted before operand lowering"),
             // `void x` — `x` is already lowered above (its side effects ran); the
             // expression always evaluates to `undefined`.
             HirUnOp::Void => {

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -544,6 +544,48 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     }
 
     /// Lower `arr[index] = value` (index-write) to `VEC_SET`.
+    /// `delete obj.key` / `delete obj[k]` — remove the property and evaluate to
+    /// `true`. Lowers the OBJECT, derives the key (a literal member name or a
+    /// ToString'd computed key), and calls the runtime `__rtsadp_obj_delete` (shape
+    /// transition + value-slot shift). A numeric computed key (`delete arr[i]`) or a
+    /// non-property target (`delete x`) is outside this increment → bail.
+    pub(super) fn lower_delete(
+        &mut self,
+        module: &mut dyn Module,
+        operand: &HirExpr,
+    ) -> FrontResult<Val> {
+        let (object_expr, obj_word, key) = match &operand.kind {
+            HirExprKind::Member { object, prop } => {
+                let obj = self.lower_expr(module, object)?;
+                let obj_word = self.box_value(obj);
+                (object.as_ref(), obj_word, self.intern_key_word(prop))
+            }
+            HirExprKind::Index { object, index } => {
+                let obj = self.lower_expr(module, object)?;
+                let obj_word = self.box_value(obj);
+                let Some(key) = self.dynamic_key_word(module, index)? else {
+                    return unsupported!(
+                        "`delete obj[k]` with a numeric / non-string computed key (later increment)"
+                    );
+                };
+                (object.as_ref(), obj_word, key)
+            }
+            _ => {
+                return unsupported!("`delete` on a non-property target (a no-op in strict mode)");
+            }
+        };
+        let res = self
+            .call_runtime(module, "__rtsadp_obj_delete", &[obj_word, key])?
+            .expect("__rtsadp_obj_delete returns a value");
+        // The delete reshapes the object at RUNTIME, so the local's compile-time
+        // shape is no longer authoritative — route future `o.k` / `Object.keys(o)`
+        // through the DYNAMIC path (which reads the live slot-0 shape).
+        if let Some(name) = self.object_receiver_name(object_expr) {
+            self.demote_local_to_dynamic(&name);
+        }
+        Ok(Val::new(res, Repr::Bool))
+    }
+
     pub(super) fn lower_index_assign(
         &mut self,
         module: &mut dyn Module,
@@ -947,7 +989,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// Tagged index is ToString'd via the box + the lowering's key coercion: a
     /// proven-string value passes its word straight through; a Tagged index is
     /// boxed and ToString happens inside the trampoline's `key_text`.
-    fn dynamic_key_word(
+    pub(super) fn dynamic_key_word(
         &mut self,
         module: &mut dyn Module,
         index: &HirExpr,

--- a/crates/rts-codegen-new/src/front/run/tests/precision.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/precision.rs
@@ -143,10 +143,15 @@ fn object_typed_param_literal_annotation_now_dynamic() {
 }
 
 // ===========================================================================
-// Sound bails preserved: `delete` (slot removal) and spread forms not covered.
+// `delete` (slot removal via shape transition) — now implemented (#218 object
+// model). The property is removed and a later read yields `undefined`.
 // ===========================================================================
 
 #[test]
-fn delete_still_bails() {
-    assert_bails("let o = { a: 1 }; delete o.a; console.log(o.a);");
+fn delete_removes_the_property() {
+    assert_stdout(
+        "let o = { a: 1, b: 2 }; const ok = delete o.a; \
+         console.log(ok, o.a, o.b, Object.keys(o).join(\",\"));",
+        "true undefined 2 b\n",
+    );
 }

--- a/crates/rts-codegen-new/src/front/run/tests/reflect.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/reflect.rs
@@ -27,6 +27,16 @@ fn reflect_get_fires_proxy_get_trap() {
 }
 
 #[test]
+fn reflect_delete_property_and_own_keys() {
+    assert_stdout(
+        "const o: any = { a: 1, b: 2, c: 3 }; \
+         const ok = Reflect.deleteProperty(o, \"b\"); \
+         console.log(ok, Reflect.ownKeys(o).join(\",\"), Reflect.has(o, \"b\"));",
+        "true a,c false\n",
+    );
+}
+
+#[test]
 fn reflect_set_fires_proxy_set_trap() {
     // `Reflect.set(proxy, k, v)` → `proxy[k] = v` → the proxy's `set` trap.
     assert_stdout(

--- a/crates/rts-codegen-new/src/runtime_link.rs
+++ b/crates/rts-codegen-new/src/runtime_link.rs
@@ -625,6 +625,7 @@ pub fn jit_symbols() -> Vec<JitSymbol> {
         sym("__rtsadp_obj_get", objops::__rtsadp_obj_get as *const u8),
         sym("__rtsadp_obj_set", objops::__rtsadp_obj_set as *const u8),
         sym("__rtsadp_obj_has", objops::__rtsadp_obj_has as *const u8),
+        sym("__rtsadp_obj_delete", objops::__rtsadp_obj_delete as *const u8),
         sym("__rtsadp_obj_values", objops::__rtsadp_obj_values as *const u8),
         sym("__rtsadp_obj_entries", objops::__rtsadp_obj_entries as *const u8),
         sym(

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -763,6 +763,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64],
             ret: Bool,
         },
+        "__rtsadp_obj_delete" => SymSig {
+            params: &[U64, U64],
+            ret: Bool,
+        },
         // obj_keys/values/entries(obj_word) -> fresh array PolyValue word (dynamic
         // Object.keys/values/entries; Object is primordial → engine-direct).
         "__rtsadp_obj_values" | "__rtsadp_obj_entries" | "__rtsadp_obj_from_entries" => SymSig {

--- a/crates/rts-codegen-new/src/value/objops.rs
+++ b/crates/rts-codegen-new/src/value/objops.rs
@@ -242,6 +242,40 @@ pub extern "C" fn __rtsadp_obj_has(obj_word: u64, key_str_handle: u64) -> i64 {
     resolve_slot(obj_word, key_str_handle).is_some() as i64
 }
 
+/// `delete obj.key` — slot removal via a shape transition (the inverse of the
+/// `obj_set` key-append). Resolve the key's slot: ABSENT (or a non-object) → `1`
+/// (a no-op delete evaluates to `true` in JS). PRESENT → shift the value slots
+/// after it down by one over the hole, drop the now-duplicate tail slot, and set
+/// slot 0 to the shape WITHOUT the key. Always returns `1` (own/configurable/absent
+/// deletes are all `true`; this model has no non-configurable props). A Proxy
+/// `deleteProperty` trap is a later increment — a proxy receiver is not a keyed
+/// object, so `resolve_slot` misses and it returns `1` (no-op) rather than trapping.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_obj_delete(obj_word: u64, key_str_handle: u64) -> i64 {
+    let Some((handle, idx)) = resolve_slot(obj_word, key_str_handle) else {
+        return 1;
+    };
+    // Read the keys + intern the key-less shape BEFORE mutating the Vec: the shift +
+    // pop below transiently breaks the shape↔length invariant `object_keys_vec`
+    // relies on, so computing the new shape after the mutation would read empty.
+    let mut keys = object_keys_vec(obj_word);
+    keys.remove(idx as usize);
+    let new_shape = crate::shape::intern_global_shape(&keys);
+    let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(handle).max(0);
+    // Shift the value slots (1+idx+1 .. len) down by one, over the removed slot.
+    let mut j = 1 + idx;
+    while j + 1 < len {
+        let next = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, j + 1);
+        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(handle, j, next);
+        j += 1;
+    }
+    // Drop the now-duplicate tail slot, then commit the key-less shape header.
+    rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_POP(handle);
+    let slot0 = PolyValue::from_i32(new_shape as i32).raw() as i64;
+    rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(handle, 0, slot0);
+    1
+}
+
 /// Recover a keyed object's ordered keys from its slot-0 global shape-id. Empty
 /// for a non-object / unrecognized header (the safe default — `Object.keys` of a
 /// non-object yields `[]`).

--- a/crates/rts-shared/src/stdlib/reflect.ts
+++ b/crates/rts-shared/src/stdlib/reflect.ts
@@ -33,4 +33,18 @@ class Reflect {
   static has(target: any, key: any): any {
     return Object.keys(target).indexOf(key) >= 0;
   }
+
+  // Reflect.deleteProperty(target, key) — `delete target[key]`; returns whether the
+  // property is gone afterward (always true here — the model has no
+  // non-configurable own properties).
+  static deleteProperty(target: any, key: any): any {
+    delete target[key];
+    return true;
+  }
+
+  // Reflect.ownKeys(target) — the target's own (string) keys. Symbol keys are a
+  // later increment (Symbol itself is not yet modeled).
+  static ownKeys(target: any): any {
+    return Object.keys(target);
+  }
 }


### PR DESCRIPTION
## `delete` + Reflect.deleteProperty/ownKeys

`delete obj.key` / `delete obj[k]` removem a propriedade (antes bailava "transition tree"). Runtime `__rtsadp_obj_delete`: shift dos slots de valor sobre o buraco + pop da cauda + slot 0 = shape sem a chave (inversa do key-append). Front `lower_delete` intercepta antes do operand (como typeof), demota o local p/ dinâmico (shape estática fica stale após reshape).

Com `delete o[k]` pronto, `Reflect.deleteProperty`/`ownKeys` viram adições `.ts` triviais.

## Validação (vs Bun)

| Caso | Saída |
|---|---|
| `delete o.b`; Object.keys; o.b | true / a,c / undefined |
| `delete o[k]` computado | idem |
| Reflect.deleteProperty/ownKeys/has | true a,c false |

cargo test 783→788 (`delete_still_bails` → `delete_removes_the_property`, regressão INTENCIONAL). Suíte 361→364. Gate sem hard violation.

Nota: tests globals (globalThis singleton process-global) têm flakiness de ordenação pré-existente — passam isolados + no full-suite limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)