### PR TITLE
feat(dom): query + mutação rica (#1758, #1756)

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -512,6 +512,122 @@ pub extern "C" fn __RTS_FN_NS_DOM_ATTR_VALUE_AT(h: u64, id: i64, i: i64) -> u64 
     intern(&val)
 }
 
+// ── Query extra — #1758: getElementsBy* + querySelector por subárvore ────────────
+// Mesmo padrão count+at do querySelectorAll (re-roda a coleção por índice).
+
+/// `getByClassCount`/`getByClassAt` — elementos com a classe (HTMLCollection).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_CLASS_COUNT(h: u64, n_ptr: *const u8, n_len: i64) -> i64 {
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_class_name(name).len() as i64).unwrap_or(0)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_CLASS_AT(h: u64, n_ptr: *const u8, n_len: i64, i: i64) -> i64 {
+    if i < 0 { return NODE_NONE; }
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_class_name(name).get(i as usize).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `getByTagCount`/`getByTagAt` — elementos da tag (`*` = todos).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_TAG_COUNT(h: u64, n_ptr: *const u8, n_len: i64) -> i64 {
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_tag_name(name).len() as i64).unwrap_or(0)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_TAG_AT(h: u64, n_ptr: *const u8, n_len: i64, i: i64) -> i64 {
+    if i < 0 { return NODE_NONE; }
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_tag_name(name).get(i as usize).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `getByNameCount`/`getByNameAt` — elementos com atributo `name`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_NAME_COUNT(h: u64, n_ptr: *const u8, n_len: i64) -> i64 {
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_name(name).len() as i64).unwrap_or(0)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_GET_BY_NAME_AT(h: u64, n_ptr: *const u8, n_len: i64, i: i64) -> i64 {
+    if i < 0 { return NODE_NONE; }
+    let name = unsafe { str_abi::from_abi(n_ptr, n_len) }.unwrap_or("");
+    with(h, |dom| dom.get_elements_by_name(name).get(i as usize).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `queryWithin(domHandle, root, selector)` → 1º descendente de `root` que casa, ou -1.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_QUERY_WITHIN(h: u64, id: i64, sel_ptr: *const u8, sel_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return NODE_NONE };
+    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.query_within(node, &sel).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `queryAllWithinCount`/`At` — descendentes de `root` que casam (subárvore).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_QUERY_ALL_WITHIN_COUNT(h: u64, id: i64, sel_ptr: *const u8, sel_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.query_all_within(node, &sel).len() as i64).unwrap_or(0)
+}
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_QUERY_ALL_WITHIN_AT(h: u64, id: i64, sel_ptr: *const u8, sel_len: i64, i: i64) -> i64 {
+    if i < 0 { return NODE_NONE; }
+    let Some(node) = NodeId::from_abi(id) else { return NODE_NONE };
+    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.query_all_within(node, &sel).get(i as usize).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+// ── Mutação rica — #1756 ─────────────────────────────────────────────────────────
+
+/// `cloneNode(domHandle, node, deep)` → NodeId do clone solto (deep!=0 = com filhos).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_CLONE_NODE(h: u64, id: i64, deep: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return NODE_NONE };
+    with_mut(h, |dom| dom.clone_node(node, deep != 0).map(|n| n.to_abi()).unwrap_or(NODE_NONE)).unwrap_or(NODE_NONE)
+}
+
+/// `prepend(domHandle, parent, child)` → insere child no início dos filhos.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_PREPEND(h: u64, parent: i64, child: i64) {
+    let (Some(p), Some(c)) = (NodeId::from_abi(parent), NodeId::from_abi(child)) else { return };
+    with_mut(h, |dom| dom.prepend_child(p, c));
+}
+
+/// `insertAdjacent(domHandle, node, other, after)` → other como irmão antes/depois.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_INSERT_ADJACENT(h: u64, node: i64, other: i64, after: i64) {
+    let (Some(n), Some(o)) = (NodeId::from_abi(node), NodeId::from_abi(other)) else { return };
+    with_mut(h, |dom| dom.insert_adjacent(n, o, after != 0));
+}
+
+/// `replaceWith(domHandle, node, other)` → substitui node por other.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_REPLACE_WITH(h: u64, node: i64, other: i64) {
+    let (Some(n), Some(o)) = (NodeId::from_abi(node), NodeId::from_abi(other)) else { return };
+    with_mut(h, |dom| dom.replace_with(n, o));
+}
+
+/// `replaceChild(domHandle, parent, new, old)` → substitui old por new.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_REPLACE_CHILD(h: u64, parent: i64, new_child: i64, old_child: i64) {
+    let (Some(p), Some(nw), Some(od)) = (NodeId::from_abi(parent), NodeId::from_abi(new_child), NodeId::from_abi(old_child)) else { return };
+    with_mut(h, |dom| dom.replace_child(p, nw, od));
+}
+
+/// `removeChild(domHandle, parent, child)` → remove child se for filho de parent.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_CHILD(h: u64, parent: i64, child: i64) {
+    let (Some(p), Some(c)) = (NodeId::from_abi(parent), NodeId::from_abi(child)) else { return };
+    with_mut(h, |dom| dom.remove_child(p, c));
+}
+
+/// `clearChildren(domHandle, parent)` → remove todos os filhos (base de replaceChildren).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_CLEAR_CHILDREN(h: u64, parent: i64) {
+    let Some(p) = NodeId::from_abi(parent) else { return };
+    with_mut(h, |dom| dom.clear_children(p));
+}
+
 /// `getAttribute(domHandle, node, name)` → valor do atributo como STRING (handle
 /// do pool GC). Atributo ausente / nó inválido ⇒ `""` (a fachada TS converte ""
 /// para `null` se quiser semântica de browser).
@@ -1111,6 +1227,120 @@ pub fn register(e: &mut Engine) {
             "attrValueAt(dom: number, node: number, i: number): string",
             "value of the i-th attribute.",
             __RTS_FN_NS_DOM_ATTR_VALUE_AT as *const u8,
+        ))
+        // ── Query extra — #1758 ─────────────────────────────────────────────────
+        .member(func(
+            "getByClassCount", "__RTS_FN_NS_DOM_GET_BY_CLASS_COUNT",
+            Sig::new(vec![Handle, StrPtr], I64),
+            "getByClassCount(dom: number, name: string): number",
+            "count of getElementsByClassName.",
+            __RTS_FN_NS_DOM_GET_BY_CLASS_COUNT as *const u8,
+        ))
+        .member(func(
+            "getByClassAt", "__RTS_FN_NS_DOM_GET_BY_CLASS_AT",
+            Sig::new(vec![Handle, StrPtr, I64], I64),
+            "getByClassAt(dom: number, name: string, i: number): number",
+            "i-th element of getElementsByClassName.",
+            __RTS_FN_NS_DOM_GET_BY_CLASS_AT as *const u8,
+        ))
+        .member(func(
+            "getByTagCount", "__RTS_FN_NS_DOM_GET_BY_TAG_COUNT",
+            Sig::new(vec![Handle, StrPtr], I64),
+            "getByTagCount(dom: number, tag: string): number",
+            "count of getElementsByTagName ('*' = all).",
+            __RTS_FN_NS_DOM_GET_BY_TAG_COUNT as *const u8,
+        ))
+        .member(func(
+            "getByTagAt", "__RTS_FN_NS_DOM_GET_BY_TAG_AT",
+            Sig::new(vec![Handle, StrPtr, I64], I64),
+            "getByTagAt(dom: number, tag: string, i: number): number",
+            "i-th element of getElementsByTagName.",
+            __RTS_FN_NS_DOM_GET_BY_TAG_AT as *const u8,
+        ))
+        .member(func(
+            "getByNameCount", "__RTS_FN_NS_DOM_GET_BY_NAME_COUNT",
+            Sig::new(vec![Handle, StrPtr], I64),
+            "getByNameCount(dom: number, name: string): number",
+            "count of getElementsByName.",
+            __RTS_FN_NS_DOM_GET_BY_NAME_COUNT as *const u8,
+        ))
+        .member(func(
+            "getByNameAt", "__RTS_FN_NS_DOM_GET_BY_NAME_AT",
+            Sig::new(vec![Handle, StrPtr, I64], I64),
+            "getByNameAt(dom: number, name: string, i: number): number",
+            "i-th element of getElementsByName.",
+            __RTS_FN_NS_DOM_GET_BY_NAME_AT as *const u8,
+        ))
+        .member(func(
+            "queryWithin", "__RTS_FN_NS_DOM_QUERY_WITHIN",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "queryWithin(dom: number, root: number, selector: string): number",
+            "element.querySelector restricted to the subtree (-1 if none).",
+            __RTS_FN_NS_DOM_QUERY_WITHIN as *const u8,
+        ))
+        .member(func(
+            "queryAllWithinCount", "__RTS_FN_NS_DOM_QUERY_ALL_WITHIN_COUNT",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "queryAllWithinCount(dom: number, root: number, selector: string): number",
+            "count of element.querySelectorAll in the subtree.",
+            __RTS_FN_NS_DOM_QUERY_ALL_WITHIN_COUNT as *const u8,
+        ))
+        .member(func(
+            "queryAllWithinAt", "__RTS_FN_NS_DOM_QUERY_ALL_WITHIN_AT",
+            Sig::new(vec![Handle, I64, StrPtr, I64], I64),
+            "queryAllWithinAt(dom: number, root: number, selector: string, i: number): number",
+            "i-th element of element.querySelectorAll in the subtree.",
+            __RTS_FN_NS_DOM_QUERY_ALL_WITHIN_AT as *const u8,
+        ))
+        // ── Mutação rica — #1756 ────────────────────────────────────────────────
+        .member(func(
+            "cloneNode", "__RTS_FN_NS_DOM_CLONE_NODE",
+            Sig::new(vec![Handle, I64, I64], I64),
+            "cloneNode(dom: number, node: number, deep: number): number",
+            "node.cloneNode(deep): detached clone (deep!=0 = with children).",
+            __RTS_FN_NS_DOM_CLONE_NODE as *const u8,
+        ))
+        .member(func(
+            "prepend", "__RTS_FN_NS_DOM_PREPEND",
+            Sig::new(vec![Handle, I64, I64], AbiType::Void),
+            "prepend(dom: number, parent: number, child: number): void",
+            "parent.prepend(child): insert at the start.",
+            __RTS_FN_NS_DOM_PREPEND as *const u8,
+        ))
+        .member(func(
+            "insertAdjacent", "__RTS_FN_NS_DOM_INSERT_ADJACENT",
+            Sig::new(vec![Handle, I64, I64, I64], AbiType::Void),
+            "insertAdjacent(dom: number, node: number, other: number, after: number): void",
+            "node.before(other)/after(other): insert as sibling (after!=0 = after).",
+            __RTS_FN_NS_DOM_INSERT_ADJACENT as *const u8,
+        ))
+        .member(func(
+            "replaceWith", "__RTS_FN_NS_DOM_REPLACE_WITH",
+            Sig::new(vec![Handle, I64, I64], AbiType::Void),
+            "replaceWith(dom: number, node: number, other: number): void",
+            "node.replaceWith(other).",
+            __RTS_FN_NS_DOM_REPLACE_WITH as *const u8,
+        ))
+        .member(func(
+            "replaceChild", "__RTS_FN_NS_DOM_REPLACE_CHILD",
+            Sig::new(vec![Handle, I64, I64, I64], AbiType::Void),
+            "replaceChild(dom: number, parent: number, newChild: number, oldChild: number): void",
+            "parent.replaceChild(new, old).",
+            __RTS_FN_NS_DOM_REPLACE_CHILD as *const u8,
+        ))
+        .member(func(
+            "removeChild", "__RTS_FN_NS_DOM_REMOVE_CHILD",
+            Sig::new(vec![Handle, I64, I64], AbiType::Void),
+            "removeChild(dom: number, parent: number, child: number): void",
+            "parent.removeChild(child).",
+            __RTS_FN_NS_DOM_REMOVE_CHILD as *const u8,
+        ))
+        .member(func(
+            "clearChildren", "__RTS_FN_NS_DOM_CLEAR_CHILDREN",
+            Sig::new(vec![Handle, I64], AbiType::Void),
+            "clearChildren(dom: number, parent: number): void",
+            "parent.replaceChildren() with no args: remove all children.",
+            __RTS_FN_NS_DOM_CLEAR_CHILDREN as *const u8,
         ))
         .member(func(
             "getAttribute",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -594,6 +594,189 @@ impl Dom {
         None
     }
 
+    // ── Query por subárvore + getElementsBy* — #1758 ─────────────────────────────
+
+    /// `element.querySelector(sel)`: o 1º descendente do nó que casa o seletor
+    /// (busca SÓ na subárvore, não na árvore toda). `None` se nenhum casa.
+    pub fn query_within(&self, root: NodeId, selector: &str) -> Option<NodeId> {
+        self.query_all_within(root, selector).into_iter().next()
+    }
+
+    /// `element.querySelectorAll(sel)` restrito à subárvore do nó (exclui o próprio).
+    pub fn query_all_within(&self, root: NodeId, selector: &str) -> Vec<NodeId> {
+        let sel = selector.trim();
+        let Some(root_idx) = self.resolve(root) else { return Vec::new() };
+        let mut out = Vec::new();
+        // só os DESCENDENTES (o próprio nó não casa a si mesmo no querySelector).
+        for &child in &self.nodes[root_idx].children {
+            self.query_all_into(child, sel, &mut out);
+        }
+        out
+    }
+
+    /// `getElementsByTagName(tag)`: todos os descendentes da árvore com a tag.
+    /// (`"*"` casa qualquer elemento.) Reusa o matcher de `query_all`.
+    pub fn get_elements_by_tag_name(&self, tag: &str) -> Vec<NodeId> {
+        let tag = tag.trim();
+        if tag == "*" {
+            // todos os elementos em ordem de documento.
+            let mut out = Vec::new();
+            self.collect_all_elements(self.root, &mut out);
+            return out;
+        }
+        self.query_all(tag)
+    }
+
+    fn collect_all_elements(&self, idx: NodeIdx, out: &mut Vec<NodeId>) {
+        if idx != self.root && matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
+            out.push(self.make_id(idx));
+        }
+        for &child in &self.nodes[idx].children {
+            self.collect_all_elements(child, out);
+        }
+    }
+
+    /// `getElementsByClassName(names)`: todos os elementos que têm TODAS as classes
+    /// dadas (separadas por espaço — semântica AND da MDN). Um único token reusa o
+    /// caminho de `.classe`; múltiplos filtram por interseção.
+    pub fn get_elements_by_class_name(&self, names: &str) -> Vec<NodeId> {
+        let wanted: Vec<&str> = names.split_whitespace().collect();
+        if wanted.is_empty() {
+            return Vec::new();
+        }
+        // varre todos os elementos, mantendo os que têm TODAS as classes pedidas.
+        let mut out = Vec::new();
+        self.collect_by_classes(self.root, &wanted, &mut out);
+        out
+    }
+
+    fn collect_by_classes(&self, idx: NodeIdx, wanted: &[&str], out: &mut Vec<NodeId>) {
+        if idx != self.root {
+            if let Some(class_attr) = self.nodes[idx].attr("class") {
+                let have: Vec<&str> = class_attr.split_whitespace().collect();
+                if wanted.iter().all(|w| have.contains(w)) {
+                    out.push(self.make_id(idx));
+                }
+            }
+        }
+        for &child in &self.nodes[idx].children {
+            self.collect_by_classes(child, wanted, out);
+        }
+    }
+
+    /// `getElementsByName(name)`: todos os elementos cujo atributo `name` é igual.
+    /// Nome vazio → lista vazia (consistente com getElementsByClassName).
+    pub fn get_elements_by_name(&self, name: &str) -> Vec<NodeId> {
+        if name.is_empty() {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        self.collect_by_name(self.root, name, &mut out);
+        out
+    }
+
+    fn collect_by_name(&self, idx: NodeIdx, name: &str, out: &mut Vec<NodeId>) {
+        if idx != self.root && self.nodes[idx].attr("name") == Some(name) {
+            out.push(self.make_id(idx));
+        }
+        for &child in &self.nodes[idx].children {
+            self.collect_by_name(child, name, out);
+        }
+    }
+
+    // ── Mutação rica — #1756 ─────────────────────────────────────────────────────
+
+    /// `node.cloneNode(deep)`: duplica o nó. `deep=false` clona só o nó (sem
+    /// filhos); `deep=true` clona a subárvore inteira. O clone é SOLTO (sem pai) —
+    /// anexe-o com appendChild/insertBefore. Devolve o `NodeId` do clone.
+    pub fn clone_node(&mut self, id: NodeId, deep: bool) -> Option<NodeId> {
+        let idx = self.resolve(id)?;
+        let new_idx = self.clone_subtree(idx, deep);
+        Some(self.make_id(new_idx))
+    }
+
+    /// Clona um nó (e opcionalmente sua subárvore) DENTRO do mesmo DOM, soltos.
+    fn clone_subtree(&mut self, src_idx: NodeIdx, deep: bool) -> NodeIdx {
+        let kind = self.nodes[src_idx].kind.clone();
+        let attrs = self.nodes[src_idx].attrs.clone();
+        let new_idx = self.push_detached(kind);
+        self.nodes[new_idx].attrs = attrs;
+        // INDEXA o clone (id/class) — senão querySelector('#x')/getElementById não o
+        // acham depois de anexado (caminhos que usam só os índices).
+        self.index_node(new_idx);
+        if deep {
+            let children = self.nodes[src_idx].children.clone();
+            for c in children {
+                let cc = self.clone_subtree(c, true);
+                self.nodes[cc].parent = Some(new_idx);
+                self.nodes[new_idx].children.push(cc);
+            }
+        }
+        new_idx
+    }
+
+    /// `parent.prepend(child)`: insere `child` no INÍCIO dos filhos de `parent`.
+    pub fn prepend_child(&mut self, parent: NodeId, child: NodeId) {
+        let first = self.first_child(parent);
+        self.insert_before(parent, child, first);
+    }
+
+    /// `node.before(other)` / `after`: insere `other` como irmão antes/depois de
+    /// `node` (no pai de `node`). `after=true` insere depois.
+    pub fn insert_adjacent(&mut self, node: NodeId, other: NodeId, after: bool) {
+        let Some(parent) = self.parent_of(node) else { return };
+        let reference = if after { self.next_sibling(node) } else { Some(node) };
+        self.insert_before(parent, other, reference);
+    }
+
+    /// `node.replaceWith(other)`: substitui `node` por `other`. ATÔMICO: insere
+    /// `other` no lugar e SÓ remove `node` se a inserção funcionou (a guarda de
+    /// ciclo pode abortar o insert — aí não destruímos `node`). No-op se `other`
+    /// é o próprio `node`.
+    pub fn replace_with(&mut self, node: NodeId, other: NodeId) {
+        if node == other {
+            return; // substituir por si mesmo é no-op (não remove)
+        }
+        let Some(parent) = self.parent_of(node) else { return };
+        self.insert_before(parent, other, Some(node)); // other ANTES de node
+        // só remove node se other realmente entrou (insert pode ter abortado por ciclo).
+        if self.parent_of(other) == Some(parent) {
+            self.remove_node(node);
+        }
+    }
+
+    /// `parent.replaceChild(new, old)`: substitui o filho `old` por `new`. ATÔMICO:
+    /// só remove `old` se `new` foi inserido (guarda de ciclo). No-op se new==old.
+    pub fn replace_child(&mut self, parent: NodeId, new_child: NodeId, old_child: NodeId) {
+        if new_child == old_child {
+            return;
+        }
+        if self.parent_of(old_child) != Some(parent) {
+            return; // old precisa ser filho de parent
+        }
+        self.insert_before(parent, new_child, Some(old_child));
+        if self.parent_of(new_child) == Some(parent) {
+            self.remove_node(old_child);
+        }
+    }
+
+    /// `parent.removeChild(child)`: remove `child` se for filho de `parent`.
+    pub fn remove_child(&mut self, parent: NodeId, child: NodeId) {
+        if self.parent_of(child) == Some(parent) {
+            self.remove_node(child);
+        }
+    }
+
+    /// `parent.replaceChildren()`: remove TODOS os filhos de `parent` (a variante
+    /// com novos filhos é montada no JS chamando isto + appendChild).
+    pub fn clear_children(&mut self, parent: NodeId) {
+        let Some(idx) = self.resolve(parent) else { return };
+        let children: Vec<NodeIdx> = self.nodes[idx].children.clone();
+        for c in children {
+            self.detach(c);
+        }
+    }
+
     // ── Node utils — #1762 ───────────────────────────────────────────────────────
 
     /// `node.contains(other)`: `other` é o próprio nó OU um descendente dele?
@@ -778,8 +961,13 @@ impl Dom {
         }
     }
 
-    /// `true` se o nó `idx` casa o seletor simples `sel` (tag / `#id` / `.classe`).
+    /// `true` se o nó `idx` casa o seletor simples `sel` (`*` / tag / `#id` /
+    /// `.classe`). O `*` (universal) casa qualquer elemento.
     fn matches(&self, idx: NodeIdx, sel: &str) -> bool {
+        // universal: casa qualquer ELEMENTO (não texto/comentário/Document).
+        if sel == "*" {
+            return matches!(self.nodes[idx].kind, NodeKind::Element { .. });
+        }
         if let Some(key) = sel.strip_prefix('#') {
             return self.nodes[idx].attr("id") == Some(key);
         }
@@ -847,10 +1035,22 @@ impl Dom {
         if parent == child || self.is_ancestor(child, parent) {
             return;
         }
+        // ref==child é no-op (inserir antes de si mesmo mantém a posição). A spec do
+        // DOM trata referenceNode==node como manter no lugar.
         let ref_idx = reference.and_then(|r| self.resolve(r));
+        if ref_idx == Some(child) {
+            // já garante o parent (caso o nó fosse solto) e mantém a ordem.
+            if self.nodes[child].parent != Some(parent) {
+                self.detach(child);
+                self.nodes[child].parent = Some(parent);
+                self.nodes[parent].children.push(child);
+            }
+            return;
+        }
+        // captura a posição da referência ANTES do detach (o detach pode mexer na
+        // lista de filhos do pai se o child já era irmão da referência).
         self.detach(child);
         self.nodes[child].parent = Some(parent);
-        // posição do nó de referência entre os filhos do pai; sem ref → fim.
         let pos = ref_idx
             .and_then(|r| self.nodes[parent].children.iter().position(|&c| c == r))
             .unwrap_or(self.nodes[parent].children.len());
@@ -1506,6 +1706,136 @@ mod tests {
         dom.remove_attr(div, "hidden");
         assert!(!dom.has_attr(div, "hidden"));
         assert_eq!(dom.attr_names(div), vec!["id", "class"]);
+    }
+
+    #[test]
+    fn query_por_subarvore() {
+        // querySelector restrito à subárvore (#1758): o <p> dentro de #b não deve
+        // ser achado pela busca dentro de #a.
+        let dom = parse_html_to_dom("<div id=\"a\"><p class=\"x\">in-a</p></div><div id=\"b\"><p class=\"x\">in-b</p></div>");
+        let a = dom.query("#a").unwrap();
+        let found = dom.query_within(a, ".x").unwrap();
+        assert_eq!(dom.text_content(found).as_deref(), Some("in-a")); // só o de dentro de #a
+        assert_eq!(dom.query_all_within(a, ".x").len(), 1); // não vê o de #b
+        // mas a busca global vê os dois.
+        assert_eq!(dom.query_all(".x").len(), 2);
+    }
+
+    #[test]
+    fn get_elements_by() {
+        let dom = parse_html_to_dom(
+            "<div class=\"card\"><p class=\"card\">x</p></div><span name=\"f\">y</span><span name=\"f\">z</span>",
+        );
+        assert_eq!(dom.get_elements_by_class_name("card").len(), 2); // div + p
+        assert_eq!(dom.get_elements_by_tag_name("span").len(), 2);
+        assert_eq!(dom.get_elements_by_name("f").len(), 2); // os 2 spans
+        // '*' = todos os elementos.
+        assert_eq!(dom.get_elements_by_tag_name("*").len(), 4); // div,p,span,span
+    }
+
+    #[test]
+    fn clone_node_deep_e_shallow() {
+        let mut dom = parse_html_to_dom("<div id=\"a\"><p>oi</p><span>tchau</span></div>");
+        let a = dom.query("#a").unwrap();
+        // shallow: clone sem filhos.
+        let shallow = dom.clone_node(a, false).unwrap();
+        assert_eq!(dom.child_nodes(shallow).len(), 0);
+        assert_eq!(dom.node_name(shallow).as_deref(), Some("div"));
+        // deep: com a subárvore.
+        let deep = dom.clone_node(a, true).unwrap();
+        assert_eq!(dom.child_elements(deep).len(), 2); // p + span
+        assert_eq!(dom.text_content(deep).as_deref(), Some("oitchau"));
+        // o clone é SOLTO (sem pai).
+        assert_eq!(dom.parent_of(deep), None);
+    }
+
+    #[test]
+    fn mutacao_rica() {
+        let mut dom = parse_html_to_dom("<div id=\"a\"><p id=\"p\">x</p></div>");
+        let a = dom.query("#a").unwrap();
+        let p = dom.query("#p").unwrap();
+        // prepend: novo elemento no início.
+        let h = dom.create_element("h1");
+        dom.prepend_child(a, h);
+        assert_eq!(dom.first_element_child(a), Some(h)); // h1 antes do p
+        // before/after: irmão de p.
+        let b = dom.create_element("b");
+        dom.insert_adjacent(p, b, false); // b antes de p
+        let i = dom.create_element("i");
+        dom.insert_adjacent(p, i, true); // i depois de p
+        // ordem: h1, b, p, i.
+        let kids = dom.child_elements(a);
+        let names: Vec<String> = kids.iter().map(|&k| dom.node_name(k).unwrap()).collect();
+        assert_eq!(names, vec!["h1", "b", "p", "i"]);
+        // replaceWith: troca p por um span.
+        let s = dom.create_element("span");
+        dom.replace_with(p, s);
+        assert!(dom.query("#p").is_none()); // p saiu
+        // clearChildren: esvazia.
+        dom.clear_children(a);
+        assert_eq!(dom.child_nodes(a).len(), 0);
+    }
+
+    #[test]
+    fn matcher_universal_e_multi_classe() {
+        // BUG (verificação adversarial): "*" não casava; multi-classe não tokenizava.
+        let dom = parse_html_to_dom("<div class=\"a b\"><p class=\"a\">x</p></div>");
+        // "*" casa todos os elementos (div + p).
+        assert_eq!(dom.query_all("*").len(), 2);
+        // multi-classe = AND: só o div tem 'a' E 'b'.
+        assert_eq!(dom.get_elements_by_class_name("a b").len(), 1);
+        assert_eq!(dom.get_elements_by_class_name("a").len(), 2); // div e p têm 'a'
+        // ordem dos tokens não importa.
+        assert_eq!(dom.get_elements_by_class_name("b a").len(), 1);
+    }
+
+    #[test]
+    fn clone_indexado_e_achavel() {
+        // BUG: o clone não entrava nos índices id/class → querySelector não achava.
+        let mut dom = parse_html_to_dom("<div id=\"src\" class=\"card\">x</div>");
+        let src = dom.query("#src").unwrap();
+        let clone = dom.clone_node(src, true).unwrap();
+        // muda o id do clone e anexa à raiz.
+        dom.set_attr(clone, "id", "copy");
+        // anexa à própria raiz #document.
+        dom.append_child(dom.root_id(), clone);
+        // agora querySelector acha o clone pela classe (índice) e pelo novo id.
+        assert!(dom.query(".card").is_some());
+        assert_eq!(dom.get_elements_by_class_name("card").len(), 2); // original + clone
+    }
+
+    #[test]
+    fn replace_with_atomico_nao_destroi_em_ciclo() {
+        // BUG CRITICAL: replaceWith(node, ancestral) destruía node sem inserir.
+        let mut dom = parse_html_to_dom("<div id=\"out\"><div id=\"in\"><p id=\"p\">x</p></div></div>");
+        let out = dom.query("#out").unwrap();
+        let p = dom.query("#p").unwrap();
+        // tentar substituir p por 'out' (ancestral de p) — guarda de ciclo aborta o
+        // insert; p NÃO deve ser destruído.
+        dom.replace_with(p, out);
+        assert!(dom.query("#p").is_some(), "p preservado quando a inserção aborta");
+        // replaceWith por si mesmo é no-op (não remove).
+        dom.replace_with(p, p);
+        assert!(dom.query("#p").is_some());
+        // caso normal: substitui p por um span novo.
+        let s = dom.create_element("span");
+        dom.set_attr(s, "id", "s");
+        dom.replace_with(p, s);
+        assert!(dom.query("#p").is_none());
+        assert!(dom.query("#s").is_some());
+    }
+
+    #[test]
+    fn after_com_proximo_irmao_mantem_ordem() {
+        // BUG: after(other) com other já sendo o próximo irmão jogava other pro fim.
+        let mut dom = parse_html_to_dom("<div id=\"a\"><b id=\"b\">1</b><i id=\"i\">2</i><u id=\"u\">3</u></div>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        let i = dom.query("#i").unwrap();
+        // b.after(i) — i JÁ é o próximo irmão de b; deve manter a ordem b,i,u.
+        dom.insert_adjacent(b, i, true);
+        let names: Vec<String> = dom.child_elements(a).iter().map(|&k| dom.node_name(k).unwrap()).collect();
+        assert_eq!(names, vec!["b", "i", "u"]); // ordem preservada, i não foi pro fim
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -117,23 +117,21 @@ class Element {
   }
 
   // `el.querySelector(sel)` — primeiro descendente que casa, ou null. MÉTODO
-  // (regra 2). NOTE: o primitivo busca na árvore inteira; refino por subárvore
-  // chega quando os seletores compostos chegarem.
+  // `el.querySelector(sel)` — 1º DESCENDENTE que casa (restrito à subárvore deste
+  // nó, fiel à MDN; #1758 corrigiu o antigo, que buscava a árvore toda).
   querySelector(sel: string): Element | null {
-    const n = dom.querySelector(this._dom, sel);
+    const n = dom.queryWithin(this._dom, this._node, sel);
     if (n === __DOM_NONE) return null;
     return new Element(this._dom, n);
   }
 
-  // `el.querySelectorAll(sel)` — todos os que casam, como array. Montado via
-  // count+at (evita retorno de array do Rust).
+  // `el.querySelectorAll(sel)` — todos os DESCENDENTES que casam (subárvore).
   querySelectorAll(sel: string): Element[] {
     const out: Element[] = [];
-    const n = dom.querySelectorAllCount(this._dom, sel);
+    const n = dom.queryAllWithinCount(this._dom, this._node, sel);
     let i = 0;
     while (i < n) {
-      const node = dom.querySelectorAllAt(this._dom, sel, i);
-      out.push(new Element(this._dom, node));
+      out.push(new Element(this._dom, dom.queryAllWithinAt(this._dom, this._node, sel, i)));
       i = i + 1;
     }
     return out;
@@ -237,6 +235,41 @@ class Element {
   // só simples; vazio/inválido → false em vez de SyntaxError.)
   matches(selector: string): boolean {
     return dom.matches(this._dom, this._node, selector) === 1;
+  }
+
+  // ── Mutação rica (#1756) ─────────────────────────────────────────────────────
+  // `el.cloneNode(deep)` — duplica o nó (deep=true com filhos); clone SOLTO.
+  cloneNode(deep: boolean): Element {
+    const n = dom.cloneNode(this._dom, this._node, deep ? 1 : 0);
+    return new Element(this._dom, n);
+  }
+  // `parent.prepend(child)` — insere no INÍCIO. (variádico não no motor → 1 nó.)
+  prepend(child: Element): void {
+    dom.prepend(this._dom, this._node, child._node);
+  }
+  // `el.before(other)` / `after(other)` — insere como irmão (no pai).
+  before(other: Element): void {
+    dom.insertAdjacent(this._dom, this._node, other._node, 0);
+  }
+  after(other: Element): void {
+    dom.insertAdjacent(this._dom, this._node, other._node, 1);
+  }
+  // `el.replaceWith(other)` — substitui este nó por outro.
+  replaceWith(other: Element): void {
+    dom.replaceWith(this._dom, this._node, other._node);
+  }
+  // `parent.replaceChild(new, old)` — substitui o filho old por new.
+  replaceChild(newChild: Element, oldChild: Element): void {
+    dom.replaceChild(this._dom, this._node, newChild._node, oldChild._node);
+  }
+  // `parent.removeChild(child)`.
+  removeChild(child: Element): void {
+    dom.removeChild(this._dom, this._node, child._node);
+  }
+  // `parent.replaceChildren()` sem args — remove todos os filhos. (a variante com
+  // novos filhos: chame replaceChildrenClear() + appendChild manualmente.)
+  replaceChildrenClear(): void {
+    dom.clearChildren(this._dom, this._node);
   }
 
   // ── Node utils (#1762) ───────────────────────────────────────────────────────
@@ -447,6 +480,38 @@ class Document {
   // `document.getElementById(id)` — atalho para `#id`.
   getElementById(id: string): Element | null {
     return this.querySelector("#" + id);
+  }
+
+  // ── getElementsBy* (#1758) — coleções por classe/tag/name ────────────────────
+  getElementsByClassName(name: string): Element[] {
+    const out: Element[] = [];
+    const n = dom.getByClassCount(this._dom, name);
+    let i = 0;
+    while (i < n) {
+      out.push(new Element(this._dom, dom.getByClassAt(this._dom, name, i)));
+      i = i + 1;
+    }
+    return out;
+  }
+  getElementsByTagName(tag: string): Element[] {
+    const out: Element[] = [];
+    const n = dom.getByTagCount(this._dom, tag);
+    let i = 0;
+    while (i < n) {
+      out.push(new Element(this._dom, dom.getByTagAt(this._dom, tag, i)));
+      i = i + 1;
+    }
+    return out;
+  }
+  getElementsByName(name: string): Element[] {
+    const out: Element[] = [];
+    const n = dom.getByNameCount(this._dom, name);
+    let i = 0;
+    while (i < n) {
+      out.push(new Element(this._dom, dom.getByNameAt(this._dom, name, i)));
+      i = i + 1;
+    }
+    return out;
   }
 
   // `document.createElement(tag)` — elemento solto (anexe com appendChild).

--- a/examples/claude-dom-query-mutation.ts
+++ b/examples/claude-dom-query-mutation.ts
@@ -1,0 +1,24 @@
+// Query (getElementsBy*/querySelector por subárvore) + mutação (cloneNode) do DOM
+// nativo — o diferencial "DOM em Rust sem jsdom".
+//   target/release/rts.exe run examples/claude-dom-query-mutation.ts
+import { io } from "rts";
+
+const d = parseDocument(
+  "<ul id='list'><li class='item'>A</li><li class='item'>B</li></ul><ul id='other'><li class='item'>X</li></ul>");
+
+// getElementsByClassName / TagName (coleções)
+io.print("itens (classe): " + d.getElementsByClassName("item").length);  // 3
+io.print("<li> (tag): " + d.getElementsByTagName("li").length);          // 3
+
+// querySelector POR SUBÁRVORE — restrito ao #list (não vê o #other)
+const list = d.querySelector("#list");
+if (list !== null) {
+  io.print("itens dentro de #list: " + list.querySelectorAll(".item").length);  // 2
+
+  // cloneNode(deep) — duplica um <li> com seu conteúdo, e anexa
+  const first = list.querySelector(".item");
+  if (first !== null) {
+    const copy = first.cloneNode(true);
+    io.print("clone textContent: '" + copy.textContent + "'");
+  }
+}


### PR DESCRIPTION
2 issues numa leva, com paridade Chrome e verificação adversarial (2 lentes vs MDN) que pegou **6 bugs reais — todos corrigidos antes do merge**.

**#1758 query:** getElementsByClassName/TagName/Name + querySelector/All por SUBÁRVORE (corrige o Element.querySelector que buscava a árvore toda).
**#1756 mutação:** cloneNode/prepend/before/after/replaceWith/replaceChild/removeChild.

**Bugs corrigidos:** [CRITICAL] replaceWith não-atômico (destruía o nó se o insert abortava); [MAJOR] querySelectorAll('*') vazio, getElementsByClassName multi-classe vazio, cloneNode não-indexado; [MINOR] after/prepend com ref=próprio nó, getElementsByName('').

104 testes (8 novos). Paridade Chrome confirmada.

Closes #1756
Closes #1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)