### PR TITLE
feat(dom): @media avaliado (fase 2) + float v1 — navbar lado a lado como no Chrome

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -520,7 +520,7 @@ impl Dom {
             style::DeclBlock::default()
         } else {
             self.stylesheet
-                .computed_for_node(|sel| self.matches_complex(idx, sel))
+                .computed_for_node(self.viewport.get().0, |sel| self.matches_complex(idx, sel))
         };
         // `style=""` inline (normal + important).
         let inline = self.nodes[idx]

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -507,9 +507,14 @@ fn layout_block(
     let p = &css.padding;
     let mut margin_left = m.left.resolve(&resolve).unwrap_or(0.0);
     let mut margin_right = m.right.resolve(&resolve).unwrap_or(0.0);
+    // margin_v (UA-stylesheet) só vale no lado que o AUTOR NÃO declarou — um
+    // `margin-top: 0` explícito ANULA o default da UA naquele lado (era o brand
+    // do cover descendo 16px apesar do `h3 { margin-top: 0 }` do Bootstrap).
     let margin_v_extra = css.margin_v.unwrap_or(0.0);
-    let margin_top = m.top.resolve(&resolve).unwrap_or(0.0) + margin_v_extra;
-    let margin_bottom = m.bottom.resolve(&resolve).unwrap_or(0.0) + margin_v_extra;
+    let mv_top = if m.top == crate::style::Side::Unset { margin_v_extra } else { 0.0 };
+    let mv_bottom = if m.bottom == crate::style::Side::Unset { margin_v_extra } else { 0.0 };
+    let margin_top = m.top.resolve(&resolve).unwrap_or(0.0) + mv_top;
+    let margin_bottom = m.bottom.resolve(&resolve).unwrap_or(0.0) + mv_bottom;
     let pad_left = p.left.resolve(&resolve).unwrap_or(0.0).max(0.0);
     let pad_right = p.right.resolve(&resolve).unwrap_or(0.0).max(0.0);
     let pad_top = p.top.resolve(&resolve).unwrap_or(0.0).max(0.0);
@@ -969,6 +974,24 @@ fn layout_children_vertical(
     // overlap = min(dos dois) para virar max(dos dois). `prev_margin` rastreia o
     // margin do último bloco posto.
     let mut prev_margin = 0.0f32;
+    // ── FLOAT LINE (v1): floats CONSECUTIVOS dividem a mesma linha — left encosta
+    // à esquerda, right à direita (o header brand+nav do Bootstrap). Um irmão
+    // NÃO-float fecha a linha (começa abaixo do float mais alto). Ver FloatSide.
+    let mut float_top: Option<f32> = None; // y do topo da linha de floats
+    let mut float_left_x = content_x;
+    let mut float_right_x = content_x + content_w;
+    let mut float_h = 0.0f32; // altura da linha (max dos floats)
+    // fecha a float line corrente (chamado antes de um não-float e no fim).
+    macro_rules! close_floats {
+        ($y:expr) => {
+            if let Some(top) = float_top.take() {
+                $y = $y.max(top + float_h);
+                float_left_x = content_x;
+                float_right_x = content_x + content_w;
+                float_h = 0.0;
+            }
+        };
+    }
     for &child in &dom.node(id).children {
         match &dom.node(child).kind {
             // Metadata não-renderável (`<head>`/`<title>`/`<style>`/`<script>`):
@@ -978,7 +1001,26 @@ fn layout_children_vertical(
             // Fora do fluxo (`position:absolute/fixed`): não ocupa espaço aqui —
             // pintado na passada out-of-flow de layout_document.
             NodeKind::Element { .. } if is_out_of_flow(dom, child) => {}
+            // FLOAT left/right: shrink-to-fit na linha de floats corrente.
+            NodeKind::Element { .. } if float_of(dom, child) != crate::style::FloatSide::None => {
+                let side = float_of(dom, child);
+                let top = *float_top.get_or_insert(child_y);
+                let w = child_outer_width(dom, child, content_w, font_size, ctx);
+                let h = child_outer_height(dom, child, content_w, avail_h, font_size, ctx);
+                let x = if side == crate::style::FloatSide::Left {
+                    let x = float_left_x;
+                    float_left_x += w;
+                    x
+                } else {
+                    float_right_x -= w;
+                    float_right_x
+                };
+                layout_block(dom, child, x, top, content_w, avail_h, true, ctx, list);
+                float_h = float_h.max(h);
+                prev_margin = 0.0; // float quebra a sequência de collapse
+            }
             NodeKind::Element { .. } if is_block_level(dom, child) => {
+                close_floats!(child_y);
                 // margin VERTICAL TOP do filho (para o collapse com o anterior):
                 // margin.top + margin_v da UA.
                 let m = dom.computed_style_idx(child)
@@ -992,7 +1034,12 @@ fn layout_children_vertical(
                             viewport_w: ctx.viewport_w,
                             viewport_h: ctx.viewport_h,
                         };
-                        c.margin.top.resolve(&r).unwrap_or(0.0) + c.margin_v.unwrap_or(0.0)
+                        let mv = if c.margin.top == crate::style::Side::Unset {
+                            c.margin_v.unwrap_or(0.0)
+                        } else {
+                            0.0
+                        };
+                        c.margin.top.resolve(&r).unwrap_or(0.0) + mv
                     })
                     .unwrap_or(0.0);
                 // Colapsa com o bloco anterior: recua o overlap antes de posicionar.
@@ -1019,12 +1066,23 @@ fn layout_children_vertical(
                 prev_margin = m;
             }
             _ => {
+                close_floats!(child_y);
                 child_y = layout_inline_line(dom, child, content_x, child_y, content_w, css, font_size, ctx, list);
                 prev_margin = 0.0; // texto inline quebra a sequência de collapse.
             }
         }
     }
+    // fecha a float line pendente: os floats CONTRIBUEM para a altura (v1 = o
+    // comportamento de BFC — correto p/ flex items, o caso do header do cover).
+    close_floats!(child_y);
     (child_y - content_y).max(0.0)
+}
+
+/// O `float` computado de um nó-elemento (None p/ não-elemento/sem estilo).
+fn float_of(dom: &Dom, id: NodeIdx) -> crate::style::FloatSide {
+    dom.computed_style_idx(id)
+        .and_then(|c| c.float_side)
+        .unwrap_or(crate::style::FloatSide::None)
 }
 
 /// Um item medido do flex (pré-pass), com a referência ao nó e seu tamanho OUTER
@@ -2350,6 +2408,23 @@ mod tests {
         let r = all_rects(&list);
         assert_eq!(r[0].w, 672.0, "42em x 16: {r:?}");
         assert_eq!(r[0].x, 164.0, "(1000-672)/2, centrado como no Chrome");
+    }
+
+    #[test]
+    fn float_left_right_dividem_a_linha() {
+        // O header clássico (brand+nav do Bootstrap cover): float:left e
+        // float:right consecutivos dividem a MESMA linha; o irmão não-float
+        // começa abaixo do float mais alto; o pai contém os floats (BFC v1).
+        let list = layout(
+            "<div style='background:#111'>               <div style='float:left; background:#222; width:100; height:30'>brand</div>               <div style='float:right; background:#333; width:150; height:40'>nav</div>               <div style='background:#444; height:20'>abaixo</div>             </div>",
+            600.0,
+        );
+        let r = all_rects(&list);
+        assert_eq!(r.len(), 4);
+        assert_eq!((r[1].x, r[1].y), (0.0, 0.0), "left encosta na esquerda: {r:?}");
+        assert_eq!((r[2].x, r[2].y), (450.0, 0.0), "right encosta na direita (600-150)");
+        assert_eq!(r[3].y, 40.0, "nao-float comeca abaixo do float mais alto");
+        assert_eq!(r[0].h, 60.0, "pai contem os floats: 40 + 20");
     }
 
     #[test]

--- a/crates/rts-dom/src/style/fmt.rs
+++ b/crates/rts-dom/src/style/fmt.rs
@@ -86,6 +86,10 @@ impl ComputedStyle {
             "max-width" => self.max_width.map(fmt_dim).unwrap_or_default(),
             "min-height" => self.min_height.map(fmt_dim).unwrap_or_default(),
             "max-height" => self.max_height.map(fmt_dim).unwrap_or_default(),
+            "float" => self
+                .float_side
+                .map(|f| format!("{f:?}").to_ascii_lowercase())
+                .unwrap_or_default(),
             "position" => self
                 .position
                 .map(|p| format!("{p:?}").to_ascii_lowercase())

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -56,9 +56,9 @@ pub use selector::{
     compound_matches, parse_selector, parse_selector_list, AttrOp, Combinator, ComplexSelector,
     CompoundSelector, PseudoClass, Selector, SimpleSelector,
 };
-pub use stylesheet::{parse_rules, DeclBlock, Rule, Stylesheet};
+pub use stylesheet::{parse_rules, DeclBlock, MediaQuery, Rule, Stylesheet};
 pub use values::{
-    clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection,
+    clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection, FloatSide,
     JustifyContent, LineHeight, Position, ResolveCtx, Rgba, Side, TextAlign, TextTransform,
     WhiteSpace, DIM_BASE_EM, DIM_BASE_PERCENT, DIM_BASE_PX, DIM_BASE_REM, DIM_BASE_VH,
     DIM_BASE_VW, DIM_RANGE,

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -9,8 +9,8 @@ use super::color::parse_color;
 use super::props::ComputedStyle;
 use super::stylesheet::DeclBlock;
 use super::values::{
-    AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection, JustifyContent,
-    LineHeight, Position, Side, TextAlign, TextTransform, WhiteSpace,
+    AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection, FloatSide,
+    JustifyContent, LineHeight, Position, Side, TextAlign, TextTransform, WhiteSpace,
 };
 
 /// Parseia um `style="prop: valor; ..."` para um [`ComputedStyle`] (só a camada
@@ -107,6 +107,7 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
             // `position` + offsets (top/right/bottom/left). Os offsets aceitam
             // negativos (deslocam para fora) — parse_dimension rejeita <0, então
             // px negativo entra por parse direto.
+            "float" => css.float_side = FloatSide::parse(val),
             "position" => css.position = Position::parse(val),
             "top" => css.inset_top = parse_inset(val),
             "right" => css.inset_right = parse_inset(val),

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -23,8 +23,8 @@
 
 use super::lerp::AnimValue;
 use super::values::{
-    AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection, JustifyContent,
-    LineHeight, Position, Rgba, Side, TextAlign, TextTransform, WhiteSpace,
+    AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection, FloatSide,
+    JustifyContent, LineHeight, Position, Rgba, Side, TextAlign, TextTransform, WhiteSpace,
 };
 
 /// Declara a tabela de propriedades e gera a struct + os 4 mecanismos da cascade.
@@ -198,6 +198,9 @@ css_props! {
         [] min_height: Dimension;
         /// `max-height` — teto da altura usada.
         [] max_height: Dimension;
+        /// `float` — v1: floats consecutivos dividem a linha no fluxo vertical
+        /// (ver [`FloatSide`]); ignorado em containers flex (spec).
+        [] float_side: FloatSide;
         /// `position` — esquema de posicionamento. `absolute`/`fixed` saem do
         /// FLUXO (não ocupam espaço) e pintam contra o viewport com os offsets
         /// abaixo (v1 — ver [`Position`]). `None` = `static`.

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -30,6 +30,97 @@ use super::parse::parse_inline_block;
 use super::props::ComputedStyle;
 use super::selector::{compound_matches, ComplexSelector, PseudoClass, Selector};
 
+/// A condição de um bloco `@media`, avaliada contra o VIEWPORT (fase 2 — antes
+/// o bloco inteiro era pulado). V1 honesta: só `min-width`/`max-width` (px, e
+/// em/rem ×16) e os keywords neutros `screen`/`all`/`only`; qualquer feature
+/// desconhecida (`prefers-reduced-motion`, `orientation`, `print`, `not …`)
+/// torna a query SEMPRE-FALSA (conservador — para `prefers-reduced-motion:
+/// reduce` é exatamente o default desejado).
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+pub struct MediaQuery {
+    pub min_width: Option<f32>,
+    pub max_width: Option<f32>,
+    /// feature não suportada na condição → a query nunca casa.
+    pub always_false: bool,
+}
+
+impl MediaQuery {
+    /// Parseia a condição após o `@media` (`(min-width: 768px)`,
+    /// `screen and (max-width: 991.98px)`, lista por vírgula = OR de queries).
+    pub fn parse(cond: &str) -> MediaQuery {
+        // lista por vírgula é OR — v1: se QUALQUER query da lista for só de
+        // width, usamos a primeira suportada; senão always_false. (Bootstrap não
+        // usa listas em @media; mantém simples.)
+        let first = cond.split(',').next().unwrap_or("");
+        let mut q = MediaQuery::default();
+        for term in first.split(" and ") {
+            let t = term.trim().to_ascii_lowercase();
+            if t.is_empty() || t == "screen" || t == "all" || t == "only screen" || t == "only all" {
+                continue; // keywords neutros
+            }
+            // `(feature: valor)`
+            let inner = t.strip_prefix('(').and_then(|s| s.strip_suffix(')')).unwrap_or(&t);
+            let Some((feat, val)) = inner.split_once(':') else {
+                q.always_false = true; // `not`, `print`, feature sem valor…
+                continue;
+            };
+            let px = parse_media_len(val.trim());
+            match (feat.trim(), px) {
+                ("min-width", Some(v)) => q.min_width = Some(v),
+                ("max-width", Some(v)) => q.max_width = Some(v),
+                _ => q.always_false = true,
+            }
+        }
+        q
+    }
+
+    /// `true` se a query casa o viewport dado.
+    pub fn matches(&self, viewport_w: f32) -> bool {
+        if self.always_false {
+            return false;
+        }
+        if let Some(mn) = self.min_width {
+            if viewport_w < mn {
+                return false;
+            }
+        }
+        if let Some(mx) = self.max_width {
+            if viewport_w > mx {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Combina com uma query EXTERNA (aninhamento `@media` dentro de `@media`):
+    /// AND dos limites.
+    fn and(self, outer: MediaQuery) -> MediaQuery {
+        MediaQuery {
+            min_width: match (self.min_width, outer.min_width) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (a, b) => a.or(b),
+            },
+            max_width: match (self.max_width, outer.max_width) {
+                (Some(a), Some(b)) => Some(a.min(b)),
+                (a, b) => a.or(b),
+            },
+            always_false: self.always_false || outer.always_false,
+        }
+    }
+}
+
+/// Um comprimento de condição de media: px (ou em/rem ×16, como o browser).
+fn parse_media_len(v: &str) -> Option<f32> {
+    let low = v.to_ascii_lowercase();
+    if let Some(n) = low.strip_suffix("px") {
+        return n.trim().parse().ok();
+    }
+    if let Some(n) = low.strip_suffix("rem").or_else(|| low.strip_suffix("em")) {
+        return n.trim().parse::<f32>().ok().map(|x| x * 16.0);
+    }
+    low.parse().ok()
+}
+
 /// Uma regra do stylesheet: um seletor + as declarações já parseadas (separadas
 /// nas camadas normal/important da cascade). A ordem de declaração no fonte
 /// (`order`) desempata especificidades iguais.
@@ -39,6 +130,9 @@ pub struct Rule {
     pub decls: DeclBlock,
     /// Posição da regra no fonte (0-based) — desempate da cascade.
     pub order: u32,
+    /// A condição `@media` que ENVOLVE a regra (None = sempre aplica). Avaliada
+    /// contra o viewport na cascade ([`Stylesheet::computed_for_node`]).
+    pub media: Option<MediaQuery>,
 }
 
 /// Um bloco de declarações separado nas DUAS camadas de importância da cascade
@@ -141,8 +235,17 @@ impl Stylesheet {
     /// casa (decidido pelo `matches` fornecido — o `Dom` passa um que navega a
     /// árvore p/ os combinadores). Retorna um [`DeclBlock`] (normal + important
     /// separados). Dentro de cada camada, ordem de (especificidade, order) crescente.
-    pub fn computed_for_node(&self, matches: impl Fn(&ComplexSelector) -> bool) -> DeclBlock {
-        let mut matched: Vec<&Rule> = self.rules.iter().filter(|r| matches(&r.selector)).collect();
+    pub fn computed_for_node(
+        &self,
+        viewport_w: f32,
+        matches: impl Fn(&ComplexSelector) -> bool,
+    ) -> DeclBlock {
+        let mut matched: Vec<&Rule> = self
+            .rules
+            .iter()
+            .filter(|r| r.media.map(|m| m.matches(viewport_w)).unwrap_or(true))
+            .filter(|r| matches(&r.selector))
+            .collect();
         matched.sort_by_key(|r| (r.selector.specificity(), r.order));
         let mut out = DeclBlock::default();
         for r in &matched {
@@ -161,7 +264,8 @@ impl Stylesheet {
     pub fn computed_for(&self, tag: &str, id: Option<&str>, classes: &[&str]) -> DeclBlock {
         let no_attr = |_: &str| None;
         let no_pseudo = |_: &PseudoClass| false;
-        self.computed_for_node(|sel| {
+        // viewport de referência 1280 (helper sem árvore/viewport — testes).
+        self.computed_for_node(1280.0, |sel| {
             // só seletores de 1 compound casam sem a árvore.
             sel.compounds.len() == 1
                 && compound_matches(&sel.compounds[0], tag, id, classes, &no_attr, &no_pseudo)
@@ -179,14 +283,14 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
     let bytes = css.as_bytes();
     let mut i = 0usize;
     while i < bytes.len() {
-        // AT-RULES (`@media`/`@supports`/`@font-face`/…): têm um BLOCO ANINHADO
-        // próprio (`@media (...) { .x { … } }`) — o fechamento raso no primeiro `}`
-        // CORROMPIA o parse (o `}` externo órfão dessincronizava e ENGOLIA as regras
-        // vizinhas; era assim que o bootstrap.min.css perdia `h1{font-size}` etc.).
-        // Fase 1: PULAR o bloco inteiro com chaves casadas (as regras internas ficam
-        // de fora — a responsividade real de `@media (min-width)` chega quando a
-        // cascade souber o viewport, fase 2). `@import`/`@charset` (sem bloco) pulam
-        // até o `;`. `@keyframes` nunca chega aqui (extraído antes em append_css).
+        // AT-RULES: blocos ANINHADOS (`@media (...) { .x { … } }`) — o fechamento
+        // raso no primeiro `}` CORROMPIA o parse (o `}` órfão engolia as regras
+        // vizinhas do bootstrap.min.css). `@media` agora é AVALIADO (fase 2): a
+        // condição vira [`MediaQuery`] e as regras INTERNAS entram com ela anexada
+        // (a cascade filtra pelo viewport). Os demais at-rules com bloco
+        // (`@supports`/`@font-face`/…) são pulados com chaves casadas;
+        // `@import`/`@charset` (sem corpo) pulam até o `;`. `@keyframes` nunca
+        // chega aqui (extraído antes em append_css).
         let ws = css[i..].find(|c: char| !c.is_whitespace()).map(|r| i + r).unwrap_or(css.len());
         if css[ws..].starts_with('@') {
             let brace_rel = css[ws..].find('{');
@@ -195,11 +299,28 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
                 // `;` antes do `{` (ou sem bloco): at-rule sem corpo → pula até o `;`.
                 (None, Some(s)) => i = ws + s + 1,
                 (Some(b), Some(s)) if s < b => i = ws + s + 1,
-                // com bloco: pula até o `}` CASADO (conta aninhamento).
-                (Some(b), _) => match find_matching_brace(&css[ws + b + 1..]) {
-                    Some(end) => i = ws + b + 1 + end + 1,
-                    None => break, // bloco não fecha: nada mais a parsear.
-                },
+                // com bloco: @media parseia o corpo recursivo; o resto pula casado.
+                (Some(b), _) => {
+                    let body_start = ws + b + 1;
+                    match find_matching_brace(&css[body_start..]) {
+                        Some(end) => {
+                            let header = &css[ws..ws + b];
+                            if let Some(cond) = header.strip_prefix("@media") {
+                                let outer = MediaQuery::parse(cond.trim());
+                                for mut rule in parse_rules(&css[body_start..body_start + end]) {
+                                    // aninhamento @media-em-@media: AND das queries.
+                                    rule.media = Some(match rule.media {
+                                        Some(inner) => inner.and(outer),
+                                        None => outer,
+                                    });
+                                    rules.push(rule);
+                                }
+                            }
+                            i = body_start + end + 1;
+                        }
+                        None => break, // bloco não fecha: nada mais a parsear.
+                    }
+                }
                 (None, None) => break,
             }
             continue;
@@ -217,7 +338,7 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
         // `a, b, .c { }` → uma regra por seletor (lista separada por vírgula).
         for sel_str in selectors_raw.split(',') {
             if let Some(selector) = ComplexSelector::parse(sel_str) {
-                rules.push(Rule { selector, decls: decls.clone(), order: 0 });
+                rules.push(Rule { selector, decls: decls.clone(), order: 0, media: None });
             }
         }
         i = next;

--- a/crates/rts-dom/src/style/tests.rs
+++ b/crates/rts-dom/src/style/tests.rs
@@ -422,9 +422,23 @@ fn at_rules_nao_corrompem_o_parse() {
     // as regras APÓS as at-rules sobrevivem (antes eram corrompidas).
     assert_eq!(sheet.computed_for("h1", None, &[]).normal.color, Some(0xFF0000FF));
     assert_eq!(sheet.computed_for("p", None, &[]).normal.color, Some(0x00FF00FF));
-    // as regras INTERNAS do @media ficam de fora (fase 1: pular o bloco; a
-    // avaliação de min-width contra o viewport é a fase 2).
-    assert_eq!(sheet.computed_for("h1", None, &[]).normal.font_size, None);
+    // FASE 2: as regras INTERNAS do @media APLICAM quando o viewport casa (o
+    // helper computed_for usa 1280 ≥ 1200)…
+    assert_eq!(
+        sheet.computed_for("h1", None, &[]).normal.font_size,
+        Some(Dimension::Px(40.0))
+    );
+    // …e NÃO aplicam quando não casa (viewport 800 < 1200).
+    let no_match = sheet.computed_for_node(800.0, |sel| {
+        sel.compounds.len() == 1
+            && compound_matches(&sel.compounds[0], "h1", None, &[], &|_| None, &|_| false)
+    });
+    assert_eq!(no_match.normal.font_size, None);
+    assert_eq!(no_match.normal.color, Some(0xFF0000FF), "a regra fora do @media segue");
+    // feature desconhecida (prefers-*) nunca casa.
+    let mut s3 = Stylesheet::new();
+    s3.append_css("@media (prefers-reduced-motion: reduce){ p{ color:#111111 } }");
+    assert_eq!(s3.computed_for("p", None, &[]).normal.color, None);
     // @media sem fechar não panica (tolerância).
     let mut s2 = Stylesheet::new();
     s2.append_css("p { color:#0000ff } @media (x) { .a { color:#fff }");

--- a/crates/rts-dom/src/style/values.rs
+++ b/crates/rts-dom/src/style/values.rs
@@ -407,6 +407,33 @@ impl Position {
     }
 }
 
+/// `float` — v1: floats CONSECUTIVOS dividem a mesma linha no fluxo vertical
+/// (left encosta à esquerda, right à direita — o header clássico brand+nav do
+/// Bootstrap cover via `float-md-start/end`); um irmão não-float começa ABAIXO
+/// deles (clear implícito). ⚠️ Cortes documentados: sem texto fluindo AO REDOR
+/// do float, sem `clear` explícito; floats sempre contribuem para a altura do
+/// pai (o comportamento de BFC — correto para flex items, que é o caso do
+/// cover; um block sem clearfix renderiza "contido demais"). Em containers
+/// FLEX, float é IGNORADO (spec: float não se aplica a flex items).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FloatSide {
+    None,
+    Left,
+    Right,
+}
+
+impl FloatSide {
+    pub fn parse(v: &str) -> Option<FloatSide> {
+        Some(match v.trim().to_ascii_lowercase().as_str() {
+            "none" => FloatSide::None,
+            // `inline-start`/`inline-end` = left/right em LTR (nosso único modo).
+            "left" | "inline-start" => FloatSide::Left,
+            "right" | "inline-end" => FloatSide::Right,
+            _ => return None,
+        })
+    }
+}
+
 /// O contexto de resolução de uma [`Dimension`] relativa, conhecido só no
 /// render. Cada unidade resolve contra um eixo diferente (north-star risco 5: a
 /// resolução de `%`/`em`/`vw`/… é TARDIA, no layout, não no parse). Egui-free.


### PR DESCRIPTION
## Validado número-a-número contra o Chrome (cover, 1000×800)

| | Chrome | RTS |
|---|---|---|
| brand (`float-md-start`) | 180, 16 | **180, 16 (exato)** |
| nav (`float-md-end`) | 621, 16 (mesma linha) | **627, 16 (mesma linha)** |

## O quê

- **`@media` fase 2**: a condição vira `MediaQuery` (min/max-width; em/rem ×16) anexada às regras internas; a cascade filtra pelo viewport do `Dom`. `prefers-*`/`print`/`not` = sempre-falso (conservador). Destrava os 109 blocos do Bootstrap (`float-md-*`, `.col-md-*`, h1 ≥1200…).
- **`float` v1**: floats consecutivos dividem a linha (left/right, shrink-to-fit); irmão não-float abaixo (clear implícito); pai contém os floats (BFC — o caso dos flex items). Ignorado em flex (spec). Na tabela `css_props!`: 1 linha.
- **Fix `margin_v`**: `margin-top: 0` do autor anula o default vertical da UA naquele lado.

## Validação

`cargo test -p rts-dom`: **174/174**. O teste da fase 1 do @media foi atualizado para o comportamento novo (mudança intencional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgwXzwpwovEs5YLN9rAHfH