### PR TITLE
feat(date): superficie deterministica UTC - remove UNSOUND do spec do Date

### DIFF
--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -20,10 +20,12 @@
 //! is in `class_meta`; `Map`/`Set`/`URL`/… have ambient `.ts` classes). Routing
 //! is now DATA-DRIVEN — no `"Date"` literal in the dispatch control flow.
 //!
-//! The unsound-to-lower method set (Date's timezone-divergent formatters + `setX`
-//! mutators) is now SPEC DATA: the `rts-shared` Date class stamps those members
+//! The unsound-to-lower mechanism is SPEC DATA: a class may stamp a member
 //! `MemberFlags::UNSOUND` and [`Lowerer::try_registry_instance_method`] bails on
-//! the flag generically — no per-class predicate in the engine.
+//! the flag generically — no per-class predicate in the engine. (Date's
+//! formatters + `setX` mutators carried the flag until 2026-07-02; the suite
+//! defines their DETERMINISTIC UTC surface as the modeled semantic, so the flag
+//! was dropped from the spec — the mechanism stays for future specs.)
 //!
 //! CONSTRUCTORS ([`Lowerer::emit_registry_ctor`]) and STATIC calls
 //! ([`Lowerer::try_registry_static_call`]) are now FULLY GENERIC: resolved from
@@ -35,8 +37,8 @@
 //! still DATA from the registered ctors, no method-name / arity literal.
 //!
 //! The engine now encodes ZERO Date-specific knowledge: every Date semantic
-//! (overloads, defaults, unsound methods) is SPEC DATA in the `rts-shared` Date
-//! class (`Sig::default_args` + `MemberFlags::UNSOUND` + the registered members).
+//! (overloads, defaults) is SPEC DATA in the `rts-shared` Date class
+//! (`Sig::default_args` + the registered members).
 
 use cranelift_codegen::ir::{InstBuilder, Value, types};
 use cranelift_module::Module;
@@ -189,8 +191,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         // Some methods resolve in the Registry but are NOT sound to lower (the
         // honesty floor). The spec marks them `MemberFlags::UNSOUND` — data, not a
-        // hardcoded per-class predicate. For `Date` these are the timezone-divergent
-        // formatters + the `setX` mutators. BAIL instead of emitting a wrong value.
+        // hardcoded per-class predicate. BAIL instead of emitting a wrong value.
         if call.flags.contains(MemberFlags::UNSOUND) {
             return unsupported!(
                 "`{class}.{method}()` — unsound-to-lower method (timezone-divergent / \

--- a/crates/rts-codegen-new/src/front/run/tests/date.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/date.rs
@@ -10,7 +10,7 @@
 //! deterministically regardless of the machine timezone. The bails pin the honesty
 //! floor (TZ-dependent / unmodeled constructs refuse, never a wrong value).
 
-use super::{assert_bails, assert_stdout};
+use super::assert_stdout;
 
 // ---------------------------------------------------------------------------
 // getTime / valueOf — the stored epoch ms (deterministic).
@@ -178,22 +178,39 @@ fn non_date_not_instanceof_date() {
 }
 
 // ---------------------------------------------------------------------------
-// Bails — the honesty floor.
+// Deterministic UTC surface — setters mutate in place; formatters emit the
+// UTC-deterministic forms (the modeled semantic; `MemberFlags::UNSOUND` was
+// dropped from the Date spec on 2026-07-02, the TS suite defines these).
 // ---------------------------------------------------------------------------
 
 #[test]
-fn set_time_bails() {
-    // Mutating setters are not modeled (a later increment) → refuse.
-    assert_bails(r#"let d = new Date(0); d.setTime(1000); console.log(d.getTime());"#);
+fn set_time_mutates() {
+    assert_stdout(
+        r#"let d = new Date(0); d.setTime(1000); console.log(d.getTime());"#,
+        "1000\n",
+    );
 }
 
 #[test]
-fn to_string_bails() {
-    // `toString()` format (the long GMT form) is a divergence risk → refuse.
-    assert_bails(r#"let d = new Date(0); console.log(d.toString());"#);
+fn set_full_year_mutates() {
+    assert_stdout(
+        r#"let d = new Date(0); d.setFullYear(2024); console.log(d.getUTCFullYear());"#,
+        "2024\n",
+    );
 }
 
 #[test]
-fn to_date_string_bails() {
-    assert_bails(r#"let d = new Date(0); console.log(d.toDateString());"#);
+fn to_string_js_spec_utc() {
+    assert_stdout(
+        r#"let d = new Date(0); console.log(d.toString());"#,
+        "Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)\n",
+    );
+}
+
+#[test]
+fn to_date_string_utc() {
+    assert_stdout(
+        r#"let d = new Date(0); console.log(d.toDateString());"#,
+        "Thu Jan 01 1970\n",
+    );
 }

--- a/crates/rts-shared/src/globals/date/mod.rs
+++ b/crates/rts-shared/src/globals/date/mod.rs
@@ -92,27 +92,6 @@ fn m(
     }
 }
 
-/// Como [`m`], mas marca o membro `MemberFlags::UNSOUND`: resolve no Registry mas
-/// NÃO é seguro de lowerar (a honesty floor vira DADO no spec). Usado nos
-/// formatadores timezone-divergentes (`toString`/`toLocale*`/`toDateString`/
-/// `toUTCString`/`toGMTString`/`toTimeString`) e em todos os mutadores `setX` —
-/// o codegen dá bail genérico via a flag, sem predicado hardcoded por classe.
-#[allow(clippy::too_many_arguments)]
-fn m_unsound(
-    name: &str,
-    kind: MemberKind,
-    sig: Sig,
-    symbol: &str,
-    ts: &str,
-    doc: &str,
-    pure: bool,
-) -> Member {
-    Member {
-        flags: MemberFlags::UNSOUND,
-        ..m(name, kind, sig, symbol, ts, doc, pure)
-    }
-}
-
 /// Registra a classe global `Date` no motor (hand-written, sem macro).
 /// Stores UTC timestamp as ms since Unix epoch.
 pub fn register_class_spec(e: &mut Engine) {
@@ -332,7 +311,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "ISO 8601 UTC string.",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -341,7 +320,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "String representation (ISO 8601 UTC).",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toLocaleDateString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -431,7 +410,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Minutos entre UTC e local. RTS sempre 0.",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toUTCString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -440,7 +419,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "UTC string (alias de toISOString em v0).",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toGMTString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -449,7 +428,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Deprecated alias de toUTCString.",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toDateString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -459,7 +438,7 @@ pub fn register_class_spec(e: &mut Engine) {
             true,
         ))
         // ── Setters ──────────────────────────────────────────────────────────
-        .member(m_unsound(
+        .member(m(
             "setFullYear",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -468,7 +447,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o ano. Retorna ms novos.",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setMonth",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -477,7 +456,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o mes (0-11). Retorna ms novos.",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setDate",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -486,7 +465,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o dia do mes (1-31). Retorna ms novos.",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setHours",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -495,7 +474,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui hour (0-23).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setMinutes",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -504,7 +483,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui min (0-59).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setSeconds",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -513,7 +492,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui sec (0-59).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setMilliseconds",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -522,7 +501,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui ms (0-999).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setTime",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -531,7 +510,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui timestamp completo (ms desde epoch).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCFullYear",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -540,7 +519,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o ano (UTC). Retorna ms novos.",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCMonth",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -549,7 +528,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o mes (0-11, UTC).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCDate",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -558,7 +537,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui o dia do mes (1-31, UTC).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCHours",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -567,7 +546,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui hour (0-23, UTC).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCMinutes",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -576,7 +555,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui min (0-59, UTC).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCSeconds",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -585,7 +564,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Substitui sec (0-59, UTC).",
             false,
         ))
-        .member(m_unsound(
+        .member(m(
             "setUTCMilliseconds",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
@@ -604,7 +583,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "JSON serialization — alias de toISOString.",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toLocaleString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -613,7 +592,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Locale string (sem locale support em v0).",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toLocaleTimeString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),
@@ -622,7 +601,7 @@ pub fn register_class_spec(e: &mut Engine) {
             "Time portion (HH:MM:SS.mmmZ) — alias de toTimeString.",
             true,
         ))
-        .member(m_unsound(
+        .member(m(
             "toTimeString",
             MemberKind::InstanceMethod,
             Sig::new(vec![AbiType::Handle], AbiType::Handle),


### PR DESCRIPTION
## O que

Remove `MemberFlags::UNSOUND` dos membros do Date em `rts-shared/globals/date/mod.rs` — setters mutantes + formatadores agora loweram pelo caminho genérico do Registry que já existia. Zero mudança de mecanismo no motor (o bail genérico por flag permanece para specs futuros).

## Por quê

As impls Rust (`instance.rs`) já produzem exatamente a superfície determinística UTC que a suite TS define como semântica modelada (#220/#552/PR #1202/#1203). A flag era assimétrica: `getHours()` (igualmente UTC-determinística vs JS local) nunca foi UNSOUND.

## Resultado

- 6 arquivos da suite que falhavam → verdes: `date_setters`, `date_to_json`, `date_to_string_jsspec`, `date_to_utc_string`, `date_utc_getters`, `js_parity_epic226`
- Suite TS: **587/623** arquivos (era 581/623)
- 3 unit tests do motor que asseguravam o bail atualizados para o novo comportamento (regressão intencional e justificada — regra regress-explicitly)
- 16 falhas de unit test PRÉ-EXISTENTES na main (verificado via stash; nenhuma causada por este PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
