### PR TITLE
feat(css): min/max-width + min/max-height (#1751) — fecha o CSS

### DIFF
--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -258,6 +258,17 @@ fn layout_block(
         }
         None => (avail_w - frame).max(0.0),
     };
+    // CLAMP min/max-width (#1751): `used = clamp(min, width, max)`. min/max são sobre
+    // a CAIXA (border-box) na spec — descontamos o frame p/ aplicar ao content quando
+    // border-box; em content-box o min/max já são do content. (aprox: aplicamos ao
+    // content, descontando pad+border só no border-box.)
+    let mnw = css.min_width.and_then(|d| d.resolve(&resolve)).map(|v| {
+        if border_box { (v - (padding_h + 2.0 * border)).max(0.0) } else { v }
+    });
+    let mxw = css.max_width.and_then(|d| d.resolve(&resolve)).map(|v| {
+        if border_box { (v - (padding_h + 2.0 * border)).max(0.0) } else { v }
+    });
+    let content_w = crate::style::clamp_size(content_w, mnw, mxw);
 
     // Posição do content-box (canto sup-esq): deslocado pelo lado ESQUERDO/TOPO
     // (margin+border+padding daquele lado), não a soma do eixo.
@@ -297,6 +308,15 @@ fn layout_block(
         Some(h) => h,
         None => content_h,
     };
+    // CLAMP min/max-height (#1751): used = clamp(min, height, max).
+    let frame_v = pad_top + pad_bottom + 2.0 * border;
+    let mnh = css.min_height.and_then(|d| d.resolve(&resolve)).map(|v| {
+        if border_box { (v - frame_v).max(0.0) } else { v }
+    });
+    let mxh = css.max_height.and_then(|d| d.resolve(&resolve)).map(|v| {
+        if border_box { (v - frame_v).max(0.0) } else { v }
+    });
+    let content_h = crate::style::clamp_size(content_h, mnh, mxh);
 
     // ── Insere a CAIXA (fundo + borda) no índice reservado, ATRÁS dos filhos ─────
     // O BORDER-BOX do nó: content + padding + border (NÃO a margin — esta é espaço
@@ -1012,6 +1032,41 @@ mod tests {
         let last = rects[2];
         assert!(last.x + last.w <= 1000.0, "cabem todos: {rects:?}");
         assert!(1000.0 - (last.x + last.w) >= 30.0, "sobra espaço à direita: {rects:?}");
+    }
+
+    #[test]
+    fn min_max_width_clamp() {
+        // VALIDADO no Chrome: used_width = clamp(min, width, max) (#1751).
+        crate::block::define("div", crate::block::BlockDef { display: 0, indent: 0.0, prefix: 0, flags: 0 });
+        let cases = [
+            ("width:500px;max-width:300px", 300.0),  // max limita
+            ("width:50px;min-width:200px", 200.0),   // min eleva
+            ("width:1000px;max-width:400px;min-width:100px", 400.0), // clamp
+            ("width:600px;max-width:50%", 400.0),    // % de 800
+        ];
+        for (style, expected) in cases {
+            let dom = parse_html_to_dom(&format!("<div id=\"t\" style=\"{style}\">x</div>"));
+            let t = dom.query("#t").unwrap();
+            let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+            let rect = bounding_rect(&dom, dom.resolve(t).unwrap(), &ctx).unwrap();
+            assert!((rect.w - expected).abs() < 1.0, "{style}: w={} esperado {expected}", rect.w);
+        }
+    }
+
+    #[test]
+    fn min_max_height_clamp() {
+        crate::block::define("div", crate::block::BlockDef { display: 0, indent: 0.0, prefix: 0, flags: 0 });
+        // height:500 max-height:200 → caixa de 200.
+        let dom = parse_html_to_dom("<div id=\"t\" style=\"height:500px;max-height:200px;width:100px\">x</div>");
+        let t = dom.query("#t").unwrap();
+        let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+        let rect = bounding_rect(&dom, dom.resolve(t).unwrap(), &ctx).unwrap();
+        assert!((rect.h - 200.0).abs() < 1.0, "max-height: h={}", rect.h);
+        // min-height:300 num conteúdo pequeno → caixa de 300.
+        let dom2 = parse_html_to_dom("<div id=\"t\" style=\"min-height:300px;width:100px\">x</div>");
+        let t2 = dom2.query("#t").unwrap();
+        let rect2 = bounding_rect(&dom2, dom2.resolve(t2).unwrap(), &ctx).unwrap();
+        assert!(rect2.h >= 300.0, "min-height: h={}", rect2.h);
     }
 
     #[test]

--- a/crates/rts-dom/src/style.rs
+++ b/crates/rts-dom/src/style.rs
@@ -555,6 +555,29 @@ pub struct ComputedStyle {
     /// `height` — altura explícita da caixa. `None` = auto (altura do conteúdo).
     /// Necessária para align-items:stretch ter cross-size de referência e p/ flex-column.
     pub height: Option<Dimension>,
+    // ── Constraints de tamanho (#1751) — clamp sobre width/height ────────────────
+    /// `min-width` — piso da largura usada: `used = max(min, width)`.
+    pub min_width: Option<Dimension>,
+    /// `max-width` — teto da largura usada: `used = min(width, max)`.
+    pub max_width: Option<Dimension>,
+    /// `min-height` — piso da altura usada.
+    pub min_height: Option<Dimension>,
+    /// `max-height` — teto da altura usada.
+    pub max_height: Option<Dimension>,
+}
+
+/// Aplica o clamp de min/max a um valor base resolvido: `clamp(min, base, max)` =
+/// `max(min, min(base, max))`. `min`/`max` resolvidos a px (None = sem limite).
+pub fn clamp_size(base: f32, min: Option<f32>, max: Option<f32>) -> f32 {
+    let mut v = base;
+    // max primeiro, min depois (min vence se min > max — regra do CSS).
+    if let Some(mx) = max {
+        v = v.min(mx);
+    }
+    if let Some(mn) = min {
+        v = v.max(mn);
+    }
+    v
 }
 
 impl ComputedStyle {
@@ -650,6 +673,18 @@ impl ComputedStyle {
         }
         if other.height.is_some() {
             self.height = other.height;
+        }
+        if other.min_width.is_some() {
+            self.min_width = other.min_width;
+        }
+        if other.max_width.is_some() {
+            self.max_width = other.max_width;
+        }
+        if other.min_height.is_some() {
+            self.min_height = other.min_height;
+        }
+        if other.max_height.is_some() {
+            self.max_height = other.max_height;
         }
     }
 
@@ -807,6 +842,10 @@ impl ComputedStyle {
             "border-radius" => self.corner_radius.map(fmt_px).unwrap_or_default(),
             "width" => self.width.map(fmt_dim).unwrap_or_default(),
             "height" => self.height.map(fmt_dim).unwrap_or_default(),
+            "min-width" => self.min_width.map(fmt_dim).unwrap_or_default(),
+            "max-width" => self.max_width.map(fmt_dim).unwrap_or_default(),
+            "min-height" => self.min_height.map(fmt_dim).unwrap_or_default(),
+            "max-height" => self.max_height.map(fmt_dim).unwrap_or_default(),
             "display" => self.display.map(fmt_display).unwrap_or_default(),
             "box-sizing" => match self.border_box {
                 Some(true) => "border-box".into(),
@@ -1532,6 +1571,10 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
                 css.gap = cg;
             }
             "height" => css.height = parse_dimension(val),
+            "min-width" => css.min_width = parse_dimension(val),
+            "max-width" => css.max_width = parse_dimension(val),
+            "min-height" => css.min_height = parse_dimension(val),
+            "max-height" => css.max_height = parse_dimension(val),
             _ => {}
         }
     }


### PR DESCRIPTION
Fecha #1751 — **a última sub-issue do tracking CSS #1744**. clamp_size(min, base, max) aplicado a width/height; % resolve contra o container. Validado no Chrome (max-width:300→300, min-width:200→200, clamp 100-400→400, 50%→400). 129 testes.

Closes #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)