### PR TITLE
perf(ci): cross-runtime não instala Rust — o binário chega pronto do build

### DIFF
--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -28,8 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+      # O binário rts chega PRONTO do job `build` — nada compila aqui, então
+      # NENHUM toolchain Rust é instalado (o setup-rust adicionava rustup +
+      # restore de ~650MB de cargo-cache por nada, ~2min/run). Só as libs de
+      # RUNTIME que o binário carrega: libasound2 (cpal/ALSA) + jq do script.
+      - name: Install runtime deps (ALSA + jq)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2t64 jq
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Resumo
O job cross-runtime baixa o `rts` já compilado (`download-artifact`) e **não compila nada**, mas rodava o `setup-rust` completo: rustup + restore de ~650MB de cargo-cache + apt de build-deps — ~2min/run desperdiçados (era o "instalando rust" visível em todo run).

Troca por apt só das libs de **runtime** que o binário carrega: `libasound2t64` (cpal/ALSA) + `jq` do script de report.

O ts-suite já era limpo. O setup-rust continua nos jobs que compilam (build/runtime-archives), onde o cargo-cache vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj