### PR TITLE
fix(runtime): slice/substring/substr indexam por UTF-16 code units (spec JS)

### DIFF
--- a/crates/rts-primitives/src/string/rt.rs
+++ b/crates/rts-primitives/src/string/rt.rs
@@ -379,7 +379,10 @@ pub extern "C" fn __RTS_FN_GL_STRING_SLICE(recv: u64, start: i64, end: i64) -> u
     let Some(s) = handle_to_str(recv) else {
         return alloc_str("");
     };
-    let count = s.chars().count() as i64;
+    // JS string indices are UTF-16 CODE UNITS (never code points): slicing a
+    // surrogate pair at its middle keeps only the half the range covers.
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let count = units.len() as i64;
     let norm = |i: i64| -> usize {
         let n = if i < 0 { count + i } else { i };
         n.clamp(0, count) as usize
@@ -389,8 +392,7 @@ pub extern "C" fn __RTS_FN_GL_STRING_SLICE(recv: u64, start: i64, end: i64) -> u
     if si >= ei {
         return alloc_str("");
     }
-    let result: String = s.chars().skip(si).take(ei - si).collect();
-    alloc_str(&result)
+    alloc_str(&String::from_utf16_lossy(&units[si..ei]))
 }
 
 /// str.substring(start, end) — like slice but negatives clamp to 0, swaps if start>end.
@@ -399,7 +401,9 @@ pub extern "C" fn __RTS_FN_GL_STRING_SUBSTRING(recv: u64, start: i64, end: i64) 
     let Some(s) = handle_to_str(recv) else {
         return alloc_str("");
     };
-    let count = s.chars().count() as i64;
+    // UTF-16 code-unit indices (JS spec), like `slice`.
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let count = units.len() as i64;
     let clamp = |i: i64| i.clamp(0, count) as usize;
     let (si, ei) = {
         let a = clamp(start);
@@ -413,8 +417,7 @@ pub extern "C" fn __RTS_FN_GL_STRING_SUBSTRING(recv: u64, start: i64, end: i64) 
     if si >= ei {
         return alloc_str("");
     }
-    let result: String = s.chars().skip(si).take(ei - si).collect();
-    alloc_str(&result)
+    alloc_str(&String::from_utf16_lossy(&units[si..ei]))
 }
 
 /// str.substr(start, length) — deprecated start+count form.
@@ -423,11 +426,13 @@ pub extern "C" fn __RTS_FN_GL_STRING_SUBSTR(recv: u64, start: i64, length: i64) 
     let Some(s) = handle_to_str(recv) else {
         return alloc_str("");
     };
-    let count = s.chars().count() as i64;
+    // UTF-16 code-unit indices (JS spec), like `slice`.
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let count = units.len() as i64;
     let si = (if start < 0 { count + start } else { start }).clamp(0, count) as usize;
     let take = if length < 0 { 0 } else { length as usize };
-    let result: String = s.chars().skip(si).take(take).collect();
-    alloc_str(&result)
+    let ei = si.saturating_add(take).min(units.len());
+    alloc_str(&String::from_utf16_lossy(&units[si..ei]))
 }
 
 // ── Transform methods ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixture **412_unicode_surrogate_iteration** passa. Os três fatiadores indexavam por code points — `'A🙂B'.slice(1,3)` dava `🙂B` em vez de `🙂`. Agora operam sobre `encode_utf16()` com `from_utf16_lossy` no range.

Sweep: **415 pass, ZERO regressão**. Suíte TS 1688/1688. Gate verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj