### PR TITLE
feat(codegen): mapear sentinels da async state-machine + async generators

### DIFF
--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -678,5 +678,14 @@ fn generator_symbols() -> Vec<JitSymbol> {
         // `{value, done}` result-Map accessors (new engine builds its own result obj).
         sym("__RTS_FN_NS_GC_ITER_VALUE", rt_gen::__RTS_FN_NS_GC_ITER_VALUE as *const u8),
         sym("__RTS_FN_NS_GC_ITER_DONE", rt_gen::__RTS_FN_NS_GC_ITER_DONE as *const u8),
+        // ASYNC state machine (async fn com loop/try — desugar lazy do parser) +
+        // async generator (#392): ctor/start/suspend/awaited/resolve/next.
+        sym("__RTS_FN_NS_GC_ASYNC_SM_NEW", rt_gen::__RTS_FN_NS_GC_ASYNC_SM_NEW as *const u8),
+        sym("__RTS_FN_NS_GC_AGEN_NEW", rt_gen::__RTS_FN_NS_GC_AGEN_NEW as *const u8),
+        sym("__RTS_FN_NS_GC_ASYNC_SM_START", rt_gen::__RTS_FN_NS_GC_ASYNC_SM_START as *const u8),
+        sym("__RTS_FN_NS_GC_ASYNC_SM_SUSPEND", rt_gen::__RTS_FN_NS_GC_ASYNC_SM_SUSPEND as *const u8),
+        sym("__RTS_FN_NS_GC_ASYNC_SM_AWAITED", rt_gen::__RTS_FN_NS_GC_ASYNC_SM_AWAITED as *const u8),
+        sym("__RTS_FN_NS_GC_ASYNC_SM_RESOLVE", rt_gen::__RTS_FN_NS_GC_ASYNC_SM_RESOLVE as *const u8),
+        sym("__RTS_FN_NS_GC_AGEN_NEXT", rt_gen::__RTS_FN_NS_GC_AGEN_NEXT as *const u8),
     ]
 }

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -674,9 +674,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         let mut call_args: Vec<Value> = Vec::with_capacity(args.len());
         for (i, a) in args.iter().enumerate() {
-            // `GEN_SM_NEW(state_fn, nslots)`: arg0 is the state-fn ident → its raw
-            // code address (the C-ABI `fn(u64)->i64` the runtime calls).
-            if symbol == "__RTS_FN_NS_GC_GEN_SM_NEW" && i == 0 {
+            // `GEN_SM_NEW/ASYNC_SM_NEW/AGEN_NEW(state_fn, nslots)`: arg0 is the
+            // state-fn ident → its raw code address (the C-ABI `fn(u64)->i64`
+            // the runtime calls).
+            if matches!(
+                symbol,
+                "__RTS_FN_NS_GC_GEN_SM_NEW"
+                    | "__RTS_FN_NS_GC_ASYNC_SM_NEW"
+                    | "__RTS_FN_NS_GC_AGEN_NEW"
+            ) && i == 0
+            {
                 if let HirExprKind::Ident(fname) = &a.kind {
                     let fid = *self.ids.get(fname).ok_or_else(|| {
                         Unsupported::new(format!("generator state-fn `{fname}` not declared"))
@@ -1490,6 +1497,16 @@ fn gen_sm_sentinel(name: &str, argc: usize) -> Option<(&'static str, GenRet, &'s
         ("__RTS_GEN_DELEGATE_START", 1) => ("__RTS_FN_NS_GC_GEN_DELEGATE_START", Int, &[0]),
         ("__RTS_GEN_DELEGATE_NEXT", 1) => ("__RTS_FN_NS_GC_GEN_DELEGATE_NEXT", Word, &[]),
         ("__RTS_GEN_DELEGATE_DONE", 1) => ("__RTS_FN_NS_GC_GEN_DELEGATE_DONE", Int, &[]),
+        // ASYNC state machine (async fn com loop/try) + async generator (#392):
+        // o parser emite estes sentinels; os externs já existiam no runtime
+        // (collector/generator.rs) — só o mapa faltava ("call to unknown
+        // function `__RTS_AGEN_NEW`").
+        ("__RTS_ASYNC_SM_NEW", 2) => ("__RTS_FN_NS_GC_ASYNC_SM_NEW", Int, &[]),
+        ("__RTS_AGEN_NEW", 2) => ("__RTS_FN_NS_GC_AGEN_NEW", Int, &[]),
+        ("__RTS_ASYNC_SM_START", 1) => ("__RTS_FN_NS_GC_ASYNC_SM_START", Int, &[]),
+        ("__RTS_ASYNC_SM_SUSPEND", 2) => ("__RTS_FN_NS_GC_ASYNC_SM_SUSPEND", Int, &[]),
+        ("__RTS_ASYNC_SM_AWAITED", 1) => ("__RTS_FN_NS_GC_ASYNC_SM_AWAITED", Word, &[]),
+        ("__RTS_ASYNC_SM_RESOLVE", 2) => ("__RTS_FN_NS_GC_ASYNC_SM_RESOLVE", Int, &[1]),
         _ => return None,
     })
 }

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -655,8 +655,19 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         "__RTS_FN_NS_GC_GEN_SM_NEW"
         | "__RTS_FN_NS_GC_GEN_SM_FGET"
         | "__RTS_FN_NS_GC_GEN_SM_YIELD"
-        | "__RTS_FN_NS_GC_GEN_SM_DONE" => SymSig {
+        | "__RTS_FN_NS_GC_GEN_SM_DONE"
+        // ASYNC state machine + async generator (same (handle, arg) → i64 shape).
+        | "__RTS_FN_NS_GC_ASYNC_SM_NEW"
+        | "__RTS_FN_NS_GC_AGEN_NEW"
+        | "__RTS_FN_NS_GC_ASYNC_SM_SUSPEND"
+        | "__RTS_FN_NS_GC_ASYNC_SM_RESOLVE" => SymSig {
             params: &[U64, U64],
+            ret: U64,
+        },
+        "__RTS_FN_NS_GC_ASYNC_SM_START"
+        | "__RTS_FN_NS_GC_ASYNC_SM_AWAITED"
+        | "__RTS_FN_NS_GC_AGEN_NEXT" => SymSig {
+            params: &[U64],
             ret: U64,
         },
         "__RTS_FN_NS_GC_GEN_SM_FSET" => SymSig {


### PR DESCRIPTION
O parser desugara async fn com loop/try e async generators emitindo \__RTS_ASYNC_SM_*\/\__RTS_AGEN_NEW\ — os externs sempre existiram no runtime, mas o mapa \gen_sm_sentinel\ do front não os conhecia: **toda async fn não-trivial falhava compile** ('call to unknown function').

- **call.rs**: 6 mapeamentos sentinel → extern real; special-case func_addr do arg0 cobre ASYNC_SM_NEW/AGEN_NEW.
- **abi_sig.rs + adapter_symbols**: assinaturas + registro JIT dos 7 externs.

Sweep: **389 pass (+12, ZERO regressão)** — destrava 92_promise_with_resolvers, claude-to-fixed-rounding e cluster object-meta dependente de helpers async. Próxima camada anotada: \or await..of\ e \.next()\ em instância agen. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj