### PR TITLE
feat(codegen/runtime): Object.create(proto, descriptors) + Object.defineProperties

### DIFF
--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -1235,6 +1235,39 @@ fn array_word(vec: u64) -> u64 {
 // `Object.keys` (dynamic) reuses the existing `iterops::__rtsadp_obj_keys` (for-in
 // already builds the key array) — not redefined here.
 
+/// `Object.defineProperties(obj, props)` / the descriptors arg of
+/// `Object.create(proto, props)`: define every own enumerable key of `props` on
+/// `obj` through the single `__rtsadp_obj_define_property` authority (canonical
+/// key order). Returns `obj`.
+///
+/// Spec shape (ObjectDefineProperties): ALL descriptors are READ first (their
+/// getters run in key order and may THROW — the pending-error slot is checked
+/// after each read, aborting with NOTHING applied), and only then applied.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_obj_define_properties(obj_word: u64, props_word: u64) -> u64 {
+    // Enumerate through the KEYS authority (`__rtsadp_obj_keys`), which lists an
+    // accessor slot (`__get_<k>`) under its PROPERTY name — reading it below runs
+    // the getter (the storage-key list would read the raw slot and skip it).
+    let keys_word = super::iterops::__rtsadp_obj_keys(props_word);
+    let keys_h =
+        rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(PolyValue::from_raw(keys_word).as_handle());
+    let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(keys_h).max(0);
+    let mut gathered: Vec<(u64, u64)> = Vec::new();
+    for i in 0..len {
+        let key_word = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(keys_h, i) as u64;
+        let desc = __rtsadp_obj_get(props_word, key_word);
+        if super::errslot::__rtsadp_err_pending() != 0 {
+            // A descriptor getter threw: propagate the unwind, applying nothing.
+            return obj_word;
+        }
+        gathered.push((key_word, desc));
+    }
+    for (key_word, desc) in gathered {
+        __rtsadp_obj_define_property(obj_word, key_word, desc);
+    }
+    obj_word
+}
+
 /// `__rtsadp_obj_values(obj_word)` — `Object.values(obj)` at RUNTIME: a fresh array
 /// of the object's slot VALUES (slots `1..`; slot 0 is the shape-id header).
 #[unsafe(no_mangle)]

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -342,6 +342,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
         sym("__rtsadp_obj_set", objops::__rtsadp_obj_set as *const u8),
         sym("__rtsadp_obj_assign", objops::__rtsadp_obj_assign as *const u8),
         sym("__rtsadp_obj_define_property", objops::__rtsadp_obj_define_property as *const u8),
+        sym(
+            "__rtsadp_obj_define_properties",
+            objops::__rtsadp_obj_define_properties as *const u8,
+        ),
         sym("__rtsadp_obj_get_own_property_descriptor", objops::__rtsadp_obj_get_own_property_descriptor as *const u8),
         sym("__rtsadp_obj_get_own_property_descriptors", objops::__rtsadp_obj_get_own_property_descriptors as *const u8),
         sym("__rtsadp_obj_has", objops::__rtsadp_obj_has as *const u8),

--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -98,6 +98,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 Ok(Some(Val::new(res, Repr::Bool)))
             }
             "defineProperty" => self.object_define_property(module, args).map(Some),
+            "defineProperties" => self.object_define_properties(module, args).map(Some),
             "getOwnPropertyDescriptor" => {
                 if args.len() != 2 {
                     return unsupported!("Object.getOwnPropertyDescriptor expects 2 args");
@@ -206,7 +207,51 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let word = self
             .call_runtime(module, "__rtsadp_obj_create", &[proto_word])?
             .expect("__rtsadp_obj_create returns an object word");
+        // `Object.create(proto, descriptors)`: apply the property-descriptor bag
+        // through the single defineProperty authority (same as defineProperties).
+        if let Some(props) = args.get(1) {
+            let p = self.lower_expr(module, props)?;
+            let props_word = self.box_value(p);
+            let defined = self
+                .call_runtime(
+                    module,
+                    "__rtsadp_obj_define_properties",
+                    &[word, props_word],
+                )?
+                .expect("__rtsadp_obj_define_properties returns the object word");
+            // Descriptor-bag getters can THROW — route the pending error.
+            self.emit_post_call_error_check(module)?;
+            return Ok(Val::tagged_kind(defined, JsKind::Object));
+        }
         Ok(Val::tagged_kind(word, JsKind::Object))
+    }
+
+    /// `Object.defineProperties(obj, props)` → every own enumerable key of
+    /// `props` defined on `obj` via the runtime authority; evaluates to `obj`.
+    fn object_define_properties(
+        &mut self,
+        module: &mut dyn Module,
+        args: &[HirExpr],
+    ) -> FrontResult<Val> {
+        if args.len() != 2 {
+            return unsupported!("Object.defineProperties expects 2 args, got {}", args.len());
+        }
+        // Added keys live in runtime slots the target's compile-time shape does
+        // not know — same demotion `Object.assign`/`defineProperty` apply.
+        if let HirExprKind::Ident(name) = &args[0].kind {
+            self.demote_local_to_dynamic(name);
+        }
+        let o = self.lower_expr(module, &args[0])?;
+        let o_word = self.box_value(o);
+        let p = self.lower_expr(module, &args[1])?;
+        let p_word = self.box_value(p);
+        let res = self
+            .call_runtime(module, "__rtsadp_obj_define_properties", &[o_word, p_word])?
+            .expect("__rtsadp_obj_define_properties returns the object word");
+        // Reading the descriptor bag runs its GETTERS, which can THROW — route
+        // the pending error like any throwing call.
+        self.emit_post_call_error_check(module)?;
+        Ok(Val::tagged_kind(res, JsKind::Object))
     }
 
     /// `Object.setPrototypeOf(obj, proto)` → record `obj`'s prototype (a null/non-

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -880,6 +880,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64, U64],
             ret: U64,
         },
+        "__rtsadp_obj_define_properties" => SymSig {
+            params: &[U64, U64],
+            ret: U64,
+        },
         "__rtsadp_obj_get_own_property_descriptor" => SymSig {
             params: &[U64, U64],
             ret: U64,


### PR DESCRIPTION
## Resumo
- Novo extern `__rtsadp_obj_define_properties(obj, props)`: enumera o bag pela **autoridade de chaves** (`__rtsadp_obj_keys` — accessor slot `__get_<k>` aparece pelo nome, e a leitura roda o getter), no shape da spec: **todos os descriptors lidos primeiro** (getter que lança aborta sem aplicar nada — `err_pending` checado por leitura), só então aplicados via `__rtsadp_obj_define_property`.
- `Object.create(proto, descriptors)` aplica o bag; arm `defineProperties`; alvo Ident demovido para acesso dinâmico (mesma demotion de assign/defineProperty); post-call error check após as chamadas.

387_object_create_descriptors segue aberta: a parte create+descriptors passa, mas a fixture também exige function-constructor com prototype chain manual — gap separado (nota na #1534).

## Validação
- `162_object_create_null` e `codex_defineproperties_partial_side_effect` byte-a-byte com Node
- Suíte TS 623/623 (1688), gate verde
- Sweep: **426/609, 0 regressões, +2 exatos**

Closes #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj