### PR TITLE
feat(dom): calc() linear + font-size em qualquer unidade — h1 37px exato igual ao Chrome

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -1863,7 +1863,7 @@ mod tests {
         );
         let s = crate::style::lookup_style(tag).expect("style registrado");
         assert_eq!(s.color, Some(0x0088FFFF));
-        assert_eq!(s.font_size, Some(28.0));
+        assert_eq!(s.font_size, Some(crate::style::Dimension::Px(28.0)));
 
         let btag = "claudeblk";
         __RTS_FN_NS_DOM_DEFINE_BLOCK(

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -200,6 +200,13 @@ pub struct Dom {
     computed_memo: std::cell::RefCell<HashMap<NodeIdx, crate::style::ComputedStyle>>,
     /// A revisão de render em que o `computed_memo` foi preenchido.
     memo_revision: std::cell::Cell<u64>,
+    /// O VIEWPORT corrente (w, h) — setado pelo layout no início da passada
+    /// ([`set_viewport`](Dom::set_viewport)); a base de `vw`/`vh` na cascade
+    /// (font-size fluido) e do `@media` futuro. Default 1280×800 (headless).
+    viewport: std::cell::Cell<(f32, f32)>,
+    /// O viewport com que o `computed_memo` foi preenchido (o computed depende
+    /// dele via vw/vh) — muda → memo invalida.
+    memo_viewport: std::cell::Cell<(u32, u32)>,
 }
 
 // Igualdade estrutural: compara só a árvore (nodes+root). Os índices e a `generation`
@@ -237,7 +244,16 @@ impl Dom {
             revision: 0,
             computed_memo: std::cell::RefCell::new(HashMap::new()),
             memo_revision: std::cell::Cell::new(0),
+            viewport: std::cell::Cell::new((1280.0, 800.0)),
+            memo_viewport: std::cell::Cell::new((1280.0f32.to_bits(), 800.0f32.to_bits())),
         }
+    }
+
+    /// Informa o VIEWPORT da passada de layout (base de `vw`/`vh` no computed).
+    /// `&self` (Cell) — o layout roda sobre `&Dom`; o memo de estilo invalida
+    /// sozinho quando o viewport muda (compara em `computed_style_idx`).
+    pub fn set_viewport(&self, w: f32, h: f32) {
+        self.viewport.set((w, h));
     }
 
     /// Marca que ALGO que afeta o render mudou (bumpa a revisão). Chamado por todo
@@ -474,9 +490,12 @@ impl Dom {
         // pintura). Um clone do ComputedStyle é muito mais barato que re-rodar
         // todas as regras do stylesheet (Bootstrap: ~2700).
         let rev = self.render_revision();
-        if self.memo_revision.get() != rev {
+        let (vw, vh) = self.viewport.get();
+        let vp_key = (vw.to_bits(), vh.to_bits());
+        if self.memo_revision.get() != rev || self.memo_viewport.get() != vp_key {
             self.computed_memo.borrow_mut().clear();
             self.memo_revision.set(rev);
+            self.memo_viewport.set(vp_key);
         }
         if let Some(hit) = self.computed_memo.borrow().get(&idx) {
             return Some(hit.clone());
@@ -521,13 +540,39 @@ impl Dom {
         css.merge_over(&author.important); // <style> !important
         css.merge_over(&inline.important); // inline !important
 
+        // ── FONT-SIZE resolve CEDO (aqui na cascade, não no layout): a base de
+        // `em`/`%` de font-size é o font do PAI (já computado em Px pela recursão
+        // abaixo) e `rem`/`vw`/`vh` usam root/viewport — assim a HERANÇA desce
+        // sempre o VALOR (Px), nunca a forma (um `2em` herdado re-multiplicaria a
+        // cada nível). É o que permite `calc(1.375rem + 1.5vw)` no font-size (a
+        // tipografia fluida do h1 do Bootstrap).
+        let parent_css = self
+            .element_parent_idx(idx)
+            .and_then(|p| self.computed_style_idx_inner(p, with_anim));
+        if let Some(d) = css.font_size {
+            let parent_font = parent_css
+                .as_ref()
+                .and_then(|p| match p.font_size {
+                    Some(style::Dimension::Px(v)) => Some(v),
+                    _ => None,
+                })
+                .unwrap_or(crate::layout::DEFAULT_FONT_SIZE);
+            let (vw, vh) = self.viewport.get();
+            let rctx = style::ResolveCtx {
+                parent_content_w: parent_font, // `%` de font-size = % do font do PAI
+                node_font_size: parent_font,   // `em` de font-size = × font do PAI
+                root_font_size: crate::layout::DEFAULT_FONT_SIZE,
+                viewport_w: vw,
+                viewport_h: vh,
+            };
+            css.font_size = d.resolve(&rctx).filter(|v| *v > 0.0).map(style::Dimension::Px);
+        }
+
         // ── HERANÇA (CSS inherited properties): color/font/text-align/etc. que NÃO
         // foram declaradas neste nó descem do PAI-elemento. É o que faz o texto pegar
         // a cor do body sem cada elemento redeclarar (sem isto, texto fica preto).
-        if let Some(parent_idx) = self.element_parent_idx(idx) {
-            if let Some(parent_css) = self.computed_style_idx_inner(parent_idx, with_anim) {
-                css.inherit_from(&parent_css);
-            }
+        if let Some(parent_css) = &parent_css {
+            css.inherit_from(parent_css);
         }
 
         // ── Camada de ANIMAÇÃO (#1776): o estilo interpolado do frame atual vence
@@ -2184,11 +2229,11 @@ mod tests {
         // <p> normal: regra de tag.
         let s0 = dom.computed_style(ps[0]).unwrap();
         assert_eq!(s0.color, Some(0xFF0000FF));
-        assert_eq!(s0.font_size, Some(14.0));
+        assert_eq!(s0.font_size, Some(crate::style::Dimension::Px(14.0)));
         // <p class="hl">: classe vence a tag na cor; font-size herda da tag.
         let s1 = dom.computed_style(ps[1]).unwrap();
         assert_eq!(s1.color, Some(0x00FF00FF));
-        assert_eq!(s1.font_size, Some(14.0));
+        assert_eq!(s1.font_size, Some(crate::style::Dimension::Px(14.0)));
         // <p id="x" class="hl">: id vence tudo.
         let s2 = dom.computed_style(ps[2]).unwrap();
         assert_eq!(s2.color, Some(0x0000FFFF));
@@ -2738,7 +2783,6 @@ mod tests {
     fn eventos_add_dispatch_poll() {
         // addEventListener marca o nó; dispatchEvent enfileira; poll consome (#1760).
         let mut dom = parse_html_to_dom("<div id=\"a\"><button id=\"b\">x</button></div>");
-        let a = dom.query("#a").unwrap();
         let b = dom.query("#b").unwrap();
         dom.add_event_listener(b, "click");
         assert!(dom.has_listener(b, "click"));

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -171,6 +171,9 @@ pub struct LayoutCtx<'a> {
 /// entrada do motor: percorre os filhos de `#document` como blocos empilhados na
 /// largura do viewport, resolvendo box model e emitindo os itens de pintura.
 pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
+    // informa o viewport à CASCADE (base de vw/vh no font-size fluido/calc; o
+    // memo de estilo do Dom invalida sozinho se mudou).
+    dom.set_viewport(ctx.viewport_w, ctx.viewport_h);
     let mut list = DisplayList::default();
     // PROPAGAÇÃO DO FUNDO do <body>/<html> (regra especial do CSS): o background
     // desses dois elementos "vaza" para o VIEWPORT inteiro, não só a caixa deles.
@@ -226,7 +229,7 @@ fn layout_out_of_flow(dom: &Dom, id: NodeIdx, ctx: &LayoutCtx, list: &mut Displa
     let css = dom.computed_style_idx(id).unwrap_or_default();
     let resolve = ResolveCtx {
         parent_content_w: ctx.viewport_w,
-        node_font_size: css.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+        node_font_size: font_px(&css, DEFAULT_FONT_SIZE),
         root_font_size: DEFAULT_FONT_SIZE,
         viewport_w: ctx.viewport_w,
         viewport_h: ctx.viewport_h,
@@ -492,7 +495,7 @@ fn layout_block(
     // unidades relativas — `p-3` = 1rem do Bootstrap — e resolvem AQUI, como width).
     let resolve = ResolveCtx {
         parent_content_w: avail_w,
-        node_font_size: css.font_size.unwrap_or(DEFAULT_FONT_SIZE),
+        node_font_size: font_px(&css, DEFAULT_FONT_SIZE),
         root_font_size: DEFAULT_FONT_SIZE,
         viewport_w: ctx.viewport_w,
         viewport_h: ctx.viewport_h,
@@ -519,7 +522,7 @@ fn layout_block(
     // `frame` horizontal = o que cerca o content no eixo X (margin+border+padding
     // dos DOIS lados). border conta 2× (left+right); padding/margin já são a soma.
     let frame = margin_h + 2.0 * border + padding_h;
-    let font_for_content = css.font_size.unwrap_or(DEFAULT_FONT_SIZE);
+    let font_for_content = font_px(&css, DEFAULT_FONT_SIZE);
     let border_box = css.border_box.unwrap_or(false);
     let content_w = match css.width.and_then(|d| d.resolve(&resolve)) {
         // `width` explícito. Em `border-box`, o `width` INCLUI padding+border —
@@ -582,7 +585,7 @@ fn layout_block(
     // horizontal (`display:horizontal`/flex-row): cada filho À DIREITA do anterior,
     // a altura do content = a do filho mais alto (MDN flow: inline-axis stacking).
     let display = css_display(dom, id);
-    let font_size = css.font_size.unwrap_or(DEFAULT_FONT_SIZE);
+    let font_size = font_px(&css, DEFAULT_FONT_SIZE);
 
     // SCROLL CONTAINER (#1744): uma div com `overflow-x:auto/scroll` NÃO comprime os
     // filhos — eles transbordam e a div rola. Nesse caso layoutamos os filhos com a
@@ -813,7 +816,7 @@ fn intrinsic_outer_width(dom: &Dom, id: NodeIdx, parent_font: f32, ctx: &LayoutC
                 }
             }
             let css = dom.computed_style_idx(id).unwrap_or_default();
-            let f = css.font_size.unwrap_or(parent_font);
+            let f = font_px(&css, parent_font);
             let border_box = css.border_box.unwrap_or(false);
             let resolve = ResolveCtx {
                 parent_content_w: ctx.viewport_w,
@@ -916,6 +919,16 @@ fn css_display(dom: &Dom, id: NodeIdx) -> i64 {
     }
 }
 
+/// O `font-size` COMPUTADO em pontos: a CASCADE já resolveu a forma para `Px`
+/// (dom.rs — base de em/% é o pai; rem/vw/vh contra root/viewport), então aqui é
+/// só extrair; `fallback` cobre o não-declarado (herda) e formas não-resolvidas.
+fn font_px(css: &ComputedStyle, fallback: f32) -> f32 {
+    match css.font_size {
+        Some(crate::style::Dimension::Px(v)) => v,
+        _ => fallback,
+    }
+}
+
 /// Resolve uma dimensão do EIXO VERTICAL (`height`/`min-height`/`max-height`):
 /// `%` resolve contra a ALTURA do containing block (não a largura — era o bug que
 /// fazia `height:100%` virar 100% da largura do pai); as demais unidades usam o
@@ -974,7 +987,7 @@ fn layout_children_vertical(
                         // resolvem contra o content deste container).
                         let r = ResolveCtx {
                             parent_content_w: content_w,
-                            node_font_size: c.font_size.unwrap_or(font_size),
+                            node_font_size: font_px(&c, font_size),
                             root_font_size: DEFAULT_FONT_SIZE,
                             viewport_w: ctx.viewport_w,
                             viewport_h: ctx.viewport_h,
@@ -1397,7 +1410,7 @@ fn child_outer_width(dom: &Dom, id: NodeIdx, container_w: f32, parent_font: f32,
     match &dom.node(id).kind {
         NodeKind::Element { .. } if is_block_level(dom, id) => {
             let css = dom.computed_style_idx(id).unwrap_or_default();
-            let font = css.font_size.unwrap_or(parent_font);
+            let font = font_px(&css, parent_font);
             let resolve = ResolveCtx {
                 parent_content_w: container_w,
                 node_font_size: font,

--- a/crates/rts-dom/src/style/fmt.rs
+++ b/crates/rts-dom/src/style/fmt.rs
@@ -27,7 +27,7 @@ impl ComputedStyle {
         match n.as_str() {
             "color" => self.color.map(fmt_color).unwrap_or_default(),
             "background-color" | "background" => self.bg.map(fmt_color).unwrap_or_default(),
-            "font-size" => self.font_size.map(fmt_px).unwrap_or_default(),
+            "font-size" => self.font_size.map(fmt_dim).unwrap_or_default(),
             "font-weight" => match self.bold {
                 Some(true) => "700".into(),
                 Some(false) => "400".into(),
@@ -166,6 +166,23 @@ pub(crate) fn fmt_dim(d: Dimension) -> String {
         Dimension::Vw(v) => format!("{v}vw"),
         Dimension::Vh(v) => format!("{v}vh"),
         Dimension::Auto => "auto".into(),
+        // calc: reconstrói a forma canônica com os termos não-zero.
+        Dimension::Calc(c) => {
+            let mut parts: Vec<String> = Vec::new();
+            for (v, u) in [
+                (c.px, "px"), (c.pct, "%"), (c.em, "em"),
+                (c.rem, "rem"), (c.vw, "vw"), (c.vh, "vh"),
+            ] {
+                if v != 0.0 {
+                    parts.push(format!("{v}{u}"));
+                }
+            }
+            if parts.is_empty() {
+                "0px".into()
+            } else {
+                format!("calc({})", parts.join(" + "))
+            }
+        }
     }
 }
 

--- a/crates/rts-dom/src/style/lerp.rs
+++ b/crates/rts-dom/src/style/lerp.rs
@@ -32,6 +32,15 @@ pub fn lerp_dimension(a: Dimension, b: Dimension, t: f32) -> Dimension {
         (Dimension::Percent(x), Dimension::Percent(y)) => Dimension::Percent(lerp_f32(x, y, t)),
         (Dimension::Em(x), Dimension::Em(y)) => Dimension::Em(lerp_f32(x, y, t)),
         (Dimension::Rem(x), Dimension::Rem(y)) => Dimension::Rem(lerp_f32(x, y, t)),
+        // calc interpola por COMPONENTE (a combinação linear é fechada sob lerp).
+        (Dimension::Calc(x), Dimension::Calc(y)) => Dimension::Calc(crate::style::CalcLen {
+            px: lerp_f32(x.px, y.px, t),
+            pct: lerp_f32(x.pct, y.pct, t),
+            em: lerp_f32(x.em, y.em, t),
+            rem: lerp_f32(x.rem, y.rem, t),
+            vw: lerp_f32(x.vw, y.vw, t),
+            vh: lerp_f32(x.vh, y.vh, t),
+        }),
         _ => if t < 0.5 { a } else { b }, // unidades diferentes → discreto
     }
 }

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -58,7 +58,7 @@ pub use selector::{
 };
 pub use stylesheet::{parse_rules, DeclBlock, Rule, Stylesheet};
 pub use values::{
-    clamp_size, AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection,
+    clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection,
     JustifyContent, LineHeight, Position, ResolveCtx, Rgba, Side, TextAlign, TextTransform,
     WhiteSpace, DIM_BASE_EM, DIM_BASE_PERCENT, DIM_BASE_PX, DIM_BASE_REM, DIM_BASE_VH,
     DIM_BASE_VW, DIM_RANGE,

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -38,7 +38,7 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
         match prop.as_str() {
             "color" => css.color = parse_color(val),
             "background-color" | "background" => css.bg = parse_color(val),
-            "font-size" => css.font_size = parse_len(val),
+            "font-size" => css.font_size = parse_dimension(val),
             "font-weight" => css.bold = Some(is_bold(val)),
             "font-style" => {
                 css.italic =
@@ -151,6 +151,11 @@ fn parse_dimension(v: &str) -> Option<Dimension> {
     let v = v.trim();
     if v.eq_ignore_ascii_case("auto") {
         return Some(Dimension::Auto);
+    }
+    // `calc(...)` — expressão linear reduzida no parse (resolve tarde).
+    let low_full = v.to_ascii_lowercase();
+    if let Some(inner) = low_full.strip_prefix("calc(").and_then(|r| r.strip_suffix(')')) {
+        return parse_calc(inner).map(Dimension::Calc);
     }
     // (sufixo, construtor, clamp_max) — `%`/`vw`/`vh` em 0..=100; resto sem teto.
     let num = |s: &str| s.trim().parse::<f32>().ok().filter(|n| *n >= 0.0);
@@ -288,6 +293,128 @@ fn parse_side(tok: &str, allow_auto: bool) -> Side {
     }
 }
 
+// ── calc() — expressão LINEAR de comprimentos, reduzida no parse ────────────────
+// `calc(1.375rem + 1.5vw)` / `calc(100% - 2rem)` / `calc(2 * (1rem + 4px))`.
+// Gramática (recursive descent): expr := term (('+'|'-') term)* ;
+// term := atom (('*'|'/') atom)* ; atom := comprimento | número | '(' expr ')'.
+// Multiplicação/divisão só com ESCALAR de um dos lados (regra da spec). O
+// resultado é um [`CalcLen`] (combinação das 6 bases) que resolve TARDE.
+
+/// Um valor intermediário do parser de calc: comprimento (combinação linear) ou
+/// número puro (escalar de multiplicação).
+enum CalcVal {
+    Len(crate::style::CalcLen),
+    Num(f32),
+}
+
+/// Parseia o MIOLO de um `calc(...)` (sem o `calc(` e `)`), ou `None` se inválido.
+fn parse_calc(inner: &str) -> Option<crate::style::CalcLen> {
+    let toks: Vec<char> = inner.chars().collect();
+    let mut pos = 0usize;
+    let v = calc_expr(&toks, &mut pos)?;
+    // sobrou lixo → inválido.
+    while pos < toks.len() {
+        if !toks[pos].is_whitespace() {
+            return None;
+        }
+        pos += 1;
+    }
+    match v {
+        CalcVal::Len(l) => Some(l),
+        CalcVal::Num(_) => None, // calc(2) não é um comprimento
+    }
+}
+
+fn calc_ws(t: &[char], p: &mut usize) {
+    while *p < t.len() && t[*p].is_whitespace() {
+        *p += 1;
+    }
+}
+
+fn calc_expr(t: &[char], p: &mut usize) -> Option<CalcVal> {
+    let mut acc = calc_term(t, p)?;
+    loop {
+        calc_ws(t, p);
+        let op = match t.get(*p) {
+            Some('+') => 1.0f32,
+            Some('-') => -1.0f32,
+            _ => return Some(acc),
+        };
+        *p += 1;
+        let rhs = calc_term(t, p)?;
+        acc = match (acc, rhs) {
+            (CalcVal::Len(a), CalcVal::Len(b)) => CalcVal::Len(a.add(b.scale(op))),
+            (CalcVal::Num(a), CalcVal::Num(b)) => CalcVal::Num(a + op * b),
+            _ => return None, // comprimento ± número é inválido na spec
+        };
+    }
+}
+
+fn calc_term(t: &[char], p: &mut usize) -> Option<CalcVal> {
+    let mut acc = calc_atom(t, p)?;
+    loop {
+        calc_ws(t, p);
+        let mul = match t.get(*p) {
+            Some('*') => true,
+            Some('/') => false,
+            _ => return Some(acc),
+        };
+        *p += 1;
+        let rhs = calc_atom(t, p)?;
+        acc = match (acc, rhs, mul) {
+            (CalcVal::Len(a), CalcVal::Num(k), true) => CalcVal::Len(a.scale(k)),
+            (CalcVal::Num(k), CalcVal::Len(a), true) => CalcVal::Len(a.scale(k)),
+            (CalcVal::Num(a), CalcVal::Num(b), true) => CalcVal::Num(a * b),
+            (CalcVal::Len(a), CalcVal::Num(k), false) if k != 0.0 => CalcVal::Len(a.scale(1.0 / k)),
+            (CalcVal::Num(a), CalcVal::Num(b), false) if b != 0.0 => CalcVal::Num(a / b),
+            _ => return None, // len*len, num/len, divisão por zero: inválidos
+        };
+    }
+}
+
+fn calc_atom(t: &[char], p: &mut usize) -> Option<CalcVal> {
+    calc_ws(t, p);
+    if t.get(*p) == Some(&'(') {
+        *p += 1;
+        let v = calc_expr(t, p)?;
+        calc_ws(t, p);
+        if t.get(*p) != Some(&')') {
+            return None;
+        }
+        *p += 1;
+        return Some(v);
+    }
+    // número (com sinal) + unidade opcional.
+    let start = *p;
+    if matches!(t.get(*p), Some('-') | Some('+')) {
+        *p += 1;
+    }
+    while matches!(t.get(*p), Some(c) if c.is_ascii_digit() || *c == '.') {
+        *p += 1;
+    }
+    if *p == start {
+        return None;
+    }
+    let num: f32 = t[start..*p].iter().collect::<String>().parse().ok()?;
+    // unidade (letras/%).
+    let ustart = *p;
+    while matches!(t.get(*p), Some(c) if c.is_ascii_alphabetic() || *c == '%') {
+        *p += 1;
+    }
+    let unit: String = t[ustart..*p].iter().collect::<String>().to_ascii_lowercase();
+    use crate::style::CalcLen;
+    Some(match unit.as_str() {
+        "" => CalcVal::Num(num),
+        "px" => CalcVal::Len(CalcLen { px: num, ..Default::default() }),
+        "%" => CalcVal::Len(CalcLen { pct: num, ..Default::default() }),
+        "em" => CalcVal::Len(CalcLen { em: num, ..Default::default() }),
+        "rem" => CalcVal::Len(CalcLen { rem: num, ..Default::default() }),
+        "vw" => CalcVal::Len(CalcLen { vw: num, ..Default::default() }),
+        "vh" => CalcVal::Len(CalcLen { vh: num, ..Default::default() }),
+        _ => return None, // unidade desconhecida (ch/vmin/…): calc inválido
+    })
+}
+
 /// Como [`parse_dimension`], mas aceita valores NEGATIVOS (margens/offsets). O
 /// `%`/`vw`/`vh` não são clampados a 0..=100 aqui (o sinal importa).
 fn parse_dimension_signed(v: &str) -> Option<Dimension> {
@@ -308,6 +435,7 @@ fn parse_dimension_signed(v: &str) -> Option<Dimension> {
         Dimension::Rem(x) => Dimension::Rem(-x),
         Dimension::Vw(x) => Dimension::Vw(-x),
         Dimension::Vh(x) => Dimension::Vh(-x),
+        Dimension::Calc(c) => Dimension::Calc(c.scale(-1.0)),
     })
 }
 
@@ -382,7 +510,7 @@ fn apply_font_shorthand(css: &mut ComputedStyle, val: &str) {
     };
     // px direto; se for relativo (em/rem/%), parse_px falha e fica None (herda) —
     // mesma limitação da longhand font-size (documentada).
-    css.font_size = parse_len(sz);
+    css.font_size = parse_dimension(sz);
     if let Some(l) = lh {
         css.line_height = LineHeight::parse(l);
     }

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -115,8 +115,11 @@ css_props! {
         [inh anim] color: Rgba;
         /// Cor de fundo, `0xRRGGBBAA`.
         [anim] bg: Rgba;
-        /// Tamanho da fonte em pontos (> 0).
-        [inh anim] font_size: f32;
+        /// Tamanho da fonte. Declarado em QUALQUER unidade (px/em/%/rem/vw/vh/
+        /// calc — a tipografia fluida `calc(1.375rem + 1.5vw)` do Bootstrap), mas
+        /// a CASCADE resolve para `Px` cedo (base de em/% = font do pai; ver
+        /// dom.rs) — o layout sempre lê `Px`.
+        [inh anim] font_size: Dimension;
         /// `font-weight` colapsado em negrito (≥600/bold). Herdável.
         [inh] bold: bool;
         /// `font-style: italic/oblique`. Herdável.
@@ -262,7 +265,12 @@ impl ComputedStyle {
         match slot {
             SLOT_COLOR => self.color.map(|c| c as i64).unwrap_or(-1),
             SLOT_BG => self.bg.map(|c| c as i64).unwrap_or(-1),
-            SLOT_FONT_SIZE => dim(self.font_size),
+            // font-size: só a forma ABSOLUTA cruza o slot (a cascade resolve
+            // para Px de qualquer jeito; uma forma relativa crua reporta -1).
+            SLOT_FONT_SIZE => dim(match self.font_size {
+                Some(Dimension::Px(v)) => Some(v),
+                _ => None,
+            }),
             // o slot opaco reporta o lado `top` como representante (compat com o
             // shorthand de 1 valor que a camada TS usa via defineStyle/setStyle).
             SLOT_PADDING => dim(self.padding.top.px()),
@@ -293,7 +301,7 @@ impl ComputedStyle {
             SLOT_FONT_SIZE => {
                 let f = val as f32;
                 if f > 0.0 {
-                    self.font_size = Some(f);
+                    self.font_size = Some(Dimension::Px(f));
                 }
             }
             // slot opaco de 1 valor (defineStyle/setStyle) → os 4 lados iguais.

--- a/crates/rts-dom/src/style/tests.rs
+++ b/crates/rts-dom/src/style/tests.rs
@@ -7,7 +7,7 @@ use super::*;
 fn parses_typography() {
     let c = parse_inline("color:#ff0000; font-size:18px; font-weight:bold; font-style:italic");
     assert_eq!(c.color, Some(0xFF0000FF));
-    assert_eq!(c.font_size, Some(18.0));
+    assert_eq!(c.font_size, Some(Dimension::Px(18.0)));
     assert_eq!(c.bold, Some(true));
     assert_eq!(c.italic, Some(true));
 }
@@ -154,7 +154,7 @@ fn apply_slot_opaco() {
     s.apply_slot(SLOT_FONT_SIZE, 28);
     s.apply_slot(SLOT_BG, 0x111111FF);
     assert_eq!(s.color, Some(0x0088FFFF));
-    assert_eq!(s.font_size, Some(28.0));
+    assert_eq!(s.font_size, Some(Dimension::Px(28.0)));
     assert_eq!(s.bg, Some(0x111111FF));
 }
 
@@ -293,12 +293,12 @@ fn stylesheet_seletores_e_especificidade() {
     // <p> simples: só a regra de tag.
     let s = sheet.computed_for("p", None, &[]).normal;
     assert_eq!(s.color, Some(0xFF0000FF));
-    assert_eq!(s.font_size, Some(14.0));
+    assert_eq!(s.font_size, Some(Dimension::Px(14.0)));
     // <p class="card">: classe vence a tag na COR (10>1), mas font-size só a
     // tag tem (herda), e padding só a classe.
     let s = sheet.computed_for("p", None, &["card"]).normal;
     assert_eq!(s.color, Some(0x00FF00FF)); // classe > tag
-    assert_eq!(s.font_size, Some(14.0)); // só a tag define
+    assert_eq!(s.font_size, Some(Dimension::Px(14.0))); // só a tag define
     assert_eq!(s.padding.top, Side::px_len(10.0)); // só a classe define
     // <p id="alvo" class="card">: id vence tudo na cor (100>10>1).
     let s = sheet.computed_for("p", Some("alvo"), &["card"]).normal;
@@ -315,9 +315,9 @@ fn stylesheet_empate_ordem_e_virgula() {
     // seletor-lista `h1, h2, .big { ... }` → aplica aos três.
     let mut s2 = Stylesheet::new();
     s2.append_css("h1, h2, .big { font-size:30 }");
-    assert_eq!(s2.computed_for("h1", None, &[]).normal.font_size, Some(30.0));
-    assert_eq!(s2.computed_for("h2", None, &[]).normal.font_size, Some(30.0));
-    assert_eq!(s2.computed_for("p", None, &["big"]).normal.font_size, Some(30.0));
+    assert_eq!(s2.computed_for("h1", None, &[]).normal.font_size, Some(Dimension::Px(30.0)));
+    assert_eq!(s2.computed_for("h2", None, &[]).normal.font_size, Some(Dimension::Px(30.0)));
+    assert_eq!(s2.computed_for("p", None, &["big"]).normal.font_size, Some(Dimension::Px(30.0)));
     assert_eq!(s2.computed_for("p", None, &[]).normal.font_size, None); // não casa
 }
 
@@ -338,7 +338,7 @@ fn important_separa_camadas() {
     let b = parse_inline_block("color:#ff0000 !important; font-size:14");
     assert_eq!(b.important.color, Some(0xFF0000FF));
     assert_eq!(b.important.font_size, None);
-    assert_eq!(b.normal.font_size, Some(14.0));
+    assert_eq!(b.normal.font_size, Some(Dimension::Px(14.0)));
     assert_eq!(b.normal.color, None);
     // case-insensitive e com espaço antes do `!`.
     let b2 = parse_inline_block("padding: 10  !IMPORTANT");
@@ -384,16 +384,19 @@ fn define_style_acumula_por_tag() {
     define_style("h1_acum", SLOT_FONT_SIZE, 28);
     let s = lookup_style("h1_acum").expect("tag registrada");
     assert_eq!(s.color, Some(0x0088FFFF));
-    assert_eq!(s.font_size, Some(28.0));
+    assert_eq!(s.font_size, Some(Dimension::Px(28.0)));
     // tag não registrada → None.
     assert_eq!(lookup_style("tag_inexistente_xyz"), None);
 }
 
 #[test]
 fn font_size_e_lados_em_rem() {
-    // font-size em rem resolve contra o root FIXO 16 (browser default; o Bootstrap
-    // define a tipografia toda em rem): 2.5rem = 40px.
-    assert_eq!(parse_inline("font-size: 2.5rem").font_size, Some(40.0));
+    // font-size preserva a FORMA no parse (rem/em/%/vw/calc); quem resolve para
+    // Px é a CASCADE (base de em/% = font do pai — ver dom.rs). 2.5rem → Rem(2.5).
+    assert_eq!(parse_inline("font-size: 2.5rem").font_size, Some(Dimension::Rem(2.5)));
+    // calc() linear reduz no parse: calc(1.375rem + 1.5vw) → {rem:1.375, vw:1.5}.
+    let c = parse_inline("font-size: calc(1.375rem + 1.5vw)").font_size;
+    assert_eq!(c, Some(Dimension::Calc(CalcLen { rem: 1.375, vw: 1.5, ..Default::default() })));
     // padding/margin carregam a unidade (resolve TARDE no layout).
     let c = parse_inline("padding: 1rem; margin: -0.5rem 2em");
     assert_eq!(c.padding.top, Side::Len(Dimension::Rem(1.0)));
@@ -439,10 +442,10 @@ fn mecanismos_gerados_da_tabela() {
     let mut parent = ComputedStyle::default();
     parent.color = Some(0x112233FF); // inh
     parent.bg = Some(0x445566FF); // NÃO herda (box)
-    parent.font_size = Some(20.0); // inh
+    parent.font_size = Some(Dimension::Px(20.0)); // inh
     child.inherit_from(&parent);
     assert_eq!(child.color, Some(0x112233FF));
-    assert_eq!(child.font_size, Some(20.0));
+    assert_eq!(child.font_size, Some(Dimension::Px(20.0)));
     assert_eq!(child.bg, None); // bg não herda
     // diff animado: campo [anim] dispara; não-animável não.
     let mut a = ComputedStyle::default();

--- a/crates/rts-dom/src/style/values.rs
+++ b/crates/rts-dom/src/style/values.rs
@@ -425,10 +425,53 @@ pub struct ResolveCtx {
     pub viewport_h: f32,
 }
 
+/// Uma expressão `calc()` LINEAR já reduzida à combinação das 6 bases de
+/// comprimento: `px + pct·CB + em·font + rem·root + vw·VW + vh·VH`. Qualquer
+/// calc de soma/subtração/multiplicação-por-escalar reduz a esta forma no PARSE
+/// (simbolicamente), e a resolução continua TARDIA como toda [`Dimension`] — é o
+/// que faz `calc(1.375rem + 1.5vw)` (a tipografia fluida do Bootstrap) funcionar.
+/// `Copy` de propósito (a `Dimension` viaja por valor pelo layout inteiro).
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct CalcLen {
+    pub px: f32,
+    /// coeficiente de `%` (resolve contra o containing block, como `Percent`).
+    pub pct: f32,
+    pub em: f32,
+    pub rem: f32,
+    pub vw: f32,
+    pub vh: f32,
+}
+
+impl CalcLen {
+    /// Soma termo a termo (o `+`/`-` do calc; para `-`, chame com `rhs.scale(-1.0)`).
+    pub fn add(self, rhs: CalcLen) -> CalcLen {
+        CalcLen {
+            px: self.px + rhs.px,
+            pct: self.pct + rhs.pct,
+            em: self.em + rhs.em,
+            rem: self.rem + rhs.rem,
+            vw: self.vw + rhs.vw,
+            vh: self.vh + rhs.vh,
+        }
+    }
+    /// Multiplica por um escalar (o `*`/`/` do calc — a spec só permite escalar).
+    pub fn scale(self, k: f32) -> CalcLen {
+        CalcLen {
+            px: self.px * k,
+            pct: self.pct * k,
+            em: self.em * k,
+            rem: self.rem * k,
+            vw: self.vw * k,
+            vh: self.vh * k,
+        }
+    }
+}
+
 /// Uma dimensão de caixa que SOBREVIVE a unidade relativa até o layout (north-star
 /// risco 5): só `Px`/`Auto` resolvem de imediato; `Percent`/`Em`/`Rem`/`Vw`/`Vh`
-/// precisam de um eixo conhecido só no render (pai/fonte/viewport), então o tipo
-/// PRESERVA a forma e [`resolve`](Dimension::resolve) calcula tarde.
+/// (e o [`Calc`](Dimension::Calc) que os combina) precisam de um eixo conhecido só
+/// no render (pai/fonte/viewport), então o tipo PRESERVA a forma e
+/// [`resolve`](Dimension::resolve) calcula tarde.
 /// Egui-free (tipo próprio, não `Vec2`/`f32`), como o resto do `style`.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Dimension {
@@ -446,6 +489,9 @@ pub enum Dimension {
     Vw(f32),
     /// `vh` — `%` da altura da viewport (0..=100): `viewport_h * v/100`.
     Vh(f32),
+    /// `calc(...)` linear reduzido no parse ([`CalcLen`]). Não cruza a ABI de
+    /// faixas (`to_abi` → `-1`, corte documentado — o TS não empacota calc).
+    Calc(CalcLen),
 }
 
 impl Dimension {
@@ -468,6 +514,14 @@ impl Dimension {
             Dimension::Rem(r) => ctx.root_font_size * r,
             Dimension::Vw(v) => ctx.viewport_w * v / 100.0,
             Dimension::Vh(v) => ctx.viewport_h * v / 100.0,
+            // calc linear: cada base resolvida no seu eixo e somada.
+            Dimension::Calc(c) => {
+                c.px + ctx.parent_content_w * c.pct / 100.0
+                    + ctx.node_font_size * c.em
+                    + ctx.root_font_size * c.rem
+                    + ctx.viewport_w * c.vw / 100.0
+                    + ctx.viewport_h * c.vh / 100.0
+            }
         })
     }
 
@@ -505,6 +559,9 @@ impl Dimension {
             Dimension::Rem(r) => (3, r),
             Dimension::Vw(v) => (4, v),
             Dimension::Vh(v) => (5, v),
+            // calc não cabe na codificação de faixas — o TS lê `-1` (corte
+            // documentado; calc resolve no layout, não cruza slots).
+            Dimension::Calc(_) => return -1,
         };
         unit * DIM_RANGE + (val * 1000.0) as i64
     }


### PR DESCRIPTION
## Validado número-a-número contra o Chrome (Bootstrap cover, viewport 1000×800)

| | Chrome | RTS agora |
|---|---|---|
| h1 font-size (`calc(1.375rem + 1.5vw)`) | 37px | **37px (exato)** |
| h1 rect height | 44.4 | **44.4 (exato)** |
| h3 brand (`calc(1.3rem + 0.6vw)`) | 26.8px | **26.8px (exato)** |

## O quê

- **`CalcLen`**: todo `calc()` linear reduz no parse a uma combinação `Copy` das 6 bases (px/%/em/rem/vw/vh); resolução tardia como qualquer `Dimension`. Parser recursive-descent (+, −, ×/÷ por escalar, parênteses). Funciona em width/height/padding/margin/insets/gap; anima por componente.
- **`font_size` vira `Dimension` na tabela `css_props!`** (1 linha) — aceita qualquer unidade. A cascade resolve para Px cedo: base de em/% é o font do **pai** (a herança desce o valor, nunca a forma); rem/vw/vh contra root(16)/viewport.
- **`Dom.viewport`** (Cell) informado pelo layout — base de vw/vh na cascade, na chave do memo.

## Validação

`cargo test -p rts-dom`: **173/173**. Diff Chrome acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgwXzwpwovEs5YLN9rAHfH