### PR TITLE
fix(ci): timeout-minutes 60 em todos os jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,6 +28,7 @@ jobs:
   bench:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       version: ${{ steps.compute.outputs.version }}
     steps:
@@ -47,6 +48,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     # Job-level so the build composite's cargo invocation sees it (step-level env
     # on a `uses:` step is not forwarded into composite action steps).
     env:
@@ -119,6 +121,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -164,6 +167,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [version, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   cross-runtime:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Reporta divergencias mas nao bloqueia merge — pull-request continua
     # passando mesmo se RTS divergir (issue eh aberta automaticamente).
     continue-on-error: true

--- a/.github/workflows/runtime-archives.yml
+++ b/.github/workflows/runtime-archives.yml
@@ -71,6 +71,7 @@ jobs:
 
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     continue-on-error: ${{ matrix.continue == true }}
 
     steps:


### PR DESCRIPTION
## Resumo
Default do GitHub é **6h**: um job travado ficava "in progress" por horas segurando runner (a fila travou hoje). Nossos testes/builds nunca passam de 1h saudáveis — acima disso é problema e o job é morto automaticamente.

`timeout-minutes: 60` nos 7 jobs (build-artifacts ×4, cross-runtime, benchmarks, runtime-archives). YAML validado.

Complementa o #1852 (concurrency cancel-in-progress: commit novo na main supersede o build anterior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj