### PR TITLE
feat(codegen): TCO via return_call + lift ES5 prototype-chain + arguments object (+7 arquivos)

### DIFF
--- a/crates/rts-adapters/src/value/dyndispatch.rs
+++ b/crates/rts-adapters/src/value/dyndispatch.rs
@@ -282,6 +282,31 @@ pub extern "C" fn __rtsadp_idx_get(recv: u64, idx: u64) -> u64 {
         }
     }
     if is_array_word(recv) {
+        // A SYMBOL key on an array (#216/#299): `arr[Symbol.iterator]` yields
+        // the native values-iterator FUNCTION (a real callable Entry::Function,
+        // `typeof === "function"`); any other symbol key is an absent property
+        // → `undefined`. Checked BEFORE the numeric decode — a symbol word must
+        // never coerce to an element index (it silently read `arr[0..]`).
+        {
+            use rts_runtime::namespaces::gc::handles as rt_handles;
+            let k = PolyValue::from_raw(idx);
+            if k.is_object() {
+                let kh = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(k.as_handle());
+                let is_symbol = rt_handles::with_entry(kh, |e| {
+                    matches!(e, Some(rt_handles::Entry::Symbol { .. }))
+                });
+                if is_symbol {
+                    let iter_sym =
+                        rts_runtime::namespaces::globals::symbol::__RTS_FN_GL_SYMBOL_ITERATOR();
+                    if kh == iter_sym {
+                        let f = rts_runtime::namespaces::gc::generator::__RTS_FN_GL_ARRAY_ITERATOR_FN();
+                        let slot = rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(f);
+                        return PolyValue::from_function_handle(slot).raw();
+                    }
+                    return undef();
+                }
+            }
+        }
         let h = arr_handle(recv);
         let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(h).max(0);
         let i = genops_to_i64(idx);

--- a/crates/rts-codegen-new/src/front/run/argsobj.rs
+++ b/crates/rts-codegen-new/src/front/run/argsobj.rs
@@ -1,0 +1,259 @@
+//! The `arguments` object (#450/#299) — a pre-pass over the lowered HirFuncs.
+//!
+//! A NON-arrow user function whose body references the bare ident `arguments`
+//! gets it materialized as an ordinary ARRAY local, riding the existing array
+//! machinery (`.length`, `arguments[i]`, iteration):
+//!
+//! - **No declared params** (`function variadic() { … arguments … }`): a
+//!   synthetic VARIADIC rest param named `arguments` is appended — the call
+//!   marshal packs EVERY passed arg into a fresh array bound to it (the real
+//!   variadic surface, #299).
+//! - **Declared params** (`function f(a, b) { … arguments … }`): a prologue
+//!   `let arguments = [a, b]` array literal of the declared params (the
+//!   old-engine #450 surface — extra args beyond the declared arity are not
+//!   observed; a fixed-arity native signature cannot receive them).
+//!
+//! Arrow functions are skipped (JS: an arrow has no own `arguments`; it reads
+//! the enclosing function's — unsupported, so the free ident keeps its honest
+//! "unbound identifier" bail). A function already declaring a rest param or an
+//! own binding named `arguments` is left untouched.
+
+use rts_hir::ir::{HirExprKind, HirStmt};
+use rts_hir::{HirExpr, HirFunc, HirParam, HirType};
+
+/// Materialize `arguments` in every qualifying function of `funcs` (in place).
+pub(crate) fn expand_arguments_object(funcs: &mut [HirFunc]) {
+    for f in funcs.iter_mut() {
+        if f.is_arrow || f.is_async {
+            continue;
+        }
+        // An own param named `arguments` (incl. an already-synthesized rest)
+        // shadows the object — nothing to do.
+        if f.params.iter().any(|p| p.name == "arguments") {
+            continue;
+        }
+        if !body_references_arguments(&f.body) {
+            continue;
+        }
+        let user_params: Vec<(String, HirType)> = f
+            .params
+            .iter()
+            .filter(|p| p.name != "this")
+            .map(|p| (p.name.clone(), p.ty.clone()))
+            .collect();
+        if user_params.is_empty() && !f.params.iter().any(|p| p.variadic) {
+            // Zero-arity fn → real variadic: a rest param sees every call arg.
+            f.params.push(HirParam {
+                name: "arguments".to_string(),
+                ty: HirType::Array(Box::new(HirType::Unknown)),
+                variadic: true,
+                has_default: false,
+                optional: false,
+                default_expr: None,
+            });
+        } else {
+            // Declared params → `let arguments = [p1, …, pN]` prologue.
+            let elems: Vec<HirExpr> = user_params
+                .into_iter()
+                .map(|(name, ty)| HirExpr::new(HirExprKind::Ident(name), ty))
+                .collect();
+            f.body.insert(
+                0,
+                HirStmt::Let {
+                    name: "arguments".to_string(),
+                    ty: HirType::Array(Box::new(HirType::Unknown)),
+                    init: Some(HirExpr::new(
+                        HirExprKind::Array(elems),
+                        HirType::Array(Box::new(HirType::Unknown)),
+                    )),
+                },
+            );
+        }
+    }
+}
+
+/// Whether any statement in `body` references the bare ident `arguments`.
+/// (Shadowing inner `let arguments` is not tracked — the injected binding is
+/// then simply shadowed, matching JS.)
+fn body_references_arguments(body: &[HirStmt]) -> bool {
+    let mut found = false;
+    for s in body {
+        walk_stmt(s, &mut found);
+        if found {
+            return true;
+        }
+    }
+    false
+}
+
+fn walk_stmt(s: &HirStmt, found: &mut bool) {
+    if *found {
+        return;
+    }
+    match s {
+        HirStmt::Expr(e) | HirStmt::Return(Some(e)) | HirStmt::Throw(e) => walk(e, found),
+        HirStmt::Let { init, .. } => {
+            if let Some(v) = init {
+                walk(v, found);
+            }
+        }
+        HirStmt::Const { init, .. } => walk(init, found),
+        HirStmt::If { cond, then, else_ } => {
+            walk(cond, found);
+            for st in then {
+                walk_stmt(st, found);
+            }
+            if let Some(el) = else_ {
+                for st in el {
+                    walk_stmt(st, found);
+                }
+            }
+        }
+        HirStmt::While { cond, body } => {
+            walk(cond, found);
+            for st in body {
+                walk_stmt(st, found);
+            }
+        }
+        HirStmt::DoWhile { body, cond } => {
+            for st in body {
+                walk_stmt(st, found);
+            }
+            walk(cond, found);
+        }
+        HirStmt::For {
+            init,
+            cond,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                walk_stmt(i, found);
+            }
+            if let Some(c) = cond {
+                walk(c, found);
+            }
+            if let Some(u) = update {
+                walk(u, found);
+            }
+            for st in body {
+                walk_stmt(st, found);
+            }
+        }
+        HirStmt::ForOf { iterable, body, .. } => {
+            walk(iterable, found);
+            for st in body {
+                walk_stmt(st, found);
+            }
+        }
+        HirStmt::ForIn { object, body, .. } => {
+            walk(object, found);
+            for st in body {
+                walk_stmt(st, found);
+            }
+        }
+        HirStmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            for st in body {
+                walk_stmt(st, found);
+            }
+            if let Some(c) = catch {
+                for st in &c.body {
+                    walk_stmt(st, found);
+                }
+            }
+            if let Some(fin) = finally {
+                for st in fin {
+                    walk_stmt(st, found);
+                }
+            }
+        }
+        HirStmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            walk(discriminant, found);
+            for c in cases {
+                if let Some(t) = &c.test {
+                    walk(t, found);
+                }
+                for st in &c.body {
+                    walk_stmt(st, found);
+                }
+            }
+        }
+        HirStmt::Block(b) => {
+            for st in b {
+                walk_stmt(st, found);
+            }
+        }
+        HirStmt::Labeled { body, .. } => walk_stmt(body, found),
+        _ => {}
+    }
+}
+
+fn walk(e: &HirExpr, found: &mut bool) {
+    if *found {
+        return;
+    }
+    match &e.kind {
+        HirExprKind::Ident(n) if n == "arguments" => *found = true,
+        HirExprKind::Call { callee, args } => {
+            walk(callee, found);
+            for a in args {
+                walk(a, found);
+            }
+        }
+        HirExprKind::MethodCall { object, args, .. } => {
+            walk(object, found);
+            for a in args {
+                walk(a, found);
+            }
+        }
+        HirExprKind::Bin { lhs, rhs, .. } => {
+            walk(lhs, found);
+            walk(rhs, found);
+        }
+        HirExprKind::Unary { operand, .. } => walk(operand, found),
+        HirExprKind::Ternary { cond, then, else_ } => {
+            walk(cond, found);
+            walk(then, found);
+            walk(else_, found);
+        }
+        HirExprKind::Member { object, .. } => walk(object, found),
+        HirExprKind::Index { object, index } => {
+            walk(object, found);
+            walk(index, found);
+        }
+        HirExprKind::Array(elems) => {
+            for el in elems {
+                walk(el, found);
+            }
+        }
+        HirExprKind::Object(entries) => {
+            for (_, v) in entries {
+                walk(v, found);
+            }
+        }
+        HirExprKind::New { args, .. } => {
+            for a in args {
+                walk(a, found);
+            }
+        }
+        HirExprKind::Assign { target, value } => {
+            walk(target, found);
+            walk(value, found);
+        }
+        HirExprKind::AssignOp { target, value, .. } => {
+            walk(target, found);
+            walk(value, found);
+        }
+        HirExprKind::Cast { expr, .. } => walk(expr, found),
+        HirExprKind::Await(inner) => walk(inner, found),
+        HirExprKind::Spread(inner) => walk(inner, found),
+        _ => {}
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -454,6 +454,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let base_fn = last.1.clone();
                 return self.emit_virtual_dispatch(module, object, rest, &base_fn, args);
             }
+            // The Object-PROTOCOL surface every JS object inherits
+            // (`hasOwnProperty`/`isPrototypeOf`/`propertyIsEnumerable`): a class
+            // instance answers these like any object when its class chain does
+            // not define them.
+            if let Some(val) = self.try_object_protocol_method(module, object, method, args)? {
+                return Ok(val);
+            }
             return unsupported!(
                 "`{class}.{method}()` — no such method on class `{class}` \
                  (a field-as-function / dynamic method is a later increment)"

--- a/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
@@ -183,13 +183,55 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let u = self.builder.ins().iconst(types::I64, undef);
         self.builder.ins().jump(merge, &[u.into()]);
 
-        // Object receiver → shape switch over every class-with-method, default undef.
+        // Object receiver → shape switch over every class-with-method; the
+        // DEFAULT arm falls through below.
         self.builder.switch_to_block(guarded);
         self.builder.seal_block(guarded);
         let shape_word = self.read_shape_word(module, recv_word);
         self.emit_shape_arms(module, recv_word, shape_word, &targets, args, merge)?;
-        let u = self.builder.ins().iconst(types::I64, undef);
-        self.builder.ins().jump(merge, &[u.into()]);
+        // DEFAULT arm — no class shape matched: the receiver may still carry
+        // `method` as an OWN function-valued property (`{ add: (a, b) => a + b }`
+        // — an object literal whose fn-valued member shares a name with some
+        // class's method, or an own override). Read the own slot; when it holds a
+        // FUNCTION word, invoke it as a method (`__rtsadp_fn_invoke_method` binds
+        // `this` for a this-first callee); anything else keeps the `undefined`
+        // sentinel. Mirrors `try_user_getter_dynamic`'s data-slot default arm —
+        // an own property beats "no method" (JS). Without this, a class defining
+        // `method` ANYWHERE in the program (e.g. the prelude `Set.add`) stole the
+        // call from every plain object carrying an own fn of that name.
+        if args.len() <= 3 {
+            use cranelift_codegen::ir::condcodes::IntCC;
+            let key = crate::value::abi_adapter::intern_poly(method);
+            let key_word = self.builder.ins().iconst(types::I64, key.raw() as i64);
+            let own = self
+                .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
+                .expect("__rtsadp_obj_get returns a value");
+            let boxed = value::emit_is_boxed(self.builder, own);
+            let shifted = self.builder.ins().ushr_imm(own, value::TAG_SHIFT as i64);
+            let tag = self.builder.ins().band_imm(shifted, value::TAG_MASK as i64);
+            let is_fn_tag = self
+                .builder
+                .ins()
+                .icmp_imm(IntCC::Equal, tag, value::TAG_FUNCTION as i64);
+            let is_fn = self.builder.ins().band(boxed, is_fn_tag);
+            let b_fn = self.builder.create_block();
+            let b_undef = self.builder.create_block();
+            self.builder.ins().brif(is_fn, b_fn, &[], b_undef, &[]);
+            self.builder.seal_block(b_fn);
+            self.builder.seal_block(b_undef);
+
+            self.builder.switch_to_block(b_fn);
+            let v = self.lower_value_call_word_with_this(module, own, recv_word, args)?;
+            let w = self.box_value(v);
+            self.builder.ins().jump(merge, &[w.into()]);
+
+            self.builder.switch_to_block(b_undef);
+            let u = self.builder.ins().iconst(types::I64, undef);
+            self.builder.ins().jump(merge, &[u.into()]);
+        } else {
+            let u = self.builder.ins().iconst(types::I64, undef);
+            self.builder.ins().jump(merge, &[u.into()]);
+        }
 
         let result = self.finish_merge(merge);
         Ok(Some(Val::new_with_kind(result, Repr::Tagged, JsKind::Unknown)))

--- a/crates/rts-codegen-new/src/front/run/ctorfn.rs
+++ b/crates/rts-codegen-new/src/front/run/ctorfn.rs
@@ -49,19 +49,43 @@ pub(super) fn lift_constructor_functions(mut program: Program) -> Program {
     // ES5 prototype methods: `F.prototype.m = __fnprop_N` (the parser hoists the
     // assigned fn-expr to a top-level `__fnprop_N`). Map class → [(method, fn)].
     let mut proto_methods: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    // ES5 prototype-chain inheritance: `F.prototype = Object.create(G.prototype)`
+    // → the lifted `class F` gets `extends G` (map F → G). The statement itself
+    // is consumed (the class model carries the chain).
+    let mut extends_map: HashMap<String, String> = HashMap::new();
     for item in &program.items {
         if let Item::Statement(Statement::Raw(raw)) = item {
             if let Some(stmt) = &raw.stmt {
                 if let Some((cls, m, fnid)) = parse_proto_method(stmt) {
                     proto_methods.entry(cls).or_default().push((m, fnid));
                 }
+                if let Some((cls, base)) = parse_proto_extends(stmt) {
+                    extends_map.insert(cls, base);
+                }
+                // Descriptor form: `F.prototype = Object.create(proto, { m:
+                // { value: fn, … }, … })` — each `value:` fn becomes a method;
+                // a non-`Object` proto base becomes `extends`.
+                if let Some((cls, base, methods)) = parse_proto_descriptor(stmt) {
+                    if let Some(b) = base {
+                        extends_map.insert(cls.clone(), b);
+                    }
+                    proto_methods.entry(cls).or_default().extend(methods);
+                }
             }
         }
     }
-    // A name is a constructor iff it has `this.x=` fields, is `new`ed, or has a
-    // prototype method assigned. Only such names trigger conversion / consumption.
+    // A name is a constructor iff it has `this.x=` fields, is `new`ed, has a
+    // prototype method assigned, or participates in a prototype-chain link
+    // (either side of `F.prototype = Object.create(G.prototype)` — the BASE must
+    // also lift so `extends` resolves). Only such names trigger conversion /
+    // consumption.
+    let extends_bases: HashSet<String> = extends_map.values().cloned().collect();
     let is_ctor = |name: &str| {
-        own_fields.contains_key(name) || newed.contains(name) || proto_methods.contains_key(name)
+        own_fields.contains_key(name)
+            || newed.contains(name)
+            || proto_methods.contains_key(name)
+            || extends_map.contains_key(name)
+            || extends_bases.contains(name)
     };
     // Hoisted fns moved into a class as methods — dropped from the top level.
     let consumed_fns: HashSet<String> = proto_methods
@@ -95,11 +119,53 @@ pub(super) fn lift_constructor_functions(mut program: Program) -> Program {
             {
                 None
             }
+            // Drop a consumed `F.prototype = Object.create(G.prototype)` link
+            // (it became `class F extends G`).
+            Item::Statement(Statement::Raw(ref raw))
+                if raw
+                    .stmt
+                    .as_ref()
+                    .and_then(parse_proto_extends)
+                    .is_some_and(|(cls, _)| is_ctor(&cls)) =>
+            {
+                None
+            }
+            // Drop a consumed descriptor-form proto replace (its `value:` fns
+            // became methods; a non-Object base became `extends`).
+            Item::Statement(Statement::Raw(ref raw))
+                if raw
+                    .stmt
+                    .as_ref()
+                    .and_then(parse_proto_descriptor)
+                    .is_some_and(|(cls, _, _)| is_ctor(&cls)) =>
+            {
+                None
+            }
+            // Drop the `F.prototype.constructor = F` re-link idiom — the class
+            // model carries the constructor identity (`inst.constructor.name`
+            // resolves from the static class), so the statement is a no-op here.
+            Item::Statement(Statement::Raw(ref raw))
+                if raw
+                    .stmt
+                    .as_ref()
+                    .and_then(parse_proto_ctor_link)
+                    .is_some_and(|cls| is_ctor(&cls)) =>
+            {
+                None
+            }
             // `async function` is its own rewrite (returns a Promise) — never a ctor.
             Item::Function(f) if !f.is_async => {
                 let protos = proto_methods.get(&f.name);
+                let super_class = extends_map.get(&f.name).cloned();
                 Some(
-                    match function_to_class(&f, is_ctor(&f.name), &own_fields, protos, &fn_bodies) {
+                    match function_to_class(
+                        &f,
+                        is_ctor(&f.name),
+                        &own_fields,
+                        protos,
+                        &fn_bodies,
+                        super_class,
+                    ) {
                         Some(class) => Item::Class(class),
                         None => Item::Function(f),
                     },
@@ -112,7 +178,11 @@ pub(super) fn lift_constructor_functions(mut program: Program) -> Program {
 }
 
 /// Parse `F.prototype.m = <ident>` (the hoisted prototype-method form) →
-/// `(class "F", method "m", fn-ident)`. `None` for any other statement.
+/// `(class "F", method "m", fn-ident)`. `None` for any other statement — and
+/// deliberately `None` for `m == "constructor"` (the ES5 re-link idiom
+/// `F.prototype.constructor = F` is NOT a method: treating it as one used to
+/// CONSUME the constructor function itself, dropping `F` from the program —
+/// "unbound identifier F". See [`parse_proto_ctor_link`]).
 fn parse_proto_method(stmt: &swc_ecma_ast::Stmt) -> Option<(String, String, String)> {
     use swc_ecma_ast::{AssignTarget, Expr, MemberProp, SimpleAssignTarget, Stmt};
     let Stmt::Expr(es) = stmt else { return None };
@@ -126,6 +196,9 @@ fn parse_proto_method(stmt: &swc_ecma_ast::Stmt) -> Option<(String, String, Stri
     let MemberProp::Ident(method) = &m.prop else {
         return None;
     };
+    if method.sym.as_ref() == "constructor" {
+        return None;
+    }
     let Expr::Member(inner) = m.obj.as_ref() else {
         return None;
     };
@@ -140,6 +213,202 @@ fn parse_proto_method(stmt: &swc_ecma_ast::Stmt) -> Option<(String, String, Stri
     Some((cls, method.sym.to_string(), fnid))
 }
 
+/// Parse the ES5 constructor RE-LINK idiom `F.prototype.constructor = F` →
+/// `Some("F")`. Only the exact self-link form matches (LHS class == RHS ident);
+/// anything else passes through to the normal lowering.
+fn parse_proto_ctor_link(stmt: &swc_ecma_ast::Stmt) -> Option<String> {
+    use swc_ecma_ast::{AssignTarget, Expr, MemberProp, SimpleAssignTarget, Stmt};
+    let Stmt::Expr(es) = stmt else { return None };
+    let Expr::Assign(a) = es.expr.as_ref() else {
+        return None;
+    };
+    let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &a.left else {
+        return None;
+    };
+    let MemberProp::Ident(method) = &m.prop else {
+        return None;
+    };
+    if method.sym.as_ref() != "constructor" {
+        return None;
+    }
+    let Expr::Member(inner) = m.obj.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(proto) = &inner.prop else {
+        return None;
+    };
+    if proto.sym.as_ref() != "prototype" {
+        return None;
+    }
+    let cls = callee_ident(&inner.obj)?;
+    let rhs = callee_ident(&a.right)?;
+    (cls == rhs).then_some(cls)
+}
+
+/// Parse the ES5 prototype-chain link `F.prototype = Object.create(G.prototype)`
+/// → `Some(("F", "G"))`. The lifted `class F` gets `extends G` (field
+/// flattening + method inheritance + `instanceof` chain all ride the class
+/// model). `None` for any other statement.
+fn parse_proto_extends(stmt: &swc_ecma_ast::Stmt) -> Option<(String, String)> {
+    use swc_ecma_ast::{AssignTarget, Callee, Expr, MemberProp, SimpleAssignTarget, Stmt};
+    let Stmt::Expr(es) = stmt else { return None };
+    let Expr::Assign(a) = es.expr.as_ref() else {
+        return None;
+    };
+    let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &a.left else {
+        return None;
+    };
+    // LHS must be exactly `F.prototype`.
+    let MemberProp::Ident(proto) = &m.prop else {
+        return None;
+    };
+    if proto.sym.as_ref() != "prototype" {
+        return None;
+    }
+    let cls = callee_ident(&m.obj)?;
+    // RHS must be `Object.create(G.prototype)`.
+    let Expr::Call(call) = a.right.as_ref() else {
+        return None;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(cm) = callee.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(create) = &cm.prop else {
+        return None;
+    };
+    if create.sym.as_ref() != "create" || callee_ident(&cm.obj).as_deref() != Some("Object") {
+        return None;
+    }
+    let arg = call.args.first()?;
+    if arg.spread.is_some() {
+        return None;
+    }
+    let Expr::Member(am) = arg.expr.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(aproto) = &am.prop else {
+        return None;
+    };
+    if aproto.sym.as_ref() != "prototype" {
+        return None;
+    }
+    let base = callee_ident(&am.obj)?;
+    Some((cls, base))
+}
+
+/// Parse the DESCRIPTOR-map proto replace
+/// `F.prototype = Object.create(<G|Object>.prototype, { m: { value: fn, … }, … })`
+/// → `Some((cls, base, methods))` where `base` is `None` for `Object.prototype`
+/// (no user parent) and `methods` maps each descriptor key with a `value:` fn
+/// (the parser hoists the fn-expr to a top-level ident) to that fn's name.
+/// `None` for any other statement.
+fn parse_proto_descriptor(
+    stmt: &swc_ecma_ast::Stmt,
+) -> Option<(String, Option<String>, Vec<(String, String)>)> {
+    use swc_ecma_ast::{
+        AssignTarget, Callee, Expr, MemberProp, Prop, PropName, PropOrSpread, SimpleAssignTarget,
+        Stmt,
+    };
+    let Stmt::Expr(es) = stmt else { return None };
+    let Expr::Assign(a) = es.expr.as_ref() else {
+        return None;
+    };
+    let AssignTarget::Simple(SimpleAssignTarget::Member(m)) = &a.left else {
+        return None;
+    };
+    let MemberProp::Ident(proto) = &m.prop else {
+        return None;
+    };
+    if proto.sym.as_ref() != "prototype" {
+        return None;
+    }
+    let cls = callee_ident(&m.obj)?;
+    // RHS `Object.create(<base>.prototype, { … })` — exactly 2 args.
+    let Expr::Call(call) = a.right.as_ref() else {
+        return None;
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(cm) = callee.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(create) = &cm.prop else {
+        return None;
+    };
+    if create.sym.as_ref() != "create"
+        || callee_ident(&cm.obj).as_deref() != Some("Object")
+        || call.args.len() != 2
+        || call.args.iter().any(|a| a.spread.is_some())
+    {
+        return None;
+    }
+    // arg0: `<base>.prototype`.
+    let Expr::Member(am) = call.args[0].expr.as_ref() else {
+        return None;
+    };
+    let MemberProp::Ident(aproto) = &am.prop else {
+        return None;
+    };
+    if aproto.sym.as_ref() != "prototype" {
+        return None;
+    }
+    let base_name = callee_ident(&am.obj)?;
+    let base = (base_name != "Object").then_some(base_name);
+    // arg1: `{ m: { value: <fn-ident>, … }, … }` — every prop must contribute a
+    // `value:` fn (a getter/setter descriptor is not modeled here → None, so
+    // the statement falls through to the normal lowering and bails honestly).
+    let Expr::Object(desc_obj) = call.args[1].expr.as_ref() else {
+        return None;
+    };
+    let mut methods: Vec<(String, String)> = Vec::new();
+    for p in &desc_obj.props {
+        let PropOrSpread::Prop(prop) = p else {
+            return None;
+        };
+        let Prop::KeyValue(kv) = prop.as_ref() else {
+            return None;
+        };
+        let name = match &kv.key {
+            PropName::Ident(id) => id.sym.to_string(),
+            PropName::Str(s) => s.value.to_string_lossy().into_owned(),
+            _ => return None,
+        };
+        // The descriptor body: an object literal with a `value:` key whose value
+        // is a (hoisted) fn ident. `writable`/`configurable`/`enumerable` flags
+        // are irrelevant to the class model and ignored.
+        let Expr::Object(desc) = kv.value.as_ref() else {
+            return None;
+        };
+        let mut fnid: Option<String> = None;
+        for dp in &desc.props {
+            let PropOrSpread::Prop(dprop) = dp else {
+                return None;
+            };
+            let Prop::KeyValue(dkv) = dprop.as_ref() else {
+                return None;
+            };
+            let dname = match &dkv.key {
+                PropName::Ident(id) => id.sym.to_string(),
+                PropName::Str(s) => s.value.to_string_lossy().into_owned(),
+                _ => return None,
+            };
+            if dname == "value" {
+                fnid = callee_ident(&dkv.value);
+            }
+            if dname == "get" || dname == "set" {
+                // Accessor descriptors are a different surface — not lifted.
+                return None;
+            }
+        }
+        methods.push((name, fnid?));
+    }
+    Some((cls, base, methods))
+}
+
 /// Build a synthetic `ClassDecl` from `f` iff it is a constructor: it writes to
 /// `this.<field>`, OR it is used as a `new` target (`is_newed`). `None` for an
 /// ordinary function — left untouched. `own_fields` maps each constructor name to
@@ -151,6 +420,7 @@ fn function_to_class(
     own_fields: &std::collections::HashMap<String, Vec<String>>,
     proto_methods: Option<&Vec<(String, String)>>,
     fn_bodies: &std::collections::HashMap<String, FunctionDecl>,
+    super_class: Option<String>,
 ) -> Option<ClassDecl> {
     let fields = discover_this_fields(&f.body, own_fields);
     if fields.is_empty() && !is_ctor {
@@ -192,7 +462,7 @@ fn function_to_class(
     }
     Some(ClassDecl {
         name: f.name.clone(),
-        super_class: None,
+        super_class,
         members,
         is_abstract: false,
         static_init_body: Vec::new(),

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -469,24 +469,66 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     ) -> FrontResult<Val> {
         let c = self.lower_expr(module, cond)?;
         let cond_v = self.as_bool_value(module, c)?;
+        // FAST PATH — both arms side-effect-free: evaluate both eagerly and
+        // `select` (the order is unobservable, and a numeric ternary keeps its
+        // UNBOXED repr — the winning path for `a < b ? a : b`). An arm with a
+        // CALL/assignment must NOT take this path: JS evaluates only the chosen
+        // arm, so `n <= 1 ? 1 : n * fact(n - 1)` under an eager `select` ran the
+        // recursive call unconditionally — infinite recursion / stack overflow
+        // (the `function_expression` bug). Same rule `lower_logical` applies to
+        // its select fast path.
+        if super::binop::is_effect_free(then) && super::binop::is_effect_free(else_) {
+            let t = self.lower_expr(module, then)?;
+            let e = self.lower_expr(module, else_)?;
+            let target = ternary_target(t.repr, e.repr)?;
+            let tv = self.coerce(t, target)?;
+            let ev = self.coerce(e, target)?;
+            let v = self.builder.ins().select(cond_v, tv, ev);
+            // Kind is provable only when both arms share it; otherwise fall to
+            // the repr-implied kind (Unknown for Tagged).
+            let kind = if t.kind == e.kind {
+                t.kind
+            } else {
+                JsKind::Unknown
+            };
+            return Ok(Val {
+                v,
+                repr: target,
+                kind,
+            });
+        }
+        // GENERAL PATH — true branching: each arm evaluates ONLY when chosen,
+        // mirroring `lower_logical`'s short-circuit form. The join carries the
+        // BOXED word (Tagged) since the arms lower in disjoint blocks and may
+        // differ in repr; the egraph folds the box where it is redundant.
+        let then_blk = self.builder.create_block();
+        let else_blk = self.builder.create_block();
+        let join_blk = self.builder.create_block();
+        self.builder.append_block_param(join_blk, types::I64);
+
+        self.builder
+            .ins()
+            .brif(cond_v, then_blk, &[], else_blk, &[]);
+
+        self.builder.switch_to_block(then_blk);
+        self.builder.seal_block(then_blk);
         let t = self.lower_expr(module, then)?;
+        let t_kind = t.kind;
+        let t_word = self.box_value(t);
+        self.builder.ins().jump(join_blk, &[t_word.into()]);
+
+        self.builder.switch_to_block(else_blk);
+        self.builder.seal_block(else_blk);
         let e = self.lower_expr(module, else_)?;
-        let target = ternary_target(t.repr, e.repr)?;
-        let tv = self.coerce(t, target)?;
-        let ev = self.coerce(e, target)?;
-        let v = self.builder.ins().select(cond_v, tv, ev);
-        // Kind is provable only when both arms share it; otherwise fall to the
-        // repr-implied kind (Unknown for Tagged).
-        let kind = if t.kind == e.kind {
-            t.kind
-        } else {
-            JsKind::Unknown
-        };
-        Ok(Val {
-            v,
-            repr: target,
-            kind,
-        })
+        let e_kind = e.kind;
+        let e_word = self.box_value(e);
+        self.builder.ins().jump(join_blk, &[e_word.into()]);
+
+        self.builder.switch_to_block(join_blk);
+        self.builder.seal_block(join_blk);
+        let out = self.builder.block_params(join_blk)[0];
+        let kind = if t_kind == e_kind { t_kind } else { JsKind::Unknown };
+        Ok(Val::new_with_kind(out, Repr::Tagged, kind))
     }
 }
 

--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -33,6 +33,37 @@ use crate::front::error::{FrontResult, unsupported};
 use super::lower::{JsKind, Lowerer, Val};
 
 impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// The Object-PROTOCOL methods every JS object inherits from
+    /// `Object.prototype`, over ANY object receiver expression:
+    /// `proto.isPrototypeOf(obj)` (the `Object.create` chain walk),
+    /// `o.hasOwnProperty(k)` (OWN-slot check, no prototype walk) and
+    /// `o.propertyIsEnumerable(k)`. Shared by the whole-heap-object receiver
+    /// path and the user-class not-found fallback in `try_class_method` (a
+    /// class instance inherits these like any object). `Ok(None)` ⇒ not one of
+    /// the three (the caller keeps its own fallbacks).
+    pub(in crate::front::run) fn try_object_protocol_method(
+        &mut self,
+        module: &mut dyn Module,
+        object: &HirExpr,
+        method: &str,
+        args: &[HirExpr],
+    ) -> FrontResult<Option<Val>> {
+        let symbol = match (method, args.len()) {
+            ("isPrototypeOf", 1) => "__rtsadp_is_prototype_of",
+            ("hasOwnProperty", 1) => "__rtsadp_has_own",
+            ("propertyIsEnumerable", 1) => "__rtsadp_prop_is_enumerable",
+            _ => return Ok(None),
+        };
+        let recv = self.lower_expr(module, object)?;
+        let recv_word = self.box_value(recv);
+        let arg = self.lower_expr(module, &args[0])?;
+        let arg_word = self.box_value(arg);
+        let res = self
+            .call_runtime(module, symbol, &[recv_word, arg_word])?
+            .expect("an object-protocol trampoline returns a value");
+        Ok(Some(self.poly_bool_to_bool(res)))
+    }
+
     /// Try to lower `recv.method(args)` via data-driven dispatch. Returns
     /// `Ok(Some(val))` on success, `Ok(None)` when the receiver class is not a
     /// dispatchable primordial (so the caller falls through to its next handler,
@@ -122,49 +153,11 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // The receiver must lower AND have a statically-proven class. Lower it
         // first (a whole object/array value is not a dispatch receiver here).
         if self.is_whole_heap_value(object) {
-            // A whole OBJECT value receiver (`o.hasOwnProperty(k)`, `o.toString()`):
-            // route to the ambient prelude `class Object` (object.ts), passing the
-            // object as `this`. The `.ts` bodies use the shape-aware `engine.obj_*`
-            // bridge. Arrays were already handled above; guard against an array
-            // value slipping through. `Ok(None)` when the method is not on
-            // `class Object` (the caller bails — never a guess).
-            // `proto.isPrototypeOf(obj)` on a whole-object receiver → the runtime
-            // prototype-chain walk (`Object.create` side-table). Routed here because a
-            // PROVEN object never reaches the Tagged dynamic-method path.
-            if method == "isPrototypeOf" && args.len() == 1 {
-                let recv = self.lower_expr(module, object)?;
-                let recv_word = self.box_value(recv);
-                let arg = self.lower_expr(module, &args[0])?;
-                let arg_word = self.box_value(arg);
-                let res = self
-                    .call_runtime(module, "__rtsadp_is_prototype_of", &[recv_word, arg_word])?
-                    .expect("__rtsadp_is_prototype_of returns a value");
-                return Ok(Some(self.poly_bool_to_bool(res)));
-            }
-            // `o.hasOwnProperty(k)` → OWN-slot check (`__rtsadp_obj_has`, which reads
-            // the receiver's own shape only and does NOT walk the prototype chain —
-            // unlike `obj_get`). Routed here for a proven-object receiver.
-            if method == "hasOwnProperty" && args.len() == 1 {
-                let recv = self.lower_expr(module, object)?;
-                let recv_word = self.box_value(recv);
-                let arg = self.lower_expr(module, &args[0])?;
-                let arg_word = self.box_value(arg);
-                let res = self
-                    .call_runtime(module, "__rtsadp_has_own", &[recv_word, arg_word])?
-                    .expect("__rtsadp_has_own returns a value");
-                return Ok(Some(self.poly_bool_to_bool(res)));
-            }
-            // `o.propertyIsEnumerable(k)` — polymorphic tag-dispatched runtime
-            // check (array index bounds / keyed enumerable flag).
-            if method == "propertyIsEnumerable" && args.len() == 1 {
-                let recv = self.lower_expr(module, object)?;
-                let recv_word = self.box_value(recv);
-                let arg = self.lower_expr(module, &args[0])?;
-                let arg_word = self.box_value(arg);
-                let res = self
-                    .call_runtime(module, "__rtsadp_prop_is_enumerable", &[recv_word, arg_word])?
-                    .expect("__rtsadp_prop_is_enumerable returns a value");
-                return Ok(Some(self.poly_bool_to_bool(res)));
+            // The Object-protocol surface (`hasOwnProperty`/`isPrototypeOf`/
+            // `propertyIsEnumerable`) — shared with the user-class not-found
+            // fallback in `try_class_method` (every JS object inherits these).
+            if let Some(val) = self.try_object_protocol_method(module, object, method, args)? {
+                return Ok(Some(val));
             }
             if !self.is_array_valued(object) {
                 let recv = self.lower_expr(module, object)?;

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -62,6 +62,7 @@ mod stmt;
 mod stmt_assign;
 mod stmt_let;
 mod switch;
+mod tco;
 mod thunk;
 mod toprimitive;
 mod trycatch;

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -22,6 +22,7 @@
 //! (driver + locals + coercions), [`expr`] (expressions, incl. the Tagged path),
 //! [`stmt`] (statements + control flow), [`module_jit`] (N-function JIT).
 
+mod argsobj;
 mod assign;
 mod binop;
 mod floatscan;
@@ -464,6 +465,13 @@ fn build_from_program(
             funcs.push(rts_hir::lower::lower_func(fdecl, &mut scope));
         }
     }
+
+    // 1b. Materialize the `arguments` object (#450/#299): a zero-arity fn
+    //     referencing `arguments` gains a synthetic variadic rest param (sees
+    //     every call arg); a declared-params fn gains a `let arguments = [p…]`
+    //     prologue. Runs on the lowered HirFuncs (incl. class methods), before
+    //     signatures freeze in `populate_module`.
+    argsobj::expand_arguments_object(&mut funcs);
 
     // 2. Lower the top-level statements (everything that is `Item::Statement`)
     //    against the same scope, in source order.

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -64,6 +64,9 @@ impl Program {
 fn make_module() -> JITModule {
     let mut flags = settings::builder();
     flags.set("opt_level", "speed").unwrap();
+    // TCO (`return_call` between `CallConv::Tail` fns) requires frame pointers
+    // preserved on x86-64 — the documented requirement the old engine also set.
+    flags.set("preserve_frame_pointers", "true").unwrap();
     let isa = cranelift_native::builder()
         .expect("host isa builder")
         .finish(settings::Flags::new(flags))
@@ -182,6 +185,15 @@ pub(crate) fn populate_module(
     // + main agrees on one known class (a single non-class / disagreeing write
     // poisons it). Lets `const G = globalThis.X; new G().m()` dispatch statically.
     let globalthis_class_refs = infer_globalthis_classes(funcs, main, classes);
+    // TAIL SET (TCO): fns participating in a direct `return f(args)` edge whose
+    // both endpoints are safe under `CallConv::Tail` get `sig.tail = true` —
+    // their declarations switch callconv and qualifying return sites emit
+    // `return_call` (deep self/mutual tail recursion stops consuming stack).
+    for name in super::tco::compute_tail_set(funcs, &sigs) {
+        if let Some(s) = sigs.get_mut(&name) {
+            s.tail = true;
+        }
+    }
     let main_sig = FnSig::main_sig();
 
     // 2. Declare every function up front so cross-calls resolve to a FuncId.

--- a/crates/rts-codegen-new/src/front/run/sig.rs
+++ b/crates/rts-codegen-new/src/front/run/sig.rs
@@ -74,6 +74,13 @@ pub struct FnSig {
     /// True when this is a desugared EAGER generator (body calls `__RTS_GEN_FINISH`,
     /// result = the `__gen_buf` ARRAY). `g().next()` cursors it via `GENERATOR_NEXT`.
     pub ret_eager_gen: bool,
+    /// True when this fn is in the program's TAIL SET (participates in a direct
+    /// `return f(args)` edge and is safe to compile under `CallConv::Tail` —
+    /// see [`super::tco::compute_tail_set`]). Drives both the Cranelift callconv
+    /// ([`Self::to_cranelift`]) and the `return_call` emission at qualifying
+    /// return sites. Stamped by `populate_module`; `of_func`/`main_sig` leave it
+    /// `false`.
+    pub tail: bool,
 }
 
 impl FnSig {
@@ -153,6 +160,7 @@ impl FnSig {
                 ret_array: false,
                 ret_lazy_gen: false,
                 ret_eager_gen: false,
+                tail: false,
             };
         }
         // The declared return repr — trusted in general (an explicit `boolean` /
@@ -229,6 +237,7 @@ impl FnSig {
             ret_array: matches!(func.ret, rts_hir::HirType::Array(_)) || is_eager_generator,
             ret_lazy_gen: is_lazy_gen,
             ret_eager_gen: is_eager_generator,
+            tail: false,
         }
     }
 
@@ -246,12 +255,21 @@ impl FnSig {
             ret_array: false,
                 ret_lazy_gen: false,
                 ret_eager_gen: false,
+            tail: false,
         }
     }
 
-    /// Build the Cranelift `Signature` for this function under the host call conv.
+    /// Build the Cranelift `Signature` for this function: the host call conv, or
+    /// `CallConv::Tail` for a tail-set fn (both endpoints of a `return f(args)`
+    /// edge must share it for `return_call` — see [`super::tco`]). A normal
+    /// `call` to a Tail-conv callee from any conv is still valid Cranelift.
     pub fn to_cranelift(&self, module: &dyn Module) -> Signature {
-        let mut sig = Signature::new(module.isa().default_call_conv());
+        let conv = if self.tail {
+            cranelift_codegen::isa::CallConv::Tail
+        } else {
+            module.isa().default_call_conv()
+        };
+        let mut sig = Signature::new(conv);
         for &p in &self.params {
             sig.params.push(AbiParam::new(cl_type(p)));
         }

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -101,6 +101,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 return unsupported!("`return;` with no value in a value-returning function");
             }
             (Some(ret), Some(e)) => {
+                // TAIL CALL (TCO): `return f(args)` where both this fn and `f`
+                // are in the program's tail set (CallConv::Tail) and the site
+                // qualifies (no enclosing try/finally, exact arity, matching
+                // return repr) → ONE `return_call`, no frame growth. All checks
+                // run before any lowering, so the fallback below never
+                // double-evaluates. See `super::tco`.
+                if self.try_tail_return_call(module, e)? {
+                    return Ok(());
+                }
                 let v = self.lower_expr(module, e)?;
                 Some(self.coerce(v, ret)?)
             }

--- a/crates/rts-codegen-new/src/front/run/tco.rs
+++ b/crates/rts-codegen-new/src/front/run/tco.rs
@@ -1,0 +1,356 @@
+//! Tail-call optimization (TCO) — the SELECTIVE tail set + the `return_call`
+//! emission for `return f(args)` in tail position.
+//!
+//! ## Design (mirrors the preserved old-engine optimization, made selective)
+//!
+//! Cranelift's `return_call` requires BOTH caller and callee to use
+//! `CallConv::Tail`. Blanket-switching every user fn to `Tail` is unsound here:
+//! some user fns have their RAW code address handed to the runtime and are
+//! called back as `extern "C"` (`getPointer(f)` → `thread`/`parallel`;
+//! `__RTS_GEN_SM_NEW(state_fn, …)`; the async-inner fns invoked by
+//! `promise.create`) — a callconv mismatch there is the historical #206 crash.
+//!
+//! So the tail set is computed per program: a fn enters it only when it
+//! participates in a DIRECT tail edge (`return g(args)` with a bare-Ident
+//! callee — never a member/method callee, per the `tco_method_chain_not_tail`
+//! regression) AND both endpoints are safe to re-conv:
+//!
+//! - not `__rtsn_main` (the host calls it as `extern "C" fn()`);
+//! - not `async` (its inner fn's ptr crosses to the runtime);
+//! - not a generator constructor (lazy or eager);
+//! - never named as an argument to `getPointer(..)` / `__RTS_GEN_SM_NEW(..)`
+//!   anywhere in the program (raw-address takers).
+//!
+//! Function VALUES are unaffected: a reified fn value carries its uniform-ABI
+//! THUNK address (the thunk keeps the default callconv and `call`s the real fn
+//! by its declared signature — a normal cross-callconv direct call).
+//!
+//! At the return site, `return_call` is emitted only when it is ALSO locally
+//! sound: no enclosing `try` (a throw in the callee must reach OUR catch — with
+//! a tail call our frame is gone) and no enclosing `finally` (JS runs the
+//! finalizer AFTER the return expression evaluates — a tail call would skip
+//! it), exact positional arity (no spread / rest / defaulted tail / `this`),
+//! and the callee's return repr EXACTLY matches ours (Cranelift validates
+//! `return_call` return types against the caller's signature).
+
+use std::collections::{HashMap, HashSet};
+
+use cranelift_codegen::ir::InstBuilder;
+use cranelift_module::Module;
+
+use rts_hir::ir::{HirExprKind, HirStmt};
+use rts_hir::{HirExpr, HirFunc};
+
+use crate::front::error::{FrontResult, Unsupported};
+
+use super::lower::Lowerer;
+use super::sig::FnSig;
+
+/// Compute the program's TAIL SET (fn names to compile under `CallConv::Tail`).
+/// See the module doc for the rules.
+pub(crate) fn compute_tail_set(
+    funcs: &[HirFunc],
+    sigs: &HashMap<String, FnSig>,
+) -> HashSet<String> {
+    // Raw-address takers: any fn named as a bare-Ident ARG of `getPointer(..)`
+    // or `__RTS_GEN_SM_NEW(..)` anywhere (body of any fn) must keep the default
+    // callconv — the runtime calls that address as `extern "C"`.
+    let mut addr_taken: HashSet<String> = HashSet::new();
+    for f in funcs {
+        collect_addr_taken_stmts(&f.body, &mut addr_taken);
+    }
+
+    let eligible = |name: &str| -> bool {
+        let Some(sig) = sigs.get(name) else {
+            return false;
+        };
+        name != "__rtsn_main"
+            && !sig.is_async
+            && !sig.ret_lazy_gen
+            && !sig.ret_eager_gen
+            && !addr_taken.contains(name)
+    };
+
+    // Tail edges: `return g(args)` with a bare-Ident callee and no spread arg.
+    let mut set = HashSet::new();
+    for f in funcs {
+        if !eligible(&f.name) {
+            continue;
+        }
+        let mut callees: HashSet<String> = HashSet::new();
+        collect_tail_callees(&f.body, &mut callees);
+        for g in callees {
+            if eligible(&g) {
+                set.insert(f.name.clone());
+                set.insert(g);
+            }
+        }
+    }
+    set
+}
+
+/// Record every bare-Ident fn name used as an argument of `getPointer(..)` /
+/// `__RTS_GEN_SM_NEW(..)` in `stmts` (recursing through every statement and
+/// expression that can contain a call).
+fn collect_addr_taken_stmts(stmts: &[HirStmt], out: &mut HashSet<String>) {
+    for s in stmts {
+        walk_stmt_exprs(s, &mut |e| {
+            if let HirExprKind::Call { callee, args } = &e.kind {
+                if let HirExprKind::Ident(n) = &callee.kind {
+                    if n == "getPointer" || n == "__RTS_GEN_SM_NEW" {
+                        for a in args {
+                            if let HirExprKind::Ident(fn_name) = &a.kind {
+                                out.insert(fn_name.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Collect the callee names of every `return <Ident>(args…)` (no spread) in
+/// `stmts`, recursing into nested statement bodies (if/loops/blocks — a tail
+/// return anywhere in the body is a tail return when executed). `try`/`finally`
+/// bodies are DELIBERATELY included in the walk: membership in the tail SET
+/// only switches the callconv; the per-site `try_stack`/`finally_stack` guard
+/// in [`Lowerer::try_tail_return_call`] keeps those sites on the plain call.
+fn collect_tail_callees(stmts: &[HirStmt], out: &mut HashSet<String>) {
+    for s in stmts {
+        match s {
+            HirStmt::Return(Some(e)) => {
+                if let Some(name) = direct_call_callee(e) {
+                    out.insert(name);
+                }
+            }
+            other => {
+                for b in stmt_child_blocks(other) {
+                    collect_tail_callees(b, out);
+                }
+            }
+        }
+    }
+}
+
+/// The callee name of a DIRECT bare-Ident call with purely positional args
+/// (`f(a, b)` — no spread), or `None`. A member/method callee is NEVER a tail
+/// call (`return g(n-1).concat([n])`'s tail is `.concat`, not `g` — the
+/// `tco_method_chain_not_tail` regression).
+fn direct_call_callee(e: &HirExpr) -> Option<String> {
+    let HirExprKind::Call { callee, args } = &e.kind else {
+        return None;
+    };
+    let HirExprKind::Ident(name) = &callee.kind else {
+        return None;
+    };
+    if args
+        .iter()
+        .any(|a| matches!(a.kind, HirExprKind::Spread(_)))
+    {
+        return None;
+    }
+    Some(name.clone())
+}
+
+/// The nested statement BLOCKS of `s` (bodies the walk recurses into).
+fn stmt_child_blocks(s: &HirStmt) -> Vec<&[HirStmt]> {
+    match s {
+        HirStmt::If { then, else_, .. } => {
+            let mut v = vec![then.as_slice()];
+            if let Some(el) = else_ {
+                v.push(el.as_slice());
+            }
+            v
+        }
+        HirStmt::While { body, .. } | HirStmt::DoWhile { body, .. } => vec![body.as_slice()],
+        HirStmt::For { body, .. } => vec![body.as_slice()],
+        HirStmt::ForOf { body, .. } | HirStmt::ForIn { body, .. } => vec![body.as_slice()],
+        HirStmt::Block(b) => vec![b.as_slice()],
+        HirStmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            let mut v = vec![body.as_slice()];
+            if let Some(c) = catch {
+                v.push(c.body.as_slice());
+            }
+            if let Some(f) = finally {
+                v.push(f.as_slice());
+            }
+            v
+        }
+        HirStmt::Switch { cases, .. } => cases.iter().map(|c| c.body.as_slice()).collect(),
+        HirStmt::Labeled { body, .. } => vec![std::slice::from_ref(body.as_ref())],
+        _ => Vec::new(),
+    }
+}
+
+/// Walk every expression contained in `s` (this visits the stmt's OWN exprs,
+/// then recurses through [`stmt_child_blocks`]).
+fn walk_stmt_exprs(s: &HirStmt, f: &mut impl FnMut(&HirExpr)) {
+    match s {
+        HirStmt::Expr(e) | HirStmt::Return(Some(e)) | HirStmt::Throw(e) => walk_expr(e, f),
+        HirStmt::Let { init, .. } => {
+            if let Some(v) = init {
+                walk_expr(v, f);
+            }
+        }
+        HirStmt::Const { init, .. } => walk_expr(init, f),
+        HirStmt::If { cond, .. } => walk_expr(cond, f),
+        HirStmt::While { cond, .. } | HirStmt::DoWhile { cond, .. } => walk_expr(cond, f),
+        HirStmt::For { init, cond, update, .. } => {
+            if let Some(i) = init {
+                walk_stmt_exprs(i, f);
+            }
+            if let Some(c) = cond {
+                walk_expr(c, f);
+            }
+            if let Some(u) = update {
+                walk_expr(u, f);
+            }
+        }
+        HirStmt::ForOf { iterable, .. } => walk_expr(iterable, f),
+        HirStmt::ForIn { object, .. } => walk_expr(object, f),
+        HirStmt::Switch { discriminant, cases } => {
+            walk_expr(discriminant, f);
+            for c in cases {
+                if let Some(t) = &c.test {
+                    walk_expr(t, f);
+                }
+            }
+        }
+        _ => {}
+    }
+    for b in stmt_child_blocks(s) {
+        for inner in b {
+            walk_stmt_exprs(inner, f);
+        }
+    }
+}
+
+/// Walk `e` and every sub-expression, calling `f` on each node.
+fn walk_expr(e: &HirExpr, f: &mut impl FnMut(&HirExpr)) {
+    f(e);
+    match &e.kind {
+        HirExprKind::Call { callee, args } => {
+            walk_expr(callee, f);
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        HirExprKind::MethodCall { object, args, .. } => {
+            walk_expr(object, f);
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        HirExprKind::Bin { lhs, rhs, .. } => {
+            walk_expr(lhs, f);
+            walk_expr(rhs, f);
+        }
+        HirExprKind::Unary { operand, .. } => walk_expr(operand, f),
+        HirExprKind::Ternary { cond, then, else_ } => {
+            walk_expr(cond, f);
+            walk_expr(then, f);
+            walk_expr(else_, f);
+        }
+        HirExprKind::Member { object, .. } => walk_expr(object, f),
+        HirExprKind::Index { object, index } => {
+            walk_expr(object, f);
+            walk_expr(index, f);
+        }
+        HirExprKind::Array(elems) => {
+            for el in elems {
+                walk_expr(el, f);
+            }
+        }
+        HirExprKind::New { args, .. } => {
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        HirExprKind::Assign { target, value } => {
+            walk_expr(target, f);
+            walk_expr(value, f);
+        }
+        HirExprKind::AssignOp { target, value, .. } => {
+            walk_expr(target, f);
+            walk_expr(value, f);
+        }
+        HirExprKind::Object(entries) => {
+            for (_, v) in entries {
+                walk_expr(v, f);
+            }
+        }
+        HirExprKind::Cast { expr, .. } => walk_expr(expr, f),
+        HirExprKind::Await(inner) => walk_expr(inner, f),
+        HirExprKind::Spread(inner) => walk_expr(inner, f),
+        _ => {}
+    }
+}
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// Try to lower `return e` as a Cranelift `return_call`. Returns `Ok(true)`
+    /// when the tail call was emitted (the block is terminated), `Ok(false)`
+    /// when the site does not qualify (the caller lowers the plain
+    /// call-then-return). NOTHING is emitted on the `false` path — every check
+    /// runs before any arg lowers, so the fallback never double-evaluates.
+    pub(super) fn try_tail_return_call(
+        &mut self,
+        module: &mut dyn Module,
+        e: &HirExpr,
+    ) -> FrontResult<bool> {
+        // Local soundness: no enclosing try (the callee's throw must reach OUR
+        // catch) and no enclosing finally (it must run AFTER the call returns).
+        if !self.try_stack.is_empty() || !self.finally_stack.is_empty() {
+            return Ok(false);
+        }
+        let Some(callee_name) = direct_call_callee(e) else {
+            return Ok(false);
+        };
+        // The name must resolve to the top-level user fn — not a shadowing
+        // local/closure/gcell/builtin.
+        if self.local(&callee_name).is_some()
+            || self.captures.contains_key(&callee_name)
+            || self.gcell_id(&callee_name).is_some()
+            || self.builtins.contains_key(&callee_name)
+        {
+            return Ok(false);
+        }
+        let (Some(callee_sig), Some(cur_sig)) = (
+            self.sigs.get(&callee_name).cloned(),
+            self.sigs.get(&self.current_fn).cloned(),
+        ) else {
+            return Ok(false);
+        };
+        // Both endpoints must be in the tail set (CallConv::Tail on both).
+        if !callee_sig.tail || !cur_sig.tail {
+            return Ok(false);
+        }
+        // Exact positional arity only (no rest/`this`/defaulted tail) and an
+        // EXACTLY matching return repr — `return_call` validates the callee's
+        // returns against OUR signature.
+        let HirExprKind::Call { args, .. } = &e.kind else {
+            return Ok(false);
+        };
+        if callee_sig.has_this
+            || callee_sig.rest_param.is_some()
+            || args.len() != callee_sig.params.len()
+            || callee_sig.ret != self.ret
+        {
+            return Ok(false);
+        }
+        // Marshal the args exactly like a plain user call, then `return_call`.
+        let lowered = self.marshal_call_args(module, &callee_sig, None, args)?;
+        let cl_sig = callee_sig.to_cranelift(module);
+        let callee_id = module
+            .declare_function(&callee_name, cranelift_module::Linkage::Local, &cl_sig)
+            .map_err(|e| Unsupported::new(format!("declare tail callee `{callee_name}`: {e}")))?;
+        let func_ref = module.declare_func_in_func(callee_id, self.builder.func);
+        self.builder.ins().return_call(func_ref, &lowered);
+        self.block_terminated = true;
+        Ok(true)
+    }
+}

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -108,7 +108,72 @@ impl swc_ecma_visit::VisitMut for MemberAssignFnHoister {
                 let ident = self.hoist(function);
                 assign.right = Box::new(Expr::Ident(ident));
             }
+            // `F.prototype = Object.create(proto, { m: { value: function(){…} },
+            // … })` — the ES5 descriptor-map form: hoist each descriptor's
+            // `value:` fn-expr exactly like the direct `F.prototype.m = fn`
+            // form, so the ctor-fn lift (`ctorfn::parse_proto_descriptor`) sees
+            // hoisted idents. Same capture-risk profile as the direct form (a
+            // top-level statement, no enclosing fn scope).
+            Expr::Call(call) => {
+                self.hoist_object_create_descriptor_values(call);
+            }
             _ => {}
+        }
+    }
+}
+
+impl MemberAssignFnHoister {
+    /// When `call` is `Object.create(_, { k: { value: <fn-expr>, … }, … })`,
+    /// hoist each `value:` fn/arrow to a `__fnprop_N` decl and rewrite the
+    /// descriptor value to the ident. Any other call is left untouched.
+    fn hoist_object_create_descriptor_values(&mut self, call: &mut swc_ecma_ast::CallExpr) {
+        use swc_ecma_ast::{Callee, MemberProp, Prop, PropName, PropOrSpread};
+        let Callee::Expr(callee) = &call.callee else {
+            return;
+        };
+        let Expr::Member(cm) = callee.as_ref() else {
+            return;
+        };
+        let (MemberProp::Ident(create), Expr::Ident(obj)) = (&cm.prop, cm.obj.as_ref()) else {
+            return;
+        };
+        if create.sym.as_ref() != "create" || obj.sym.as_ref() != "Object" || call.args.len() != 2
+        {
+            return;
+        }
+        let Expr::Object(desc_map) = call.args[1].expr.as_mut() else {
+            return;
+        };
+        for p in &mut desc_map.props {
+            let PropOrSpread::Prop(prop) = p else { continue };
+            let Prop::KeyValue(kv) = prop.as_mut() else {
+                continue;
+            };
+            let Expr::Object(desc) = kv.value.as_mut() else {
+                continue;
+            };
+            for dp in &mut desc.props {
+                let PropOrSpread::Prop(dprop) = dp else { continue };
+                let Prop::KeyValue(dkv) = dprop.as_mut() else {
+                    continue;
+                };
+                let is_value = matches!(&dkv.key, PropName::Ident(id) if id.sym.as_ref() == "value");
+                if !is_value {
+                    continue;
+                }
+                match dkv.value.as_mut() {
+                    Expr::Fn(fe) if !fe.function.is_generator && !fe.function.is_async => {
+                        let ident = self.hoist((*fe.function).clone());
+                        dkv.value = Box::new(Expr::Ident(ident));
+                    }
+                    Expr::Arrow(arrow) if !arrow.is_generator && !arrow.is_async => {
+                        let function = arrow_to_function(arrow);
+                        let ident = self.hoist(function);
+                        dkv.value = Box::new(Expr::Ident(ident));
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## O que (3 commits)

**1. TCO seletivo via `return_call`** (`front/run/tco.rs` novo):
- Tail set por programa: só fns em aresta `return f(args)` com callee Ident direto, excluindo main/async/generators/fns com endereço cru tomado (getPointer/GEN_SM_NEW) — a lição do bug histórico #206 (Tail × extern "C").
- `FnSig.tail` → `CallConv::Tail`; `return_call` só em site qualificado (sem try/finally envolvente, aridade exata, ret repr idêntico), checks ANTES de lowerar args. `preserve_frame_pointers=true`.

**2. Lift ES5 prototype-chain completo** (`ctorfn.rs` + parser):
- Bug: `F.prototype.constructor = F` era lido como método "constructor" e CONSUMIA a própria fn F ("unbound identifier Dog"). Agora é o re-link idiom (no-op no modelo de classes).
- `F.prototype = Object.create(G.prototype)` → `class F extends G` (herança real: campos flattened, métodos, instanceof).
- Forma descriptor `Object.create(proto, { m: { value: fn } })`: parser hoista os `value:` fns (mesmo `__fnprop_N` da forma direta) e o lift os absorve.
- Object-protocol (hasOwnProperty/isPrototypeOf/propertyIsEnumerable) em instância de classe — herdado de Object.prototype, helper único.

**3. Objeto `arguments` (#450/#299) + `arr[Symbol.iterator]`**:
- Pre-pass `argsobj.rs`: fn zero-params c/ `arguments` → rest variádico sintético (vê TODOS os args); fn com params → prologue `let arguments = [p…]`.
- `__rtsadp_idx_get`: chave SYMBOL não coage mais para índice (lia `arr[0]` silenciosamente!); Symbol.iterator → Entry::Function REAL callable; symbol custom → undefined.

## Resultado

- **+7 arquivos da suite verdes**: tail_call, tco_method_chain_not_tail, prototype_chain, instanceof_ctor_fn, proto_method_f64_descriptor, arguments_object, array_symbol_iterator
- Unit tests do motor: **812 passed, mesmas 16 falhas pré-existentes da main** (lista verificada nome a nome) — zero regressão nova

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
