### PR TITLE
feat(runtime): Invalid Date da spec — NaN atravessa a ABI de Date + toString opaco por entry-kind

### DIFF
--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -51,7 +51,22 @@ pub(super) fn to_string(v: PolyValue) -> String {
     // `null`/`undefined` elements rendering as the empty string. A keyed OBJECT
     // stays `[object Object]`.
     if v.is_object() && !crate::value::inspect::looks_like_object(v) {
-        return array_to_string(v);
+        // A REAL array joins its elements; an OPAQUE runtime entry (Date /
+        // RegExp / …) ToStrings through the runtime-layer authority
+        // (`OPAQUE_TO_STRING` — entry-kind dispatch, no class name here);
+        // an unknown opaque entry keeps the object default.
+        use rts_engine::heap::handles::{Entry, with_entry};
+        use rts_runtime::namespaces::gc::handles as rt_handles;
+        let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
+        let is_vec = with_entry(h, |e| matches!(e, Some(Entry::Vec(_))));
+        if is_vec {
+            return array_to_string(v);
+        }
+        let s = rts_runtime::namespaces::globals::date::instance::__RTS_FN_RT_OPAQUE_TO_STRING(h);
+        if s != 0 {
+            return abi_adapter::real_handle_to_string(s);
+        }
+        return "[object Object]".to_string();
     }
     // A keyed object with a `[Symbol.toPrimitive]` method: ToString runs it with
     // hint "string" and stringifies the primitive result (spec ToPrimitive).

--- a/crates/rts-shared/src/globals/date/instance.rs
+++ b/crates/rts-shared/src/globals/date/instance.rs
@@ -14,6 +14,62 @@ fn get_ms(handle: u64) -> i64 {
     })
 }
 
+/// Sentinel do estado INVALID DATE no slot `DateMs` (JS: um time value NaN).
+/// `i64::MIN` nunca é um timestamp válido (o range JS é ±8.64e15 ms) — e é o
+/// mesmo valor que `DATE_FROM_ISO` já devolve num parse falho.
+const INVALID_MS: i64 = i64::MIN;
+
+/// O range de time values válidos da spec (±8.64e15 ms). Fora dele → Invalid.
+fn clamp_time_value(ms: f64) -> i64 {
+    const MAX: f64 = 8.64e15;
+    if ms.is_finite() && ms.abs() <= MAX {
+        ms as i64
+    } else {
+        INVALID_MS
+    }
+}
+
+/// Um componente de setter: o sentinel de OMITIDO (`i64::MIN as f64`, o
+/// `DefaultArg::Int(i64::MIN)` coerced) mantém o campo atual; NaN INVALIDA
+/// (None); um número usa seu truncamento.
+fn keep_f(v: f64, cur: i64) -> Option<i64> {
+    if v == i64::MIN as f64 {
+        Some(cur)
+    } else if v.is_nan() {
+        None
+    } else {
+        Some(v as i64)
+    }
+}
+
+/// Os campos-base de um setter: os do instante atual, ou — num Invalid Date —
+/// os de `t = +0` (spec 21.4.4.*: um setter completo REVIVE a data).
+fn setter_base_parts(handle: u64) -> (i64, i64, i64, i64, i64, i64, i64) {
+    let cur = get_ms(handle);
+    if cur == INVALID_MS {
+        (1970, 0, 1, 0, 0, 0, 0)
+    } else {
+        ms_to_parts(cur)
+    }
+}
+
+/// Fecha um setter: `None` em qualquer componente → estado INVALID + NaN;
+/// senão grava e devolve os ms novos como f64.
+fn finish_setter(handle: u64, parts: Option<(i64, i64, i64, i64, i64, i64, i64)>) -> f64 {
+    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
+    match parts {
+        Some((y, mo, d, h, mi, s, ms)) => {
+            let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, d, h, mi, s, ms);
+            set_ms(handle, new_ms);
+            new_ms as f64
+        }
+        None => {
+            set_ms(handle, INVALID_MS);
+            f64::NAN
+        }
+    }
+}
+
 // ── Constructors ──────────────────────────────────────────────────────────────
 
 /// `new Date()` — current Unix timestamp in milliseconds.
@@ -25,8 +81,9 @@ pub extern "C" fn __RTS_FN_GL_DATE_NEW_NOW() -> u64 {
 
 /// `new Date(ms)` — from explicit milliseconds since epoch.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_NEW_FROM_MS(ms: i64) -> u64 {
-    alloc_entry(Entry::DateMs(ms))
+pub extern "C" fn __RTS_FN_GL_DATE_NEW_FROM_MS(ms: f64) -> u64 {
+    // NaN / fora do range da spec → INVALID DATE.
+    alloc_entry(Entry::DateMs(clamp_time_value(ms)))
 }
 
 /// `new Date(iso_str)` — from ISO 8601 string (`ptr`/`len` ABI).
@@ -71,13 +128,14 @@ pub extern "C" fn __RTS_FN_GL_DATE_NEW_FROM_FIELDS(
 // ── Instance methods ──────────────────────────────────────────────────────────
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_GET_TIME(handle: u64) -> i64 {
-    get_ms(handle)
+pub extern "C" fn __RTS_FN_GL_DATE_GET_TIME(handle: u64) -> f64 {
+    let ms = get_ms(handle);
+    if ms == INVALID_MS { f64::NAN } else { ms as f64 }
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_VALUE_OF(handle: u64) -> i64 {
-    get_ms(handle)
+pub extern "C" fn __RTS_FN_GL_DATE_VALUE_OF(handle: u64) -> f64 {
+    __RTS_FN_GL_DATE_GET_TIME(handle)
 }
 
 #[unsafe(no_mangle)]
@@ -135,6 +193,9 @@ pub extern "C" fn __RTS_FN_GL_DATE_TO_STRING(handle: u64) -> u64 {
         Some(Entry::DateMs(v)) => *v,
         _ => 0,
     });
+    if ms == INVALID_MS {
+        return alloc_entry(Entry::String(b"Invalid Date".to_vec()));
+    }
     let year = __RTS_FN_NS_DATE_YEAR(ms);
     let month = __RTS_FN_NS_DATE_MONTH(ms);
     let day = __RTS_FN_NS_DATE_DAY(ms);
@@ -334,73 +395,61 @@ fn set_ms(handle: u64, new_ms: i64) {
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_FULL_YEAR(handle: u64, year: i64, month: i64, day: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (_, mo, d, h, mi, s, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(year, keep(month, mo), keep(day, d), h, mi, s, ms);
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_FULL_YEAR(handle: u64, year: f64, month: f64, day: f64) -> f64 {
+    let (_, mo, d, h, mi, s, ms) = setter_base_parts(handle);
+    let parts = (|| Some((keep_f(year, 0)?, keep_f(month, mo)?, keep_f(day, d)?, h, mi, s, ms)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_MONTH(handle: u64, month: i64, day: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, _, d, h, mi, s, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, month, keep(day, d), h, mi, s, ms);
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_MONTH(handle: u64, month: f64, day: f64) -> f64 {
+    let (y, _, d, h, mi, s, ms) = setter_base_parts(handle);
+    let parts = (|| Some((y, keep_f(month, 0)?, keep_f(day, d)?, h, mi, s, ms)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_DATE(handle: u64, day: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, mo, _, h, mi, s, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, day, h, mi, s, ms);
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_DATE(handle: u64, day: f64) -> f64 {
+    let (y, mo, _, h, mi, s, ms) = setter_base_parts(handle);
+    let parts = (|| Some((y, mo, keep_f(day, 0)?, h, mi, s, ms)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_HOURS(handle: u64, hour: i64, min: i64, sec: i64, msec: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, mo, d, _, mi, s, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, d, hour, keep(min, mi), keep(sec, s), keep(msec, ms));
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_HOURS(handle: u64, hour: f64, min: f64, sec: f64, msec: f64) -> f64 {
+    let (y, mo, d, _, mi, s, ms) = setter_base_parts(handle);
+    let parts =
+        (|| Some((y, mo, d, keep_f(hour, 0)?, keep_f(min, mi)?, keep_f(sec, s)?, keep_f(msec, ms)?)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_MINUTES(handle: u64, min: i64, sec: i64, msec: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, mo, d, h, _, s, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, d, h, min, keep(sec, s), keep(msec, ms));
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_MINUTES(handle: u64, min: f64, sec: f64, msec: f64) -> f64 {
+    let (y, mo, d, h, _, s, ms) = setter_base_parts(handle);
+    let parts = (|| Some((y, mo, d, h, keep_f(min, 0)?, keep_f(sec, s)?, keep_f(msec, ms)?)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_SECONDS(handle: u64, sec: i64, msec: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, mo, d, h, mi, _, ms) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, d, h, mi, sec, keep(msec, ms));
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_SECONDS(handle: u64, sec: f64, msec: f64) -> f64 {
+    let (y, mo, d, h, mi, _, ms) = setter_base_parts(handle);
+    let parts = (|| Some((y, mo, d, h, mi, keep_f(sec, 0)?, keep_f(msec, ms)?)))();
+    finish_setter(handle, parts)
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_MILLISECONDS(handle: u64, ms_in: i64) -> i64 {
-    use crate::date::__RTS_FN_NS_DATE_FROM_PARTS;
-    let (y, mo, d, h, mi, s, _) = ms_to_parts(get_ms(handle));
-    let new_ms = __RTS_FN_NS_DATE_FROM_PARTS(y, mo, d, h, mi, s, ms_in);
-    set_ms(handle, new_ms);
-    new_ms
+pub extern "C" fn __RTS_FN_GL_DATE_SET_MILLISECONDS(handle: u64, ms_in: f64) -> f64 {
+    let (y, mo, d, h, mi, s, _) = setter_base_parts(handle);
+    let parts = (|| Some((y, mo, d, h, mi, s, keep_f(ms_in, 0)?)))();
+    finish_setter(handle, parts)
 }
 
 /// `setTime(ms)` — substitui timestamp completo. Retorna ms.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_DATE_SET_TIME(handle: u64, ms_in: i64) -> i64 {
-    set_ms(handle, ms_in);
-    ms_in
+pub extern "C" fn __RTS_FN_GL_DATE_SET_TIME(handle: u64, ms_in: f64) -> f64 {
+    let v = clamp_time_value(ms_in);
+    set_ms(handle, v);
+    if v == INVALID_MS { f64::NAN } else { v as f64 }
 }
 
 /// `toJSON()` — alias de toISOString (JS spec retorna ISO).
@@ -463,8 +512,31 @@ pub extern "C" fn __RTS_FN_GL_DATE_TO_TIME_STRING(handle: u64) -> u64 {
     }
 }
 
-/// Optional-tail sentinel of the variadic Date setters: the spec injects
-/// `i64::MIN` for an omitted arg — keep the current field then.
-fn keep(v: i64, cur: i64) -> i64 {
-    if v == i64::MIN { cur } else { v }
+/// ToString de um heap-entry OPACO (não-Vec/não-Map) — a autoridade fica NESTA
+/// camada (rts-shared), onde as classes não-primordiais moram: o genérico
+/// `to_string` do motor chama isto para um OBJECT word cujo entry não é um
+/// array/objeto keyed; `0` = "não sei" (o caller usa "[object Object]").
+/// Dispatch por ENTRY KIND — nenhum nome de classe no motor.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_OPAQUE_TO_STRING(handle: u64) -> u64 {
+    let kind = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(_)) => 1u8,
+        Some(Entry::Regex(_)) => 2,
+        _ => 0,
+    });
+    match kind {
+        1 => __RTS_FN_GL_DATE_TO_STRING(handle),
+        2 => {
+            let text = with_entry(handle, |e| match e {
+                Some(Entry::Regex(rx)) => {
+                    let src = rx.engine.source();
+                    let src = if src.is_empty() { "(?:)".to_string() } else { src };
+                    format!("/{}/{}", src, rx.flags)
+                }
+                _ => String::new(),
+            });
+            alloc_entry(Entry::String(text.into_bytes()))
+        }
+        _ => 0,
+    }
 }

--- a/crates/rts-shared/src/globals/date/mod.rs
+++ b/crates/rts-shared/src/globals/date/mod.rs
@@ -162,7 +162,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "new",
             MemberKind::Constructor,
-            Sig::new(vec![AbiType::I64], AbiType::Handle),
+            Sig::new(vec![AbiType::F64], AbiType::Handle),
             "__RTS_FN_GL_DATE_NEW_FROM_MS",
             "new Date(value: number): Date",
             "Creates a Date from milliseconds since Unix epoch.",
@@ -215,7 +215,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "getTime",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle], AbiType::I64),
+            Sig::new(vec![AbiType::Handle], AbiType::F64),
             "__RTS_FN_GL_DATE_GET_TIME",
             "getTime(): number",
             "Returns ms since epoch.",
@@ -224,7 +224,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "valueOf",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle], AbiType::I64),
+            Sig::new(vec![AbiType::Handle], AbiType::F64),
             "__RTS_FN_GL_DATE_VALUE_OF",
             "valueOf(): number",
             "Same as getTime().",
@@ -442,8 +442,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setFullYear",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_FULL_YEAR",
@@ -455,8 +455,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setMonth",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_MONTH",
@@ -467,7 +467,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "setDate",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
+            Sig::new(vec![AbiType::Handle, AbiType::F64], AbiType::F64),
             "__RTS_FN_GL_DATE_SET_DATE",
             "setDate(day: number): number",
             "Substitui o dia do mes (1-31). Retorna ms novos.",
@@ -477,8 +477,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setHours",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_HOURS",
@@ -490,8 +490,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setMinutes",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_MINUTES",
@@ -503,8 +503,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setSeconds",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_SECONDS",
@@ -515,7 +515,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "setMilliseconds",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
+            Sig::new(vec![AbiType::Handle, AbiType::F64], AbiType::F64),
             "__RTS_FN_GL_DATE_SET_MILLISECONDS",
             "setMilliseconds(ms: number): number",
             "Substitui ms (0-999).",
@@ -524,7 +524,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "setTime",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
+            Sig::new(vec![AbiType::Handle, AbiType::F64], AbiType::F64),
             "__RTS_FN_GL_DATE_SET_TIME",
             "setTime(ms: number): number",
             "Substitui timestamp completo (ms desde epoch).",
@@ -534,8 +534,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setUTCFullYear",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_FULL_YEAR",
@@ -547,8 +547,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setUTCMonth",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_MONTH",
@@ -559,7 +559,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "setUTCDate",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
+            Sig::new(vec![AbiType::Handle, AbiType::F64], AbiType::F64),
             "__RTS_FN_GL_DATE_SET_DATE",
             "setUTCDate(day: number): number",
             "Substitui o dia do mes (1-31, UTC).",
@@ -569,8 +569,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setUTCHours",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_HOURS",
@@ -582,8 +582,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setUTCMinutes",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN), DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_MINUTES",
@@ -595,8 +595,8 @@ pub fn register_class_spec(e: &mut Engine) {
             "setUTCSeconds",
             MemberKind::InstanceMethod,
             Sig::with_defaults(
-                vec![AbiType::Handle, AbiType::I64, AbiType::I64],
-                AbiType::I64,
+                vec![AbiType::Handle, AbiType::F64, AbiType::F64],
+                AbiType::F64,
                 vec![DefaultArg::Required, DefaultArg::Required, DefaultArg::Int(i64::MIN)],
             ),
             "__RTS_FN_GL_DATE_SET_SECONDS",
@@ -607,7 +607,7 @@ pub fn register_class_spec(e: &mut Engine) {
         .member(m(
             "setUTCMilliseconds",
             MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::I64], AbiType::I64),
+            Sig::new(vec![AbiType::Handle, AbiType::F64], AbiType::F64),
             "__RTS_FN_GL_DATE_SET_MILLISECONDS",
             "setUTCMilliseconds(ms: number): number",
             "Substitui ms (0-999, UTC).",


### PR DESCRIPTION
Fixtures **414_date_overflow_utc** e **codex_date_invalid_setters_nan** passam (date 9/12 → 11/12).

- **Spec de Date**: ctor `new Date(ms)` I64→F64; getTime/valueOf e setters (params+ret) I64→F64 — o front saturava NaN→0 antes do runtime ver, tornando Invalid Date irrepresentável.
- **instance.rs**: sentinel INVALID_MS=i64::MIN no slot (o mesmo que DATE_FROM_ISO já devolve em parse falho); clamp ±8.64e15 (spec); setters NaN-aware (`keep_f`: sentinel de omitido mantém campo, NaN invalida) + revive por setter completo (base t=+0, spec) ; toString → 'Invalid Date'; `keep()` órfão deletado.
- **OPAQUE_TO_STRING** (rts-shared): autoridade de ToString de entries opacos na camada certa — dispatch por ENTRY KIND (DateMs/Regex), zero nome de classe no motor; genops distingue Vec real de entry opaco (String(date) imprimia o join vazio).

Sweep: **411 pass, ZERO regressão** (6 vizinhas de date re-checadas). Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj