### PR TITLE
feat(egui): F0(b) — cache do DOM por hash do HTML (fecha o F0)

### DIFF
--- a/crates/rts-egui/src/app.rs
+++ b/crates/rts-egui/src/app.rs
@@ -234,6 +234,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(
         frame_active: false,
         cmds: Vec::new(),
         dom: None,
+        html_hash: 0,
         button_results: Vec::new(),
         slider_results: Vec::new(),
         button_cursor: 0,

--- a/crates/rts-egui/src/ctx.rs
+++ b/crates/rts-egui/src/ctx.rs
@@ -127,6 +127,11 @@ pub struct UiCtx {
     /// frame): o render percorre esta árvore, `egui.domDump` a serializa para
     /// inspeção, e é ela que o JS vai MUTAR (Fatia 3). `None` até o 1º `html`.
     pub dom: Option<crate::dom::Dom>,
+    /// Hash do HTML que gerou o `dom` atual (F0(b), base de cache). `html()` só
+    /// RE-PARSEIA quando a string muda; HTML idêntico é no-op — evita rebuild por
+    /// frame E preserva a geração dos NodeId (re-parsear cria geração nova, o que
+    /// invalidaria os NodeId que o TS guardou). `0` = nenhum HTML ainda.
+    pub html_hash: u64,
     /// Resultado de cada `button` do frame ANTERIOR (true = clicado), por índice.
     pub button_results: Vec<bool>,
     /// Resultado de cada `slider` do frame ANTERIOR (valor atual), por índice.

--- a/crates/rts-egui/src/widgets.rs
+++ b/crates/rts-egui/src/widgets.rs
@@ -106,14 +106,31 @@ pub extern "C" fn __RTS_FN_NS_EGUI_HTML(h: u64, ptr: *const u8, len: i64) {
     let html = unsafe { str_abi::from_abi(ptr, len) }
         .unwrap_or("")
         .to_string();
+    let hash = html_hash(&html);
     ctx::with_ctx(h, |c| {
         if c.frame_active {
-            // Guarda a árvore RETIDA no UiCtx (fonte da verdade persistente) e
-            // enfileira só o marcador de posição; o render lê de `c.dom`.
-            c.dom = Some(crate::dom::parse_html_to_dom(&html));
+            // F0(b) — cache por hash: só RE-PARSEIA quando a string muda. HTML
+            // idêntico (o caso comum de um loop que chama `html()` todo frame)
+            // reusa a árvore: evita rebuild por frame E preserva a geração dos
+            // NodeId que o TS guardou (re-parsear criaria geração nova → ids
+            // stale). O 1º html() sempre parseia (hash inicial = 0).
+            if c.dom.is_none() || c.html_hash != hash {
+                c.dom = Some(crate::dom::parse_html_to_dom(&html));
+                c.html_hash = hash;
+            }
+            // O marcador entra todo frame: ele sinaliza ao render "há DOM neste
+            // frame" (o render desenha `c.dom`), independente de ter re-parseado.
             c.cmds.push(WidgetCmd::Html);
         }
     });
+}
+
+/// Hash não-criptográfico do HTML (só para detectar mudança — "igual ou não").
+fn html_hash(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
 }
 
 /// Registra o layout de uma TAG no "alocador dinâmico de blocos" (mapa tag →


### PR DESCRIPTION
## Contexto

**F0(b)** do roadmap (base de cache/incrementalidade) — e o **último item do F0**.

## Problema

`html()` re-parseava a árvore **toda** chamada, mesmo com string idêntica. Num loop que chama `html()` por frame isso (a) refazia o parse à toa e (b) — pior — **destruía qualquer mutação** (`setText`/`append`) e trocava a geração dos NodeId, invalidando os ids que o TS guardou.

## Solução

`UiCtx.html_hash` guarda o hash do HTML que gerou o `dom` atual; `html()` só re-parseia quando a string muda. HTML idêntico = no-op de parse: reusa a árvore (mutações persistem, geração estável). O 1º `html()` sempre parseia.

## Validação
- `cargo test -p rts-egui --lib` → **32/32 verdes**.
- `cargo build --release` OK.
- **E2E**: exemplo que chama `html()` com a **mesma string por frame** + `setText` → contador sobe 60→120. Sem o cache, o re-parse travaria em 0.

## F0 está fechado ✅
sentinela `-1` · NodeId versionado `{gen,idx}` · split `frame.rs` · `style.rs` egui-free · vsync + kill-gate · hash do HTML. Próximo: **F1** (estilo via slot opaco — `defineStyle` ligando o `apply_slot` já pronto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)