### PR TITLE
feat(egui): F1 — estilo de texto por slot opaco (defineStyle)

### DIFF
--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -26,23 +26,38 @@ fn rgba_to_color32(c: crate::style::Rgba) -> egui::Color32 {
     egui::Color32::from_rgba_unmultiplied(r, g, b, a)
 }
 
-/// Mescla o `style="..."` (CSS inline) de um nó SOBRE um `InlineStyle` herdado.
-/// Propriedade ausente no CSS mantém a herdada; presente sobrescreve.
+/// Aplica um `ComputedStyle` (cor/bg/tamanho/peso) SOBRE um `InlineStyle`:
+/// propriedade `Some` sobrescreve, `None` mantém a herdada. (`bg` ainda não é
+/// usado no inline — chega no box model, F2.)
+fn apply_computed(st: &mut InlineStyle, css: &crate::style::ComputedStyle) {
+    if let Some(c) = css.color {
+        st.color = Some(rgba_to_color32(c));
+    }
+    if let Some(sz) = css.font_size {
+        st.size = Some(sz);
+    }
+    if let Some(b) = css.bold {
+        st.bold = b;
+    }
+    if let Some(i) = css.italic {
+        st.italic = i;
+    }
+}
+
+/// Mescla o estilo de um nó SOBRE um `InlineStyle` herdado, na ordem de
+/// precedência CSS: herdado < estilo-de-TAG (`defineStyle`, F1) < `style=""`
+/// inline do nó. Propriedade ausente mantém a anterior; presente sobrescreve.
 fn merge_node_style(dom: &crate::dom::Dom, id: crate::dom::NodeIdx, mut st: InlineStyle) -> InlineStyle {
+    // 1) estilo registrado para a TAG (slot opaco via defineStyle).
+    if let crate::dom::NodeKind::Element { tag } = &dom.node(id).kind {
+        if let Some(tag_css) = crate::style::lookup_style(tag) {
+            apply_computed(&mut st, &tag_css);
+        }
+    }
+    // 2) `style="..."` inline do nó sobrepõe o estilo da tag.
     if let Some(s) = dom.node(id).attr("style") {
         let css = crate::style::parse_inline(s);
-        if let Some(c) = css.color {
-            st.color = Some(rgba_to_color32(c));
-        }
-        if let Some(sz) = css.font_size {
-            st.size = Some(sz);
-        }
-        if let Some(b) = css.bold {
-            st.bold = b;
-        }
-        if let Some(i) = css.italic {
-            st.italic = i;
-        }
+        apply_computed(&mut st, &css);
     }
     st
 }
@@ -89,13 +104,18 @@ fn render_block(
     // Heading: texto concatenado; `indent` é reusado como TAMANHO de fonte.
     if def.has(crate::block::FLAG_HEADING) {
         let text = collect_text(dom, id);
-        // `style="..."` do heading sobrepõe tamanho/cor; senão usa o default do
-        // nível (indent reusado como tamanho).
-        let css = dom
-            .node(id)
-            .attr("style")
-            .map(crate::style::parse_inline)
-            .unwrap_or_default();
+        // Precedência: estilo-de-TAG (defineStyle) < `style=""` inline. O tamanho
+        // cai para o default do nível (indent) se nenhum dos dois o definir.
+        let mut css = crate::style::lookup_style(tag).unwrap_or_default();
+        if let Some(s) = dom.node(id).attr("style") {
+            let inline = crate::style::parse_inline(s);
+            if inline.color.is_some() {
+                css.color = inline.color;
+            }
+            if inline.font_size.is_some() {
+                css.font_size = inline.font_size;
+            }
+        }
         let size = css.font_size.unwrap_or(if def.indent > 0.0 { def.indent } else { 20.0 });
         let mut rt = egui::RichText::new(text).strong().size(size);
         if let Some(c) = css.color {

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -177,6 +177,14 @@ pub fn register(e: &mut Engine) {
             widgets::__RTS_FN_NS_EGUI_DEFINE_BLOCK as *const u8,
         ))
         .member(func(
+            "defineStyle",
+            "__RTS_FN_NS_EGUI_DEFINE_STYLE",
+            Sig::new(vec![AbiType::StrPtr, I64, I64], AbiType::Void),
+            "defineStyle(tag: string, slot: number, val: number): void",
+            "Registers one opaque style slot for a tag (0=color 1=bg 2=font_size; color/bg as 0xRRGGBBAA u32). The TS maps CSS-name->slot; Rust never matches a CSS string. Accumulates per tag.",
+            widgets::__RTS_FN_NS_EGUI_DEFINE_STYLE as *const u8,
+        ))
+        .member(func(
             "defineInline",
             "__RTS_FN_NS_EGUI_DEFINE_INLINE",
             Sig::new(vec![AbiType::StrPtr, I64], AbiType::Void),

--- a/crates/rts-egui/src/style.rs
+++ b/crates/rts-egui/src/style.rs
@@ -38,6 +38,34 @@ pub const SLOT_COLOR: i64 = 0;
 pub const SLOT_BG: i64 = 1;
 pub const SLOT_FONT_SIZE: i64 = 2;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    /// Mapa `tag → ComputedStyle`, povoado pelo TS via `defineStyle(tag, slot, val)`.
+    /// É o estilo POR-TAG (uma UA-stylesheet de estilo, paralela ao `block::BLOCKS`
+    /// de layout). O render consulta `lookup_style(tag)` e aplica antes do
+    /// `style=""` inline do nó. Vazio até o TS registrar.
+    static STYLES: RefCell<HashMap<String, ComputedStyle>> = RefCell::new(HashMap::new());
+}
+
+/// Registra/atualiza UM slot de estilo de uma TAG (primitivo `defineStyle`).
+/// ACUMULA: chamar com slots diferentes na mesma tag mantém os anteriores
+/// (`defineStyle("h1",0,cor)` + `defineStyle("h1",2,tam)` → cor E tamanho). O
+/// `(slot, val)` é opaco (invariante 4); o Rust nunca vê o nome CSS.
+pub fn define_style(tag: &str, slot: i64, val: i64) {
+    STYLES.with(|m| {
+        let mut m = m.borrow_mut();
+        let entry = m.entry(tag.to_ascii_lowercase()).or_default();
+        entry.apply_slot(slot, val);
+    });
+}
+
+/// Consulta o `ComputedStyle` registrado de uma TAG. `None` ⇒ sem estilo de tag.
+pub fn lookup_style(tag: &str) -> Option<ComputedStyle> {
+    STYLES.with(|m| m.borrow().get(tag).copied())
+}
+
 impl ComputedStyle {
     /// Aplica um par `(slot, val)` OPACO (invariante 4). O `val` é interpretado
     /// conforme o slot: cor/bg = `u32` RGBA; font_size = pontos (o `i64` vira
@@ -227,5 +255,18 @@ mod tests {
         // A cor é u32; o teste compila SÓ se ComputedStyle for egui-free.
         let s = ComputedStyle { color: Some(0xAABBCCFF), ..Default::default() };
         let _raw: Option<u32> = s.color; // se fosse Color32, isto não compilaria.
+    }
+
+    #[test]
+    fn define_style_acumula_por_tag() {
+        // F1: defineStyle por slot OPACO acumula na mesma tag (cor + tamanho).
+        // (thread_local — usa uma tag única pra não colidir com outros testes.)
+        define_style("h1_acum", SLOT_COLOR, 0x0088FFFF);
+        define_style("h1_acum", SLOT_FONT_SIZE, 28);
+        let s = lookup_style("h1_acum").expect("tag registrada");
+        assert_eq!(s.color, Some(0x0088FFFF));
+        assert_eq!(s.font_size, Some(28.0));
+        // tag não registrada → None.
+        assert_eq!(lookup_style("tag_inexistente_xyz"), None);
     }
 }

--- a/crates/rts-egui/src/widgets.rs
+++ b/crates/rts-egui/src/widgets.rs
@@ -164,6 +164,25 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_BLOCK(
     );
 }
 
+/// Registra UM slot de estilo de uma TAG (`defineStyle(tag, slot, val)`, F1).
+/// `slot` é OPACO (invariante 4): 0=color, 1=bg, 2=font_size — o TS mapeia
+/// nome-CSS→índice, o Rust nunca casa string CSS. `val`: cor/bg = `u32` RGBA
+/// (`0xRRGGBBAA`); font_size = pontos. Acumula por tag (slots diferentes somam).
+/// Independe de janela (igual `defineBlock`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_STYLE(
+    tag_ptr: *const u8,
+    tag_len: i64,
+    slot: i64,
+    val: i64,
+) {
+    let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("");
+    if tag.is_empty() {
+        return;
+    }
+    crate::style::define_style(tag, slot, val);
+}
+
 /// Sentinela de "nó não encontrado" para os primitivos que retornam `NodeId`.
 /// É `-1` num `i64` (invariante 3 do roadmap): `u64::MAX` > 2^53 não é exato como
 /// `number` no TS e a comparação inline erra; `-1` é exato e comparável direto.

--- a/examples/claude-egui-style.ts
+++ b/examples/claude-egui-style.ts
@@ -1,0 +1,38 @@
+import egui from "rts:egui";
+
+// F1 — estilo de texto por SLOT OPACO (defineStyle). O TS mapeia nome-CSS → índice;
+// o Rust nunca casa string CSS (invariante 4). Cores como 0xRRGGBBAA em i64.
+//
+// Slots (contrato com o Rust): 0=color, 1=bg, 2=font_size.
+// Critério de sucesso: h1 AZUL tamanho 28 + p CINZA, 100% via egui RichText
+// (zero painter absoluto). Rodar:
+//   target/release/rts.exe run examples/claude-egui-style.ts
+
+const SLOT_COLOR = 0;
+const SLOT_BG = 1;
+const SLOT_FONT_SIZE = 2;
+
+// Layout das tags (mesmo padrão dos outros exemplos).
+egui.defineBlock("h1", 0, 26, 0, 4); // heading
+egui.defineBlock("p", 1, 0, 0, 0); // parágrafo (wrap)
+
+// Estilo por TAG — acumula slots (cor + tamanho na mesma tag).
+egui.defineStyle("h1", SLOT_COLOR, 0x0088FFFF); // h1 azul
+egui.defineStyle("h1", SLOT_FONT_SIZE, 28); // tamanho 28
+egui.defineStyle("p", SLOT_COLOR, 0xCCCCCCFF); // p cinza claro
+
+const win = egui.openWindow("F1 — estilo por slot opaco", 460, 220, 0);
+
+const HTML =
+  "<h1>Titulo azul tamanho 28</h1>" +
+  "<p>Paragrafo cinza claro, estilizado via defineStyle (slot opaco). " +
+  "O <b>negrito</b> herda a cor do paragrafo.</p>";
+
+while (egui.isOpen(win) !== 0) {
+  if (egui.pump(win) !== 0) break;
+  egui.beginFrame(win);
+  egui.html(win, HTML);
+  egui.endFrame(win);
+}
+
+egui.close(win);


### PR DESCRIPTION
**F1 do roadmap** — o primeiro pixel novo (estilo de texto via slot opaco). Liga o `apply_slot` do F0d à renderização.

## Mudanças

- **`style.rs`**: mapa thread_local `STYLES` (`tag→ComputedStyle`) + `define_style(tag, slot, val)` que **acumula** slots na mesma tag + `lookup_style`. Mesmo padrão do `block::BLOCKS`.
- **ABI**: `defineStyle(tag, slot, val)` (`__RTS_FN_NS_EGUI_DEFINE_STYLE`, molde do `defineBlock`), registrado no `lib.rs`.
- **render**: `merge_node_style` aplica na ordem CSS **herdado < estilo-de-TAG (`defineStyle`) < `style=""` inline**; helper `apply_computed` extraído; heading combina os dois. Cobre inline/wrap/heading.
- **exemplo `claude-egui-style.ts`**: `h1` azul tam 28 + `p` cinza via `RichText`, **zero painter** — o critério de sucesso do roadmap §7/F1.

Slots: `SLOT_COLOR=0`/`SLOT_BG=1`/`SLOT_FONT_SIZE=2` (invariante 4: o Rust nunca casa string CSS; o TS mapeia nome→índice). `bg` ainda não pintado no inline — chega no box model (F2).

## Validação
- `cargo test -p rts-egui --lib` → **33/33 verdes** (+`define_style_acumula_por_tag`).
- `cargo build --release` OK.
- **Visual**: janela mostra "Título azul tamanho 28" em azul e grande (screenshot confirmado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)