### PR TITLE
feat(codegen): dispatch dinâmico de métodos de classe Registry em receiver Tagged

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -236,6 +236,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                         return Ok(Some(val));
                     }
                 }
+                // LAST: DYNAMIC Registry-class instance dispatch — the receiver
+                // may be a Registry instance (a Date/URL/… reached through an
+                // `any` param or a stored slot). Resolved at RUNTIME by each
+                // candidate class's `instanceof_predicate` (data-driven; the
+                // Registry counterpart of the user-class virtual dispatch).
+                if let Some(val) =
+                    self.try_registry_virtual_dynamic(module, recv, method, args)?
+                {
+                    return Ok(Some(val));
+                }
                 return Ok(None);
             }
             return Ok(None);

--- a/crates/rts-codegen-new/src/front/run/registry.rs
+++ b/crates/rts-codegen-new/src/front/run/registry.rs
@@ -414,3 +414,39 @@ pub fn instanceof_predicate(class: &str) -> Option<&'static str> {
     let c: &'static rts_engine::Class = registry().class(class)?;
     c.instanceof_predicate.as_deref()
 }
+
+/// The candidate set for the DYNAMIC (runtime-predicate) Registry instance
+/// dispatch: every Registry class that BOTH declares an `instanceof_predicate`
+/// AND resolves instance method `method` for a call with `argc` explicit args
+/// (arity window `[required, total]`, same rule the static instance path uses).
+/// Ordered as registered. Data-driven — the front names no class.
+pub fn dyn_instance_candidates(
+    method: &str,
+    argc: usize,
+) -> Vec<(String, &'static str, ResolvedCall)> {
+    let reg: &'static rts_engine::Registry = registry();
+    reg.classes()
+        .filter_map(|c| {
+            let pred = c.instanceof_predicate.as_deref()?;
+            let m = c.resolve_instance_method(method, argc)?;
+            let call = instance_call(m);
+            // The call must ADMIT argc: within [required, total] of the explicit
+            // params (the emitter pads the omitted defaulted tail). Same rule as
+            // `required_args` in registryclass.rs: an empty `default_args` means
+            // every param is required.
+            let total = call.arg_abis.len();
+            let required = if call.default_args.is_empty() {
+                total
+            } else {
+                call.default_args
+                    .iter()
+                    .take_while(|d| matches!(d, DefaultArg::Required))
+                    .count()
+            };
+            if argc < required || argc > total {
+                return None;
+            }
+            Some((c.name.clone(), pred, call))
+        })
+        .collect()
+}

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -352,6 +352,128 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     }
 }
 
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// DYNAMIC Registry-class instance dispatch on a TAGGED receiver of unproven
+    /// class (the Registry counterpart of `try_user_virtual_dynamic`): for every
+    /// Registry class that declares an `instanceof_predicate` AND resolves
+    /// `method` at this argc, emit a runtime arm
+    /// `if is_object(recv) && predicate(handle) { marshal + call }` — fully
+    /// DATA-DRIVEN (iterates the Registry metadata; the front names no class).
+    /// Args lower ONCE before any branch (single-eval; a Spread declines). The
+    /// fall-through (no predicate matched / non-object receiver) yields the
+    /// `undefined` sentinel — a TypeError class in JS, never a wrong value.
+    ///
+    /// `Ok(None)` when NO candidate exists — the caller keeps its later
+    /// fallbacks, so this must be tried LAST in the Tagged dispatch chain.
+    pub(super) fn try_registry_virtual_dynamic(
+        &mut self,
+        module: &mut dyn Module,
+        recv: Val,
+        method: &str,
+        args: &[HirExpr],
+    ) -> FrontResult<Option<Val>> {
+        use super::registry;
+        let cands = registry::dyn_instance_candidates(method, args.len());
+        if cands.is_empty() {
+            return Ok(None);
+        }
+        if args
+            .iter()
+            .any(|a| matches!(a.kind, HirExprKind::Spread(_)))
+        {
+            return Ok(None);
+        }
+        // Single-eval: lower every arg ONCE; the SSA values dominate all arms.
+        let mut argvals: Vec<Val> = Vec::with_capacity(args.len());
+        for a in args {
+            argvals.push(self.lower_expr(module, a)?);
+        }
+        let recv_word = self.box_value(recv);
+        // is_object gate + the real handle (same emission as
+        // `emit_registry_instanceof`; predicates tolerate a bogus handle → 0).
+        let boxed = value::emit_is_boxed(self.builder, recv_word);
+        let shifted = self
+            .builder
+            .ins()
+            .ushr_imm(recv_word, value::TAG_SHIFT as i64);
+        let tag = self.builder.ins().band_imm(shifted, value::TAG_MASK as i64);
+        let want = self
+            .builder
+            .ins()
+            .iconst(types::I64, value::TAG_OBJECT as i64);
+        let is_obj_tag = self.builder.ins().icmp(
+            cranelift_codegen::ir::condcodes::IntCC::Equal,
+            tag,
+            want,
+        );
+        let is_object = self.builder.ins().band(boxed, is_obj_tag);
+        let handle = value::emit_marshal::emit_table_load(module, self.builder, recv_word);
+
+        let merge = self.builder.create_block();
+        self.builder
+            .append_block_param(merge, types::I64);
+        for (class, pred, call) in &cands {
+            let pred_v = value::emit_marshal::emit_call_sig(
+                module,
+                self.builder,
+                pred,
+                &[handle],
+                &[AbiType::Handle],
+                AbiType::Bool,
+            )
+            .expect("instanceof predicate returns a value");
+            // Normalize the predicate's i64 0/1 to the icmp width before the
+            // `band` with `is_object` (mixed-width band is a verifier error).
+            let pred_b = self.builder.ins().icmp_imm(
+                cranelift_codegen::ir::condcodes::IntCC::NotEqual,
+                pred_v,
+                0,
+            );
+            let cond = self.builder.ins().band(is_object, pred_b);
+            let arm_blk = self.builder.create_block();
+            let next_blk = self.builder.create_block();
+            self.builder.ins().brif(cond, arm_blk, &[], next_blk, &[]);
+
+            self.builder.switch_to_block(arm_blk);
+            self.builder.seal_block(arm_blk);
+            // Pad the omitted defaulted tail (same rule as the static instance
+            // path) and classify the Handle return by the spec's flags.
+            let mut vals = argvals.clone();
+            for i in args.len()..call.arg_abis.len() {
+                vals.push(self.default_arg_val(call.default_args.get(i), class, i)?);
+            }
+            let result_kind = match call.ret {
+                AbiType::Handle if call.ret_is_string_handle => JsKind::Str,
+                AbiType::Handle if call.ret_is_array_handle => JsKind::Array,
+                AbiType::Handle => JsKind::Object,
+                AbiType::Bool => JsKind::Bool,
+                _ => JsKind::Number,
+            };
+            let v = self.emit_registry_call(module, call, Some(recv), &vals, result_kind)?;
+            let w = self.box_value(v);
+            self.builder.ins().jump(merge, &[w.into()]);
+
+            self.builder.switch_to_block(next_blk);
+            self.builder.seal_block(next_blk);
+        }
+        // DEFAULT: no predicate matched → the `undefined` sentinel.
+        let undef = self
+            .builder
+            .ins()
+            .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
+        self.builder.ins().jump(merge, &[undef.into()]);
+
+        self.builder.switch_to_block(merge);
+        self.builder.seal_block(merge);
+        let result = self.builder.block_params(merge)[0];
+        Ok(Some(Val::new_with_kind(
+            result,
+            crate::repr::Repr::Tagged,
+            JsKind::Unknown,
+        )))
+    }
+}
+
 /// The minimum explicit arg count a member accepts: the leading run of
 /// `DefaultArg::Required`. An empty `default_args` slice means every declared
 /// param is required (`required == total`). The `[required, total]` window is the

--- a/crates/rts-shared/src/stdlib/structured_clone.ts
+++ b/crates/rts-shared/src/stdlib/structured_clone.ts
@@ -73,11 +73,13 @@ function __structuredCloneInner(__scValue: any, __scSeen: any[], __scClones: any
   }
   // TYPE-PRESERVING Date clone: a fresh instance at the same epoch (the opaque
   // as-is return shared the instance — `copy.setFullYear` mutated the original).
-  // Date stays the AS-IS return below (the backend-opaque path): reading its
-  // epoch needs an instance-method call on an `any` receiver, and the dynamic
-  // Registry-class dispatch is a separate increment — a `getTime()` here was a
-  // runtime TypeError. Data is preserved; only clone-mutation isolation for
-  // Date is deferred (the pre-existing behavior).
+  // TYPE-PRESERVING Date clone: a fresh instance at the same epoch (the opaque
+  // as-is return shared the instance — `copy.setFullYear` mutated the
+  // original). `getTime()` on the `any` receiver rides the dynamic
+  // Registry-class dispatch; `* 1` proves the ctor's number overload.
+  if (__scValue instanceof Date) {
+    return new Date(__scValue.getTime() * 1);
+  }
   const __scKeys = Object.keys(__scValue);
   // A BACKEND-OPAQUE instance (Date/RegExp/URL — a Rust-backed object with NO
   // enumerable own keys): cloning key-by-key would produce an empty `{}` and


### PR DESCRIPTION
O maior gap do histograma de erros: método de instância de classe Registry num receiver any/Tagged (`x.getTime()` num param/slot/clone) não despachava — compile ok, runtime TypeError. Afetava Date/URL/RegExp alcançados fora de um local provado.

- **registry.rs**: `dyn_instance_candidates(method, argc)` — toda classe Registry com instanceof_predicate + método na janela [required, total]. Data-driven, zero nome de classe no front.
- **registryclass.rs**: `try_registry_virtual_dynamic` — contraparte Registry do virtual dispatch de user-class: single-eval dos args, gate is_object, um arm por candidato `if predicate(handle) { marshal via emit_registry_call + defaults do spec }`, fall-through = sentinela undefined.
- **method.rs**: tentado por ÚLTIMO na cadeia Tagged (não rouba fallbacks).
- **structured_clone.ts**: arm de Date restaurado — clone type-preserving real (`new Date(getTime()*1)`).

Sweep: **397 pass, ZERO regressão**. Suíte TS 1688/1688 (structuredclone_type_preserve 6/6). Gate verde. Próxima camada anotada: getters de instância dinâmicos (re.source em any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj