### PR TITLE
fix(codegen): const_int_value vê através de ineg — fold de -0 em 0 * -1 dispara

### DIFF
--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -453,12 +453,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     fn const_int_value(&self, v: cranelift_codegen::ir::Value) -> Option<i64> {
         use cranelift_codegen::ir::{InstructionData, Opcode, ValueDef};
         if let ValueDef::Result(inst, _) = self.builder.func.dfg.value_def(v) {
-            if let InstructionData::UnaryImm {
-                opcode: Opcode::Iconst,
-                imm,
-            } = self.builder.func.dfg.insts[inst]
-            {
-                return Some(imm.bits());
+            match self.builder.func.dfg.insts[inst] {
+                InstructionData::UnaryImm {
+                    opcode: Opcode::Iconst,
+                    imm,
+                } => return Some(imm.bits()),
+                // A negative literal lowers as `ineg(iconst n)` — see through it
+                // (`0 * -1`'s signed-zero fold needs the `-1`).
+                InstructionData::Unary {
+                    opcode: Opcode::Ineg,
+                    arg,
+                } => return self.const_int_value(arg).map(|n| n.wrapping_neg()),
+                _ => {}
             }
         }
         None


### PR DESCRIPTION
## Resumo
O fold de zero com sinal em multiplicação (`0 * negativo` → `f64const -0.0`, já existente em `lower_arith`) nunca disparava: um literal negativo lowera como `ineg(iconst n)` e `const_int_value` só reconhecia `iconst` direto. Agora resolve `Ineg` recursivamente; o mesmo helper beneficia o gate de divisor constante do `%`.

`1 / (0 * -1)` → -Infinity e `Object.is(-0, 0 * -1)` → true (spec). O fast path int com operandos variáveis segue inalterado.

## Validação
- `claude-negative-zero-identity` byte-a-byte com Node
- Suíte TS 623/623 (1688), gate verde
- Sweep: **429/609, 0 regressões** (+fixture alvo; +286_setimmediate flaky voltando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj