### PR TITLE
feat: async REAL no motor novo (spawn paralelo + rejeições + pontes word/i64) + var hoisting (+11 arquivos)

### DIFF
--- a/crates/rts-adapters/src/value/errslot.rs
+++ b/crates/rts-adapters/src/value/errslot.rs
@@ -86,3 +86,24 @@ pub extern "C" fn __rtsadp_err_clear() {
 pub fn reset_state() {
     PENDING.with(|p| p.set((0, false)));
 }
+
+/// Register THIS slot's readers with the runtime's `promise.create` watcher, so
+/// a `throw` inside a spawned async-fn body (which lands HERE, not in the
+/// legacy handle slot) rejects the Promise instead of resolving with the
+/// sentinel. Idempotent (`OnceLock` on the runtime side). Called by the engine
+/// bootstrap: JIT via `compile_program`, AOT via [`__rtsadp_engine_bootstrap`]
+/// in the generated `main` shim.
+pub fn install_async_error_hook() {
+    rts_runtime::namespaces::promise::set_async_error_hook(
+        __rtsadp_err_pending,
+        __rtsadp_err_take,
+    );
+}
+
+/// AOT bootstrap entry: the generated `main` shim calls this right after
+/// `__RTS_FN_RT_INIT` (the shim cannot reach Rust-side adapters fns except by
+/// symbol). Today it only installs the async-error hook.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_engine_bootstrap() {
+    install_async_error_hook();
+}

--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -245,6 +245,77 @@ pub extern "C" fn __rtsadp_fn_reify(addr: u64, nparams: u64, has_rest: u64, env_
     fn_reify_core(addr, nparams, has_rest, env_word, false)
 }
 
+/// fn_ptr → the BOX kind of an async fn's RESOLVE value (see
+/// [`__rtsadp_promise_spawn`]): 0 = raw int (→ INT32/f64 number word),
+/// 1 = f64 BITS (→ inline double word), 2 = bool, 3 = already a WORD (a
+/// Tagged-return body — verbatim). Distinct from the INVOKE return kind (which
+/// tells `invoke_typed` which register to read).
+fn async_box_kinds() -> &'static Mutex<HashMap<u64, u8>> {
+    static T: OnceLock<Mutex<HashMap<u64, u8>>> = OnceLock::new();
+    T.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The resolve-value BOXER installed on the async spawn: converts the raw
+/// invoke return into the correct PolyValue WORD by the registered box kind.
+/// This is what makes a NEGATIVE i64 return survive — its raw bits fall inside
+/// the NaN-box quadrant and would read back as a boxed garbage object.
+extern "C" fn box_async_result(fn_ptr: u64, raw: i64) -> i64 {
+    let kind = async_box_kinds()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&fn_ptr)
+        .copied()
+        .unwrap_or(3);
+    let w = match kind {
+        1 => PolyValue::from_f64(f64::from_bits(raw as u64)).raw(),
+        2 => PolyValue::bool(raw != 0).raw(),
+        3 => raw as u64,
+        _ => match i32::try_from(raw) {
+            Ok(i) => PolyValue::from_i32(i).raw(),
+            // An integer beyond i32 rides as a JS double (exact ≤ 2^53).
+            Err(_) => PolyValue::from_f64(raw as f64).raw(),
+        },
+    };
+    w as i64
+}
+
+/// `__rtsadp_promise_spawn(fn_addr, args_vec, kinds_packed, meta)` — the ASYNC
+/// function CALL spawn (see `front/run/asyncspawn.rs`). Registers the callee's
+/// packed ABI (one kind byte per param — 0 = i64-class, 1 = f64-bits, 2 = bool)
+/// in the FN_KINDS registry so the spawned invoke goes through `invoke_typed`
+/// with the REAL param kinds (an f64 param reads its bits back into xmm —
+/// never the raw-i64 misload), records the BOX kind of the return (`meta`
+/// bits 16..23), and spawns via `create_spawn_boxed` — the resolve value is
+/// boxed into a proper PolyValue WORD (see [`box_async_result`]).
+///
+/// `meta`: bits 0..7 = invoke return kind, bits 8..15 = argc, bits 16..23 =
+/// resolve box kind.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_promise_spawn(
+    fn_addr: u64,
+    args_vec: u64,
+    kinds_packed: u64,
+    meta: u64,
+) -> u64 {
+    let argc = ((meta >> 8) & 0xFF) as usize;
+    let ret_kind = (meta & 0xFF) as i32;
+    let box_kind = ((meta >> 16) & 0xFF) as u8;
+    let kinds: Vec<u8> = (0..argc)
+        .map(|i| ((kinds_packed >> (8 * i)) & 0xFF) as u8)
+        .collect();
+    rts_runtime::namespaces::globals::function::ops::__RTS_FN_RT_REGISTER_FN_KINDS(
+        fn_addr,
+        kinds.as_ptr() as i64,
+        kinds.len() as i64,
+        ret_kind,
+    );
+    async_box_kinds()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(fn_addr, box_kind);
+    rts_runtime::namespaces::promise::create_spawn_boxed(fn_addr, args_vec, box_async_result)
+}
+
 /// Reify a THIS-FIRST function (a method or ES5 `function (this: any)` expr):
 /// identical to `__rtsadp_fn_reify` but marks `has_this_param` - the
 /// method-aware invoker binds `this` into the thunk a0; the plain invoker

--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -438,7 +438,11 @@ pub extern "C" fn __rtsadp_await(word: u64) -> u64 {
     use rts_runtime::namespaces::promise as rt_promise;
     let mut h = handle;
     loop {
-        let settled = rt_promise::__RTS_FN_NS_PROMISE_WAIT(h);
+        // `wait_raw` — the settled value VERBATIM (a new-engine word or a legacy
+        // raw i64); `rebox_settled` below does the honest rebox. The PUBLIC
+        // `PROMISE_WAIT` normalizes for the TS i64 surface and would round a
+        // fractional double word.
+        let settled = rt_promise::wait_raw(h);
         let rejected = rt_promise::__RTS_FN_NS_PROMISE_STATE(h) == 2;
         // JS `await` FLATTENS: a promise settled with another promise resolves to
         // the inner value. Follow the raw-id chain (finite — each hop consumes one

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -182,6 +182,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             rts_runtime::namespaces::globals::symbol::__RTS_FN_GL_SYMBOL_TO_STRING_TAG as *const u8,
         ),
         // ---- codegen-owned FUNCTION-value trampolines (__rtsadp_fn_*, P4.6) ----
+        sym(
+            "__rtsadp_promise_spawn",
+            funcops::__rtsadp_promise_spawn as *const u8,
+        ),
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym("__rtsadp_fn_reify_this", funcops::__rtsadp_fn_reify_this as *const u8),
         sym("__rtsadp_fn_invoke_method", funcops::__rtsadp_fn_invoke_method as *const u8),

--- a/crates/rts-codegen-new/src/front/run/asyncspawn.rs
+++ b/crates/rts-codegen-new/src/front/run/asyncspawn.rs
@@ -1,0 +1,133 @@
+//! ASYNC function CALLS — the promise-centric model (#437) on the new engine.
+//!
+//! An `async function f(…)` COMPILES as a plain function (its body is ordinary
+//! code; `await` inside it lowers to the blocking `__rtsadp_await`, which is
+//! correct on the spawned worker). What makes it ASYNC is the CALL SITE: a
+//! direct call `f(args)` does NOT run the body inline — it packs the marshaled
+//! args into a fresh raw `Vec<i64>`, takes `f`'s REAL code address, and calls
+//! `promise.create(fn_addr, args_vec)` (`__RTS_FN_NS_PROMISE_CREATE`), which
+//! spawns the body on the shared tokio runtime and returns a PENDING
+//! `Entry::PromiseAsync` handle immediately. The handle rides the NUMBER
+//! surface (`await` / `promise.wait` / `Promise.all` unwrap exactly that
+//! shape), so `Promise.all([f(..), f(..)])` runs bodies in PARALLEL — the
+//! observable async semantic the suite pins (`promise_all_parallel`).
+//!
+//! Honest bails (never a wrong value):
+//! - an `f64`-typed parameter: `promise.create`'s invoke trampoline passes raw
+//!   `i64` words, which would misload an xmm param (the historical #206 class
+//!   of bug) — refuse instead;
+//! - `this`-using / rest-param async fns — a later increment.
+//!
+//! The async fn is EXCLUDED from the TCO tail set ([`super::tco`]) — its raw
+//! address crosses to the runtime, so it must keep the default callconv.
+
+use cranelift_codegen::ir::{InstBuilder, types};
+use cranelift_module::Module;
+
+use rts_hir::HirExpr;
+
+use crate::repr::Repr;
+
+use crate::front::error::{FrontResult, unsupported};
+
+use super::lower::{JsKind, Lowerer, Val};
+use super::sig::FnSig;
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// Lower a direct CALL of the async function `sig` to a `promise.create`
+    /// spawn. Returns the pending Promise handle as an `Int64` NUMBER value.
+    pub(super) fn lower_async_spawn(
+        &mut self,
+        module: &mut dyn Module,
+        sig: &FnSig,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        if sig.has_this || sig.rest_param.is_some() {
+            return unsupported!(
+                "async call to `{}` with `this`/rest params (a later increment)",
+                sig.name
+            );
+        }
+        if sig.params.len() > 8 {
+            return unsupported!(
+                "async call to `{}` with more than 8 params (the packed kinds word \
+                 carries 8 — a later increment)",
+                sig.name
+            );
+        }
+        // Marshal the args exactly like a direct call (coerced to the callee's
+        // native param reprs), then pack them into a fresh RAW `Vec<i64>` — the
+        // `promise.create` args convention (`read_promise_vec` reads raw slots).
+        // An `f64` param value travels as its BITS (kind 1 below); the typed
+        // invoke (`invoke_typed` via the FN_KINDS registry) `from_bits` it back
+        // into the xmm register — never the raw-i64 misload (the #206 family).
+        let lowered = self.marshal_call_args(module, sig, None, args)?;
+        let vec_h = self
+            .call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[])?
+            .expect("VEC_NEW returns a handle");
+        for (v, &repr) in lowered.iter().zip(&sig.params) {
+            let slot = match repr {
+                // An i32 register widens to the i64 slot.
+                Repr::Int32 => self.builder.ins().sextend(types::I64, *v),
+                // An f64 register rides as its BITS (pure bitcast).
+                Repr::Float64 => self
+                    .builder
+                    .ins()
+                    .bitcast(types::I64, cranelift_codegen::ir::MemFlags::new(), *v),
+                _ => *v,
+            };
+            self.call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[vec_h, slot])?;
+        }
+        // The PACKED ABI the spawn registers for the typed invoke: one kind byte
+        // per param (0 = i64-class, 1 = f64-bits, 2 = bool) + the return kind.
+        let mut kinds_packed: u64 = 0;
+        for (i, &repr) in sig.params.iter().enumerate() {
+            let k: u64 = match repr {
+                Repr::Float64 => 1,
+                Repr::Bool => 2,
+                _ => 0,
+            };
+            kinds_packed |= k << (8 * i);
+        }
+        let ret_kind: u64 = match sig.ret {
+            Some(Repr::Float64) => 1,
+            Some(Repr::Bool) => 2,
+            _ => 0,
+        };
+        // The RESOLVE-value BOX kind (meta bits 16..23): how the raw invoke
+        // return becomes a PolyValue WORD. A Tagged body already returns a word
+        // (3 = verbatim); native reprs box by kind — a raw NEGATIVE i64 falls
+        // inside the NaN-box quadrant and MUST be boxed, never stored raw.
+        let box_kind: u64 = match sig.ret {
+            Some(Repr::Float64) => 1,
+            Some(Repr::Bool) => 2,
+            Some(Repr::Int32) | Some(Repr::Int64) => 0,
+            _ => 3,
+        };
+        let meta = (box_kind << 16) | ((sig.params.len() as u64) << 8) | ret_kind;
+        let kinds_word = self.builder.ins().iconst(types::I64, kinds_packed as i64);
+        let meta_word = self.builder.ins().iconst(types::I64, meta as i64);
+        // The REAL code address of the async body (default callconv — excluded
+        // from the TCO tail set by `sig.is_async`).
+        let fid = self
+            .ids
+            .get(&sig.name)
+            .copied()
+            .ok_or_else(|| crate::front::error::Unsupported::new(format!(
+                "async fn `{}` has no declared FuncId",
+                sig.name
+            )))?;
+        let fref = module.declare_func_in_func(fid, self.builder.func);
+        let fn_addr = self.builder.ins().func_addr(types::I64, fref);
+        let handle = self
+            .call_runtime(
+                module,
+                "__rtsadp_promise_spawn",
+                &[fn_addr, vec_h, kinds_word, meta_word],
+            )?
+            .expect("__rtsadp_promise_spawn returns a handle");
+        // The pending-Promise handle rides the NUMBER surface (`await` /
+        // `promise.wait` / the combinator collectors unwrap it).
+        Ok(Val::new_with_kind(handle, Repr::Int64, JsKind::Number))
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -361,6 +361,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
         // A statically-known user function → the native fast path (NOT regressed).
         if let Some(sig) = self.sigs.get(&name).cloned() {
+            // An ASYNC function call SPAWNS its body on the shared runtime and
+            // returns the pending Promise handle immediately (the
+            // promise-centric model, #437) — `Promise.all([f(..), g(..)])`
+            // genuinely runs in parallel. See `super::asyncspawn`.
+            if sig.is_async {
+                return self.lower_async_spawn(module, &sig, args);
+            }
             return self.lower_user_call(module, &sig, args);
         }
         // A MODULE-GLOBAL cell (#195) holding a function VALUE, called as `f()`:

--- a/crates/rts-codegen-new/src/front/run/class/synth.rs
+++ b/crates/rts-codegen-new/src/front/run/class/synth.rs
@@ -310,6 +310,25 @@ pub(super) fn build_class(
             member_access.insert(md.name.clone(), (v, decl.name.clone()));
         }
     }
+    // STATIC `#name` members also mark the LEXICAL declaring class (the
+    // `check_private_name_lexical` re-check keys on member_access membership —
+    // a `static #table` read from the class's own static method must pass).
+    for pd in &m.static_props {
+        if pd.name.starts_with('#') {
+            member_access.insert(
+                pd.name.clone(),
+                (rts_ast::ast::Visibility::Private, decl.name.clone()),
+            );
+        }
+    }
+    for md in &m.static_methods {
+        if md.name.starts_with('#') {
+            member_access.insert(
+                md.name.clone(),
+                (rts_ast::ast::Visibility::Private, decl.name.clone()),
+            );
+        }
+    }
 
     // --- abstract accounting: own abstract decls + parent's unimplemented,
     // minus what THIS class's `methods` now implements. A CONCRETE class with

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -24,6 +24,7 @@
 
 mod argsobj;
 mod assign;
+mod asyncspawn;
 mod binop;
 mod floatscan;
 mod binop_eq;
@@ -65,6 +66,7 @@ mod stmt_let;
 mod switch;
 mod tco;
 mod thunk;
+mod varhoist;
 mod toprimitive;
 mod trycatch;
 
@@ -462,7 +464,15 @@ fn build_from_program(
     let mut funcs: Vec<HirFunc> = class_funcs;
     for item in &program.items {
         if let rts_ast::ast::Item::Function(fdecl) = item {
-            funcs.push(rts_hir::lower::lower_func(fdecl, &mut scope));
+            // `var` HOISTING (#301): predeclare every `var`-kind name at the
+            // top of the fn body (JS function scope) — the real `var x = init`
+            // later is a flat re-`let` (same slot). See `varhoist`.
+            let hoists = varhoist::hoisted_var_lets(&fdecl.body);
+            let mut f = rts_hir::lower::lower_func(fdecl, &mut scope);
+            if !hoists.is_empty() {
+                f.body.splice(0..0, hoists);
+            }
+            funcs.push(f);
         }
     }
 
@@ -481,7 +491,14 @@ fn build_from_program(
             top_stmts.push(stmt.clone());
         }
     }
-    let body = rts_hir::lower::lower_stmts(&top_stmts, &mut scope);
+    // `var` HOISTING (#301) at MODULE scope: a top-level `var z` predeclares
+    // at the head of main so a read before its line resolves (same flat-slot
+    // model as the fn-body hoist above).
+    let top_var_hoists = varhoist::hoisted_var_lets(&top_stmts);
+    let mut body = rts_hir::lower::lower_stmts(&top_stmts, &mut scope);
+    if !top_var_hoists.is_empty() {
+        body.splice(0..0, top_var_hoists);
+    }
 
     // STATIC fields + `static {}` init blocks: every static FIELD of a user class
     // lives in a WRITABLE module-global cell named by the synth convention
@@ -515,8 +532,33 @@ fn build_from_program(
                 }
             }
         }
-        for (_pos, stmts) in &c.static_init_blocks {
-            static_prelude.extend(rts_hir::lower::lower_stmts(stmts, &mut scope));
+        // `static { … }` blocks run LEXICALLY inside the class body (JS): a
+        // `C.#priv` access inside one must pass the private-name re-check. They
+        // are therefore synthesized as STATIC fns (`__rtsn_static_<C>_init<i>` —
+        // the `enclosing_class` prefix parse recovers `<C>`), called from the
+        // static prelude in declaration order — not inlined into `__rtsn_main`
+        // (whose enclosing class is None, which refused the access).
+        for (i, (_pos, stmts)) in c.static_init_blocks.iter().enumerate() {
+            let fn_name = format!("__rtsn_static_{}_init{}", c.name, i);
+            let block_body = rts_hir::lower::lower_stmts(stmts, &mut scope);
+            funcs.push(rts_hir::ir::HirFunc {
+                name: fn_name.clone(),
+                params: Vec::new(),
+                ret: HirType::Void,
+                body: block_body,
+                is_async: false,
+                is_arrow: false,
+            });
+            static_prelude.push(HirStmt::Expr(rts_hir::ir::HirExpr::new(
+                rts_hir::ir::HirExprKind::Call {
+                    callee: Box::new(rts_hir::ir::HirExpr::new(
+                        rts_hir::ir::HirExprKind::Ident(fn_name),
+                        HirType::Unknown,
+                    )),
+                    args: Vec::new(),
+                },
+                HirType::Void,
+            )));
         }
     }
     let body = if static_prelude.is_empty() {

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -91,6 +91,9 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
     // the equivalent via `__RTS_FN_RT_INIT`. Same facade entry both paths use.
     // Idempotent (OnceLock + thread-id dedup + backend box overwrite).
     rts_runtime::runtime_init();
+    // Wire the engine's pending-error slot into the runtime's async watcher (a
+    // `throw` inside a spawned async body must REJECT, not resolve). Idempotent.
+    rts_adapters::value::errslot::install_async_error_hook();
     let mut module = make_module();
     let main_id = populate_module(&mut module, prog)?;
     module

--- a/crates/rts-codegen-new/src/front/run/tests/closure.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/closure.rs
@@ -145,15 +145,17 @@ fn top_level_runtime_const_read_in_function() {
 }
 
 #[test]
-fn async_await_synchronous_model() {
-    // SYNCHRONOUS async (no event loop / parallel yet — the suspension SM is
-    // disabled, to be redesigned). An `async` fn runs its body synchronously and
-    // returns the value; `await x` is the value of `x`. Covers the common
-    // resolved/sequential case.
+fn async_await_real_spawn_chain() {
+    // REAL async (2026-07-02): an async CALL spawns its body on the shared
+    // runtime and returns a pending Promise handle; `await` blocks (pumping the
+    // event loop) and unwraps the settled value. `: number` (f64) params ride
+    // the typed spawn (`__rtsadp_promise_spawn` registers the packed kinds so
+    // the invoke reads the bits back into xmm). The top-level `await` keeps the
+    // print on the MAIN thread — deterministic capture.
     assert_stdout(
         "async function add(a: number, b: number): Promise<number> { return a + b; } \
          async function run(): Promise<number> { const x = await add(2, 3); return await add(x, 10); } \
-         async function main(): Promise<void> { console.log(await run()); } main();",
+         console.log(await run());",
         "15\n",
     );
 }

--- a/crates/rts-codegen-new/src/front/run/tests/trycatch.rs
+++ b/crates/rts-codegen-new/src/front/run/tests/trycatch.rs
@@ -165,15 +165,16 @@ try { outer(); } catch (e) { console.log(e.message); }"#,
 // ---- bails (out of the implemented subset; explicit Unsupported, not a crash) ----
 
 #[test]
-fn async_try_no_await_runs_synchronously() {
-    // A no-`await` `async` function body runs synchronously to completion (JS: the
-    // body runs up to the first await; with none, it fully runs). The discarded
-    // promise result is unobservable, so the catch's `console.log` is the only
-    // output. Now reaches this (previously bailed on the void fall-through before
-    // the body compiled). The real await/event-loop machinery is still open.
+fn async_try_awaited_runs_catch() {
+    // REAL async (2026-07-02): the CALL spawns the body on the shared runtime;
+    // the top-level `await` unwraps the settled value. The catch RETURNS the
+    // message and MAIN prints it — the unit harness's console capture is
+    // thread-local by design (parallel test isolation), so a worker-side
+    // `console.log` is not observable HERE (it reaches the real stdout in a
+    // real run — the TS suite covers that path).
     assert_stdout(
-        r#"async function f() { try { throw new Error("x"); } catch (e) { console.log(e.message); } }
-f();"#,
+        r#"async function f() { try { throw new Error("x"); } catch (e) { return e.message; } }
+console.log(await f());"#,
         "x\n",
     );
 }

--- a/crates/rts-codegen-new/src/front/run/varhoist.rs
+++ b/crates/rts-codegen-new/src/front/run/varhoist.rs
@@ -1,0 +1,177 @@
+//! `var` HOISTING (#301 fase 1) — a pre-pass over a function/module body.
+//!
+//! JS `var` is FUNCTION-scoped and hoisted: the NAME is visible (undefined)
+//! from the top of the enclosing function, and a `var` declared inside a
+//! `for`/block outlives it. The engine's locals are already FLAT per function
+//! (a re-`let` reuses the slot), so the only missing piece is the PREDECLARE:
+//! reading `x` before its `var x = 5` line bailed "unbound identifier".
+//!
+//! This pass walks the RAW swc statements of a body (the parser keeps
+//! `Statement::Raw`), collects every `var`-kind declarator name — recursing
+//! through nested blocks/if/loops/try/switch but NOT into nested
+//! function/arrow/class bodies (their `var`s belong to THEIR scope) — and
+//! returns one synthetic `let <name> = <zero-ish>` per name, to prepend to the
+//! lowered HIR body. The real `var x = init` later in the body is a flat
+//! re-`let` (same slot), i.e. an assignment — exactly the `var` semantic.
+//!
+//! The hoisted initial value: `0` for a numeric annotation (the suite's typed
+//! `var x: i64` prints `0` pre-init, the documented #301 proxy for undefined),
+//! `undefined` otherwise.
+
+use rts_ast::ast::Statement;
+use rts_hir::ir::{HirExprKind, HirLit, HirStmt};
+use rts_hir::{HirExpr, HirType};
+
+/// The synthetic hoist prologue for `body` — empty when it declares no `var`s.
+pub(crate) fn hoisted_var_lets(body: &[Statement]) -> Vec<HirStmt> {
+    let mut names: Vec<(String, Option<String>)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for s in body {
+        let Statement::Raw(raw) = s;
+        if let Some(stmt) = &raw.stmt {
+            collect_stmt(stmt, &mut names, &mut seen);
+        }
+    }
+    names
+        .into_iter()
+        .map(|(name, ann)| {
+            let ty = ann
+                .as_deref()
+                .map(rts_hir::lower::parse_type_annotation)
+                .unwrap_or(HirType::Unknown);
+            let init = if matches!(
+                ty,
+                HirType::I8
+                    | HirType::I16
+                    | HirType::I32
+                    | HirType::I64
+                    | HirType::U8
+                    | HirType::U16
+                    | HirType::U32
+                    | HirType::U64
+                    | HirType::F32
+                    | HirType::F64
+            ) {
+                HirExpr::new(HirExprKind::Lit(HirLit::Int(0)), ty.clone())
+            } else {
+                HirExpr::new(HirExprKind::Lit(HirLit::Undefined), HirType::Unknown)
+            };
+            HirStmt::Let {
+                name,
+                ty,
+                init: Some(init),
+            }
+        })
+        .collect()
+}
+
+/// Collect `var`-kind declarator names (+ type annotation text) from `stmt`,
+/// recursing through statement bodies but never into a nested fn/arrow/class.
+fn collect_stmt(
+    stmt: &swc_ecma_ast::Stmt,
+    out: &mut Vec<(String, Option<String>)>,
+    seen: &mut std::collections::HashSet<String>,
+) {
+    use swc_ecma_ast::{Decl, ForHead, Stmt, VarDeclKind, VarDeclOrExpr};
+    let mut add_var_decl = |vd: &swc_ecma_ast::VarDecl,
+                            out: &mut Vec<(String, Option<String>)>,
+                            seen: &mut std::collections::HashSet<String>| {
+        if vd.kind != VarDeclKind::Var {
+            return;
+        }
+        for d in &vd.decls {
+            if let swc_ecma_ast::Pat::Ident(bi) = &d.name {
+                let name = bi.id.sym.to_string();
+                if seen.insert(name.clone()) {
+                    let ann = bi
+                        .type_ann
+                        .as_deref()
+                        .map(|t| type_ann_text(&t.type_ann));
+                    out.push((name, ann.flatten()));
+                }
+            }
+        }
+    };
+    match stmt {
+        Stmt::Decl(Decl::Var(vd)) => add_var_decl(vd, out, seen),
+        Stmt::Block(b) => {
+            for s in &b.stmts {
+                collect_stmt(s, out, seen);
+            }
+        }
+        Stmt::If(i) => {
+            collect_stmt(&i.cons, out, seen);
+            if let Some(alt) = &i.alt {
+                collect_stmt(alt, out, seen);
+            }
+        }
+        Stmt::While(w) => collect_stmt(&w.body, out, seen),
+        Stmt::DoWhile(w) => collect_stmt(&w.body, out, seen),
+        Stmt::For(f) => {
+            if let Some(VarDeclOrExpr::VarDecl(vd)) = &f.init {
+                add_var_decl(vd, out, seen);
+            }
+            collect_stmt(&f.body, out, seen);
+        }
+        Stmt::ForIn(f) => {
+            if let ForHead::VarDecl(vd) = &f.left {
+                add_var_decl(vd, out, seen);
+            }
+            collect_stmt(&f.body, out, seen);
+        }
+        Stmt::ForOf(f) => {
+            if let ForHead::VarDecl(vd) = &f.left {
+                add_var_decl(vd, out, seen);
+            }
+            collect_stmt(&f.body, out, seen);
+        }
+        Stmt::Try(t) => {
+            for s in &t.block.stmts {
+                collect_stmt(s, out, seen);
+            }
+            if let Some(h) = &t.handler {
+                for s in &h.body.stmts {
+                    collect_stmt(s, out, seen);
+                }
+            }
+            if let Some(f) = &t.finalizer {
+                for s in &f.stmts {
+                    collect_stmt(s, out, seen);
+                }
+            }
+        }
+        Stmt::Switch(sw) => {
+            for c in &sw.cases {
+                for s in &c.cons {
+                    collect_stmt(s, out, seen);
+                }
+            }
+        }
+        Stmt::Labeled(l) => collect_stmt(&l.body, out, seen),
+        // Nested function/arrow/class bodies own their `var`s — not descended
+        // (fn decls are separate Items anyway; exprs cannot contain `var`).
+        _ => {}
+    }
+}
+
+/// The source text of a simple type annotation (`i64`, `number`, …) — `None`
+/// for a composite annotation the hoist does not model (falls to `Unknown`).
+fn type_ann_text(t: &swc_ecma_ast::TsType) -> Option<String> {
+    use swc_ecma_ast::{TsEntityName, TsKeywordTypeKind, TsType};
+    match t {
+        TsType::TsKeywordType(k) => Some(
+            match k.kind {
+                TsKeywordTypeKind::TsNumberKeyword => "number",
+                TsKeywordTypeKind::TsBooleanKeyword => "boolean",
+                TsKeywordTypeKind::TsStringKeyword => "string",
+                _ => return None,
+            }
+            .to_string(),
+        ),
+        TsType::TsTypeRef(r) => match &r.type_name {
+            TsEntityName::Ident(id) => Some(id.sym.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -267,6 +267,21 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             ret: Handle,
         },
 
+        // `promise.create(fn_addr, args_vec)` — the async-fn CALL spawn
+        // (front/run/asyncspawn.rs): runs the body on the shared runtime,
+        // returns the pending PromiseAsync handle.
+        "__RTS_FN_NS_PROMISE_CREATE" => SymSig {
+            params: &[U64, U64],
+            ret: U64,
+        },
+        // The typed async spawn: registers the callee's packed param/ret kinds
+        // (an f64 param travels as bits and reads back into xmm), then
+        // delegates to `promise.create`.
+        "__rtsadp_promise_spawn" => SymSig {
+            params: &[U64, U64, U64, U64],
+            ret: U64,
+        },
+
         // ---- REAL collections Vec (rts-shared collections::vec) ----
         "__RTS_FN_NS_COLLECTIONS_VEC_NEW" => SymSig {
             params: &[],

--- a/crates/rts-primitives/src/function/ops.rs
+++ b/crates/rts-primitives/src/function/ops.rs
@@ -1449,6 +1449,28 @@ pub extern "C" fn __RTS_FN_RT_INVOKE_AUTO_AS_F64(
     }
 }
 
+/// Invoca um CALLABLE em qualquer das convenções vivas, com args crus:
+/// - uma WORD `TAG_FUNCTION` do motor novo → normaliza para o handle real;
+/// - um handle `Entry::Function` vivo → `INVOKE_AUTO` (aplica bound_args,
+///   param_kinds, env de uniform-thunk — a convenção correta do fn VALUE);
+/// - um fn_ptr cru legado → `invoke_fn_ptr_with_registry` (kinds do registry
+///   quando conhecidos, senão o transmute i64 histórico).
+///
+/// É a ponte ÚNICA usada pelos consumidores de callback do runtime (watcher de
+/// `promise.create`, drain de microtasks then/catch/finally) — sem ela, um
+/// callback uniform-thunk era invocado como fn crua e lia o arg no slot do env
+/// (valores "a0b0" no lugar de "a1b2").
+pub fn invoke_callable_auto(callable: u64, args: &[i64]) -> i64 {
+    use rts_engine::heap::handles::{alloc_entry, with_entry, Entry};
+    let h = rts_engine::heap::poly::poly_handle_normalize(callable).unwrap_or(callable);
+    let is_fn_handle = with_entry(h, |e| matches!(e, Some(Entry::Function(_))));
+    if is_fn_handle {
+        let args_h = alloc_entry(Entry::Vec(Box::new(args.to_vec())));
+        return __RTS_FN_RT_INVOKE_AUTO(h as i64, 0, args_h);
+    }
+    invoke_fn_ptr_with_registry(callable, args)
+}
+
 /// (issue-pai) Para invoke de fn_ptr raw i64-ABI: os args number vieram como
 /// bits-f64 (convencao do call site dinamico). Aloca um novo args Vec com cada
 /// elemento convertido de bits-f64 -> i64 truncado, p/ a fn i64-param ler o

--- a/crates/rts-std/src/crypto/mod.rs
+++ b/crates/rts-std/src/crypto/mod.rs
@@ -531,21 +531,27 @@ pub fn register(e: &mut Engine) {
             ),
             &["randomUUID"],
         ))
-        .member(func(
-            "hash_new",
-            "__RTS_FN_NS_CRYPTO_HASH_NEW",
-            Sig::new(vec![AbiType::StrPtr], AbiType::Handle),
-            "hash_new(alg: string): number",
-            "`crypto.createHash(\"sha256\")` — new streaming hasher. 0 if unsupported.",
-            __RTS_FN_NS_CRYPTO_HASH_NEW as *const u8,
+        .member(with_aliases(
+            func(
+                "hash_new",
+                "__RTS_FN_NS_CRYPTO_HASH_NEW",
+                Sig::new(vec![AbiType::StrPtr], AbiType::Handle),
+                "hash_new(alg: string): number",
+                "`crypto.createHash(\"sha256\")` — new streaming hasher. 0 if unsupported.",
+                __RTS_FN_NS_CRYPTO_HASH_NEW as *const u8,
+            ),
+            &["createHash"],
         ))
-        .member(func(
-            "hash_update_str",
-            "__RTS_FN_NS_CRYPTO_HASH_UPDATE_STR",
-            Sig::new(vec![AbiType::Handle, AbiType::StrPtr], AbiType::I64),
-            "hash_update_str(h: number, data: string): number",
-            "`hash.update(data: string)` — feed bytes into the streaming hasher.",
-            __RTS_FN_NS_CRYPTO_HASH_UPDATE_STR as *const u8,
+        .member(with_aliases(
+            func(
+                "hash_update_str",
+                "__RTS_FN_NS_CRYPTO_HASH_UPDATE_STR",
+                Sig::new(vec![AbiType::Handle, AbiType::StrPtr], AbiType::I64),
+                "hash_update_str(h: number, data: string): number",
+                "`hash.update(data: string)` — feed bytes into the streaming hasher.",
+                __RTS_FN_NS_CRYPTO_HASH_UPDATE_STR as *const u8,
+            ),
+            &["hashUpdate"],
         ))
         .member(func(
             "hash_update_bytes",
@@ -555,21 +561,27 @@ pub fn register(e: &mut Engine) {
             "`hash.update(buf)` — feed raw ptr+len bytes.",
             __RTS_FN_NS_CRYPTO_HASH_UPDATE_BYTES as *const u8,
         ))
-        .member(func(
-            "hash_digest_hex",
-            "__RTS_FN_NS_CRYPTO_HASH_DIGEST_HEX",
-            Sig::new(vec![AbiType::Handle], AbiType::Handle),
-            "hash_digest_hex(h: number): string",
-            "`hash.digest(\"hex\")` — finalize, return a hex string handle.",
-            __RTS_FN_NS_CRYPTO_HASH_DIGEST_HEX as *const u8,
+        .member(with_aliases(
+            func(
+                "hash_digest_hex",
+                "__RTS_FN_NS_CRYPTO_HASH_DIGEST_HEX",
+                Sig::new(vec![AbiType::Handle], AbiType::Handle),
+                "hash_digest_hex(h: number): string",
+                "`hash.digest(\"hex\")` — finalize, return a hex string handle.",
+                __RTS_FN_NS_CRYPTO_HASH_DIGEST_HEX as *const u8,
+            ),
+            &["hashDigestHex"],
         ))
-        .member(func(
-            "hash_digest_base64",
-            "__RTS_FN_NS_CRYPTO_HASH_DIGEST_BASE64",
-            Sig::new(vec![AbiType::Handle], AbiType::Handle),
-            "hash_digest_base64(h: number): string",
-            "`hash.digest(\"base64\")` — finalize, return a base64 string handle.",
-            __RTS_FN_NS_CRYPTO_HASH_DIGEST_BASE64 as *const u8,
+        .member(with_aliases(
+            func(
+                "hash_digest_base64",
+                "__RTS_FN_NS_CRYPTO_HASH_DIGEST_BASE64",
+                Sig::new(vec![AbiType::Handle], AbiType::Handle),
+                "hash_digest_base64(h: number): string",
+                "`hash.digest(\"base64\")` — finalize, return a base64 string handle.",
+                __RTS_FN_NS_CRYPTO_HASH_DIGEST_BASE64 as *const u8,
+            ),
+            &["hashDigestBase64"],
         ))
         .member(with_aliases(
             func(

--- a/crates/rts-std/src/globals/text_encoding/instance.rs
+++ b/crates/rts-std/src/globals/text_encoding/instance.rs
@@ -852,7 +852,10 @@ unsafe fn invoke_microtask_callback(fn_ptr: u64, bound: &[i64], extra: Option<i6
     if let Some(v) = extra {
         args.push(v);
     }
-    rts_primitives::function::ops::invoke_fn_ptr_with_registry(fn_ptr, &args)
+    // Ponte de convenção ÚNICA: um callable que é fn VALUE do motor novo
+    // (word/handle Entry::Function — possivelmente uniform-thunk com env)
+    // invoca via INVOKE_AUTO; um fn_ptr cru mantém o caminho registry.
+    rts_primitives::function::ops::invoke_callable_auto(fn_ptr, &args)
 }
 
 // TextEncoder / TextDecoder constructors — stateless, token handle.

--- a/crates/rts-std/src/promise/mod.rs
+++ b/crates/rts-std/src/promise/mod.rs
@@ -1,4 +1,4 @@
-//! `promise` namespace — primitivas de Promise<T> async (issue #412).
+﻿//! `promise` namespace — primitivas de Promise<T> async (issue #412).
 //!
 //! Diferente de `Entry::Promise(i64)` (Promise sincrona ja' resolvida —
 //! caminho rapido legado de `globals/fetch`), aqui temos
@@ -23,6 +23,46 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Drain do pipeline aguarda chegar a 0 para que async fns fire-and-forget
 /// (sem await no top-level) terminem antes do processo sair.
 pub(crate) static PENDING_PROMISE_TASKS: AtomicUsize = AtomicUsize::new(0);
+
+/// HOOK do slot de erro do MOTOR (rts-adapters `errslot`): o `throw` do motor
+/// novo grava a WORD lançada num thread-local PRÓPRIO do codegen, distinto do
+/// slot handle legado (`__RTS_FN_RT_ERROR_*`). O watcher de `promise.create`
+/// consulta AMBOS ao decidir resolve/reject — sem o hook, um `throw` dentro de
+/// uma async fn spawnada resolvia a Promise com o sentinela em vez de rejeitar.
+/// `(pending, take)`: `pending() != 0` ⇒ há erro; `take()` lê+limpa a word.
+/// Instalado pelo bootstrap do motor (JIT: `compile_program`; AOT: o shim main
+/// chama `__rtsadp_engine_bootstrap`). rts-std não pode depender de
+/// rts-adapters (direção de deps), daí o registro dinâmico.
+#[allow(clippy::type_complexity)]
+static ASYNC_ERR_HOOK: std::sync::OnceLock<(extern "C" fn() -> i64, extern "C" fn() -> u64)> =
+    std::sync::OnceLock::new();
+
+/// Registra o leitor do slot de erro do motor (chamado pelo rts-adapters).
+pub fn set_async_error_hook(pending: extern "C" fn() -> i64, take: extern "C" fn() -> u64) {
+    let _ = ASYNC_ERR_HOOK.set((pending, take));
+}
+
+/// Lê+limpa o erro pendente do MOTOR nesta thread, se houver: `Some(word)`.
+fn take_engine_pending_error() -> Option<u64> {
+    let (pending, take) = ASYNC_ERR_HOOK.get()?;
+    if pending() != 0 { Some(take()) } else { None }
+}
+
+/// O CALLABLE a enfileirar/invocar: um fn VALUE do motor novo (uma WORD
+/// `TAG_FUNCTION` ou um handle `Entry::Function` vivo) fica VERBATIM com bound
+/// vazio — `invoke_callable_auto` roteia via INVOKE_AUTO (env de uniform-thunk,
+/// bound_args, param_kinds). Qualquer outra forma mantém a decomposição legada
+/// `resolve_callback_ptr` (fn_ptr cru + bound).
+fn callable_or_decomposed(fp: u64) -> (u64, Vec<i64>) {
+    let h = rts_engine::heap::poly::poly_handle_normalize(fp).unwrap_or(fp);
+    let is_fn_handle = with_entry(h, |e| matches!(e, Some(Entry::Function(_))));
+    if is_fn_handle {
+        (h, Vec::new())
+    } else {
+        let (fn_ptr, bound, _has_this, _this) = resolve_callback_ptr(fp);
+        (fn_ptr, bound)
+    }
+}
 
 /// Bloqueia ate todas as tasks de promise.create completarem, com deadline
 /// de 5s para evitar hang em tasks que nunca settle.
@@ -104,9 +144,43 @@ fn resolve_callback_ptr(fp: u64) -> (u64, Vec<i64>, bool, i64) {
 /// Le o Vec<i64> de handles de Promise.
 fn collect_promise_handles(vec_handle: u64) -> Vec<u64> {
     with_entry(vec_handle, |entry| match entry {
-        Some(Entry::Vec(v)) => v.iter().map(|x| *x as u64).collect(),
+        Some(Entry::Vec(v)) => v.iter().map(|x| element_to_handle(*x as u64)).collect(),
         _ => Vec::new(),
     })
+}
+
+/// Normalize ONE collection element to a real promise handle, accepting every
+/// convention that reaches a `Promise.all/race/any/allSettled` array:
+/// - a NaN-boxed `TAG_OBJECT` PolyValue word (the new-engine array element for
+///   a promise OBJECT) → its real handle;
+/// - a NaN-boxed INT32 / an inline-f64 NUMBER word (a promise handle riding the
+///   `promise.*` i64 surface, stored into the array as a plain number) → the
+///   integer it encodes;
+/// - anything else (a raw handle from the low-level `collections.vec` path) →
+///   verbatim. An element that is not actually a promise still becomes a `None`
+///   slot downstream (the per-op invalid-element path), same as before.
+fn element_to_handle(w: u64) -> u64 {
+    if let Some(h) = rts_engine::heap::poly::poly_handle_normalize(w) {
+        return h;
+    }
+    const BOX_BASE: u64 = 0xFFF8_0000_0000_0000;
+    if (w & BOX_BASE) == BOX_BASE {
+        // Boxed non-handle: an INT32 payload is the handle-as-number form; any
+        // other tag (singleton/…) is not a promise — 0 keeps the invalid path.
+        let tag = (w >> 48) & 0x7;
+        if tag == 1 {
+            return (w & 0xFFFF_FFFF) as u32 as u64;
+        }
+        return 0;
+    }
+    // An inline f64 word encoding a non-negative integer (a handle > 2^31 —
+    // generation bits — stored as a plain number): decode it. A RAW handle's
+    // bit-pattern reads as a denormal/fractional f64 and falls through verbatim.
+    let as_f = f64::from_bits(w);
+    if as_f.is_finite() && as_f >= 1.0 && as_f.fract() == 0.0 && as_f < (1u64 << 53) as f64 {
+        return as_f as u64;
+    }
+    w
 }
 
 /// Clone os Arc<PromiseSlot> de cada handle. Handle invalido vira None
@@ -123,39 +197,6 @@ fn collect_slots(
             })
         })
         .collect()
-}
-
-/// Variante de invoke_callback que recebe args ja' empacotados (sem extra).
-unsafe fn invoke_callback_full(fn_ptr: u64, args: &[i64]) -> i64 {
-    use std::mem::transmute;
-    unsafe {
-        match args.len() {
-            0 => transmute::<u64, extern "C" fn() -> i64>(fn_ptr)(),
-            1 => transmute::<u64, extern "C" fn(i64) -> i64>(fn_ptr)(args[0]),
-            2 => transmute::<u64, extern "C" fn(i64, i64) -> i64>(fn_ptr)(args[0], args[1]),
-            3 => transmute::<u64, extern "C" fn(i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2],
-            ),
-            4 => transmute::<u64, extern "C" fn(i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3],
-            ),
-            5 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4],
-            ),
-            6 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4], args[5],
-            ),
-            7 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64, i64) -> i64>(fn_ptr)(
-                args[0], args[1], args[2], args[3], args[4], args[5], args[6],
-            ),
-            8 => transmute::<u64, extern "C" fn(i64, i64, i64, i64, i64, i64, i64, i64) -> i64>(
-                fn_ptr,
-            )(
-                args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
-            ),
-            _ => 0,
-        }
-    }
 }
 
 /// Le o conteudo de um Vec<i64> handle (ou retorna vazio se nao for Vec).
@@ -225,9 +266,53 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_STATE(promise: U64) -> I64 {
     with_slot(promise, -1, |slot| promise_slot::current_state(slot) as i64)
 }
 
-/// Bloqueia thread chamadora ate Promise settle e retorna o valor. Se rejected, retorna o erro com bit alto setado (F5 vai tratar isso pra integrar try/catch). 0 se handle invalido.
+/// Bloqueia thread chamadora ate Promise settle e retorna o valor NORMALIZADO
+/// para a superfície i64 (`promise.wait` do TS): uma WORD PolyValue settled por
+/// um produtor do motor novo decodifica para o inteiro/handle que representa
+/// (um número imprime como número, não como os bits). O `await` do motor NÃO
+/// passa por aqui — usa [`wait_raw`] (verbatim) e reboxa a word ele mesmo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_PROMISE_WAIT(promise: U64) -> I64 {
+    normalize_settled_i64(wait_raw(promise))
+}
+
+/// Normaliza um valor settled cru para a superfície i64: word `TAG_*`-handle →
+/// handle real; word INT32 → o inteiro; word SINGLETON (undefined/null) → 0;
+/// word f64 inteira → o inteiro; qualquer outra forma passa VERBATIM — em
+/// particular um i64 cru NEGATIVO legado, cujos bits caem no quadrante do
+/// NaN-box (tag 7) e NÃO podem ser tratados como word (`Promise.resolve(-42)`
+/// zerava sem esta distinção).
+fn normalize_settled_i64(raw: i64) -> i64 {
+    let w = raw as u64;
+    if let Some(h) = rts_engine::heap::poly::poly_handle_normalize(w) {
+        return h as i64;
+    }
+    const BOX_BASE: u64 = 0xFFF8_0000_0000_0000;
+    if (w & BOX_BASE) == BOX_BASE {
+        let tag = (w >> 48) & 0x7;
+        if tag == 1 {
+            return (w & 0xFFFF_FFFF) as u32 as i32 as i64;
+        }
+        if tag == 2 {
+            // singleton (undefined/null) — a superfície i64 lê 0.
+            return 0;
+        }
+        // tag 3/5 já saíram pelo poly_handle_normalize; o resto do quadrante é
+        // um i64 cru NEGATIVO legado — verbatim.
+        return raw;
+    }
+    let f = f64::from_bits(w);
+    if f.is_finite() && f.fract() == 0.0 && f.abs() >= 1.0 && f.abs() < 9.007e15 {
+        return f as i64;
+    }
+    raw
+}
+
+/// O valor settled VERBATIM (a word do motor novo OU o i64 cru legado), com o
+/// mesmo bombeio de event-loop do `WAIT` público. Consumido pelo `await` do
+/// motor (`__rtsadp_await`), que faz o próprio rebox — normalizar aqui
+/// arredondaria um double fracionário.
+pub fn wait_raw(promise: u64) -> i64 {
     // Clona o Arc fora do `with_entry` pra liberar o lock do shard
     // antes de bloquear em wait_blocking (que pode esperar minutos).
     // Sem isso, qualquer outra op no mesmo shard fica bloqueada.
@@ -314,8 +399,11 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_THEN(p_handle: U64, fp: U64) -> Handle {
     let result_clone = result.clone();
     let result_handle = alloc_entry(Entry::PromiseAsync(result));
 
-    // Resolve handle Function -> fn_ptr + bound args (ou usa fp como ptr direto).
-    let (fn_ptr, bound, _has_this, _this) = resolve_callback_ptr(fp);
+    // Um fn VALUE do motor novo (word/handle Entry::Function) fica VERBATIM como
+    // callable — o invocador (`invoke_callable_auto`) aplica env/bound/kinds via
+    // INVOKE_AUTO; decompor em fn_ptr+bound aqui perdia o env do uniform-thunk
+    // (callback recebia o valor no slot errado). Um fp cru mantém a decomposição.
+    let (fn_ptr, bound) = callable_or_decomposed(fp);
 
     // (cross-runtime #56/#285) Fast-path: se a Promise ja' esta settled,
     // enfileira no microtask queue em vez de spawn_blocking. Isso preserva
@@ -365,7 +453,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CATCH(p_handle: U64, fp: U64) -> Handle {
     let result_clone = result.clone();
     let result_handle = alloc_entry(Entry::PromiseAsync(result));
 
-    let (fn_ptr, bound, _h, _t) = resolve_callback_ptr(fp);
+    let (fn_ptr, bound) = callable_or_decomposed(fp);
     // (#207) Determinista via microtask queue (igual ao .then). is_catch=true:
     // o callback so' roda no rejected; fulfilled propaga o valor.
     crate::globals::text_encoding::instance::enqueue_microtask_pending_then(
@@ -392,7 +480,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_FINALLY(p_handle: U64, fp: U64) -> Handle 
     let result_clone = result.clone();
     let result_handle = alloc_entry(Entry::PromiseAsync(result));
 
-    let (fn_ptr, _bound, _h, _t) = resolve_callback_ptr(fp);
+    let (fn_ptr, _bound) = callable_or_decomposed(fp);
     // (#207) Determinista via microtask queue (igual ao .then/.catch).
     crate::globals::text_encoding::instance::enqueue_microtask_pending_finally(
         arc,
@@ -437,7 +525,9 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_ALL(promises: U64) -> Handle {
                 promise_slot::reject(&result, value);
                 return result_handle;
             }
-            values.push(value);
+            // Normaliza para a superfície i64 do Vec de resultados (uma WORD
+            // de produtor novo-motor decodifica; cru legado passa verbatim).
+            values.push(normalize_settled_i64(value));
         }
         let result_vec = alloc_entry(Entry::Vec(Box::new(values)));
         promise_slot::resolve(&result, result_vec as i64);
@@ -462,7 +552,9 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_ALL(promises: U64) -> Handle {
                 promise_slot::reject(&result_clone, value);
                 return;
             }
-            values.push(value);
+            // Normaliza para a superfície i64 do Vec de resultados (uma WORD
+            // de produtor novo-motor decodifica; cru legado passa verbatim).
+            values.push(normalize_settled_i64(value));
         }
         // Todos resolveram — empacota num Vec novo.
         let result_vec = alloc_entry(Entry::Vec(Box::new(values)));
@@ -596,7 +688,33 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CREATE(fn_handle: U64, args_vec_handle: U6
     let result_clone = result.clone();
     let handle = alloc_entry(Entry::PromiseAsync(result));
 
-    let (fn_ptr, bound, _h, _t) = resolve_callback_ptr(fn_handle);
+    create_spawn(fn_handle, args_vec_handle, result_clone, handle, None)
+}
+
+/// O spawn de `promise.create`, com um `boxer` OPCIONAL aplicado ao valor de
+/// RESOLVE: o async-spawn do MOTOR NOVO (`__rtsadp_promise_spawn`) instala um
+/// boxer que converte o retorno cru do invoke na WORD PolyValue correta (um
+/// i64 NEGATIVO cru colide com o quadrante NaN-box — só o produtor sabe a
+/// convenção). Rejeições (ambos os slots de erro) idênticas nos dois modos.
+pub fn create_spawn_boxed(
+    fn_handle: u64,
+    args_vec_handle: u64,
+    boxer: extern "C" fn(u64, i64) -> i64,
+) -> u64 {
+    let result = promise_slot::new_pending();
+    let result_clone = result.clone();
+    let handle = alloc_entry(Entry::PromiseAsync(result));
+    create_spawn(fn_handle, args_vec_handle, result_clone, handle, Some(boxer))
+}
+
+fn create_spawn(
+    fn_handle: u64,
+    args_vec_handle: u64,
+    result_clone: std::sync::Arc<rts_engine::heap::handles::PromiseSlot>,
+    handle: u64,
+    boxer: Option<extern "C" fn(u64, i64) -> i64>,
+) -> u64 {
+    let (fn_ptr, bound) = callable_or_decomposed(fn_handle);
     if fn_ptr == 0 {
         // fn invalida — Promise rejeitada com 0.
         promise_slot::reject(&result_clone, 0);
@@ -614,14 +732,23 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CREATE(fn_handle: U64, args_vec_handle: U6
         // Combina bound (de bind) + extra_args do caller.
         let mut all: Vec<i64> = bound;
         all.extend(extra_args);
-        // Tudo ja' empacotado em `all`, invocamos diretamente.
-        let r = unsafe { invoke_callback_full(fn_ptr, &all) };
-        // Checa error slot pra detectar throw dentro do body.
+        // Ponte de convenção: um fn VALUE (handle) invoca via INVOKE_AUTO
+        // (env/kinds do uniform-thunk); um fn_ptr cru mantém o transmute i64.
+        let r = rts_primitives::function::ops::invoke_callable_auto(fn_ptr, &all);
+        // Checa AMBOS os slots de erro pra detectar throw dentro do body: o
+        // handle-slot legado E o errslot do motor novo (via hook — um `throw`
+        // novo-motor grava a WORD lançada lá, não aqui).
         let err = crate::gc_surface::__RTS_FN_RT_ERROR_GET();
         if err != 0 {
             crate::gc_surface::__RTS_FN_RT_ERROR_CLEAR();
             promise_slot::reject(&result_clone, err as i64);
+        } else if let Some(word) = take_engine_pending_error() {
+            promise_slot::reject(&result_clone, word as i64);
         } else {
+            let r = match boxer {
+                Some(b) => b(fn_ptr, r),
+                None => r,
+            };
             promise_slot::resolve(&result_clone, r);
         }
         PENDING_PROMISE_TASKS.fetch_sub(1, Ordering::AcqRel);


### PR DESCRIPTION
## O que

**Async REAL no motor novo (o corte de #207/#437)** + `var` hoisting (#301 fase 1) + aliases node:crypto:

1. **Spawn no call-site** (`front/run/asyncspawn.rs` novo): `f(args)` de uma fn `async` não roda mais inline (o interim síncrono) — empacota os args num Vec cru e chama `promise.create(func_addr, vec)` (tokio spawn_blocking), retornando a Promise pending como número-handle que `await`/`promise.*`/combinators já desembrulham. `Promise.all([f(..), g(..)])` roda em PARALELO de verdade. Params f64 bailam honesto (o trampolim de invoke é i64 — família do #206).
2. **Hook de erro errslot→watcher**: o `throw` do motor novo grava a WORD no errslot dos adapters; o watcher de `promise.create` lia só o slot-handle legado → um throw em async fn RESOLVIA com sentinela. Agora consulta ambos (`set_async_error_hook`, instalado no bootstrap JIT + `__rtsadp_engine_bootstrap` p/ AOT). Rejeições fluem para catch/combinators.
3. **Pontes de convenção word↔i64** (o seam mixed-boundary):
   - `invoke_callable_auto` (rts-primitives): callable word/handle → INVOke_AUTO (env/kinds de uniform-thunk); ptr cru → registry. Usado por promise.create + drain de microtasks.
   - `element_to_handle`: `Promise.all/race/any/allSettled` aceitam elementos em TODAS as formas vivas (word TAG_OBJECT, INT32-word, f64-word-inteira, handle cru).
   - `normalize_settled_i64`: `promise.wait` público decodifica words para a superfície i64; o `await` usa `wait_raw` (verbatim) + rebox próprio — um double fracionário não arredonda.
4. **`var` hoisting (#301 fase 1)** (`front/run/varhoist.rs` novo): coleta `var`s nos statements swc crus (recursão em blocos/loops/try/switch, nunca em fn/arrow/class aninhados) e predeclara no topo do corpo — o `var x = init` real vira re-`let` flat (o modelo de slot já era function-scoped).
5. **Aliases node:crypto**: `createHash`/`hashUpdate`/`hashDigestHex`/`hashDigestBase64` como aliases dos membros `hash_*` (o lookup já era alias-aware).
6. Dead code removido: `invoke_callback_full` (substituído pela ponte).

## Resultado

- **+6 arquivos verdes**: promise_all_parallel (paralelismo real confirmado por timing!), promise_static_methods, promise_rejection_combinators, throw_unhandled_runtime*, promise_basic*, var_hoisting (*já verdes antes, revalidados)
- crypto_streaming_hash: 6/7 subtestes (o sentinela length=-1 de alg inválido segue aberto)
- Parqueados com nota: promise_microtask_order (marshal U64 de callback passa addr cru — mesma seam do new Function, task dedicada), let_const_var (block-scoping de `let`)
- Unit tests do motor: mesmas 16 falhas pré-existentes (verificado) — zero regressão nova
- Suite completa: ver comentário do PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
