### PR TITLE
feat(codegen): classificar receiver de getter Registry encadeado pelo ts-signature do spec

### DIFF
--- a/crates/rts-codegen-new/src/front/run/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/globalclass.rs
@@ -359,6 +359,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let recv = self.global_instance_class(inner)?;
                 super::registry::class_member_ret_class(&recv, method)
             }
+            // A CHAINED registry GETTER receiver (`url.searchParams.get(..)`
+            // without the intermediate local): the getter's spec ts-signature
+            // names its class (`readonly searchParams: URLSearchParams`) —
+            // data-driven, recursion covers N-deep chains.
+            HirExprKind::Member { object: inner, prop } => {
+                let recv = self.global_instance_class(inner)?;
+                super::registry::class_getter_ret_class(&recv, prop)
+            }
             _ => None,
         }
     }

--- a/crates/rts-codegen-new/src/front/run/registry.rs
+++ b/crates/rts-codegen-new/src/front/run/registry.rs
@@ -290,6 +290,20 @@ pub fn class_member_ret_class(class: &str, method: &str) -> Option<String> {
         .filter(|rc| has_class(rc))
 }
 
+/// The provable RETURN CLASS of instance GETTER `class.prop` — the getter's ts
+/// signature naming a registered class (`readonly searchParams: URLSearchParams`).
+/// Lets a CHAINED getter receiver classify (`url.searchParams.get(..)` without
+/// the intermediate local).
+pub fn class_getter_ret_class(class: &str, prop: &str) -> Option<String> {
+    let c = registry().class(class)?;
+    // A property may be modeled as a real InstanceGetter OR as a recv-only
+    // InstanceMethod read as a member (URL's `searchParams`) — accept both.
+    let m = c
+        .instance_getter(prop)
+        .or_else(|| c.resolve_instance_method(prop, 0))?;
+    ts_return_class(&m.ts_signature).filter(|rc| has_class(rc))
+}
+
 /// Resolve `inst.prop` as an INSTANCE GETTER (a `MemberKind::InstanceGetter`, read
 /// with no `()`) to its [`ResolvedCall`]. `None` when the class has no such getter.
 /// (Distinct from `class_member`, which only matches `InstanceMethod` — some


### PR DESCRIPTION
`url.searchParams.get('x')` sem o local intermediário caía no dinâmico e lia undefined (URLSearchParams não tem instanceof_predicate; Entry::Env/Vec genéricos são ambíguos para predicate).

- **registry.rs**: `class_getter_ret_class(class, prop)` — classe de retorno do getter pelo ts_signature, aceitando InstanceGetter real OU propriedade modelada como InstanceMethod recv-only (caso do URL spec). Data-driven.
- **globalclass.rs**: arm `Member` em `global_instance_class` — receiver encadeado classifica por recursão + ret-class (mesmo padrão do arm MethodCall).

Fixtures **55_url_searchparams** e **107_url_edge_cases** passam. Sweep: **406 pass, ZERO regressão**. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj