### PR TITLE
fix(codegen/runtime): typeof de Symbol em word OBJECT + typeof Math

### DIFF
--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -478,6 +478,18 @@ fn loose_eq(av: PolyValue, bv: PolyValue) -> bool {
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_typeof(a: u64) -> u64 {
     let v = PolyValue::from_raw(a);
+    // A Symbol instance rides as an OBJECT word (no distinct tag yet, #216) —
+    // `typeof` must still read `"symbol"` (`typeof Symbol.iterator`, a
+    // symbol-holding variable the front can't classify statically).
+    if v.is_object() {
+        use rts_runtime::namespaces::gc::handles as rt_handles;
+        let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(v.as_handle());
+        let is_sym =
+            rt_handles::with_entry(h, |e| matches!(e, Some(rt_handles::Entry::Symbol { .. })));
+        if is_sym {
+            return abi_adapter::intern_poly("symbol").raw();
+        }
+    }
     abi_adapter::intern_poly(v.typeof_str()).raw()
 }
 

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -336,6 +336,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     }
                 }
             }
+            // `typeof Math` is `"object"` — the bare PRIMORDIAL namespace object
+            // (the engine may name Math); a local/user class shadows it.
+            if let HirExprKind::Ident(name) = &operand.kind {
+                if name == "Math" && self.local(name).is_none() && self.classes.get(name).is_none()
+                {
+                    let pv = abi_adapter::intern_poly("object");
+                    let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                    return Ok(Val::tagged_kind(v, JsKind::Str));
+                }
+            }
             // `typeof <truly-undeclared ident>` is the ONE JS construct that may
             // name an unbound identifier without a ReferenceError — it yields
             // `"undefined"`. A bare ident that resolves to NOTHING (not a local/


### PR DESCRIPTION
## Resumo
- `__rtsadp_typeof`: word OBJECT cujo entry é `Entry::Symbol` responde "symbol" (Symbol ainda não tem tag própria no NaN-box, #216). Cobre `typeof Symbol.iterator`, variáveis symbol não classificadas estaticamente e `typeof Symbol.for(k)`.
- Fold `typeof Math` → "object" no front (Math é primordial — namespace object; caía no fold de unbound → "undefined").

Nota: `typeof JSON`/`Reflect` seguem "function" — fora do escopo (JSON é não-primordial; nomeá-lo no front violaria a doutrina).

## Validação
- `claude-typeof-edge-cases` byte-a-byte com Node; `184_symbol_for_keyfor` passou de bônus
- Suíte TS 623/623 (1688), gate verde
- Sweep: **432/609, 0 regressões, +2 reais** (+flaky 286 voltando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj