### PR TITLE
feat(codegen/runtime): rest-fn indireto + [Symbol.toPrimitive] + sentinel handle-0 (613/623)

### DIFF
--- a/crates/rts-adapters/src/value/dyndispatch.rs
+++ b/crates/rts-adapters/src/value/dyndispatch.rs
@@ -115,6 +115,14 @@ pub extern "C" fn __rtsadp_dyn_length(recv: u64) -> u64 {
     use rts_runtime::namespaces::collections::vec as rt_vec;
     let v = PolyValue::from_raw(recv);
     if v.is_string() {
+        // An INVALID string handle (a runtime fn's error sentinel — e.g. digest
+        // over an unknown-algorithm hasher returns handle 0, never interned):
+        // `.length` reports the pool's own -1 sentinel. An EMPTY string is a
+        // LIVE pool entry, so `""` still reads 0 through the code-unit path.
+        let h = abi_adapter::real_handle_of(v);
+        if rts_runtime::namespaces::collector::string_pool::__RTS_FN_NS_GC_STRING_LEN(h) < 0 {
+            return PolyValue::from_i32(-1).raw();
+        }
         // JS `String.prototype.length` is the UTF-16 CODE-UNIT count, NOT the byte
         // length (`STRING_LEN` is bytes — they differ for any non-ASCII char). We
         // OWN this trampoline, so we read the real bytes and count code units

--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -279,6 +279,49 @@ extern "C" fn box_async_result(fn_ptr: u64, raw: i64) -> i64 {
     w as i64
 }
 
+/// `__rtsadp_invoke_auto_word(callee_word, this_word, args_vec)` — invoke a
+/// function VALUE word through the FULL `INVOKE_AUTO` machinery (bound args,
+/// param kinds, uniform-thunk env, VARIADIC tail packing — a `(...args)` rest
+/// callee gets its overflow packed into ONE array). The raw 6-slot
+/// `__rtsadp_fn_invoke` cannot pack (it carries no arg COUNT); call sites that
+/// know the exact argc (the singleton-override dispatch) route here with a
+/// counted args vec instead.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_invoke_auto_word(callee_word: u64, this_word: u64, args_vec: u64) -> u64 {
+    use rts_engine::heap::handles::{alloc_entry, with_entry, Entry as E};
+    let h = rts_engine::heap::poly::poly_handle_normalize(callee_word).unwrap_or(callee_word);
+    // A VARIADIC uniform-thunk callee (post-expand: the rest param is ONE array
+    // at `rest_param_idx`): pack the positional tail HERE — INVOKE_AUTO's
+    // uniform-thunk fast path passes the vec slots verbatim (no packing), so a
+    // `(...args)` override would read a bare first arg where its array goes.
+    let (uniform, rest_idx, has_this) = with_entry(h, |e| match e {
+        Some(E::Function(d)) => (d.uniform_thunk, d.rest_param_idx, d.has_this_param),
+        _ => (false, -1, false),
+    });
+    let mut vec_arg = args_vec;
+    if uniform && rest_idx >= 0 && !has_this {
+        let items: Vec<i64> = with_entry(args_vec, |e| match e {
+            Some(E::Vec(v)) => v.as_ref().clone(),
+            _ => Vec::new(),
+        });
+        let ri = (rest_idx as usize).min(items.len());
+        let tail: Vec<i64> = items[ri..].to_vec();
+        let arr_h = alloc_entry(E::Vec(Box::new(tail)));
+        let arr_word = PolyValue::from_object_handle(
+            rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(arr_h),
+        )
+        .raw() as i64;
+        let mut packed: Vec<i64> = items[..ri].to_vec();
+        packed.push(arr_word);
+        vec_arg = alloc_entry(E::Vec(Box::new(packed)));
+    }
+    rts_runtime::namespaces::globals::function::ops::__RTS_FN_RT_INVOKE_AUTO(
+        h as i64,
+        this_word as i64,
+        vec_arg,
+    ) as u64
+}
+
 /// `__rtsadp_register_fn_abi(fn_addr, kinds_packed, meta)` — register a user
 /// fn's packed ABI (param kinds + return kind) in the FN_KINDS registry, so any
 /// RAW-pointer consumer that invokes through the registry path
@@ -427,9 +470,14 @@ pub extern "C" fn __rtsadp_fn_invoke(
     // Reconstruct the full real handle (generation read from the live slot) from
     // the bare 48-bit payload, then read the stored thunk address AND env word.
     let real = rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(pv.as_handle());
-    let (addr, env, has_this) = with_entry(real, |e| match e {
-        Some(Entry::Function(d)) => (d.fn_ptr, d.bound_this as u64, d.has_this_param),
-        _ => (0, 0, false),
+    let (addr, env, has_this, rest_idx) = with_entry(real, |e| match e {
+        Some(Entry::Function(d)) => (
+            d.fn_ptr,
+            d.bound_this as u64,
+            d.has_this_param,
+            d.rest_param_idx,
+        ),
+        _ => (0, 0, false, -1),
     });
     if addr == 0 {
         return PolyValue::undefined().raw();
@@ -447,6 +495,47 @@ pub extern "C" fn __rtsadp_fn_invoke(
     // whole run (`Program` owns it). Transmuting a code address to its true
     // declared signature is sound.
     let f: UniformFn = unsafe { std::mem::transmute::<u64, UniformFn>(addr) };
+    // A VARIADIC callee (post-expand: the rest param is ONE array at
+    // `rest_idx`): pack the positional tail into a fresh array. The caller's
+    // `rest` slot carries the exact ARG COUNT as an INT32 word for ≤4 args (or
+    // the overflow ARRAY for >4); a legacy `undefined` rest falls back to
+    // counting the trailing non-undefined slots.
+    if rest_idx >= 0 && !has_this {
+        use rts_engine::heap::handles::{alloc_entry, Entry as E};
+        let slots = [a0, a1, a2, a3];
+        let rest_pv = PolyValue::from_raw(rest);
+        let (argc, overflow): (usize, Vec<i64>) = if rest_pv.is_int32() {
+            ((rest_pv.as_i32().max(0) as usize).min(4), Vec::new())
+        } else if let Some(h) = rts_engine::heap::poly::poly_handle_normalize(rest) {
+            let items: Vec<i64> = with_entry(h, |e| match e {
+                Some(E::Vec(v)) => v.as_ref().clone(),
+                _ => Vec::new(),
+            });
+            (4, items)
+        } else {
+            let undef = PolyValue::undefined().raw();
+            let n = slots.iter().rposition(|&w| w != undef).map_or(0, |i| i + 1);
+            (n, Vec::new())
+        };
+        let ri = rest_idx as usize;
+        if ri <= 4 {
+            let mut tail: Vec<i64> = Vec::new();
+            for &w in slots.iter().take(argc).skip(ri) {
+                tail.push(w as i64);
+            }
+            tail.extend(overflow);
+            let arr_h = alloc_entry(E::Vec(Box::new(tail)));
+            let arr_word = PolyValue::from_object_handle(
+                rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(arr_h),
+            )
+            .raw();
+            let undef = PolyValue::undefined().raw();
+            let mut call = [undef; 4];
+            call[..ri].copy_from_slice(&slots[..ri]);
+            call[ri] = arr_word;
+            return f(env_word, call[0], call[1], call[2], call[3], undef);
+        }
+    }
     if has_this {
         // A this-first function called WITHOUT a receiver (plain `f(x)`): JS
         // binds `this = undefined`; positional args shift past it (a3 drops -

--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -52,8 +52,38 @@ pub(super) fn to_string(v: PolyValue) -> String {
     if v.is_object() && !crate::value::inspect::looks_like_object(v) {
         return array_to_string(v);
     }
+    // A keyed object with a `[Symbol.toPrimitive]` method: ToString runs it with
+    // hint "string" and stringifies the primitive result (spec ToPrimitive).
+    if let Some(p) = to_primitive_via_method(v, "string") {
+        return to_string(p);
+    }
     // objects (and any reserved/leaked singleton)
     "[object Object]".to_string()
+}
+
+/// JS `ToPrimitive(v, hint)` OBJECT step: when `v` is a keyed object carrying an
+/// own `[Symbol.toPrimitive](hint)` method (the object-literal desugar recovers
+/// it as the `@@toPrimitive` own-prop fn slot — see `desugar::objmethod`),
+/// invoke it with the hint string and return the PRIMITIVE result. `None` = no
+/// such method, or the method returned a non-primitive (spec: TypeError; here
+/// the caller keeps its default coercion — never a wrong recursion).
+pub(super) fn to_primitive_via_method(v: PolyValue, hint: &str) -> Option<PolyValue> {
+    if !v.is_object() || !crate::value::inspect::looks_like_object(v) {
+        return None;
+    }
+    let key = abi_adapter::intern_poly("@@toPrimitive").raw();
+    let f = super::objops::__rtsadp_obj_get(v.raw(), key);
+    if !PolyValue::from_raw(f).is_function() {
+        return None;
+    }
+    let hint_w = abi_adapter::intern_poly(hint).raw();
+    let undef = PolyValue::undefined().raw();
+    let r = super::funcops::__rtsadp_fn_invoke_method(f, v.raw(), hint_w, undef, undef, undef);
+    let p = PolyValue::from_raw(r);
+    if p.is_object() || p.is_function() {
+        return None;
+    }
+    Some(p)
 }
 
 /// JS `Array.prototype.toString` = `join(",")` with `null`/`undefined` elements
@@ -124,6 +154,11 @@ pub(super) fn to_number(v: PolyValue) -> f64 {
     }
     if v.is_string() {
         return string_to_number(&abi_adapter::resolve_poly(v));
+    }
+    // A keyed object with a `[Symbol.toPrimitive]` method: ToNumber runs it with
+    // hint "number" and coerces the primitive result (spec ToPrimitive).
+    if let Some(p) = to_primitive_via_method(v, "number") {
+        return to_number(p);
     }
     // undefined, object, function, hole, empty → NaN.
     f64::NAN
@@ -214,6 +249,22 @@ pub extern "C" fn __rtsadp_add(a: u64, b: u64) -> u64 {
     let av = PolyValue::from_raw(a);
     let bv = PolyValue::from_raw(b);
 
+    // JS `+` runs ToPrimitive(default) on BOTH operands FIRST (spec 13.15.3):
+    // an object with a `[Symbol.toPrimitive]` method converts through it even
+    // when the other side is already a string (`obj + ""` gets hint "default",
+    // NOT the concat's later ToString hint "string"). One re-entry with the
+    // primitive results; without the method the tag checks below decide as
+    // before.
+    if av.is_object() || bv.is_object() {
+        let ap = to_primitive_via_method(av, "default");
+        let bp = to_primitive_via_method(bv, "default");
+        if ap.is_some() || bp.is_some() {
+            let a2 = ap.map_or(a, |p| p.raw());
+            let b2 = bp.map_or(b, |p| p.raw());
+            return __rtsadp_add(a2, b2);
+        }
+    }
+
     // String path: if either side is a string, ToString both and concat through
     // the REAL pool.
     if av.is_string() || bv.is_string() {
@@ -234,7 +285,8 @@ pub extern "C" fn __rtsadp_add(a: u64, b: u64) -> u64 {
         return PolyValue::from_f64(sum).raw();
     }
 
-    // Mixed/other: JS would ToPrimitive; stringify both (never panics).
+    // Mixed/other: JS would ToPrimitive (the `[Symbol.toPrimitive]` step already
+    // ran above); stringify both (never panics).
     concat_via_real_pool(av, bv).raw()
 }
 

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -190,6 +190,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             "__rtsadp_register_fn_abi",
             funcops::__rtsadp_register_fn_abi as *const u8,
         ),
+        sym(
+            "__rtsadp_invoke_auto_word",
+            funcops::__rtsadp_invoke_auto_word as *const u8,
+        ),
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym("__rtsadp_fn_reify_this", funcops::__rtsadp_fn_reify_this as *const u8),
         sym("__rtsadp_fn_invoke_method", funcops::__rtsadp_fn_invoke_method as *const u8),

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -36,6 +36,38 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let fn_name = self.classes.get(&class)?.methods.get(m)?.clone();
         self.sigs.get(&fn_name)?.ret_class.clone()
     }
+
+    /// Whether `e`, as a `+` operand, is EXACT through the runtime generic `+`'s
+    /// ToPrimitive: a non-object operand always is; an OBJECT operand is when
+    /// its statically-known class defines no custom `toString`/`valueOf` (those
+    /// are unreachable from the trampoline → wrong value, keep the bail). A
+    /// `[Symbol.toPrimitive]` method (`@@toPrimitive` slot) is fine — the
+    /// generic path consults it; a method-free object renders the spec
+    /// `[object Object]`.
+    fn add_operand_to_primitive_safe(&self, e: &HirExpr) -> bool {
+        if !self.is_whole_object_value(e) {
+            return true;
+        }
+        // An INLINE literal carries its recovered class in the marker field.
+        let class = match &e.kind {
+            rts_hir::ir::HirExprKind::Object(fields) => fields
+                .iter()
+                .find(|(k, _)| k == crate::front::run::desugar::LIT_CLASS_MARKER)
+                .and_then(|(_, v)| match &v.kind {
+                    rts_hir::ir::HirExprKind::Lit(rts_hir::ir::HirLit::Str(s)) => Some(s.clone()),
+                    _ => None,
+                }),
+            _ => self.static_instance_class(e),
+        };
+        match class {
+            Some(class) => self.classes.get(&class).is_none_or(|d| {
+                !d.methods.contains_key("toString") && !d.methods.contains_key("valueOf")
+            }),
+            // An anonymous plain shape (no class ⇒ no methods) renders the spec
+            // `[object Object]` — exact.
+            None => true,
+        }
+    }
 }
 
 /// The Rust-style operator-overload method name for `op` (`a + b` → `a.add(b)`
@@ -196,7 +228,19 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 && !obj_operand
                 && !array_has_object_element
                 && (is_proven_string_expr(lhs) || is_proven_string_expr(rhs));
-            if !array_string_concat {
+            // GENERIC-`+` OBJECT path: `Add` where every OBJECT operand is
+            // ToPrimitive-safe through the runtime generic `+` — its statically
+            // known class (if any) defines neither `toString` nor `valueOf` (a
+            // custom one is unreachable from the trampoline → wrong value;
+            // `[Symbol.toPrimitive]` IS consulted by the generic path, and a
+            // method-free object renders the spec `[object Object]`). Array
+            // operands keep the stricter `array_string_concat` rule above.
+            let object_generic_add = matches!(op, HirBinOp::Add)
+                && !self.is_whole_array_value(lhs)
+                && !self.is_whole_array_value(rhs)
+                && self.add_operand_to_primitive_safe(lhs)
+                && self.add_operand_to_primitive_safe(rhs);
+            if !array_string_concat && !object_generic_add {
                 return unsupported!(
                     "binary `{op:?}` on a whole object/array operand (ToPrimitive coercion is a later increment)"
                 );

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -806,9 +806,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let addr = self.builder.ins().func_addr(types::I64, func_ref);
 
         let nparams_v = self.builder.ins().iconst(types::I64, nparams);
-        // No `...rest` in this increment's reify surface (variadic arrows are
-        // rejected at extraction); has_rest is always 0.
-        let has_rest_v = self.builder.ins().iconst(types::I64, 0);
+        // A `(...rest)` fn (post-expand: ONE packed-array param at the tail)
+        // records `has_rest` so the value-invoke (`__rtsadp_fn_invoke` /
+        // INVOKE_AUTO) packs the caller's positional tail into that array —
+        // an indirect `g("x","y")` on a rest arrow read a bare "x" otherwise.
+        let has_rest_v = self
+            .builder
+            .ins()
+            .iconst(types::I64, i64::from(sig.rest_param.is_some()));
         // A this-first function reifies through the `_this` variant: FunctionData
         // marks `has_this_param`, so the method-aware invoker binds the receiver
         // into a0 and the plain invoker shifts (JS `this = undefined`).
@@ -1021,7 +1026,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             slots[i] = self.box_value(v);
         }
 
-        // Overflow args (5th onward) go into a fresh rest ARRAY; ≤4 args → undefined.
+        // Overflow args (5th onward) go into a fresh rest ARRAY. For ≤4 args the
+        // rest slot carries the ARG COUNT as an INT32 word (NOT `undefined`): a
+        // VARIADIC callee's `__rtsadp_fn_invoke` needs the exact count to pack
+        // `a0..a3` into its rest array (undefined-padding is ambiguous — an
+        // explicit `undefined` arg is indistinguishable from an absent one). A
+        // non-variadic ≤4-param thunk never reads the slot, so this is invisible
+        // to every other callee.
         let rest = if args.len() > 4 {
             let arr = emit_marshal::emit_new_vec_object(module, self.builder);
             for a in &args[4..] {
@@ -1031,7 +1042,8 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
             arr
         } else {
-            self.builder.ins().iconst(types::I64, undef())
+            let argc_word = value::PolyValue::from_i32(args.len() as i32).raw() as i64;
+            self.builder.ins().iconst(types::I64, argc_word)
         };
 
         self.emit_fn_invoke(module, fn_word, slots, rest)

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -376,8 +376,23 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         self.builder.seal_block(b_static);
 
         self.builder.switch_to_block(b_fn);
-        let v1 = self.lower_value_call_word(module, own, args)?;
-        let w1 = self.box_value(v1);
+        // Invoke through the FULL INVOKE_AUTO machinery with a COUNTED args
+        // vec — a `(...args)` REST override needs its tail packed into one
+        // array (the raw 6-slot invoke carries no argc and cannot pack; the
+        // callbacks then read a bare first arg where the array should be).
+        let vec_h = self
+            .call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[])?
+            .expect("VEC_NEW returns a handle");
+        for a in args {
+            let v = self.lower_expr(module, a)?;
+            let w = self.box_value(v);
+            self.call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[vec_h, w])?;
+        }
+        let zero = self.builder.ins().iconst(types::I64, 0);
+        let w1 = self
+            .call_runtime(module, "__rtsadp_invoke_auto_word", &[own, zero, vec_h])?
+            .expect("__rtsadp_invoke_auto_word returns a word");
+        self.emit_post_call_error_check(module)?;
         self.builder.ins().jump(merge, &[w1.into()]);
 
         self.builder.switch_to_block(b_static);

--- a/crates/rts-codegen-new/src/front/run/desugar/objmethod/collect.rs
+++ b/crates/rts-codegen-new/src/front/run/desugar/objmethod/collect.rs
@@ -83,11 +83,19 @@ pub(super) fn recover_methods(obj: &swc_ecma_ast::ObjectLit) -> Recovered<'_> {
                 Prop::Method(m) => {
                     // Plain method only: a generator/async method, a non-identifier
                     // (computed/string/number) name, or a non-simple param → bail.
+                    // EXCEPTION: a computed key that IS a well-known `Symbol.X`
+                    // member (`[Symbol.toPrimitive](hint) {…}`) recovers as the
+                    // internal `@@X` method name — Symbol is PRIMORDIAL, and the
+                    // coercion trampolines look the method up by that own-prop
+                    // key (`@@` is not spellable as a plain JS identifier key).
                     if m.function.is_generator || m.function.is_async {
                         return Recovered::Unsupported;
                     }
-                    let Some(name) = prop_ident_name(&m.key) else {
-                        return Recovered::Unsupported;
+                    let name = match prop_ident_name(&m.key)
+                        .or_else(|| wellknown_symbol_method_name(&m.key))
+                    {
+                        Some(name) => name,
+                        None => return Recovered::Unsupported,
                     };
                     for param in &m.function.params {
                         if super::super::super::class::ident_param_name(&param.pat).is_none() {
@@ -151,4 +159,29 @@ fn prop_ident_name(key: &swc_ecma_ast::PropName) -> Option<String> {
         swc_ecma_ast::PropName::Ident(id) => Some(id.sym.to_string()),
         _ => None,
     }
+}
+
+/// `[Symbol.X](){}` — a COMPUTED key that is literally the well-known `Symbol.X`
+/// member expression, recovered as the internal `@@X` method name (`Symbol` is
+/// PRIMORDIAL — the engine may name it). The literal class materializes the
+/// method as an own-prop fn slot under that key, and the generic coercion
+/// trampolines (`to_number`/`to_string`/`__rtsadp_add`) look `@@toPrimitive` up
+/// by it. Any other computed key stays out of subset.
+fn wellknown_symbol_method_name(key: &swc_ecma_ast::PropName) -> Option<String> {
+    let swc_ecma_ast::PropName::Computed(c) = key else {
+        return None;
+    };
+    let swc_ecma_ast::Expr::Member(m) = &*c.expr else {
+        return None;
+    };
+    let swc_ecma_ast::Expr::Ident(obj) = &*m.obj else {
+        return None;
+    };
+    if obj.sym.as_ref() != "Symbol" {
+        return None;
+    }
+    let swc_ecma_ast::MemberProp::Ident(p) = &m.prop else {
+        return None;
+    };
+    Some(format!("@@{}", p.sym))
 }

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -78,6 +78,24 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // OUTER names persist (they `def_var` the outer Variable — the map
             // entry itself is untouched). `var` declarations were rewritten to
             // plain assignments by the hoist pass, so they escape correctly.
+            //
+            // EXCEPTION — a DECLARATIONS-ONLY block: rts-hir encodes a
+            // multi-declarator (`let i = 0, j = 10` — one statement, NO lexical
+            // scope of its own) as a Block of individual Lets, indistinguishable
+            // from a real `{ let … }` here. Lower it WITHOUT the scope restore:
+            // the multi-declarator NEEDS its names to escape (a `for` header /
+            // plain statement declares into the enclosing scope), and for a real
+            // declarations-only block the extra visibility can never change a
+            // VALID program's value (nothing else inside the block observes the
+            // names; an invalid out-of-scope read is tsc's to reject).
+            HirStmt::Block(stmts)
+                if !stmts.is_empty()
+                    && stmts.iter().all(|s| {
+                        matches!(s, HirStmt::Let { .. } | HirStmt::Const { .. })
+                    }) =>
+            {
+                self.lower_block(module, stmts)
+            }
             HirStmt::Block(stmts) => {
                 let saved_locals = self.locals.clone();
                 let saved_shapes = self.local_shapes.clone();

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -287,6 +287,12 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64, U64],
             ret: Void,
         },
+        // Counted-args fn-value invoke through INVOKE_AUTO (variadic packing;
+        // the singleton-override dispatch).
+        "__rtsadp_invoke_auto_word" => SymSig {
+            params: &[U64, U64, U64],
+            ret: U64,
+        },
 
         // ---- REAL collections Vec (rts-shared collections::vec) ----
         "__RTS_FN_NS_COLLECTIONS_VEC_NEW" => SymSig {

--- a/crates/rts-engine/src/heap/handles.rs
+++ b/crates/rts-engine/src/heap/handles.rs
@@ -1293,6 +1293,16 @@ pub fn mark_handle(handle: u64) {
 /// the slot+shard field with the generation cleared.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_GC_POLY_FROM_HANDLE(full: u64) -> u64 {
+    // The all-zero HANDLE is the ABI-wide error sentinel (a live handle always
+    // has `generation >= 1`). Its payload must NOT be 0 — payload 0 is the
+    // legitimate live slot (0, 0), so boxing a sentinel as payload 0 would
+    // ALIAS the first entry allocated in shard 0 (e.g. an invalid digest's
+    // string word reading some unrelated live string). Map the sentinel to the
+    // all-ones payload: never an allocatable slot, so `POLY_TO_HANDLE`
+    // round-trips it back to the 0 sentinel (`slot_generation` → `None`).
+    if full == 0 {
+        return SLOT_MASK;
+    }
     full & SLOT_MASK
 }
 


### PR DESCRIPTION
## Batch 6 — rumo a 100% da suite TS: 613/623 (+4 vs batch 5)

### Fixes

**1. `console_override_variadic` — rest-fn invocada como VALOR recebia args vazios**
- `reify_function_inner` agora grava `has_rest` (de `sig.rest_param`) no `__rtsadp_fn_reify` → `FunctionData.rest_param_idx` correto.
- `__rtsadp_invoke_auto_word` empacota o tail posicional num array quando o callee é uniform-thunk variadic (o fast path uniform do `INVOKE_AUTO` passava os slots crus, sem packing).
- `lower_value_call_word` passa o ARGC como INT32 word no slot `rest` para ≤4 args (era `undefined`), permitindo o packing contado.

**2. `crypto_streaming_hash` — sentinel handle-0 aliasava o slot (0,0)** *(fix de soundness geral)*
- `POLY_FROM_HANDLE(0)` → payload all-ones (jamais alocável; `TO_HANDLE` devolve o sentinel 0). Antes, o sentinel de erro boxado lia a PRIMEIRA entry viva do shard 0.
- `__rtsadp_dyn_length` → `-1` para string word cujo handle não resolve (o mesmo sentinel do pool); `""` viva continua 0.

**3. `symbol_to_primitive` — `[Symbol.toPrimitive](hint)` em object literal**
- Literal com método computed `[Symbol.X]` recuperado como método `@@X` da classe literal (Symbol é PRIMORDIAL — o motor pode nomeá-lo; nenhum nome não-primordial no front).
- ToPrimitive consultado em `to_number` (hint "number"), `to_string` (hint "string") e no TOPO do `__rtsadp_add` (hint "default", spec 13.15.3 — antes do check de string, então `obj + ""` usa "default").
- Gate de `Add`-objeto refinado: libera o caminho genérico quando nenhum operando-objeto tem `toString`/`valueOf` custom (que seriam inalcançáveis do trampoline → mantém o bail honesto nesses casos).

**4. `sequence_expr` + `switch_jump_table` — regressão do block scoping (#1804, já na main)**
- Verificado via stash: falhavam na main sem este branch.
- rts-hir encodifica multi-declarator (`let i = 0, j = 10`) como Block de Lets — indistinguível de bloco léxico. Um Block SÓ-de-declarações agora lowera SEM scope restore: multi-declarator não cria escopo, e num bloco léxico real só-de-decls a visibilidade extra nunca muda o valor de um programa válido.

### Validação
- Unit tests (rts-codegen-new + rts-adapters + rts-engine): **812 passed / 16 failed** — os mesmos 16 pré-existentes na main (verificado via stash).
- Suite TS: **613/623 files** (1659/1670 tests).
- `read_before_commit.sh`: sem violação HARD.
- Nota: o link do test binary de `rts-std` (`cargo test -p rts-std --lib`) está quebrado na main (símbolo `__rtsadp_fn_invoke` de `invoke_listener`, pré-existente — verificado via stash).

### Restantes (10 files)
TypedArray views reais com write-through (3), new Function eval hook (2), BigInt #219 (1), `export * as ns` (1), microtask U64 marshal a0b0 (1), tls arrow lift (1), structuredclone flaky sob carga (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
