### PR TITLE
feat(dom): traversal + atributos + Node-utils (#1757, #1761, #1762)

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -388,6 +388,130 @@ pub extern "C" fn __RTS_FN_NS_DOM_SET_INNER_HTML(h: u64, id: i64, html_ptr: *con
     with_mut(h, |dom| dom.set_inner_html(node, &html));
 }
 
+// ── Traversal por elemento — #1757 ──────────────────────────────────────────────
+
+/// Macro de navegação que devolve um `NodeId` (ou `-1`). Reduz boilerplate.
+macro_rules! nav_fn {
+    ($fn:ident, $method:ident) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn $fn(h: u64, id: i64) -> i64 {
+            let Some(node) = NodeId::from_abi(id) else { return NODE_NONE };
+            with(h, |dom| dom.$method(node).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+        }
+    };
+}
+nav_fn!(__RTS_FN_NS_DOM_FIRST_ELEMENT_CHILD, first_element_child);
+nav_fn!(__RTS_FN_NS_DOM_LAST_ELEMENT_CHILD, last_element_child);
+nav_fn!(__RTS_FN_NS_DOM_NEXT_ELEMENT_SIBLING, next_element_sibling);
+nav_fn!(__RTS_FN_NS_DOM_PREVIOUS_ELEMENT_SIBLING, previous_element_sibling);
+nav_fn!(__RTS_FN_NS_DOM_PARENT_ELEMENT, parent_element);
+
+/// `closest(domHandle, node, selector)` → o NodeId do ancestral (ou o próprio) que
+/// casa o seletor simples, ou `-1`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_CLOSEST(h: u64, id: i64, sel_ptr: *const u8, sel_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return NODE_NONE };
+    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.closest(node, &sel).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `matches(domHandle, node, selector)` → 1 se o nó casa o seletor, 0 senão.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_MATCHES(h: u64, id: i64, sel_ptr: *const u8, sel_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.matches_selector(node, &sel) as i64).unwrap_or(0)
+}
+
+// ── Node utils — #1762 ──────────────────────────────────────────────────────────
+
+/// `contains(domHandle, node, other)` → 1 se `node` contém `other` (ou é ele), 0 senão.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_CONTAINS(h: u64, id: i64, other: i64) -> i64 {
+    let (Some(node), Some(o)) = (NodeId::from_abi(id), NodeId::from_abi(other)) else { return 0 };
+    with(h, |dom| dom.contains(node, o) as i64).unwrap_or(0)
+}
+
+/// `hasChildNodes(domHandle, node)` → 1 se tem ao menos um filho, 0 senão.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_HAS_CHILD_NODES(h: u64, id: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    with(h, |dom| dom.has_child_nodes(node) as i64).unwrap_or(0)
+}
+
+/// `nodeValue(domHandle, node)` → o texto cru de um nó Text/Comment como STRING; ""
+/// para Element/Document (nodeValue null).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_NODE_VALUE(h: u64, id: i64) -> u64 {
+    let Some(node) = NodeId::from_abi(id) else { return intern("") };
+    let v = with(h, |dom| dom.node_value(node).unwrap_or_default()).unwrap_or_default();
+    intern(&v)
+}
+
+/// `setNodeValue(domHandle, node, value)` → substitui o texto de um nó Text/Comment.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_SET_NODE_VALUE(h: u64, id: i64, v_ptr: *const u8, v_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let v = unsafe { str_abi::from_abi(v_ptr, v_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.set_node_value(node, &v));
+}
+
+/// `createComment(domHandle, text)` → NodeId de um nó de comentário solto.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_CREATE_COMMENT(h: u64, t_ptr: *const u8, t_len: i64) -> i64 {
+    let text = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.create_comment(&text).to_abi()).unwrap_or(NODE_NONE)
+}
+
+/// `normalize(domHandle, node)` → funde nós de texto adjacentes + remove vazios.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_NORMALIZE(h: u64, id: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    with_mut(h, |dom| dom.normalize(node));
+}
+
+// ── Atributos extra — #1761 ─────────────────────────────────────────────────────
+
+/// `removeAttr(domHandle, node, name)` → remove o atributo (no-op se ausente).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_ATTR(h: u64, id: i64, n_ptr: *const u8, n_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.remove_attr(node, &name));
+}
+
+/// `hasAttr(domHandle, node, name)` → 1 se o atributo está PRESENTE (mesmo vazio),
+/// 0 senão. Corrige atributos booleanos (`hidden`/`disabled`, valor `""`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_HAS_ATTR(h: u64, id: i64, n_ptr: *const u8, n_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.has_attr(node, &name) as i64).unwrap_or(0)
+}
+
+/// `attrCount(domHandle, node)` → nº de atributos (para getAttributeNames/attributes).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_ATTR_COUNT(h: u64, id: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    with(h, |dom| dom.attr_names(node).len() as i64).unwrap_or(0)
+}
+
+/// `attrNameAt(domHandle, node, i)` → nome do i-ésimo atributo como STRING.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_ATTR_NAME_AT(h: u64, id: i64, i: i64) -> u64 {
+    let Some(node) = NodeId::from_abi(id) else { return intern("") };
+    let name = with(h, |dom| dom.attr_names(node).get(i as usize).cloned().unwrap_or_default()).unwrap_or_default();
+    intern(&name)
+}
+
+/// `attrValueAt(domHandle, node, i)` → valor do i-ésimo atributo como STRING.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_ATTR_VALUE_AT(h: u64, id: i64, i: i64) -> u64 {
+    let Some(node) = NodeId::from_abi(id) else { return intern("") };
+    let val = with(h, |dom| dom.attr_value_at(node, i as usize).unwrap_or_default()).unwrap_or_default();
+    intern(&val)
+}
+
 /// `getAttribute(domHandle, node, name)` → valor do atributo como STRING (handle
 /// do pool GC). Atributo ausente / nó inválido ⇒ `""` (a fachada TS converte ""
 /// para `null` se quiser semântica de browser).
@@ -858,6 +982,135 @@ pub fn register(e: &mut Engine) {
             "setInnerHtml(dom: number, node: number, html: string): void",
             "element.innerHTML = html (set): parses the HTML and replaces the node's children.",
             __RTS_FN_NS_DOM_SET_INNER_HTML as *const u8,
+        ))
+        // ── Traversal por elemento — #1757 ──────────────────────────────────────
+        .member(func(
+            "firstElementChild", "__RTS_FN_NS_DOM_FIRST_ELEMENT_CHILD",
+            Sig::new(vec![Handle, I64], I64),
+            "firstElementChild(dom: number, node: number): number",
+            "element.firstElementChild: first child that is an Element (-1 if none).",
+            __RTS_FN_NS_DOM_FIRST_ELEMENT_CHILD as *const u8,
+        ))
+        .member(func(
+            "lastElementChild", "__RTS_FN_NS_DOM_LAST_ELEMENT_CHILD",
+            Sig::new(vec![Handle, I64], I64),
+            "lastElementChild(dom: number, node: number): number",
+            "element.lastElementChild: last child Element (-1 if none).",
+            __RTS_FN_NS_DOM_LAST_ELEMENT_CHILD as *const u8,
+        ))
+        .member(func(
+            "nextElementSibling", "__RTS_FN_NS_DOM_NEXT_ELEMENT_SIBLING",
+            Sig::new(vec![Handle, I64], I64),
+            "nextElementSibling(dom: number, node: number): number",
+            "element.nextElementSibling: next sibling Element, skipping text (-1 if none).",
+            __RTS_FN_NS_DOM_NEXT_ELEMENT_SIBLING as *const u8,
+        ))
+        .member(func(
+            "previousElementSibling", "__RTS_FN_NS_DOM_PREVIOUS_ELEMENT_SIBLING",
+            Sig::new(vec![Handle, I64], I64),
+            "previousElementSibling(dom: number, node: number): number",
+            "element.previousElementSibling: previous sibling Element (-1 if none).",
+            __RTS_FN_NS_DOM_PREVIOUS_ELEMENT_SIBLING as *const u8,
+        ))
+        .member(func(
+            "parentElement", "__RTS_FN_NS_DOM_PARENT_ELEMENT",
+            Sig::new(vec![Handle, I64], I64),
+            "parentElement(dom: number, node: number): number",
+            "node.parentElement: the parent if it is an Element (not the Document) (-1 otherwise).",
+            __RTS_FN_NS_DOM_PARENT_ELEMENT as *const u8,
+        ))
+        .member(func(
+            "closest", "__RTS_FN_NS_DOM_CLOSEST",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "closest(dom: number, node: number, selector: string): number",
+            "element.closest(sel): nearest ancestor (incl. self) matching the simple selector (-1 if none).",
+            __RTS_FN_NS_DOM_CLOSEST as *const u8,
+        ))
+        .member(func(
+            "matches", "__RTS_FN_NS_DOM_MATCHES",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "matches(dom: number, node: number, selector: string): number",
+            "element.matches(sel): 1 if the node matches the simple selector, 0 otherwise.",
+            __RTS_FN_NS_DOM_MATCHES as *const u8,
+        ))
+        // ── Node utils — #1762 ──────────────────────────────────────────────────
+        .member(func(
+            "contains", "__RTS_FN_NS_DOM_CONTAINS",
+            Sig::new(vec![Handle, I64, I64], I64),
+            "contains(dom: number, node: number, other: number): number",
+            "node.contains(other): 1 if other is node or a descendant, 0 otherwise.",
+            __RTS_FN_NS_DOM_CONTAINS as *const u8,
+        ))
+        .member(func(
+            "hasChildNodes", "__RTS_FN_NS_DOM_HAS_CHILD_NODES",
+            Sig::new(vec![Handle, I64], I64),
+            "hasChildNodes(dom: number, node: number): number",
+            "node.hasChildNodes(): 1 if it has any child, 0 otherwise.",
+            __RTS_FN_NS_DOM_HAS_CHILD_NODES as *const u8,
+        ))
+        .member(func(
+            "nodeValue", "__RTS_FN_NS_DOM_NODE_VALUE",
+            Sig::new(vec![Handle, I64], AbiType::Handle),
+            "nodeValue(dom: number, node: number): string",
+            "node.nodeValue: raw text of a Text/Comment node ('' for Element/Document).",
+            __RTS_FN_NS_DOM_NODE_VALUE as *const u8,
+        ))
+        .member(func(
+            "setNodeValue", "__RTS_FN_NS_DOM_SET_NODE_VALUE",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "setNodeValue(dom: number, node: number, value: string): void",
+            "node.nodeValue = value: replaces the text of a Text/Comment node.",
+            __RTS_FN_NS_DOM_SET_NODE_VALUE as *const u8,
+        ))
+        .member(func(
+            "createComment", "__RTS_FN_NS_DOM_CREATE_COMMENT",
+            Sig::new(vec![Handle, StrPtr], I64),
+            "createComment(dom: number, text: string): number",
+            "document.createComment(text): a detached comment node.",
+            __RTS_FN_NS_DOM_CREATE_COMMENT as *const u8,
+        ))
+        .member(func(
+            "normalize", "__RTS_FN_NS_DOM_NORMALIZE",
+            Sig::new(vec![Handle, I64], AbiType::Void),
+            "normalize(dom: number, node: number): void",
+            "node.normalize(): merge adjacent text nodes and drop empty ones, recursively.",
+            __RTS_FN_NS_DOM_NORMALIZE as *const u8,
+        ))
+        // ── Atributos extra — #1761 ─────────────────────────────────────────────
+        .member(func(
+            "removeAttr", "__RTS_FN_NS_DOM_REMOVE_ATTR",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "removeAttr(dom: number, node: number, name: string): void",
+            "element.removeAttribute(name).",
+            __RTS_FN_NS_DOM_REMOVE_ATTR as *const u8,
+        ))
+        .member(func(
+            "hasAttr", "__RTS_FN_NS_DOM_HAS_ATTR",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "hasAttr(dom: number, node: number, name: string): number",
+            "element.hasAttribute(name): 1 if present (even empty value), 0 otherwise.",
+            __RTS_FN_NS_DOM_HAS_ATTR as *const u8,
+        ))
+        .member(func(
+            "attrCount", "__RTS_FN_NS_DOM_ATTR_COUNT",
+            Sig::new(vec![Handle, I64], I64),
+            "attrCount(dom: number, node: number): number",
+            "number of attributes (for getAttributeNames/attributes).",
+            __RTS_FN_NS_DOM_ATTR_COUNT as *const u8,
+        ))
+        .member(func(
+            "attrNameAt", "__RTS_FN_NS_DOM_ATTR_NAME_AT",
+            Sig::new(vec![Handle, I64, I64], AbiType::Handle),
+            "attrNameAt(dom: number, node: number, i: number): string",
+            "name of the i-th attribute.",
+            __RTS_FN_NS_DOM_ATTR_NAME_AT as *const u8,
+        ))
+        .member(func(
+            "attrValueAt", "__RTS_FN_NS_DOM_ATTR_VALUE_AT",
+            Sig::new(vec![Handle, I64, I64], AbiType::Handle),
+            "attrValueAt(dom: number, node: number, i: number): string",
+            "value of the i-th attribute.",
+            __RTS_FN_NS_DOM_ATTR_VALUE_AT as *const u8,
         ))
         .member(func(
             "getAttribute",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -529,6 +529,189 @@ impl Dom {
         self.nodes[idx].children.iter().map(|&c| self.make_id(c)).collect()
     }
 
+    // ── Traversal POR ELEMENTO (pula nós de texto/comentário) — #1757 ────────────
+    // `*ElementChild`/`*ElementSibling`/`parentElement` são as variantes "só
+    // elemento" das de cima. O JS usa muito mais estas (ignora whitespace/texto).
+
+    /// `element.firstElementChild`: o 1º filho que é ELEMENTO (pula Text/Comment).
+    pub fn first_element_child(&self, id: NodeId) -> Option<NodeId> {
+        self.child_elements(id).first().copied()
+    }
+
+    /// `element.lastElementChild`: o último filho-elemento.
+    pub fn last_element_child(&self, id: NodeId) -> Option<NodeId> {
+        self.child_elements(id).last().copied()
+    }
+
+    /// `element.nextElementSibling`: o próximo irmão que é ELEMENTO (pula texto).
+    pub fn next_element_sibling(&self, id: NodeId) -> Option<NodeId> {
+        self.element_sibling(id, 1)
+    }
+
+    /// `element.previousElementSibling`: o irmão-elemento anterior.
+    pub fn previous_element_sibling(&self, id: NodeId) -> Option<NodeId> {
+        self.element_sibling(id, -1)
+    }
+
+    /// Caminha irmão-a-irmão na direção `delta` até achar um ELEMENTO (ou acabar).
+    fn element_sibling(&self, id: NodeId, delta: isize) -> Option<NodeId> {
+        let mut cur = id;
+        loop {
+            cur = self.sibling(cur, delta)?;
+            let idx = self.resolve(cur)?;
+            if matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
+                return Some(cur);
+            }
+        }
+    }
+
+    /// `element.parentElement`: o pai SE for um elemento; `None` se o pai é o
+    /// `#document` (a raiz não é um elemento) ou não há pai.
+    pub fn parent_element(&self, id: NodeId) -> Option<NodeId> {
+        let parent = self.parent_of(id)?;
+        let pidx = self.resolve(parent)?;
+        matches!(self.nodes[pidx].kind, NodeKind::Element { .. }).then_some(parent)
+    }
+
+    /// `element.matches(sel)`: o nó casa o seletor SIMPLES (tag/`#id`/`.classe`)?
+    /// Reusa o matcher de `querySelector` (mesma sintaxe). Combinadores → #1752.
+    pub fn matches_selector(&self, id: NodeId, sel: &str) -> bool {
+        self.resolve(id).map(|i| self.matches(i, sel.trim())).unwrap_or(false)
+    }
+
+    /// `element.closest(sel)`: sobe pela cadeia de ancestrais (incluindo o próprio
+    /// nó) e devolve o PRIMEIRO que casa o seletor; `None` se nenhum casa.
+    pub fn closest(&self, id: NodeId, sel: &str) -> Option<NodeId> {
+        let sel = sel.trim();
+        let mut cur = Some(id);
+        while let Some(node) = cur {
+            let idx = self.resolve(node)?;
+            if matches!(self.nodes[idx].kind, NodeKind::Element { .. }) && self.matches(idx, sel) {
+                return Some(node);
+            }
+            cur = self.parent_of(node);
+        }
+        None
+    }
+
+    // ── Node utils — #1762 ───────────────────────────────────────────────────────
+
+    /// `node.contains(other)`: `other` é o próprio nó OU um descendente dele?
+    /// (Reusa a guarda de ciclo `is_ancestor`, que é exatamente esta relação.)
+    pub fn contains(&self, node: NodeId, other: NodeId) -> bool {
+        let (Some(a), Some(b)) = (self.resolve(node), self.resolve(other)) else { return false };
+        a == b || self.is_ancestor(a, b)
+    }
+
+    /// `node.hasChildNodes()`: tem ao menos um filho (de qualquer tipo)?
+    pub fn has_child_nodes(&self, id: NodeId) -> bool {
+        self.resolve(id).map(|i| !self.nodes[i].children.is_empty()).unwrap_or(false)
+    }
+
+    /// `node.nodeValue`: o texto cru de um nó Text/Comment; `None` para
+    /// Element/Document (que têm `nodeValue` null no DOM). Distinto de
+    /// `textContent` (que concatena descendentes).
+    pub fn node_value(&self, id: NodeId) -> Option<String> {
+        let idx = self.resolve(id)?;
+        match &self.nodes[idx].kind {
+            NodeKind::Text(t) | NodeKind::Comment(t) => Some(t.clone()),
+            _ => None,
+        }
+    }
+
+    /// `node.nodeValue = v`: substitui o texto de um nó Text/Comment (no-op em
+    /// Element/Document).
+    pub fn set_node_value(&mut self, id: NodeId, value: &str) {
+        let Some(idx) = self.resolve(id) else { return };
+        match &mut self.nodes[idx].kind {
+            NodeKind::Text(t) | NodeKind::Comment(t) => *t = value.to_string(),
+            _ => {}
+        }
+    }
+
+    /// `document.createComment(text)`: cria um nó de comentário solto.
+    pub fn create_comment(&mut self, text: &str) -> NodeId {
+        let idx = self.push_detached(NodeKind::Comment(text.to_string()));
+        self.make_id(idx)
+    }
+
+    /// `node.normalize()`: funde nós de Texto ADJACENTES num só e remove os de
+    /// texto vazio, recursivamente. Mantém a semântica do DOM (não toca elementos).
+    pub fn normalize(&mut self, id: NodeId) {
+        let Some(idx) = self.resolve(id) else { return };
+        // 1) recursão nos filhos-elemento primeiro.
+        let children: Vec<NodeIdx> = self.nodes[idx].children.clone();
+        for c in &children {
+            if matches!(self.nodes[*c].kind, NodeKind::Element { .. }) {
+                let cid = self.make_id(*c);
+                self.normalize(cid);
+            }
+        }
+        // 2) funde Text adjacentes + remove vazios nos filhos diretos.
+        let mut new_children: Vec<NodeIdx> = Vec::new();
+        for c in self.nodes[idx].children.clone() {
+            if let NodeKind::Text(t) = &self.nodes[c].kind {
+                if t.is_empty() {
+                    continue; // remove texto vazio
+                }
+                // funde com o anterior se também for Text.
+                if let Some(&prev) = new_children.last() {
+                    if let NodeKind::Text(pt) = &self.nodes[prev].kind {
+                        let merged = format!("{pt}{t}");
+                        if let NodeKind::Text(pt_mut) = &mut self.nodes[prev].kind {
+                            *pt_mut = merged;
+                        }
+                        continue; // não acrescenta o nó atual (foi fundido)
+                    }
+                }
+            }
+            new_children.push(c);
+        }
+        self.nodes[idx].children = new_children;
+    }
+
+    // ── Atributos extra — #1761 ──────────────────────────────────────────────────
+
+    /// `element.removeAttribute(name)`: remove o atributo (no-op se ausente).
+    /// Limpa os índices id/class para o nó (a busca revalida, mas evita stale).
+    pub fn remove_attr(&mut self, id: NodeId, name: &str) {
+        let Some(idx) = self.resolve(id) else { return };
+        let name_lc = name.to_ascii_lowercase();
+        self.nodes[idx].attrs.retain(|a| a.name != name_lc);
+        // limpa o índice correspondente (entradas stale são toleradas, mas
+        // remover ajuda a manter o índice enxuto).
+        match name_lc.as_str() {
+            "id" => self.id_index.retain(|_, &mut v| v != idx),
+            "class" => {
+                for v in self.class_index.values_mut() {
+                    v.retain(|&x| x != idx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// `element.hasAttribute(name)`: o atributo ESTÁ PRESENTE (mesmo com valor
+    /// vazio — `hidden`/`disabled` são booleanos com valor `""`)? Checa a presença
+    /// na lista, não o valor (o `getAttribute("").length>0` da fachada errava aqui).
+    pub fn has_attr(&self, id: NodeId, name: &str) -> bool {
+        let Some(idx) = self.resolve(id) else { return false };
+        let name_lc = name.to_ascii_lowercase();
+        self.nodes[idx].attrs.iter().any(|a| a.name == name_lc)
+    }
+
+    /// `element.getAttributeNames()`: os nomes dos atributos, em ordem do HTML.
+    pub fn attr_names(&self, id: NodeId) -> Vec<String> {
+        let Some(idx) = self.resolve(id) else { return Vec::new() };
+        self.nodes[idx].attrs.iter().map(|a| a.name.clone()).collect()
+    }
+
+    /// Valor do atributo N-ésimo (para `attributes`), por índice. `None` fora do range.
+    pub fn attr_value_at(&self, id: NodeId, i: usize) -> Option<String> {
+        let idx = self.resolve(id)?;
+        self.nodes[idx].attrs.get(i).map(|a| a.value.clone())
+    }
+
     // ── Navegação do DOM (parentNode / first|lastChild / next|previousSibling) ───
     // O `parent`/`children` da arena já têm tudo; aqui só expomos no vocabulário do
     // DOM. `None`/`-1` na fronteira ABI quando não há (raiz não tem pai; primeiro
@@ -1261,6 +1444,76 @@ mod tests {
         let sec = dom.query("#s").unwrap();
         let serial = dom.outer_html(sec).unwrap();
         assert_eq!(serial, html);
+    }
+
+    #[test]
+    fn traversal_por_elemento() {
+        // firstElementChild/nextElementSibling pulam texto e comentário (#1757).
+        let dom = parse_html_to_dom("<div id=\"a\"><!--c--><p class=\"x\">um</p>txt<span>dois</span></div>");
+        let div = dom.query("#a").unwrap();
+        let p = dom.first_element_child(div).unwrap();
+        // node_name no Rust é minúsculo (a fachada TS faz toUpperCase).
+        assert_eq!(dom.node_name(p).as_deref(), Some("p")); // pulou o comentário
+        let span = dom.next_element_sibling(p).unwrap();
+        assert_eq!(dom.node_name(span).as_deref(), Some("span")); // pulou o texto "txt"
+        assert_eq!(dom.last_element_child(div), Some(span));
+        assert_eq!(dom.parent_element(p), Some(div));
+        // matches/closest com seletor simples.
+        assert!(dom.matches_selector(p, ".x"));
+        assert!(!dom.matches_selector(p, ".y"));
+        assert_eq!(dom.closest(p, "#a"), Some(div));
+        assert_eq!(dom.closest(p, "p"), Some(p)); // o próprio nó conta
+    }
+
+    #[test]
+    fn node_utils_contains_e_nodevalue() {
+        let dom = parse_html_to_dom("<div id=\"a\"><p>oi</p></div>");
+        let div = dom.query("#a").unwrap();
+        let p = dom.query("p").unwrap();
+        assert!(dom.contains(div, p)); // div contém p
+        assert!(dom.contains(div, div)); // contém a si mesmo
+        assert!(!dom.contains(p, div)); // p NÃO contém o div
+        assert!(dom.has_child_nodes(div));
+        // nodeValue: só Text/Comment; Element = None.
+        let txt = dom.first_child(p).unwrap();
+        assert_eq!(dom.node_value(txt).as_deref(), Some("oi"));
+        assert_eq!(dom.node_value(div), None);
+    }
+
+    #[test]
+    fn normalize_funde_textos_adjacentes() {
+        let mut dom = parse_html_to_dom("<div id=\"a\"></div>");
+        let div = dom.query("#a").unwrap();
+        for s in ["a", "b", "", "c"] {
+            let t = dom.create_text_node(s);
+            dom.append_child(div, t);
+        }
+        assert_eq!(dom.child_nodes(div).len(), 4);
+        dom.normalize(div);
+        let kids = dom.child_nodes(div);
+        assert_eq!(kids.len(), 1, "4 textos (1 vazio) → 1 fundido");
+        assert_eq!(dom.node_value(kids[0]).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn atributos_remove_has_e_names() {
+        let mut dom = parse_html_to_dom("<div id=\"a\" class=\"c\" hidden>x</div>");
+        let div = dom.query("#a").unwrap();
+        // hidden é booleano (valor "") mas PRESENTE — has_attr o detecta.
+        assert!(dom.has_attr(div, "hidden"));
+        assert!(!dom.has_attr(div, "title"));
+        assert_eq!(dom.attr_names(div), vec!["id", "class", "hidden"]);
+        dom.remove_attr(div, "hidden");
+        assert!(!dom.has_attr(div, "hidden"));
+        assert_eq!(dom.attr_names(div), vec!["id", "class"]);
+    }
+
+    #[test]
+    fn create_comment_node() {
+        let mut dom = parse_html_to_dom("<div></div>");
+        let c = dom.create_comment("nota");
+        assert_eq!(dom.node_type(c), 8);
+        assert_eq!(dom.node_value(c).as_deref(), Some("nota"));
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -15,6 +15,23 @@
 
 const __DOM_NONE = -1;
 
+// camelCase → kebab-case para o açúcar de `dataset` (`userId` → `user-id`).
+function __camelToKebab(s: string): string {
+  let out = "";
+  let i = 0;
+  while (i < s.length) {
+    const ch = s.charAt(i);
+    const lo = ch.toLowerCase();
+    if (ch !== lo) {
+      out = out + "-" + lo;
+    } else {
+      out = out + ch;
+    }
+    i = i + 1;
+  }
+  return out;
+}
+
 // DOMRect-like — o retorno de `getBoundingClientRect()`. Campos numéricos simples
 // (o browser tem um objeto DOMRect; aqui um literal com os mesmos campos).
 interface DOMRectLike {
@@ -95,7 +112,8 @@ class Element {
     dom.setAttr(this._dom, this._node, name, value);
   }
   hasAttribute(name: string): boolean {
-    return dom.getAttribute(this._dom, this._node, name).length > 0;
+    // checa PRESENÇA (não valor) — atributos booleanos têm valor "" mas existem.
+    return dom.hasAttr(this._dom, this._node, name) === 1;
   }
 
   // `el.querySelector(sel)` — primeiro descendente que casa, ou null. MÉTODO
@@ -174,6 +192,124 @@ class Element {
     const n = dom.previousSibling(this._dom, this._node);
     if (n === __DOM_NONE) return null;
     return new Element(this._dom, n);
+  }
+
+  // ── Traversal POR ELEMENTO (#1757) — pula nós de texto/comentário ────────────
+  get firstElementChild(): Element | null {
+    const n = dom.firstElementChild(this._dom, this._node);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  get lastElementChild(): Element | null {
+    const n = dom.lastElementChild(this._dom, this._node);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  get nextElementSibling(): Element | null {
+    const n = dom.nextElementSibling(this._dom, this._node);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  get previousElementSibling(): Element | null {
+    const n = dom.previousElementSibling(this._dom, this._node);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  get parentElement(): Element | null {
+    const n = dom.parentElement(this._dom, this._node);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  // `el.childElementCount` — reusa o primitivo childCount (já existente).
+  get childElementCount(): number {
+    return dom.childCount(this._dom, this._node);
+  }
+  // `el.closest(sel)` — sobe até o 1º ancestral (ou o próprio) que casa o seletor.
+  // ⚠️ CORTE: só seletor SIMPLES (tag/#id/.classe). Combinadores/compostos → #1752.
+  // Seletor vazio/inválido devolve null (a spec lança SyntaxError — o motor não
+  // propaga exceções da fronteira; tolerante por ora).
+  closest(selector: string): Element | null {
+    const n = dom.closest(this._dom, this._node, selector);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
+  }
+  // `el.matches(sel)` — testa o seletor simples NESTE nó. (mesmos cortes do closest:
+  // só simples; vazio/inválido → false em vez de SyntaxError.)
+  matches(selector: string): boolean {
+    return dom.matches(this._dom, this._node, selector) === 1;
+  }
+
+  // ── Node utils (#1762) ───────────────────────────────────────────────────────
+  // `node.contains(other)` — other é este nó ou um descendente?
+  contains(other: Element): boolean {
+    return dom.contains(this._dom, this._node, other._node) === 1;
+  }
+  // `node.hasChildNodes()`.
+  hasChildNodes(): boolean {
+    return dom.hasChildNodes(this._dom, this._node) === 1;
+  }
+  // `node.nodeValue` — texto cru de Text/Comment. ⚠️ CORTE: a spec dá `null` para
+  // Element/Document, mas a fronteira ABI (string) não carrega null → devolve `''`
+  // nesses casos (um Text vazio também é '', indistinguível). SET é método
+  // (setNodeValue) porque o motor não dispara setters de propriedade.
+  get nodeValue(): string {
+    return dom.nodeValue(this._dom, this._node);
+  }
+  setNodeValue(value: string): void {
+    dom.setNodeValue(this._dom, this._node, value);
+  }
+  // `node.normalize()` — funde textos adjacentes + remove vazios.
+  normalize(): void {
+    dom.normalize(this._dom, this._node);
+  }
+
+  // ── Atributos extra (#1761) ──────────────────────────────────────────────────
+  // `el.removeAttribute(name)`.
+  removeAttribute(name: string): void {
+    dom.removeAttr(this._dom, this._node, name);
+  }
+  // `el.toggleAttribute(name)` — alterna: adiciona se ausente, remove se presente.
+  toggleAttribute(name: string): boolean {
+    if (dom.hasAttr(this._dom, this._node, name) === 1) {
+      dom.removeAttr(this._dom, this._node, name);
+      return false;
+    }
+    dom.setAttr(this._dom, this._node, name, "");
+    return true;
+  }
+  // `el.toggleAttribute(name, force)` — força o estado: force=true só ADICIONA
+  // (nunca remove); force=false só REMOVE (nunca adiciona). Devolve o estado final.
+  // (método separado porque o motor não tem parâmetro opcional/default real.)
+  toggleAttributeForce(name: string, force: boolean): boolean {
+    if (force) {
+      if (dom.hasAttr(this._dom, this._node, name) !== 1) {
+        dom.setAttr(this._dom, this._node, name, "");
+      }
+      return true;
+    }
+    dom.removeAttr(this._dom, this._node, name);
+    return false;
+  }
+  // `el.getAttributeNames()` — nomes dos atributos, em ordem.
+  getAttributeNames(): string[] {
+    const out: string[] = [];
+    const n = dom.attrCount(this._dom, this._node);
+    let i = 0;
+    while (i < n) {
+      out.push(dom.attrNameAt(this._dom, this._node, i));
+      i = i + 1;
+    }
+    return out;
+  }
+  // `el.dataset.foo` não é viável (sem objeto-proxy no motor) → métodos sobre
+  // `data-*`. datasetGet("userId") lê `data-user-id`; datasetSet idem.
+  // ⚠️ CORTES vs DOMStringMap: sem enumeração (for..in), sem delete, e o
+  // camelCase→kebab só cobre letras ASCII A-Z (input não-ASCII não hifeniza).
+  datasetGet(key: string): string {
+    return dom.getAttribute(this._dom, this._node, "data-" + __camelToKebab(key));
+  }
+  datasetSet(key: string, value: string): void {
+    dom.setAttr(this._dom, this._node, "data-" + __camelToKebab(key), value);
   }
 
   // `el.nodeType` — Element=1, Text=3, Comment=8, Document=9.
@@ -322,6 +458,12 @@ class Document {
   // `document.createTextNode(text)` — nó de texto solto (anexe com appendChild).
   createTextNode(text: string): Element {
     const n = dom.createTextNode(this._dom, text);
+    return new Element(this._dom, n);
+  }
+
+  // `document.createComment(text)` — nó de comentário solto (nodeType 8).
+  createComment(text: string): Element {
+    const n = dom.createComment(this._dom, text);
     return new Element(this._dom, n);
   }
 


### PR DESCRIPTION
3 issues numa leva (mesma infra ABI+fachada), com **paridade DOM validada no Chrome** (14 pontos) e verificação adversarial de 3 lentes vs MDN.

**#1757 traversal:** firstElementChild/lastElementChild/next-previousElementSibling/parentElement/childElementCount/closest/matches.
**#1761 atributos:** removeAttribute/toggleAttribute(+force)/getAttributeNames/dataset/hasAttr.
**#1762 Node:** contains/hasChildNodes/nodeValue/normalize/createComment.

**Bug corrigido:** hasAttribute checava valor (não presença) → atributos booleanos (hidden/disabled) pareciam ausentes.

Cortes documentados (nodeValue null→'', selector inválido não-throw, dataset sem enum/delete). 96 testes. Paridade Chrome confirmada.

Closes #1757
Closes #1761
Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)