### PR TITLE
fix(egui): fecha o DOM no nível P1 — sentinela -1 + entidades completas

### DIFF
--- a/crates/rts-egui/src/html.rs
+++ b/crates/rts-egui/src/html.rs
@@ -73,11 +73,105 @@ pub(crate) fn tokenize(html: &str) -> Vec<Token> {
     tokens
 }
 
-/// Decodifica as 3 entidades básicas do P1. Substituímos as três de uma vez, sem
-/// risco de dupla-decodificação. `pub(crate)` — reusada por `dom.rs` ao decodar
+/// Decodifica entidades HTML num único passe (sem `.replace` encadeado, que não
+/// pega as numéricas e arrisca dupla-decodificação). Cobre as nomeadas comuns
+/// (`&lt; &gt; &amp; &quot; &apos; &nbsp;`) e as numéricas decimais (`&#NN;`) e
+/// hex (`&#xNN;`). Uma entidade desconhecida ou malformada é deixada literal —
+/// robustez de parser real. `pub(crate)` — reusada por `dom.rs` ao decodar
 /// valores de atributo.
 pub(crate) fn decode_entities(s: &str) -> String {
-    s.replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
+    // Atalho: sem `&`, nada a decodificar (caso comum).
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    while i < s.len() {
+        if bytes[i] != b'&' {
+            // Copia o char inteiro (UTF-8-safe).
+            let ch = s[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+        // Acha o `;` de fechamento numa janela curta (entidades são curtas).
+        match s[i + 1..].find(';').filter(|&rel| rel <= 10) {
+            Some(rel) => {
+                let body = &s[i + 1..i + 1 + rel];
+                if let Some(ch) = decode_one_entity(body) {
+                    out.push(ch);
+                    i += 1 + rel + 1; // pula `&body;`
+                    continue;
+                }
+                // Desconhecida: deixa o `&` literal e segue.
+                out.push('&');
+                i += 1;
+            }
+            None => {
+                // `&` solto sem `;`: literal.
+                out.push('&');
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+/// Decodifica o MIOLO de uma entidade (sem o `&` e o `;`). `None` se desconhecida.
+fn decode_one_entity(body: &str) -> Option<char> {
+    if let Some(num) = body.strip_prefix('#') {
+        // Numérica: `#NN` decimal ou `#xNN`/`#XNN` hex.
+        let code = if let Some(hex) = num.strip_prefix(['x', 'X']) {
+            u32::from_str_radix(hex, 16).ok()?
+        } else {
+            num.parse::<u32>().ok()?
+        };
+        return char::from_u32(code);
+    }
+    Some(match body {
+        "lt" => '<',
+        "gt" => '>',
+        "amp" => '&',
+        "quot" => '"',
+        "apos" => '\'',
+        "nbsp" => '\u{00A0}',
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entidades_nomeadas() {
+        assert_eq!(decode_entities("a &lt; b &gt; c &amp; d"), "a < b > c & d");
+        assert_eq!(decode_entities("&quot;aspas&quot; &apos;simples&apos;"), "\"aspas\" 'simples'");
+        assert_eq!(decode_entities("x&nbsp;y"), "x\u{00A0}y");
+    }
+
+    #[test]
+    fn entidades_numericas() {
+        assert_eq!(decode_entities("&#65;&#66;&#67;"), "ABC"); // decimal
+        assert_eq!(decode_entities("&#x41;&#x42;"), "AB"); // hex minúsculo
+        assert_eq!(decode_entities("&#X41;"), "A"); // hex maiúsculo
+        assert_eq!(decode_entities("caf&#233;"), "café"); // não-ASCII decimal
+        assert_eq!(decode_entities("&#9731;"), "☃"); // BMP fora do Latin-1
+    }
+
+    #[test]
+    fn malformadas_ficam_literais() {
+        assert_eq!(decode_entities("Tom & Jerry"), "Tom & Jerry"); // `&` solto
+        assert_eq!(decode_entities("&naoexiste;"), "&naoexiste;"); // nome desconhecido
+        assert_eq!(decode_entities("&#abc;"), "&#abc;"); // numérica inválida
+        assert_eq!(decode_entities("100% & mais"), "100% & mais");
+        assert_eq!(decode_entities("sem ampersand"), "sem ampersand"); // atalho sem `&`
+    }
+
+    #[test]
+    fn entidade_no_fim_e_consecutivas() {
+        assert_eq!(decode_entities("fim &amp;"), "fim &");
+        assert_eq!(decode_entities("&lt;&lt;&gt;&gt;"), "<<>>");
+    }
 }

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -188,9 +188,9 @@ pub fn register(e: &mut Engine) {
         .member(func(
             "querySelector",
             "__RTS_FN_NS_EGUI_QUERY_SELECTOR",
-            Sig::new(vec![U64, AbiType::StrPtr], U64),
+            Sig::new(vec![U64, AbiType::StrPtr], I64),
             "querySelector(h: number, selector: string): number",
-            "First node matching a simple selector (tag / #id / .class) in the retained DOM; returns its NodeId, or 0xFFFFFFFFFFFFFFFF if none.",
+            "First node matching a simple selector (tag / #id / .class) in the retained DOM; returns its NodeId (>= 0), or -1 if none. Extract the result to a const before comparing.",
             widgets::__RTS_FN_NS_EGUI_QUERY_SELECTOR as *const u8,
         ))
         .member(func(
@@ -212,9 +212,9 @@ pub fn register(e: &mut Engine) {
         .member(func(
             "createElement",
             "__RTS_FN_NS_EGUI_CREATE_ELEMENT",
-            Sig::new(vec![U64, AbiType::StrPtr], U64),
+            Sig::new(vec![U64, AbiType::StrPtr], I64),
             "createElement(h: number, tag: string): number",
-            "Creates a detached element; returns its NodeId (document.createElement).",
+            "Creates a detached element; returns its NodeId >= 0 (document.createElement), or -1 if no DOM.",
             widgets::__RTS_FN_NS_EGUI_CREATE_ELEMENT as *const u8,
         ))
         .member(func(

--- a/crates/rts-egui/src/widgets.rs
+++ b/crates/rts-egui/src/widgets.rs
@@ -147,17 +147,20 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_BLOCK(
     );
 }
 
-/// Sentinela de "nó não encontrado" para os primitivos que retornam `NodeId`
-/// (não há `-1` em `u64`). O TS compara contra `0xFFFF_FFFF_FFFF_FFFF`.
-const NODE_NONE: u64 = u64::MAX;
+/// Sentinela de "nó não encontrado" para os primitivos que retornam `NodeId`.
+/// É `-1` num `i64` (invariante 3 do roadmap): `u64::MAX` > 2^53 não é exato como
+/// `number` no TS e a comparação inline erra; `-1` é exato e comparável direto.
+/// Regra de uso no TS: extrair o retorno para uma const antes de comparar (ver
+/// `project_codegen_i64_cmp_bug`).
+const NODE_NONE: i64 = -1;
 
 /// `querySelector`: primeiro nó que casa com um seletor simples (`tag`, `#id`,
-/// `.classe`) no DOM retido da janela. Retorna o `NodeId` (u64) ou `NODE_NONE`.
+/// `.classe`) no DOM retido da janela. Retorna o `NodeId` (`i64` ≥ 0) ou `-1`.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_QUERY_SELECTOR(h: u64, sel_ptr: *const u8, sel_len: i64) -> u64 {
+pub extern "C" fn __RTS_FN_NS_EGUI_QUERY_SELECTOR(h: u64, sel_ptr: *const u8, sel_len: i64) -> i64 {
     let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("");
     ctx::with_ctx(h, |c| match &c.dom {
-        Some(dom) => dom.query(sel).map(|id| id as u64).unwrap_or(NODE_NONE),
+        Some(dom) => dom.query(sel).map(|id| id as i64).unwrap_or(NODE_NONE),
         None => NODE_NONE,
     })
     .unwrap_or(NODE_NONE)
@@ -193,12 +196,13 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_ATTR(
     });
 }
 
-/// `document.createElement(tag)`: cria um elemento solto; retorna seu `NodeId`.
+/// `document.createElement(tag)`: cria um elemento solto; retorna seu `NodeId`
+/// (`i64` ≥ 0), ou `-1` se não houver DOM na janela.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_CREATE_ELEMENT(h: u64, tag_ptr: *const u8, tag_len: i64) -> u64 {
+pub extern "C" fn __RTS_FN_NS_EGUI_CREATE_ELEMENT(h: u64, tag_ptr: *const u8, tag_len: i64) -> i64 {
     let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("").to_string();
     ctx::with_ctx(h, |c| match c.dom.as_mut() {
-        Some(dom) => dom.create_element(&tag) as u64,
+        Some(dom) => dom.create_element(&tag) as i64,
         None => NODE_NONE,
     })
     .unwrap_or(NODE_NONE)

--- a/examples/egui_dom_mutacao.ts
+++ b/examples/egui_dom_mutacao.ts
@@ -19,7 +19,7 @@ egui.defineBlock("ul", 0, 16, 0, 0);
 egui.defineBlock("li", 1, 0, 1, 0);
 egui.defineInline("b", 8);
 
-const NONE = 18446744073709551615; // 0xFFFFFFFFFFFFFFFF — "não encontrado"
+const NONE = -1; // sentinela "não encontrado" (invariante 3: -1, nunca u64::MAX)
 
 const win = new Window("DOM mutacao", 460, 360);
 


### PR DESCRIPTION
## Contexto

Auditoria do `dom.rs`/`html.rs` (a pedido: "termine o DOM, do P1") revelou dois furos reais que travam o uso do DOM retido pelo TS no escopo P1.

## Mudanças

**1. Sentinela `u64::MAX` → `-1` (invariante 3 do roadmap)**
`querySelector`/`createElement` retornavam `0xFFFFFFFFFFFFFFFF` quando não achavam — mas esse valor `> 2^53` **não é exato como `number`** no TS e a comparação inline erra (`project_codegen_i64_cmp_bug`). Agora retornam `i64` com `-1`. ABI (`Sig` `U64`→`I64`) + `ts_signature` + doc atualizados; exemplo `egui_dom_mutacao.ts` migrado de `18446744073709551615` para `-1`.

**2. Entidades HTML completas**
`decode_entities` cobria só `&lt;/&gt;/&amp;` via `.replace` encadeado (não pega numéricas). Reescrito como parser de 1 passe:
- nomeadas comuns: `&quot;` `&apos;` `&nbsp;`
- numéricas decimais `&#NN;` e hex `&#xNN;`/`&#XNN;`
- desconhecida/malformada fica literal; atalho quando não há `&`.
- **+4 testes** (`html.rs` não tinha nenhum).

## Fora de escopo (é F0, não P1)
Versionamento de `NodeId {idx, gen}` (invariante 2) — fica para o F0.

## Validação
- `cargo test -p rts-egui --lib` → **25/25 verdes** (21 antigos + 4 novos).
- `cargo build --release` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)