### PR TITLE
feat(runtime/codegen): Object/Map.groupBy + Set operations ES2025 via polyfill .ts

### DIFF
--- a/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
@@ -395,6 +395,13 @@ fn is_side_effect_free_arg(e: &HirExpr) -> bool {
         // double-lowering only re-reads — accepted (matches the member reads the
         // dispatch arms themselves perform).
         HirExprKind::Member { object, .. } => is_side_effect_free_arg(object),
+        // An INDEX READ (`arr[i]`, `this.#items[i]`) over side-effect-free
+        // operands re-lowers as a plain re-read, same reasoning as Member.
+        // Rejecting it made `other.has(this.#items[i])` (the stdlib Set ops)
+        // decline the virtual dispatch and fall to a dynamic own-prop miss.
+        HirExprKind::Index { object, index } => {
+            is_side_effect_free_arg(object) && is_side_effect_free_arg(index)
+        }
         _ => false,
     }
 }

--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -131,6 +131,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 .object_proto_unary(module, args, "__rtsadp_obj_proto_of")
                 .map(Some),
             "setPrototypeOf" => self.object_set_proto(module, args).map(Some),
+            // `Object.groupBy(items, cb)` (ES2024) → the prelude `.ts`
+            // `__object_group_by` (object.ts), same routing as `Object(x)` →
+            // `ObjectFactory`.
+            "groupBy" if args.len() == 2 && self.sigs.contains_key("__object_group_by") => {
+                let v = self.call_synth_fn(module, "__object_group_by", None, args)?;
+                let word = self.box_value(v);
+                Ok(Some(Val::tagged_kind(word, JsKind::Object)))
+            }
             other => unsupported!("Object.{other}(...) static method (later increment)"),
         }
     }

--- a/crates/rts-primitives/src/object.ts
+++ b/crates/rts-primitives/src/object.ts
@@ -28,6 +28,27 @@ function ObjectFactory(value?: any): any {
   return value;
 }
 
+// `Object.groupBy(items, cb)` — ES2024 (routed here by `objstatic.rs`). Groups
+// `items` into a fresh plain object keyed by the PROPERTY KEY of `cb(item, index)`
+// (string-coerced), buckets in first-seen key order. Parallel proven arrays keep
+// the buckets pushable; the dynamic `out[key] = bucket` writes append via the
+// runtime shape transition.
+function __object_group_by(items: any[], cb: any): any {
+  const keys: string[] = [];
+  const buckets: any[][] = [];
+  for (let i = 0; i < items.length; i++) {
+    const k = "" + cb(items[i], i);
+    let found = false;
+    for (let j = 0; j < keys.length; j++) {
+      if (keys[j] === k) { buckets[j].push(items[i]); found = true; break; }
+    }
+    if (!found) { keys.push(k); buckets.push([items[i]]); }
+  }
+  const out: any = {};
+  for (let j = 0; j < keys.length; j++) { out[keys[j]] = buckets[j]; }
+  return out;
+}
+
 class Object {
   // `obj.hasOwnProperty(key)` — true iff `key` is an own property of `this`,
   // decided by the engine's shape-aware membership check.

--- a/crates/rts-shared/src/stdlib/map_set.ts
+++ b/crates/rts-shared/src/stdlib/map_set.ts
@@ -71,6 +71,21 @@ class Map<K, V> {
     for (let i = 0; i < this.#keys.length; i++) { cb(this.#vals[i], this.#keys[i], this); }
   }
   clear(): void { this.#keys = []; this.#vals = []; }
+  // `Map.groupBy(items, cb)` — ES2024. Groups `items` by `cb(item, index)` under
+  // SameValueZero key identity, buckets in first-seen key order (JS spec).
+  static groupBy(items: any[], cb: (item: any, index: number) => any): Map<any, any[]> {
+    const m = new Map<any, any[]>();
+    for (let i = 0; i < items.length; i++) {
+      const k = cb(items[i], i);
+      const bucket = m.get(k);
+      if (bucket === undefined) {
+        m.set(k, [items[i]]);
+      } else {
+        bucket.push(items[i]);
+      }
+    }
+    return m;
+  }
   // Default iterator (`for (const [k,v] of map)`): a real generator yielding
   // `[key, value]` pairs in insertion order. Plain JS — the parser desugars the
   // `*`/`yield`, the engine drives it through the generator state machine.
@@ -124,6 +139,63 @@ class Set<T> {
     for (let i = 0; i < this.#items.length; i++) { cb(this.#items[i], this.#items[i], this); }
   }
   clear(): void { this.#items = []; }
+  // --- ES2025 Set operations. Each takes another Set and reads it through its
+  // public surface (`values()`/`has()`), returning a fresh Set / boolean.
+  union(other: Set<T>): Set<T> {
+    const out = new Set<T>();
+    for (let i = 0; i < this.#items.length; i++) { out.add(this.#items[i]); }
+    const ov = other.values();
+    for (let i = 0; i < ov.length; i++) { out.add(ov[i]); }
+    return out;
+  }
+  intersection(other: Set<T>): Set<T> {
+    const out = new Set<T>();
+    for (let i = 0; i < this.#items.length; i++) {
+      const v = this.#items[i];
+      if (other.has(v)) { out.add(v); }
+    }
+    return out;
+  }
+  difference(other: Set<T>): Set<T> {
+    const out = new Set<T>();
+    for (let i = 0; i < this.#items.length; i++) {
+      const v = this.#items[i];
+      if (!other.has(v)) { out.add(v); }
+    }
+    return out;
+  }
+  symmetricDifference(other: Set<T>): Set<T> {
+    const out = new Set<T>();
+    for (let i = 0; i < this.#items.length; i++) {
+      const v = this.#items[i];
+      if (!other.has(v)) { out.add(v); }
+    }
+    const ov = other.values();
+    for (let i = 0; i < ov.length; i++) {
+      const v = ov[i];
+      if (!this.has(v)) { out.add(v); }
+    }
+    return out;
+  }
+  isSubsetOf(other: Set<T>): boolean {
+    for (let i = 0; i < this.#items.length; i++) {
+      if (!other.has(this.#items[i])) return false;
+    }
+    return true;
+  }
+  isSupersetOf(other: Set<T>): boolean {
+    const ov = other.values();
+    for (let i = 0; i < ov.length; i++) {
+      if (!this.has(ov[i])) return false;
+    }
+    return true;
+  }
+  isDisjointFrom(other: Set<T>): boolean {
+    for (let i = 0; i < this.#items.length; i++) {
+      if (other.has(this.#items[i])) return false;
+    }
+    return true;
+  }
   // Default iterator (`for (const x of set)`): a real generator yielding values.
   *[Symbol.iterator](): T[] {
     for (let i = 0; i < this.size; i++) { yield this.#items[i]; }


### PR DESCRIPTION
## Resumo

Ataca o cluster **collections** do cross-runtime (tracker #875, ex-#678): `89_groupby`, `90_set_operations`, `301_groupby_dedicated` e `302_set_ops_dedicated` agora produzem saída **idêntica a Bun/Node** (verificado byte a byte). Categoria collections: **8/18 → 14/19 pass**.

## Mudanças

- **`map_set.ts`** (rts-shared stdlib): `static Map.groupBy(items, cb)` (ES2024, SameValueZero, buckets em ordem first-seen) + família de operações de Set ES2025 (`union`, `intersection`, `difference`, `symmetricDifference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`) — **puro polyfill .ts**, zero nome não-primordial novo no motor.
- **`object.ts`** (rts-primitives): `__object_group_by` — agrupamento com arrays paralelos provados + escrita dinâmica `out[key]` via shape transition.
- **`objstatic.rs`**: arm `Object.groupBy` → prelude `__object_group_by` (mesmo padrão `Object(x)` → `ObjectFactory`). *Nota: arquivo já estava na lista >500 do gate; +9 linhas.*
- **`vdispatch.rs`**: `is_side_effect_free_arg` aceita INDEX READ puro (`arr[i]`, `this.#items[i]`) — re-lower é só re-leitura, mesmo racional do arm Member já aceito. Sem isso, o dispatch virtual dinâmico declinava `other.has(this.#items[i])` e caía em own-prop miss → `TypeError: not a function` em runtime.

## Testes

- Suíte TS: **623/623** arquivos, 1688/1688 testes verdes.
- Cross-runtime collections local: 14/19 pass (os 5 restantes são problemas distintos com issues próprias: #1398, #1399, #1403, mutation-order de forEach).
- `read_before_commit.sh`: verde, sem violação HARD.
- `cargo test --release --lib -p rts-codegen-new`: 826 passed; **2 falhas pré-existentes na main** (`negative_zero_still_prints_zero`, `negative_number_formatting`) — reproduzidas sem este diff, não relacionadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj