### PR TITLE
feat(dom): unidades relativas (rem/em/%) em padding/margin/font-size + fonte 16 + margem negativa

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -2204,7 +2204,7 @@ mod tests {
         let div = dom.query(".c").unwrap();
         let s = dom.computed_style(div).unwrap();
         assert_eq!(s.color, Some(0x0000FFFF)); // inline vence o <style>
-        assert_eq!(s.padding.top, crate::style::Side::Px(10.0)); // padding só o <style> define
+        assert_eq!(s.padding.top, crate::style::Side::px_len(10.0)); // padding só o <style> define
         // o <style> também vira NÓ no DOM (fiel), com o CSS como texto cru filho.
         let st = dom.query("style").unwrap();
         assert_eq!(dom.node_type(st), 1); // Element

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -154,8 +154,10 @@ impl TextMeasurer for ApproxMeasurer {
 }
 
 /// Tamanho de fonte default (pontos) quando o estilo não especifica — base de
-/// `em`/`rem` e do texto sem `font-size`. Casa com o default do render antigo.
-pub const DEFAULT_FONT_SIZE: f32 = 20.0;
+/// `em`/`rem` e do texto sem `font-size`. **16px, o default de todo browser**
+/// (era 20, o que inflava cada `em`/`rem` em 25% — `max-width:42em` dava 840 em
+/// vez dos 672 do Chrome; validado número-a-número no cover).
+pub const DEFAULT_FONT_SIZE: f32 = 16.0;
 
 /// O contexto de uma passada de layout: o viewport (para `vw`/`vh` e largura
 /// inicial) e o medidor de texto. Imutável durante a passada.
@@ -486,28 +488,8 @@ fn layout_block(
     };
 
     // ── Box model (content-box): resolve as bordas/espaços absolutos ─────────────
-    // Margin/padding POR LADO (Edges). O `margin_v` (UA-stylesheet, só vertical) é
-    // somado ao top/bottom. `margin_left/right` deslocam no x; o vertical empilha.
-    let m = &css.margin;
-    let p = &css.padding;
-    let mut margin_left = m.left.px().unwrap_or(0.0);
-    let mut margin_right = m.right.px().unwrap_or(0.0);
-    let margin_v_extra = css.margin_v.unwrap_or(0.0);
-    let margin_top = m.top.px().unwrap_or(0.0) + margin_v_extra;
-    let margin_bottom = m.bottom.px().unwrap_or(0.0) + margin_v_extra;
-    let pad_left = p.left.px().unwrap_or(0.0);
-    let pad_right = p.right.px().unwrap_or(0.0);
-    let pad_top = p.top.px().unwrap_or(0.0);
-    let pad_bottom = p.bottom.px().unwrap_or(0.0);
-    let border = css.border_width.unwrap_or(0.0);
-    // Atalhos para o eixo (horizontal = left+right): a maioria do box model usa o
-    // total por eixo. (`margin_h`/`padding_h` = soma do eixo horizontal.)
-    let margin_h = margin_left + margin_right;
-    let padding_h = pad_left + pad_right;
-
-    // Largura do CONTENT: `width` explícito (px/% resolvido contra `avail_w`), ou
-    // o que sobra do container menos margin+border+padding dos dois lados (block
-    // ocupa a largura disponível por padrão — MDN flow layout).
+    // O contexto de RESOLUÇÃO tardia primeiro (margens/paddings agora aceitam
+    // unidades relativas — `p-3` = 1rem do Bootstrap — e resolvem AQUI, como width).
     let resolve = ResolveCtx {
         parent_content_w: avail_w,
         node_font_size: css.font_size.unwrap_or(DEFAULT_FONT_SIZE),
@@ -515,6 +497,25 @@ fn layout_block(
         viewport_w: ctx.viewport_w,
         viewport_h: ctx.viewport_h,
     };
+    // Margin/padding POR LADO (Edges). O `margin_v` (UA-stylesheet, só vertical) é
+    // somado ao top/bottom. Margens são SIGNED (negativa puxa — gutters `.row`);
+    // padding é clampado ≥ 0 (padding negativo não existe no CSS).
+    let m = &css.margin;
+    let p = &css.padding;
+    let mut margin_left = m.left.resolve(&resolve).unwrap_or(0.0);
+    let mut margin_right = m.right.resolve(&resolve).unwrap_or(0.0);
+    let margin_v_extra = css.margin_v.unwrap_or(0.0);
+    let margin_top = m.top.resolve(&resolve).unwrap_or(0.0) + margin_v_extra;
+    let margin_bottom = m.bottom.resolve(&resolve).unwrap_or(0.0) + margin_v_extra;
+    let pad_left = p.left.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let pad_right = p.right.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let pad_top = p.top.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let pad_bottom = p.bottom.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let border = css.border_width.unwrap_or(0.0);
+    // Atalhos para o eixo (horizontal = left+right): a maioria do box model usa o
+    // total por eixo. (`margin_h`/`padding_h` = soma do eixo horizontal.)
+    let margin_h = margin_left + margin_right;
+    let padding_h = pad_left + pad_right;
     // `frame` horizontal = o que cerca o content no eixo X (margin+border+padding
     // dos DOIS lados). border conta 2× (left+right); padding/margin já são a soma.
     let frame = margin_h + 2.0 * border + padding_h;
@@ -814,7 +815,6 @@ fn intrinsic_outer_width(dom: &Dom, id: NodeIdx, parent_font: f32, ctx: &LayoutC
             let css = dom.computed_style_idx(id).unwrap_or_default();
             let f = css.font_size.unwrap_or(parent_font);
             let border_box = css.border_box.unwrap_or(false);
-            let frame = css.margin.horizontal_px() + 2.0 * css.border_width.unwrap_or(0.0) + css.padding.horizontal_px();
             let resolve = ResolveCtx {
                 parent_content_w: ctx.viewport_w,
                 node_font_size: f,
@@ -822,9 +822,12 @@ fn intrinsic_outer_width(dom: &Dom, id: NodeIdx, parent_font: f32, ctx: &LayoutC
                 viewport_w: ctx.viewport_w,
                 viewport_h: ctx.viewport_h,
             };
+            let frame = css.margin.resolve_h(&resolve)
+                + 2.0 * css.border_width.unwrap_or(0.0)
+                + css.padding.resolve_h(&resolve);
             // width fixo: a caixa tem essa largura.
             if let Some(w) = css.width.and_then(|d| d.resolve(&resolve)) {
-                return if border_box { w + css.margin.horizontal_px() } else { w + frame };
+                return if border_box { w + css.margin.resolve_h(&resolve) } else { w + frame };
             }
             // senão: a intrínseca do conteúdo + frame.
             intrinsic_content_width(dom, id, f, ctx) + frame
@@ -966,7 +969,18 @@ fn layout_children_vertical(
                 // margin VERTICAL TOP do filho (para o collapse com o anterior):
                 // margin.top + margin_v da UA.
                 let m = dom.computed_style_idx(child)
-                    .map(|c| c.margin.top.px().unwrap_or(0.0) + c.margin_v.unwrap_or(0.0))
+                    .map(|c| {
+                        // margem TOP do filho p/ o collapse (unidades relativas
+                        // resolvem contra o content deste container).
+                        let r = ResolveCtx {
+                            parent_content_w: content_w,
+                            node_font_size: c.font_size.unwrap_or(font_size),
+                            root_font_size: DEFAULT_FONT_SIZE,
+                            viewport_w: ctx.viewport_w,
+                            viewport_h: ctx.viewport_h,
+                        };
+                        c.margin.top.resolve(&r).unwrap_or(0.0) + c.margin_v.unwrap_or(0.0)
+                    })
                     .unwrap_or(0.0);
                 // Colapsa com o bloco anterior: recua o overlap antes de posicionar.
                 child_y -= prev_margin.min(m);
@@ -1384,8 +1398,6 @@ fn child_outer_width(dom: &Dom, id: NodeIdx, container_w: f32, parent_font: f32,
         NodeKind::Element { .. } if is_block_level(dom, id) => {
             let css = dom.computed_style_idx(id).unwrap_or_default();
             let font = css.font_size.unwrap_or(parent_font);
-            // frame horizontal = margin_h + 2*border + padding_h (cada já é o eixo).
-            let frame = css.margin.horizontal_px() + 2.0 * css.border_width.unwrap_or(0.0) + css.padding.horizontal_px();
             let resolve = ResolveCtx {
                 parent_content_w: container_w,
                 node_font_size: font,
@@ -1393,11 +1405,16 @@ fn child_outer_width(dom: &Dom, id: NodeIdx, container_w: f32, parent_font: f32,
                 viewport_w: ctx.viewport_w,
                 viewport_h: ctx.viewport_h,
             };
+            // frame horizontal = margin_h + 2*border + padding_h (cada já é o eixo;
+            // unidades relativas resolvidas contra o container).
+            let frame = css.margin.resolve_h(&resolve)
+                + 2.0 * css.border_width.unwrap_or(0.0)
+                + css.padding.resolve_h(&resolve);
             // Em border-box, o `width` declarado JÁ é a caixa (outer sem margin) —
             // não soma pad/border de novo; só a margin. Em content-box, soma o frame.
             match css.width.and_then(|d| d.resolve(&resolve)) {
                 Some(w) if css.border_box.unwrap_or(false) => {
-                    w + css.margin.horizontal_px()
+                    w + css.margin.resolve_h(&resolve)
                 }
                 Some(w) => w + frame,
                 None => content_natural_width(dom, id, font, ctx) + frame,
@@ -1715,7 +1732,7 @@ mod tests {
             .collect();
         assert_eq!(texts.len(), 2);
         assert_eq!(texts[0], 0.0); // primeiro no topo
-        assert!(texts[1] >= 26.0, "segundo bloco abaixo do primeiro (y={})", texts[1]); // 20×1.3
+        assert!(texts[1] >= 20.8, "segundo bloco abaixo do primeiro (y={})", texts[1]); // 16×1.3
     }
 
     #[test]
@@ -1922,12 +1939,12 @@ mod tests {
             DisplayItem::Text { text, x, .. } => Some((text.clone(), *x)),
             _ => None,
         }).collect();
-        // "x" (1 char, ~10px de largura) centrado em 400 → x ≈ (400-10)/2 = 195.
+        // "x" (1 char, ~8px = 16×0.5) centrado em 400 → x ≈ (400-8)/2 = 196.
         let cx = texts.iter().find(|(t, _)| t == "x").unwrap().1;
-        assert!((cx - 195.0).abs() < 2.0, "center: {cx}");
-        // "y" à direita → x ≈ 400-10 = 390.
+        assert!((cx - 196.0).abs() < 2.0, "center: {cx}");
+        // "y" à direita → x ≈ 400-8 = 392.
         let rx = texts.iter().find(|(t, _)| t == "y").unwrap().1;
-        assert!((rx - 390.0).abs() < 2.0, "right: {rx}");
+        assert!((rx - 392.0).abs() < 2.0, "right: {rx}");
     }
 
     #[test]
@@ -1945,10 +1962,10 @@ mod tests {
         // uppercase aplicado.
         assert!(texts.iter().any(|(t, _)| t == "OI"));
         assert!(texts.iter().any(|(t, _)| t == "TCHAU"));
-        // line-height:3 = 3×20 = 60px entre as linhas (div sem margin).
+        // line-height:3 = 3×16 = 48px entre as linhas (div sem margin).
         let y_oi = texts.iter().find(|(t, _)| t == "OI").unwrap().1;
         let y_tchau = texts.iter().find(|(t, _)| t == "TCHAU").unwrap().1;
-        assert!((y_tchau - y_oi - 60.0).abs() < 5.0, "line-height: {y_oi} → {y_tchau}");
+        assert!((y_tchau - y_oi - 48.0).abs() < 5.0, "line-height: {y_oi} → {y_tchau}");
     }
 
     #[test]
@@ -2284,6 +2301,42 @@ mod tests {
         );
         let r2 = all_rects(&l2);
         assert!(r2[1].h < 40.0, "height %% com pai auto = altura natural: {r2:?}");
+    }
+
+    #[test]
+    fn unidades_relativas_em_padding_e_margem_negativa() {
+        // padding: 1rem = 16px (root 16, o default de browser) — o `p-3` do
+        // Bootstrap; margem NEGATIVA puxa (os gutters `.row` usam margin -12px).
+        let list = layout("<div style='background:#111; padding:1rem'>x</div>", 600.0);
+        let tx = list
+            .items
+            .iter()
+            .find_map(|it| match it {
+                DisplayItem::Text { x, y, .. } => Some((*x, *y)),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(tx, (16.0, 16.0), "texto após o padding de 1rem = 16px");
+        // margem negativa: o segundo bloco com margin-top:-10 SOBE sobre o primeiro.
+        let l2 = layout(
+            "<div style='background:#111; height:30'>a</div>             <div style='background:#222; height:30; margin-top:-10px'>b</div>",
+            600.0,
+        );
+        let r2 = all_rects(&l2);
+        assert_eq!(r2[1].y, 20.0, "30 - 10 (negativa nao clampa): {r2:?}");
+    }
+
+    #[test]
+    fn max_width_em_bate_com_o_chrome() {
+        // `max-width: 42em` com root 16 = 672px — o `.cover-container` do Bootstrap
+        // cover, VALIDADO numero-a-numero no Chrome (viewport 1000: rect 164,0,672).
+        let list = layout(
+            "<div style='background:#111; max-width:42em; margin:0 auto; height:50'>x</div>",
+            1000.0,
+        );
+        let r = all_rects(&list);
+        assert_eq!(r[0].w, 672.0, "42em x 16: {r:?}");
+        assert_eq!(r[0].x, 164.0, "(1000-672)/2, centrado como no Chrome");
     }
 
     #[test]

--- a/crates/rts-dom/src/style/fmt.rs
+++ b/crates/rts-dom/src/style/fmt.rs
@@ -68,14 +68,14 @@ impl ComputedStyle {
                 None => String::new(),
             },
             "font-family" => self.font_family.clone().unwrap_or_default(),
-            "padding-top" => self.padding.top.px().map(fmt_px).unwrap_or_default(),
-            "padding-right" => self.padding.right.px().map(fmt_px).unwrap_or_default(),
-            "padding-bottom" => self.padding.bottom.px().map(fmt_px).unwrap_or_default(),
-            "padding-left" => self.padding.left.px().map(fmt_px).unwrap_or_default(),
-            "margin-top" => self.margin.top.px().map(fmt_px).unwrap_or_default(),
-            "margin-right" => self.margin.right.px().map(fmt_px).unwrap_or_default(),
-            "margin-bottom" => self.margin.bottom.px().map(fmt_px).unwrap_or_default(),
-            "margin-left" => self.margin.left.px().map(fmt_px).unwrap_or_default(),
+            "padding-top" => side_css(self.padding.top),
+            "padding-right" => side_css(self.padding.right),
+            "padding-bottom" => side_css(self.padding.bottom),
+            "padding-left" => side_css(self.padding.left),
+            "margin-top" => side_css(self.margin.top),
+            "margin-right" => side_css(self.margin.right),
+            "margin-bottom" => side_css(self.margin.bottom),
+            "margin-left" => side_css(self.margin.left),
             "border-width" => self.border_width.map(fmt_px).unwrap_or_default(),
             "border-color" => self.border_color.map(fmt_color).unwrap_or_default(),
             "border-style" => self.border_style.map(|s| format!("{s:?}").to_ascii_lowercase()).unwrap_or_default(),
@@ -106,6 +106,16 @@ impl ComputedStyle {
             "row-gap" => self.row_gap.map(fmt_dim).unwrap_or_default(),
             _ => String::new(),
         }
+    }
+}
+
+/// Um lado de margin/padding → string CSS: comprimento cru (`fmt_dim` — px sai
+/// `Npx` como antes; relativo sai `Nrem` etc, corte documentado), `auto`, ou `""`.
+fn side_css(s: crate::style::Side) -> String {
+    match s {
+        crate::style::Side::Len(d) => fmt_dim(d),
+        crate::style::Side::Auto => "auto".into(),
+        crate::style::Side::Unset => String::new(),
     }
 }
 

--- a/crates/rts-dom/src/style/lerp.rs
+++ b/crates/rts-dom/src/style/lerp.rs
@@ -36,10 +36,12 @@ pub fn lerp_dimension(a: Dimension, b: Dimension, t: f32) -> Dimension {
     }
 }
 
-/// Interpola um lado de [`Edges`]: só Px↔Px interpola; o resto salta discreto.
+/// Interpola um lado de [`Edges`]: comprimentos interpolam pela regra de
+/// [`lerp_dimension`] (mesma unidade — px↔px, rem↔rem; misto salta); Auto/Unset
+/// saltam discretos.
 fn lerp_side(a: Side, b: Side, t: f32) -> Side {
     match (a, b) {
-        (Side::Px(x), Side::Px(y)) => Side::Px(lerp_f32(x, y, t)),
+        (Side::Len(x), Side::Len(y)) => Side::Len(lerp_dimension(x, y, t)),
         _ => if t < 0.5 { a } else { b },
     }
 }

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -38,7 +38,7 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
         match prop.as_str() {
             "color" => css.color = parse_color(val),
             "background-color" | "background" => css.bg = parse_color(val),
-            "font-size" => css.font_size = parse_px(val),
+            "font-size" => css.font_size = parse_len(val),
             "font-weight" => css.bold = Some(is_bold(val)),
             "font-style" => {
                 css.italic =
@@ -75,10 +75,10 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
             // shorthand `border: <width> <style> <color>` (qualquer ordem, qualquer
             // omitível). Setar os 3 de uma vez. (Por-lado fica para fase 2.)
             "border" => apply_border_shorthand(css, val),
-            "border-width" => css.border_width = parse_px(val),
+            "border-width" => css.border_width = parse_len(val),
             "border-style" => css.border_style = BorderStyle::parse(val),
             "border-color" => css.border_color = parse_color(val),
-            "border-radius" => css.corner_radius = parse_px(val),
+            "border-radius" => css.corner_radius = parse_len(val),
             "width" => css.width = parse_dimension(val),
             // `box-sizing: border-box | content-box` — border-box faz o `width`
             // incluir padding+border (3 cards de 32% cabem). Default content-box.
@@ -271,20 +271,57 @@ fn parse_edges(val: &str, allow_auto: bool) -> Edges {
     }
 }
 
-/// Parseia UM lado de margin/padding: comprimento px (aceita "10" ou "10px"),
-/// `auto` (se `allow_auto`), ou `Unset` se inválido. Negativo permitido em margin
-/// (puxa o elemento); padding clamp em ≥ 0 — mas aqui aceitamos o número e o layout
-/// trata (padding negativo é raro e o render ignora).
+/// Parseia UM lado de margin/padding: um COMPRIMENTO em qualquer unidade
+/// (px/%/em/rem/vw/vh — resolve tarde, como width), `auto` (se `allow_auto`), ou
+/// `Unset` se inválido. NEGATIVO permitido (margem negativa é o gutter `.row` do
+/// Bootstrap; padding negativo é clampado ≥ 0 no consumo do layout).
 fn parse_side(tok: &str, allow_auto: bool) -> Side {
     let t = tok.trim();
     if allow_auto && t.eq_ignore_ascii_case("auto") {
         return Side::Auto;
     }
-    let num = t.strip_suffix("px").unwrap_or(t);
-    match num.trim().parse::<f32>() {
-        Ok(v) => Side::Px(v),
-        Err(_) => Side::Unset,
+    match parse_dimension_signed(t) {
+        // `auto` já foi tratado acima (só margin); um Auto aqui é inválido
+        // (padding: auto não existe) — vira Unset, nunca `Len(Auto)`.
+        Some(Dimension::Auto) | None => Side::Unset,
+        Some(d) => Side::Len(d),
     }
+}
+
+/// Como [`parse_dimension`], mas aceita valores NEGATIVOS (margens/offsets). O
+/// `%`/`vw`/`vh` não são clampados a 0..=100 aqui (o sinal importa).
+fn parse_dimension_signed(v: &str) -> Option<Dimension> {
+    let v = v.trim();
+    let (neg, abs) = match v.strip_prefix('-') {
+        Some(rest) => (true, rest.trim()),
+        None => (false, v),
+    };
+    let d = parse_dimension(abs)?;
+    if !neg {
+        return Some(d);
+    }
+    Some(match d {
+        Dimension::Auto => Dimension::Auto,
+        Dimension::Px(x) => Dimension::Px(-x),
+        Dimension::Percent(x) => Dimension::Percent(-x),
+        Dimension::Em(x) => Dimension::Em(-x),
+        Dimension::Rem(x) => Dimension::Rem(-x),
+        Dimension::Vw(x) => Dimension::Vw(-x),
+        Dimension::Vh(x) => Dimension::Vh(-x),
+    })
+}
+
+/// Um comprimento de TEXTO/BORDA (`font-size`/`border-width`/`border-radius`, que
+/// são `f32` px no modelo): aceita `px`/número E `rem` (× o root FIXO de 16px —
+/// igual ao browser sem `html{font-size}` custom; o Bootstrap define TODA a
+/// tipografia em rem). ⚠️ CORTE documentado: `em`/`%` de font-size dependem do
+/// font do PAI (só a cascade sabe) — ficam de fora até o campo virar `Dimension`.
+fn parse_len(v: &str) -> Option<f32> {
+    let low = v.trim().to_ascii_lowercase();
+    if let Some(n) = low.strip_suffix("rem") {
+        return n.trim().parse::<f32>().ok().filter(|x| *x > 0.0).map(|x| x * 16.0);
+    }
+    parse_px(&low)
 }
 
 /// `font-weight`: `bold`/`bolder` ou peso numérico ≥ 600 → negrito.
@@ -345,7 +382,7 @@ fn apply_font_shorthand(css: &mut ComputedStyle, val: &str) {
     };
     // px direto; se for relativo (em/rem/%), parse_px falha e fica None (herda) —
     // mesma limitação da longhand font-size (documentada).
-    css.font_size = parse_px(sz);
+    css.font_size = parse_len(sz);
     if let Some(l) = lh {
         css.line_height = LineHeight::parse(l);
     }

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -299,12 +299,12 @@ impl ComputedStyle {
             // slot opaco de 1 valor (defineStyle/setStyle) → os 4 lados iguais.
             SLOT_PADDING => {
                 if let Some(p) = dim(val) {
-                    self.padding = Edges::all(Side::Px(p));
+                    self.padding = Edges::all(Side::px_len(p));
                 }
             }
             SLOT_MARGIN => {
                 if let Some(m) = dim(val) {
-                    self.margin = Edges::all(Side::Px(m));
+                    self.margin = Edges::all(Side::px_len(m));
                 }
             }
             SLOT_MARGIN_V => self.margin_v = dim(val),

--- a/crates/rts-dom/src/style/tests.rs
+++ b/crates/rts-dom/src/style/tests.rs
@@ -25,48 +25,48 @@ fn color_forms() {
 fn margin_padding_shorthand() {
     // 1 valor: todos os lados.
     let c = parse_inline("padding: 10px");
-    assert_eq!(c.padding, Edges::all(Side::Px(10.0)));
+    assert_eq!(c.padding, Edges::all(Side::px_len(10.0)));
     // 2 valores: vertical | horizontal.
     let c = parse_inline("margin: 10px 20px");
-    assert_eq!(c.margin.top, Side::Px(10.0));
-    assert_eq!(c.margin.bottom, Side::Px(10.0));
-    assert_eq!(c.margin.left, Side::Px(20.0));
-    assert_eq!(c.margin.right, Side::Px(20.0));
+    assert_eq!(c.margin.top, Side::px_len(10.0));
+    assert_eq!(c.margin.bottom, Side::px_len(10.0));
+    assert_eq!(c.margin.left, Side::px_len(20.0));
+    assert_eq!(c.margin.right, Side::px_len(20.0));
     // 3 valores: top | horizontal | bottom.
     let c = parse_inline("padding: 1px 2px 3px");
-    assert_eq!(c.padding.top, Side::Px(1.0));
-    assert_eq!(c.padding.right, Side::Px(2.0));
-    assert_eq!(c.padding.left, Side::Px(2.0));
-    assert_eq!(c.padding.bottom, Side::Px(3.0));
+    assert_eq!(c.padding.top, Side::px_len(1.0));
+    assert_eq!(c.padding.right, Side::px_len(2.0));
+    assert_eq!(c.padding.left, Side::px_len(2.0));
+    assert_eq!(c.padding.bottom, Side::px_len(3.0));
     // 4 valores: top right bottom left (horário).
     let c = parse_inline("margin: 1px 2px 3px 4px");
-    assert_eq!(c.margin.top, Side::Px(1.0));
-    assert_eq!(c.margin.right, Side::Px(2.0));
-    assert_eq!(c.margin.bottom, Side::Px(3.0));
-    assert_eq!(c.margin.left, Side::Px(4.0));
+    assert_eq!(c.margin.top, Side::px_len(1.0));
+    assert_eq!(c.margin.right, Side::px_len(2.0));
+    assert_eq!(c.margin.bottom, Side::px_len(3.0));
+    assert_eq!(c.margin.left, Side::px_len(4.0));
 }
 
 #[test]
 fn margin_padding_longhand_e_auto() {
     // por-lado.
     let c = parse_inline("padding-left: 12px; margin-top: 8px");
-    assert_eq!(c.padding.left, Side::Px(12.0));
-    assert_eq!(c.margin.top, Side::Px(8.0));
+    assert_eq!(c.padding.left, Side::px_len(12.0));
+    assert_eq!(c.margin.top, Side::px_len(8.0));
     assert_eq!(c.padding.top, Side::Unset); // outros lados Unset
     // margin: 0 auto (centralização) — left/right auto.
     let c = parse_inline("margin: 0 auto");
-    assert_eq!(c.margin.top, Side::Px(0.0));
+    assert_eq!(c.margin.top, Side::px_len(0.0));
     assert!(c.margin.left.is_auto());
     assert!(c.margin.right.is_auto());
     // padding NÃO aceita auto (vira Unset).
     assert_eq!(parse_inline("padding: auto").padding.left, Side::Unset);
     // margin negativo permitido.
-    assert_eq!(parse_inline("margin-top: -5px").margin.top, Side::Px(-5.0));
+    assert_eq!(parse_inline("margin-top: -5px").margin.top, Side::px_len(-5.0));
     // longhand VENCE o shorthand na cascade (merge_over por lado).
     let mut base = parse_inline("padding: 10px");
     base.merge_over(&parse_inline("padding-left: 30px"));
-    assert_eq!(base.padding.left, Side::Px(30.0));
-    assert_eq!(base.padding.top, Side::Px(10.0)); // os outros mantêm
+    assert_eq!(base.padding.left, Side::px_len(30.0));
+    assert_eq!(base.padding.top, Side::px_len(10.0)); // os outros mantêm
 }
 
 #[test]
@@ -186,8 +186,8 @@ fn box_model_slots() {
     s.apply_slot(SLOT_BORDER_COLOR, 0xFF0000FF);
     s.apply_slot(SLOT_CORNER_RADIUS, 6);
     s.apply_slot(SLOT_BG, 0x222222FF);
-    assert_eq!(s.padding.top, Side::Px(8.0));
-    assert_eq!(s.margin.top, Side::Px(4.0));
+    assert_eq!(s.padding.top, Side::px_len(8.0));
+    assert_eq!(s.margin.top, Side::px_len(4.0));
     assert_eq!(s.border_width, Some(2.0));
     assert_eq!(s.border_color, Some(0xFF0000FF));
     assert_eq!(s.corner_radius, Some(6.0));
@@ -275,8 +275,8 @@ fn width_slot_e_parse() {
     assert_eq!(parse_inline("width: auto").width, Some(Dimension::Auto));
     // box props inline (F2): padding/margin/border/raio.
     let c = parse_inline("padding: 12; margin: 6; border-width: 2; border-radius: 8");
-    assert_eq!(c.padding.top, Side::Px(12.0));
-    assert_eq!(c.margin.top, Side::Px(6.0));
+    assert_eq!(c.padding.top, Side::px_len(12.0));
+    assert_eq!(c.margin.top, Side::px_len(6.0));
     assert_eq!(c.border_width, Some(2.0));
     assert_eq!(c.corner_radius, Some(8.0));
 }
@@ -299,11 +299,11 @@ fn stylesheet_seletores_e_especificidade() {
     let s = sheet.computed_for("p", None, &["card"]).normal;
     assert_eq!(s.color, Some(0x00FF00FF)); // classe > tag
     assert_eq!(s.font_size, Some(14.0)); // só a tag define
-    assert_eq!(s.padding.top, Side::Px(10.0)); // só a classe define
+    assert_eq!(s.padding.top, Side::px_len(10.0)); // só a classe define
     // <p id="alvo" class="card">: id vence tudo na cor (100>10>1).
     let s = sheet.computed_for("p", Some("alvo"), &["card"]).normal;
     assert_eq!(s.color, Some(0x0000FFFF)); // id > classe > tag
-    assert_eq!(s.padding.top, Side::Px(10.0)); // classe ainda aplica onde o id não toca
+    assert_eq!(s.padding.top, Side::px_len(10.0)); // classe ainda aplica onde o id não toca
 }
 
 #[test]
@@ -342,7 +342,7 @@ fn important_separa_camadas() {
     assert_eq!(b.normal.color, None);
     // case-insensitive e com espaço antes do `!`.
     let b2 = parse_inline_block("padding: 10  !IMPORTANT");
-    assert_eq!(b2.important.padding.top, Side::Px(10.0));
+    assert_eq!(b2.important.padding.top, Side::px_len(10.0));
 }
 
 #[test]
@@ -387,6 +387,20 @@ fn define_style_acumula_por_tag() {
     assert_eq!(s.font_size, Some(28.0));
     // tag não registrada → None.
     assert_eq!(lookup_style("tag_inexistente_xyz"), None);
+}
+
+#[test]
+fn font_size_e_lados_em_rem() {
+    // font-size em rem resolve contra o root FIXO 16 (browser default; o Bootstrap
+    // define a tipografia toda em rem): 2.5rem = 40px.
+    assert_eq!(parse_inline("font-size: 2.5rem").font_size, Some(40.0));
+    // padding/margin carregam a unidade (resolve TARDE no layout).
+    let c = parse_inline("padding: 1rem; margin: -0.5rem 2em");
+    assert_eq!(c.padding.top, Side::Len(Dimension::Rem(1.0)));
+    assert_eq!(c.margin.top, Side::Len(Dimension::Rem(-0.5)), "negativo preserva o sinal");
+    assert_eq!(c.margin.left, Side::Len(Dimension::Em(2.0)));
+    // border-radius em rem: 0.375rem = 6px (o .btn do Bootstrap).
+    assert_eq!(parse_inline("border-radius: 0.375rem").corner_radius, Some(6.0));
 }
 
 #[test]

--- a/crates/rts-dom/src/style/values.rs
+++ b/crates/rts-dom/src/style/values.rs
@@ -146,24 +146,40 @@ impl TextTransform {
     }
 }
 
-/// Valor de UM lado de margin/padding: um comprimento em pontos, `auto` (só faz
-/// sentido em margin — centralização), ou não-especificado. Egui-free.
+/// Valor de UM lado de margin/padding: um COMPRIMENTO (px/%/em/rem/vw/vh — a
+/// unidade relativa sobrevive até o layout, como em `width`), `auto` (só faz
+/// sentido em margin — centralização/flex), ou não-especificado. Egui-free.
+/// É o que destrava o `p-3`/`px-2` (padding em rem) do Bootstrap — antes só px.
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub enum Side {
     /// Não especificado (herda o default / 0 efetivo).
     #[default]
     Unset,
-    /// Comprimento absoluto em pontos.
-    Px(f32),
+    /// Um comprimento — resolve TARDE no layout ([`Side::resolve`]); pode ser
+    /// NEGATIVO (margem negativa é válida: os gutters `.row` do Bootstrap).
+    Len(Dimension),
     /// `auto` — margin que absorve o espaço livre (`margin: 0 auto` centraliza).
     Auto,
 }
 
 impl Side {
-    /// O valor em pontos (Px), ou `None` para Unset/Auto (o layout decide).
+    /// Constrói um lado ABSOLUTO em pontos (o caso comum de UA-stylesheet/slots).
+    pub fn px_len(v: f32) -> Side {
+        Side::Len(Dimension::Px(v))
+    }
+    /// O valor em pontos SE já absoluto (`Len(Px)`); `None` para Unset/Auto e
+    /// para unidades relativas (essas precisam de [`resolve`](Side::resolve)).
     pub fn px(self) -> Option<f32> {
         match self {
-            Side::Px(v) => Some(v),
+            Side::Len(Dimension::Px(v)) => Some(v),
+            _ => None,
+        }
+    }
+    /// Resolve para pontos com o contexto do layout — SIGNED (margem negativa
+    /// vale; padding é clampado ≥0 pelo CONSUMIDOR). `None` = Unset/Auto.
+    pub fn resolve(self, ctx: &ResolveCtx) -> Option<f32> {
+        match self {
+            Side::Len(d) => d.resolve_signed(ctx),
             _ => None,
         }
     }
@@ -201,14 +217,14 @@ impl Edges {
         if other.bottom != Side::Unset { self.bottom = other.bottom; }
         if other.left != Side::Unset { self.left = other.left; }
     }
-    /// Valor horizontal efetivo (left+right em px, auto/unset = 0) — para somar à
-    /// largura. (O `auto` não soma largura; é resolvido à parte no layout.)
-    pub fn horizontal_px(&self) -> f32 {
-        self.left.px().unwrap_or(0.0) + self.right.px().unwrap_or(0.0)
+    /// Valor horizontal efetivo (left+right) RESOLVIDO com o contexto do layout
+    /// (unidades relativas contam; auto/unset = 0 — o `auto` é resolvido à parte).
+    pub fn resolve_h(&self, ctx: &ResolveCtx) -> f32 {
+        self.left.resolve(ctx).unwrap_or(0.0) + self.right.resolve(ctx).unwrap_or(0.0)
     }
-    /// Valor vertical efetivo (top+bottom em px).
-    pub fn vertical_px(&self) -> f32 {
-        self.top.px().unwrap_or(0.0) + self.bottom.px().unwrap_or(0.0)
+    /// Valor vertical efetivo (top+bottom) resolvido com o contexto.
+    pub fn resolve_v(&self, ctx: &ResolveCtx) -> f32 {
+        self.top.resolve(ctx).unwrap_or(0.0) + self.bottom.resolve(ctx).unwrap_or(0.0)
     }
 }
 
@@ -435,8 +451,16 @@ pub enum Dimension {
 impl Dimension {
     /// Resolve para PONTOS absolutos, dado o contexto do render. `Auto` → `None`
     /// (o layout decide). É chamado TARDE (em `frame/render.rs`), nunca no parse.
+    /// Clampa em ≥ 0 (largura/altura negativa não existe); para MARGENS/offsets
+    /// (negativo é válido), use [`resolve_signed`](Dimension::resolve_signed).
     pub fn resolve(self, ctx: &ResolveCtx) -> Option<f32> {
-        let px = match self {
+        self.resolve_signed(ctx).map(|px| px.max(0.0))
+    }
+
+    /// Como [`resolve`](Dimension::resolve), mas SEM o clamp ≥ 0 — para margens
+    /// negativas (`.row` gutters do Bootstrap) e offsets de posicionamento.
+    pub fn resolve_signed(self, ctx: &ResolveCtx) -> Option<f32> {
+        Some(match self {
             Dimension::Auto => return None,
             Dimension::Px(v) => v,
             Dimension::Percent(p) => ctx.parent_content_w * p / 100.0,
@@ -444,8 +468,7 @@ impl Dimension {
             Dimension::Rem(r) => ctx.root_font_size * r,
             Dimension::Vw(v) => ctx.viewport_w * v / 100.0,
             Dimension::Vh(v) => ctx.viewport_h * v / 100.0,
-        };
-        Some(px.max(0.0))
+        })
     }
 
     /// Decodifica a forma ABI `i64` (o TS empacota a dimensão num único inteiro,


### PR DESCRIPTION
## Validado número-a-número contra o Chrome (MCP DevTools, viewport 1000×800)

| Elemento (Bootstrap cover) | Chrome | RTS antes | RTS agora |
|---|---|---|---|
| `.cover-container` | 164, 0, 672, 800 | 80, 0, 840, 800 | **164, 0, 672, 800 (exato)** |
| header | 180, **16**, 640 | 80, 0, 840 | **180, 16, 640 (x/y/w exatos)** |
| `.lead` font-size | 20px | 20 (por coincidência) | **20px (1.25rem×16, pela razão certa)** |

## O quê

- **`Side::Len(Dimension)`** — margin/padding por lado carregam a unidade (px/%/em/rem/vw/vh) e resolvem tarde no layout, como `width` já fazia. Era o item nº 1 do backlog (rem = 1102× no bootstrap.min.css).
- **Margem negativa** respeitada (`resolve_signed`) — os gutters `.row` do Bootstrap.
- **font-size/border-width/border-radius aceitam rem** (×16 no parse, root fixo igual ao browser; `em`/`%` de font-size = corte documentado).
- **`DEFAULT_FONT_SIZE` 20 → 16** (default de browser; 20 inflava todo em/rem em 25%). Regressão intencional: 3 testes de layout atualizados com os números derivados.

## Validação

`cargo test -p rts-dom`: **173/173** (novos testes de paridade com os rects do Chrome). Divergências restantes têm causa conhecida no mapa: `calc()`, `float`, inline-flow, `var()` por elemento (#1779).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgwXzwpwovEs5YLN9rAHfH