### PR TITLE
feat(runtime/codegen): split com regex spec-completo — captures + limit + empty-match por posição

### DIFF
--- a/crates/rts-adapters/src/value/regexops.rs
+++ b/crates/rts-adapters/src/value/regexops.rs
@@ -394,20 +394,81 @@ fn utf8_len(b: u8) -> usize {
     }
 }
 
-/// `s.split(re)` — split the subject on each regex match; an array of boxed string
-/// words (built codegen-side from the REAL `REGEX_SPLIT` Vec-of-string-handles).
+/// `s.split(re, limit?)` — the JS-spec regex split, in full: CAPTURE GROUPS are
+/// spliced into the result (`"abc".split(/(b)/)` → `["a","b","c"]`, an unmatched
+/// group as `undefined`), `limit` is ToUint32 (`undefined` → 2³²−1, `0` → `[]`),
+/// and EMPTY matches split per position without consuming (`"xxx".split(/x*/)`
+/// → `["",""]`; a match at/after the end never splits). Match data is
+/// snapshotted like the replace trampoline. Returns a fresh array word.
 #[unsafe(no_mangle)]
-pub extern "C" fn __rtsadp_re_str_split(subj_word: u64, re_word: u64) -> u64 {
+pub extern "C" fn __rtsadp_re_str_split(subj_word: u64, re_word: u64, limit_word: u64) -> u64 {
+    use rts_engine::heap::handles::{Entry, with_entry};
     let s = handle_str(str_handle(subj_word));
-    let raw_vec = rt_re::__RTS_FN_NS_REGEX_SPLIT(unbox_re(re_word), s.as_ptr(), s.len() as i64);
-    if raw_vec == 0 {
-        // Bad handle: JS `split` of a string with no match yields `[s]`. Build it.
-        let out = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
-        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(out, subj_word as i64);
-        return PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(out))
-            .raw();
+    let lim: u32 = {
+        let v = PolyValue::from_raw(limit_word);
+        if v.is_undefined() || v.is_hole() {
+            u32::MAX
+        } else {
+            // JS ToUint32 (wraps negatives / truncates).
+            let f = genops::dyn_to_number(limit_word);
+            if f.is_finite() { (f as i64) as u32 } else { 0 }
+        }
+    };
+    let out = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
+    let finish =
+        |h: u64| PolyValue::from_object_handle(rt_handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(h)).raw();
+    if lim == 0 {
+        return finish(out);
     }
-    rebox_string_vec_as_array(raw_vec)
+    let re_h = unbox_re(re_word);
+    let matches: Vec<(usize, usize, Vec<Option<String>>)> = with_entry(re_h, |e| match e {
+        Some(Entry::Regex(rx)) => rx
+            .engine
+            .captures_all(&s)
+            .into_iter()
+            .filter_map(|caps| {
+                let m0 = caps.groups.first().cloned().flatten()?;
+                let texts = caps.groups.iter().map(|g| g.clone().map(|m| m.text)).collect();
+                Some((m0.start, m0.end, texts))
+            })
+            .collect(),
+        _ => Vec::new(),
+    });
+    // Empty subject: a regex that matches the empty string yields `[]`, else `[s]`.
+    if s.is_empty() {
+        if matches.is_empty() {
+            rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(out, subj_word as i64);
+        }
+        return finish(out);
+    }
+    let undef = PolyValue::undefined().raw() as i64;
+    let mut push = |w: i64| -> bool {
+        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(out, w);
+        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(out) as u64 >= lim as u64
+    };
+    let mut p = 0usize;
+    for (start, end, groups) in matches {
+        // A match at/after the end never splits; an EMPTY match exactly at the
+        // current cursor advances without splitting (spec `e == p`).
+        if start >= s.len() || (start == end && end == p) {
+            continue;
+        }
+        if push(abi_adapter::intern_poly(&s[p..start]).raw() as i64) {
+            return finish(out);
+        }
+        for g in groups.iter().skip(1) {
+            let w = match g {
+                Some(t) => abi_adapter::intern_poly(t).raw() as i64,
+                None => undef,
+            };
+            if push(w) {
+                return finish(out);
+            }
+        }
+        p = end;
+    }
+    push(abi_adapter::intern_poly(&s[p..]).raw() as i64);
+    finish(out)
 }
 
 /// `s.search(re)` — the byte index of the first match, or `-1`. A PolyValue number

--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -373,9 +373,25 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     ) -> FrontResult<Option<Val>> {
         match (method, args.len()) {
             ("split", 1) | ("split", 2) => {
-                // sep must be a proven string (a regex separator is a later
-                // increment). Lower + marshal it to a real string handle.
+                // sep must be a proven string (a regex separator routes through
+                // the regex-first path before this). Lower + marshal it to a
+                // real string handle.
                 let sep = self.lower_expr(module, &args[0])?;
+                // `split(undefined)` — JS: the whole string as the ONE element.
+                if matches!(sep.kind, JsKind::Undefined) {
+                    let arr = crate::value::emit_marshal::emit_new_vec_object(
+                        module,
+                        self.builder,
+                    );
+                    let recv_word = self.box_value(recv);
+                    crate::value::emit_marshal::emit_vec_push(
+                        module,
+                        self.builder,
+                        arr,
+                        recv_word,
+                    );
+                    return Ok(Some(Val::tagged_kind(arr, JsKind::Array)));
+                }
                 if !matches!(sep.kind, JsKind::Str) {
                     return unsupported!(
                         "String.split with a non-string (regex?) separator is a later increment"

--- a/crates/rts-codegen-new/src/front/run/regex.rs
+++ b/crates/rts-codegen-new/src/front/run/regex.rs
@@ -155,20 +155,32 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     .expect("re_str_search returns a value");
                 Ok(Some(Val::tagged_kind(word, JsKind::Number)))
             }
-            // `s.split(re)` → array of string parts. A 2-arg `split(re, limit)` with
-            // a non-negative limit is a later increment (the runtime split has no
-            // limit param); BAIL rather than ignore the limit (which would diverge).
-            ("split", 1) => {
+            // `s.split(re, limit?)` → the FULL JS-spec regex split (capture
+            // groups spliced into the result, ToUint32 limit, per-position
+            // empty-match rule) — one polymorphic trampoline; the omitted limit
+            // rides `undefined`.
+            ("split", 1 | 2) => {
                 let re = self.lower_regex_value(module, &args[0])?;
                 let re_word = self.box_value(re);
+                let limit_word = match args.get(1) {
+                    Some(a) => {
+                        let v = self.lower_expr(module, a)?;
+                        self.box_value(v)
+                    }
+                    None => self.builder.ins().iconst(
+                        cranelift_codegen::ir::types::I64,
+                        crate::value::PolyValue::undefined().raw() as i64,
+                    ),
+                };
                 let word = self
-                    .call_runtime(module, "__rtsadp_re_str_split", &[recv_word, re_word])?
+                    .call_runtime(
+                        module,
+                        "__rtsadp_re_str_split",
+                        &[recv_word, re_word, limit_word],
+                    )?
                     .expect("re_str_split returns a value");
                 Ok(Some(Val::tagged_kind(word, JsKind::Array)))
             }
-            ("split", 2) => crate::front::error::unsupported!(
-                "`s.split(re, limit)` with a regex separator + limit is a later increment"
-            ),
             // `s.replace(re, repl)` / `s.replaceAll(re, repl)` → string, via the
             // ONE polymorphic trampoline: a STRING replacement runs the JS
             // `GetSubstitution` token expansion ($$, $&, $`, $', $n, $<name>);

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -836,8 +836,13 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64],
             ret: U64,
         },
-        "__rtsadp_re_str_match" | "__rtsadp_re_str_split" | "__rtsadp_re_str_search" => SymSig {
+        "__rtsadp_re_str_match" | "__rtsadp_re_str_search" => SymSig {
             params: &[U64, U64],
+            ret: U64,
+        },
+        // Full JS-spec split: (subj, re, limit_word) — `undefined` limit = none.
+        "__rtsadp_re_str_split" => SymSig {
+            params: &[U64, U64, U64],
             ret: U64,
         },
         // replace/replaceAll — the ONE polymorphic replacement trampoline


### PR DESCRIPTION
Fixtures **243_string_split_regex**, **claude-split-regex-limit** e **codex_string_split_captures_limits** passam idênticas a Bun/Node.

- **regexops.rs**: `__rtsadp_re_str_split` reescrito para a semântica da spec sobre o snapshot de matches (mesmo esqueleto do replace_fn): capture groups no resultado (grupo não-casado → undefined), limit ToUint32 (undefined → 2³²−1, 0 → []), match vazio divide por posição sem consumir. O antigo delegava ao REGEX_SPLIT do crate (sem captures/limit) — **deletado o caminho legacy**.
- **regex.rs**: arms (split,1|2) unificados no trampolim único.
- **method.rs**: `split(undefined)` → `[s]` (JS) em vez de bail.

Sweep: **409 pass, ZERO regressão**. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj