### PR TITLE
feat(dom): eventos addEventListener/dispatchEvent (#1760)

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -684,6 +684,71 @@ pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_STYLE_PROPERTY(h: u64, id: i64, n_ptr: 
     with_mut(h, |dom| dom.remove_style_property(node, &name));
 }
 
+// ── Eventos (#1760) — polling + bubbling ─────────────────────────────────────────
+// `poll_event` devolve (NodeId, tipo). Como a ABI retorna um escalar por chamada, o
+// `pollEvent` avança a fila e GUARDA o tipo num thread_local; `pollEventType` lê
+// esse tipo logo após. O loop TS: `n = pollEvent(); if (n>=0) { t = pollEventType(); ... }`.
+thread_local! {
+    static LAST_EVENT_TYPE: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+}
+
+/// `addListener(domHandle, node, type)` → registra que o nó escuta o tipo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_ADD_LISTENER(h: u64, id: i64, t_ptr: *const u8, t_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.add_event_listener(node, &t));
+}
+
+/// `removeListener(domHandle, node, type)` → para de escutar o tipo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_LISTENER(h: u64, id: i64, t_ptr: *const u8, t_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.remove_event_listener(node, &t));
+}
+
+/// `hasListener(domHandle, node, type)` → 1 se o nó escuta o tipo, 0 senão.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_HAS_LISTENER(h: u64, id: i64, t_ptr: *const u8, t_len: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with(h, |dom| dom.has_listener(node, &t) as i64).unwrap_or(0)
+}
+
+/// `dispatchEvent(domHandle, target, type, bubbles)` → dispara; `bubbles!=0` sobe
+/// pelos ancestrais. Devolve quantos listeners foram enfileirados.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_DISPATCH_EVENT(h: u64, id: i64, t_ptr: *const u8, t_len: i64, bubbles: i64) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.dispatch_event(node, &t, bubbles != 0)).unwrap_or(0)
+}
+
+/// `pollEvent(domHandle)` → NodeId do próximo evento pendente (ou -1 se a fila está
+/// vazia). GUARDA o tipo p/ `pollEventType` ler em seguida.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_POLL_EVENT(h: u64) -> i64 {
+    match with_mut(h, |dom| dom.poll_event()) {
+        Some(Some((node, t))) => {
+            LAST_EVENT_TYPE.with(|c| *c.borrow_mut() = t);
+            node.to_abi()
+        }
+        _ => {
+            LAST_EVENT_TYPE.with(|c| c.borrow_mut().clear());
+            NODE_NONE
+        }
+    }
+}
+
+/// `pollEventType(domHandle)` → o tipo do evento entregue no último `pollEvent` (""
+/// se nenhum). Ler imediatamente após `pollEvent`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_POLL_EVENT_TYPE(_h: u64) -> u64 {
+    let t = LAST_EVENT_TYPE.with(|c| c.borrow().clone());
+    intern(&t)
+}
+
 /// `getAttribute(domHandle, node, name)` → valor do atributo como STRING (handle
 /// do pool GC). Atributo ausente / nó inválido ⇒ `""` (a fachada TS converte ""
 /// para `null` se quiser semântica de browser).
@@ -1440,6 +1505,49 @@ pub fn register(e: &mut Engine) {
             "removeStyleProperty(dom: number, node: number, name: string): void",
             "el.style.removeProperty(name).",
             __RTS_FN_NS_DOM_REMOVE_STYLE_PROPERTY as *const u8,
+        ))
+        // ── Eventos (#1760) ─────────────────────────────────────────────────────
+        .member(func(
+            "addListener", "__RTS_FN_NS_DOM_ADD_LISTENER",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "addListener(dom: number, node: number, type: string): void",
+            "element.addEventListener(type): register the node as listening for type.",
+            __RTS_FN_NS_DOM_ADD_LISTENER as *const u8,
+        ))
+        .member(func(
+            "removeListener", "__RTS_FN_NS_DOM_REMOVE_LISTENER",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "removeListener(dom: number, node: number, type: string): void",
+            "element.removeEventListener(type).",
+            __RTS_FN_NS_DOM_REMOVE_LISTENER as *const u8,
+        ))
+        .member(func(
+            "hasListener", "__RTS_FN_NS_DOM_HAS_LISTENER",
+            Sig::new(vec![Handle, I64, StrPtr], I64),
+            "hasListener(dom: number, node: number, type: string): number",
+            "1 if the node listens for the type, 0 otherwise.",
+            __RTS_FN_NS_DOM_HAS_LISTENER as *const u8,
+        ))
+        .member(func(
+            "dispatchEvent", "__RTS_FN_NS_DOM_DISPATCH_EVENT",
+            Sig::new(vec![Handle, I64, StrPtr, I64], I64),
+            "dispatchEvent(dom: number, target: number, type: string, bubbles: number): number",
+            "element.dispatchEvent(type, bubbles): fire; bubbles!=0 propagates to ancestors.",
+            __RTS_FN_NS_DOM_DISPATCH_EVENT as *const u8,
+        ))
+        .member(func(
+            "pollEvent", "__RTS_FN_NS_DOM_POLL_EVENT",
+            Sig::new(vec![Handle], I64),
+            "pollEvent(dom: number): number",
+            "next pending event's NodeId (-1 if none); stores type for pollEventType.",
+            __RTS_FN_NS_DOM_POLL_EVENT as *const u8,
+        ))
+        .member(func(
+            "pollEventType", "__RTS_FN_NS_DOM_POLL_EVENT_TYPE",
+            Sig::new(vec![Handle], AbiType::Handle),
+            "pollEventType(dom: number): string",
+            "type of the event delivered by the last pollEvent ('' if none).",
+            __RTS_FN_NS_DOM_POLL_EVENT_TYPE as *const u8,
         ))
         .member(func(
             "getAttribute",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -158,6 +158,14 @@ pub struct Dom {
     /// `defineStyle` (por-tag, mais fraco) e o `style=""` inline. Estado DERIVADO
     /// do HTML — não entra no `PartialEq` do `Dom`.
     stylesheet: crate::style::Stylesheet,
+    /// Eventos (#1760, modelo de POLLING — F3): que TIPOS cada nó escuta
+    /// (`addEventListener`). Os callbacks vivem no TS (o motor não guarda fn-handles
+    /// de forma confiável — limite #195); aqui só registramos o tipo p/ saber se um
+    /// `dispatchEvent` deve notificar o nó. `NodeIdx → tipos`. DERIVADO, fora do Eq.
+    listeners: HashMap<NodeIdx, Vec<String>>,
+    /// Fila de eventos PENDENTES a entregar ao loop TS via `pollEvent`. Cada entrada
+    /// é `(nó-alvo a notificar, tipo)` — já expandida pelo bubbling no `dispatch`.
+    event_queue: std::collections::VecDeque<(NodeIdx, String)>,
 }
 
 // Igualdade estrutural: compara só a árvore (nodes+root). Os índices e a `generation`
@@ -185,6 +193,8 @@ impl Dom {
             class_index: HashMap::new(),
             style_overrides: HashMap::new(),
             stylesheet: crate::style::Stylesheet::new(),
+            listeners: HashMap::new(),
+            event_queue: std::collections::VecDeque::new(),
         }
     }
 
@@ -454,6 +464,70 @@ impl Dom {
         let cur = self.css_text(id);
         let new = upsert_css_decl(&cur, name.trim(), ""); // valor vazio = remover
         self.set_attr(id, "style", &new);
+    }
+
+    // ── Eventos (#1760) — modelo de polling + bubbling headless ──────────────────
+    // O motor não guarda callbacks de fn de forma confiável (limite #195), então o
+    // Rust registra só QUE TIPO cada nó escuta; os callbacks vivem no TS. O
+    // `dispatchEvent` enfileira (nó, tipo) já expandido pelo BUBBLING (alvo → pais
+    // que escutam), e o loop TS consome via `poll_event` e chama o handler certo.
+
+    /// `element.addEventListener(type, handler)`: registra que o nó escuta `type`.
+    /// (O handler real é guardado no lado TS, indexado por (nó, tipo).) Idempotente:
+    /// não duplica o mesmo tipo. O tipo é CASE-SENSITIVE (spec DOM: `click`≠`CLICK`).
+    pub fn add_event_listener(&mut self, id: NodeId, event_type: &str) {
+        let Some(idx) = self.resolve(id) else { return };
+        let types = self.listeners.entry(idx).or_default();
+        let t = event_type.to_string();
+        if !types.contains(&t) {
+            types.push(t);
+        }
+    }
+
+    /// `element.removeEventListener(type)`: para de escutar `type` neste nó.
+    pub fn remove_event_listener(&mut self, id: NodeId, event_type: &str) {
+        let Some(idx) = self.resolve(id) else { return };
+        if let Some(types) = self.listeners.get_mut(&idx) {
+            types.retain(|x| x != event_type);
+        }
+    }
+
+    /// `true` se o nó escuta o tipo de evento dado (case-sensitive).
+    pub fn has_listener(&self, id: NodeId, event_type: &str) -> bool {
+        let Some(idx) = self.resolve(id) else { return false };
+        self.listeners.get(&idx).map(|v| v.iter().any(|x| x == event_type)).unwrap_or(false)
+    }
+
+    /// `element.dispatchEvent(type, bubbles)`: dispara um evento no nó-alvo. Sempre
+    /// notifica o ALVO; se `bubbles`, sobe pelos ancestrais que escutam o tipo (fiel
+    /// ao DOM: `focus`/`blur`/`new Event(t)` não borbulham). Para cada nó na cadeia
+    /// que escuta, enfileira `(nó, tipo)` para o loop TS via `poll_event`. Devolve
+    /// quantos listeners foram enfileirados. Tipo CASE-SENSITIVE.
+    pub fn dispatch_event(&mut self, target: NodeId, event_type: &str, bubbles: bool) -> i64 {
+        let mut count = 0;
+        let mut cur = Some(target);
+        let mut first = true;
+        while let Some(node) = cur {
+            let Some(idx) = self.resolve(node) else { break };
+            if self.listeners.get(&idx).map(|v| v.iter().any(|x| x == event_type)).unwrap_or(false) {
+                self.event_queue.push_back((idx, event_type.to_string()));
+                count += 1;
+            }
+            // sem bubbling: só o alvo (primeira iteração) é notificado.
+            if !bubbles && first {
+                break;
+            }
+            first = false;
+            cur = self.parent_of(node);
+        }
+        count
+    }
+
+    /// `poll_event`: remove e devolve o próximo evento pendente `(NodeId, tipo)`, ou
+    /// `None` se a fila está vazia. O loop TS chama em laço por frame e despacha o
+    /// callback certo (que vive no TS, indexado por nó+tipo). O NodeId é versionado.
+    pub fn poll_event(&mut self) -> Option<(NodeId, String)> {
+        self.event_queue.pop_front().map(|(idx, t)| (self.make_id(idx), t))
     }
 
     /// `true` se a tag do nó é texto-cru não-renderável (`<style>`/`<script>`): o
@@ -1992,6 +2066,112 @@ mod tests {
         dom.set_css_text(a, "background: green; margin: 4px");
         assert_eq!(dom.inline_property(a, "color"), ""); // o color sumiu
         assert_eq!(dom.inline_property(a, "background-color"), "rgb(0, 128, 0)");
+    }
+
+    #[test]
+    fn eventos_add_dispatch_poll() {
+        // addEventListener marca o nó; dispatchEvent enfileira; poll consome (#1760).
+        let mut dom = parse_html_to_dom("<div id=\"a\"><button id=\"b\">x</button></div>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        dom.add_event_listener(b, "click");
+        assert!(dom.has_listener(b, "click"));
+        assert!(!dom.has_listener(b, "mousedown"));
+        // dispatch no botão → 1 listener (só o botão escuta).
+        assert_eq!(dom.dispatch_event(b, "click", true), 1);
+        let (target, t) = dom.poll_event().unwrap();
+        assert_eq!(target, b);
+        assert_eq!(t, "click");
+        assert!(dom.poll_event().is_none()); // fila esvaziou
+    }
+
+    #[test]
+    fn eventos_bubbling() {
+        // dispatch no filho borbulha para o pai que também escuta (#1760).
+        let mut dom = parse_html_to_dom("<div id=\"a\"><button id=\"b\">x</button></div>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        dom.add_event_listener(a, "click"); // o PAI escuta
+        dom.add_event_listener(b, "click"); // o filho também
+        // dispatch no filho: notifica filho E pai (bubbling) → 2.
+        assert_eq!(dom.dispatch_event(b, "click", true), 2);
+        // ordem: alvo primeiro, depois o ancestral (target → bubble).
+        let (first, _) = dom.poll_event().unwrap();
+        let (second, _) = dom.poll_event().unwrap();
+        assert_eq!(first, b);
+        assert_eq!(second, a);
+    }
+
+    #[test]
+    fn eventos_arvore_profunda_e_filtro_por_tipo() {
+        // VALIDADO no Chrome: árvore de 6 níveis, bubbling seletivo + filtro de tipo.
+        let mut dom = parse_html_to_dom(
+            "<section id=\"sec\"><article id=\"art\"><div id=\"box\"><p id=\"par\"><a id=\"link\">t</a></p></div></article></section>",
+        );
+        let sec = dom.query("#sec").unwrap();
+        let box_ = dom.query("#box").unwrap();
+        let link = dom.query("#link").unwrap();
+        dom.add_event_listener(sec, "click");
+        dom.add_event_listener(box_, "click");
+        dom.add_event_listener(link, "click");
+        dom.add_event_listener(box_, "mouseover");
+        // click no link borbulha por link→box→sec (pula art/par que não escutam).
+        assert_eq!(dom.dispatch_event(link, "click", true), 3);
+        let chain: Vec<NodeId> = std::iter::from_fn(|| dom.poll_event().map(|(n, _)| n)).collect();
+        assert_eq!(chain, vec![link, box_, sec]); // ordem target→bubble
+        // mouseover no link: só o box escuta esse TIPO (apesar do bubbling).
+        assert_eq!(dom.dispatch_event(link, "mouseover", true), 1);
+        assert_eq!(dom.poll_event().unwrap().0, box_);
+        // remove o do box → re-dispatch click enfileira só link+sec.
+        dom.remove_event_listener(box_, "click");
+        assert_eq!(dom.dispatch_event(link, "click", true), 2);
+    }
+
+    #[test]
+    fn eventos_no_solto_sem_bubbling() {
+        // dispatch num nó SOLTO (sem pai): só ele, sem bubbling.
+        let mut dom = parse_html_to_dom("<div></div>");
+        let solto = dom.create_element("button");
+        dom.add_event_listener(solto, "click");
+        assert_eq!(dom.dispatch_event(solto, "click", true), 1); // só ele, não tem pai
+    }
+
+    #[test]
+    fn eventos_bubbles_false_so_o_alvo() {
+        // bubbles=false: só o alvo é notificado, mesmo com o pai escutando (#1760).
+        let mut dom = parse_html_to_dom("<div id=\"a\"><button id=\"b\">x</button></div>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        dom.add_event_listener(a, "focus");
+        dom.add_event_listener(b, "focus");
+        // focus não borbulha (bubbles=false): só o botão, não o pai.
+        assert_eq!(dom.dispatch_event(b, "focus", false), 1);
+        assert_eq!(dom.poll_event().unwrap().0, b);
+        assert!(dom.poll_event().is_none());
+    }
+
+    #[test]
+    fn eventos_tipo_case_sensitive() {
+        // tipos de evento são CASE-SENSITIVE (spec DOM: click ≠ CLICK).
+        let mut dom = parse_html_to_dom("<div id=\"a\">x</div>");
+        let a = dom.query("#a").unwrap();
+        dom.add_event_listener(a, "click");
+        assert!(dom.has_listener(a, "click"));
+        assert!(!dom.has_listener(a, "CLICK")); // case diferente não casa
+        assert_eq!(dom.dispatch_event(a, "Click", true), 0); // não dispara
+        assert_eq!(dom.dispatch_event(a, "click", true), 1); // o exato dispara
+    }
+
+    #[test]
+    fn eventos_remove_e_sem_listener() {
+        let mut dom = parse_html_to_dom("<div id=\"a\">x</div>");
+        let a = dom.query("#a").unwrap();
+        dom.add_event_listener(a, "click");
+        dom.remove_event_listener(a, "click");
+        assert!(!dom.has_listener(a, "click"));
+        // dispatch sem ninguém escutando → 0 enfileirados.
+        assert_eq!(dom.dispatch_event(a, "click", true), 0);
+        assert!(dom.poll_event().is_none());
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -305,6 +305,35 @@ class Element {
     return dom.computedProperty(this._dom, this._node, __camelToKebab(name));
   }
 
+  // ── Eventos (#1760) — modelo de POLLING (limite do motor: callbacks vivem no TS) ─
+  // `el.addEventListener(type)` — registra que o nó escuta o tipo. ⚠️ O motor não
+  // guarda fn-handles de forma confiável (#195), então NÃO recebe o callback aqui;
+  // o loop chama `pumpEvents()` por frame e despacha via getEventTargetId()/Type().
+  // O padrão de uso:
+  //   el.addEventListener("click");
+  //   ... // num laço por frame:
+  //   while (pumpEvents(d) !== -1) { if (getEventTargetId() === el.nodeId) { ... } }
+  addEventListener(type: string): void {
+    dom.addListener(this._dom, this._node, type);
+  }
+  removeEventListener(type: string): void {
+    dom.removeListener(this._dom, this._node, type);
+  }
+  // `el.dispatchEvent(type)` — dispara COM BUBBLING (como `new Event(t, {bubbles:
+  // true})`). Devolve quantos listeners foram enfileirados.
+  dispatchEvent(type: string): number {
+    return dom.dispatchEvent(this._dom, this._node, type, 1);
+  }
+  // `el.dispatchEventNoBubble(type)` — dispara SÓ no alvo (como `new Event(t)`, que
+  // é bubbles:false por padrão; focus/blur/mouseenter não borbulham).
+  dispatchEventNoBubble(type: string): number {
+    return dom.dispatchEvent(this._dom, this._node, type, 0);
+  }
+  // `el.nodeId` — o NodeId cru deste elemento (p/ comparar no switch do polling).
+  get nodeId(): number {
+    return this._node;
+  }
+
   // ── Node utils (#1762) ───────────────────────────────────────────────────────
   // `node.contains(other)` — other é este nó ou um descendente?
   contains(other: Element): boolean {
@@ -576,4 +605,21 @@ class Document {
 // retorno `| null`, então é segura; o `| null` só seria problema em função livre.)
 function parseDocument(html: string): Document {
   return new Document(dom.parseHtml(html));
+}
+
+// ── Polling de eventos (#1760) — consumir a fila gerada por dispatchEvent ─────────
+// `pumpEvents(domHandle)` — o NodeId do próximo evento pendente (-1 = fila vazia).
+// Chame em laço; após cada chamada não-(-1), use `getLastEventType(domHandle)` para
+// o tipo. O domHandle vem de `document._dom` (ou guarde-o).
+//
+// ⚠️ USO ATÔMICO: o tipo é guardado num slot único — SEMPRE chame getLastEventType
+// IMEDIATAMENTE após o pumpEvents correspondente, sem intercalar pumpEvents de OUTRO
+// dom no meio (senão o tipo lido pode ser do outro evento). Padrão seguro:
+//   let n = pumpEvents(d); while (n !== -1) { const t = getLastEventType(d); /* usa n,t */ n = pumpEvents(d); }
+function pumpEvents(domHandle: number): number {
+  return dom.pollEvent(domHandle);
+}
+// O tipo do evento entregue pelo último `pumpEvents` ('' se nenhum).
+function getLastEventType(domHandle: number): string {
+  return dom.pollEventType(domHandle);
 }

--- a/examples/claude-dom-events.ts
+++ b/examples/claude-dom-events.ts
@@ -1,0 +1,29 @@
+// Eventos do DOM (#1760) — modelo de POLLING + bubbling. addEventListener marca o
+// nó; dispatchEvent enfileira com bubbling; o loop consome via pollEvent/Type.
+// (O motor não guarda callbacks de fn — os handlers ficam no switch do loop TS.)
+//   target/release/rts.exe run examples/claude-dom-events.ts
+import dom from "rts:dom";
+import { io } from "rts";
+
+const d = dom.parseHtml("<form id='form'><input id='name'><button id='submit'>OK</button></form>");
+const form = dom.querySelector(d, "#form");
+const submit = dom.querySelector(d, "#submit");
+
+// registra: o form escuta 'submit' (bubbling), o botão escuta 'click'.
+dom.addListener(d, form, "submit");
+dom.addListener(d, submit, "click");
+
+// simula um clique no botão E um submit no form.
+dom.dispatchEvent(d, submit, "click");
+dom.dispatchEvent(d, form, "submit");
+
+// o LOOP consome a fila e despacha (aqui um switch por NodeId+tipo).
+io.print("=== processando eventos ===");
+let ev = dom.pollEvent(d);
+while (ev !== -1) {
+  const t = dom.pollEventType(d);
+  if (ev === submit && t === "click") { io.print("-> botão clicado!"); }
+  if (ev === form && t === "submit") { io.print("-> formulário enviado!"); }
+  ev = dom.pollEvent(d);
+}
+io.print("=== fim ===");


### PR DESCRIPTION
Fecha #1760 — a **última sub-issue do DOM #1753** (100% das 9 fechadas).

Modelo de POLLING (F3): o Rust registra os tipos escutados + uma fila; os callbacks vivem no loop TS (pumpEvents/getLastEventType). addEventListener/removeEventListener/dispatchEvent(+bubbling) + dispatchEventNoBubble.

dispatch sobe do alvo pelos ancestrais que escutam (bubbling) — suporta DELEGAÇÃO. Validado no Chrome: ordem [link,box,sec] numa árvore de 6 níveis, idêntica.

**Bugs corrigidos:** [MAJOR] tipo era case-insensitive (DOM é case-sensitive: click≠CLICK); [MINOR] flag bubbles (focus/blur não borbulham).

Cortes documentados (modelo F3): sem callbacks no Rust, capture phase, preventDefault real, objeto Event rico, window. 116 testes.

Closes #1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)