### PR TITLE
docs: sincroniza CLAUDE.md + rules ao estado pós-cutover + regra egui obrigatória

### DIFF
--- a/.claude/rules/00-meta.md
+++ b/.claude/rules/00-meta.md
@@ -30,8 +30,8 @@ Read these files in order (path relative to repo root):
 
 | File | Content |
 |---|---|
-| `.claude/rules/00-meta.md` | This file — meta + local-rules + regress-when-needed + redesign-status |
-| `.claude/rules/01-architecture.md` | Project + Architecture (two codegen crates) + ABI + Namespaces |
+| `.claude/rules/00-meta.md` | This file — meta + local-rules + regress-when-needed + current-status |
+| `.claude/rules/01-architecture.md` | Project + Architecture (single engine + rts-adapters) + ABI + Namespaces |
 | `.claude/rules/02-runtime.md` | HandleTable + tokio + GC (PolyValue scanner note) + State |
 | `.claude/rules/03-features.md` | New value model (PolyValue/Repr/shapes/ICs) + target semantics |
 | `.claude/rules/04-workflow.md` | Conventions + progress bar + issues + tests + benchmarks |
@@ -42,11 +42,18 @@ Read these files in order (path relative to repo root):
 - **RULE #0** (this) — read all files in order
 - **MANDATORY REQUIREMENT: local-rules.md** (below)
 - **MANDATORY RULE: REGRESS WHEN NECESSARY (EXPLICITLY)** (below)
-- **MANDATORY RULE: PRIMORDIAL-vs-REGISTRY DOCTRINE** (in `CLAUDE.md`; survives
-  the redesign — engine names only primordials, no builtins in the engine)
-- **MANDATORY RULE: FOLLOW THE REDESIGN DESIGN DOC** (below) — work is picked
-  from the migration phases of `docs/specs/rts-codegen-new-design.md`, not from a
-  fixture-grind roadmap
+- **MANDATORY RULE: PRIMORDIAL-vs-REGISTRY DOCTRINE** (in `CLAUDE.md`; engine
+  names only primordials, no builtins in the engine)
+- **MANDATORY RULE: DRIVE COVERAGE BY MEASURED CLUSTERS** (below) — the migration
+  is done; work is picked by measure → attack biggest failure cluster → re-measure,
+  with `docs/specs/rts-codegen-new-design.md` as the canonical architecture
+  reference
+- **MANDATORY RULE: READ THE EGUI/WEB ENGINE PLAN BEFORE TOUCHING IT** (in
+  `CLAUDE.md`) — before changing anything in `crates/rts-egui/` or any
+  egui/HTML/web-UI code, read the frozen plan in full
+  (`docs/specs/html-engine/rts-html-roadmap.md` F0–F5 +
+  `rts-html-north-star.md` + `arquitetura.md` + `docs/specs/egui-ui-crate-design.md`)
+  and follow its phases in order. STRICTLY MANDATORY — no exceptions.
 - **MANDATORY RULE: read_before_commit.sh GATE + FILE LAYOUT** (in `CLAUDE.md`;
   workflow detail in `04-workflow.md`) — run `bash read_before_commit.sh` before
   every engine commit; no engine source file > 500 lines (split into
@@ -57,32 +64,33 @@ The honesty + build floor (parity number stays real; no crash/hang as "pass";
 build must compile) never lifts. Adding/removing a meta-rule requires updating
 this list in the same commit.
 
-## MANDATORY RULE: FOLLOW THE REDESIGN DESIGN DOC
+## MANDATORY RULE: DRIVE COVERAGE BY MEASURED CLUSTERS
 
-The project is mid-redesign of its codegen engine (strangler-fig). The canonical
-plan is **`docs/specs/rts-codegen-new-design.md`** — read it before any engine
-work. The frozen old engine is `crates/rts-codegen-old/`; the active redesign is
-`crates/rts-codegen-new/`.
-
-There is no longer a topological fixture-fix roadmap (the old
-`ROADMAP-CORRECAO.md` and `MAINTENANCE.md` are deleted — that grind was the local
-max of a hardcoded approach on an unsound value model). Instead:
+The migration is over — there is ONE engine (`crates/rts-codegen-new/`, value
+model in `crates/rts-adapters/`). The phase roadmap (P0→P5) is done through the
+cutover. `docs/specs/rts-codegen-new-design.md` is still the canonical
+**architecture** reference (PolyValue / Repr lattice / shapes + data ICs /
+data-driven dispatch / single lowering); read it before any engine work. Note its
+file-path map is **stale** — it describes `value.rs`/`repr.rs`/`shape.rs`/`ic.rs`/
+`dispatch.rs`/`abi_gen.rs` under `rts-codegen-new/src/`, but the value model now
+lives in the `rts-adapters` crate, and there is no `abi_gen.rs` (the JIT symbol
+table is harvested in `crates/rts-codegen-new/src/adapter_symbols/`). Trust the
+tree on disk over the doc's paths.
 
 ### How to apply
 
-1. Pick work from the design doc's **migration phases (P0→P5, §12)**,
-   highest-leverage first. Do not jump ahead of a phase's prerequisites.
-2. Each phase runs the suite incrementally (not only at the end) and keeps an
-   A/B guard against the old engine where the doc specifies one.
-3. The honesty + build floor never lifts: no fixture deleted/disabled/hardcoded
-   to inflate the number; nothing that crashes/hangs committed as "pass"; build
-   must compile. At cutover (P5) parity must be ≥ the `v0.0-202606072107` tag,
+1. Work is picked by the loop **measure → attack the biggest failure cluster →
+   re-measure**. Measure with `bash measure_new.sh` (per-file pass/bail histogram)
+   and the cross-runtime report (`cross_runtime_report.json`). The biggest cluster
+   is the biggest lever; resolving it reveals the next.
+2. Run the suite incrementally (not only at the end).
+3. The honesty + build floor never lifts: no fixture deleted/disabled/hardcoded to
+   inflate the number; nothing that crashes/hangs committed as "pass"; build must
+   compile. The bar to re-clear is the deleted old engine's peak (`v0.0-202606072107`),
    measured real.
-4. If the design changes (new constraint discovered), update
+4. If the architecture changes (new constraint discovered), update
    `docs/specs/rts-codegen-new-design.md` in the same PR — never leave the spec
    stale.
-5. If the user asks to work out of phase order, confirm first, pointing out the
-   missing prerequisite.
 
 ## MANDATORY REQUIREMENT: local-rules.md
 
@@ -137,21 +145,23 @@ discipline here is not "never break a test" — it is "never break a test withou
 knowing and saying so". Explicit, justified regression is acceptable; invisible
 regression rots the project.
 
-## HONEST CURRENT STATUS — redesign in progress
+## HONEST CURRENT STATUS — cutover done, one engine
 
-Do not act on stale numbers. The "parity ≥90% push mode" / "94.3%" / "100%"
-framing is **dead**.
+Do not act on stale numbers or a stale architecture. The "94.3%" / "100%" /
+"70.7%" framings are **dead** — they were the deleted old engine.
 
-- The OLD engine reached 100% cross-runtime parity (372/372, tag
-  `v0.0-202606072107`, commit `27e16378`; TS suite 1719/1719). That was the
-  **local maximum of a hardcoded approach** on an unsound value model (a single
-  overloaded `i64` ABI slot + 4 compile-time side-tables), admitted as the wall
-  by the now-deleted `MAINTENANCE.md`.
-- The fixture set then grew 391 → **612** (harder cases) and parity is now
-  **70.7%** — the honest figure to quote.
-- A ground-up engine (`crates/rts-codegen-new/`) is being built **strangler-fig
-  behind the frozen `crates/rts-codegen-old/`**. Canonical plan:
-  `docs/specs/rts-codegen-new-design.md`.
+- **The cutover happened.** The old engine (`rts-codegen-old`) and `rts-mir` are
+  DELETED. `crates/rts-codegen-new/` is the only engine (value model in
+  `crates/rts-adapters/`); `rts run`/`compile`/`test`/`eval` run it. AOT works
+  (`rts compile` emits `.o` + native link). Canonical architecture:
+  `docs/specs/rts-codegen-new-design.md` (path map stale — see the rule above).
+- **Honest parity now: ~31.5% (192/609)** as of 2026-06-23
+  (`cross_runtime_report.json`, `status=pass`; rest ≈ 341 `rts_error`, 59
+  `rts_diverge`, 17 bun/node diverge). The engine has the sound value model and is
+  re-filling JS/TS coverage. **Always re-measure; never quote a remembered
+  number.**
+- The old engine once hit 100% (372/372, tag `v0.0-202606072107`) on an unsound
+  value model — that is the bar to re-clear, not a current figure.
 
 ### The floor (NEVER lifts, no mode suspends it)
 - **The parity number stays real.** No deleting, disabling, skipping,
@@ -161,13 +171,5 @@ framing is **dead**.
 - **No crashing / hanging code committed as "pass".** ACCESS_VIOLATION /
   verifier error / stack overflow / infinite loop = not passed.
 - **Build must compile.** A broken build still blocks merge.
-- **At cutover (design doc P5) parity must be ≥ the `v0.0-202606072107` tag,
-  measured real.** The redesign exists to clear the wall, not to trade the number
-  away.
-
-### Why the old fixture-grind ceremony is gone
-The remaining fixtures need **full feature completion on a sound value model**,
-not bounded patches against a hardcoded switchboard — a half-feature crashes
-rather than producing wrong-but-closer output, so there is no "regress X to pass
-Y" trade to police. The work is now organized by the design doc's phases; the
-honesty floor guards the only real risk (faking the metric) directly.
+- **The bar to re-clear is the deleted old engine's peak (`v0.0-202606072107`),
+  measured real.**

--- a/.claude/rules/01-architecture.md
+++ b/.claude/rules/01-architecture.md
@@ -6,10 +6,10 @@ RTS is a TypeScript-to-native compiler/runtime using Cranelift as codegen
 backend. Goal: compile TS/JS to native binaries with a minimal Rust runtime,
 shipped as a standalone toolchain (no external runtime support library).
 
-The runtime layer is organized around the `rts-engine::abi` + `SPECS` contract,
-with a module-graph pipeline + incremental cache. Two execution paths: JIT via
-`cranelift_jit::JITModule` (direct executable memory, `rts run`) and AOT via
-`cranelift_object::ObjectModule` (external linker, `rts compile`).
+The runtime layer is organized around the `rts-engine::abi` + `SPECS` contract.
+Two execution paths share the engine's lowering: JIT via `cranelift_jit::JITModule`
+(direct executable memory, `rts run`) and AOT via `cranelift_object::ObjectModule`
+(`rts compile` emits `.o` + native link).
 
 The canonical engine direction is `docs/specs/rts-codegen-new-design.md`.
 
@@ -19,8 +19,8 @@ Cargo workspace in `crates/`. `src/` is the facade of the `rts` bin
 (re-exports); real paths live under `crates/<crate>/src/`.
 
 > **PRIMORDIAL-vs-Registry doctrine + crate partition** (see `CLAUDE.md` §
-> "MANDATORY RULE: PRIMORDIAL-vs-REGISTRY DOCTRINE", which **survives the
-> redesign**). The engine may name ONLY the primordial classes
+> "MANDATORY RULE: PRIMORDIAL-vs-REGISTRY DOCTRINE"). The engine may name ONLY the
+> primordial classes
 > (String/Object/Array/Function/Promise/Boolean/Number/Error+subclasses);
 > everything else resolves via the Registry (`global_class_lookup`,
 > `instanceof_predicate`, member metadata), zero hardcoded mention, no builtins
@@ -28,13 +28,13 @@ Cargo workspace in `crates/`. `src/` is the facade of the `rts` bin
 > `rts-primitives` (primordials) + `rts-shared` (non-primordial universal) ←
 > `rts-std` ← `rts-runtime` facade. The ABI contract lives in `rts-engine::abi`.
 
-> **Two codegen crates during the strangler-fig migration.**
-> `crates/rts-codegen-old/` is the **frozen** old engine (dual HIR→MIR /
-> authoritative-AST path, overloaded-`i64` value model, 4.6k-LOC switchboard,
-> 1113 manual `add_fn!`) — still plugged into the bin/cli until cutover.
-> `crates/rts-codegen-new/` is the **active redesign** (single HIR→Cranelift
-> lowering, `PolyValue` NaN-box, shapes + data ICs, data-driven dispatch +
-> generated ABI). Canonical design: `docs/specs/rts-codegen-new-design.md`.
+> **One codegen engine (post-cutover).** The old engine (`rts-codegen-old`) and
+> `rts-mir` are DELETED. `crates/rts-codegen-new/` is the live engine (single
+> HIR→Cranelift lowering, no MIR tier); the value model lives in
+> `crates/rts-adapters/` (`PolyValue` NaN-box, Repr lattice, shapes + data ICs,
+> data-driven dispatch). Canonical design: `docs/specs/rts-codegen-new-design.md`
+> (its file-path map predates the `rts-adapters` extraction — trust the tree on
+> disk).
 
 ```
 crates/
@@ -44,46 +44,50 @@ crates/
   rts-engine/       — heap GC + ABI contract (abi:: SPECS, types, symbols,
                       signatures, Intrinsic, global_class, handles) + Registry/builder
   rts-hir/          — typed HIR (HirType I8..I128/F32/F64/Bool/Str/Handle/Array/Function/Class/Object/Any/Unknown)
-  rts-mir/          — SSA MIR — used ONLY by rts-codegen-old (frozen); the redesign deletes the MIR tier
-  rts-codegen-old/  — FROZEN old engine (dual MIR/AST codegen, switchboard, manual add_fn!)
-  rts-codegen-new/  — ACTIVE redesign (see module map below)
-    src/value.rs    — PolyValue (64-bit NaN-box) — Pilar 1
-    src/repr.rs     — Repr lattice (Int32/Float64/Bool/Ref/Tagged) + join — Pilar 2 (soundness core)
-    src/shape.rs    — hidden classes (Shape / transition tree / slot layout) — Pilar 4
-    src/ic.rs       — AOT-safe data inline caches (PropIcCell, uninit→mono→poly→mega) — Pilar 4
-    src/dispatch.rs — data-driven method resolution (Target / resolve_method) — Pilar 6
-    src/abi_gen.rs  — JIT symbol table derived from SPECS (SymbolEntry / jit_symbols) — Pilar 6
-    src/lower/      — single HIR → Cranelift lowering path (no MIR) — Pilar 5
-    src/pipeline.rs — shared JIT (run_jit) + AOT (compile_aot) — Pilar 5
+  rts-adapters/     — value model shared by the engine:
+    src/value/      — PolyValue (64-bit NaN-box)
+    src/repr.rs     — Repr lattice (Int32/Float64/Bool/Ref/Tagged) + join (soundness core)
+    src/shape.rs    — hidden classes (Shape / transition tree / slot layout)
+    src/ic.rs       — AOT-safe data inline caches (PropIcCell, uninit→mono→poly→mega)
+    src/dispatch.rs — data-driven method resolution (Target / resolve_method)
+    src/state.rs    — codegen state (reset between runs)
+  rts-codegen-new/  — THE engine (single HIR → Cranelift lowering, no MIR):
+    src/front/hir_lower — AST/HIR → lowering front
+    src/front/run/  — the lowering itself (expr/stmt/call/class/registry_call/…);
+                      module_jit.rs (JIT) + module_aot.rs (AOT object emission);
+                      shapes in front/run/class/
+    src/value/      — value-model emission + ABI signatures + marshalling
+    src/adapter_symbols/ — JIT symbol table harvested from Registry fn-ptrs
+                      (drift/coverage guard); replaces manual add_fn!
   rts-primitives/   — PRIMORDIAL classes
   rts-shared/       — non-primordial universal (math/num/collections/json/globals)
   rts-std/          — backend (io/net/tokio/console/promise impl)
   rts-runtime/      — facade ("rts" + "rts:<ns>" submodules); AOT staticlib
   rts-node/         — Node.js builtin shims (fs, os, path, process, crypto, util)
-  rts-linker/       — native link (system linker with object-backend fallback)
-  rts-cli/          — CLI (run, compile, apis, init, repl, eval, ir)
+  rts-egui/         — egui-based GUI / web-UI engine. Follow the FROZEN plan
+                      (docs/specs/html-engine/ + egui-ui-crate-design.md) — see the
+                      MANDATORY egui/web-plan rule in CLAUDE.md / 00-meta.md
+  rts-linker/       — native link (system linker with object-backend fallback);
+                      per-target runtime archives (cross-compile prep)
+  rts-cli/          — CLI (run, run-new, compile, apis, init, repl, eval, ir)
 
 src/                — bin facade (re-exports), runtime_objects.rs, main.rs
 ```
 
-### New-engine pipeline (the redesign — single path, no MIR)
+### Engine pipeline (single path, no MIR)
 
 ```
-TS → SWC → AST → HIR (rts-hir) → lower/ (HIR → Cranelift IR, one path) → Cranelift egraph → JIT/AOT
+TS → SWC → AST → HIR (rts-hir) → front/run (HIR → Cranelift IR, one path) → Cranelift egraph → JIT/AOT
 ```
 
-There is **no MIR tier and no dual AST/MIR codegen** in `rts-codegen-new`. The
-Cranelift egraph (`use_egraphs=true`) is the **sole** optimizer. The front-end
-does only what Cranelift cannot (JS semantics): coercions, the polymorphic `+`,
-box/unbox insertion (pure IR the egraph folds), shape/IC site emission,
-narrow-int wrap, exception edges. See `docs/specs/rts-codegen-new-design.md` §9.
+There is **no MIR tier and no dual AST/MIR codegen**. The Cranelift egraph
+(`use_egraphs=true`) is the **sole** optimizer. The front-end does only what
+Cranelift cannot (JS semantics): coercions, the polymorphic `+`, box/unbox
+insertion (pure IR the egraph folds), shape/IC site emission, narrow-int wrap,
+exception edges. See `docs/specs/rts-codegen-new-design.md` §9.
 
-`FnCtx.module` is `&mut dyn Module` to serve AOT and JIT without duplicating
-codegen (`compile_program` shared, `pipeline.rs`).
-
-> The frozen `rts-codegen-old/` still runs the old hybrid HIR→MIR→Cranelift
-> (default, gated by `RTS_USE_MIR`) with authoritative-AST fallback. That
-> machinery is NOT carried into the new engine.
+`FnCtx.module` is `&mut dyn Module` to serve AOT (`module_aot.rs`) and JIT
+(`module_jit.rs`) without duplicating the lowering.
 
 ## ABI (`rts-engine::abi`) — single contract
 
@@ -92,9 +96,10 @@ per-namespace `SPEC/MEMBERS/dispatch()`, no more `__rts_call_dispatch`.
 
 - `abi::SPECS` (`mod.rs`) — static slice with the `NamespaceSpec` of each
   registered namespace (`io`, `fs`, `gc`, `math`, `bigfloat`, …). Single source
-  consumed by codegen, runtime, JIT, and the `rts.d.ts` generator. In the new
-  engine, `abi_gen.rs` **derives** the JIT symbol table from these SPECS (no
-  manual `add_fn!`), with a build-time coverage assertion.
+  consumed by codegen, runtime, JIT, and the `rts.d.ts` generator. The JIT symbol
+  table is harvested from Registry fn-ptrs in
+  `crates/rts-codegen-new/src/adapter_symbols/` (drift/coverage guard, no manual
+  `add_fn!`).
 - `abi::lookup(qualified)` — resolves `"io.print"` → `&NamespaceMember` with
   symbol and signature.
 - `member.rs` — `NamespaceSpec`, `NamespaceMember` (static consts) and
@@ -109,10 +114,8 @@ per-namespace `SPEC/MEMBERS/dispatch()`, no more `__rts_call_dispatch`.
 - `symbols.rs` — convention `__RTS_<KIND>_<SCOPE>_<NS>_<NAME>` (e.g.
   `__RTS_FN_NS_IO_PRINT`). Macro `rts_sym!` generates symbols at compile time;
   `validate_symbol()` enforces uppercase ASCII.
-- `guards.rs` — `guard_for(expected, caller)`. In the old engine this is **dead
-  code** (zero production call sites; coercion is ad-hoc `TPL_COERCE_AUTO`). The
-  redesign makes coercion ONE real authority (design doc §7) — `guard_for` is
-  promoted to the real path or replaced in `rts-codegen-new`.
+- `guards.rs` — `guard_for(expected, caller)`. Coercion is ONE real authority in
+  the engine (design doc §7); the old ad-hoc `TPL_COERCE_AUTO` scattering is gone.
 
 The monomorphic numeric path still emits `call <symbol>` directly via Cranelift,
 no intermediaries; PolyValues cross the runtime boundary tagged-in/tagged-out for
@@ -236,10 +239,8 @@ global JS classes.
   AtomicBool, AtomicF64 (via AtomicU64 + bit-transmute), fences
 - `sync/` — `std::sync`: Mutex<i64>, RwLock<i64>, Once. Thread-local guards to
   cross extern "C" calls
-- `parallel/` — `rayon`: map/for_each/reduce + num_threads. Backed the OLD
-  engine's silent-parallelism passes (purity_pass, reduce_pass,
-  array_methods_pass; frozen in `rts-codegen-old`, not carried into the new
-  engine unless re-justified)
+- `parallel/` — `rayon`: map/for_each/reduce + num_threads (the old
+  silent-parallelism passes were deleted with the old engine)
 - `mem/` — size_of/align_of constants, swap_i64, drop/forget_handle
 - `num/` — checked/saturating/wrapping arith, bit ops (rotate,
   count_ones/zeros, leading/trailing_zeros, reverse_bits, swap_bytes), bitcast

--- a/.claude/rules/02-runtime.md
+++ b/.claude/rules/02-runtime.md
@@ -80,9 +80,9 @@ redesign's `PolyValue` (NaN-box) value model requires the scanner to also
 Two execution paths sharing the same Cranelift codegen:
 
 - **`rts run`**: compiles directly to executable memory via `JITModule`. No disk,
-  no external linker. All ABI symbols are registered in `JITBuilder::symbol` at
-  JIT module startup (the JIT emitter; in the new engine the symbol table is
-  derived from `SPECS` via `abi_gen.rs`, not hand-written `add_fn!`).
+  no external linker. ABI symbols are registered in `JITBuilder::symbol` at JIT
+  module startup; the symbol table is harvested from Registry fn-ptrs in
+  `crates/rts-codegen-new/src/adapter_symbols/`, not hand-written `add_fn!`.
 - **`rts compile`**: applies use-slicing, generates only the objects of the
   effectively used modules, produces the final binary.
 

--- a/.claude/rules/03-features.md
+++ b/.claude/rules/03-features.md
@@ -1,17 +1,17 @@
 # Engine model + target semantics — value model, async/Promise/Function
 
 > Canonical design: `docs/specs/rts-codegen-new-design.md`. This file describes
-> the NEW engine's value model and the JS/TS **semantics it must cover**. The old
-> HIR→MIR hybrid routing, silent-parallelism passes, and MIR-capability list are
-> **frozen in `crates/rts-codegen-old/`** and are NOT carried into the new engine
-> unless re-justified.
+> the engine's value model and the JS/TS **semantics it must cover**. The value
+> model lives in the `crates/rts-adapters/` crate (the design doc's `src/*.rs`
+> path map is stale — trust the tree on disk).
 
-## The new value model (no MIR, no dual codegen)
+## The value model (single engine, no MIR, no dual codegen)
 
 Single lowering path `HIR → Cranelift IR`; the Cranelift egraph
-(`use_egraphs=true`) is the **sole** optimizer. The four pillars:
+(`use_egraphs=true`) is the **sole** optimizer. The four pillars (in
+`rts-adapters`):
 
-- **PolyValue (`value.rs`, Pilar 1)** — one 64-bit NaN-boxed word. A bit-pattern
+- **PolyValue (`value/`, Pilar 1)** — one 64-bit NaN-boxed word. A bit-pattern
   with `(bits & BOX_BASE) == BOX_BASE` (`BOX_BASE = 0xFFF8_0000_0000_0000`, the
   negative-qNaN quadrant) is **boxed**; anything else is a genuine inline `f64`.
   Boxed = 3-bit tag (bits 50..48) + 48-bit payload: `INT32(1)`, `SINGLETON(2)`
@@ -32,7 +32,7 @@ Single lowering path `HIR → Cranelift IR`; the Cranelift egraph
   boundaries, never "tracked elsewhere" in a `HashSet`. Hard points (loop-header
   phis, catch bindings, destructuring, closure captures, generator state) all
   default conservatively to `Tagged` — correct, never silently wrong.
-- **Shapes + data ICs (`shape.rs` + `ic.rs`, Pilar 4)** — objects are
+- **Shapes + data ICs (`shape.rs` + `ic.rs` in rts-adapters, Pilar 4)** — objects are
   `{ shape_id, slots: [PolyValue; N] }`. Property access = compare `shape_id` +
   fixed-offset load (not hash lookup); construction walks a transition tree so
   same-key-sequence objects share a shape; method dispatch is **shape-keyed, not
@@ -52,9 +52,8 @@ Single lowering path `HIR → Cranelift IR`; the Cranelift egraph
 
 ## Target semantics the engine must cover
 
-The JS/TS surface the engine must support (same intent under both engines). The
-OLD engine implemented these on the overloaded-`i64` model; the NEW engine must
-reproduce the same **semantics** via PolyValue/shapes/ICs. The per-category list:
+The JS/TS surface the engine must support, via PolyValue/shapes/ICs. The
+per-category list:
 
 - Object/array literals.
 - Classes: constructor, method, this, extends, super(args), super.method(args),
@@ -82,14 +81,6 @@ reproduce the same **semantics** via PolyValue/shapes/ICs. The per-category list
   semantics for now, #217); Boolean class; parseInt with radix. Every
   non-primordial method resolves via the Registry/`MethodSpec` (no builtins in
   the engine).
-
-## Silent parallelism (Level-1) — OLD ENGINE ONLY (frozen)
-
-`crates/rts-codegen-old` has 3 passes that auto-rewrite common TS to `parallel.*`
-(`array_methods_pass`, `reduce_pass`, `purity_pass`; 96 `pure: true` fns). This is
-**frozen in the old engine and NOT carried into the new engine unless
-re-justified** against the redesign. (The standalone `silent-parallelism.md`
-spec was removed — old-engine-only.)
 
 ## async / Promise / Function (Promise-centric, #437)
 

--- a/.claude/rules/04-workflow.md
+++ b/.claude/rules/04-workflow.md
@@ -11,8 +11,8 @@
 - `rts.d.ts` contains only `declare module "rts"` — generated from `abi::SPECS`,
   CI lints the committed file against the generator
 - Build is via `cargo` directly — `xtask` was removed. The project is a crate
-  workspace in `crates/` (incl. the frozen `rts-codegen-old` and the active
-  `rts-codegen-new`); `cargo test --workspace` covers all crates in one run
+  workspace in `crates/` (the engine is `rts-codegen-new` + the `rts-adapters`
+  value model); `cargo test --workspace` covers all crates in one run
 
 ## General design rules
 
@@ -108,9 +108,9 @@ bash read_before_commit.sh --no-build # fast static-only pass while iterating
 It enforces the binding rules as a commit gate:
 
 - **HARD (exit non-zero — never commit):** forbidden crate dep / direct `use` of
-  `rts-shared`/`rts-std`/`rts-codegen-old`; broken `cargo build`. `rts-shared`
-  and `rts-std` are **NOT** native/primitive — the engine reaches the runtime
-  ONLY through the `rts-runtime` facade and names ONLY primordials.
+  `rts-shared`/`rts-std`; broken `cargo build`. `rts-shared` and `rts-std` are
+  **NOT** native/primitive — the engine reaches the runtime ONLY through the
+  `rts-runtime` facade and names ONLY primordials.
 - **REVIEW (read every entry; the list must shrink, never grow):** a
   non-primordial class named in codegen (`Map`/`Set`/`Date`/`Symbol`/… — must
   resolve via the Registry, never a hardcoded per-class path; current draining
@@ -268,15 +268,16 @@ powershell.exe -ExecutionPolicy Bypass -File bench/benchmark.ps1
 
 ## Status
 
-The OLD engine hit 100% cross-runtime parity (372/372, tag `v0.0-202606072107`)
-and TS suite 1719/1719 — the local max of a hardcoded approach. The fixture set
-then grew to 612 (harder cases) and parity is now **70.7%**; the new engine
-(`crates/rts-codegen-new/`) is being built strangler-fig to clear the real wall.
-See `00-meta.md` "HONEST CURRENT STATUS" and
-`docs/specs/rts-codegen-new-design.md`. Do not quote the old 94.3%/100%/push-mode
-framing.
+The cutover happened: `rts-codegen-new` (value model in `rts-adapters`) is the
+only engine; the old engine + `rts-mir` are deleted. Honest cross-runtime parity
+is **~31.5% (192/609)** as of 2026-06-23 (`cross_runtime_report.json`) — the
+engine has the sound value model and is re-filling coverage. The deleted old
+engine's 100% (372/372, tag `v0.0-202606072107`) is the bar to re-clear. Always
+re-measure (`measure_new.sh` / cross-runtime report); never quote a remembered
+number or the old 94.3%/100%/70.7% framings. See `00-meta.md` "HONEST CURRENT
+STATUS".
 
-Heavy issues still open (some now in-scope for redesign phases):
+Heavy issues still open:
 
 - **#195** mutable closures — env-record refactor; blocked by #90 (block params).
 - **#207** real async/await event loop — Promise refactor.

--- a/.claude/rules/05-codegen-notes.md
+++ b/.claude/rules/05-codegen-notes.md
@@ -1,23 +1,21 @@
-# Codegen notes (new engine) + artifact layout + docs
+# Codegen notes (engine) + artifact layout + docs
 
-> Canonical design: `docs/specs/rts-codegen-new-design.md`. The new engine's
-> codegen lives in `crates/rts-codegen-new/src/lower/` (single HIR → Cranelift
-> path). The old `mir_codegen/` + dual AST path is **frozen in
-> `crates/rts-codegen-old/`** and is deleted at cutover.
+> Canonical design: `docs/specs/rts-codegen-new-design.md`. The engine's lowering
+> lives in `crates/rts-codegen-new/src/front/run/` (single HIR → Cranelift path);
+> the value model is in `crates/rts-adapters/`. There is no MIR tier and no dual
+> AST path.
 
 ## One optimizer tier — the Cranelift egraph
 
-The new engine has **no second optimizer tier**. The single lowering path
+The engine has **no second optimizer tier**. The single lowering path
 `HIR → Cranelift IR` feeds the Cranelift egraph (`use_egraphs=true`), which is the
 **sole** optimizer: const-fold, CSE, DCE, FMA, strength reduction, intraprocedural
-inlining. The old `rts-mir` passes (`fold`/`fma`/`cse`/`dce`/`narrow`/`inline`)
-**re-did exactly what the egraph already does** — the old `fold.rs` even said so
-about float folding — and are deleted with the MIR tier (design doc §2.5/§9).
+inlining (the deleted MIR tier re-did exactly what the egraph already does).
 
 The front-end's only job is what Cranelift genuinely cannot do (JS semantics):
 `ToNumber`/`ToString`/`ToBoolean` coercions, the polymorphic `+` resolution,
 box/unbox insertion, shape/IC site emission, narrow-int (i8/u8/i16/u16) wrap
-semantics (what `narrow.rs` did), and exception edges. Everything else is the
+semantics, and exception edges. Everything else is the
 egraph's.
 
 ### box/unbox as pure Cranelift IR (the key coupling)
@@ -48,13 +46,12 @@ would survive.
 - **First-class function pointers**: an ident resolving to a user fn materializes
   `func_addr`; call via local/param ident does `call_indirect`.
 - **Imm forms / MemFlags::trusted / f64 mod via libc fmod / constants as
-  properties** — the front-end emits these; the egraph cleans up. (In the old
-  engine some were hand-rolled MIR passes; in the new engine they fall out of the
-  egraph.)
-- **Data-driven dispatch + generated ABI**: every non-primordial method is a
+  properties** — the front-end emits these; the egraph cleans up.
+- **Data-driven dispatch + harvested ABI**: every non-primordial method is a
   `MethodSpec` resolved by one `resolve_method` path; the JIT symbol table is
-  derived from `SPECS` (`abi_gen.rs`) with a build-time coverage assert — killing
-  the link-OK/runtime-SIGILL class of bug (design doc §10).
+  harvested from Registry fn-ptrs in `crates/rts-codegen-new/src/adapter_symbols/`
+  (drift/coverage guard) — killing the link-OK/runtime-SIGILL class of bug (design
+  doc §10).
 
 ## Inline assembly (`std::arch::asm!`) — available technique
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,52 @@ This is the first and most important rule. It governs all others.
   folder/subfolder); the engine names ONLY primordials —
   `rts-shared`/`rts-std` are **NOT** native/primitive and a direct mention is a
   regression
+- **MANDATORY RULE: READ THE EGUI/WEB ENGINE PLAN BEFORE TOUCHING IT** —
+  before changing ANYTHING in the egui / HTML / web UI engine (`crates/rts-egui/`,
+  the `.ts` UI lib over it, or any web/HTML-engine code) you MUST first read the
+  canonical plan in full: `docs/specs/html-engine/rts-html-roadmap.md` (roadmap
+  F0–F5) + `docs/specs/html-engine/rts-html-north-star.md` (frozen vision) +
+  `docs/specs/html-engine/arquitetura.md` + `docs/specs/egui-ui-crate-design.md`.
+  Then pick work from the roadmap's phases in order. **STRICTLY MANDATORY — no
+  exceptions.** See the dedicated section below.
 
 Keep this list in sync with the sections below. The honesty + build floor
 (parity number stays real, no crash/hang committed as "pass", build must
 compile) never lifts under any mode.
+
+## MANDATORY RULE: READ THE EGUI/WEB ENGINE PLAN BEFORE TOUCHING IT
+
+**STRICTLY MANDATORY — no exceptions.** The egui / HTML / web UI engine is built
+to a frozen plan. Before you change ANYTHING in it — `crates/rts-egui/`, the
+high-level `.ts` UI library layered over it, or any web/HTML-engine code — you
+**MUST FIRST read the canonical plan in full**:
+
+- `docs/specs/html-engine/rts-html-roadmap.md` — operational roadmap **F0–F5**
+  (the phase order you pick work from)
+- `docs/specs/html-engine/rts-html-north-star.md` — the **frozen** north-star
+  vision (do not redesign it; it is congelado)
+- `docs/specs/html-engine/arquitetura.md` — architecture decision (evolve the
+  light engine in-place; egui-layout by default, absolute paint only surgically
+  in F4)
+- `docs/specs/egui-ui-crate-design.md` — the `rts-egui` crate design
+
+### How to apply
+
+1. Reading those docs end-to-end is a **precondition** to any egui/web edit — not
+   optional, do not skip, do not assume content, do not start coding from memory.
+2. Pick work from the roadmap's phases **in order** (F0→F5), highest-leverage
+   first; do not jump ahead of a phase's prerequisites.
+3. The north-star is **frozen**. If you believe the plan must change, propose the
+   change to the doc FIRST and get confirmation — never silently diverge from it
+   in code.
+4. If the plan is stale (code no longer matches), update the plan doc in the same
+   PR — never leave a lying plan in effect.
+5. If a user instruction conflicts with the plan, ask for confirmation before
+   violating it. Do not decide alone.
+
+This exists because the web/egui engine must follow ONE agreed plan across
+contributors — an agent improvising its own UI architecture is the failure mode
+this rule prevents.
 
 ## MANDATORY REQUIREMENT: local-rules.md
 
@@ -140,39 +182,49 @@ migration), it is correct to **shift focus and implement the blocker first**,
 then return to the main feature. State the shift explicitly in the commit/PR.
 Keep the change modest and incremental — small focused modules, gate green.
 
-## HONEST CURRENT STATUS — engine redesign in progress (strangler-fig)
+## HONEST CURRENT STATUS — new engine is LIVE (cutover already happened)
 
-The project is mid-redesign of its codegen engine. Read this so you do not act on
-stale numbers or a stale architecture.
+Read this so you do not act on stale numbers or a stale architecture. **The
+strangler-fig migration is over: the new engine is the only engine.**
+
+**The old engine is DELETED.** `crates/rts-codegen-old/` and the `rts-mir/` crate
+no longer exist (not in the workspace, not on disk). `rts run` / `rts compile` /
+`rts test` / `rts eval` all execute through the **new engine**
+(`crates/rts-codegen-new/`, value model in `crates/rts-adapters/`). The
+`run-new` command and `measure_new.sh` still exist as the campaign harness from
+the migration; `run`/`run-new` are now the same engine. The old overloaded-`i64`
+value model, the 4.6k-LOC switchboard, and the 1113 manual `add_fn!` are gone.
 
 **The truth about the 100%.** On 2026-06-06/07 RTS reached **100% cross-runtime
-parity** (372/372, 0 divergences; TS suite 1719/1719), tag `v0.0-202606072107`,
-commit `27e16378`. Factual and git-verifiable — **but** it was the *local maximum
-of a hardcoded approach* on the OLD engine, not validation of its design. That
-engine's value model (a single `i64` ABI slot overloaded to mean
-int/handle/boxed-float/string/sentinel, with the type tag smeared across four
-compile-time side-tables) was admitted to be the wall by the old engine's own
-(now-deleted) `MAINTENANCE.md`. It is **unsound by construction** and does not
-scale.
+parity** (372/372; TS suite 1719/1719), tag `v0.0-202606072107`, commit
+`27e16378` — on the OLD engine. That was the *local maximum of a hardcoded
+approach* on an unsound value model, not validation of its design. It is the bar
+the new engine must re-clear, not a number to quote as current.
 
-**The current number.** After the 100% the fixture set grew 391 → 612 (harder
-cases) and parity is now **70.7%**. That is the honest figure to quote. Do not
-cite "94.3%" or "100%/push mode" — those framings are dead.
+**The current number (honest, measured).** The new engine's cross-runtime parity
+is **~31.5% (192/609)** as of 2026-06-23 (`cross_runtime_report.json`,
+`status=pass`; the rest: ~341 `rts_error`, ~59 `rts_diverge`, ~17 bun/node
+diverge). The new engine has the sound value model but is still **filling JS/TS
+coverage back in** — the number is below the old engine's peak because the
+fixture set grew to 609 harder cases AND the new engine re-implements semantics
+from scratch. **Do not quote 70.7%, 94.3%, or 100% — those are the old engine.**
+Re-measure with the cross-runtime report; do not cite a remembered figure.
 
-**The redesign.** A ground-up engine is being built **strangler-fig style behind
-the frozen old one**. Frozen old engine: `crates/rts-codegen-old/` (still plugged
-into the bin/cli). Active redesign: `crates/rts-codegen-new/`. The canonical plan
-is `docs/specs/rts-codegen-new-design.md` — **read it before any engine work**.
-Its thesis: *prove-monomorphic-and-unbox where the type system can (keep the
-winning numeric path); fall to ONE honest in-value tagged representation
-(`PolyValue`, a 64-bit NaN-box) + hidden-class shapes + AOT-safe data inline-
-caches where it can't.*
+**The thesis (unchanged).** *Prove-monomorphic-and-unbox where the type system
+can (keep the winning numeric path); fall to ONE honest in-value tagged
+representation (`PolyValue`, a 64-bit NaN-box) + hidden-class shapes + AOT-safe
+data inline-caches where it can't.* Canonical plan still
+`docs/specs/rts-codegen-new-design.md` — **read it before any engine work**
+(note: its file-path map is partly stale post-cutover; the value model now lives
+in the `rts-adapters` crate, not `rts-codegen-new/src/*.rs`).
 
 ### How work is picked now
-Follow the design doc's **migration phases (P0→P5)**, highest-leverage first, not
-a fixture-by-fixture grind. Large multi-crate work and the deferred epics (#195
-mutable closures, #207 async event loop, #216/#222 Symbol, #218 Proxy, #219
-BigInt, #223 dynamic import) are in scope where a phase calls for them.
+Drive coverage up by attacking the largest failure cluster from the cross-runtime
+/ `measure_new.sh` histogram (measure → attack biggest cluster → re-measure),
+highest-leverage first. The deferred epics (#195 mutable closures — partly landed
+via mutable-local-capture, #207 async event loop, #216/#222 Symbol, #218 Proxy —
+get/set/delete traps landed, #219 BigInt, #223 dynamic import) are in scope where
+the cluster calls for them.
 
 ### The honesty + build floor (NEVER lifts, no mode suspends it)
 - **The parity number stays real.** No deleting, disabling, skipping,
@@ -256,24 +308,22 @@ syntactic form?**
   engine": a primitive's *implementation* still lives in `rts-primitives`; the
   engine just has a more-direct lowering for its native syntax.
 
-### How the redesign enforces this
-In the new engine the doctrine is no longer maintained by *draining* hardcoded
-arms one at a time (the old-engine grind). It is the default: every non-primordial
-method is a `MethodSpec` metadata entry resolved through ONE generic path
-(`crates/rts-codegen-new/src/dispatch.rs`, `resolve_method`), and the JIT symbol
-table is **derived from `SPECS`** (`abi_gen.rs`) with a build-time coverage assert
-— so a direct mention of a non-primordial class in the new engine is simply not
-how dispatch is written. See design doc §10. The old engine
-(`rts-codegen-old/`) still carries the hardcoded switchboard (`calls/mod.rs`
-~4.6k LOC) and 1113 manual `add_fn!`; those are frozen and deleted at cutover,
-not patched further.
+### How the engine enforces this
+The doctrine is the default in the engine: every non-primordial method is a
+`MethodSpec` metadata entry resolved through ONE generic path
+(`crates/rts-codegen-new/src/front/run/registry_call.rs` +
+`crates/rts-adapters/src/dispatch.rs`, `resolve_method`), and the JIT symbol
+table is **derived from `SPECS`** (the `adapter_symbols/` module, harvested from
+Registry fn-ptrs with a drift/coverage guard) — so a direct mention of a
+non-primordial class in the engine is simply not how dispatch is written. See
+design doc §10. (The old engine's hardcoded switchboard and 1113 manual
+`add_fn!` are deleted, not patched further.)
 
-### Runtime layer (still valid for both engines)
+### Runtime layer
 The primordial classes live in the `rts-primitives` crate (depends only on
 `rts-engine`, wasm-safe); non-primordial universal surface in `rts-shared`;
 backend in `rts-std`; `rts-runtime` is the thin facade (`pub use` of all four).
-This partition is unchanged by the engine redesign — both `rts-codegen-old` and
-`rts-codegen-new` read the runtime through the facade.
+The engine reads the runtime through this facade.
 
 ### ANTI-HARDCODE — how to add a feature WITHOUT naming a non-primordial (binding)
 
@@ -319,10 +369,10 @@ RTS is a TypeScript-to-native compiler/runtime using Cranelift as codegen
 backend. Goal: compile TS/JS to native binaries with a minimal Rust runtime,
 shipped as a standalone toolchain (no external runtime support library).
 
-Runtime is organized around the ABI `SPECS` contract (in `rts-engine::abi`), with
-a module-graph pipeline + incremental cache. Two execution paths: JIT via
-`cranelift_jit::JITModule` (`rts run`, direct executable memory) and AOT via
-`cranelift_object::ObjectModule` (`rts compile`, external linker).
+Runtime is organized around the ABI `SPECS` contract (in `rts-engine::abi`). Two
+execution paths share the engine's lowering: JIT via `cranelift_jit::JITModule`
+(`rts run`, direct executable memory) and AOT via `cranelift_object::ObjectModule`
+(`rts compile`, emits `.o` + native link).
 
 The canonical direction for the engine is `docs/specs/rts-codegen-new-design.md`.
 
@@ -332,23 +382,21 @@ Cargo workspace in `crates/`. `src/` is the `rts` bin facade (re-exports);
 `src/main.rs` calls into the codegen + `rts_cli::cli::dispatch`. Real paths live
 under `crates/<crate>/src/`.
 
-> **Two codegen crates during the strangler-fig migration.**
-> `crates/rts-codegen-old/` is the **frozen** old engine (HIR→MIR→Cranelift dual
-> path + AST fallback, the overloaded-`i64` value model, the 4.6k-LOC
-> switchboard, 1113 manual `add_fn!`) — still plugged into the bin/cli until
-> cutover. `crates/rts-codegen-new/` is the **active redesign** (single
-> HIR→Cranelift lowering, `PolyValue` NaN-box value model, shapes + data ICs,
-> data-driven dispatch + generated ABI). Canonical design:
-> `docs/specs/rts-codegen-new-design.md`.
+> **One codegen engine (post-cutover).** The old engine (`rts-codegen-old/`) and
+> the `rts-mir/` crate are **DELETED**. `crates/rts-codegen-new/` is the live
+> engine (single HIR→Cranelift lowering, no MIR tier); the value model lives in
+> `crates/rts-adapters/` (`PolyValue` NaN-box, Repr lattice, shapes + data ICs,
+> data-driven dispatch). Canonical design: `docs/specs/rts-codegen-new-design.md`
+> (its file-path map predates the `rts-adapters` extraction — trust the tree on
+> disk over the doc's paths).
 
-> **Runtime layer partition:** the old monolith is split into an acyclic graph
-> `rts-engine` (heap GC + ABI vocab/SPECS + Registry/builder + collector
-> contract) ← `rts-primitives` (PRIMORDIAL classes — see the Primordial doctrine
-> above) + `rts-shared` (universal non-primordial: math/num/collections(Map/Set)/
-> json/globals…) ← `rts-std` (backend: io/net/tokio/console/promise impl) ←
-> `rts-runtime` (thin facade, `pub use` of all four; AOT staticlib). The codegen
-> reads everything via the `rts-runtime` facade. This partition is shared by both
-> codegen crates and is **not** changed by the engine redesign.
+> **Runtime layer partition:** acyclic graph `rts-engine` (heap GC + ABI
+> vocab/SPECS + Registry/builder + collector contract) ← `rts-primitives`
+> (PRIMORDIAL classes — see the Primordial doctrine above) + `rts-shared`
+> (universal non-primordial: math/num/collections(Map/Set)/json/globals…) ←
+> `rts-std` (backend: io/net/tokio/console/promise impl) ← `rts-runtime` (thin
+> facade, `pub use` of all four; AOT staticlib). The engine reads everything via
+> the `rts-runtime` facade.
 
 ```
 crates/
@@ -359,18 +407,18 @@ crates/
                       signatures, Intrinsic, global_class, handles), Registry
   rts-hir/          — typed HIR (I8..I128/F32/F64/Bool/Str/Handle/Array/Function/
                       Class/Object/Any/Unknown)
-  rts-mir/          — SSA MIR — used ONLY by rts-codegen-old (frozen); the
-                      redesign deletes the MIR tier
-  rts-codegen-old/  — FROZEN old engine (dual HIR→MIR / AST path, switchboard)
-  rts-codegen-new/  — ACTIVE redesign; see module map below + design doc
-    src/value.rs    — PolyValue (64-bit NaN-box; the one in-value tagged repr)
-    src/repr.rs     — Repr lattice (Int32/Float64/Bool/Ref/Tagged) + join — soundness core
-    src/shape.rs    — hidden classes (Shape / transition tree / slot layout)
-    src/ic.rs       — AOT-safe data inline caches (PropIcCell, uninit→mono→poly→mega)
-    src/dispatch.rs — data-driven method resolution (Target / resolve_method via SPECS)
-    src/abi_gen.rs  — JIT symbol table DERIVED from SPECS (kills manual add_fn!)
-    src/lower/      — single HIR → Cranelift lowering path (no MIR)
-    src/pipeline.rs — shared JIT (run_jit) + AOT (compile_aot)
+  rts-adapters/     — value model shared by the engine: value/ (PolyValue 64-bit
+                      NaN-box), repr.rs (Repr lattice Int32/Float64/Bool/Ref/Tagged
+                      + join), shape.rs (hidden classes), ic.rs (AOT-safe data
+                      inline caches), dispatch.rs (data-driven resolve_method),
+                      state.rs (codegen state, reset between runs)
+  rts-codegen-new/  — THE engine (single HIR → Cranelift lowering, no MIR). Map:
+    src/value/         — value-model emission + ABI signatures + marshalling
+    src/front/hir_lower — AST/HIR → lowering front
+    src/front/run/     — the lowering itself (expr/stmt/call/class/registry/…),
+                         module_jit.rs (JIT) + module_aot.rs (AOT object emission)
+    src/adapter_symbols/ — JIT symbol table harvested from Registry fn-ptrs
+                         (drift/coverage guard); replaces manual add_fn!
   rts-primitives/   — PRIMORDIAL classes (String/Object/Array/Function/Promise/
                       Boolean/Number/Error+subclasses)
   rts-shared/       — non-primordial universal (math/num/collections/json/globals)
@@ -381,30 +429,31 @@ crates/
                       engine HandleTable (ArrayBuffer/BigInt/External). 159 N-API
                       fns. Loader `__RTS_FN_NS_NAPI_LOAD_ADDON`; re-exported by
                       rts-runtime as `napi`. Spec: docs/specs/napi-implementation.md
-  rts-linker/       — native link (system linker + object backend fallback)
-  rts-cli/          — CLI (run, compile, apis, init, repl, eval, ir)
+  rts-egui/         — egui-based GUI / web-UI engine. Follow the FROZEN plan
+                      (docs/specs/html-engine/ + egui-ui-crate-design.md) — see the
+                      MANDATORY egui/web-plan rule at the top of this file
+  rts-linker/       — native link (system linker + object backend fallback);
+                      per-target runtime archives (cross-compile prep, #1724)
+  rts-cli/          — CLI (run, run-new, compile, apis, init, repl, eval, ir)
 
 src/                — bin facade (re-exports), runtime_objects.rs, main.rs
 ```
 
-### New-engine pipeline (the redesign, single path)
+### Engine pipeline (single path, no MIR)
 
 ```
-TS → SWC → AST → HIR → lower/ (HIR → Cranelift IR, one path) → Cranelift egraph → JIT/AOT
+TS → SWC → AST → HIR → front/run (HIR → Cranelift IR, one path) → Cranelift egraph → JIT/AOT
 ```
 
-There is **no MIR tier and no dual AST/MIR codegen** in the new engine. The
-Cranelift egraph (`use_egraphs=true`) is the **sole** optimizer (const-fold, CSE,
-DCE, FMA, strength reduction, intraprocedural inlining). The front-end only does
-what Cranelift genuinely cannot (JS semantics): `ToNumber`/`ToString`/`ToBoolean`
+There is **no MIR tier and no dual AST/MIR codegen**. The Cranelift egraph
+(`use_egraphs=true`) is the **sole** optimizer (const-fold, CSE, DCE, FMA,
+strength reduction, intraprocedural inlining). The front-end only does what
+Cranelift genuinely cannot (JS semantics): `ToNumber`/`ToString`/`ToBoolean`
 coercions, the polymorphic `+`, box/unbox insertion (as pure IR the egraph
-folds), shape/IC site emission, narrow-int wrap semantics, exception edges. Both
-AOT/JIT share `compile_program`/`pipeline.rs`; `FnCtx.module` is
+folds), shape/IC site emission, narrow-int wrap semantics, exception edges. AOT
+(`module_aot.rs`, `rts compile` emits `.o` + native link) and JIT
+(`module_jit.rs`, `rts run`) share the lowering; `FnCtx.module` is
 `&mut dyn Module`. See design doc §9 (Pilar 5) and the per-pillar sections.
-
-> The frozen `rts-codegen-old/` still runs the old hybrid `HIR→MIR→Cranelift`
-> (default) with silent AST fallback, gated by `RTS_USE_MIR`. That machinery is
-> NOT carried into the new engine.
 
 ## ABI (`rts-engine::abi`) — single contract
 
@@ -431,12 +480,9 @@ per-namespace `SPEC/MEMBERS/dispatch()`, no `__rts_call_dispatch`.
 - `symbols.rs` — convention `__RTS_<KIND>_<SCOPE>_<NS>_<NAME>` (e.g.
   `__RTS_FN_NS_IO_PRINT`, `__RTS_FN_GL_NUMBER_IS_NAN`). Macro `rts_sym!`;
   `validate_symbol()` enforces uppercase ASCII.
-- `guards.rs` — `guard_for(expected, caller)`. NOTE: in the old engine this is
-  **dead code** (zero production call sites; coercion is ad-hoc `TPL_COERCE_AUTO`
-  scattered across files). The redesign makes coercion ONE real authority (design
-  doc §7, Pilar 3) — `guard_for` is either promoted to the real path or replaced
-  by an equivalent in `rts-codegen-new`; the scattered ad-hoc coercion does not
-  survive.
+- `guards.rs` — `guard_for(expected, caller)`. The engine makes coercion ONE real
+  authority (design doc §7, Pilar 3); the old ad-hoc `TPL_COERCE_AUTO` scattering
+  was removed with the old engine.
 
 ### Machine ABI — typed extern "C", no dispatch
 
@@ -548,11 +594,10 @@ No central state system — each namespace owns its own via `Arc<Mutex<T>>`
 
 ## Language capabilities (target semantics the engine must cover)
 
-This is the JS/TS surface the engine must support — the same intent under both
-engines. The OLD engine implemented these on the overloaded-`i64` value model
-(per-feature notes in parentheses describe its mechanism, frozen). The NEW engine
-must reproduce the same **semantics** through the `PolyValue`/shapes/IC model;
-see the design doc's coverage plan and `.claude/rules/03-features.md`.
+This is the JS/TS surface the engine must support. Some parenthetical notes below
+describe how the deleted old engine implemented a feature — historical context
+only. The engine reproduces these **semantics** through the `PolyValue`/shapes/IC
+model; see the design doc's coverage plan and `.claude/rules/03-features.md`.
 
 - Object/array literals (old: `collections.map_*`/`vec_*`; new: shapes + slots).
 - Classes: constructor, method, this, extends, super(args), super.method,
@@ -581,15 +626,6 @@ source, keep_alive }`. `invoke_n` trampoline transmutes to
 `extern "C" fn(i64...) -> i64`. Known limits: thisArg ignored in `.call`,
 no `fn.prototype`/`arguments`, no async in `new Function`. Spec:
 `docs/specs/async-promise-function.md`.
-
-### Silent parallelism (Level-1) — OLD ENGINE ONLY
-
-3 codegen passes in `rts-codegen-old` rewrite common TS to `parallel.*`
-automatically (`array_methods_pass`, `reduce_pass`, `purity_pass`). This
-machinery is **frozen in the old engine and is NOT carried into the new engine
-unless re-justified** against the redesign. (The standalone
-`silent-parallelism.md` spec was removed — old-engine-only, not a guide for the
-new engine.)
 
 ## Codegen optimizations (new engine)
 
@@ -774,17 +810,13 @@ metadata).
   release/<project_name>   — only on rts compile
 ```
 
-## Status
+## Open heavy items
 
-On the OLD engine the TS suite hit 1719/1719 and cross-runtime parity hit 100%
-(372/372) at tag `v0.0-202606072107` — a local max of a hardcoded approach (see
-"HONEST CURRENT STATUS" above). The fixture set then grew to **612** and parity
-is now **70.7%**; the `rts-codegen-new` redesign is being built strangler-fig to
-clear the real wall (the unsound value model), not to chase the next plateau of
-hacks. Heavy items still open (some now in-scope for redesign phases): #195
-mutable closures, #207 real async event loop, #216/#222 Symbol, #217 weak
-WeakMap/Set + FinalizationRegistry, #218 Proxy, #219 BigInt, #223 dynamic import,
-#301 var hoisting, #304 toString/valueOf coercion.
+(Status + parity number: see "HONEST CURRENT STATUS" above.) Still open: #195
+mutable closures (partly landed), #207 real async event loop, #216/#222 Symbol,
+#217 weak WeakMap/Set + FinalizationRegistry, #218 Proxy (get/set/delete traps
+landed), #219 BigInt, #223 dynamic import, #301 var hoisting, #304 toString/valueOf
+coercion.
 
 ## Docs
 


### PR DESCRIPTION
## Contexto

Ao estudar as mudanças recentes (incl. #1724 do @drysius) descobri que o **estado real do projeto avançou além dos docs**: o cutover do motor já aconteceu, mas CLAUDE.md e `.claude/rules/` ainda descreviam o mundo "strangler-fig em andamento, dois motores, paridade 70.7%".

## Mudanças

**Sincroniza docs ao estado pós-cutover:**
- `rts-codegen-old` + `rts-mir` **deletados** — motor novo é o único; `rts run`/`compile`/`test`/`eval` rodam por ele. Sem two-engines, sem MIR tier, sem fallback AST.
- value-model extraído p/ crate novo **`rts-adapters`** (`value/`/`repr.rs`/`shape.rs`/`ic.rs`/`dispatch.rs`/`state.rs`); o path-map do design doc ficou stale (avisos adicionados).
- **AOT funciona** no motor novo (`rts compile` emite `.o` + link nativo).
- paridade honesta: **~31.5% (192/609)** em 2026-06-23 — removidas citações de 70.7%/94.3%/100% (motor antigo); instrução p/ sempre re-medir.
- removido o que não existe mais: two-codegen-crates, silent-parallelism, `abi_gen.rs` (agora harvest em `adapter_symbols/`), `src/lower/`, `## Status` redundante. Crate map corrigido (`rts-adapters` + `rts-egui`); pipeline single-path.

**Nova regra estritamente obrigatória:** `READ THE EGUI/WEB ENGINE PLAN BEFORE TOUCHING IT` — antes de mexer em `rts-egui`/HTML/web-UI, ler em full `docs/specs/html-engine/` (roadmap F0–F5 + north-star congelado + arquitetura) + `egui-ui-crate-design.md` e seguir as fases na ordem. Adicionada no topo do CLAUDE.md e na lista canônica de meta-rules do `00-meta.md`.

## Verificação
- `cargo build --release` compila (exit 0).
- Varredura de referências stale: as únicas menções restantes a "old engine"/"70.7%" são afirmações de deleção ou avisos para **não** citar os números antigos.

Só docs/regras — zero mudança de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)