### PR TITLE
feat(codegen): ctor de async generator é o mesmo kind lazy-gen do front

### DIFF
--- a/crates/rts-codegen-new/src/front/run/sig.rs
+++ b/crates/rts-codegen-new/src/front/run/sig.rs
@@ -226,8 +226,12 @@ impl FnSig {
         let is_eager_generator = body_calls_fn(func, "__RTS_GEN_FINISH");
         // A LAZY generator constructor returns the GenState HANDLE from
         // `__RTS_GEN_SM_NEW` — a raw `i64` (kept `Int64`; it is an opaque handle, not
-        // a PolyValue, and is consumed by `GENERATOR_NEXT`/`GEN_SM_DRAIN`).
-        let is_lazy_gen = body_calls_fn(func, "__RTS_GEN_SM_NEW");
+        // a PolyValue, and is consumed by `GENERATOR_NEXT`/`GEN_SM_DRAIN`). An ASYNC
+        // generator ctor (`__RTS_AGEN_NEW`) returns the SAME GenState-handle shape —
+        // the runtime's NEXT/DRAIN dispatch `is_async_gen` themselves (polymorphic),
+        // so the front treats both as ONE lazy-generator kind.
+        let is_lazy_gen =
+            body_calls_fn(func, "__RTS_GEN_SM_NEW") || body_calls_fn(func, "__RTS_AGEN_NEW");
         if is_eager_generator {
             ret = Repr::Tagged;
         }


### PR DESCRIPTION
__RTS_AGEN_NEW devolve o mesmo shape de handle GenState que __RTS_GEN_SM_NEW, e o runtime já despacha is_async_gen POLIMORFICAMENTE em GEN_SM_NEXT/GEN_SM_DRAIN — mas a flag ret_lazy_gen do front só olhava o sentinel sync: 'for await..of' sobre agen caía em 'for-of over a non-iterable'.

**sig.rs (1 linha)**: is_lazy_gen também para corpos que chamam __RTS_AGEN_NEW — um kind só no front, dispatch todo no runtime.

Fixture 109_async_generator passa. Sweep: 390 pass; as 2 divergências novas NÃO são deste diff (286_setimmediate = Bun/Node divergindo entre si; 61_structured_clone reproduz sem este diff — regressão upstream). Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj