### PR TITLE
fix(codegen/runtime): Math.hypot variádico exato + typeof Math.<m> data-driven

### DIFF
--- a/crates/rts-adapters/src/value/globalops.rs
+++ b/crates/rts-adapters/src/value/globalops.rs
@@ -436,25 +436,65 @@ pub extern "C" fn __rtsadp_math_reduce(arr_word: u64, op: i64) -> f64 {
     let v = PolyValue::from_raw(arr_word);
     let handle = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
     let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(handle).max(0);
+    if op == 2 {
+        // hypot needs ALL elements up front (the scale factor is the max
+        // magnitude) — a pairwise `acc.hypot(x)` fold drifted 1 ULP from
+        // V8/JSC on `Math.hypot(1, 1, 1)`.
+        let mut xs = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            let w = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, i) as u64;
+            xs.push(to_number(PolyValue::from_raw(w)));
+        }
+        return hypot_n(&xs);
+    }
     let mut acc = match op {
         0 => f64::INFINITY,
-        1 => f64::NEG_INFINITY,
-        _ => 0.0,
+        _ => f64::NEG_INFINITY,
     };
     for i in 0..len {
         let w = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, i) as u64;
         let x = to_number(PolyValue::from_raw(w));
         acc = match op {
             0 => acc.min(x),
-            1 => acc.max(x),
-            _ => acc.hypot(x),
+            _ => acc.max(x),
         };
         // JS min/max propagate NaN (Rust's f64::min/max do NOT — guard).
-        if x.is_nan() && op != 2 {
+        if x.is_nan() {
             return f64::NAN;
         }
     }
     acc
+}
+
+/// N-ary `Math.hypot` the way V8/JSC compute it: ±Infinity dominates (even over
+/// NaN, JS spec), then NaN; otherwise scale every element by the max magnitude,
+/// Neumaier-sum the squared ratios, and return `sqrt(sum) * max` — exact in the
+/// normal range and immune to overflow/underflow of the naive sum of squares.
+fn hypot_n(xs: &[f64]) -> f64 {
+    if xs.iter().any(|x| x.is_infinite()) {
+        return f64::INFINITY;
+    }
+    if xs.iter().any(|x| x.is_nan()) {
+        return f64::NAN;
+    }
+    let max = xs.iter().fold(0.0f64, |m, x| m.max(x.abs()));
+    if max == 0.0 {
+        return 0.0;
+    }
+    let mut sum = 0.0f64;
+    let mut comp = 0.0f64;
+    for &x in xs {
+        let r = x / max;
+        let sq = r * r;
+        let t = sum + sq;
+        comp += if sum.abs() >= sq.abs() {
+            (sum - t) + sq
+        } else {
+            (sq - t) + sum
+        };
+        sum = t;
+    }
+    (sum + comp).sqrt() * max
 }
 
 /// `__rtsadp_canon_double(word)` — `ToNumber` the PolyValue `word` and return it

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -313,6 +313,20 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     return Ok(Val::tagged_kind(v, JsKind::Str));
                 }
             }
+            // `typeof Math.<m>` — fold from the SAME data the Math call path
+            // dispatches on ("number" constant / "function" method /
+            // "undefined"). Math is PRIMORDIAL (the engine may name it); a
+            // local or user class named `Math` shadows and falls through.
+            if let HirExprKind::Member { object, prop } = &operand.kind {
+                if let HirExprKind::Ident(n) = &object.kind {
+                    if n == "Math" && self.local(n).is_none() && self.classes.get(n).is_none() {
+                        let s = super::mathobj::math_member_typeof(prop);
+                        let pv = abi_adapter::intern_poly(s);
+                        let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                        return Ok(Val::tagged_kind(v, JsKind::Str));
+                    }
+                }
+            }
             // `typeof <truly-undeclared ident>` is the ONE JS construct that may
             // name an unbound identifier without a ReferenceError — it yields
             // `"undefined"`. A bare ident that resolves to NOTHING (not a local/

--- a/crates/rts-codegen-new/src/front/run/mathobj.rs
+++ b/crates/rts-codegen-new/src/front/run/mathobj.rs
@@ -311,14 +311,28 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             MathOp::Min => self.fold_pairwise(fargs, |b, x, y| b.ins().fmin(x, y)),
             MathOp::Max => self.fold_pairwise(fargs, |b, x, y| b.ins().fmax(x, y)),
             MathOp::Sym(sym, _) => {
-                if *sym == "__RTS_FN_NS_MATH_HYPOT" && fargs.len() > 2 {
-                    // hypot(a,b,c,…) = hypot(hypot(a,b),c)… — fold with the 2-arg sym.
-                    let mut acc = fargs[0];
-                    for &x in &fargs[1..] {
-                        acc = emit_marshal::emit_call(module, self.builder, sym, &[acc, x])
-                            .expect("MATH_HYPOT returns a value");
+                if *sym == "__RTS_FN_NS_MATH_HYPOT" && fargs.len() == 1 {
+                    // hypot(x) = sqrt(x²) = |x| — calling the 2-slot symbol with
+                    // 1 marshaled arg would assert in emit_call.
+                    self.builder.ins().fabs(fargs[0])
+                } else if *sym == "__RTS_FN_NS_MATH_HYPOT" && fargs.len() > 2 {
+                    // hypot(a,b,c,…): pack the args into a fresh vec and run the
+                    // SAME `__rtsadp_math_reduce` the spread form uses (V8-style
+                    // max-scaled compensated sum) — a pairwise 2-arg fold drifted
+                    // 1 ULP from V8/JSC on `Math.hypot(1, 1, 1)`.
+                    let arr = emit_marshal::emit_new_vec_object(module, self.builder);
+                    for &x in fargs {
+                        let word = self.box_value(Val::new(x, Repr::Float64));
+                        emit_marshal::emit_vec_push(module, self.builder, arr, word);
                     }
-                    acc
+                    let op_v = self.builder.ins().iconst(cranelift_codegen::ir::types::I64, 2);
+                    emit_marshal::emit_call(
+                        module,
+                        self.builder,
+                        "__rtsadp_math_reduce",
+                        &[arr, op_v],
+                    )
+                    .expect("__rtsadp_math_reduce returns a value")
                 } else {
                     emit_marshal::emit_call(module, self.builder, sym, fargs)
                         .expect("real math symbol returns a value")
@@ -476,6 +490,24 @@ fn op_arity(op: &MathOp) -> usize {
         MathOp::Sqrt | MathOp::Abs => 1,
         MathOp::Min | MathOp::Max => 2,
         MathOp::Sym(_, n) => *n,
+    }
+}
+
+/// Compile-time `typeof Math.<prop>` — resolved from the SAME data the Math
+/// call path dispatches on: a constant → `"number"`, a method in the f64 table
+/// or the i32-domain `math` Registry namespace → `"function"`, anything else →
+/// `"undefined"`. Lets `typeof Math.f16round === "function"` feature-detection
+/// fold instead of bailing on the member read.
+pub(super) fn math_member_typeof(prop: &str) -> &'static str {
+    if math_const(prop).is_some() {
+        "number"
+    } else if prop == "random"
+        || math_op(prop).is_some()
+        || (0..=4).any(|n| super::registry::namespace_member("math", prop, n).is_some())
+    {
+        "function"
+    } else {
+        "undefined"
     }
 }
 


### PR DESCRIPTION
Fixtures math do cross-runtime: 137_math_cbrt_hypot e 284_math_f16round passam idênticos a Bun/Node (categoria math 18/18).

- **mathobj.rs**: Math.hypot(x) com 1 arg emitia call de 1 slot no símbolo de 2 slots — **PANIC de assertion**. Agora hypot(x)=|x| (fabs inline); N>2 args empacota num vec e roda o mesmo __rtsadp_math_reduce da forma spread (fold pairwise desviava 1 ULP do V8 em hypot(1,1,1)).
- **globalops.rs**: __rtsadp_math_reduce op hypot com algoritmo V8/JSC (Infinity domina, escala pelo máximo, soma compensada de Neumaier, sqrt*max).
- **expr.rs**: typeof Math.<m> folda em compile-time a partir dos MESMOS dados do call path — destrava feature-detection typeof Math.f16round === 'function'. Data-driven; Math é PRIMORDIAL.

Sweep completo: **340 pass, zero regressão deste diff** (as 3 divergências novas de delete/in vêm do commit 192b878b já na main — verificado). Suíte TS 623/623 verde. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj