### PR TITLE
fix(ci): concurrency com cancel-in-progress no Build Artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -16,6 +16,14 @@ permissions:
   issues: write         # cross-runtime: auto-create de issue em divergencia
   pull-requests: write  # cross-runtime: comentar em PR
 
+# Um push novo SUPERSEDE o build anterior do mesmo ref: sem isto, cada commit
+# na main abria um build multi-hora novo e os antigos ficavam "in progress"
+# acumulando até saturar os runners hospedados (a fila inteira travou —
+# 2026-07-04, 17 runs presos). Só o build do commit mais recente importa.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Resumo
Cada push na main abria um build multi-hora **novo** sem cancelar o anterior; os antigos ficavam "in progress" acumulando até saturar os runners hospedados — a fila inteira do Actions travou hoje (17 runs presos por 3–15h, cancelados manualmente).

Com `concurrency.group` por workflow+ref e `cancel-in-progress: true`, um push novo supersede o build anterior do mesmo ref — só o commit mais recente conta.

O Cross-Runtime Parity é `workflow_call` e herda a concorrência do caller — não precisa de mudança própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj