### PR TITLE
fix(runtime/codegen): combinators marcam inputs handled + classificação polimórfica de Handle em statics do Registry

### DIFF
--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -619,11 +619,19 @@ fn box_handle_auto_depth(h: u64, depth: u32) -> u64 {
     let kind = with_entry(h, |e| match e {
         Some(Entry::String(_)) => 1u8,
         Some(Entry::Vec(_)) => 2,
+        // A callable entry boxes as TAG_FUNCTION — an OBJECT-tagged function
+        // word fails every invoke path ("not a function"). Reached by e.g. the
+        // `resolve`/`reject` members of `Promise.withResolvers()`.
+        Some(Entry::Function(_)) => 4,
         Some(_) => 3,
         None => 0,
     });
     match kind {
         1 => abi_adapter::poly_from_real_handle(h).raw(),
+        4 => {
+            let slot = rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h);
+            PolyValue::from_function_handle(slot).raw()
+        }
         2 => {
             // Normalize legacy RAW elements (outside the entry lock — VEC_GET
             // re-locks the shard). A raw handle is NOT a boxed word and NOT a

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -335,8 +335,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         for i in argc..total {
             vals.push(self.default_arg_val(call.default_args.get(i), name, i)?);
         }
+        // Same data-driven Handle-return classification as the instance path:
+        // a string only when the ts-signature says so, an array when it
+        // declares `T[]`, otherwise an OBJECT handle (tag-dispatched rebox).
+        // The old blanket "Handle ⇒ Str" made `Promise.withResolvers()` (a
+        // `{promise, resolve, reject}` Map handle) ride as a string.
         let result_kind = match call.ret {
-            AbiType::Handle => JsKind::Str,
+            AbiType::Handle if call.ret_is_string_handle => JsKind::Str,
+            AbiType::Handle if call.ret_is_array_handle => JsKind::Array,
+            AbiType::Handle => JsKind::Object,
             AbiType::Bool => JsKind::Bool,
             _ => JsKind::Number,
         };

--- a/crates/rts-std/src/globals/fetch/instance.rs
+++ b/crates/rts-std/src/globals/fetch/instance.rs
@@ -475,7 +475,11 @@ fn make_resolver_fn(promise_h: u64, is_resolve: bool) -> u64 {
     };
     alloc_entry(Entry::Function(Box::new(FunctionData {
         fn_ptr,
-        arity: 1,
+        // Convencao: `arity` e' o TOTAL de params do fn_ptr (bound INCLUSOS) —
+        // `.length` e o invoke leem `arity - bound_args.len()` como a aridade
+        // visivel. O trampolim recebe (promise_h, value) = 2, promise_h bound.
+        // Com 1, `invoke_legacy_fn` fatiava 0 args e o resolve nunca settlava.
+        arity: 2,
         name: (if is_resolve { "resolve" } else { "reject" })
             .to_string()
             .into_boxed_str(),

--- a/crates/rts-std/src/promise/mod.rs
+++ b/crates/rts-std/src/promise/mod.rs
@@ -183,6 +183,18 @@ fn element_to_handle(w: u64) -> u64 {
     w
 }
 
+/// Um combinator (all/allSettled/race/any) É um handler dos seus inputs — em
+/// JS ele anexa reactions em cada promise passada. Marca cada slot como
+/// handled para o report pós-main não acusar "Unhandled promise rejection"
+/// numa rejection que o combinator consumiu (os fast-paths leem
+/// `current_state`/`current_value` sem passar pelo `wait_blocking`, que era
+/// o único ponto que marcava).
+fn mark_inputs_handled(slots: &[Option<std::sync::Arc<rts_engine::heap::handles::PromiseSlot>>]) {
+    for s in slots.iter().flatten() {
+        promise_slot::mark_handled(s);
+    }
+}
+
 /// Clone os Arc<PromiseSlot> de cada handle. Handle invalido vira None
 /// (filtrado depois).
 fn collect_slots(
@@ -515,6 +527,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_TAKE_ERROR() -> I64 {
 pub extern "C" fn __RTS_FN_NS_PROMISE_ALL(promises: U64) -> Handle {
     let handles = collect_promise_handles(promises);
     let slots = collect_slots(&handles);
+    mark_inputs_handled(&slots);
     let result = promise_slot::new_pending();
     let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
 
@@ -578,6 +591,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_ALL(promises: U64) -> Handle {
 pub extern "C" fn __RTS_FN_NS_PROMISE_RACE(promises: U64) -> Handle {
     let handles = collect_promise_handles(promises);
     let slots = collect_slots(&handles);
+    mark_inputs_handled(&slots);
     let result = promise_slot::new_pending();
     let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
 
@@ -628,6 +642,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_RACE(promises: U64) -> Handle {
 pub extern "C" fn __RTS_FN_NS_PROMISE_ANY(promises: U64) -> Handle {
     let handles = collect_promise_handles(promises);
     let slots = collect_slots(&handles);
+    mark_inputs_handled(&slots);
     let result = promise_slot::new_pending();
     let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
 
@@ -782,6 +797,7 @@ fn create_spawn(
 pub extern "C" fn __RTS_FN_NS_PROMISE_ALL_SETTLED(promises: U64) -> Handle {
     let handles = collect_promise_handles(promises);
     let slots = collect_slots(&handles);
+    mark_inputs_handled(&slots);
     let result = promise_slot::new_pending();
     let result_handle = alloc_entry(Entry::PromiseAsync(result.clone()));
 


### PR DESCRIPTION
Cluster promises + colaterais: 54_symbol_registry e 355_obf_number_encoding passam; 167_promise_race_any e 200_promise_allsettled param de emitir 'Unhandled promise rejection' espúrio no stderr.

- **promise/mod.rs**: Promise.all/allSettled/race/any marcam TODOS os inputs como handled (combinator É um handler; os fast-paths liam current_state sem wait_blocking, único ponto que marcava).
- **registryclass.rs**: retorno AbiType::Handle de STATIC classificado pelos mesmos flags data-driven do caminho de instância (ret_is_string_handle/ret_is_array_handle/Object) — o blanket 'Handle ⇒ Str' fazia Promise.withResolvers() e Symbol.for() cavalgarem como string.
- **genops.rs**: __rtsadp_box_handle_auto boxa Entry::Function como TAG_FUNCTION (word OBJECT falhava todo invoke).
- **fetch/instance.rs**: make_resolver_fn arity 2 (arity = total de params, bound inclusos).

Nota: 92_promise_with_resolvers segue falhando (race/hang própria do invoke método-posição do resolver legado — investigação separada).

Sweep completo: **342 pass, ZERO regressão** (diff fixture a fixture). Suíte TS 623/623 verde. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj