### PR TITLE
feat(egui): F2 (fatia 1) — box model de bloco via egui::Frame

### DIFF
--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -125,12 +125,78 @@ fn render_block(
         return;
     }
 
-    // Recuo à esquerda (lista/blockquote) via `ui.indent`; senão renderiza direto.
-    if def.indent > 0.0 {
-        ui.indent(("blk", id), |ui| render_block_body(ui, dom, id, def, this_index));
-    } else {
-        render_block_body(ui, dom, id, def, this_index);
+    // Box model (F2): se a tag tem caixa (bg/padding/margin/border/raio), envolve
+    // o corpo num `egui::Frame`; senão renderiza direto (sem overhead). O estilo de
+    // TAG e o `style=""` inline já combinados aqui (mesma precedência do texto).
+    let mut box_css = crate::style::lookup_style(tag).unwrap_or_default();
+    if let Some(s) = dom.node(id).attr("style") {
+        let inline = crate::style::parse_inline(s);
+        merge_box_props(&mut box_css, &inline);
     }
+
+    let body = |ui: &mut egui::Ui| {
+        // Recuo à esquerda (lista/blockquote) via `ui.indent`; senão direto.
+        if def.indent > 0.0 {
+            ui.indent(("blk", id), |ui| render_block_body(ui, dom, id, def, this_index));
+        } else {
+            render_block_body(ui, dom, id, def, this_index);
+        }
+    };
+
+    if box_css.has_box() {
+        block_frame(&box_css).show(ui, body);
+    } else {
+        body(ui);
+    }
+}
+
+/// Mescla SÓ as propriedades de caixa de `src` sobre `dst` (`Some` sobrescreve).
+/// Usado para o `style=""` inline sobrepor o estilo-de-tag na caixa do bloco.
+fn merge_box_props(dst: &mut crate::style::ComputedStyle, src: &crate::style::ComputedStyle) {
+    if src.bg.is_some() {
+        dst.bg = src.bg;
+    }
+    if src.padding.is_some() {
+        dst.padding = src.padding;
+    }
+    if src.margin.is_some() {
+        dst.margin = src.margin;
+    }
+    if src.border_width.is_some() {
+        dst.border_width = src.border_width;
+    }
+    if src.border_color.is_some() {
+        dst.border_color = src.border_color;
+    }
+    if src.corner_radius.is_some() {
+        dst.corner_radius = src.corner_radius;
+    }
+}
+
+/// Monta um `egui::Frame` a partir do `ComputedStyle` de caixa. Mapeia padding→
+/// inner_margin, margin→outer_margin, bg→fill, border→stroke, raio→corner_radius.
+/// LIMITE DE PRODUTO (F2): `egui::Frame` NÃO é o box model do CSS — sem
+/// margin-collapse, sem `box-sizing`, sem padding/margin por-lado (um valor para
+/// os 4 lados). É o "card" pragmático, não conformidade CSS.
+fn block_frame(css: &crate::style::ComputedStyle) -> egui::Frame {
+    let mut frame = egui::Frame::new();
+    if let Some(p) = css.padding {
+        frame = frame.inner_margin(p);
+    }
+    if let Some(m) = css.margin {
+        frame = frame.outer_margin(m);
+    }
+    if let Some(bg) = css.bg {
+        frame = frame.fill(rgba_to_color32(bg));
+    }
+    if let Some(w) = css.border_width {
+        let color = css.border_color.map(rgba_to_color32).unwrap_or(egui::Color32::GRAY);
+        frame = frame.stroke(egui::Stroke::new(w, color));
+    }
+    if let Some(r) = css.corner_radius {
+        frame = frame.corner_radius(r);
+    }
+    frame
 }
 
 /// Corpo de um bloco (já dentro do recuo): aplica o eixo (`display`) + o

--- a/crates/rts-egui/src/style.rs
+++ b/crates/rts-egui/src/style.rs
@@ -28,6 +28,30 @@ pub struct ComputedStyle {
     pub font_size: Option<f32>,
     pub bold: Option<bool>,
     pub italic: Option<bool>,
+    // ── Box model (F2) — pontos (f32). `None` = não especificado. ───────────────
+    /// Espaço INTERNO entre a borda e o conteúdo (todos os lados).
+    pub padding: Option<f32>,
+    /// Espaço EXTERNO ao redor da caixa (todos os lados).
+    pub margin: Option<f32>,
+    /// Espessura da borda em pontos (0 = sem borda).
+    pub border_width: Option<f32>,
+    /// Cor da borda, `0xRRGGBBAA`.
+    pub border_color: Option<Rgba>,
+    /// Raio dos cantos em pontos.
+    pub corner_radius: Option<f32>,
+}
+
+impl ComputedStyle {
+    /// `true` se algum atributo de CAIXA está setado (bg/padding/margin/border/
+    /// raio) — gatilho para o render envolver o bloco num `egui::Frame`. Sem
+    /// nenhum, o render desenha direto (sem o overhead do Frame).
+    pub fn has_box(&self) -> bool {
+        self.bg.is_some()
+            || self.padding.is_some()
+            || self.margin.is_some()
+            || self.border_width.is_some()
+            || self.corner_radius.is_some()
+    }
 }
 
 // ── Slots numéricos opacos (invariante 4) ──────────────────────────────────────
@@ -37,6 +61,12 @@ pub struct ComputedStyle {
 pub const SLOT_COLOR: i64 = 0;
 pub const SLOT_BG: i64 = 1;
 pub const SLOT_FONT_SIZE: i64 = 2;
+// Box model (F2):
+pub const SLOT_PADDING: i64 = 3;
+pub const SLOT_MARGIN: i64 = 4;
+pub const SLOT_BORDER_WIDTH: i64 = 5;
+pub const SLOT_BORDER_COLOR: i64 = 6;
+pub const SLOT_CORNER_RADIUS: i64 = 7;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -72,6 +102,12 @@ impl ComputedStyle {
     /// `f32`). Slot desconhecido é ignorado (robustez; o TS pode registrar slots
     /// futuros antes deste Rust conhecê-los). É a base do `defineStyle`/`setStyle`.
     pub fn apply_slot(&mut self, slot: i64, val: i64) {
+        // Dimensões (padding/margin/border/raio) em pontos: `i64` → `f32`, clamp em
+        // ≥ 0 (negativo não faz sentido numa caixa; ignora).
+        let dim = |v: i64| -> Option<f32> {
+            let f = v as f32;
+            if f >= 0.0 { Some(f) } else { None }
+        };
         match slot {
             SLOT_COLOR => self.color = Some(val as u32),
             SLOT_BG => self.bg = Some(val as u32),
@@ -81,6 +117,11 @@ impl ComputedStyle {
                     self.font_size = Some(f);
                 }
             }
+            SLOT_PADDING => self.padding = dim(val),
+            SLOT_MARGIN => self.margin = dim(val),
+            SLOT_BORDER_WIDTH => self.border_width = dim(val),
+            SLOT_BORDER_COLOR => self.border_color = Some(val as u32),
+            SLOT_CORNER_RADIUS => self.corner_radius = dim(val),
             _ => {} // slot desconhecido: ignora (o TS mapeia o vocabulário CSS).
         }
     }
@@ -255,6 +296,44 @@ mod tests {
         // A cor é u32; o teste compila SÓ se ComputedStyle for egui-free.
         let s = ComputedStyle { color: Some(0xAABBCCFF), ..Default::default() };
         let _raw: Option<u32> = s.color; // se fosse Color32, isto não compilaria.
+    }
+
+    #[test]
+    fn box_model_slots() {
+        // F2: slots de caixa (padding/margin/border/raio) via apply_slot opaco.
+        let mut s = ComputedStyle::default();
+        assert!(!s.has_box()); // vazio: sem caixa.
+        s.apply_slot(SLOT_PADDING, 8);
+        s.apply_slot(SLOT_MARGIN, 4);
+        s.apply_slot(SLOT_BORDER_WIDTH, 2);
+        s.apply_slot(SLOT_BORDER_COLOR, 0xFF0000FF);
+        s.apply_slot(SLOT_CORNER_RADIUS, 6);
+        s.apply_slot(SLOT_BG, 0x222222FF);
+        assert_eq!(s.padding, Some(8.0));
+        assert_eq!(s.margin, Some(4.0));
+        assert_eq!(s.border_width, Some(2.0));
+        assert_eq!(s.border_color, Some(0xFF0000FF));
+        assert_eq!(s.corner_radius, Some(6.0));
+        assert_eq!(s.bg, Some(0x222222FF));
+        assert!(s.has_box());
+    }
+
+    #[test]
+    fn box_slots_negativos_ignorados() {
+        let mut s = ComputedStyle::default();
+        s.apply_slot(SLOT_PADDING, -3); // negativo não faz sentido numa caixa
+        s.apply_slot(SLOT_CORNER_RADIUS, -1);
+        assert_eq!(s.padding, None);
+        assert_eq!(s.corner_radius, None);
+    }
+
+    #[test]
+    fn has_box_so_com_texto_e_false() {
+        // só cor/tamanho de texto NÃO conta como caixa (não vira egui::Frame).
+        let mut s = ComputedStyle::default();
+        s.apply_slot(SLOT_COLOR, 0xFFFFFFFF);
+        s.apply_slot(SLOT_FONT_SIZE, 18);
+        assert!(!s.has_box());
     }
 
     #[test]

--- a/examples/claude-egui-box.ts
+++ b/examples/claude-egui-box.ts
@@ -1,0 +1,45 @@
+import egui from "rts:egui";
+
+// F2 — box model de bloco via egui::Frame: bg + padding + margin + border + raio.
+// Slots opacos (invariante 4): 0=color 1=bg 2=font_size 3=padding 4=margin
+// 5=border_width 6=border_color 7=corner_radius. Cores 0xRRGGBBAA em i64.
+//
+// Critério: um "card" com fundo escuro, padding interno, borda e cantos
+// arredondados, 100% via egui::Frame (zero painter absoluto). Rodar:
+//   target/release/rts.exe run examples/claude-egui-box.ts
+
+const COLOR = 0, BG = 1, FONT = 2, PAD = 3, MARGIN = 4, BW = 5, BC = 6, RADIUS = 7;
+
+egui.defineBlock("h1", 0, 22, 0, 4);
+egui.defineBlock("p", 1, 0, 0, 0);
+egui.defineBlock("div", 0, 0, 0, 0); // card = bloco vertical
+
+// O card: fundo, padding, margem externa, borda azul, cantos arredondados.
+egui.defineStyle("div", BG, 0x1E2530FF);
+egui.defineStyle("div", PAD, 16);
+egui.defineStyle("div", MARGIN, 10);
+egui.defineStyle("div", BW, 2);
+egui.defineStyle("div", BC, 0x0088FFFF);
+egui.defineStyle("div", RADIUS, 10);
+
+// Tipografia dentro do card.
+egui.defineStyle("h1", COLOR, 0xFFFFFFFF);
+egui.defineStyle("p", COLOR, 0xB0B8C0FF);
+
+const win = egui.openWindow("F2 — box model (card)", 460, 280, 0);
+
+const HTML =
+  "<div>" +
+  "<h1>Card com caixa</h1>" +
+  "<p>Fundo, padding, borda azul e cantos arredondados — tudo via egui::Frame, " +
+  "controlado por slots opacos do defineStyle.</p>" +
+  "</div>";
+
+while (egui.isOpen(win) !== 0) {
+  if (egui.pump(win) !== 0) break;
+  egui.beginFrame(win);
+  egui.html(win, HTML);
+  egui.endFrame(win);
+}
+
+egui.close(win);


### PR DESCRIPTION
**F2 do roadmap, primeira fatia** — cards/caixas: bg + padding + margin + border + cantos arredondados via `egui::Frame`. ✅ Confirmado visual pelo usuário ("a caixa tá com borda mesmo, e ainda arredondadas").

## Mudanças

- **`style.rs`**: `ComputedStyle` ganha `padding`/`margin`/`border_width`/`border_color`/`corner_radius` (egui-free); `apply_slot` trata os novos slots (dims clampadas ≥ 0); `has_box()` é o gatilho do Frame. Slots opacos (invariante 4): `3=padding 4=margin 5=border_width 6=border_color 7=corner_radius`.
- **render**: `render_block` resolve o `ComputedStyle` de caixa da tag + `style=""` inline e, se `has_box()`, envolve o corpo num `egui::Frame` (`block_frame`): padding→inner_margin, margin→outer_margin, bg→fill, border→stroke, raio→corner_radius. **Sem box = render direto (zero overhead).**
- **exemplo `claude-egui-box.ts`**: card com fundo, padding, borda azul, cantos arredondados.

**Limite de produto declarado:** `egui::Frame` ≠ box model CSS (sem margin-collapse, sem `box-sizing`, um valor para os 4 lados).

## Próximas fatias do F2 (não nesta PR)
`width%`/`Dimension{Auto,Px,Percent}` (resolve tarde vs content-box do pai); `setStyleBatch` (invariante 6).

## Validação
- `cargo test -p rts-egui --lib` → **36/36 verdes** (+3 box model).
- `cargo build --release` OK.
- Visual confirmado pelo usuário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)