### PR TITLE
docs(html-engine): follow-up do F0 — reanálise de eficiência + padrão

### DIFF
--- a/docs/specs/html-engine/rts-html-roadmap.md
+++ b/docs/specs/html-engine/rts-html-roadmap.md
@@ -124,6 +124,26 @@ rede de segurança (se F4 atrasar, nada regride).
 > e do prelude achatado, que ainda não existem — movidas para o início do F3
 > (eventos/fachada), onde são pré-requisito natural.
 
+> **⚠️ FOLLOW-UP do F0 — REANÁLISE DE EFICIÊNCIA + PADRÃO (pendente, fazer antes/durante o F1).**
+> O F0 foi entregue rápido, em 6 PRs sequenciais; é possível que alguma feature
+> tenha **fugido do padrão pedido** ou deixado ineficiência. Antes de empilhar o
+> F1 por cima, revisar criticamente o que entrou:
+> - **Aderência à doutrina/invariantes:** o `style.rs` é mesmo 100% egui-free no
+>   código (sim, teste `egui_free_garantia` cobre)? algum nome não-primordial/CSS
+>   vazou pro Rust (invariante 4)? a separação `NodeIdx` interno × `NodeId`
+>   versionado na fronteira ficou consistente em TODOS os call sites (widgets/
+>   render), ou sobrou conversão dúbia?
+> - **Eficiência:** o `html_hash` roda `DefaultHasher` sobre a string inteira por
+>   frame — ok agora, mas medir se vira gargalo em HTML grande; o re-parse-zero
+>   está realmente economizando (não há outro rebuild escondido por frame)? o
+>   `present_mode=Fifo` resolveu o CPU-spin, mas confirmar que não há mais trabalho
+>   redundante no `endFrame`.
+> - **Padrão de código:** o split `frame/` agrupou por responsabilidade (gpu/mod/
+>   render) em vez do `render_block/render_inline/painter` que o plano pedia —
+>   decidir se isso vira o padrão oficial (atualizar o plano) ou se realinha.
+> - **Saída:** ou um PR de limpeza/realinhamento, ou uma nota explícita "revisado,
+>   está conforme". Não deixar dívida silenciosa antes do F1.
+
 ### F1 — Estilo de texto (cor / font-size / bg) via egui. ⭐ MAIOR VALOR-POR-ESFORÇO. — ◐ PRÓXIMO (base pronta no F0)
 
 > **STATUS — base já entregue no F0:** o `style.rs` egui-free, o `ComputedStyle`,


### PR DESCRIPTION
Registra no roadmap um follow-up explícito do F0: como ele saiu em 6 PRs sequenciais rápidos, alguma feature pode ter fugido do padrão pedido ou deixado ineficiência. Item a revisar **antes/durante o F1**:

- **Doutrina/invariantes:** `style.rs` 100% egui-free no código? algum vocabulário CSS vazou pro Rust (invariante 4)? separação `NodeIdx`×`NodeId` consistente em todos os call sites?
- **Eficiência:** `html_hash` por frame em HTML grande; re-parse-zero realmente economiza; `endFrame` sem trabalho redundante.
- **Padrão:** o split ficou `gpu/mod/render` (não `render_block/render_inline/painter` do plano) — oficializar ou realinhar.
- **Saída:** PR de limpeza ou nota "revisado, conforme" — sem dívida silenciosa.

Só doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)