### PR TITLE
feat(codegen): Object.fromEntries de fonte com entries() — Map/Headers/FormData por shape

### DIFF
--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -457,6 +457,25 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if args.len() != 1 {
             return unsupported!("Object.fromEntries expects 1 arg, got {}", args.len());
         }
+        // A source whose statically-known CLASS defines `entries()` (the ambient
+        // Map / Headers / FormData, or any user class — matched by SHAPE, never a
+        // name): its eager `entries()` array IS the pair source. Lower
+        // `src.entries()` and feed the same runtime builder.
+        if let Some(class) = self.static_instance_class(&args[0]) {
+            if self
+                .classes
+                .get(&class)
+                .and_then(|d| d.method_fn("entries"))
+                .is_some()
+            {
+                let v = self.lower_method_call(module, &args[0], "entries", &[])?;
+                let entries = self.box_value(v);
+                let res = self
+                    .call_runtime(module, "__rtsadp_obj_from_entries", &[entries])?
+                    .expect("__rtsadp_obj_from_entries returns an object word");
+                return Ok(Val::tagged_kind(res, super::lower::JsKind::Object));
+            }
+        }
         // A proven array source: an array-valued expr OR an `Object.entries(...)`
         // call (whose result is always a freshly-built array of pairs — the common
         // round-trip `fromEntries(entries(o))`).


### PR DESCRIPTION
Fixtures 265_object_fromentries e 323_object_entries_fromEntries passam idênticas a Bun/Node.

**objstatic.rs**: uma fonte cuja classe estática define \entries()\ (Map/Headers/FormData ambient, ou qualquer classe de usuário — casada por SHAPE, nunca por nome) rebaixa \src.entries()\ e alimenta o mesmo \__rtsadp_obj_from_entries\ do caminho de array. Fonte desconhecida mantém o bail honesto.

Sweep completo: **358 pass, zero regressão deste diff** (a divergência nova \claude-flat-deep-and-infinity\ vem do commit de sparse-arrays 85bf5def — reproduzida sem este diff). Suíte TS 623/623. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj