### PR TITLE
fix(runtime): hasOwnProperty sobre array + String.concat coage args (ToString)

### DIFF
--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -615,7 +615,34 @@ const OBJECT_PROTO_MEMBERS: &[&str] = &[
 /// i64).
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_has_own(obj_word: u64, key_str_handle: u64) -> u64 {
-    PolyValue::bool(resolve_slot(obj_word, key_str_handle).is_some()).raw()
+    if resolve_slot(obj_word, key_str_handle).is_some() {
+        return PolyValue::bool(true).raw();
+    }
+    // ARRAY receiver: the own keys are the non-hole in-range indices and the
+    // non-enumerable `length` — NOT the prototype methods (`hasOwnProperty`
+    // never walks the chain, unlike `in`).
+    {
+        let obj = PolyValue::from_raw(obj_word);
+        if obj.is_object() && !looks_like_object(obj) {
+            let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(obj.as_handle());
+            let is_vec =
+                rt_handles::with_entry(h, |e| matches!(e, Some(rt_handles::Entry::Vec(_))));
+            if is_vec {
+                let key = key_text(key_str_handle);
+                if key == "length" {
+                    return PolyValue::bool(true).raw();
+                }
+                if let Ok(i) = key.parse::<i64>() {
+                    let len = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_LEN(h).max(0);
+                    if i >= 0 && i < len {
+                        let elem = rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_GET(h, i) as u64;
+                        return PolyValue::bool(!PolyValue::from_raw(elem).is_hole()).raw();
+                    }
+                }
+            }
+        }
+    }
+    PolyValue::bool(false).raw()
 }
 
 // ===========================================================================

--- a/crates/rts-primitives/src/string.ts
+++ b/crates/rts-primitives/src/string.ts
@@ -191,12 +191,15 @@ class String {
     return engine.str_pad_end(__str_val(this), targetLen, pad);
   }
   // concat folds up to four trailing args; empty-string defaults make the fold
-  // an identity for the omitted slots (`"a".concat("b")` === "ab").
-  concat(a: string = "", b: string = "", c: string = "", d: string = ""): string {
-    let r = engine.str_concat(__str_val(this), a);
-    r = engine.str_concat(r, b);
-    r = engine.str_concat(r, c);
-    r = engine.str_concat(r, d);
+  // an identity for the omitted slots (`"a".concat("b")` === "ab"). Each arg is
+  // coerced through the generic `+` (JS ToString — `concat(1, true, null)` is
+  // "1truenull"); handing a non-string word straight to the engine bridge
+  // misread a singleton as a heap handle.
+  concat(a: any = "", b: any = "", c: any = "", d: any = ""): string {
+    let r = engine.str_concat(__str_val(this), "" + a);
+    r = engine.str_concat(r, "" + b);
+    r = engine.str_concat(r, "" + c);
+    r = engine.str_concat(r, "" + d);
     return r;
   }
   // replace/replaceAll with a STRING search (a regex first arg is handled by the


### PR DESCRIPTION
## Resumo
- `__rtsadp_has_own`: receiver array reconhece índices em range (não-hole) e `length` como own properties — sem andar o prototype (diferente do `in`). Antes `arr.hasOwnProperty(0)`/`"length"` davam false.
- `String.prototype.concat` (string.ts): cada arg coage pelo `+` genérico (JS ToString). Entregar a word não-string direto à bridge fazia um singleton (null, payload 1) ser lido como handle de heap — slot 1 = proto de Error do prelude — e imprimia "Error".

## Validação
- `227_object_hasownproperty` e `claude-concat-type-coercion` byte-a-byte com Node
- Suíte TS 623/623 (1688), gate verde
- Sweep: **427/609, +2 exatos, 0 regressões RTS** (286_setimmediate = flaky de timing conhecido oscilando para bun_node_diverge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj