### PR TITLE
feat: thread.spawn f64 tipado + block scoping de let + interop shape/map + Tagged new-return (+4 arquivos)

### DIFF
--- a/crates/rts-adapters/src/value/errslot.rs
+++ b/crates/rts-adapters/src/value/errslot.rs
@@ -98,6 +98,14 @@ pub fn install_async_error_hook() {
         __rtsadp_err_pending,
         __rtsadp_err_take,
     );
+    // The SHAPED-OBJECT bridge for the low-level `collections.map_*` surface
+    // (#264): a fn-ctor's `this` (a shape-vec instance) reaching `map_get`/
+    // `map_set` routes through the shape-aware obj_get/obj_set instead of a
+    // silent no-op. Same dynamic-hook pattern (dep direction).
+    rts_runtime::namespaces::collections::map::set_shaped_object_hook(
+        super::objops::shaped_object_get,
+        super::objops::shaped_object_set,
+    );
 }
 
 /// AOT bootstrap entry: the generated `main` shim calls this right after

--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -279,6 +279,28 @@ extern "C" fn box_async_result(fn_ptr: u64, raw: i64) -> i64 {
     w as i64
 }
 
+/// `__rtsadp_register_fn_abi(fn_addr, kinds_packed, meta)` — register a user
+/// fn's packed ABI (param kinds + return kind) in the FN_KINDS registry, so any
+/// RAW-pointer consumer that invokes through the registry path
+/// (`invoke_fn_ptr_with_registry` — `thread.spawn`, dynamic HOFs, the async
+/// spawn) reads f64 params/returns through the right registers. Emitted by
+/// `getPointer(f)` when `f` carries an f64 in its signature (#247).
+/// `meta`: bits 0..7 = return kind, bits 8..15 = argc.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_register_fn_abi(fn_addr: u64, kinds_packed: u64, meta: u64) {
+    let argc = ((meta >> 8) & 0xFF) as usize;
+    let ret_kind = (meta & 0xFF) as i32;
+    let kinds: Vec<u8> = (0..argc)
+        .map(|i| ((kinds_packed >> (8 * i)) & 0xFF) as u8)
+        .collect();
+    rts_runtime::namespaces::globals::function::ops::__RTS_FN_RT_REGISTER_FN_KINDS(
+        fn_addr,
+        kinds.as_ptr() as i64,
+        kinds.len() as i64,
+        ret_kind,
+    );
+}
+
 /// `__rtsadp_promise_spawn(fn_addr, args_vec, kinds_packed, meta)` — the ASYNC
 /// function CALL spawn (see `front/run/asyncspawn.rs`). Registers the callee's
 /// packed ABI (one kind byte per param — 0 = i64-class, 1 = f64-bits, 2 = bool)

--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -1,4 +1,4 @@
-//! Codegen-owned DYNAMIC property-access trampolines (P5.5).
+﻿//! Codegen-owned DYNAMIC property-access trampolines (P5.5).
 //!
 //! P3.6 / P5.4 do `obj.key` only when the object's SHAPE is statically proven in
 //! the lowering ctx (an object literal / typed local), resolving the slot index at
@@ -258,6 +258,53 @@ pub extern "C" fn __rtsadp_obj_get(obj_word: u64, key_str_handle: u64) -> u64 {
 /// slot — so `obj[k] = v` for an absent `k` works generically (`JSON.parse`, any
 /// dynamic property add). A non-object receiver is a no-op. (`Object` is a
 /// PRIMORDIAL → property addition is engine-direct.)
+/// SHAPED-OBJECT bridge for the LOW-LEVEL `collections.map_get` surface
+/// (#264): a fn-ctor writing `collections.map_set(this, k, v)` receives the
+/// new-engine shape-vec instance, not an `Entry::Map`. The map namespace
+/// routes a non-Map `Entry::Vec` handle here (hook installed at bootstrap);
+/// the read goes through the SAME shape-aware `obj_get` any property read
+/// uses, and the result is normalized to the raw-i64 map surface.
+pub extern "C" fn shaped_object_get(h: u64, key_ptr: *const u8, key_len: i64) -> i64 {
+    use rts_runtime::namespaces::gc::handles as rt_handles;
+    let Some(key) = (unsafe { rts_engine::abi::str_abi::from_abi(key_ptr, key_len) }) else {
+        return 0;
+    };
+    let word = PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h)).raw();
+    let kh = rts_runtime::namespaces::collector::string_pool::__RTS_FN_NS_GC_STRING_NEW(key.as_ptr(), key.len() as i64);
+    let kw = PolyValue::from_str_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(kh)).raw();
+    let out = PolyValue::from_raw(__rtsadp_obj_get(word, kw));
+    // Normalize to the i64 surface: INT32 → the int; a heap value → its real
+    // handle; a double → truncated; undefined/absent → 0.
+    if out.is_int32() {
+        return out.as_i32() as i64;
+    }
+    if let Some(hh) = rts_engine::heap::poly::poly_handle_normalize(out.raw()) {
+        return hh as i64;
+    }
+    if out.is_double() {
+        return out.as_f64() as i64;
+    }
+    0
+}
+
+/// SHAPED-OBJECT write bridge (see [`shaped_object_get`]): boxes the raw-i64
+/// value as a number word and routes through the shape-aware `obj_set`
+/// (existing-slot write or append-with-transition).
+pub extern "C" fn shaped_object_set(h: u64, key_ptr: *const u8, key_len: i64, value: i64) {
+    use rts_runtime::namespaces::gc::handles as rt_handles;
+    let Some(key) = (unsafe { rts_engine::abi::str_abi::from_abi(key_ptr, key_len) }) else {
+        return;
+    };
+    let word = PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h)).raw();
+    let kh = rts_runtime::namespaces::collector::string_pool::__RTS_FN_NS_GC_STRING_NEW(key.as_ptr(), key.len() as i64);
+    let kw = PolyValue::from_str_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(kh)).raw();
+    let vw = match i32::try_from(value) {
+        Ok(i) => PolyValue::from_i32(i),
+        Err(_) => PolyValue::from_f64(value as f64),
+    };
+    __rtsadp_obj_set(word, kw, vw.raw());
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_obj_set(obj_word: u64, key_str_handle: u64, val_word: u64) -> u64 {
     // PROXY (#218): a proxy receiver routes through its `set` trap.

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -186,6 +186,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             "__rtsadp_promise_spawn",
             funcops::__rtsadp_promise_spawn as *const u8,
         ),
+        sym(
+            "__rtsadp_register_fn_abi",
+            funcops::__rtsadp_register_fn_abi as *const u8,
+        ),
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym("__rtsadp_fn_reify_this", funcops::__rtsadp_fn_reify_this as *const u8),
         sym("__rtsadp_fn_invoke_method", funcops::__rtsadp_fn_invoke_method as *const u8),

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -539,6 +539,38 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         let fref = module.declare_func_in_func(fid, self.builder.func);
         let addr = self.builder.ins().func_addr(types::I64, fref);
+        // When the target's signature carries an f64 anywhere, register its
+        // packed ABI (FN_KINDS) so RAW-pointer consumers (`thread.spawn`,
+        // dynamic HOFs) invoke through the typed path — an f64 param reads its
+        // BITS back into xmm instead of the raw-i64 misload (#247).
+        if let Some(sig) = self.sigs.get(fname) {
+            let has_f64 = sig.params.iter().any(|&p| matches!(p, Repr::Float64))
+                || matches!(sig.ret, Some(Repr::Float64));
+            if has_f64 && sig.params.len() <= 8 {
+                let mut kinds_packed: u64 = 0;
+                for (i, &repr) in sig.params.iter().enumerate() {
+                    let k: u64 = match repr {
+                        Repr::Float64 => 1,
+                        Repr::Bool => 2,
+                        _ => 0,
+                    };
+                    kinds_packed |= k << (8 * i);
+                }
+                let ret_kind: u64 = match sig.ret {
+                    Some(Repr::Float64) => 1,
+                    Some(Repr::Bool) => 2,
+                    _ => 0,
+                };
+                let meta = ((sig.params.len() as u64) << 8) | ret_kind;
+                let kinds_word = self.builder.ins().iconst(types::I64, kinds_packed as i64);
+                let meta_word = self.builder.ins().iconst(types::I64, meta as i64);
+                self.call_runtime(
+                    module,
+                    "__rtsadp_register_fn_abi",
+                    &[addr, kinds_word, meta_word],
+                )?;
+            }
+        }
         Ok(Some(Val::new(addr, Repr::Int64)))
     }
 

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -465,11 +465,15 @@ fn build_from_program(
     for item in &program.items {
         if let rts_ast::ast::Item::Function(fdecl) = item {
             // `var` HOISTING (#301): predeclare every `var`-kind name at the
-            // top of the fn body (JS function scope) — the real `var x = init`
-            // later is a flat re-`let` (same slot). See `varhoist`.
+            // top of the fn body (JS function scope); the in-body `var x = init`
+            // decls are rewritten to plain ASSIGNMENTS of the hoisted binding
+            // (so one inside an explicit `{ }` block escapes the lexical
+            // save/restore — the `var` semantic). See `varhoist`.
             let hoists = varhoist::hoisted_var_lets(&fdecl.body);
             let mut f = rts_hir::lower::lower_func(fdecl, &mut scope);
             if !hoists.is_empty() {
+                let names = varhoist::hoisted_var_names(&fdecl.body);
+                varhoist::rewrite_var_decls_to_assigns(&mut f.body, &names);
                 f.body.splice(0..0, hoists);
             }
             funcs.push(f);
@@ -492,11 +496,13 @@ fn build_from_program(
         }
     }
     // `var` HOISTING (#301) at MODULE scope: a top-level `var z` predeclares
-    // at the head of main so a read before its line resolves (same flat-slot
-    // model as the fn-body hoist above).
+    // at the head of main so a read before its line resolves; in-body decls
+    // become assignments (see the fn-body hoist above).
     let top_var_hoists = varhoist::hoisted_var_lets(&top_stmts);
     let mut body = rts_hir::lower::lower_stmts(&top_stmts, &mut scope);
     if !top_var_hoists.is_empty() {
+        let names = varhoist::hoisted_var_names(&top_stmts);
+        varhoist::rewrite_var_decls_to_assigns(&mut body, &names);
         body.splice(0..0, top_var_hoists);
     }
 

--- a/crates/rts-codegen-new/src/front/run/registry_call.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_call.rs
@@ -103,7 +103,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 // `U64` params — e.g. `vec_len(await Promise.all(v))`), a number its
                 // truncation. The blind Tagged→Int saturating convert read garbage
                 // from an OBJECT word.
-                let i = if matches!(val.repr, Repr::Tagged)
+                let i = if matches!(ty, AbiType::U64) && matches!(val.repr, Repr::Float64) {
+                    // An f64 arg into an OPAQUE `U64` slot rides as its BITS —
+                    // the historical `thread.spawn(fp, 3.14)` convention (#247):
+                    // the typed invoke reads the bits back via the FN_KINDS
+                    // registry. Truncating (fcvt) here destroyed the fraction
+                    // before the worker ever ran.
+                    self.builder.ins().bitcast(
+                        types::I64,
+                        cranelift_codegen::ir::MemFlags::new(),
+                        val.v,
+                    )
+                } else if matches!(val.repr, Repr::Tagged)
                     && !matches!(val.kind, JsKind::Number)
                 {
                     let w = self.box_value(val);

--- a/crates/rts-codegen-new/src/front/run/sig.rs
+++ b/crates/rts-codegen-new/src/front/run/sig.rs
@@ -210,6 +210,15 @@ impl FnSig {
         if ret != Repr::Tagged && any_return_is_function(func) {
             ret = Repr::Tagged;
         }
+        // A `return new C(..)` yields a HEAP INSTANCE word: a numeric-declared
+        // ret would coerce it through the f64/int decode (NaN→garbage; and a
+        // handle does NOT survive an f64 slot — generations push it past 2^53).
+        // Ride `Tagged` — the honest word — and let the CALLER decide (a
+        // `collections.*`-style U64 consumer gets the real handle via
+        // `word_to_abi_i64`; property/method access keeps the object word).
+        if ret != Repr::Tagged && any_return_is_new(func) {
+            ret = Repr::Tagged;
+        }
         // A desugared eager GENERATOR returns the `__gen_buf` ARRAY word (a `Tagged`
         // PolyValue), but the parser stamps its declared return type `i64` (→ would
         // force `Int64`). Coercing the array word to `Int64` corrupts it (`g()` then
@@ -327,6 +336,34 @@ fn any_return_is_function(func: &HirFunc) -> bool {
     found
 }
 
+/// Whether any `return e` in `func` returns a `new C(..)` HEAP INSTANCE — such
+/// a fn rides a `Tagged` return (see `of_func`; a numeric slot corrupts the
+/// word/handle). Mirrors [`any_return_is_function`]'s walk.
+fn any_return_is_new(func: &HirFunc) -> bool {
+    fn walk(stmts: &[HirStmt], found: &mut bool) {
+        for s in stmts {
+            match s {
+                HirStmt::Return(Some(e)) => {
+                    if matches!(e.kind, rts_hir::ir::HirExprKind::New { .. }) {
+                        *found = true;
+                    }
+                }
+                HirStmt::If { then, else_, .. } => {
+                    walk(then, found);
+                    if let Some(el) = else_ {
+                        walk(el, found);
+                    }
+                }
+                HirStmt::While { body, .. } | HirStmt::Block(body) => walk(body, found),
+                _ => {}
+            }
+        }
+    }
+    let mut found = false;
+    walk(&func.body, &mut found);
+    found
+}
+
 /// Walk the lowering-subset statements; set `any` if any `return e` is seen and
 /// clear `all_float` unless every `return e` is a provable Float64 expression.
 fn walk_returns(stmts: &[HirStmt], any: &mut bool, all_float: &mut bool) {
@@ -334,7 +371,12 @@ fn walk_returns(stmts: &[HirStmt], any: &mut bool, all_float: &mut bool) {
         match s {
             HirStmt::Return(Some(e)) => {
                 *any = true;
-                if repr_of(&e.ty) != Repr::Float64 {
+                // A `new C(..)` yields a HEAP INSTANCE whatever the (unreliable)
+                // inferred expression type says — it must never trigger the
+                // Float64 override (`function make(): number { return new (F as
+                // any)(); }` returned f64 and NaN-canonicalized the object word).
+                let is_new = matches!(e.kind, rts_hir::ir::HirExprKind::New { .. });
+                if is_new || repr_of(&e.ty) != Repr::Float64 {
                     *all_float = false;
                 }
             }

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -70,7 +70,34 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.pending_label = None;
                 Ok(())
             }
-            HirStmt::Block(stmts) => self.lower_block(module, stmts),
+            // An EXPLICIT `{ … }` block is a LEXICAL SCOPE: a `let`/`const`
+            // declared inside must not leak (JS block scoping) — save the
+            // name-keyed binding maps, lower, restore. An inner `let a` gets a
+            // FRESH Variable (see `fresh_local_var`), so the outer `a` keeps its
+            // register AND its map entry after the block. Reassignments to
+            // OUTER names persist (they `def_var` the outer Variable — the map
+            // entry itself is untouched). `var` declarations were rewritten to
+            // plain assignments by the hoist pass, so they escape correctly.
+            HirStmt::Block(stmts) => {
+                let saved_locals = self.locals.clone();
+                let saved_shapes = self.local_shapes.clone();
+                let saved_obj = self.object_locals.clone();
+                let saved_str = self.string_locals.clone();
+                let saved_classes = self.local_classes.clone();
+                let saved_class_refs = self.local_class_refs.clone();
+                let saved_gen = self.generator_locals.clone();
+                let saved_glob = self.global_instance_classes.clone();
+                let r = self.lower_block(module, stmts);
+                self.locals = saved_locals;
+                self.local_shapes = saved_shapes;
+                self.object_locals = saved_obj;
+                self.string_locals = saved_str;
+                self.local_classes = saved_classes;
+                self.local_class_refs = saved_class_refs;
+                self.generator_locals = saved_gen;
+                self.global_instance_classes = saved_glob;
+                r
+            }
             HirStmt::Throw(arg) => self.lower_throw(module, arg),
             HirStmt::Try {
                 body,
@@ -111,7 +138,31 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     return Ok(());
                 }
                 let v = self.lower_expr(module, e)?;
-                Some(self.coerce(v, ret)?)
+                // A PROVEN HEAP value returned through an `Int*`-declared fn
+                // (`function make(): number { return new (F as any)(); }` — the
+                // handle-as-number interop surface): the numeric decode would
+                // read the OBJECT word as NaN→0. Route through the
+                // tag-dispatched `__rtsadp_word_to_abi_i64` (heap → real handle
+                // id, number → truncation) — the same rule the registry marshal
+                // applies to a U64 param. Numeric kinds keep the pure-IR path.
+                if matches!(ret, Repr::Int32 | Repr::Int64)
+                    && matches!(v.repr, Repr::Tagged)
+                    && matches!(
+                        v.kind,
+                        super::lower::JsKind::Object
+                            | super::lower::JsKind::Array
+                            | super::lower::JsKind::Str
+                            | super::lower::JsKind::Function
+                    )
+                {
+                    let w = self.box_value(v);
+                    let h = self
+                        .call_runtime(module, "__rtsadp_word_to_abi_i64", &[w])?
+                        .expect("__rtsadp_word_to_abi_i64 returns a value");
+                    Some(h)
+                } else {
+                    Some(self.coerce(v, ret)?)
+                }
             }
         };
 

--- a/crates/rts-codegen-new/src/front/run/varhoist.rs
+++ b/crates/rts-codegen-new/src/front/run/varhoist.rs
@@ -18,6 +18,8 @@
 //! `var x: i64` prints `0` pre-init, the documented #301 proxy for undefined),
 //! `undefined` otherwise.
 
+use std::collections::HashSet;
+
 use rts_ast::ast::Statement;
 use rts_hir::ir::{HirExprKind, HirLit, HirStmt};
 use rts_hir::{HirExpr, HirType};
@@ -63,6 +65,98 @@ pub(crate) fn hoisted_var_lets(body: &[Statement]) -> Vec<HirStmt> {
             }
         })
         .collect()
+}
+
+/// The NAMES the hoist prologue predeclares for `body` (the set the in-body
+/// `var` declarations must be REWRITTEN against).
+pub(crate) fn hoisted_var_names(body: &[Statement]) -> HashSet<String> {
+    let mut names: Vec<(String, Option<String>)> = Vec::new();
+    let mut seen = HashSet::new();
+    for s in body {
+        let Statement::Raw(raw) = s;
+        if let Some(stmt) = &raw.stmt {
+            collect_stmt(stmt, &mut names, &mut seen);
+        }
+    }
+    seen
+}
+
+/// Rewrite every in-body `let <name> = init` whose `name` was HOISTED into a
+/// plain ASSIGNMENT (`name = init`; an initializer-less decl is dropped — the
+/// prologue already bound it). Without this, a `var v = 7` inside an explicit
+/// `{ }` block would bind a fresh BLOCK-scoped local that dies at the block
+/// exit (the lexical-scope save/restore), instead of assigning the hoisted
+/// function-scoped binding. Recurses through every statement body (never into
+/// nested fn/arrow bodies — those are separate HirFuncs).
+pub(crate) fn rewrite_var_decls_to_assigns(stmts: &mut Vec<HirStmt>, hoisted: &HashSet<String>) {
+    for s in stmts.iter_mut() {
+        rewrite_stmt(s, hoisted);
+    }
+}
+
+fn rewrite_stmt(s: &mut HirStmt, hoisted: &HashSet<String>) {
+    match s {
+        HirStmt::Let { name, init, .. } if hoisted.contains(name.as_str()) => {
+            let assign = match init.take() {
+                Some(v) => HirStmt::Expr(HirExpr::new(
+                    HirExprKind::Assign {
+                        target: Box::new(HirExpr::new(
+                            HirExprKind::Ident(name.clone()),
+                            HirType::Unknown,
+                        )),
+                        value: Box::new(v),
+                    },
+                    HirType::Unknown,
+                )),
+                // `var x;` with no init — the prologue already bound it; the
+                // statement becomes a no-op expression.
+                None => HirStmt::Expr(HirExpr::new(
+                    HirExprKind::Lit(HirLit::Undefined),
+                    HirType::Unknown,
+                )),
+            };
+            *s = assign;
+        }
+        HirStmt::If { then, else_, .. } => {
+            rewrite_var_decls_to_assigns(then, hoisted);
+            if let Some(el) = else_ {
+                rewrite_var_decls_to_assigns(el, hoisted);
+            }
+        }
+        HirStmt::While { body, .. } | HirStmt::DoWhile { body, .. } => {
+            rewrite_var_decls_to_assigns(body, hoisted)
+        }
+        HirStmt::For { init, body, .. } => {
+            if let Some(i) = init {
+                rewrite_stmt(i, hoisted);
+            }
+            rewrite_var_decls_to_assigns(body, hoisted);
+        }
+        HirStmt::ForOf { body, .. } | HirStmt::ForIn { body, .. } => {
+            rewrite_var_decls_to_assigns(body, hoisted)
+        }
+        HirStmt::Block(b) => rewrite_var_decls_to_assigns(b, hoisted),
+        HirStmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            rewrite_var_decls_to_assigns(body, hoisted);
+            if let Some(c) = catch {
+                rewrite_var_decls_to_assigns(&mut c.body, hoisted);
+            }
+            if let Some(f) = finally {
+                rewrite_var_decls_to_assigns(f, hoisted);
+            }
+        }
+        HirStmt::Switch { cases, .. } => {
+            for c in cases.iter_mut() {
+                rewrite_var_decls_to_assigns(&mut c.body, hoisted);
+            }
+        }
+        HirStmt::Labeled { body, .. } => rewrite_stmt(body, hoisted),
+        _ => {}
+    }
 }
 
 /// Collect `var`-kind declarator names (+ type annotation text) from `stmt`,

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -281,6 +281,12 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64, U64, U64],
             ret: U64,
         },
+        // Register a user fn's packed ABI for raw-pointer consumers
+        // (`getPointer` emission — thread.spawn f64 workers, #247).
+        "__rtsadp_register_fn_abi" => SymSig {
+            params: &[U64, U64, U64],
+            ret: Void,
+        },
 
         // ---- REAL collections Vec (rts-shared collections::vec) ----
         "__RTS_FN_NS_COLLECTIONS_VEC_NEW" => SymSig {

--- a/crates/rts-primitives/src/function/ops.rs
+++ b/crates/rts-primitives/src/function/ops.rs
@@ -1129,6 +1129,17 @@ fn fn_kinds_registry() -> &'static std::sync::RwLock<std::collections::HashMap<u
     FN_KINDS_REGISTRY.get_or_init(|| std::sync::RwLock::new(std::collections::HashMap::new()))
 }
 
+/// A ABI registrada (param_kinds, return_kind) de uma user fn pelo endereço —
+/// `None` quando o codegen não a registrou. Consumido pelos spawners de thread
+/// (`thread.spawn` invoca `fn(f64)` quando o worker declara `arg: number`).
+pub fn registered_fn_kinds(fn_ptr: u64) -> Option<(Vec<u8>, u8)> {
+    fn_kinds_registry()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&fn_ptr)
+        .cloned()
+}
+
 /// Registra a ABI (param_kinds + return_kind) de uma user fn pelo seu endereço.
 /// Emitido pelo codegen no início de `__RTS_MAIN` para cada fn address-taken.
 #[unsafe(no_mangle)]

--- a/crates/rts-shared/src/collections/map.rs
+++ b/crates/rts-shared/src/collections/map.rs
@@ -119,6 +119,38 @@ fn is_array_proto_member(key: &str) -> bool {
     )
 }
 
+/// HOOK shape-object (instalado pelo rts-adapters no bootstrap do motor): um
+/// handle que NÃO é `Entry::Map` mas um OBJETO shape-vec do motor novo (uma
+/// instância de classe/fn-ctor cujo `this` chega à superfície de baixo nível
+/// `collections.map_*(this, …)` — #264) roteia pelo get/set shape-aware dos
+/// adapters (obj_get / obj_set com transition) em vez de virar no-op/0.
+/// `(get, set)`. rts-shared não pode depender de rts-adapters (direção de
+/// deps), daí o registro dinâmico — o mesmo padrão do async-error hook.
+#[allow(clippy::type_complexity)]
+static SHAPED_OBJ_HOOK: std::sync::OnceLock<(
+    extern "C" fn(u64, *const u8, i64) -> i64,
+    extern "C" fn(u64, *const u8, i64, i64),
+)> = std::sync::OnceLock::new();
+
+/// Registra a ponte shape-object (chamado pelo rts-adapters no bootstrap).
+pub fn set_shaped_object_hook(
+    get: extern "C" fn(u64, *const u8, i64) -> i64,
+    set: extern "C" fn(u64, *const u8, i64, i64),
+) {
+    let _ = SHAPED_OBJ_HOOK.set((get, set));
+}
+
+/// Se `h` é um OBJETO shape-vec (Entry::Vec, não Map) e o hook está instalado,
+/// devolve a ponte; senão `None` (o caminho Map normal segue).
+fn shaped_object_route(h: u64) -> Option<(
+    extern "C" fn(u64, *const u8, i64) -> i64,
+    extern "C" fn(u64, *const u8, i64, i64),
+)> {
+    let hook = SHAPED_OBJ_HOOK.get()?;
+    let is_vec = with_entry(h, |e| matches!(e, Some(Entry::Vec(_))));
+    if is_vec { Some(*hook) } else { None }
+}
+
 /// Creates an empty HashMap<string, number> and returns its handle.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_NEW() -> Handle {
