### PR TITLE
fix(runtime): JSON.stringify itera strings por code points — surrogate pair não corrompe

### DIFF
--- a/crates/rts-shared/src/stdlib/json.ts
+++ b/crates/rts-shared/src/stdlib/json.ts
@@ -166,11 +166,13 @@ function __json_repeat(pad: string, n: number): string {
   return s;
 }
 
-// Double-quote a string with the JSON escape set.
+// Double-quote a string with the JSON escape set. Iterates by CODE POINTS
+// (for-of), never by UTF-16 unit index: `s[i]` on half a surrogate pair reads
+// a LONE surrogate the engine's UTF-8 pool cannot hold (it became U+FFFD —
+// JSON.stringify("😀") printed replacement chars).
 function __json_quote(s: string): string {
   let out = '"';
-  for (let i = 0; i < s.length; i++) {
-    const c = s[i];
+  for (const c of s) {
     if (c === '"') out += '\\"';
     else if (c === "\\") out += "\\\\";
     else if (c === "\n") out += "\\n";


### PR DESCRIPTION
JSON.stringify('😀') imprimia U+FFFD: `__json_quote` iterava por índice UTF-16 e meio surrogate pair vira lone surrogate que o pool UTF-8 não representa. Agora itera por for-of (code points).

Sweep: **413 pass, ZERO regressão**. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj