### PR TITLE
feat(runtime/codegen): TextDecoder {fatal, ignoreBOM} + decode streaming + Array.from(Buffer)

### DIFF
--- a/crates/rts-adapters/src/value/errslot.rs
+++ b/crates/rts-adapters/src/value/errslot.rs
@@ -92,6 +92,27 @@ pub(crate) fn throw_js_error(kind: &str, message: &str) {
     __rtsadp_throw_set(msg.raw());
 }
 
+/// Link-reachable form of [`throw_js_error`] for the runtime layer: an
+/// `rts-std`/`rts-shared` impl cannot depend on this crate (dep direction), but
+/// CAN reach the extern by symbol to throw a real `kind` Error instance with
+/// `message` into the engine's pending-error slot (a THROWS-flagged Registry
+/// member pairs this with the front's post-call error check).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_throw_js_error(
+    kind_ptr: *const u8,
+    kind_len: i64,
+    msg_ptr: *const u8,
+    msg_len: i64,
+) {
+    let read = |p: *const u8, n: i64| -> &str {
+        if p.is_null() || n <= 0 {
+            return "";
+        }
+        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(p, n as usize)) }
+    };
+    throw_js_error(read(kind_ptr, kind_len), read(msg_ptr, msg_len));
+}
+
 /// `1` iff a thrown value is pending (an unwind is in progress), else `0`. Emitted
 /// after every call that can throw; the lowering branches on the result.
 #[unsafe(no_mangle)]

--- a/crates/rts-adapters/src/value/globalops.rs
+++ b/crates/rts-adapters/src/value/globalops.rs
@@ -297,6 +297,26 @@ pub extern "C" fn __rtsadp_arr_from(a: u64) -> u64 {
     if v.is_object() && !super::inspect::looks_like_object(v) {
         // A real array → shallow copy of its boxed element words.
         let src = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
+        // An `Entry::Buffer` source (a `TextEncoder.encode()` result / raw
+        // ArrayBuffer bytes): each byte is one element — `VEC_LEN` on a Buffer
+        // reads 0 and yielded `[]` (58_text_encoding's `hex=` was empty).
+        let buf_bytes: Option<Vec<u8>> = {
+            use rts_engine::heap::handles::{Entry, with_entry};
+            with_entry(src, |e| match e {
+                Some(Entry::Buffer(b)) => Some(b.clone()),
+                _ => None,
+            })
+        };
+        if let Some(b) = buf_bytes {
+            let vec = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
+            for byte in b {
+                rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(
+                    vec,
+                    PolyValue::from_i32(byte as i32).raw() as i64,
+                );
+            }
+            return box_vec_as_array(vec);
+        }
         let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(src).max(0);
         let vec = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
         for i in 0..len {

--- a/crates/rts-codegen-new/src/front/run/registry_call.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_call.rs
@@ -48,6 +48,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     ) -> FrontResult<()> {
         match ty {
             AbiType::Handle => {
+                // A spec-DEFAULTED omitted Handle arg (DefaultArg::Undefined on a
+                // Handle slot — an optional options-bag like `new TextDecoder(l,
+                // opts?)`): the ABSENT handle `0`, never a table-load of the
+                // `undefined` word (whose payload 0 would read a bogus slot).
+                if matches!(val.kind, JsKind::Undefined) {
+                    out.push(self.builder.ins().iconst(types::I64, 0));
+                    return Ok(());
+                }
                 // Two kinds of value reach a `Handle` param:
                 //  * an OPAQUE RESOURCE handle — a raw `u64` id riding as an INTEGER
                 //    PolyValue (`audio`/`buffer`/`net` results, TS `number`). It is
@@ -349,6 +357,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             &params,
             call.ret,
         );
+        // A THROWS-flagged member may have set the pending-error slot: emit the
+        // same post-call check user calls get, so `try/catch` routes the unwind
+        // (data on the spec — the engine names no class here).
+        if call.flags.contains(rts_engine::MemberFlags::THROWS) {
+            self.emit_post_call_error_check(module)?;
+        }
         // NULLABLE string return (`: string | null`): a `0` handle is ABSENT → rebox
         // as `null`, not the empty string (`URLSearchParams.get(missing)` etc.). An
         // empty `""` interns to a NON-zero handle, so `0` is unambiguously absent.

--- a/crates/rts-engine/src/abi/member.rs
+++ b/crates/rts-engine/src/abi/member.rs
@@ -111,6 +111,11 @@ impl MemberFlags {
     /// stamped on `Date`'s `toString`/`toLocale*`/`toDateString`/`toUTCString`/
     /// `toTimeString` formatters and every `setX` mutator.
     pub const UNSOUND: Self = Self(1 << 6);
+    /// Member can THROW: the impl may set the pending-error slot
+    /// (`__RTS_FN_RT_ERROR_SET`) — codegen emits the post-call error check
+    /// after the call so a `try/catch` routes the unwind (e.g. a
+    /// `{fatal: true}` TextDecoder rejecting malformed input with TypeError).
+    pub const THROWS: Self = Self(1 << 7);
 
     /// Union of two flag sets (const, for building composite literals).
     pub const fn or(self, other: Self) -> Self {

--- a/crates/rts-std/src/globals/text_encoding/instance.rs
+++ b/crates/rts-std/src/globals/text_encoding/instance.rs
@@ -944,12 +944,44 @@ pub extern "C" fn __RTS_FN_GL_TEXTENC_NEW() -> u64 {
     alloc_entry(Entry::Env(vec![1])) // token "TextEncoder"
 }
 
-/// (cross-runtime #874) Aceita label opcional como (ptr, len). Em RTS so'
-/// UTF-8 e' suportado; o label e' aceito mas ignorado (Bun/Node aceitam
-/// `new TextDecoder("utf-8")` sem erro).
+// ── TextDecoder options + streaming state ──────────────────────────────────────
+//
+// A TextDecoder instance is an `Entry::Env` vec:
+//   [0] = 2 (the "TextDecoder" token), [1] = fatal, [2] = ignoreBOM,
+//   [3] = started (current stream already began — BOM handled),
+//   [4..] = pending bytes (an incomplete UTF-8 tail carried between
+//           `decode(chunk, {stream: true})` calls).
+
+/// Read a boolean option `key` from an options-bag handle (a keyed object /
+/// `Entry::Map`; `0` = absent bag). Resolves through the engine's own dynamic
+/// property read + ToBoolean (link-resolved externs — no crate cycle).
+fn opt_flag(opts_h: u64, key: &str) -> bool {
+    unsafe extern "C" {
+        fn __rtsadp_obj_get(obj_word: u64, key_word: u64) -> u64;
+        fn __rtsadp_to_boolean(word: u64) -> u64;
+    }
+    use rts_engine::heap::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE;
+    use rts_engine::heap::poly::{POLY_BOX_BASE, POLY_TAG_OBJECT, POLY_TAG_SHIFT, POLY_TAG_STR};
+    if opts_h == 0 {
+        return false;
+    }
+    let obj_word = POLY_BOX_BASE
+        | (POLY_TAG_OBJECT << POLY_TAG_SHIFT)
+        | __RTS_FN_NS_GC_POLY_FROM_HANDLE(opts_h);
+    let key_h = alloc_entry(Entry::String(key.as_bytes().to_vec()));
+    let key_word = POLY_BOX_BASE
+        | (POLY_TAG_STR << POLY_TAG_SHIFT)
+        | __RTS_FN_NS_GC_POLY_FROM_HANDLE(key_h);
+    unsafe { __rtsadp_to_boolean(__rtsadp_obj_get(obj_word, key_word)) != 0 }
+}
+
+/// (cross-runtime #874/#1407) Label opcional (so' UTF-8; aceito e ignorado) +
+/// options-bag opcional `{fatal, ignoreBOM}` guardado no estado da instância.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_TEXTDEC_NEW(_label_ptr: i64, _label_len: i64) -> u64 {
-    alloc_entry(Entry::Env(vec![2])) // token "TextDecoder"
+pub extern "C" fn __RTS_FN_GL_TEXTDEC_NEW(_label_ptr: i64, _label_len: i64, opts_h: u64) -> u64 {
+    let fatal = opt_flag(opts_h, "fatal") as i64;
+    let ignore_bom = opt_flag(opts_h, "ignoreBOM") as i64;
+    alloc_entry(Entry::Env(vec![2, fatal, ignore_bom, 0]))
 }
 
 // Instance method variants: (self_handle, ptr, len) — self ignored.
@@ -959,7 +991,127 @@ pub extern "C" fn __RTS_FN_GL_TEXTENC_ENCODE_INSTANCE(_self_h: u64, ptr: i64, le
     __RTS_FN_GL_TEXTENC_ENCODE(ptr, len)
 }
 
+/// The length of the maximal WELL-FORMED-so-far prefix of `bytes`: everything
+/// except a trailing incomplete (but still potentially valid) UTF-8 sequence.
+/// A trailing sequence that can never become valid is NOT held back — it stays
+/// in the prefix so the caller surfaces it (U+FFFD / fatal TypeError) now.
+fn utf8_complete_prefix_len(bytes: &[u8]) -> usize {
+    let n = bytes.len();
+    // A lead byte at most 3 positions from the end can still be incomplete.
+    let start = n.saturating_sub(3);
+    for i in (start..n).rev() {
+        let b = bytes[i];
+        let need = match b {
+            0xC2..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xF4 => 4,
+            _ => continue, // continuation/ASCII/invalid — not a lead byte
+        };
+        let have = n - i;
+        if have < need && bytes[i + 1..].iter().all(|&c| (0x80..=0xBF).contains(&c)) {
+            return i; // a potentially-valid incomplete tail — hold it back
+        }
+        return n; // the last lead's sequence is complete (or already invalid)
+    }
+    n
+}
+
+/// (#1407/#1408) `decoder.decode(buf?, opts?)` — instance decode with the WHATWG
+/// semantics the token-only path lacked: per-stream BOM strip (unless
+/// `ignoreBOM`), `{stream: true}` carrying a split UTF-8 tail between chunks,
+/// a no-arg flush call, and `fatal` throwing TypeError on malformed input.
 #[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_GL_TEXTDEC_DECODE_INSTANCE(_self_h: u64, buf_h: u64) -> u64 {
-    __RTS_FN_GL_TEXTENC_DECODE(buf_h)
+pub extern "C" fn __RTS_FN_GL_TEXTDEC_DECODE_INSTANCE(self_h: u64, buf_h: u64, opts_h: u64) -> u64 {
+    use rts_engine::heap::handles::with_entry_mut;
+    let stream = opt_flag(opts_h, "stream");
+    // Drain the instance state: flags + any pending bytes from a prior chunk.
+    let (fatal, ignore_bom, started, mut bytes) = with_entry_mut(self_h, |e| match e {
+        Some(Entry::Env(v)) if v.first() == Some(&2) => {
+            let fatal = v.get(1).copied().unwrap_or(0) != 0;
+            let ib = v.get(2).copied().unwrap_or(0) != 0;
+            let started = v.get(3).copied().unwrap_or(0) != 0;
+            let pending: Vec<u8> = v.iter().skip(4).map(|&x| x as u8).collect();
+            v.truncate(4.min(v.len()));
+            (fatal, ib, started, pending)
+        }
+        _ => (false, false, false, Vec::new()),
+    });
+    // Append this call's input (absent on the flush call `decode()`).
+    if buf_h != 0 {
+        let extra = with_entry(buf_h, |entry| match entry {
+            Some(Entry::Buffer(v)) | Some(Entry::String(v)) => Some(v.clone()),
+            Some(Entry::Vec(v)) => Some(v.iter().map(|&x| slot_byte(x)).collect()),
+            _ => None,
+        });
+        if let Some(b) = extra {
+            bytes.extend_from_slice(&b);
+        }
+    }
+    // Streaming: hold back a potentially-valid incomplete UTF-8 tail.
+    let mut hold: Vec<u8> = Vec::new();
+    if stream {
+        let cut = utf8_complete_prefix_len(&bytes);
+        hold = bytes.split_off(cut);
+    }
+    // BOM: stripped ONCE at the start of each stream, unless ignoreBOM. The
+    // stream only "starts" when bytes are actually EMITTED — a fully held-back
+    // tail (a BOM split across chunks) keeps the strip armed for the next call.
+    let mut emit: &[u8] = &bytes;
+    let mut new_started = started;
+    if !bytes.is_empty() {
+        new_started = true;
+    }
+    if !started && !ignore_bom && emit.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        emit = &emit[3..];
+    }
+    // Decode: fatal throws TypeError on malformed input (WHATWG); otherwise
+    // U+FFFD replacement. The flush call also fails a fatal decoder whose
+    // pending tail never completed.
+    let text: String = match std::str::from_utf8(emit) {
+        Ok(s) => s.to_owned(),
+        Err(_) if fatal => {
+            // Throw into the ENGINE's pending-error slot (a real TypeError
+            // instance, so `e instanceof TypeError` / `e.constructor.name`
+            // hold) — link-reached extern, paired with the member's THROWS flag.
+            unsafe extern "C" {
+                fn __rtsadp_throw_js_error(
+                    kind_ptr: *const u8,
+                    kind_len: i64,
+                    msg_ptr: *const u8,
+                    msg_len: i64,
+                );
+            }
+            let kind = "TypeError";
+            let msg = "The encoded data was not valid utf-8";
+            unsafe {
+                __rtsadp_throw_js_error(
+                    kind.as_ptr(),
+                    kind.len() as i64,
+                    msg.as_ptr(),
+                    msg.len() as i64,
+                );
+            }
+            return alloc_entry(Entry::String(Vec::new()));
+        }
+        Err(_) => String::from_utf8_lossy(emit).into_owned(),
+    };
+    // Persist / reset the stream state.
+    let _ = with_entry_mut(self_h, |e| {
+        if let Some(Entry::Env(v)) = e {
+            if v.first() == Some(&2) {
+                while v.len() < 4 {
+                    v.push(0);
+                }
+                if stream {
+                    v[3] = new_started as i64;
+                    v.extend(hold.iter().map(|&b| b as i64));
+                } else {
+                    v[3] = 0; // a non-stream decode ends the stream
+                }
+            }
+        }
+    });
+    // A FINAL (non-stream) call with an incomplete tail still pending would
+    // have kept it in `emit` (no cut) — already surfaced above.
+    alloc_entry(Entry::String(text.into_bytes()))
 }

--- a/crates/rts-std/src/globals/text_encoding/mod.rs
+++ b/crates/rts-std/src/globals/text_encoding/mod.rs
@@ -157,25 +157,47 @@ pub fn register_text_decoder_class_spec(e: &mut Engine) {
         .member(m(
             "new",
             MemberKind::Constructor,
-            // `label` is OPTIONAL (`new TextDecoder()` valid); default it to
-            // `undefined` so the generic ctor resolver admits a 0-arg call. UTF-8
-            // only, label ignored, so the runtime never reads a missing label.
-            Sig::with_defaults(vec![AbiType::StrPtr], AbiType::Handle, vec![DefaultArg::Undefined]),
+            // `label` and the `{fatal, ignoreBOM}` options bag are both OPTIONAL
+            // (`new TextDecoder()` valid); default them to `undefined` so the
+            // generic ctor resolver admits 0/1/2-arg calls. UTF-8 only — the
+            // label is accepted and ignored; the options land in instance state.
+            Sig::with_defaults(
+                vec![AbiType::StrPtr, AbiType::Handle],
+                AbiType::Handle,
+                vec![DefaultArg::Undefined, DefaultArg::Undefined],
+            ),
             "__RTS_FN_GL_TEXTDEC_NEW",
-            "new TextDecoder(label?: string)",
-            "new TextDecoder(label?) — label opcional (so' UTF-8 suportado, label ignorado).",
+            "new TextDecoder(label?: string, options?: TextDecoderOptions)",
+            "new TextDecoder(label?, {fatal?, ignoreBOM?}?) — so' UTF-8; options guardadas na instância.",
             core::ptr::null::<u8>(),
             true,
         ))
-        .member(m(
-            "decode",
-            MemberKind::InstanceMethod,
-            Sig::new(vec![AbiType::Handle, AbiType::Handle], AbiType::Handle),
-            "__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE",
-            "decode(buf: Uint8Array): string",
-            "decoder.decode(buf) — Buffer handle para string handle.",
-            core::ptr::null::<u8>(),
-            true,
-        ))
+        .member({
+            let mut mem = m(
+                "decode",
+                MemberKind::InstanceMethod,
+                // `buf` optional (a no-arg call FLUSHES a streaming decoder) and
+                // an optional `{stream}` options bag; defaults cover ALL sig
+                // slots (receiver included — the front drops slot 0).
+                Sig::with_defaults(
+                    vec![AbiType::Handle, AbiType::Handle, AbiType::Handle],
+                    AbiType::Handle,
+                    vec![
+                        DefaultArg::Undefined,
+                        DefaultArg::Undefined,
+                        DefaultArg::Undefined,
+                    ],
+                ),
+                "__RTS_FN_GL_TEXTDEC_DECODE_INSTANCE",
+                "decode(buf?: Uint8Array, options?: TextDecodeOptions): string",
+                "decoder.decode(buf?, {stream?}?) — BOM por stream, carry de UTF-8 dividido, fatal lança TypeError.",
+                core::ptr::null::<u8>(),
+                false,
+            );
+            // `{fatal: true}` rejeita input malformado com TypeError pendente —
+            // o front emite o post-call error check ao ver esta flag.
+            mem.flags = MemberFlags::THROWS;
+            mem
+        })
         .done();
 }


### PR DESCRIPTION
## Resumo
- `new TextDecoder(label?, {fatal, ignoreBOM}?)` — options lidas data-driven (obj_get + ToBoolean do motor, externs link-resolvidos) e guardadas no estado da instância.
- `decode(buf?, {stream}?)` WHATWG: BOM removido uma vez por stream (salvo ignoreBOM); `{stream: true}` carrega a cauda UTF-8 incompleta entre chunks; `decode()` é o flush; chamada não-stream reseta o stream.
- `{fatal: true}` lança **TypeError real** (proto + constructor.name) via novo extern `__rtsadp_throw_js_error` no errslot do motor.
- **Novo `MemberFlags::THROWS`** (data no spec): `emit_registry_call` emite o post-call error check ao ver a flag — mesmo unwind dos user calls, zero nome de classe no front.
- Marshal de `Handle` com arg defaulted/undefined vira handle 0 (antes table-loadava a word undefined).
- `Array.from(Entry::Buffer)` — cada byte vira elemento (`hex=` do 58_text_encoding saía vazio).

## Validação
- Fixtures batem com Node: `codex_textdecoder_fatal_ignorebom`, `codex_textdecoder_streaming_split_utf8`, `58_text_encoding`
- Suíte TS 623/623 (1688 testes), gate estático verde
- Sweep completo: **419/609 pass**; diff fixture-a-fixture: +58_text_encoding, sem regressão RTS (única mudança: `286_setimmediate` pass→bun_node_diverge, o flaky de timing conhecido — Bun≠Node entre si nesta rodada, RTS não comparado)

Closes #1407
Closes #1408

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj