### PR TITLE
feat(dom): innerHTML/outerHTML (get) + setInnerHTML (#1755)

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -361,6 +361,33 @@ pub extern "C" fn __RTS_FN_NS_DOM_GET_TEXT(h: u64, id: i64) -> u64 {
     intern(&txt)
 }
 
+/// `innerHtml(domHandle, node)` → `element.innerHTML` como STRING (handle do pool
+/// GC): o HTML serializado dos FILHOS do nó. Nó inválido ⇒ `""`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_INNER_HTML(h: u64, id: i64) -> u64 {
+    let Some(node) = NodeId::from_abi(id) else { return intern("") };
+    let s = with(h, |dom| dom.inner_html(node).unwrap_or_default()).unwrap_or_default();
+    intern(&s)
+}
+
+/// `outerHtml(domHandle, node)` → `element.outerHTML` (inclui o próprio elemento).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_OUTER_HTML(h: u64, id: i64) -> u64 {
+    let Some(node) = NodeId::from_abi(id) else { return intern("") };
+    let s = with(h, |dom| dom.outer_html(node).unwrap_or_default()).unwrap_or_default();
+    intern(&s)
+}
+
+/// `setInnerHtml(domHandle, node, html)` → `element.innerHTML = html`: parseia o
+/// HTML e SUBSTITUI os filhos do nó pela nova subárvore. Nó inválido / não-elemento
+/// ⇒ no-op.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_SET_INNER_HTML(h: u64, id: i64, html_ptr: *const u8, html_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let html = unsafe { str_abi::from_abi(html_ptr, html_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.set_inner_html(node, &html));
+}
+
 /// `getAttribute(domHandle, node, name)` → valor do atributo como STRING (handle
 /// do pool GC). Atributo ausente / nó inválido ⇒ `""` (a fachada TS converte ""
 /// para `null` se quiser semântica de browser).
@@ -807,6 +834,30 @@ pub fn register(e: &mut Engine) {
             "getText(dom: number, node: number): string",
             "node.textContent: concatenated text of all descendants. Empty string if the node is invalid.",
             __RTS_FN_NS_DOM_GET_TEXT as *const u8,
+        ))
+        .member(func(
+            "innerHtml",
+            "__RTS_FN_NS_DOM_INNER_HTML",
+            Sig::new(vec![Handle, I64], AbiType::Handle),
+            "innerHtml(dom: number, node: number): string",
+            "element.innerHTML (get): serialized HTML of the node's children. Empty string if invalid.",
+            __RTS_FN_NS_DOM_INNER_HTML as *const u8,
+        ))
+        .member(func(
+            "outerHtml",
+            "__RTS_FN_NS_DOM_OUTER_HTML",
+            Sig::new(vec![Handle, I64], AbiType::Handle),
+            "outerHtml(dom: number, node: number): string",
+            "element.outerHTML (get): serialized HTML including the element itself.",
+            __RTS_FN_NS_DOM_OUTER_HTML as *const u8,
+        ))
+        .member(func(
+            "setInnerHtml",
+            "__RTS_FN_NS_DOM_SET_INNER_HTML",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "setInnerHtml(dom: number, node: number, html: string): void",
+            "element.innerHTML = html (set): parses the HTML and replaces the node's children.",
+            __RTS_FN_NS_DOM_SET_INNER_HTML as *const u8,
         ))
         .member(func(
             "getAttribute",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -751,6 +751,100 @@ impl Dom {
         false
     }
 
+    /// `element.innerHTML` (GET) — serializa os FILHOS do nó como string HTML
+    /// válida (o inverso do parser: `<tag attrs>filhos</tag>`, texto com entidades
+    /// re-encodadas, `<!-- -->` para comentário, void tags sem fechar). `None` se o
+    /// id não resolve. Round-trip com `set_inner_html` é estável para o subset.
+    pub fn inner_html(&self, id: NodeId) -> Option<String> {
+        let idx = self.resolve(id)?;
+        let mut out = String::new();
+        for &child in &self.nodes[idx].children {
+            self.serialize_node(child, &mut out);
+        }
+        Some(out)
+    }
+
+    /// `element.outerHTML` (GET) — como [`inner_html`](Dom::inner_html) mas inclui o
+    /// PRÓPRIO elemento (a tag de abertura+fechamento ao redor dos filhos).
+    pub fn outer_html(&self, id: NodeId) -> Option<String> {
+        let idx = self.resolve(id)?;
+        let mut out = String::new();
+        self.serialize_node(idx, &mut out);
+        Some(out)
+    }
+
+    /// Serializa UM nó como HTML (recursivo). Element → `<tag a="v">filhos</tag>`
+    /// (void → `<tag>` sem fechar); Text → texto com entidades re-encodadas;
+    /// Comment → `<!-- ... -->`; Document → só os filhos.
+    fn serialize_node(&self, idx: NodeIdx, out: &mut String) {
+        match &self.nodes[idx].kind {
+            NodeKind::Document => {
+                for &c in &self.nodes[idx].children {
+                    self.serialize_node(c, out);
+                }
+            }
+            NodeKind::Text(t) => out.push_str(&crate::html::encode_text_entities(t)),
+            NodeKind::Comment(c) => {
+                out.push_str("<!--");
+                out.push_str(c);
+                out.push_str("-->");
+            }
+            NodeKind::Element { tag } => {
+                out.push('<');
+                out.push_str(tag);
+                for a in &self.nodes[idx].attrs {
+                    out.push(' ');
+                    out.push_str(&a.name);
+                    out.push_str("=\"");
+                    out.push_str(&crate::html::encode_attr_entities(&a.value));
+                    out.push('"');
+                }
+                out.push('>');
+                if is_void(tag) {
+                    return; // void: sem filhos, sem fechamento.
+                }
+                for &c in &self.nodes[idx].children {
+                    self.serialize_node(c, out);
+                }
+                out.push_str("</");
+                out.push_str(tag);
+                out.push('>');
+            }
+        }
+    }
+
+    /// `element.innerHTML = html` (SET) — parseia o HTML e SUBSTITUI todos os filhos
+    /// do nó pela nova subárvore. Reusa o parser (`parse_html_to_dom`); os nós
+    /// parseados são COPIADOS para esta arena (re-parentados sob `id`), atualizando
+    /// os índices id/class. Não faz nada num nó que não é elemento ou não resolve.
+    pub fn set_inner_html(&mut self, id: NodeId, html: &str) {
+        let Some(idx) = self.resolve(id) else { return };
+        if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
+            return;
+        }
+        // Descarta os filhos atuais (arena não compacta; viram lixo).
+        self.nodes[idx].children.clear();
+        // Parseia a nova subárvore numa árvore temporária e copia os filhos do
+        // #document dela para baixo de `idx`.
+        let sub = parse_html_to_dom(html);
+        let sub_root_children: Vec<NodeIdx> = sub.nodes[sub.root].children.clone();
+        for sub_child in sub_root_children {
+            self.copy_subtree_into(&sub, sub_child, idx);
+        }
+    }
+
+    /// Copia recursivamente o nó `src_idx` da árvore `src` para dentro desta arena,
+    /// como filho de `dst_parent`. Novos `NodeIdx`, índices id/class atualizados.
+    fn copy_subtree_into(&mut self, src: &Dom, src_idx: NodeIdx, dst_parent: NodeIdx) -> NodeIdx {
+        let src_node = &src.nodes[src_idx];
+        let new_idx = self.push(src_node.kind.clone(), src_node.attrs.clone(), dst_parent);
+        let src_children: Vec<NodeIdx> = src_node.children.clone();
+        for c in src_children {
+            self.copy_subtree_into(src, c, new_idx);
+        }
+        new_idx
+    }
+
     /// Serializa a árvore indentada (estilo devtools) — a forma legível de
     /// inspecionar/verificar o que foi gerado. Elemento vira `<tag>`; texto vira
     /// a string entre aspas; cada nível adiciona 2 espaços.
@@ -1129,6 +1223,44 @@ mod tests {
         // o combinador `a > b` é cortado (não suportado); mas `p { }` simples passa.
         assert!(!dom.stylesheet().is_empty());
         assert_eq!(dom.computed_style(dom.query("p").unwrap()).unwrap().color, Some(0x0000FFFF));
+    }
+
+    #[test]
+    fn inner_html_get_serializa() {
+        // innerHTML (get): reconstrói o HTML dos filhos.
+        let dom = parse_html_to_dom("<div><p class='x'>oi <b>forte</b></p></div>");
+        let div = dom.query("div").unwrap();
+        assert_eq!(dom.inner_html(div).unwrap(), "<p class=\"x\">oi <b>forte</b></p>");
+        // outerHTML inclui o próprio div.
+        assert_eq!(dom.outer_html(div).unwrap(), "<div><p class=\"x\">oi <b>forte</b></p></div>");
+        // entidades re-encodadas no texto.
+        let d2 = parse_html_to_dom("<p>a &lt; b &amp; c</p>");
+        let p = d2.query("p").unwrap();
+        assert_eq!(d2.inner_html(p).unwrap(), "a &lt; b &amp; c");
+    }
+
+    #[test]
+    fn inner_html_set_substitui() {
+        // innerHTML (set): parseia e troca os filhos.
+        let mut dom = parse_html_to_dom("<div><span>velho</span></div>");
+        let div = dom.query("div").unwrap();
+        dom.set_inner_html(div, "<p>novo</p><b>!</b>");
+        // os filhos novos estão lá; o velho sumiu.
+        assert_eq!(dom.inner_html(div).unwrap(), "<p>novo</p><b>!</b>");
+        // a árvore real reflete (query acha o <p> novo).
+        let p = dom.query("p").unwrap();
+        assert_eq!(dom.text_content(p).unwrap(), "novo");
+        assert!(dom.query("span").is_none()); // o velho foi descartado
+    }
+
+    #[test]
+    fn inner_html_round_trip() {
+        // parse → serialize → parse estável (subset).
+        let html = "<section id=\"s\"><h2>T</h2><p>texto <i>it</i> fim</p></section>";
+        let dom = parse_html_to_dom(html);
+        let sec = dom.query("#s").unwrap();
+        let serial = dom.outer_html(sec).unwrap();
+        assert_eq!(serial, html);
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -48,6 +48,24 @@ class Element {
     dom.setText(this._dom, this._node, t);
   }
 
+  // `el.innerHTML` — GET serializa os filhos. O jeito #1 de mexer no DOM em apps.
+  get innerHTML(): string {
+    return dom.innerHtml(this._dom, this._node);
+  }
+  // ⚠️ O SET é via MÉTODO `setInnerHTML(html)`, não o setter `el.innerHTML = ...`:
+  // o motor RTS atual não dispara setters de propriedade de classe (o `app.x = v`
+  // não chama `set x()` — cria um campo no objeto). Métodos despacham certo. Quando
+  // o motor suportar setters, o `set innerHTML` volta. (mesmo motivo de classList*
+  // serem métodos, não um objeto `.classList` vivo.)
+  setInnerHTML(html: string): void {
+    dom.setInnerHtml(this._dom, this._node, html);
+  }
+
+  // `el.outerHTML` — GET inclui o próprio elemento.
+  get outerHTML(): string {
+    return dom.outerHtml(this._dom, this._node);
+  }
+
   // `el.tagName` — o browser devolve em CAIXA ALTA para HTML.
   get tagName(): string {
     return dom.tagName(this._dom, this._node).toUpperCase();

--- a/crates/rts-dom/src/html.rs
+++ b/crates/rts-dom/src/html.rs
@@ -161,6 +161,45 @@ pub(crate) fn decode_entities(s: &str) -> String {
     out
 }
 
+/// Re-encoda um texto para conteúdo HTML (inverso de `decode_entities` no caminho
+/// de TEXTO): `&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;`. É o que `innerHTML` (GET) usa
+/// para serializar um nó de texto de forma segura. `pub(crate)`.
+pub(crate) fn encode_text_entities(s: &str) -> String {
+    // Atalho: sem caractere especial, nada a fazer (caso comum).
+    if !s.contains(['&', '<', '>']) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Re-encoda um valor de ATRIBUTO (serializado entre aspas duplas): além de
+/// `&`/`<`/`>`, escapa `"`→`&quot;` (o delimitador). Para `innerHTML`/`outerHTML`.
+pub(crate) fn encode_attr_entities(s: &str) -> String {
+    if !s.contains(['&', '<', '>', '"']) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 /// Decodifica o MIOLO de uma entidade (sem o `&` e o `;`). `None` se desconhecida.
 fn decode_one_entity(body: &str) -> Option<char> {
     if let Some(num) = body.strip_prefix('#') {

--- a/examples/claude-dom-innerhtml.ts
+++ b/examples/claude-dom-innerhtml.ts
@@ -1,0 +1,21 @@
+// innerHTML / outerHTML — manipular o DOM via HTML string (o jeito #1 em apps).
+// SET é via MÉTODO setInnerHTML() (o motor RTS não dispara setters de propriedade).
+//   target/release/rts.exe run examples/claude-dom-innerhtml.ts
+import { io } from "rts";
+
+const d = parseDocument("<div id='app'><p>conteudo inicial</p></div>");
+const app = d.querySelector("#app");
+if (app !== null) {
+  io.print("innerHTML inicial: " + app.innerHTML);
+
+  // SET — parseia o HTML e substitui os filhos (a árvore real muda).
+  app.setInnerHTML("<h2>Painel</h2><ul><li>um</li><li>dois</li></ul>");
+  io.print("apos setInnerHTML: " + app.innerHTML);
+
+  // querySelector acha os nós novos (parseados de verdade).
+  const h2 = d.querySelector("h2");
+  if (h2 !== null) io.print("h2 textContent: " + h2.textContent);
+
+  // outerHTML inclui o proprio <div>.
+  io.print("outerHTML: " + app.outerHTML);
+}


### PR DESCRIPTION
Implementa #1755. innerHTML/outerHTML GET (serializa subárvore) + setInnerHTML SET (parse+substitui filhos, atualiza índices).

⚠️ Descoberto: setters de propriedade de classe NÃO disparam no motor (app.innerHTML=v não chama o set; confirmado com className tb). SET via MÉTODO setInnerHTML(). 79 testes rts-dom.

Closes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)