### PR TITLE
feat(codegen/modules): M2 do resolver + tls no Registry + return; em arrow (622/623)

### DIFF
--- a/crates/rts-ast/src/ast.rs
+++ b/crates/rts-ast/src/ast.rs
@@ -26,6 +26,14 @@ pub struct Program {
     /// Populated by `ModuleGraph::flatten_for_jit` and by single-file
     /// AOT scan in `compile_program`.
     pub local_alias_map: HashMap<String, String>,
+    /// Top-level `export const`/`export let` NAMES (a `Statement` carries no
+    /// exported flag — the parser collects them straight off the swc module).
+    /// Read by the module resolver's export-set collection.
+    pub exported_names: Vec<String>,
+    /// The `export default function NAME(){}` name, when the module has a NAMED
+    /// default export (an anonymous default is a later increment). The resolver
+    /// exposes it under the `"default"` export key.
+    pub default_export: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +85,10 @@ pub struct ImportDecl {
     pub default_name: Option<String>,
     pub from: String,
     pub span: Span,
+    /// True when this edge came from a RE-EXPORT form (`export * from` — empty
+    /// `names` — or `export { x as y } from`): the resolver joins the target's
+    /// exports into THIS module's export set (star-chain fixpoint).
+    pub reexport: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rts-codegen-new/src/front/modules/flatten.rs
+++ b/crates/rts-codegen-new/src/front/modules/flatten.rs
@@ -33,6 +33,12 @@ pub enum Binding {
     /// A name exported by another resolved USER module, visible in the flat
     /// program under `name` (its top-level declaration name).
     Local { name: String },
+    /// An `export * as ns from "./m"` AGGREGATE: `members` maps each member
+    /// name to its FLAT top-level name. The entry lowering rewrites every
+    /// `<local>.<member>` access to the flat identifier.
+    Namespace {
+        members: std::collections::BTreeMap<String, String>,
+    },
 }
 
 /// Flatten `graph` into a single program + binding map.
@@ -124,19 +130,53 @@ pub fn flatten(graph: &ModuleGraph) -> ModuleResult<(Program, HashMap<String, Bi
                         ModuleError::Resolve(format!("dangling edge to {}", dep.display()))
                     })?;
                     for (orig, local) in &edge.names {
-                        if !dep_node.exports.contains(orig) {
+                        // A plain export: bind to its FLAT name (the export map
+                        // already resolved re-export aliases transitively).
+                        if let Some(flat) = dep_node.exports.get(orig) {
+                            bindings.insert(local.clone(), Binding::Local { name: flat.clone() });
+                            continue;
+                        }
+                        // An `export * as ns` AGGREGATE exported by `dep`: the
+                        // member map is the aggregate TARGET's fixpointed
+                        // exports (never including "default").
+                        if let Some((_, agg_dep)) = dep_node
+                            .ns_reexports
+                            .iter()
+                            .find(|(name, _)| name == orig)
+                        {
+                            let agg_node = graph.modules.get(agg_dep).ok_or_else(|| {
+                                ModuleError::Resolve(format!(
+                                    "dangling namespace re-export to {}",
+                                    agg_dep.display()
+                                ))
+                            })?;
+                            let members = agg_node
+                                .exports
+                                .iter()
+                                .filter(|(k, _)| k.as_str() != "default")
+                                .map(|(k, v)| (k.clone(), v.clone()))
+                                .collect();
+                            bindings.insert(local.clone(), Binding::Namespace { members });
+                            continue;
+                        }
+                        return Err(ModuleError::MissingExport {
+                            name: orig.clone(),
+                            from: edge.specifier.clone(),
+                        });
+                    }
+                    if let Some(default_local) = &edge.default_name {
+                        // `import x from "./m"` — the module's NAMED default
+                        // export (`export default function name(){}`).
+                        let Some(flat) = dep_node.exports.get("default") else {
                             return Err(ModuleError::MissingExport {
-                                name: orig.clone(),
+                                name: "default".to_string(),
                                 from: edge.specifier.clone(),
                             });
-                        }
-                        bindings.insert(local.clone(), Binding::Local { name: orig.clone() });
-                    }
-                    if edge.default_name.is_some() {
-                        return Err(ModuleError::Unsupported(format!(
-                            "default import from user module '{}'",
-                            edge.specifier
-                        )));
+                        };
+                        bindings.insert(
+                            default_local.clone(),
+                            Binding::Local { name: flat.clone() },
+                        );
                     }
                 }
                 Target::Unsupported { specifier } => {

--- a/crates/rts-codegen-new/src/front/modules/graph.rs
+++ b/crates/rts-codegen-new/src/front/modules/graph.rs
@@ -9,7 +9,7 @@
 //! Builtins (`rts`/`rts:<ns>`/`node:<ns>`) are LEAF edges: recorded on the
 //! importing module but never loaded from disk and never part of a cycle.
 
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 
 use rts_ast::ast::{Item, Program};
@@ -28,6 +28,10 @@ pub struct ImportEdge {
     pub names: Vec<(String, String)>,
     /// The default-import local name, if any (`import io from "..."`).
     pub default_name: Option<String>,
+    /// True for a RE-EXPORT edge (`export * from` — empty `names` — or
+    /// `export { x as y } from`): the target's exports join THIS module's
+    /// export map (the post-load star-chain fixpoint).
+    pub reexport: bool,
 }
 
 /// A single loaded user module.
@@ -39,8 +43,14 @@ pub struct ModuleNode {
     pub program: Program,
     /// Resolved import edges, in source order.
     pub imports: Vec<ImportEdge>,
-    /// The set of top-level names this module `export`s.
-    pub exports: BTreeSet<String>,
+    /// Export name → the FLAT top-level name it resolves to. For an own
+    /// declaration the two coincide; a re-export alias (`export { add as plus }
+    /// from`) maps `plus → add`; a NAMED default export maps `default → name`.
+    pub exports: BTreeMap<String, String>,
+    /// `export * as ns from "./m"` aggregates: `ns` → the resolved TARGET key.
+    /// The flatten materializes the member map from the target's (fixpointed)
+    /// exports and binds the importing side as a namespace-alias rewrite.
+    pub ns_reexports: Vec<(String, PathBuf)>,
 }
 
 /// The loaded graph: the entry key + every reachable user module, keyed by
@@ -71,8 +81,15 @@ impl ModuleGraph {
                     }
                 }
             }
+            for (_, dep) in &node.ns_reexports {
+                if !modules.contains_key(dep) {
+                    pending.push_back(dep.clone());
+                }
+            }
             modules.insert(key, node);
         }
+
+        propagate_reexports(&mut modules);
 
         let graph = Self { entry_key, modules };
         if let Some(cycle) = graph.detect_cycle() {
@@ -162,6 +179,7 @@ fn load_one(key: &Path) -> ModuleResult<ModuleNode> {
         .map_err(|e| ModuleError::Parse(format!("{}: {e}", key.display())))?;
 
     let mut imports = Vec::new();
+    let mut ns_reexports = Vec::new();
     for item in &program.items {
         match item {
             Item::Import(decl) => {
@@ -176,16 +194,21 @@ fn load_one(key: &Path) -> ModuleResult<ModuleNode> {
                     target,
                     names,
                     default_name: decl.default_name.clone(),
+                    reexport: decl.reexport,
                 });
             }
-            // `export * as ns from "./mod"` — out of M1 scope (namespace
-            // aggregate import is dropped at the parser; record as unsupported
-            // so we never silently miscompile a program that relies on it).
+            // `export * as ns from "./mod"` — a NAMESPACE AGGREGATE: record the
+            // resolved target; the flatten materializes the member map from the
+            // target's (fixpointed) exports and rewrites `ns.<m>` accesses.
             Item::ExportNamespace(d) => {
-                return Err(ModuleError::Unsupported(format!(
-                    "`export * as {} from \"{}\"` (namespace re-export)",
-                    d.local, d.from
-                )));
+                let target = resolve::resolve(&d.from, key)?;
+                let Target::File(dep) = target else {
+                    return Err(ModuleError::Unsupported(format!(
+                        "`export * as {} from \"{}\"` over a non-file module",
+                        d.local, d.from
+                    )));
+                };
+                ns_reexports.push((d.local.clone(), dep));
             }
             _ => {}
         }
@@ -197,26 +220,82 @@ fn load_one(key: &Path) -> ModuleResult<ModuleNode> {
         key: key.to_path_buf(),
         program,
         imports,
+        ns_reexports,
         exports,
     })
 }
 
 /// The set of top-level names a module exports, read from the parser's
 /// `exported: bool` flag on functions/classes.
-fn collect_exports(program: &Program) -> BTreeSet<String> {
-    let mut set = BTreeSet::new();
+fn collect_exports(program: &Program) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
     for item in &program.items {
         match item {
             Item::Function(f) if f.exported => {
-                set.insert(f.name.clone());
+                map.insert(f.name.clone(), f.name.clone());
             }
             Item::Class(c) if c.exported => {
-                set.insert(c.name.clone());
+                map.insert(c.name.clone(), c.name.clone());
             }
             _ => {}
         }
     }
-    set
+    // `export const`/`export let` names — a `Statement` carries no exported
+    // flag, so the parser collected them straight off the swc module.
+    for name in &program.exported_names {
+        map.insert(name.clone(), name.clone());
+    }
+    // A NAMED `export default function NAME(){}` — exposed under "default".
+    if let Some(name) = &program.default_export {
+        map.insert("default".to_string(), name.clone());
+    }
+    map
+}
+
+/// The star-chain FIXPOINT: a `reexport` edge joins the target's export map
+/// into the re-exporter's — an EMPTY-names edge (`export * from`) copies the
+/// whole map EXCEPT `"default"` (per spec, `export *` never re-exports the
+/// default); a NAMED edge (`export { x as y } from`) maps `y → target[x]`
+/// (already resolved to the FLAT name, so chains stay transitive). Iterated to
+/// a fixed point so chains of star re-exports converge (module counts are
+/// small; each pass only ever ADDS entries, so it terminates).
+fn propagate_reexports(modules: &mut HashMap<PathBuf, ModuleNode>) {
+    loop {
+        let mut updates: Vec<(PathBuf, String, String)> = Vec::new();
+        for node in modules.values() {
+            for edge in node.imports.iter().filter(|e| e.reexport) {
+                let Target::File(dep) = &edge.target else {
+                    continue;
+                };
+                let Some(target) = modules.get(dep) else {
+                    continue;
+                };
+                if edge.names.is_empty() {
+                    for (k, v) in &target.exports {
+                        if k != "default" && node.exports.get(k) != Some(v) {
+                            updates.push((node.key.clone(), k.clone(), v.clone()));
+                        }
+                    }
+                } else {
+                    for (orig, local) in &edge.names {
+                        if let Some(v) = target.exports.get(orig) {
+                            if node.exports.get(local) != Some(v) {
+                                updates.push((node.key.clone(), local.clone(), v.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if updates.is_empty() {
+            break;
+        }
+        for (key, k, v) in updates {
+            if let Some(node) = modules.get_mut(&key) {
+                node.exports.insert(k, v);
+            }
+        }
+    }
 }
 
 /// Render a cycle path (`a.ts -> b.ts -> a.ts`) for the error message.

--- a/crates/rts-codegen-new/src/front/run/module_entry.rs
+++ b/crates/rts-codegen-new/src/front/run/module_entry.rs
@@ -185,9 +185,12 @@ fn apply_bindings(
     program: &mut rts_ast::ast::Program,
     bindings: &HashMap<String, Binding>,
 ) -> FrontResult<HashMap<String, (String, String)>> {
-    // 1. Split the bindings into alias renames (local → orig) and builtins.
+    // 1. Split the bindings into alias renames (local → orig), namespace
+    //    aggregates (`export * as ns` — member-access rewrites), and builtins.
     let mut renames: HashMap<String, String> = HashMap::new();
     let mut builtins: HashMap<String, (String, String)> = HashMap::new();
+    let mut namespaces: HashMap<String, std::collections::BTreeMap<String, String>> =
+        HashMap::new();
     for (local, binding) in bindings {
         match binding {
             Binding::Local { name } => {
@@ -198,10 +201,26 @@ fn apply_bindings(
             Binding::Builtin { ns, member } => {
                 builtins.insert(local.clone(), (ns.clone(), member.clone()));
             }
+            Binding::Namespace { members } => {
+                namespaces.insert(local.clone(), members.clone());
+            }
         }
     }
 
-    // 2. Rewrite every identifier reference across the flattened program (only if
+    // 2. Rewrite `<ns>.<member>` aggregate accesses FIRST (`starNs.one` → `one`),
+    //    so the plain ident renamer below never sees the aggregate name. An
+    //    unknown member is left untouched — the unbound `starNs` ident then
+    //    bails at lowering (honest, never a guessed value).
+    if !namespaces.is_empty() {
+        let mut rewriter = NamespaceMemberRewriter {
+            namespaces: &namespaces,
+        };
+        for item in &mut program.items {
+            rename_item_with(item, &mut rewriter);
+        }
+    }
+
+    // 3. Rewrite every identifier reference across the flattened program (only if
     //    there is an alias to rewrite).
     if !renames.is_empty() {
         let mut renamer = Renamer { renames: &renames };
@@ -212,9 +231,19 @@ fn apply_bindings(
     Ok(builtins)
 }
 
-/// Apply the [`Renamer`] to one flattened top-level item (statement body, function
-/// body, or class property initializer — every swc subtree the lowering re-reads).
+/// Apply a swc `VisitMut` to one flattened top-level item (statement body,
+/// function body, or class property initializer — every swc subtree the
+/// lowering re-reads). Shared by the alias [`Renamer`] and the
+/// [`NamespaceMemberRewriter`].
+fn rename_item_with<V: swc_ecma_visit::VisitMut>(item: &mut Item, visitor: &mut V) {
+    rename_item_impl(item, visitor)
+}
+
 fn rename_item(item: &mut Item, renamer: &mut Renamer<'_>) {
+    rename_item_impl(item, renamer)
+}
+
+fn rename_item_impl<V: swc_ecma_visit::VisitMut>(item: &mut Item, renamer: &mut V) {
     match item {
         Item::Statement(Statement::Raw(raw)) => {
             if let Some(stmt) = raw.stmt.as_mut() {
@@ -248,7 +277,7 @@ fn rename_item(item: &mut Item, renamer: &mut Renamer<'_>) {
 
 /// Rename references inside a class member's swc subtrees (method bodies + a
 /// constructor body + a property initializer).
-fn rename_class_member(m: &mut rts_ast::ast::ClassMember, renamer: &mut Renamer<'_>) {
+fn rename_class_member<V: swc_ecma_visit::VisitMut>(m: &mut rts_ast::ast::ClassMember, renamer: &mut V) {
     use rts_ast::ast::ClassMember;
     match m {
         ClassMember::Constructor(ctor) => {
@@ -291,5 +320,40 @@ impl swc_ecma_visit::VisitMut for Renamer<'_> {
         if let Some(target) = self.renames.get(ident.sym.as_ref()) {
             ident.sym = target.clone().into();
         }
+    }
+}
+
+/// Rewrites `<aggregate>.<member>` accesses (an `export * as ns` import) to the
+/// member's FLAT top-level identifier (`starNs.one` → `one`). Only a MemberExpr
+/// whose OBJECT is the aggregate ident and whose prop is a KNOWN member is
+/// rewritten; an unknown member is left untouched — the unbound aggregate ident
+/// then bails at lowering (honest, never a guessed value).
+struct NamespaceMemberRewriter<'a> {
+    namespaces: &'a HashMap<String, std::collections::BTreeMap<String, String>>,
+}
+
+impl swc_ecma_visit::VisitMut for NamespaceMemberRewriter<'_> {
+    fn visit_mut_expr(&mut self, e: &mut swc_ecma_ast::Expr) {
+        use swc_ecma_visit::VisitMutWith;
+        e.visit_mut_children_with(self);
+        let swc_ecma_ast::Expr::Member(m) = e else {
+            return;
+        };
+        let swc_ecma_ast::Expr::Ident(obj) = &*m.obj else {
+            return;
+        };
+        let Some(members) = self.namespaces.get(obj.sym.as_ref()) else {
+            return;
+        };
+        let swc_ecma_ast::MemberProp::Ident(prop) = &m.prop else {
+            return;
+        };
+        let Some(flat) = members.get(prop.sym.as_ref()) else {
+            return;
+        };
+        *e = swc_ecma_ast::Expr::Ident(swc_ecma_ast::Ident::new_no_ctxt(
+            flat.clone().into(),
+            m.span,
+        ));
     }
 }

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -41,9 +41,10 @@ pub(super) struct Register {
 
 /// Every `fn(&mut Engine)` register, in any order (each just pushes metadata).
 /// ADD A NAMESPACE/CLASS HERE — one row, append-friendly. Heavier/feature-gated
-/// namespaces (http_server/tls/runtime) are deliberately absent until a test
-/// needs them (`ui` is now registered — egui GUI, crate `rts-egui`). `console`
-/// is NOT here — it is a `.ts` prelude (see [`PRELUDE_TS`]).
+/// namespaces (http_server/runtime) are deliberately absent until a test
+/// needs them (`ui` is now registered — egui GUI, crate `rts-egui`; `tls` is
+/// registered — `tls_basic`). `console` is NOT here — it is a `.ts` prelude
+/// (see [`PRELUDE_TS`]).
 pub(super) static REGISTER: &[Register] = &[
     // Namespaces backing class statics/ctors (Date.now/UTC/parse → `date`; Map/Set
     // → `collections`).
@@ -82,6 +83,7 @@ pub(super) static REGISTER: &[Register] = &[
     Register { label: "os", run: ns::os::register, why: "rts:os" },
     Register { label: "crypto", run: ns::crypto::register, why: "rts:crypto" },
     Register { label: "net", run: ns::net::register, why: "rts:net" },
+    Register { label: "tls", run: ns::tls::register, why: "rts:tls TLS 1.2/1.3 client (tls_basic)" },
     Register { label: "json", run: ns::json::register, why: "rts:json namespace" },
     Register { label: "promise", run: ns::promise::register, why: "rts:promise" },
     Register { label: "thread", run: ns::thread::register, why: "rts:thread" },

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -6,7 +6,7 @@
 //! condition is reduced through JS `ToBoolean` ([`Lowerer::as_bool_value`]), so
 //! `if (x)` / `while (i)` over numbers or Tagged values work, not just booleans.
 
-use cranelift_codegen::ir::InstBuilder;
+use cranelift_codegen::ir::{InstBuilder, types};
 use cranelift_module::Module;
 
 use rts_hir::ir::{HirExprKind, HirLit};
@@ -127,7 +127,6 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 cases,
             } => self.lower_switch(module, discriminant, cases),
             HirStmt::Raw(text) => unsupported!("unrecognized statement `{}`", text.trim()),
-            other => unsupported!("statement {}", stmt_name(other)),
         }
     }
 
@@ -142,8 +141,20 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 self.lower_expr(module, e)?;
                 None
             }
-            (Some(_ret), None) => {
-                return unsupported!("`return;` with no value in a value-returning function");
+            (Some(ret), None) => {
+                // A bare `return;` in a TAGGED-returning function (an early exit
+                // in a lifted arrow/callback — every lifted arrow returns a word)
+                // is JS `return undefined`. A PROVEN-numeric return keeps the
+                // bail (a void return through a proven Int/Float ABI would
+                // fabricate a 0 — tsc rejects that program anyway).
+                if !matches!(ret, Repr::Tagged) {
+                    return unsupported!("`return;` with no value in a value-returning function");
+                }
+                let undef = self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, crate::value::PolyValue::undefined().raw() as i64);
+                Some(undef)
             }
             (Some(ret), Some(e)) => {
                 // TAIL CALL (TCO): `return f(args)` where both this fn and `f`
@@ -443,29 +454,6 @@ pub(super) fn ident_target(target: &HirExpr) -> FrontResult<String> {
     }
 }
 
-/// A readable name for an unsupported statement variant.
-fn stmt_name(s: &HirStmt) -> &'static str {
-    match s {
-        HirStmt::Expr(_) => "expression",
-        HirStmt::Return(_) => "return",
-        HirStmt::Let { .. } => "let",
-        HirStmt::Const { .. } => "const",
-        HirStmt::If { .. } => "if",
-        HirStmt::While { .. } => "while",
-        HirStmt::DoWhile { .. } => "do-while",
-        HirStmt::For { .. } => "for",
-        HirStmt::ForOf { .. } => "for-of",
-        HirStmt::ForIn { .. } => "for-in",
-        HirStmt::Break(_) => "break",
-        HirStmt::Continue(_) => "continue",
-        HirStmt::Try { .. } => "try",
-        HirStmt::Throw(_) => "throw",
-        HirStmt::Switch { .. } => "switch",
-        HirStmt::Block(_) => "block",
-        HirStmt::Labeled { .. } => "labeled",
-        HirStmt::Raw(_) => "raw",
-    }
-}
 
 /// A readable name for an unsupported expression variant (used by `expr.rs`).
 pub(super) fn expr_variant_name(k: &HirExprKind) -> &'static str {

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -307,6 +307,7 @@ fn lower_program(cm: &Lrc<SourceMap>, source: &SwcProgram) -> Program {
             for item in &module.body {
                 lower_module_item(cm, item, &mut program.items);
             }
+            collect_export_meta(module, &mut program);
         }
         SwcProgram::Script(script) => {
             for stmt in &script.body {
@@ -316,6 +317,37 @@ fn lower_program(cm: &Lrc<SourceMap>, source: &SwcProgram) -> Program {
     }
 
     program
+}
+
+/// Collect the export metadata a `Statement` cannot carry: the NAMES of every
+/// top-level `export const`/`export let` declarator (Statement has no exported
+/// flag) and the NAMED `export default function NAME(){}`. Read by the module
+/// resolver's export-set collection (`front::modules::graph`).
+fn collect_export_meta(module: &swc_ecma_ast::Module, program: &mut Program) {
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+            continue;
+        };
+        match decl {
+            ModuleDecl::ExportDecl(d) => {
+                if let Decl::Var(v) = &d.decl {
+                    for declarator in &v.decls {
+                        if let swc_ecma_ast::Pat::Ident(id) = &declarator.name {
+                            program.exported_names.push(id.id.sym.to_string());
+                        }
+                    }
+                }
+            }
+            ModuleDecl::ExportDefaultDecl(d) => {
+                if let DefaultDecl::Fn(f) = &d.decl {
+                    if let Some(ident) = &f.ident {
+                        program.default_export = Some(ident.sym.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 fn lower_module_item(cm: &Lrc<SourceMap>, item: &ModuleItem, out: &mut Vec<Item>) {
@@ -402,6 +434,7 @@ fn lower_module_decl(cm: &Lrc<SourceMap>, decl: &ModuleDecl, out: &mut Vec<Item>
                         default_name: None,
                         from: src.value.to_string_lossy().to_string(),
                         span: convert_span(cm, export_named.span),
+                        reexport: true,
                     };
                     out.push(Item::Import(import));
                 }
@@ -423,6 +456,7 @@ fn lower_module_decl(cm: &Lrc<SourceMap>, decl: &ModuleDecl, out: &mut Vec<Item>
                 default_name: None,
                 from: export_all.src.value.to_string_lossy().to_string(),
                 span: convert_span(cm, export_all.span),
+                reexport: true,
             };
             out.push(Item::Import(import));
         }
@@ -922,6 +956,7 @@ fn lower_import_decl(cm: &Lrc<SourceMap>, import_decl: &SwcImportDecl) -> Import
         default_name,
         from: import_decl.src.value.to_string_lossy().to_string(),
         span: convert_span(cm, import_decl.span),
+        reexport: false,
     }
 }
 


### PR DESCRIPTION
## Batch 8 — rumo a 100% da suite TS: 622/623

### `module_imports` 14/14 — M2 do resolver de módulos
- `Program` carrega `exported_names` (export const/let — `Statement` não tem flag exported) e `default_export` (`export default function NAME`), coletados direto do swc module.
- `ImportDecl`/`ImportEdge` ganham `reexport` (`export * from` / `export { x as y } from`); os exports viram **MAP name→flat_name** com fixpoint de star-chains (`export *` nunca propaga `"default"`, per spec) e alias transitivo (`plus → add` resolve através de cadeias).
- `export * as ns from "./m"`: `ModuleNode.ns_reexports` registra o agregado; o flatten emite `Binding::Namespace{members}` e o `module_entry` reescreve `ns.<m>` → identificador flat via `NamespaceMemberRewriter`. Membro desconhecido fica intacto → o ident não-bound baila honesto no lowering.
- Default import de user module resolve `exports["default"]`.

### `tls_basic` — namespace `tls` no Registry
Estava deliberadamente ausente "até um teste precisar" — o teste precisa. Handshake TLS 1.2/1.3 real contra api.github.com passa (2/2).

### `return;` (early exit) em arrow liftada
Em fn TAGGED-returning (toda arrow/callback liftada retorna word) `return;` vira `undefined` em vez de bail; retorno proven-numeric mantém o bail. Removido arm unreachable + `stmt_name` morto.

### Validação
- Unit tests: **812/16** (mesmos 16 stale pré-existentes na main — testes "expected bail" de features já implementadas; tracking task própria).
- Suite TS: **622/623** (1687/1688 tests). Único restante: `structuredclone_type_preserve` (1 subtest — Date clone `.getUTCFullYear` precisa de dispatch dinâmico registry por entry-type).
- Gate sem violação HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZhYJX8tFhJvCFjt9JqKdL