@@ -162,6 +194,10 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_GET(h: U64, key_ptr: *const u8, ke
     if let Some((target, handler)) = crate::globals::proxy::ops::resolve_proxy(h) {
         return crate::globals::proxy::ops::dispatch_get(target, handler, key);
     }
+    // (#264) Um OBJETO shape-vec do motor novo: leitura shape-aware via hook.
+    if let Some((get, _)) = shaped_object_route(h) {
+        return get(h, key_ptr, key_len);
+    }
     with_map(h, 0, |m| m.get(key).copied().unwrap_or(0))
 }
 
@@ -189,6 +225,11 @@ pub extern "C" fn __RTS_FN_NS_COLLECTIONS_MAP_SET(
     // (#218) Proxy: trap `set(target, prop, value)` ou forward.
     if let Some((target, handler)) = crate::globals::proxy::ops::resolve_proxy(h) {
         crate::globals::proxy::ops::dispatch_set(target, handler, key, value);
+        return;
+    }
+    // (#264) Um OBJETO shape-vec do motor novo: escrita shape-aware via hook.
+    if let Some((_, set)) = shaped_object_route(h) {
+        set(h, key_ptr, key_len, value);
         return;
     }
     // (#479 follow-up) frozen impede mutacao; sealed so' impede add de novas keys.

--- a/crates/rts-std/src/thread/mod.rs
+++ b/crates/rts-std/src/thread/mod.rs
@@ -141,14 +141,31 @@ fn next_join_id() -> u64 {
     N.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Invoke a worker `fn_ptr(arg)` honoring the registered FN_KINDS ABI: a
+/// worker declaring `arg: number` compiled with an f64 param (xmm) — the raw
+/// `fn(u64)` transmute misloads it (#247). When the codegen registered the
+/// kinds (via `getPointer`), the f64 form reads `arg`'s BITS back into the
+/// float register; otherwise the historical raw-i64 call is unchanged.
+fn invoke_worker(fn_ptr: u64, arg: u64) -> u64 {
+    let f64_param = rts_primitives::function::ops::registered_fn_kinds(fn_ptr)
+        .is_some_and(|(kinds, _)| kinds.first().copied() == Some(1));
+    if f64_param {
+        // SAFETY: codegen contract for a kinds-registered f64-param worker.
+        let f: extern "C" fn(f64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+        f(f64::from_bits(arg))
+    } else {
+        // SAFETY: codegen contract — `extern "C" fn(u64) -> u64`.
+        let f: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
+        f(arg)
+    }
+}
+
 /// Spawns an OS thread running `fn_ptr(arg)`. JoinHandle, 0 on null fn.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN(fn_ptr: U64, arg: U64) -> U64 {
     if fn_ptr == 0 {
         return 0;
     }
-    // SAFETY: codegen contract — `fn_ptr` is `extern "C" fn(u64) -> u64`.
-    let f: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
     // Snapshot the SPAWNING thread's module-global cells so the worker reads the same
     // `let`/`const` values (a JS module global is shared across a program's threads).
     // `GCELLS` is thread_local, so without this the worker reads every module-global
@@ -158,7 +175,7 @@ pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN(fn_ptr: U64, arg: U64) -> U64 {
     let jh = thread::spawn(move || {
         thread_registry::register_current();
         crate::collector::collector::gcell_restore(gcells);
-        let r = f(arg);
+        let r = invoke_worker(fn_ptr, arg);
         thread_registry::unregister_current();
         r
     });
@@ -176,9 +193,7 @@ pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN_ASYNC(fn_ptr: U64, arg: U64) {
     let gcells = crate::collector::collector::gcell_snapshot();
     crate::runtime::async_rt::handle().spawn_blocking(move || {
         crate::collector::collector::gcell_restore(gcells);
-        // SAFETY: codegen contract — `extern "C" fn(u64) -> u64`.
-        let f: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-        let _ = f(arg);
+        let _ = invoke_worker(fn_ptr, arg);
     });
 }
 
@@ -191,9 +206,7 @@ pub extern "C" fn __RTS_FN_NS_THREAD_SPAWN_ASYNC_JOIN(fn_ptr: U64, arg: U64) -> 
     let gcells = crate::collector::collector::gcell_snapshot();
     let jh = crate::runtime::async_rt::handle().spawn_blocking(move || {
         crate::collector::collector::gcell_restore(gcells);
-        // SAFETY: codegen contract — `extern "C" fn(u64) -> u64`.
-        let f: extern "C" fn(u64) -> u64 = unsafe { std::mem::transmute(fn_ptr as usize) };
-        f(arg)
+        invoke_worker(fn_ptr, arg)
     });
     let id = next_join_id();
     join_store()


### PR DESCRIPTION
## O que

Quatro correções do caminho polimórfico:

1. **`thread.spawn(fp, 3.14)` preserva f64 (#247)**: `getPointer` registra a ABI packed no FN_KINDS (`__rtsadp_register_fn_abi`); marshal U64 passa BITS para Float64 provado (bitcast); `invoke_worker` consulta kinds e chama `fn(f64)` — nunca o misload raw-i64 (#206-family).
2. **Block scoping real de `let`/`const`**: `HirStmt::Block` salva/restaura os mapas de binding (shadowing correto; reassign externo persiste). `varhoist` reescreve `var x = init` in-body para assignment do binding hoisted (var escapa de bloco — semântica correta).
3. **Interop map/shape (#264)**: hook shaped-object em `collections.map_get/set` — instância shape-vec roteia pelo obj_get/obj_set com transition em vez de no-op.
4. **`return new C(..)` monta Tagged** (`any_return_is_new`): ret numérico coergia a word por NaN→0, e um handle não sobrevive a slot f64 (gerações > 2^53). `lower_return` converte heap-value→handle real via `word_to_abi_i64` em fns declaradas Int* (superfície handle-como-número).

## Resultado

- **+4 arquivos**: thread_arg_f64, thread_arg_f64_edge, new_user_fn_in_conditional, let_const_var
- Suite: 609/623 na rodada pré-block-scoping; nova rodada em curso
- Unit tests: **812 passed / mesmas 16 falhas pré-existentes** — zero regressão
- Smokes de blocos aninhados verdes (array_method_arrow_in_nested_block 4/4, destructuring_in_nested_block 4/4, object_freeze_blocks 2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
