### PR TITLE
feat(codegen): enforcement de private/protected/readonly + brand check #x in obj (+6 arquivos verdes)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -81,6 +81,109 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
     }
 
+    /// The user class whose BODY the function being lowered belongs to, if any:
+    /// a ctor/method/accessor binds `this` (`local_classes["this"]`); a STATIC
+    /// method carries no `this`, so it is recovered from the synthesized name
+    /// (`__rtsn_static_<C>_<m>`, matched against the known classes — longest
+    /// class-name match wins so `A` never shadows `A_b`).
+    pub(in crate::front::run) fn enclosing_class(&self) -> Option<String> {
+        if let Some(c) = self.local_classes.get(super::THIS) {
+            return Some(c.clone());
+        }
+        let rest = self.current_fn.strip_prefix("__rtsn_static_")?;
+        self.classes
+            .iter()
+            .filter(|d| {
+                rest.len() > d.name.len()
+                    && rest.starts_with(&d.name)
+                    && rest.as_bytes()[d.name.len()] == b'_'
+            })
+            .max_by_key(|d| d.name.len())
+            .map(|d| d.name.clone())
+    }
+
+    /// JS PRIVATE NAMES are LEXICALLY scoped: an `x.#p` access is legal only
+    /// inside the body of the class that DECLARES `#p` — real JS makes this a
+    /// syntax error receiver-type-free, so the check fires for ANY receiver,
+    /// even one of unknown class. (An inheritance-collision-mangled own access
+    /// arrives here already rewritten to `#p@Class`, whose declarer IS the
+    /// enclosing class — still exact.)
+    pub(in crate::front::run) fn check_private_name_lexical(
+        &self,
+        prop: &str,
+    ) -> FrontResult<()> {
+        if !prop.starts_with('#') {
+            return Ok(());
+        }
+        let ok = self.enclosing_class().is_some_and(|c| {
+            self.classes.get(&c).is_some_and(|d| {
+                d.member_access
+                    .get(prop)
+                    .is_some_and(|(_, declarer)| declarer == &c)
+            })
+        });
+        if ok {
+            Ok(())
+        } else {
+            unsupported!(
+                "private name `{prop}` is not accessible here — a `#name` is \
+                 lexically scoped to the body of its declaring class (JS spec)"
+            )
+        }
+    }
+
+    /// Enforce the TS/JS member-ACCESS surface for `class`.`member` from the
+    /// current lowering context — the TS compile-error re-check, same family as
+    /// the `is_abstract` re-check in `lower_new`. `Ok(())` when the member is
+    /// public/unknown or the enclosing class is inside the visibility domain:
+    /// - `private` / JS `#name`: only the DECLARING class's own body;
+    /// - `protected`: the declaring class or any subclass (parent-chain walk).
+    pub(in crate::front::run) fn check_member_access(
+        &self,
+        class: &str,
+        member: &str,
+    ) -> FrontResult<()> {
+        use rts_ast::ast::Visibility;
+        let Some((vis, declarer)) = self
+            .classes
+            .get(class)
+            .and_then(|d| d.member_access.get(member))
+        else {
+            return Ok(());
+        };
+        let caller = self.enclosing_class();
+        let allowed = match vis {
+            Visibility::Public => true,
+            Visibility::Private => caller.as_deref() == Some(declarer.as_str()),
+            Visibility::Protected => {
+                // The enclosing class or any ANCESTOR may be the declarer (a
+                // subclass touching an inherited protected member is legal).
+                let mut cur = caller;
+                let mut ok = false;
+                while let Some(c) = cur {
+                    if &c == declarer {
+                        ok = true;
+                        break;
+                    }
+                    cur = self.classes.get(&c).and_then(|d| d.parent.clone());
+                }
+                ok
+            }
+        };
+        if allowed {
+            return Ok(());
+        }
+        let vis_name = match vis {
+            Visibility::Private => "private",
+            Visibility::Protected => "protected",
+            Visibility::Public => "public",
+        };
+        unsupported!(
+            "`{member}` is {vis_name} in class `{declarer}` and not accessible here \
+             (the TS access-modifier surface, re-checked)"
+        )
+    }
+
     /// Whether `object` is a bare identifier naming a user CLASS (not a local) —
     /// the receiver of a STATIC member access `C.m(..)` / `C.f`.
     pub(in crate::front::run) fn class_name_receiver(&self, object: &HirExpr) -> Option<String> {
@@ -338,6 +441,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                  dispatch is a later increment)"
             );
         };
+        // TS/JS ACCESS SURFACE (re-check): a `private`/`protected`/`#name` method
+        // call outside its visibility domain refuses at compile time.
+        self.check_member_access(class, method)?;
         let Some(fn_name) = desc.method_fn(method).map(str::to_string) else {
             // An ABSTRACT-declared method (no base impl, defined by descendants):
             // resolve VIRTUALLY by the instance's runtime shape. The last target

--- a/crates/rts-codegen-new/src/front/run/class/litshape.rs
+++ b/crates/rts-codegen-new/src/front/run/class/litshape.rs
@@ -116,6 +116,9 @@ pub(crate) fn build_literal_class(
         field_arrays: std::collections::HashSet::new(),
         // Object-literal fields have no declared type annotation to prove `string`.
         field_strings: std::collections::HashSet::new(),
+        // Object-literal members carry no TS modifiers — everything is public.
+        member_access: HashMap::new(),
+        readonly_fields: std::collections::HashSet::new(),
     };
     (desc, out)
 }

--- a/crates/rts-codegen-new/src/front/run/class/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/class/mod.rs
@@ -119,6 +119,18 @@ pub(crate) struct ClassDesc {
     /// field of this kind reads as a `JsKind::Str` value so it reaches the same
     /// native string member/index/method paths a string literal or param does.
     pub field_strings: std::collections::HashSet<String>,
+    /// FLATTENED non-public INSTANCE members (TS `private`/`protected` fields and
+    /// methods, plus JS `#name` fields/methods): member SLOT/method name →
+    /// (visibility, DECLARING class). Parent entries first, like `fields`. The
+    /// lowering refuses an access whose enclosing class is outside the visibility
+    /// domain — the TS compile-error surface, same family as `is_abstract`. A JS
+    /// `#name` member records `Visibility::Private` (lexically scoped to the
+    /// declaring class body — the same rule).
+    pub member_access: HashMap<String, (rts_ast::ast::Visibility, String)>,
+    /// FLATTENED TS `readonly` INSTANCE field slot names. A write outside a
+    /// constructor refuses at compile time (the TS surface; the ctor prologue and
+    /// user ctor body run as `__rtsn_ctor_*`, which is allowed).
+    pub readonly_fields: std::collections::HashSet<String>,
 }
 
 impl ClassDesc {

--- a/crates/rts-codegen-new/src/front/run/class/synth.rs
+++ b/crates/rts-codegen-new/src/front/run/class/synth.rs
@@ -268,6 +268,49 @@ pub(super) fn build_class(
         static_fields.insert(sg.name.clone(), static_method_name(&decl.name, &sg.name));
     }
 
+    // --- FLATTENED access surface: TS `private`/`protected` fields + methods and
+    // JS `#name` fields record (visibility, DECLARING class); TS `readonly` fields
+    // record their slot name. Parent entries first (like `fields`); the lowering
+    // enforces the TS compile-error surface from these (same family as
+    // `is_abstract`). A JS `#name` is `Visibility::Private` — lexically scoped to
+    // the declaring class body, the same access rule.
+    let mut member_access: HashMap<String, (rts_ast::ast::Visibility, String)> =
+        parent.map(|p| p.member_access.clone()).unwrap_or_default();
+    let mut readonly_fields: std::collections::HashSet<String> =
+        parent.map(|p| p.readonly_fields.clone()).unwrap_or_default();
+    for pd in &m.props {
+        let slot = field_slot_name(&pd.name, &priv_renames);
+        let vis = if pd.name.starts_with('#') {
+            Some(rts_ast::ast::Visibility::Private)
+        } else {
+            match pd.modifiers.visibility {
+                Some(v @ (rts_ast::ast::Visibility::Private
+                | rts_ast::ast::Visibility::Protected)) => Some(v),
+                _ => None,
+            }
+        };
+        if let Some(v) = vis {
+            member_access.insert(slot.clone(), (v, decl.name.clone()));
+        }
+        if pd.modifiers.readonly {
+            readonly_fields.insert(slot);
+        }
+    }
+    for md in &m.methods {
+        let vis = if md.name.starts_with('#') {
+            Some(rts_ast::ast::Visibility::Private)
+        } else {
+            match md.modifiers.visibility {
+                Some(v @ (rts_ast::ast::Visibility::Private
+                | rts_ast::ast::Visibility::Protected)) => Some(v),
+                _ => None,
+            }
+        };
+        if let Some(v) = vis {
+            member_access.insert(md.name.clone(), (v, decl.name.clone()));
+        }
+    }
+
     // --- abstract accounting: own abstract decls + parent's unimplemented,
     // minus what THIS class's `methods` now implements. A CONCRETE class with
     // leftovers is the TS "missing implementation" compile error — re-checked.
@@ -306,6 +349,8 @@ pub(super) fn build_class(
         static_fields,
         field_arrays,
         field_strings,
+        member_access,
+        readonly_fields,
     };
     Ok((desc, out))
 }

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -288,6 +288,12 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// inside ANY function declares a fresh LOCAL that shadows the global
     /// (without this a prelude-internal `let out` clobbered a user gcell).
     pub is_main: bool,
+    /// The NAME of the function being lowered (`__rtsn_main`, `__rtsn_ctor_C`,
+    /// `__rtsn_method_C_m`, `__rtsn_static_C_m`, …). Drives the TS access-surface
+    /// re-checks: a `readonly` field write is allowed only inside a
+    /// `__rtsn_ctor_*`, and a static method's enclosing class is recovered from
+    /// the `__rtsn_static_<C>_` prefix (see `enclosing_class`).
+    pub current_fn: String,
     /// BUILTIN-IMPORT bindings (M1b): a LOCAL name imported from `rts:<ns>` →
     /// `(ns, member)`. A `name(args)` call whose `name` is here lowers to the real
     /// `__RTS_FN_NS_*` symbol via the generic Registry marshal (see [`super::call`]).
@@ -361,6 +367,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             classes,
             is_prelude,
             is_main: func.name == "__rtsn_main",
+            current_fn: func.name.clone(),
             builtins,
             float_promoted: super::floatscan::float_promoted_locals(&func.body),
             singleton_overrides: std::collections::HashSet::new(),

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -318,6 +318,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         object: &HirExpr,
         prop: &str,
     ) -> FrontResult<Val> {
+        // ---- JS PRIVATE NAME lexical scope: `x.#p` is legal only inside the
+        // declaring class's body — receiver-type-free (JS spec), so it fires
+        // before any receiver resolution. ----
+        self.check_private_name_lexical(prop)?;
         // ---- `<instance>.constructor.name` → the class NAME (a string literal),
         // when the receiver's class is statically known. JS exposes `inst.constructor`
         // as the class function and `.name` as its declared name. Matched as the CHAIN
@@ -393,6 +397,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // ---- static member read `C.f` (C is a class name, not a local) ----
         if let Some(class) = self.class_name_receiver(object) {
             return self.try_static_field_read(module, &class, prop);
+        }
+        // ---- TS/JS ACCESS SURFACE (re-check): a `private`/`protected`/`#name`
+        // member READ on a receiver of statically-known class refuses outside its
+        // visibility domain, BEFORE any instance path below resolves it. ----
+        if let Some(class) = self.static_instance_class(object) {
+            self.check_member_access(&class, prop)?;
         }
         // ---- runtime/Registry-class instance PROPERTY (`m.size`, `e.message`) ----
         if let Some(val) = self.try_global_class_member(module, object, prop)? {
@@ -659,6 +669,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         prop: &str,
         value: &HirExpr,
     ) -> FrontResult<Val> {
+        // ---- JS PRIVATE NAME lexical scope: `x.#p = v` is legal only inside the
+        // declaring class's body — receiver-type-free (JS spec). ----
+        self.check_private_name_lexical(prop)?;
         // ---- `globalThis.prop = v` write: the singleton global object's dynamic
         // property. `__rtsadp_obj_set` writes an existing slot or appends a new key
         // (shape transition), so a brand-new global property works. ----
@@ -740,6 +753,24 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return unsupported!(
                 "static field write `.{prop}` (not a declared static field of `{class}`)"
             );
+        }
+        // ---- TS/JS ACCESS SURFACE (re-check): a `private`/`protected`/`#name`
+        // member WRITE outside its visibility domain, and a TS `readonly` field
+        // write outside a constructor (`__rtsn_ctor_*` covers the initializer
+        // prologue + user ctor body), refuse at compile time. ----
+        if let Some(class) = self.static_instance_class(object) {
+            self.check_member_access(&class, prop)?;
+            if self
+                .classes
+                .get(&class)
+                .is_some_and(|d| d.readonly_fields.contains(prop))
+                && !self.current_fn.starts_with("__rtsn_ctor_")
+            {
+                return unsupported!(
+                    "cannot assign to `{prop}` — it is a `readonly` field of class \
+                     `{class}` and this is not a constructor (the TS surface, re-checked)"
+                );
+            }
         }
         // ---- accessor SET `obj.x = v` where x is a setter on the receiver class ----
         if let Some(class) = self.instance_class_of(object) {

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -581,6 +581,21 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
             HirExpr::new(HirExprKind::Raw(format!("template_literal")), HirType::Str)
         }
 
+        // `#x` in EXPRESSION position exists only as the LHS of an ergonomic
+        // brand check (`#x in obj`, ES2022) — anywhere else it is a syntax error
+        // upstream in swc. Lower it as a string literal carrying the private
+        // name: the engine's object model stores private fields as ordinary
+        // shape slots named `#x` (mangled `#x@Class` only on an inheritance
+        // collision), so the `in` lowering's shape-aware `__rtsadp_obj_has`
+        // resolves slot presence — the brand. Known approximation: two UNRELATED
+        // classes declaring the same UNMANGLED `#x` are not distinguished (JS
+        // private-name identity is per-class); exact per-class branding is a
+        // later increment.
+        swc::Expr::PrivateName(p) => HirExpr::new(
+            HirExprKind::Lit(crate::ir::HirLit::Str(format!("#{}", p.name))),
+            HirType::Str,
+        ),
+
         // TypeScript type-only expression wrappers carry ZERO runtime effect:
         // the value is just the inner expression. Erase the type and lower the
         // inner expr directly, instead of falling through to a `Raw` node that


### PR DESCRIPTION
## O que

Enforcement em compile-time da superfície de modifiers TS/JS que o motor não re-checava (mesma família do re-check `is_abstract`):

- **`private`/`protected`** (fields e métodos): `member_access` no `ClassDesc` (nome → (visibility, classe declarante), achatado parent-first) + `check_member_access` aplicado em GET/SET/chamada de método. `protected` caminha a parent chain (subclasse pode).
- **JS `#name`**: regra **léxica** exata (`check_private_name_lexical`) — `x.#p` só dentro do corpo da classe declarante, receiver-type-free (dispara mesmo com receiver de classe desconhecida).
- **`readonly`**: write fora de `__rtsn_ctor_*` recusa; prologue de initializer + corpo do ctor seguem permitidos (novo `Lowerer.current_fn`).
- **`#x in obj`** (brand check ES2022): PrivateName em expressão deixou de crashar (era `Raw` → bail); lowera como chave de slot e resolve via `__rtsadp_obj_has` shape-aware. Aproximação documentada no código.
- `enclosing_class()`: this-class do método/ctor ou prefixo `__rtsn_static_<C>_` (static da própria classe acessa private — TS correto).

## Resultado

- **+6 arquivos da suite verdes**: `private_modifier_err`, `protected_modifier_err`, `private_method_err`, `private_field_cross_class_err`, `readonly_field_reassign_err`, `private_field_unknown_receiver`
- Suite TS: **593/623** projetado (era 587 após #1800)
- Uso legal validado: private/protected/readonly internos, subclasse com protected herdado, brand check com receiver `unknown`
- Unit tests do motor: **as mesmas 16 falhas pré-existentes da main** (verificado teste a teste com `--exact`) — zero regressão nova

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
