### PR TITLE
feat(runtime/codegen): Web Streams polyfill .ts + single-eval no dispatch virtual + gcells em async

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -1312,7 +1312,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// An `undefined` PolyValue word coerced to `target` (for an omitted fillable
     /// arg). `target` is `Tagged` for any fillable param (set in [`FnSig::of_func`]),
     /// so the coerce is a no-op; the helper stays general for safety.
-    fn undefined_coerced(&mut self, target: Repr) -> FrontResult<Value> {
+    pub(in crate::front::run) fn undefined_coerced(&mut self, target: Repr) -> FrontResult<Value> {
         let w = self
             .builder
             .ins()

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -50,12 +50,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 // entry a plain `new C()` local would carry. Recover its class from the
                 // data-driven `gcell_classes` map (`name → C`, built by SHAPE from the
                 // HIR — no hardcoded name) so `x.method(..)` dispatches on `C` in any
-                // scope. Gated on `name` being an actual gcell (a same-named local
-                // shadows it via `local_classes` above, checked first).
+                // scope. Gated on `name` being an actual gcell AND on NO same-named
+                // LOCAL in the current function: a plain `const c = expr` local (whose
+                // class is unknown → absent from `local_classes`) SHADOWS a top-level
+                // `const c = new C()` — without the guard the local mis-dispatched on
+                // the singleton's class.
                 .or_else(|| {
                     self.gcell_classes
                         .get(name)
-                        .filter(|_| self.gcells.contains_key(name))
+                        .filter(|_| self.gcells.contains_key(name) && self.local(name).is_none())
                         .cloned()
                 }),
             // A CALL whose callee is a user function with a provable return class
@@ -291,6 +294,78 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return self.reify_function(module, &fn_name);
         }
         unsupported!("`{class}.{field}` — no such static field on class `{class}`")
+    }
+
+    /// [`Self::call_synth_fn`] over PRE-LOWERED, PRE-BOXED arg WORDS — the
+    /// single-eval virtual-dispatch marshal: each word is a Tagged PolyValue
+    /// coerced to the callee's param repr; an omitted FILLABLE param pads
+    /// `undefined`; extra words are dropped (JS ignores surplus args); a
+    /// trailing REST param packs the surplus words into a fresh array. Lets
+    /// the shape-arm emitters share ONE evaluation of every argument instead
+    /// of re-lowering per arm (which restricted args to side-effect-free).
+    pub(in crate::front::run) fn call_synth_fn_words(
+        &mut self,
+        module: &mut dyn Module,
+        fn_name: &str,
+        this_word: Option<Value>,
+        arg_words: &[Value],
+    ) -> FrontResult<Val> {
+        use crate::repr::Repr;
+        use crate::value::emit_marshal;
+        let sig = self
+            .sigs
+            .get(fn_name)
+            .cloned()
+            .expect("synthesized class fn must be a registered user function");
+        let mut call_args = Vec::with_capacity(sig.params.len());
+        let mut pi = 0usize;
+        if let Some(w) = this_word {
+            call_args.push(self.coerce(Val::tagged_kind(w, JsKind::Object), sig.params[0])?);
+            pi = 1;
+        }
+        let user_params = &sig.params[pi..];
+        let rest_rel = sig.rest_param.map(|r| r.saturating_sub(pi));
+        for (i, &want) in user_params.iter().enumerate() {
+            if rest_rel == Some(i) {
+                // Trailing rest: pack the surplus words into a fresh array.
+                let arr = emit_marshal::emit_new_vec_object(module, self.builder);
+                for &w in arg_words.iter().skip(i) {
+                    emit_marshal::emit_vec_push(module, self.builder, arr, w);
+                }
+                call_args.push(self.coerce(Val::tagged_kind(arr, JsKind::Object), want)?);
+                break;
+            }
+            if i < arg_words.len() {
+                call_args.push(self.coerce(Val::new(arg_words[i], Repr::Tagged), want)?);
+            } else if sig.fillable.get(pi + i).copied().unwrap_or(false) {
+                call_args.push(self.undefined_coerced(want)?);
+            } else {
+                return unsupported!("call to `{fn_name}` missing required arg {i}");
+            }
+        }
+        let cl_sig = sig.to_cranelift(module);
+        let callee = module
+            .declare_function(fn_name, cranelift_module::Linkage::Local, &cl_sig)
+            .map_err(|e| {
+                crate::front::error::Unsupported::new(format!("declare fn `{fn_name}`: {e}"))
+            })?;
+        let func_ref = module.declare_func_in_func(callee, self.builder.func);
+        let call = self.builder.ins().call(func_ref, &call_args);
+        let result = match sig.ret {
+            Some(ret) => {
+                let v = self.builder.inst_results(call)[0];
+                Val::new(v, ret)
+            }
+            None => {
+                let v = self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
+                Val::tagged_kind(v, JsKind::Undefined)
+            }
+        };
+        self.emit_post_call_error_check(module)?;
+        Ok(result)
     }
 
     /// Shared emitter for a direct call of a synthesized class fn `fn_name`,

--- a/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
@@ -123,27 +123,47 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         base_fn: &str,
         args: &[HirExpr],
     ) -> FrontResult<Val> {
-        if !args.iter().all(is_side_effect_free_arg) {
-            return unsupported!(
-                "virtual method dispatch with an effectful argument (single-eval \
-                 marshaling is a later increment)"
-            );
-        }
         let recv = self.lower_expr(module, object)?;
         let recv_word = self.box_value(recv);
+        // SINGLE-EVAL marshaling: lower + box every argument ONCE, before any
+        // branching — the SSA values dominate every arm, so an effectful arg
+        // (a call, `new`, an assignment) evaluates exactly once (JS order:
+        // receiver first, then args). A Spread arg is not a plain value and
+        // still bails.
+        let arg_words = self.lower_arg_words(module, args)?;
         let shape_word = self.read_shape_word(module, recv_word);
 
         let merge = self.builder.create_block();
         self.builder.append_block_param(merge, types::I64);
-        self.emit_shape_arms(module, recv_word, shape_word, targets, args, merge)?;
+        self.emit_shape_arms(module, recv_word, shape_word, targets, &arg_words, merge)?;
         // DEFAULT arm: the static class's own method.
-        let v = self.call_synth_fn(module, base_fn, Some(recv_word), args)?;
+        let v = self.call_synth_fn_words(module, base_fn, Some(recv_word), &arg_words)?;
         let w = self.box_value(v);
         self.builder.ins().jump(merge, &[w.into()]);
 
         let result = self.finish_merge(merge);
         let kind = ret_kind(self.sigs.get(base_fn).and_then(|s| s.ret));
         Ok(Val::new_with_kind(result, Repr::Tagged, kind))
+    }
+
+    /// Lower + box each plain argument once (the single-eval prelude of the
+    /// virtual dispatchers). A `Spread` arg has no single-value form → bail.
+    fn lower_arg_words(
+        &mut self,
+        module: &mut dyn Module,
+        args: &[HirExpr],
+    ) -> FrontResult<Vec<Value>> {
+        let mut out = Vec::with_capacity(args.len());
+        for a in args {
+            if matches!(a.kind, HirExprKind::Spread(_)) {
+                return unsupported!(
+                    "virtual method dispatch with a spread argument (later increment)"
+                );
+            }
+            let v = self.lower_expr(module, a)?;
+            out.push(self.box_value(v));
+        }
+        Ok(out)
     }
 
     /// DYNAMIC virtual dispatch on a TAGGED receiver of unproven class: dispatch to
@@ -185,11 +205,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // arg". A skipped candidate's receiver falls to the default arm (own-prop
         // read → `undefined` sentinel) — honest, never a wrong value.
         targets.retain(|(_, f)| self.sig_accepts_argc(f, args.len()));
-        if targets.is_empty() || !args.iter().all(is_side_effect_free_arg) {
+        if targets.is_empty() {
             return Ok(None);
         }
 
         let recv_word = self.box_value(recv);
+        // SINGLE-EVAL marshaling: every argument lowers ONCE here; the words
+        // dominate all arms (effectful args are sound — evaluated exactly once).
+        let arg_words = self.lower_arg_words(module, args)?;
         let is_obj = self.emit_is_object(recv_word);
         let undef = value::PolyValue::undefined().raw() as i64;
 
@@ -210,7 +233,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         self.builder.switch_to_block(guarded);
         self.builder.seal_block(guarded);
         let shape_word = self.read_shape_word(module, recv_word);
-        self.emit_shape_arms(module, recv_word, shape_word, &targets, args, merge)?;
+        self.emit_shape_arms(module, recv_word, shape_word, &targets, &arg_words, merge)?;
         // DEFAULT arm — no class shape matched: the receiver may still carry
         // `method` as an OWN function-valued property (`{ add: (a, b) => a + b }`
         // — an object literal whose fn-valued member shares a name with some
@@ -221,7 +244,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // an own property beats "no method" (JS). Without this, a class defining
         // `method` ANYWHERE in the program (e.g. the prelude `Set.add`) stole the
         // call from every plain object carrying an own fn of that name.
-        if args.len() <= 3 {
+        if arg_words.len() <= 3 {
             use cranelift_codegen::ir::condcodes::IntCC;
             let key = crate::value::abi_adapter::intern_poly(method);
             let key_word = self.builder.ins().iconst(types::I64, key.raw() as i64);
@@ -243,9 +266,26 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             self.builder.seal_block(b_undef);
 
             self.builder.switch_to_block(b_fn);
-            let v = self.lower_value_call_word_with_this(module, own, recv_word, args)?;
-            let w = self.box_value(v);
-            self.builder.ins().jump(merge, &[w.into()]);
+            // Same emission as `lower_value_call_word_with_this`, over the
+            // PRE-LOWERED words (no re-eval of effectful args).
+            let undef_c = self
+                .builder
+                .ins()
+                .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
+            let mut slots: [Value; 3] = [undef_c; 3];
+            for (i, &w) in arg_words.iter().take(3).enumerate() {
+                slots[i] = w;
+            }
+            let zero = self.builder.ins().iconst(types::I64, 0);
+            let res = self
+                .call_runtime(
+                    module,
+                    "__rtsadp_fn_invoke_method",
+                    &[own, recv_word, slots[0], slots[1], slots[2], zero],
+                )?
+                .expect("__rtsadp_fn_invoke_method returns a value");
+            self.emit_post_call_error_check(module)?;
+            self.builder.ins().jump(merge, &[res.into()]);
 
             self.builder.switch_to_block(b_undef);
             let u = self.builder.ins().iconst(types::I64, undef);
@@ -333,13 +373,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// Emit one `if shape == D.global_shape { call D's fn }` arm per target, each
     /// jumping to `merge` with its boxed result word. Leaves the builder on the
     /// fall-through block so the caller emits the DEFAULT arm + jump to `merge`.
+    /// `arg_words` are the PRE-LOWERED, boxed argument words (single-eval — they
+    /// dominate every arm; only the arm the runtime takes uses them).
     fn emit_shape_arms(
         &mut self,
         module: &mut dyn Module,
         recv_word: Value,
         shape_word: Value,
         targets: &[(u32, String)],
-        args: &[HirExpr],
+        arg_words: &[Value],
         merge: cranelift_codegen::ir::Block,
     ) -> FrontResult<()> {
         for (gs, fname) in targets {
@@ -354,7 +396,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
             self.builder.switch_to_block(call_blk);
             self.builder.seal_block(call_blk);
-            let v = self.call_synth_fn(module, fname, Some(recv_word), args)?;
+            let v = self.call_synth_fn_words(module, fname, Some(recv_word), arg_words)?;
             let w = self.box_value(v);
             self.builder.ins().jump(merge, &[w.into()]);
 
@@ -398,32 +440,6 @@ fn ret_kind(ret: Option<Repr>) -> JsKind {
     }
 }
 
-/// Whether `e` re-evaluates with NO observable side effect — a bare identifier or a
-/// literal. A virtual-dispatch arm re-lowers each argument, so only such args are
-/// safe (an effectful arg bails / declines).
-fn is_side_effect_free_arg(e: &HirExpr) -> bool {
-    match &e.kind {
-        HirExprKind::Ident(_) | HirExprKind::Lit(_) => true,
-        // Pure arithmetic/comparison over side-effect-free operands (`cur + 1`
-        // as a call arg): re-evaluating per dispatch arm is harmless. Rejecting
-        // it made the virtual dispatch DECLINE and the caller fall through to a
-        // dynamic own-prop miss — `map.set(k, cur + 1)` silently no-opped.
-        HirExprKind::Bin { lhs, rhs, .. } => {
-            is_side_effect_free_arg(lhs) && is_side_effect_free_arg(rhs)
-        }
-        HirExprKind::Unary { operand, .. } => is_side_effect_free_arg(operand),
-        // A MEMBER READ (`this.x`, `obj.k`) may hit a GETTER with effects in
-        // principle, but the object-position operand is an Ident (no call), so
-        // double-lowering only re-reads — accepted (matches the member reads the
-        // dispatch arms themselves perform).
-        HirExprKind::Member { object, .. } => is_side_effect_free_arg(object),
-        // An INDEX READ (`arr[i]`, `this.#items[i]`) over side-effect-free
-        // operands re-lowers as a plain re-read, same reasoning as Member.
-        // Rejecting it made `other.has(this.#items[i])` (the stdlib Set ops)
-        // decline the virtual dispatch and fall to a dynamic own-prop miss.
-        HirExprKind::Index { object, index } => {
-            is_side_effect_free_arg(object) && is_side_effect_free_arg(index)
-        }
-        _ => false,
-    }
-}
+// (The old `is_side_effect_free_arg` gate is GONE: the dispatchers now lower
+// every argument ONCE before branching — single-eval marshaling — so effectful
+// args are sound. Only a Spread arg still bails, in `lower_arg_words`.)

--- a/crates/rts-codegen-new/src/front/run/method_array.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array.rs
@@ -130,6 +130,30 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
         let argc = args.len();
 
+        // `arr.push(...src)` — a SINGLE spread arg appends every element of `src`
+        // (the array-literal spread trampoline `__rtsadp_arr_spread_append`, which
+        // copies the raw element WORDS shallowly), returning the new length. A
+        // spread mixed with plain args stays a bail (later increment).
+        if method == "push" && argc == 1 {
+            if let HirExprKind::Spread(inner) = &args[0].kind {
+                let arr = self.lower_expr(module, object)?;
+                let arr_word = self.box_value(arr);
+                let src = self.lower_expr(module, inner)?;
+                let src_word = self.box_value(src);
+                self.call_runtime(
+                    module,
+                    "__rtsadp_arr_spread_append",
+                    &[arr_word, src_word],
+                )?;
+                let len = crate::value::emit_marshal::emit_vec_len(
+                    module,
+                    self.builder,
+                    arr_word,
+                );
+                return Ok(Val::new(len, crate::repr::Repr::Int64));
+            }
+        }
+
         // VARIADIC `push`/`unshift` (N args): the runtime trampolines take ONE value;
         // a multi-arg call folds into N single-arg calls in `.ts`-equivalent order.
         // `push(a, b)` appends a then b (left-to-right). `unshift(a, b)` must yield

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -360,6 +360,9 @@ pub(super) static PRELUDE_TS: &[PreludeTs] = &[
     // Web event model — after timers (AbortSignal.timeout → setTimeout;
     // MessagePort → queueMicrotask) and DOMException (abort/timeout reasons).
     PreludeTs { label: "events", source: rts_runtime::stdlib::EVENTS_TS, why: "Event/EventTarget/AbortSignal/AbortController/MessageChannel" },
+    // Web Streams — after web-api (Blob.stream() builds a ReadableStream; the
+    // UTF-8 helpers live in webapi.ts; the merged prelude is one program).
+    PreludeTs { label: "streams", source: rts_runtime::stdlib::STREAMS_TS, why: "ReadableStream/WritableStream/TransformStream/TextEncoder/DecoderStream" },
     // DOM facade — `Document`/`Element` classes (browser-named API) over the `rts:dom`
     // primitives. AFTER the namespaces register (the `dom.*` it calls must exist).
     PreludeTs { label: "DOM facade", source: ns::dom::DOM_TS, why: "document/Element over rts:dom" },

--- a/crates/rts-shared/src/stdlib/mod.rs
+++ b/crates/rts-shared/src/stdlib/mod.rs
@@ -71,3 +71,9 @@ pub const WEBAPI_TS: &str = include_str!("webapi.ts");
 /// utilities (no native syntax). Pure `.ts` state machines; `AbortSignal.timeout`
 /// rides the real setTimeout queue; MessagePort delivers via queueMicrotask.
 pub const EVENTS_TS: &str = include_str!("events.ts");
+
+/// Web Streams — `ReadableStream`/`WritableStream`/`TransformStream`/
+/// `TextEncoderStream`/`TextDecoderStream` — rts-shared backend utilities (no
+/// native syntax). Pure `.ts` queues with lazy `pipeThrough` forwarding;
+/// `await reader.read()` rides the non-Promise `await` passthrough.
+pub const STREAMS_TS: &str = include_str!("streams.ts");

--- a/crates/rts-shared/src/stdlib/streams.ts
+++ b/crates/rts-shared/src/stdlib/streams.ts
@@ -1,0 +1,181 @@
+// Web Streams — ReadableStream / WritableStream / TransformStream /
+// TextEncoderStream / TextDecoderStream — rts-shared stdlib prelude (NOT
+// primordial; no native syntax). Pure `.ts` state machines over plain arrays:
+// a ReadableStream's controller queues chunks (or FORWARDS them downstream
+// once `pipeThrough` wires a destination); readers drain synchronously —
+// `await reader.read()` rides the non-Promise `await` passthrough. Underlying
+// sources/sinks/transformers are duck-typed (`'start' in source`), and every
+// internal helper is a REAL class (never an object literal inside a
+// constructor — the literal-method recovery does not reach ctor bodies yet).
+
+class RSDController {
+  __q: any[] = [];
+  __closed: boolean = false;
+  // Once piped, chunks FORWARD to the downstream sink instead of queueing.
+  __fwd: any = null;
+  enqueue(chunk: any): void {
+    const f = this.__fwd;
+    if (f !== null) { f.write(chunk); return; }
+    this.__q.push(chunk);
+  }
+  close(): void {
+    this.__closed = true;
+    const f = this.__fwd;
+    if (f !== null) { f.close(); }
+  }
+  error(e: any): void { this.__closed = true; }
+  get desiredSize(): number { return 1; }
+}
+
+class RSDReader {
+  __s: any = null;
+  read(): any {
+    const ctl = this.__s.__ctl;
+    const q = ctl.__q;
+    if (q.length > 0) {
+      const v = q[0];
+      ctl.__q = q.slice(1);
+      return { done: false, value: v };
+    }
+    return { done: true, value: undefined };
+  }
+  cancel(reason: any = undefined): any { return undefined; }
+  releaseLock(): void {}
+}
+
+class ReadableStream {
+  __ctl: RSDController;
+  locked: boolean = false;
+  constructor(source: any = undefined) {
+    this.__ctl = new RSDController();
+    if (source !== undefined && source !== null) {
+      if ("start" in source) { source.start(this.__ctl); }
+    }
+  }
+  getReader(): RSDReader {
+    const r = new RSDReader();
+    r.__s = this;
+    return r;
+  }
+  // Drain what is already queued into the pair's writable, then FORWARD every
+  // later enqueue (lazy piping — the common `pipeThrough` before the writes).
+  pipeThrough(pair: any): any {
+    const sink = pair.writable.__sink;
+    const ctl = this.__ctl;
+    const q = ctl.__q;
+    for (let i = 0; i < q.length; i++) { sink.write(q[i]); }
+    ctl.__q = [];
+    ctl.__fwd = sink;
+    if (ctl.__closed) { sink.close(); }
+    return pair.readable;
+  }
+}
+
+class WSDWriter {
+  __s: any = null;
+  write(chunk: any): any {
+    this.__s.__sink.write(chunk);
+    return undefined;
+  }
+  close(): any {
+    this.__s.__sink.close();
+    return undefined;
+  }
+  abort(reason: any = undefined): any { return undefined; }
+  releaseLock(): void {}
+}
+
+// The ONE internal sink: `__mode` selects the per-chunk behavior; `__ctl` is
+// the destination ReadableStream controller.
+class __StreamSink {
+  __t: any = null;
+  __ctl: any = null;
+  __mode: string = "identity";
+  write(chunk: any): void {
+    const c = this.__ctl;
+    if (this.__mode === "transform") {
+      const t = this.__t;
+      if (t !== undefined && t !== null && "transform" in t) {
+        t.transform(chunk, c);
+        return;
+      }
+      c.enqueue(chunk);
+      return;
+    }
+    if (this.__mode === "encode") { c.enqueue(__utf8_encode("" + chunk)); return; }
+    if (this.__mode === "decode") { c.enqueue(__utf8_decode(chunk)); return; }
+    c.enqueue(chunk);
+  }
+  close(): void {
+    if (this.__mode === "transform") {
+      const t = this.__t;
+      if (t !== undefined && t !== null && "flush" in t) { t.flush(this.__ctl); }
+    }
+    this.__ctl.close();
+  }
+}
+
+class WritableStream {
+  __sink: __StreamSink;
+  locked: boolean = false;
+  constructor(sink: any = undefined) {
+    const s = new __StreamSink();
+    s.__ctl = new RSDController();
+    if (sink !== undefined && sink !== null) {
+      s.__t = sink;
+      s.__mode = "transform";
+    }
+    this.__sink = s;
+  }
+  getWriter(): WSDWriter {
+    const w = new WSDWriter();
+    w.__s = this;
+    return w;
+  }
+}
+
+class TransformStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+  constructor(transformer: any = undefined) {
+    const rs = new ReadableStream();
+    const ws = new WritableStream();
+    const sink = ws.__sink;
+    sink.__ctl = rs.__ctl;
+    sink.__mode = "transform";
+    if (transformer !== undefined && transformer !== null) { sink.__t = transformer; }
+    else { sink.__t = null; }
+    this.readable = rs;
+    this.writable = ws;
+  }
+}
+
+class TextEncoderStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+  constructor() {
+    const rs = new ReadableStream();
+    const ws = new WritableStream();
+    const sink = ws.__sink;
+    sink.__ctl = rs.__ctl;
+    sink.__mode = "encode";
+    this.readable = rs;
+    this.writable = ws;
+  }
+  get encoding(): string { return "utf-8"; }
+}
+
+class TextDecoderStream {
+  readable: ReadableStream;
+  writable: WritableStream;
+  constructor(label: any = undefined) {
+    const rs = new ReadableStream();
+    const ws = new WritableStream();
+    const sink = ws.__sink;
+    sink.__ctl = rs.__ctl;
+    sink.__mode = "decode";
+    this.readable = rs;
+    this.writable = ws;
+  }
+  get encoding(): string { return "utf-8"; }
+}

--- a/crates/rts-shared/src/stdlib/webapi.ts
+++ b/crates/rts-shared/src/stdlib/webapi.ts
@@ -23,6 +23,38 @@ function __utf8_len_str(s: string): number {
   return n;
 }
 
+// Encode a JS string into UTF-8 bytes (a plain number[] — the byte-source
+// counterpart of `__utf8_decode`; surrogate pairs → 4 bytes).
+function __utf8_encode(s: string): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < s.length; i++) {
+    let cp = s.charCodeAt(i);
+    if (cp >= 0xd800 && cp < 0xdc00 && i + 1 < s.length) {
+      const lo = s.charCodeAt(i + 1);
+      if (lo >= 0xdc00 && lo < 0xe000) {
+        cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00);
+        i++;
+      }
+    }
+    if (cp < 0x80) {
+      out.push(cp);
+    } else if (cp < 0x800) {
+      out.push(0xc0 | (cp >> 6));
+      out.push(0x80 | (cp & 0x3f));
+    } else if (cp < 0x10000) {
+      out.push(0xe0 | (cp >> 12));
+      out.push(0x80 | ((cp >> 6) & 0x3f));
+      out.push(0x80 | (cp & 0x3f));
+    } else {
+      out.push(0xf0 | (cp >> 18));
+      out.push(0x80 | ((cp >> 12) & 0x3f));
+      out.push(0x80 | ((cp >> 6) & 0x3f));
+      out.push(0x80 | (cp & 0x3f));
+    }
+  }
+  return out;
+}
+
 // Decode a UTF-8 byte source (Uint8Array-like: `.length` + numeric indexing)
 // into a JS string.
 function __utf8_decode(bytes: any): string {
@@ -266,6 +298,16 @@ class Blob {
   get size(): number { return __utf8_len_str(this.#text); }
   get type(): string { return this.#type; }
   text(): string { return this.#text; }
+  // `blob.stream()` — a ReadableStream (streams.ts prelude) queuing ONE chunk
+  // with the blob's UTF-8 bytes, already closed.
+  stream(): any {
+    const rs = new ReadableStream();
+    const ctl = rs.__ctl;
+    ctl.enqueue(__utf8_encode(this.#text));
+    ctl.close();
+    return rs;
+  }
+  arrayBuffer(): any { return __utf8_encode(this.#text); }
   slice(start: number = 0, end: number = -1, contentType: any = undefined): Blob {
     let s = this.#text;
     // Blob.slice indexes BYTES; this interim slices code units of the decoded

--- a/crates/rts-std/src/promise/mod.rs
+++ b/crates/rts-std/src/promise/mod.rs
@@ -754,8 +754,14 @@ fn create_spawn(
     let extra_args = read_promise_vec(args_vec_handle);
 
     PENDING_PROMISE_TASKS.fetch_add(1, Ordering::AcqRel);
+    // Os GCELLS (module-globals promovidos) são THREAD-LOCAL: o corpo async
+    // roda numa thread tokio e, sem o snapshot/restore (o mesmo que
+    // `thread.spawn` faz), lia TODO módulo-global/singleton como 0/undefined
+    // (`const b = new Box(); async fn { b.v }` → undefined).
+    let gcells = crate::collector::collector::gcell_snapshot();
     let rt = crate::runtime::async_rt::handle();
     rt.spawn_blocking(move || {
+        crate::collector::collector::gcell_restore(gcells);
         // (cross-runtime #365) marca thread como async-worker: parallel.map
         // dentro do corpo roda sequencial (rayon-em-spawn_blocking crasha).
         let _aw = crate::runtime::async_rt::AsyncWorkerGuard::enter();


### PR DESCRIPTION
Cluster **streams** (tracker #864): 64_readable_stream, 86_blob_stream, 96_streams_transform e 101_textdecoder_stream passam idênticos a Bun/Node (**0/7 → 4/7**; 88 precisa de gzip nativo). Colaterais: 372_private_methods, codex_set_forEach_mutation_order, codex_weakmap_invalid_keys.

- **streams.ts** (novo prelude): ReadableStream (fila + encaminhamento lazy pós-pipeThrough), reader sync (await passthrough), WritableStream, TransformStream, TextEncoder/DecoderStream (UTF-8 em TS puro).
- **webapi.ts**: __utf8_encode + Blob.stream()/arrayBuffer().
- **SINGLE-EVAL MARSHALING** no dispatch virtual (vdispatch/dispatch): args rebaixados UMA vez antes do branch (SSA domina os arms; só o arm tomado usa) — o gate is_side_effect_free_arg foi **deletado**; args efeitosos agora despacham (era o bucket de ~12 fixtures 'TypeError: not a function').
- **static_instance_class**: fallback gcell_classes sombreado por local de mesmo nome (regressão pega pela suíte TS em edge_error_extends).
- **create_spawn**: snapshot/restore de GCELLS na thread tokio do corpo async — módulo-global/singleton lido em async fn era undefined.
- **method_array**: \rr.push(...src)\ via __rtsadp_arr_spread_append.

Sweep completo: **377 pass, ZERO regressão**. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj