### PR TITLE
perf(egui): corta 2 alocações por-frame no hot path (reanálise do F0)

### DIFF
--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -69,15 +69,17 @@ fn render_block(
     index: &mut usize,
 ) {
     use crate::dom::NodeKind;
+    // `tag` fica emprestado da arena (sem `.clone()`): só é lido por `block::lookup`
+    // logo abaixo e não sobrevive a este escopo. O `dom` é read-only no render.
     let tag = match &dom.node(id).kind {
-        NodeKind::Element { tag } => tag.clone(),
+        NodeKind::Element { tag } => tag.as_str(),
         // Texto solto / não-elemento no nível de bloco: emite inline direto.
         _ => return render_inline(ui, dom, id, InlineStyle::default()),
     };
 
     // Tag sem layout de bloco registrado ⇒ inline transparente (default seguro,
     // igual a uma tag desconhecida): preserva o texto dos filhos.
-    let Some(def) = crate::block::lookup(&tag) else {
+    let Some(def) = crate::block::lookup(tag) else {
         return render_inline(ui, dom, id, InlineStyle::default());
     };
 

--- a/crates/rts-egui/src/widgets.rs
+++ b/crates/rts-egui/src/widgets.rs
@@ -103,19 +103,19 @@ pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_END(h: u64) {
 /// (transparentes) e texto solto.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_EGUI_HTML(h: u64, ptr: *const u8, len: i64) {
-    let html = unsafe { str_abi::from_abi(ptr, len) }
-        .unwrap_or("")
-        .to_string();
-    let hash = html_hash(&html);
+    // Hash sobre o `&str` da ABI — SEM alocar. O `.to_string()` (parse) só
+    // acontece DENTRO do `if` que de fato re-parseia; no caso comum (loop chamando
+    // `html()` com a mesma string todo frame) o caminho é hash + compare, zero alloc.
+    let html = unsafe { str_abi::from_abi(ptr, len) }.unwrap_or("");
+    let hash = html_hash(html);
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             // F0(b) — cache por hash: só RE-PARSEIA quando a string muda. HTML
-            // idêntico (o caso comum de um loop que chama `html()` todo frame)
-            // reusa a árvore: evita rebuild por frame E preserva a geração dos
-            // NodeId que o TS guardou (re-parsear criaria geração nova → ids
+            // idêntico reusa a árvore: evita rebuild por frame E preserva a geração
+            // dos NodeId que o TS guardou (re-parsear criaria geração nova → ids
             // stale). O 1º html() sempre parseia (hash inicial = 0).
             if c.dom.is_none() || c.html_hash != hash {
-                c.dom = Some(crate::dom::parse_html_to_dom(&html));
+                c.dom = Some(crate::dom::parse_html_to_dom(html));
                 c.html_hash = hash;
             }
             // O marcador entra todo frame: ele sinaliza ao render "há DOM neste


### PR DESCRIPTION
Resultado da **reanálise de eficiência do F0** (follow-up registrado no roadmap). Corrige as 2 ineficiências de melhor custo-benefício no caminho quente (loop de render dirigido pelo TS):

**1. `html()` — alocação por frame no no-op** (`widgets.rs`)
Alocava a string (`.to_string()`) **toda** chamada, mesmo quando o cache por hash bate e nada é re-parseado. Agora hash + compare rodam sobre o `&str` da ABI; o parse só aloca **dentro** do `if` que re-parseia. No loop comum (`html()` com a mesma string por frame) = **zero alloc/frame**.

**2. `render_block` — `tag.clone()` por nó** (`frame/render.rs`)
Clonava a tag por nó por frame só para passar a `block::lookup(&tag)` — que recebe `&str` e não retém. Trocado por `as_str()` emprestado da arena (render é read-only). **Zero clone/nó**.

**Deixado como follow-up** (não empilhar nesta fatia): `set_text`/`set_attr` com dupla alocação `&str→String`; `parse_inline` do `style=""` sem cache por nó.

## Validação
- `cargo test -p rts-egui --lib` → **32/32 verdes**.
- `cargo build --release` OK.
- E2E `claude-egui-incrementador.ts` (html() + mutação por frame) roda — contador sobe.

Doutrina/invariantes: a auditoria confirmou **100% conforme**, sem violações — nada a corrigir nesse eixo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)