### PR TITLE
fix(runtime): slot interno __prim invisível na enumeração + wrappers JSON/for-in

### DIFF
--- a/crates/rts-adapters/src/value/iterops.rs
+++ b/crates/rts-adapters/src/value/iterops.rs
@@ -276,12 +276,31 @@ fn obj_keys_impl(obj_word: u64, enumerable_only: bool) -> u64 {
             .then(|| global_shape_keys(slot0.as_i32() as u32))
             .flatten()
         {
+            // A String/Number/Boolean WRAPPER box: its `__prim` slot is INTERNAL
+            // data, never an own property (skipped below). A STRING wrapper's own
+            // enumerable keys are its UTF-16 code-unit indices — emitted first
+            // (they are integer-index keys, ahead of any expando key).
+            if let Some(pi) = keys.iter().position(|k| k == "__prim") {
+                let pw = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, 1 + pi as i64) as u64;
+                let pv = PolyValue::from_raw(pw);
+                if pv.is_string() {
+                    let s = abi_adapter::resolve_poly(pv);
+                    for i in 0..s.encode_utf16().count() {
+                        let word = abi_adapter::intern_poly(&i.to_string()).raw() as i64;
+                        rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(vec, word);
+                    }
+                }
+            }
             let mut listed: Vec<String> = Vec::new();
             for k in reorder_enum_keys(keys) {
                 // Symbol-keyed entries (`@@sym:<handle>` canonical repr, #798) are
                 // NOT string-enumerable: `Object.keys`/for-in/`JSON.stringify`
                 // all skip them (JS spec). `Reflect.ownKeys` uses the raw path.
                 if k.starts_with("@@sym:") {
+                    continue;
+                }
+                // The wrapper's internal primitive slot (handled above).
+                if k == "__prim" {
                     continue;
                 }
                 // PRIVATE fields (`#x`, possibly mangled `#x@Class`) are not

--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -517,6 +517,30 @@ pub extern "C" fn __rtsadp_obj_has(obj_word: u64, key_str_handle: u64) -> i64 {
     if resolve_slot(obj_word, key_str_handle).is_some() {
         return 1;
     }
+    // A STRING WRAPPER box (`new String(s)` — a keyed object whose `__prim` slot
+    // holds a string): its UTF-16 code-unit indices are own properties, so the
+    // for-in [[HasProperty]] re-check accepts the index keys `obj_keys` lists.
+    {
+        let prim_key = abi_adapter::intern_poly("__prim").raw();
+        if let Some((handle, pi)) = resolve_slot(obj_word, prim_key) {
+            let pw = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(handle, 1 + pi) as u64;
+            let pv = PolyValue::from_raw(pw);
+            if pv.is_string() {
+                let key = key_text(key_str_handle);
+                if key.bytes().all(|b| b.is_ascii_digit())
+                    && !key.is_empty()
+                    && (key == "0" || !key.starts_with('0'))
+                {
+                    if let Ok(i) = key.parse::<usize>() {
+                        let len = abi_adapter::resolve_poly(pv).encode_utf16().count();
+                        if i < len {
+                            return 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
     // ARRAY receiver: `i in arr` is the INDEX-in-range check (JS: the indices
     // are own keys); `"length" in arr` is the own non-enumerable length.
     {
@@ -1219,7 +1243,8 @@ pub extern "C" fn __rtsadp_obj_values(obj_word: u64) -> u64 {
     // ENUMERATION order (array-index keys ascending first) — read each value BY KEY
     // (`obj_get`), not by storage slot, so the reorder and the value stay aligned.
     for k in super::iterops::reorder_enum_keys(object_keys_vec(obj_word)) {
-        if !prop_enumerable(obj_word, &k) {
+        // The wrapper box's internal primitive slot is not an own property.
+        if k == "__prim" || !prop_enumerable(obj_word, &k) {
             continue;
         }
         let v = __rtsadp_obj_get(obj_word, abi_adapter::intern_poly(&k).raw());
@@ -1234,7 +1259,8 @@ pub extern "C" fn __rtsadp_obj_values(obj_word: u64) -> u64 {
 pub extern "C" fn __rtsadp_obj_entries(obj_word: u64) -> u64 {
     let outer = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_NEW();
     for k in super::iterops::reorder_enum_keys(object_keys_vec(obj_word)) {
-        if !prop_enumerable(obj_word, &k) {
+        // The wrapper box's internal primitive slot is not an own property.
+        if k == "__prim" || !prop_enumerable(obj_word, &k) {
             continue;
         }
         let key_word = abi_adapter::intern_poly(&k).raw();

--- a/crates/rts-shared/src/stdlib/json.ts
+++ b/crates/rts-shared/src/stdlib/json.ts
@@ -80,6 +80,12 @@ function __json_render(v: any, pad: string, depth: number, keyFilter: any, fnRep
   // undefined / function: omitted by JSON (the caller turns this into `null` in an
   // array, or skips the key in an object, or returns undefined at top level).
   if (t === "undefined" || t === "function") return undefined;
+  // A Boolean/Number/String WRAPPER object serializes as its wrapped PRIMITIVE
+  // (SerializeJSONProperty reads [[BooleanData]]/ToNumber/ToString of the box) —
+  // expando properties are ignored. `__prim` is the engine-owned wrapper slot.
+  if (t === "object" && typeof v.__prim !== "undefined") {
+    return __json_render(v.__prim, pad, depth, keyFilter, fnReplacer, seen);
+  }
   // Cycle detection (ECMAScript SerializeJSON*): re-entering a value already on
   // the render stack throws.
   if (seen.indexOf(v) >= 0) {


### PR DESCRIPTION
## Resumo
O slot `__prim` (caixa interna dos wrappers String/Number/Boolean do prelude) vazava como own property; um String wrapper não expunha seus index-keys UTF-16.

- `obj_keys_impl` (autoridade de enumeração runtime): pula `__prim`; para String wrapper emite os index-keys UTF-16 primeiro.
- `__rtsadp_obj_values`/`__rtsadp_obj_entries`: pulam `__prim`.
- `__rtsadp_obj_has`: index-key canônico < len de String wrapper é own property (o re-check [[HasProperty]] do for-in pulava os index-keys que obj_keys listou).
- `__json_render` (json.ts): wrapper serializa o primitivo embrulhado (SerializeJSONProperty), ignorando expandos.

## Validação
- `codex_primitive_wrappers_truthiness` e `253_object_keys_empty` byte-a-byte com Node; variações (for-in, expando, stringify aninhado) conferidas
- Suíte TS 623/623 (1688), gate verde
- Sweep: **424/609, 0 regressões** (+2 alvos; +286_setimmediate = flaky de timing voltando)

Nota de escopo: `"0" in new String("ab")` (operador `in` sobre wrapper) segue false — caminho próprio do `in`, sem fixture cobrindo.

Closes #1387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj