### PR TITLE
feat(codegen/runtime): new Function + bind parcial + ponte de convencao word<->i64 (616/623)

### DIFF
--- a/crates/rts-adapters/src/value/dyndispatch.rs
+++ b/crates/rts-adapters/src/value/dyndispatch.rs
@@ -149,6 +149,14 @@ pub extern "C" fn __rtsadp_dyn_length(recv: u64) -> u64 {
         let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(arr_handle(recv)).max(0);
         return PolyValue::from_i32(len as i32).raw();
     }
+    // A FUNCTION receiver: `.length` is the Function getter — the declared
+    // arity minus the partially-bound count (`f.bind(null, x)`).
+    if v.is_function() {
+        use rts_runtime::namespaces::gc::handles as rt_handles;
+        let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
+        let len = rts_runtime::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_LENGTH(h);
+        return PolyValue::from_i32(len as i32).raw();
+    }
     // A KEYED OBJECT may carry a real own `length` property (`{length: 3}`) —
     // read it like any other key (undefined when absent, matching JS).
     if v.is_object() {

--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -470,18 +470,47 @@ pub extern "C" fn __rtsadp_fn_invoke(
     // Reconstruct the full real handle (generation read from the live slot) from
     // the bare 48-bit payload, then read the stored thunk address AND env word.
     let real = rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(pv.as_handle());
-    let (addr, env, has_this, rest_idx) = with_entry(real, |e| match e {
+    let (addr, env, has_this, rest_idx, uniform, arity, bound) = with_entry(real, |e| match e {
         Some(Entry::Function(d)) => (
             d.fn_ptr,
             d.bound_this as u64,
             d.has_this_param,
             d.rest_param_idx,
+            d.uniform_thunk,
+            d.arity,
+            d.bound_args.clone(),
         ),
-        _ => (0, 0, false, -1),
+        _ => (0, 0, false, -1, true, 0, Vec::new()),
     });
     if addr == 0 {
         return PolyValue::undefined().raw();
     }
+    // A LEGACY-convention callee (`new Function` compiles a raw all-i64 extern —
+    // `uniform_thunk: false`): unbox the arg words to raw i64s and route through
+    // the runtime's own typed invoker (`FUNCTION_CALL`, which also applies bound
+    // args), then box the raw i64 result back as a number word.
+    if !uniform {
+        return invoke_legacy_fn(real, arity, bound.len(), [a0, a1, a2, a3]);
+    }
+    // BOUND partial-application args on a UNIFORM callee (`f.bind(null, x)`):
+    // prepend the stored WORDS — the call-site args shift right, and an
+    // INT32-argc `rest` word grows by the bound count (args past slot 4 drop —
+    // the ≤4-slot subset).
+    let (a0, a1, a2, a3, rest) = if bound.is_empty() {
+        (a0, a1, a2, a3, rest)
+    } else {
+        let mut all: Vec<u64> = bound.iter().map(|&w| w as u64).collect();
+        all.extend([a0, a1, a2, a3]);
+        let undef = PolyValue::undefined().raw();
+        let get = |i: usize| all.get(i).copied().unwrap_or(undef);
+        let rest_pv = PolyValue::from_raw(rest);
+        let new_rest = if rest_pv.is_int32() {
+            PolyValue::from_i32(rest_pv.as_i32().saturating_add(bound.len() as i32)).raw()
+        } else {
+            rest
+        };
+        (get(0), get(1), get(2), get(3), new_rest)
+    };
     // A non-capturing function stored env = 0; normalize that to the `undefined`
     // singleton word the thunk's env-read path expects (it never reads it anyway).
     let env_word = if env == 0 {
@@ -543,6 +572,144 @@ pub extern "C" fn __rtsadp_fn_invoke(
         return f(env_word, PolyValue::undefined().raw(), a0, a1, a2, rest);
     }
     f(env_word, a0, a1, a2, a3, rest)
+}
+
+/// Invoke a LEGACY-convention function handle (a `new Function` compile: raw
+/// all-i64 `extern "C"`, `uniform_thunk: false`) with up to 4 PolyValue-word
+/// args: unbox each to its raw i64, route through the runtime's own
+/// `FUNCTION_CALL` (which applies bound args / kinds), box the i64 result back
+/// as the tightest number word.
+fn invoke_legacy_fn(real_handle: u64, arity: u8, bound_len: usize, slots: [u64; 4]) -> u64 {
+    use rts_engine::heap::handles::{Entry as E, alloc_entry};
+    // `FUNCTION_CALL` prepends the stored bound args itself — pass only the
+    // REMAINING positional count so the total matches the callee's arity.
+    let n = (arity as usize).saturating_sub(bound_len).min(4);
+    let raw: Vec<i64> = slots[..n].iter().map(|&w| word_to_raw_i64(w)).collect();
+    let args_h = alloc_entry(E::Vec(Box::new(raw)));
+    let r = rts_runtime::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_CALL(
+        real_handle,
+        0,
+        args_h,
+    );
+    if let Ok(i) = i32::try_from(r) {
+        PolyValue::from_i32(i).raw()
+    } else {
+        PolyValue::from_f64(r as f64).raw()
+    }
+}
+
+/// A PolyValue word → the raw i64 a legacy all-i64 callee reads: int32 → its
+/// value, inline double → truncated, bool → 0/1, anything else → 0.
+fn word_to_raw_i64(w: u64) -> i64 {
+    let v = PolyValue::from_raw(w);
+    if v.is_int32() {
+        v.as_i32() as i64
+    } else if v.is_double() {
+        v.as_f64() as i64
+    } else if v.is_bool() {
+        v.as_bool() as i64
+    } else {
+        0
+    }
+}
+
+/// `__rtsadp_fn_bind(fn_word, args_vec)` — `f.bind(thisArg, …partial)` with
+/// PARTIAL-APPLICATION args: clone the function value with the extra args
+/// appended to `bound_args` (`.length` reads `arity - bound_args.len()`, and
+/// both invoke paths prepend them). A UNIFORM-thunk callee stores the raw
+/// PolyValue WORDS (its invoke shifts them into `a0…`); a legacy callee
+/// (`new Function`) stores raw i64s (its `invoke_typed` path reads them
+/// verbatim). Non-function → `undefined`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_fn_bind(fn_word: u64, args_vec: u64) -> u64 {
+    use rts_engine::heap::handles::{Entry as E, FunctionData, alloc_entry};
+    let pv = PolyValue::from_raw(fn_word);
+    if !pv.is_function() {
+        return PolyValue::undefined().raw();
+    }
+    let real = rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(pv.as_handle());
+    let items: Vec<i64> = with_entry(args_vec, |e| match e {
+        Some(E::Vec(v)) => v.as_ref().clone(),
+        _ => Vec::new(),
+    });
+    let cloned: Option<Box<FunctionData>> = with_entry(real, |e| match e {
+        Some(E::Function(d)) => {
+            let extra: Vec<i64> = if d.uniform_thunk {
+                items.clone()
+            } else {
+                items.iter().map(|&w| word_to_raw_i64(w as u64)).collect()
+            };
+            let mut bound = d.bound_args.clone();
+            bound.extend(extra);
+            Some(Box::new(FunctionData {
+                fn_ptr: d.fn_ptr,
+                arity: d.arity,
+                name: d.name.clone(),
+                bound_this: d.bound_this,
+                has_bound_this: d.has_bound_this,
+                bound_args: bound,
+                is_arrow: d.is_arrow,
+                has_this_param: d.has_this_param,
+                param_kinds: d.param_kinds.clone(),
+                return_kind: d.return_kind,
+                packed_shim: d.packed_shim,
+                source: d.source.clone(),
+                keep_alive: d.keep_alive.clone(),
+                prototype_handle: 0,
+                rest_param_idx: d.rest_param_idx,
+                uniform_thunk: d.uniform_thunk,
+            }))
+        }
+        _ => None,
+    });
+    let Some(data) = cloned else {
+        return PolyValue::undefined().raw();
+    };
+    let h = alloc_entry(E::Function(data));
+    PolyValue::from_function_handle(
+        rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h),
+    )
+    .raw()
+}
+
+/// `__rtsadp_fn_new(args_vec)` — the PRIMORDIAL `new Function(p0…pN-1, body)`:
+/// ToString every arg word, join the leading N-1 as the params CSV, hand
+/// `(params_handle, body_handle)` to the runtime ctor (which compiles the body
+/// through the engine-installed COMPILE_FN_HOOK — see `front::run::dynfn`), and
+/// box the resulting `Entry::Function` handle as a `TAG_FUNCTION` word. A
+/// failed compile yields `undefined` (the runtime already eprintln'd why).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_fn_new(args_vec: u64) -> u64 {
+    use rts_engine::heap::handles::Entry as E;
+    let items: Vec<i64> = with_entry(args_vec, |e| match e {
+        Some(E::Vec(v)) => v.as_ref().clone(),
+        _ => Vec::new(),
+    });
+    let text = |w: i64| super::genops::to_string(PolyValue::from_raw(w as u64));
+    let (params, body) = match items.split_last() {
+        Some((last, init)) => (
+            init.iter().map(|&w| text(w)).collect::<Vec<_>>().join(","),
+            text(*last),
+        ),
+        None => (String::new(), String::new()),
+    };
+    let intern = |s: &str| {
+        rts_runtime::namespaces::collector::string_pool::__RTS_FN_NS_GC_STRING_NEW(
+            s.as_ptr(),
+            s.len() as i64,
+        )
+    };
+    let h = rts_runtime::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_NEW(
+        intern(&params),
+        intern(&body),
+    );
+    if h == 0 {
+        return PolyValue::undefined().raw();
+    }
+    PolyValue::from_function_handle(
+        rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h),
+    )
+    .raw()
 }
 
 /// METHOD-AWARE invoke: `recv.m(args)` where `m` resolved to a FUNCTION word.

--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -178,6 +178,17 @@ pub extern "C" fn __rtsadp_obj_get(obj_word: u64, key_str_handle: u64) -> u64 {
     if let Some((target, handler)) = proxy_parts(obj_word) {
         return proxy_get(target, handler, key_str_handle);
     }
+    // A FUNCTION receiver: `.name` is the Function getter (`"anonymous"` for a
+    // `new Function`); `.length` falls into the tag-dispatched length below.
+    {
+        let v = PolyValue::from_raw(obj_word);
+        if v.is_function() && key_text(key_str_handle) == "name" {
+            let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
+            let name_h =
+                rts_runtime::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_NAME(h);
+            return abi_adapter::poly_from_real_handle(name_h).raw();
+        }
+    }
     // `.length` on a NON-keyed receiver (a string / an array reached through the
     // dynamic get — `cfg?.list.length`): route the tag-dispatched length. A KEYED
     // object falls through to its own `length` slot below (`dyn_length`'s keyed

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -194,6 +194,8 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             "__rtsadp_invoke_auto_word",
             funcops::__rtsadp_invoke_auto_word as *const u8,
         ),
+        sym("__rtsadp_fn_new", funcops::__rtsadp_fn_new as *const u8),
+        sym("__rtsadp_fn_bind", funcops::__rtsadp_fn_bind as *const u8),
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym("__rtsadp_fn_reify_this", funcops::__rtsadp_fn_reify_this as *const u8),
         sym("__rtsadp_fn_invoke_method", funcops::__rtsadp_fn_invoke_method as *const u8),

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -160,6 +160,22 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         method: &str,
         args: &[HirExpr],
     ) -> FrontResult<Option<Val>> {
+        // `f.toString()` on a STATICALLY-known user fn: the source is not
+        // preserved through compilation, so the contract is the `[native code]`
+        // rendering with the fn's NAME — known here at compile time (a literal;
+        // zero runtime). A local shadowing the fn name falls through.
+        if method == "toString" && args.is_empty() {
+            if let HirExprKind::Ident(n) = &object.kind {
+                if self.sigs.contains_key(n) && self.local(n).is_none() {
+                    let s = format!("function {n}() {{ [native code] }}");
+                    let lit = rts_hir::HirExpr::new(
+                        HirExprKind::Lit(rts_hir::ir::HirLit::Str(s)),
+                        rts_hir::HirType::Str,
+                    );
+                    return Ok(Some(self.lower_expr(module, &lit)?));
+                }
+            }
+        }
         if method != "call" && method != "apply" && method != "bind" {
             return Ok(None);
         }
@@ -189,12 +205,24 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         // `f.bind(thisArg)` — plain functions have no `this` slot in the uniform
         // ABI, so binding only a thisArg is the IDENTITY on the function value
-        // (matches `.call(null, …)` ignoring thisArg above). Partial-application
-        // args (`f.bind(null, a)`) need a bound-args entry — a later increment,
-        // bail honestly.
+        // (matches `.call(null, …)` ignoring thisArg above). PARTIAL-APPLICATION
+        // args (`f.bind(null, a)`) clone the function value with the extra args
+        // in `bound_args` (`__rtsadp_fn_bind`) — both invoke paths prepend them
+        // and `.length` reads `arity - bound`.
         if method == "bind" {
             if args.len() > 1 {
-                return unsupported!("fn.bind with partial-application args (only thisArg is supported)");
+                let vec_h = self
+                    .call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[])?
+                    .expect("VEC_NEW returns a handle");
+                for a in &args[1..] {
+                    let v = self.lower_expr(module, a)?;
+                    let w = self.box_value(v);
+                    self.call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[vec_h, w])?;
+                }
+                let word = self
+                    .call_runtime(module, "__rtsadp_fn_bind", &[fn_word, vec_h])?
+                    .expect("__rtsadp_fn_bind returns a word");
+                return Ok(Some(Val::tagged_kind(word, JsKind::Function)));
             }
             return Ok(Some(Val::tagged_kind(fn_word, JsKind::Function)));
         }
@@ -539,39 +567,53 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         let fref = module.declare_func_in_func(fid, self.builder.func);
         let addr = self.builder.ins().func_addr(types::I64, fref);
-        // When the target's signature carries an f64 anywhere, register its
-        // packed ABI (FN_KINDS) so RAW-pointer consumers (`thread.spawn`,
-        // dynamic HOFs) invoke through the typed path — an f64 param reads its
-        // BITS back into xmm instead of the raw-i64 misload (#247).
-        if let Some(sig) = self.sigs.get(fname) {
-            let has_f64 = sig.params.iter().any(|&p| matches!(p, Repr::Float64))
-                || matches!(sig.ret, Some(Repr::Float64));
-            if has_f64 && sig.params.len() <= 8 {
-                let mut kinds_packed: u64 = 0;
-                for (i, &repr) in sig.params.iter().enumerate() {
-                    let k: u64 = match repr {
-                        Repr::Float64 => 1,
-                        Repr::Bool => 2,
-                        _ => 0,
-                    };
-                    kinds_packed |= k << (8 * i);
-                }
-                let ret_kind: u64 = match sig.ret {
-                    Some(Repr::Float64) => 1,
-                    Some(Repr::Bool) => 2,
-                    _ => 0,
-                };
-                let meta = ((sig.params.len() as u64) << 8) | ret_kind;
-                let kinds_word = self.builder.ins().iconst(types::I64, kinds_packed as i64);
-                let meta_word = self.builder.ins().iconst(types::I64, meta as i64);
-                self.call_runtime(
-                    module,
-                    "__rtsadp_register_fn_abi",
-                    &[addr, kinds_word, meta_word],
-                )?;
-            }
-        }
+        self.emit_register_fn_abi_if_f64(module, fname, addr)?;
         Ok(Some(Val::new(addr, Repr::Int64)))
+    }
+
+    /// When `fname`'s signature carries an f64 anywhere, register its packed
+    /// ABI (FN_KINDS) keyed by `addr` so RAW-pointer consumers (`thread.spawn`,
+    /// the promise/microtask callback bridge, dynamic HOFs) invoke through the
+    /// typed path — an f64 param reads its BITS back into xmm instead of the
+    /// raw-i64 misload (#247). Emitted at every site that hands out a bare
+    /// C-ABI code address (`getPointer`, a `U64`-param callback arg).
+    fn emit_register_fn_abi_if_f64(
+        &mut self,
+        module: &mut dyn Module,
+        fname: &str,
+        addr: Value,
+    ) -> FrontResult<()> {
+        let Some(sig) = self.sigs.get(fname) else {
+            return Ok(());
+        };
+        let has_f64 = sig.params.iter().any(|&p| matches!(p, Repr::Float64))
+            || matches!(sig.ret, Some(Repr::Float64));
+        if !has_f64 || sig.params.len() > 8 {
+            return Ok(());
+        }
+        let mut kinds_packed: u64 = 0;
+        for (i, &repr) in sig.params.iter().enumerate() {
+            let k: u64 = match repr {
+                Repr::Float64 => 1,
+                Repr::Bool => 2,
+                _ => 0,
+            };
+            kinds_packed |= k << (8 * i);
+        }
+        let ret_kind: u64 = match sig.ret {
+            Some(Repr::Float64) => 1,
+            Some(Repr::Bool) => 2,
+            _ => 0,
+        };
+        let meta = ((sig.params.len() as u64) << 8) | ret_kind;
+        let kinds_word = self.builder.ins().iconst(types::I64, kinds_packed as i64);
+        let meta_word = self.builder.ins().iconst(types::I64, meta as i64);
+        self.call_runtime(
+            module,
+            "__rtsadp_register_fn_abi",
+            &[addr, kinds_word, meta_word],
+        )?;
+        Ok(())
     }
 
     /// Lower a LAZY generator state-machine sentinel call. Returns `Ok(None)` when
@@ -693,6 +735,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                         if let Some(&fid) = self.ids.get(fname) {
                             let fref = module.declare_func_in_func(fid, self.builder.func);
                             let addr = self.builder.ins().func_addr(types::I64, fref);
+                            // An f64 anywhere in the callback's signature needs
+                            // its FN_KINDS registered — the runtime invokes this
+                            // bare address through the typed path (#247).
+                            self.emit_register_fn_abi_if_f64(module, fname, addr)?;
                             argvals.push(Val::new(addr, Repr::Int64));
                             continue;
                         }

--- a/crates/rts-codegen-new/src/front/run/dynfn.rs
+++ b/crates/rts-codegen-new/src/front/run/dynfn.rs
@@ -1,0 +1,71 @@
+//! `new Function(params…, body)` — RUNTIME compilation of one dynamic function
+//! through the SAME pipeline as any source (swc parse → HIR → lowering → JIT).
+//!
+//! rts-primitives owns the `Function` global's `__RTS_FN_GL_FUNCTION_NEW`, which
+//! needs an engine to compile the body but must not depend on one (dependency
+//! direction). It exposes a `COMPILE_FN_HOOK` the engine installs at program
+//! bootstrap ([`register_hook`], called from `module_jit::compile_program`) —
+//! the same OnceLock-hook pattern as the async errslot bridge.
+//!
+//! The compiled snippet is a NESTED program in its own `JITModule`, kept mapped
+//! for the function's whole lifetime via the `CompiledFn::keep_alive` slot the
+//! `Entry::Function` carries. Nested compilation is safe by design: the global
+//! codegen state (shapes, ctor table) is ADDITIVE and never reset mid-run (see
+//! `rts_adapters::state` — `reset_codegen_state` is a quiescent-boundary-only
+//! API precisely so `new Function`/eval can compile while the outer program is
+//! live).
+//!
+//! Invoke contract: the produced `fn_ptr` is called through the LEGACY
+//! `invoke_typed` path (all-i64 `extern "C"`), so every param and the return are
+//! annotated `i64` in the synthesized source. A dynamic function is therefore
+//! integer-typed — the `new Function` subset the old engine shipped. It is NOT
+//! in the program's tail set (no `CallConv::Tail`), so the raw pointer is
+//! extern-callable.
+
+use std::sync::{Arc, Mutex};
+
+use cranelift_module::{FuncOrDataId, Module};
+
+use rts_runtime::namespaces::globals::function::ops::{
+    CompiledFn, register_compile_fn,
+};
+
+/// The synthesized name of every dynamic function inside its own module. Never
+/// collides with user code: each snippet compiles into a FRESH `JITModule`.
+const DYN_FN_NAME: &str = "__rtsdyn_anonymous";
+
+/// Install [`compile_dynamic_fn`] as the rts-primitives `COMPILE_FN_HOOK`.
+/// Idempotent (OnceLock behind `register_compile_fn`).
+pub(super) fn register_hook() {
+    register_compile_fn(compile_dynamic_fn);
+}
+
+/// The `COMPILE_FN_HOOK` impl: build `function __rtsdyn_anonymous(p: i64, …):
+/// i64 { body }`, run it through the whole-program pipeline into a fresh
+/// `JITModule`, and hand back the finalized code pointer + the module as the
+/// keep-alive anchor.
+fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn> {
+    let plist = params
+        .iter()
+        .map(|p| format!("{p}: i64"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let src = format!("function {DYN_FN_NAME}({plist}): i64 {{\n{body}\n}}\n");
+    let prog = super::build_with_includes(&src)
+        .map_err(|e| anyhow::anyhow!("new Function body: {e}"))?;
+    let mut module = super::module_jit::make_module();
+    super::module_jit::populate_module(&mut module, &prog)
+        .map_err(|e| anyhow::anyhow!("new Function body: {e}"))?;
+    module
+        .finalize_definitions()
+        .map_err(|e| anyhow::anyhow!("new Function finalize: {e}"))?;
+    let Some(FuncOrDataId::Func(id)) = module.get_name(DYN_FN_NAME) else {
+        anyhow::bail!("new Function: compiled module lost `{DYN_FN_NAME}`");
+    };
+    let fn_ptr = module.get_finalized_function(id) as u64;
+    Ok(CompiledFn {
+        fn_ptr,
+        arity: params.len() as u8,
+        keep_alive: Arc::new(Mutex::new(module)),
+    })
+}

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -100,6 +100,11 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 {
                     return self.lower_new_value(module, class, args);
                 }
+                // `new Function(p…, body)` — the PRIMORDIAL dynamic-function ctor
+                // (unless a user class shadows the name): a function VALUE.
+                if class == "Function" && self.classes.get(class).is_none() {
+                    return self.lower_new_function(module, args);
+                }
                 // A `new C(args)` used as a bare expression (not bound to a local
                 // whose class/shape we record) still builds the instance (a valid
                 // TAG_OBJECT PolyValue, so `console.log(new C())` / method chaining

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -26,6 +26,7 @@ mod argsobj;
 mod assign;
 mod asyncspawn;
 mod binop;
+mod dynfn;
 mod floatscan;
 mod binop_eq;
 mod ctorfn;

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -61,7 +61,7 @@ impl Program {
 /// `__rtsadp_*` / … resolve at link time). The symbol set is the REAL runtime
 /// surface the lowering calls plus the codegen-owned adapter trampolines, sourced
 /// directly from [`crate::adapter_symbols::jit_symbols`].
-fn make_module() -> JITModule {
+pub(super) fn make_module() -> JITModule {
     let mut flags = settings::builder();
     flags.set("opt_level", "speed").unwrap();
     // TCO (`return_call` between `CallConv::Tail` fns) requires frame pointers
@@ -94,6 +94,10 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
     // Wire the engine's pending-error slot into the runtime's async watcher (a
     // `throw` inside a spawned async body must REJECT, not resolve). Idempotent.
     rts_adapters::value::errslot::install_async_error_hook();
+    // Wire `new Function(params…, body)` to the engine's own nested-compile
+    // pipeline (rts-primitives' COMPILE_FN_HOOK — never registered means the
+    // ctor returns handle 0 with an eprintln). Idempotent.
+    super::dynfn::register_hook();
     let mut module = make_module();
     let main_id = populate_module(&mut module, prog)?;
     module

--- a/crates/rts-codegen-new/src/front/run/newexpr.rs
+++ b/crates/rts-codegen-new/src/front/run/newexpr.rs
@@ -34,6 +34,32 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// Lower `new C(args)`. Returns the instance `Val` (kind `Object`) plus the
     /// class name + the OBJECT shape id (interned in THIS fn's ShapeTable), so a
     /// `let` can record the local's class/shape for later member/method access.
+    /// `new Function(p0…pN-1, body)` — the PRIMORDIAL dynamic-function ctor (only
+    /// when no user class shadows the name): pack every arg word into a Vec and
+    /// hand it to `__rtsadp_fn_new`, which ToStrings the params/body, compiles
+    /// the body through the engine-installed COMPILE_FN_HOOK (see
+    /// [`super::dynfn`]) and returns the boxed `TAG_FUNCTION` word (`undefined`
+    /// on a failed compile). The result is a function VALUE — no class, no
+    /// object shape — so `.call`/`.apply` dispatch through the fn-value path.
+    pub(super) fn lower_new_function(
+        &mut self,
+        module: &mut dyn Module,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        let vec_h = self
+            .call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[])?
+            .expect("VEC_NEW returns a handle");
+        for a in args {
+            let v = self.lower_expr(module, a)?;
+            let w = self.box_value(v);
+            self.call_runtime(module, "__RTS_FN_NS_COLLECTIONS_VEC_PUSH", &[vec_h, w])?;
+        }
+        let word = self
+            .call_runtime(module, "__rtsadp_fn_new", &[vec_h])?
+            .expect("__rtsadp_fn_new returns a word");
+        Ok(Val::tagged_kind(word, JsKind::Function))
+    }
+
     pub(super) fn lower_new(
         &mut self,
         module: &mut dyn Module,

--- a/crates/rts-codegen-new/src/front/run/stmt_let.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_let.rs
@@ -224,6 +224,17 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.bind_tagged_local(name, val);
                 return Ok(());
             }
+            // `const f = new Function(p…, body)` — the PRIMORDIAL dynamic-function
+            // ctor (unless a user class shadows the name): a function VALUE, so
+            // NO class/shape is recorded (`.call`/`.apply` dispatch through the
+            // fn-value path, not the class-method path).
+            HirExprKind::New { class, args }
+                if class == "Function" && self.classes.get(class).is_none() =>
+            {
+                let val = self.lower_new_function(module, args)?;
+                self.bind_tagged_local(name, val);
+                return Ok(());
+            }
             // `let c = new C(args)`: build the instance, record the local's CLASS
             // (for static `c.method()` dispatch) and OBJECT shape (for `c.field`).
             HirExprKind::New { class, args } => {

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -293,6 +293,18 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64, U64],
             ret: U64,
         },
+        // `new Function(p…, body)` — args vec of PolyValue words → TAG_FUNCTION
+        // word (`undefined` on a failed compile).
+        "__rtsadp_fn_new" => SymSig {
+            params: &[U64],
+            ret: U64,
+        },
+        // `f.bind(thisArg, …partial)` — clone the fn value with the partial
+        // args appended to bound_args.
+        "__rtsadp_fn_bind" => SymSig {
+            params: &[U64, U64],
+            ret: U64,
+        },
 
         // ---- REAL collections Vec (rts-shared collections::vec) ----
         "__RTS_FN_NS_COLLECTIONS_VEC_NEW" => SymSig {

--- a/crates/rts-primitives/src/function/ops.rs
+++ b/crates/rts-primitives/src/function/ops.rs
@@ -1482,6 +1482,80 @@ pub fn invoke_callable_auto(callable: u64, args: &[i64]) -> i64 {
     invoke_fn_ptr_with_registry(callable, args)
 }
 
+/// Ponte de CONVENÇÃO COMPLETA para callbacks da superfície i64 (`promise.then`
+/// / `promise.create` / drain de microtasks): um callee UNIFORM-THUNK (fn VALUE
+/// do motor novo) fala PolyValue WORDS nos dois sentidos; a superfície fala i64
+/// CRU. `args_are_words` marca a proveniência dos args (`true` = array do motor
+/// novo, já words; `false` = valor settled cru da superfície). O retorno volta
+/// SEMPRE cru — INT32 → valor, singleton → 0, heap-tag → handle real, double
+/// inline → trunc — para o slot i64 (o `await` do motor novo re-boxa números).
+/// Um callee NÃO-uniform (fn_ptr cru / `new Function` legado) recebe args CRUS
+/// (words decodificadas quando `args_are_words`) e devolve verbatim.
+pub fn invoke_callable_bridged(callable: u64, args: &[i64], args_are_words: bool) -> i64 {
+    use rts_engine::heap::handles::{alloc_entry, with_entry, Entry};
+    let h = rts_engine::heap::poly::poly_handle_normalize(callable).unwrap_or(callable);
+    let uniform = with_entry(h, |e| {
+        matches!(e, Some(Entry::Function(d)) if d.uniform_thunk)
+    });
+    if uniform {
+        let words: Vec<i64> = if args_are_words {
+            args.to_vec()
+        } else {
+            args.iter().map(|&a| raw_to_word(a)).collect()
+        };
+        let args_h = alloc_entry(Entry::Vec(Box::new(words)));
+        let r = __RTS_FN_RT_INVOKE_AUTO(h as i64, 0, args_h) as u64;
+        return word_to_raw(r);
+    }
+    let raw: Vec<i64> = if args_are_words {
+        args.iter().map(|&a| word_to_raw(a as u64)).collect()
+    } else {
+        args.to_vec()
+    };
+    invoke_callable_auto(callable, &raw)
+}
+
+/// i64 CRU da superfície → WORD PolyValue numérica (INT32 quando cabe, senão os
+/// bits do f64). Um valor que JÁ está no quadrante boxed passa verbatim (o
+/// produtor já falava words).
+fn raw_to_word(a: i64) -> i64 {
+    use rts_engine::heap::poly as p;
+    let w = a as u64;
+    if (w & p::POLY_BOX_BASE) == p::POLY_BOX_BASE {
+        return a;
+    }
+    if let Ok(i) = i32::try_from(a) {
+        // TAG_INT32 = 1 (the PolyValue small-int tag).
+        (p::POLY_BOX_BASE | (1u64 << p::POLY_TAG_SHIFT) | (i as u32 as u64)) as i64
+    } else {
+        f64::to_bits(a as f64) as i64
+    }
+}
+
+/// WORD PolyValue → i64 CRU da superfície: INT32 → valor, singleton → 0,
+/// heap-tag (STR/OBJECT/FUNCTION) → handle real, double inline → trunc. Um i64
+/// pequeno não-boxed (já cru — bits abaixo de 2^48, onde nenhum double normal
+/// vive) passa verbatim.
+fn word_to_raw(w: u64) -> i64 {
+    use rts_engine::heap::poly as p;
+    if (w & p::POLY_BOX_BASE) == p::POLY_BOX_BASE {
+        let tag = (w >> p::POLY_TAG_SHIFT) & p::POLY_TAG_MASK;
+        return match tag {
+            1 => (w & 0xFFFF_FFFF) as u32 as i32 as i64,
+            p::POLY_TAG_SINGLETON => 0,
+            p::POLY_TAG_STR | p::POLY_TAG_OBJECT | p::POLY_TAG_FUNCTION => {
+                p::poly_handle_normalize(w).unwrap_or(0) as i64
+            }
+            _ => w as i64,
+        };
+    }
+    if w > (1u64 << 48) {
+        f64::from_bits(w) as i64
+    } else {
+        w as i64
+    }
+}
+
 /// (issue-pai) Para invoke de fn_ptr raw i64-ABI: os args number vieram como
 /// bits-f64 (convencao do call site dinamico). Aloca um novo args Vec com cada
 /// elemento convertido de bits-f64 -> i64 truncado, p/ a fn i64-param ler o

--- a/crates/rts-std/src/globals/text_encoding/instance.rs
+++ b/crates/rts-std/src/globals/text_encoding/instance.rs
@@ -852,10 +852,12 @@ unsafe fn invoke_microtask_callback(fn_ptr: u64, bound: &[i64], extra: Option<i6
     if let Some(v) = extra {
         args.push(v);
     }
-    // Ponte de convenção ÚNICA: um callable que é fn VALUE do motor novo
-    // (word/handle Entry::Function — possivelmente uniform-thunk com env)
-    // invoca via INVOKE_AUTO; um fn_ptr cru mantém o caminho registry.
-    rts_primitives::function::ops::invoke_callable_auto(fn_ptr, &args)
+    // Ponte de convenção COMPLETA: um callable UNIFORM-THUNK do motor novo fala
+    // WORDS nos dois sentidos (o settled value cru vira INT32/f64 word, e o
+    // retorno-word volta cru pro slot i64); um fn_ptr cru/`new Function` mantém
+    // o caminho registry i64. Sem a volta word→cru, `then(fnValue)` resolvia a
+    // promise com a WORD e o await re-boxava bits de f64 como número errado.
+    rts_primitives::function::ops::invoke_callable_bridged(fn_ptr, &args, false)
 }
 
 // TextEncoder / TextDecoder constructors — stateless, token handle.

--- a/crates/rts-std/src/promise/mod.rs
+++ b/crates/rts-std/src/promise/mod.rs
@@ -688,7 +688,9 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_CREATE(fn_handle: U64, args_vec_handle: U6
     let result_clone = result.clone();
     let handle = alloc_entry(Entry::PromiseAsync(result));
 
-    create_spawn(fn_handle, args_vec_handle, result_clone, handle, None)
+    // Explicit `promise.create(fn, [args])` from source: the args array comes
+    // from the NEW engine — its elements are PolyValue WORDS.
+    create_spawn(fn_handle, args_vec_handle, result_clone, handle, None, true)
 }
 
 /// O spawn de `promise.create`, com um `boxer` OPCIONAL aplicado ao valor de
@@ -704,7 +706,10 @@ pub fn create_spawn_boxed(
     let result = promise_slot::new_pending();
     let result_clone = result.clone();
     let handle = alloc_entry(Entry::PromiseAsync(result));
-    create_spawn(fn_handle, args_vec_handle, result_clone, handle, Some(boxer))
+    // The engine's async-CALL spawn (`__rtsadp_promise_spawn`): the args ride
+    // the FN_KINDS convention (an f64 travels as its BITS) — NOT words; the
+    // registry-typed invoke reads them back. Never word-decode these.
+    create_spawn(fn_handle, args_vec_handle, result_clone, handle, Some(boxer), false)
 }
 
 fn create_spawn(
@@ -713,6 +718,7 @@ fn create_spawn(
     result_clone: std::sync::Arc<rts_engine::heap::handles::PromiseSlot>,
     handle: u64,
     boxer: Option<extern "C" fn(u64, i64) -> i64>,
+    args_are_words: bool,
 ) -> u64 {
     let (fn_ptr, bound) = callable_or_decomposed(fn_handle);
     if fn_ptr == 0 {
@@ -732,9 +738,14 @@ fn create_spawn(
         // Combina bound (de bind) + extra_args do caller.
         let mut all: Vec<i64> = bound;
         all.extend(extra_args);
-        // Ponte de convenção: um fn VALUE (handle) invoca via INVOKE_AUTO
-        // (env/kinds do uniform-thunk); um fn_ptr cru mantém o transmute i64.
-        let r = rts_primitives::function::ops::invoke_callable_auto(fn_ptr, &all);
+        // Ponte de convenção COMPLETA: o args array de um `promise.create`
+        // explícito vem do MOTOR NOVO (`args_are_words` — elementos são WORDS
+        // PolyValue): um callee uniform-thunk as recebe verbatim e devolve
+        // WORD (re-crua p/ o slot i64); um fn_ptr cru/`new Function` recebe os
+        // valores DECODIFICADOS (INT32-word 50 → 50). O async-spawn do motor
+        // (`create_spawn_boxed`) fala a convenção FN_KINDS (bits f64) — os
+        // args passam verbatim pro invoke tipado do registry.
+        let r = rts_primitives::function::ops::invoke_callable_bridged(fn_ptr, &all, args_are_words);
         // Checa AMBOS os slots de erro pra detectar throw dentro do body: o
         // handle-slot legado E o errslot do motor novo (via hook — um `throw`
         // novo-motor grava a WORD lançada lá, não aqui).


### PR DESCRIPTION
## Batch 7 — rumo a 100% da suite TS: 616/623 (+3 vs batch 6)

### Fixes

**1. `new Function` real no motor novo (`function_global` + `promise_with_function`)**
- O motor instala o `COMPILE_FN_HOOK` do rts-primitives no bootstrap (`front/run/dynfn.rs`, novo módulo): compila o body pelo MESMO pipeline (parse → HIR → lowering) num `JITModule` próprio, mantido vivo pelo `keep_alive` do `Entry::Function`. Compilação aninhada é segura por design (estado global aditivo; `reset_codegen_state` é quiescent-boundary-only).
- Front: `new Function(p…, body)` (expr + stmt_let, só quando nenhuma user class sombreia o nome) → `__rtsadp_fn_new` (ToString params/body → CSV → ctor do runtime → box TAG_FUNCTION).
- `fn.bind(thisArg, …parciais)` → `__rtsadp_fn_bind` clona o function value com os extras em `bound_args` (words p/ callee uniforme; i64 cru p/ legado); o invoke uniforme faz o shift `a0…` e ajusta o argc do slot rest; `.length` lê `arity - bound`.
- `.name`/`.length`/`.toString`: `obj_get`/`dyn_length` roteiam receiver FUNCTION para `FUNCTION_NAME`/`LENGTH`; `f.toString()` de user fn estática vira o literal `function <n>() { [native code] }` em compile time.
- Callee LEGADO via fn word: `__rtsadp_fn_invoke` detecta `uniform_thunk=false` e roteia por `FUNCTION_CALL` com args crus.

**2. Ponte de convenção COMPLETA (`invoke_callable_bridged`) — mata o seam a0b0**
- A superfície `promise.*`/microtask fala i64 CRU; um callee uniform-thunk fala WORDS nos dois sentidos. `args_are_words` marca a proveniência: array do motor = words; settled value = cru; async-spawn do motor = convenção FN_KINDS (bits f64, verbatim).
- Consertou `then(fnValue)`, `then(bound)`, `create(fn)`, `create(new Function)` e **`promise_microtask_order`** (a0b0 → a1b2).
- Callbacks U64 de namespace call registram FN_KINDS quando a sig tem f64 (`emit_register_fn_abi_if_f64`, extraído do getPointer #247) — a arrow `(v: number)` passada a `promise.then` lia lixo no xmm.

**3. Regressão detectada e corrigida no próprio batch**: `async_args_number` — `create_spawn_boxed` fala FN_KINDS (bits f64), nunca word-decode (`f(2.5)` truncava para 2).

### Validação
- Unit tests (rts-codegen-new + rts-adapters + rts-engine): **812 passed / 16 failed** — os mesmos 16 pré-existentes na main.
- Suite TS: **616/623 files** (1662/1670 tests).
- `read_before_commit.sh`: sem violação HARD.
- Limite conhecido: `new Function` requer o hook instalado pelo JIT — em AOT continua o erro claro "compile hook not registered" (mesmo modelo de eval).

### Restantes (7 files)
TypedArray views reais com write-through (3, sendo 1 flaky só sob carga), BigInt #219 (1), `export * as ns` (1), tls arrow lift (1), structuredclone flaky sob carga (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
