### PR TITLE
feat(runtime/codegen): events polyfill .ts + await polimórfico + namespace de arrows do prelude

### DIFF
--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -497,20 +497,29 @@ pub extern "C" fn __rtsadp_to_string(a: u64) -> u64 {
 /// `undefined` in that case.
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_await(word: u64) -> u64 {
-    let v = PolyValue::from_raw(word);
-    let f = if v.is_double() {
-        v.as_f64()
-    } else if v.is_int32() {
-        v.as_i32() as f64
-    } else {
-        return word;
-    };
-    const HANDLE_MIN: f64 = 281_474_976_710_656.0; // 2^48 (generation ≥ 1)
-    if !(f.is_finite() && f >= HANDLE_MIN && f <= u64::MAX as f64 && f.fract() == 0.0) {
-        return word;
-    }
-    let handle = f as u64;
     use rts_engine::heap::handles::{Entry, with_entry};
+    use rts_runtime::namespaces::gc::handles as rt_handles;
+    let v = PolyValue::from_raw(word);
+    // Tag-dispatch, no static guessing. An OBJECT word may be a boxed Promise
+    // (`new Promise(executor)` returns its handle through the heterogeneous
+    // `__rtsadp_box_handle_auto`, which tags a PromiseAsync entry OBJECT) —
+    // reconstruct the full handle from the live slot and wait on it too.
+    let handle = if v.is_object() {
+        rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle())
+    } else {
+        let f = if v.is_double() {
+            v.as_f64()
+        } else if v.is_int32() {
+            v.as_i32() as f64
+        } else {
+            return word;
+        };
+        const HANDLE_MIN: f64 = 281_474_976_710_656.0; // 2^48 (generation ≥ 1)
+        if !(f.is_finite() && f >= HANDLE_MIN && f <= u64::MAX as f64 && f.fract() == 0.0) {
+            return word;
+        }
+        f as u64
+    };
     let is_promise = with_entry(handle, |e| matches!(e, Some(Entry::PromiseAsync(_))));
     if !is_promise {
         return word;

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -391,6 +391,7 @@ pub fn extract_arrows(
     ambient_fns: &HashSet<String>,
     class_names: &HashSet<String>,
     module_globals: &HashSet<String>,
+    arrow_ns: &str,
 ) -> ExtractResult {
     let mut top_level: HashSet<String> = funcs.iter().map(|f| f.name.clone()).collect();
     top_level.insert(main.name.clone());
@@ -416,6 +417,7 @@ pub fn extract_arrows(
         current_fn: String::new(),
         current_fn_lets: HashSet::new(),
         counter: 0,
+        arrow_ns: arrow_ns.to_string(),
     };
 
     // Rewrite arrows inside every existing function body and the main body. Each
@@ -580,6 +582,12 @@ struct Ctx {
     current_fn_lets: HashSet<String>,
     /// Fresh-name counter.
     counter: usize,
+    /// Name NAMESPACE for lifted arrows (`__rtsn_arrow_{ns}{counter}`): `"p"` on
+    /// the PRELUDE build, `""` on the user build. The two sides are lowered as
+    /// separate programs (each counter starts at 0) then merged last-wins — a
+    /// shared namespace made a prelude arrow and a user arrow collide on
+    /// `__rtsn_arrow_0` (duplicate define / silent replacement).
+    arrow_ns: String,
 }
 
 impl Ctx {
@@ -874,7 +882,7 @@ impl Ctx {
         // capture list, so reify and thunk agree deterministically.
         captures.sort();
 
-        let name = format!("__rtsn_arrow_{}", self.counter);
+        let name = format!("__rtsn_arrow_{}{}", self.arrow_ns, self.counter);
         self.counter += 1;
         self.top_level.insert(name.clone());
 

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -135,14 +135,20 @@ pub fn dump_ir_source(src: &str) -> FrontResult<()> {
 fn build_with_includes(src: &str) -> FrontResult<LoweredProgram> {
     let inc = registry::includes_prelude();
     if inc.is_empty() {
-        build_program(src)
+        build_program(src, "")
     } else {
-        let prelude = build_program(&inc)?;
+        let prelude = build_program(&inc, PRELUDE_ARROW_NS)?;
         let ambient_fns = prelude_fn_names(&prelude);
         let user = build_program_with_ambient(src, &prelude.classes, &ambient_fns)?;
         merge_programs(prelude, user)
     }
 }
+
+/// Arrow-name namespace for the PRELUDE build (`__rtsn_arrow_p{N}`). The prelude
+/// and the user program are lowered separately (each arrow counter starts at 0)
+/// and merged last-wins — without distinct namespaces a prelude arrow and a user
+/// arrow collided on `__rtsn_arrow_0`.
+const PRELUDE_ARROW_NS: &str = "p";
 
 /// The set of AMBIENT names a `prelude` exposes to a user program — its top-level
 /// FUNCTIONS (`rts:test` describe/test/expect, primordial `.ts` helpers) AND its
@@ -193,7 +199,7 @@ fn render_source_core(prog: &LoweredProgram) -> FrontResult<String> {
 /// embedded stdlib includes ahead of a multi-file user program. A thin alias so
 /// the private `build_program` stays the single post-parse entry.
 fn build_program_for_prelude(src: &str) -> FrontResult<LoweredProgram> {
-    build_program(src)
+    build_program(src, PRELUDE_ARROW_NS)
 }
 
 /// [`build_program`] with AMBIENT (prelude) classes available for `extends`
@@ -206,7 +212,7 @@ fn build_program_with_ambient(
 ) -> FrontResult<LoweredProgram> {
     let program =
         rts_parser::parse_source(src).map_err(|e| Unsupported::new(format!("parse error: {e}")))?;
-    build_from_program(program, src, ambient, ambient_fns)
+    build_from_program(program, src, ambient, ambient_fns, "")
 }
 
 /// Compile `prelude_src` (a declarations-only TS stdlib) ahead of `user_src`,
@@ -226,7 +232,7 @@ pub fn render_source_with_prelude(prelude_src: &str, user_src: &str) -> FrontRes
     } else {
         format!("{engine_inc}\n{prelude_src}")
     };
-    let prelude = build_program(&merged_prelude_src)?;
+    let prelude = build_program(&merged_prelude_src, PRELUDE_ARROW_NS)?;
     let ambient_fns = prelude_fn_names(&prelude);
     let user = build_program_with_ambient(user_src, &prelude.classes, &ambient_fns)?;
     let merged = merge_programs(prelude, user)?;
@@ -394,7 +400,7 @@ pub(crate) struct LoweredProgram {
 /// body — to resolve cross-calls and return types), then the top-level
 /// statements are lowered against that same scope and wrapped as the body of a
 /// synthetic void function named `__rtsn_main`.
-fn build_program(src: &str) -> FrontResult<LoweredProgram> {
+fn build_program(src: &str, arrow_ns: &str) -> FrontResult<LoweredProgram> {
     let program =
         rts_parser::parse_source(src).map_err(|e| Unsupported::new(format!("parse error: {e}")))?;
     build_from_program(
@@ -402,6 +408,7 @@ fn build_program(src: &str) -> FrontResult<LoweredProgram> {
         src,
         &class::ClassTable::default(),
         &std::collections::HashSet::new(),
+        arrow_ns,
     )
 }
 
@@ -421,6 +428,7 @@ fn build_from_program(
     destructure_src: &str,
     ambient: &class::ClassTable,
     ambient_fns: &std::collections::HashSet<String>,
+    arrow_ns: &str,
 ) -> FrontResult<LoweredProgram> {
     let src = destructure_src;
     let mut scope = rts_hir::scope::Scope::new();
@@ -738,8 +746,14 @@ fn build_from_program(
             }
         }
     }
-    let extracted =
-        funcval::extract_arrows(&mut funcs, &mut main, ambient_fns, &class_names, &pre_globals);
+    let extracted = funcval::extract_arrows(
+        &mut funcs,
+        &mut main,
+        ambient_fns,
+        &class_names,
+        &pre_globals,
+        arrow_ns,
+    );
     funcs.extend(extracted.funcs);
 
     // Module-level mutable globals (#195): function-written top lets + the

--- a/crates/rts-codegen-new/src/front/run/module_entry.rs
+++ b/crates/rts-codegen-new/src/front/run/module_entry.rs
@@ -152,7 +152,7 @@ fn build_path(entry: &Path) -> FrontResult<super::LoweredProgram> {
     // bails at lowering (sound). Every other destructuring site recovers from the
     // swc `Stmt` nodes in `program`.
     let entry_src = std::fs::read_to_string(entry).unwrap_or_default();
-    let mut user = build_from_program(program, &entry_src, ambient, &ambient_fns)?;
+    let mut user = build_from_program(program, &entry_src, ambient, &ambient_fns, "")?;
     // Carry the BUILTIN-IMPORT bindings into the lowering so a call to an imported
     // `rts:<ns>` member resolves to its real `__RTS_FN_NS_*` symbol (M1b).
     user.builtins = builtins;

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -357,6 +357,9 @@ pub(super) static PRELUDE_TS: &[PreludeTs] = &[
     // Web-platform value classes — pure `.ts` holders; after Object/JSON (their
     // ctors read `Object.keys` + `JSON.parse` from the merged prelude).
     PreludeTs { label: "web-api", source: rts_runtime::stdlib::WEBAPI_TS, why: "Headers/FormData/Blob/File/Request/Response" },
+    // Web event model — after timers (AbortSignal.timeout → setTimeout;
+    // MessagePort → queueMicrotask) and DOMException (abort/timeout reasons).
+    PreludeTs { label: "events", source: rts_runtime::stdlib::EVENTS_TS, why: "Event/EventTarget/AbortSignal/AbortController/MessageChannel" },
     // DOM facade — `Document`/`Element` classes (browser-named API) over the `rts:dom`
     // primitives. AFTER the namespaces register (the `dom.*` it calls must exist).
     PreludeTs { label: "DOM facade", source: ns::dom::DOM_TS, why: "document/Element over rts:dom" },

--- a/crates/rts-shared/src/stdlib/events.ts
+++ b/crates/rts-shared/src/stdlib/events.ts
@@ -1,0 +1,174 @@
+// Web event-model classes — Event, EventTarget, AbortSignal, AbortController,
+// MessageChannel/MessagePort — rts-shared stdlib prelude (NOT primordial; no
+// native syntax). Pure `.ts` state machines: EventTarget keeps parallel
+// listener arrays and dispatches synchronously (spec order); AbortController
+// flips its AbortSignal and fires "abort"; MessagePort delivers via
+// queueMicrotask. `AbortSignal.timeout` arms a real setTimeout — it flips the
+// signal when the engine's timer pump reaches it (the cross-thread timer
+// ordering under `await` is #207; until then a mid-await timeout may fire only
+// at the post-main drain).
+
+class Event {
+  type: string;
+  defaultPrevented: boolean = false;
+  cancelable: boolean = false;
+  bubbles: boolean = false;
+  target: any = null;
+  currentTarget: any = null;
+  constructor(type: any, opts: any = undefined) {
+    this.type = "" + type;
+    if (opts !== undefined && opts !== null) {
+      const c = opts.cancelable;
+      if (c !== undefined) { this.cancelable = !!c; }
+      const b = opts.bubbles;
+      if (b !== undefined) { this.bubbles = !!b; }
+    }
+  }
+  preventDefault(): void {
+    if (this.cancelable) { this.defaultPrevented = true; }
+  }
+  stopPropagation(): void {}
+  stopImmediatePropagation(): void {}
+}
+
+class EventTarget {
+  #types: string[] = [];
+  #cbs: any[] = [];
+  #onces: boolean[] = [];
+  // Duplicate (type, callback) pairs are ignored (spec).
+  addEventListener(type: any, cb: any, opts: any = undefined): void {
+    const t = "" + type;
+    for (let i = 0; i < this.#types.length; i++) {
+      if (this.#types[i] === t && this.#cbs[i] === cb) return;
+    }
+    let once = false;
+    if (opts !== undefined && opts !== null) {
+      const o = opts.once;
+      if (o !== undefined) { once = !!o; }
+    }
+    this.#types.push(t);
+    this.#cbs.push(cb);
+    this.#onces.push(once);
+  }
+  removeEventListener(type: any, cb: any): void {
+    const t = "" + type;
+    const kt: string[] = [];
+    const kc: any[] = [];
+    const ko: boolean[] = [];
+    for (let i = 0; i < this.#types.length; i++) {
+      if (this.#types[i] === t && this.#cbs[i] === cb) continue;
+      kt.push(this.#types[i]); kc.push(this.#cbs[i]); ko.push(this.#onces[i]);
+    }
+    this.#types = kt; this.#cbs = kc; this.#onces = ko;
+  }
+  // Synchronous dispatch in registration order; `once` listeners are removed
+  // BEFORE their callback runs (spec). Returns `!defaultPrevented`.
+  dispatchEvent(ev: any): boolean {
+    ev.target = this;
+    ev.currentTarget = this;
+    const t = "" + ev.type;
+    const run: any[] = [];
+    const runOnce: boolean[] = [];
+    for (let i = 0; i < this.#types.length; i++) {
+      if (this.#types[i] === t) { run.push(this.#cbs[i]); runOnce.push(this.#onces[i]); }
+    }
+    for (let i = 0; i < run.length; i++) {
+      if (runOnce[i]) { this.removeEventListener(t, run[i]); }
+      const cb = run[i];
+      cb(ev);
+    }
+    return !ev.defaultPrevented;
+  }
+}
+
+class AbortSignal extends EventTarget {
+  aborted: boolean = false;
+  reason: any = undefined;
+  onabort: any = null;
+  // Internal transition (double-underscore: called by AbortController /
+  // statics; a `#name` would be lexically confined to THIS class body).
+  __doAbort(reason: any): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    this.reason = reason;
+    const ev = new Event("abort");
+    this.dispatchEvent(ev);
+    const h = this.onabort;
+    if (h !== null && h !== undefined) { h(ev); }
+  }
+  throwIfAborted(): void {
+    if (this.aborted) { throw this.reason; }
+  }
+  static abort(reason: any = undefined): AbortSignal {
+    const s = new AbortSignal();
+    if (reason === undefined) {
+      s.__doAbort(new DOMException("This operation was aborted", "AbortError"));
+    } else {
+      s.__doAbort(reason);
+    }
+    return s;
+  }
+  static timeout(ms: any): AbortSignal {
+    const s = new AbortSignal();
+    setTimeout(() => {
+      // Hoisted: an inline `new DOMException(...)` ARG makes the captured-`s`
+      // dynamic dispatch decline (effectful-arg rule) — an Ident arg is fine.
+      const err = new DOMException("The operation timed out.", "TimeoutError");
+      s.__doAbort(err);
+    }, ms);
+    return s;
+  }
+  static any(signals: any): AbortSignal {
+    const out = new AbortSignal();
+    for (const src of signals) {
+      if (src.aborted) { out.__doAbort(src.reason); return out; }
+    }
+    for (const src of signals) { __abort_follow(out, src); }
+    return out;
+  }
+}
+
+// Helper (not a class member): registering the propagator in a free function
+// keeps the closure a plain param capture, not a per-iteration loop capture.
+function __abort_follow(out: AbortSignal, src: AbortSignal): void {
+  src.addEventListener("abort", () => { out.__doAbort(src.reason); });
+}
+
+class AbortController {
+  signal: AbortSignal;
+  constructor() { this.signal = new AbortSignal(); }
+  abort(reason: any = undefined): void {
+    if (reason === undefined) {
+      this.signal.__doAbort(new DOMException("This operation was aborted", "AbortError"));
+    } else {
+      this.signal.__doAbort(reason);
+    }
+  }
+}
+
+class MessagePort {
+  onmessage: any = null;
+  // Wired by MessageChannel (double-underscore internal, same rationale as
+  // AbortSignal.__doAbort).
+  __peer: any = null;
+  postMessage(data: any): void {
+    const peer = this.__peer;
+    queueMicrotask(() => {
+      const h = peer.onmessage;
+      if (h !== null && h !== undefined) { h({ data: data }); }
+    });
+  }
+  start(): void {}
+  close(): void {}
+}
+
+class MessageChannel {
+  port1: MessagePort;
+  port2: MessagePort;
+  constructor() {
+    this.port1 = new MessagePort();
+    this.port2 = new MessagePort();
+    this.port1.__peer = this.port2;
+    this.port2.__peer = this.port1;
+  }
+}

--- a/crates/rts-shared/src/stdlib/mod.rs
+++ b/crates/rts-shared/src/stdlib/mod.rs
@@ -65,3 +65,9 @@ pub const TIMERS_TS: &str = include_str!("timers.ts");
 /// value holders (insertion-ordered parallel arrays; UTF-8 measured/decoded in
 /// TS); ambient classes so `new Headers()` is ordinary user-class construction.
 pub const WEBAPI_TS: &str = include_str!("webapi.ts");
+
+/// Web event-model classes — `Event`/`EventTarget`/`AbortSignal`/
+/// `AbortController`/`MessageChannel`/`MessagePort` — rts-shared backend
+/// utilities (no native syntax). Pure `.ts` state machines; `AbortSignal.timeout`
+/// rides the real setTimeout queue; MessagePort delivers via queueMicrotask.
+pub const EVENTS_TS: &str = include_str!("events.ts");


### PR DESCRIPTION
## Resumo

Ataca o cluster **events-async** do cross-runtime (tracker #883): `62_abort_controller`, `63_event_target`, `76_message_channel`, `84_abortsignal_advanced` e `288_abortsignal_timeout_any` agora passam **idênticos a Bun/Node**. Categoria: **2/8 → 7/8** (resta `393_promise_microtask`, #1599).

## Mudanças

- **`events.ts`** (rts-shared/stdlib, novo prelude): `Event`/`EventTarget` (listeners em arrays paralelos, dispatch síncrono em ordem de registro, `once`, `preventDefault`), `AbortSignal extends EventTarget` (estáticos `abort`/`timeout`/`any` + `throwIfAborted`), `AbortController`, `MessageChannel`/`MessagePort` (entrega via `queueMicrotask`). Puro `.ts` — zero nome não-primordial novo no motor.
- **`genops.rs` — `__rtsadp_await` polimórfico**: dispatch por **tag em runtime** — uma word OBJECT cuja entry viva é `PromiseAsync` (o retorno de `new Promise(executor)` boxeado pelo `box_handle_auto`) reconstrói o handle e espera nele. **Antes o `await` era no-op nesse shape**: `await new Promise(r => setTimeout(r, N))` retornava `undefined` imediatamente e os timers disparavam só no drain pós-main (ordem invertida). Isso destrava o padrão await+setTimeout usado em várias fixtures.
- **Namespace de arrows do prelude** (`funcval/mod.rs` + `mod.rs` + `module_entry.rs`): prelude e user são rebaixados como programas separados (contador de arrows zera nos dois) e mergeados last-wins — uma arrow no prelude colidia com a `__rtsn_arrow_0` do usuário (duplicate define / captura atribuída ao contexto errado). Agora prelude usa `__rtsn_arrow_p{N}`. **Era o motivo de nenhum prelude poder usar arrows.**

## Testes

- Suíte TS: **623/623** arquivos, 1688/1688 verdes.
- **Sweep cross-runtime completo (609): 339 pass, ZERO regressão** vs relatório da main — diff fixture a fixture (13 corrigidas nesta medição: 5 events-async + 6 web-api do PR #1811 + `53_proxy_reflect` + 1 flaky de timing).
- `read_before_commit.sh`: verde, sem violação HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj
