### PR TITLE
fix(tests): net_tcp_echo sem deadlock em CI + margens do setInterval

### DIFF
--- a/tests/net_tcp_echo.test.ts
+++ b/tests/net_tcp_echo.test.ts
@@ -1,6 +1,14 @@
 // TCP echo end-to-end via subprocess. Toda a logica vive dentro do
 // test() pra alinhar com o padrao dos outros testes que usam
 // process.spawn (vide abstract_class_no_new_err.test.ts).
+//
+// ANTI-DEADLOCK (CI 2026-07-04): num runner frio/lento o sleep fixo de
+// 300ms nao bastava — o connect falhava, o server ficava PRESO em
+// tcp_accept eterno e o `process.wait(child)` incondicional esperava o
+// server PARA SEMPRE (job "in progress" por horas; 3 processos rts
+// orfaos no cleanup). Agora: connect com RETRY em janela de ~5s, e no
+// caminho de falha o server e' MORTO (process.kill) em vez de aguardado
+// — o teste FALHA normalmente, nunca trava a suite.
 import { describe, test, expect } from "rts:test";
 import { net, gc, buffer, process, thread, fs } from "rts";
 
@@ -17,24 +25,36 @@ describe("fixture:net_tcp_echo", () => {
     const exe = resolveRtsExe();
     const child = process.spawn(exe, "run\ntests/_net_echo_server.ts");
 
-    // Server precisa de tempo pra bind+listen.
-    thread.sleep_ms(300);
+    // Server precisa de tempo pra bind+listen: tenta conectar em janela de
+    // ~5s (25 x 200ms) em vez de um sleep fixo — cobre runner frio de CI.
+    let client: i64 = 0;
+    for (let attempt = 0; attempt < 25 && client == 0; attempt++) {
+      thread.sleep_ms(200);
+      client = net.tcp_connect("127.0.0.1:45123");
+    }
 
-    const client = net.tcp_connect("127.0.0.1:45123");
-    const sent = net.tcp_send(client, "rts-echo");
+    if (client == 0) {
+      // Server nunca aceitou: mata o subprocess (preso no accept) e falha o
+      // teste sem deadlock — `process.wait` aqui esperaria para sempre.
+      process.kill(child);
+      expect("server nao aceitou conexao em ~5s").toBe("roundtrip ok");
+    } else {
+      const sent = net.tcp_send(client, "rts-echo");
 
-    const rxbuf = buffer.alloc_zeroed(8);
-    const got = net.tcp_recv(client, buffer.ptr(rxbuf), 8);
-    const echoed = buffer.to_string(rxbuf);
-    buffer.free(rxbuf);
-    net.tcp_close(client);
+      const rxbuf = buffer.alloc_zeroed(8);
+      const got = net.tcp_recv(client, buffer.ptr(rxbuf), 8);
+      const echoed = buffer.to_string(rxbuf);
+      buffer.free(rxbuf);
+      net.tcp_close(client);
 
-    const exitCode = process.wait(child);
+      // Roundtrip completo: o server ja saiu sozinho (echo + exit 0) — o
+      // wait colhe o exit code sem risco de bloqueio.
+      const exitCode = process.wait(child);
 
-    expect(client != 0 ? "1" : "0").toBe("1");
-    expect(sent == 8 ? "1" : "0").toBe("1");
-    expect(got == 8 ? "1" : "0").toBe("1");
-    expect(echoed).toBe("rts-echo");
-    expect(exitCode == 0 ? "1" : "0").toBe("1");
+      expect(sent == 8 ? "1" : "0").toBe("1");
+      expect(got == 8 ? "1" : "0").toBe("1");
+      expect(echoed).toBe("rts-echo");
+      expect(exitCode == 0 ? "1" : "0").toBe("1");
+    }
   });
 });

--- a/tests/set_timeout_interval.test.ts
+++ b/tests/set_timeout_interval.test.ts
@@ -17,10 +17,12 @@ clearTimeout(h2);
 time.sleep_ms(50);
 const fired2_end = fired2;
 
-// 3. setInterval dispara periodicamente
+// 3. setInterval dispara periodicamente. Janela LARGA (100ms / 15ms ~ 6
+// fires esperados) com bounds folgados nos DOIS lados: um runner de CI
+// lento (macos) pausa a VM e derruba a contagem — `> 2` em 70ms flakava.
 let count3 = 0;
 const h3 = setInterval(() => { count3 = count3 + 1; }, 15);
-time.sleep_ms(70);
+time.sleep_ms(100);
 clearInterval(h3);
 time.sleep_ms(30);
 const count3_end = count3;
@@ -44,9 +46,9 @@ describe("set_timeout_interval", () => {
     test("setTimeout fires after delay", () => expect(fired1_end).toBe(1));
     test("clearTimeout prevents fire", () => expect(fired2_end).toBe(0));
     test("setInterval fires periodically", () =>
-        expect(count3_end > 2).toBe(true));
+        expect(count3_end > 1).toBe(true));
     test("clearInterval stops interval", () =>
-        expect(count3_end < 8).toBe(true));
+        expect(count3_end < 12).toBe(true));
     test("setImmediate fires", () => expect(fired4_end).toBe(1));
     test("setTimeout returns non-zero handle", () =>
         expect(h5_nonzero).toBe(true));


### PR DESCRIPTION
## Causa raiz dos ts-suite presos (encontrada nos logs dos runs cancelados)
O `ts-suite (ubuntu)` travou **sempre em `tests/net_tcp_echo.test.ts`** (2 runs reproduzidos; 3 processos `rts` órfãos no cleanup):
1. Runner frio → 300ms de sleep não bastam → `tcp_connect` retorna 0
2. O server subprocess fica preso em `tcp_accept` eterno
3. `process.wait(child)` incondicional espera o server **para sempre** → job "in progress" por horas

## Fix
- **net_tcp_echo**: connect com retry (~5s de janela); no caminho de falha o server é morto (`process.kill`) e o teste falha normalmente — nunca trava a suíte; `wait` só após o roundtrip completo.
- **set_timeout_interval**: o macos falhava `setInterval fires periodically` (runner lento → <3 fires em 70ms) — janela de 100ms com bounds folgados (>1 e <12).

Complementa #1852 (concurrency supersede) e #1853 (timeout 60min por job).

## Validação
Suíte TS 623/623 (1688) local; ambos os testes passam individualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj