### PR TITLE
fix(codegen): ordem canônica de chaves no caminho estático de Object.keys/values/entries

### DIFF
--- a/crates/rts-adapters/src/value/iterops.rs
+++ b/crates/rts-adapters/src/value/iterops.rs
@@ -130,6 +130,20 @@ pub extern "C" fn __rtsadp_to_iter_array(word: u64) -> u64 {
 /// "1": … }` enumerates `1, 3, 10, b`. Used for `Object.keys`/`getOwnPropertyNames`/
 /// `for-in` — NOT for the storage-order `object_keys_vec` (slot manipulation).
 pub(crate) fn reorder_enum_keys(keys: Vec<String>) -> Vec<String> {
+    let order = enum_key_order(&keys);
+    let mut keys: Vec<Option<String>> = keys.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|i| keys[i].take().expect("permutation visits each index once"))
+        .collect()
+}
+
+/// The PERMUTATION that puts `keys` in the canonical own-property enumeration
+/// order (the rule above), as ORIGINAL indices. This is the form the front's
+/// static `Object.keys/values/entries` emission consumes: a value still lives
+/// at the slot of its original (insertion) index, so the emitter needs the
+/// index mapping, not just the reordered names.
+pub fn enum_key_order(keys: &[String]) -> Vec<usize> {
     let as_index = |s: &str| -> Option<u32> {
         if s == "0" {
             return Some(0);
@@ -139,16 +153,16 @@ pub(crate) fn reorder_enum_keys(keys: Vec<String>) -> Vec<String> {
         }
         s.parse::<u32>().ok().filter(|&n| n != u32::MAX)
     };
-    let mut idx: Vec<(u32, String)> = Vec::new();
-    let mut rest: Vec<String> = Vec::new();
-    for k in keys {
-        match as_index(&k) {
-            Some(n) => idx.push((n, k)),
-            None => rest.push(k),
+    let mut idx: Vec<(u32, usize)> = Vec::new();
+    let mut rest: Vec<usize> = Vec::new();
+    for (i, k) in keys.iter().enumerate() {
+        match as_index(k) {
+            Some(n) => idx.push((n, i)),
+            None => rest.push(i),
         }
     }
     idx.sort_by_key(|(n, _)| *n);
-    idx.into_iter().map(|(_, k)| k).chain(rest).collect()
+    idx.into_iter().map(|(_, i)| i).chain(rest).collect()
 }
 
 /// `Reflect.ownKeys(target)` — the trap's list VERBATIM (the ECMA `ownKeys`

--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -297,12 +297,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     }
 
     /// `Object.keys(obj)` / `Object.getOwnPropertyNames(obj)` → a fresh array of
-    /// the object's keys as string PolyValue words (the compile-time shape order).
+    /// the object's keys as string PolyValue words, in the CANONICAL enumeration
+    /// order (integer-index keys ascending first, then insertion order) — the
+    /// same `enum_key_order` authority the runtime `__rtsadp_obj_keys` applies.
     fn object_keys(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
         let (_obj, keys) = self.receiver(module, args)?;
         let arr = emit_marshal::emit_new_vec_object(module, self.builder);
-        for k in &keys {
-            let pv = abi_adapter::intern_poly(k);
+        for i in crate::value::iterops::enum_key_order(&keys) {
+            let pv = abi_adapter::intern_poly(&keys[i]);
             let word = self.builder.ins().iconst(types::I64, pv.raw() as i64);
             emit_marshal::emit_vec_push(module, self.builder, arr, word);
         }
@@ -315,8 +317,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     fn object_values(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
         let (obj, keys) = self.receiver(module, args)?;
         let arr = emit_marshal::emit_new_vec_object(module, self.builder);
-        for i in 0..keys.len() {
-            // Property values live at slot 1 + slot_index (slot 0 = shape-id).
+        // Canonical enumeration order; a value still lives at the slot of its
+        // ORIGINAL insertion index (slot 0 = shape-id header).
+        for i in crate::value::iterops::enum_key_order(&keys) {
             let idx = self.builder.ins().iconst(types::I64, 1 + i as i64);
             let word = emit_marshal::emit_vec_get(module, self.builder, obj, idx);
             emit_marshal::emit_vec_push(module, self.builder, arr, word);
@@ -330,8 +333,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     fn object_entries(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
         let (obj, keys) = self.receiver(module, args)?;
         let outer = emit_marshal::emit_new_vec_object(module, self.builder);
-        for (i, k) in keys.iter().enumerate() {
-            // value at slot 1+i.
+        // Canonical enumeration order (same authority as `object_keys`).
+        for i in crate::value::iterops::enum_key_order(&keys) {
+            let k = &keys[i];
+            // value at slot 1+i (the ORIGINAL insertion index).
             let idx = self.builder.ins().iconst(types::I64, 1 + i as i64);
             let value_word = emit_marshal::emit_vec_get(module, self.builder, obj, idx);
             // key as a string word.


### PR DESCRIPTION
## Resumo
A autoridade runtime (`reorder_enum_keys`) já aplicava a ordem de enumeração da spec (índices inteiros ascendentes primeiro, depois inserção), mas o caminho **estático** do front (`objstatic.rs`, shape provado em compile time) emitia ordem de inserção.

- `enum_key_order(&[String]) -> Vec<usize>` exposto em `iterops`: a mesma regra como **permutação de índices originais** (o valor continua no slot do índice de inserção); `reorder_enum_keys` delega nela — uma autoridade só.
- `object_keys`/`object_values`/`object_entries` estáticos iteram pela permutação canônica, lendo valores em `1 + índice_original`.

## Validação
- `216_object_keys_order` e `claude-keys-numeric-order` batem com Node (keys/values/entries/JSON.stringify conferidos)
- Suíte TS 623/623 (1688 testes), gate verde
- Sweep completo: **421/609 pass, 0 regressões, +2 exatos**

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj