### PR TITLE
feat(hir): new (C as any)() — desembrulha cast/paren no callee do construtor

### DIFF
--- a/crates/rts-codegen-new/src/front/run/tests/class.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/class.rs
@@ -125,3 +125,15 @@ fn new_of_unknown_class_bails() {
     // `Foo` is not a user class in the program.
     assert_bails("let x = new Foo(1); console.log(x);");
 }
+
+#[test]
+fn new_with_type_cast_callee_resolves_the_class() {
+    // `new (C as any)(..)` / `new (C)(..)` — the TS cast / paren around the ctor name
+    // is a runtime no-op; the constructed class is the inner ident. Without seeing
+    // through it the callee was not a bare ident → the `class ``` empty-name bail.
+    assert_stdout(
+        "class C { v: number; constructor(n: number) { this.v = n; } get(): number { return this.v; } } \
+         const c: any = new (C as any)(7); const d = new (C)(3); console.log(c.get(), d.get());",
+        "7 3\n",
+    );
+}

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -819,6 +819,17 @@ fn member_prop_name(prop: &swc::MemberProp) -> String {
 fn expr_to_ident_name(expr: &swc::Expr) -> Option<String> {
     match expr {
         swc::Expr::Ident(id) => Some(id.sym.to_string()),
+        // See through a type-only wrapper around the constructor name: `new (Foo as
+        // any)()`, `new (Foo)()`, `new (Foo satisfies T)()`, `new (Foo!)()`,
+        // `new (<any>Foo)()`. These are TS no-ops at runtime — the constructed class
+        // is the inner ident. Without this the callee is not a bare `Ident`, the name
+        // came back empty, and `new (Foo as any)()` bailed with `class ``.
+        swc::Expr::Paren(p) => expr_to_ident_name(&p.expr),
+        swc::Expr::TsAs(a) => expr_to_ident_name(&a.expr),
+        swc::Expr::TsConstAssertion(a) => expr_to_ident_name(&a.expr),
+        swc::Expr::TsSatisfies(a) => expr_to_ident_name(&a.expr),
+        swc::Expr::TsNonNull(a) => expr_to_ident_name(&a.expr),
+        swc::Expr::TsTypeAssertion(a) => expr_to_ident_name(&a.expr),
         _ => None,
     }
 }


### PR DESCRIPTION
## `new (C as any)()` — desembrulha cast/paren no callee

`new (Foo as any)()` / `new (Foo)()` / `new (Foo!)()` / `new (<any>Foo)()` bailavam com `class ``` (nome vazio): `expr_to_ident_name` no lowering HIR do `new` só casava `Expr::Ident`, e o cast/paren TS embrulha o nome (no-op em runtime — a classe é o ident interno).

Agora desce por `Paren`/`TsAs`/`TsConstAssertion`/`TsSatisfies`/`TsNonNull`/`TsTypeAssertion` até o ident.

## Validação (vs Bun)

`new (C as any)(7).get()` → 7, `new (C)(3).get()` → 3. +1 teste unitário. cargo test rts-codegen-new 787→788, rts-hir 30/30, zero regressão.

**Cluster de bail `class ``` 13→0** — os 13 testes avançam do nome-vazio para o próximo bloqueio (abstract/typed-array/etc., fases seguintes). Gate sem hard violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)