### PR TITLE
fix(egui): live-resize — o conteúdo acompanha o arrasto da borda (replay + throttle)

### DIFF
--- a/crates/rts-egui/src/app.rs
+++ b/crates/rts-egui/src/app.rs
@@ -281,6 +281,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(
         open: true,
         frame_active: false,
         cmds: Vec::new(),
+        last_cmds: Vec::new(),
+        last_resize_redraw: None,
         dom: None,
         html_hash: 0,
         button_results: Vec::new(),
@@ -321,6 +323,13 @@ impl ApplicationHandler for Pumper {
                 }
                 WindowEvent::Resized(size) => {
                     c.backend.resize(size.width, size.height);
+                    // LIVE-RESIZE: durante o arrasto de borda o Windows prende o
+                    // pump num loop modal (WM_SIZING) — o loop TS (que faz o
+                    // draw) congela até soltar. Re-apresenta o último frame AQUI
+                    // (dentro do handler, como apps winit fazem no Redraw): o
+                    // DOM re-layouta na largura nova (cache por viewport) e o
+                    // conteúdo acompanha a janela.
+                    crate::frame::redraw_retained(c);
                 }
                 _ => {}
             }

--- a/crates/rts-egui/src/ctx.rs
+++ b/crates/rts-egui/src/ctx.rs
@@ -79,6 +79,8 @@ pub fn with_event_loop<R>(f: impl FnOnce(&mut EventLoop<()>) -> Option<R>) -> Op
 ///
 /// O índice posicional na fila é o "id" estável do widget dentro do frame: o
 /// N-ésimo `button` deste frame casa com o N-ésimo resultado do frame anterior.
+/// `Clone` p/ o REPLAY do frame durante o resize modal (ver `redraw_retained`).
+#[derive(Clone)]
 pub enum WidgetCmd {
     Label(String),
     Button(String),
@@ -143,6 +145,17 @@ pub struct UiCtx {
     pub frame_active: bool,
     /// Fila de widgets do frame corrente (drenada no `endFrame`).
     pub cmds: Vec<WidgetCmd>,
+    /// A fila do ÚLTIMO frame apresentado — o REPLAY do live-resize: durante o
+    /// arrasto de borda o Windows prende o `pump` num loop modal (WM_SIZING) e o
+    /// loop TS não roda; o handler de `Resized` re-apresenta este frame para o
+    /// conteúdo acompanhar a janela (ver `frame::redraw_retained`).
+    pub last_cmds: Vec<WidgetCmd>,
+    /// Instante do último replay de resize — THROTTLE do live-resize (~30fps):
+    /// os `Resized` chegam em rajada durante o arrasto e cada replay re-layouta
+    /// a página inteira na largura nova + espera o vsync no present; sem o
+    /// freio o arrasto fica pesado. O frame de assentamento (largura final
+    /// exata) vem do loop TS assim que o arrasto solta.
+    pub last_resize_redraw: Option<std::time::Instant>,
     /// Árvore de DOM RETIDA da última chamada a `egui.html(...)`. É a fonte da
     /// verdade persistente entre frames (ao contrário de `cmds`, zerada a cada
     /// frame): o render percorre esta árvore, `egui.domDump` a serializa para

--- a/crates/rts-egui/src/frame/mod.rs
+++ b/crates/rts-egui/src/frame/mod.rs
@@ -72,12 +72,48 @@ pub extern "C" fn __RTS_FN_NS_EGUI_END_FRAME(h: u64) {
             return;
         }
         c.frame_active = false;
-
-        // ── 1. Drena a fila num CentralPanel, coletando interações ───────────
-        // Toma a fila por valor (evita emprestar `c` dentro do closure). O DOM
-        // retido (`c.dom`) é só LIDO pelo render — saca por valor com `take` e
-        // devolve depois, mantendo `c` livre para o `egui_ctx` no `show`.
         let cmds = std::mem::take(&mut c.cmds);
+        // guarda a fila p/ o REPLAY do live-resize (redraw_retained).
+        c.last_cmds = cmds.clone();
+        finish_frame(c, cmds);
+    });
+}
+
+/// RE-APRESENTA o último frame — o live-resize: chamado pelo handler de
+/// `Resized` (app.rs) enquanto o loop modal de resize do Windows prende o pump
+/// (o loop TS não roda durante o arrasto). Abre um pass próprio e re-executa a
+/// última fila; o conteúdo DOM re-layouta na largura nova (o cache de layout é
+/// por viewport). No-op no meio de um frame TS (pass já aberto) ou sem frame
+/// anterior. Efeito colateral aceito: input consumido neste replay (um clique
+/// exatamente durante o arrasto) alimenta este frame interno.
+pub(crate) fn redraw_retained(c: &mut crate::ctx::UiCtx) {
+    if c.frame_active || c.last_cmds.is_empty() {
+        return;
+    }
+    // THROTTLE (~30fps): os Resized chegam em rajada no arrasto e cada replay é
+    // um re-layout completo na largura nova (+ vsync no present). Pular eventos
+    // intermediários mantém a sensação de acompanhar sem afogar a CPU; o frame
+    // de assentamento (largura final exata) vem do loop TS ao soltar o arrasto.
+    if let Some(t) = c.last_resize_redraw {
+        if t.elapsed() < std::time::Duration::from_millis(33) {
+            return;
+        }
+    }
+    c.last_resize_redraw = Some(std::time::Instant::now());
+    let raw_input = c.egui_state.take_egui_input(&c.window);
+    c.egui_ctx.begin_pass(raw_input);
+    let cmds = c.last_cmds.clone();
+    finish_frame(c, cmds);
+}
+
+/// O corpo do frame (drena a fila num CentralPanel + end_pass + tessellate +
+/// present) — compartilhado entre `endFrame` (fila nova do TS) e
+/// `redraw_retained` (replay no resize). Pré-condição: um pass ABERTO.
+fn finish_frame(c: &mut crate::ctx::UiCtx, cmds: Vec<WidgetCmd>) {
+    {
+        // ── 1. Drena a fila num CentralPanel, coletando interações ───────────
+        // O DOM retido (`c.dom`) é só LIDO pelo render — saca por valor com
+        // `take` e devolve depois, mantendo `c` livre p/ o `egui_ctx` no `show`.
         let dom = c.dom.take();
         let mut new_buttons: Vec<bool> = Vec::new();
         let mut new_sliders: Vec<f64> = Vec::new();
@@ -140,7 +176,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_END_FRAME(h: u64) {
             #[cfg(feature = "glow-backend")]
             Backend::Glow(g) => g.paint(&window, paint_jobs, full_output.textures_delta, ppp),
         }
-    });
+    }
 }
 
 /// Agenda um snapshot do PRÓXIMO `endFrame` num arquivo PPM (teste visual


### PR DESCRIPTION
O conteúdo congelava ao arrastar a borda da janela: o loop modal de resize do Windows (WM_SIZING) prende o `pump_app_events` e o loop TS (que desenha) não roda até soltar. O handler de `Resized` agora re-apresenta o último frame de dentro do handler (padrão winit), com throttle ~30fps — o DOM re-layouta na largura nova (cache por viewport) e o conteúdo acompanha ao vivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgwXzwpwovEs5YLN9rAHfH