### PR TITLE
feat(codegen): métodos de classe como propriedades do proto — método-como-valor dinâmico

### DIFF
--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -679,6 +679,22 @@ fn desc_flags_table() -> &'static Mutex<HashMap<(u64, String), u8>> {
     T.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Store a CLASS METHOD on a prototype object: a plain `obj_set` plus the
+/// non-enumerable descriptor bits (writable + configurable, NOT enumerable) —
+/// class methods are non-enumerable in JS, so `for-in` over an instance (which
+/// walks the proto chain) must skip them, unlike a manual
+/// `C.prototype.m = fn` assignment (enumerable, and it takes the plain
+/// `obj_set` path). Called by the main prologue's method registration.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_proto_set_method(proto_word: u64, key_word: u64, val_word: u64) {
+    __rtsadp_obj_set(proto_word, key_word, val_word);
+    let key = key_text(key_word);
+    desc_flags_table()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert((proto_word, key), 0b101);
+}
+
 /// Object words marked non-extensible (`Object.preventExtensions`/`freeze`/`seal`).
 fn non_extensible_table() -> &'static Mutex<HashSet<u64>> {
     static T: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -346,6 +346,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             "__rtsadp_obj_define_properties",
             objops::__rtsadp_obj_define_properties as *const u8,
         ),
+        sym(
+            "__rtsadp_proto_set_method",
+            objops::__rtsadp_proto_set_method as *const u8,
+        ),
         sym("__rtsadp_obj_get_own_property_descriptor", objops::__rtsadp_obj_get_own_property_descriptor as *const u8),
         sym("__rtsadp_obj_get_own_property_descriptors", objops::__rtsadp_obj_get_own_property_descriptors as *const u8),
         sym("__rtsadp_obj_has", objops::__rtsadp_obj_has as *const u8),

--- a/crates/rts-codegen-new/src/front/run/class/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/class/mod.rs
@@ -169,6 +169,12 @@ impl ClassTable {
         self.by_name.get(name)
     }
 
+    /// Every collected class descriptor (the METHOD-TABLE prologue walks all
+    /// classes to register their methods with the runtime).
+    pub fn descs(&self) -> impl Iterator<Item = &ClassDesc> {
+        self.by_name.values()
+    }
+
     /// Whether class `name` is already collected (used by the literal-class
     /// recovery pass to share one descriptor across identical literals).
     pub fn contains(&self, name: &str) -> bool {

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -437,6 +437,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // for plain functions, methods, AND constructors (all reach here).
         ctx.fill_default_params(module, func)?;
 
+        // METHOD-TABLE prologue (main only): register every class method's
+        // (instance shape-id, name) → thunk addr in the runtime table, so the
+        // dynamic property read reifies a class method as a VALUE (obj_get miss
+        // → `__rtsadp_method_table_add` counterpart in rts-adapters).
+        if ctx.is_main {
+            ctx.emit_method_table_registrations(module)?;
+        }
+
         ctx.lower_block(module, &func.body)?;
 
         // Fall-through at the end of the body. JS: a function with no `return`

--- a/crates/rts-codegen-new/src/front/run/methodtable.rs
+++ b/crates/rts-codegen-new/src/front/run/methodtable.rs
@@ -1,0 +1,98 @@
+//! PROTO-METHOD prologue emission (main only) — reify every class method as a
+//! this-first function WORD and store it as an own property of the class's
+//! SHARED prototype object. The dynamic property read (`__rtsadp_obj_get`)
+//! already walks the prototype chain on an own-slot miss, so a class-instance
+//! method becomes readable as a VALUE from a Tagged receiver (`typeof v.m ===
+//! "function"`, borrowed methods, the prelude's JSON `toJSON` hook) — exactly
+//! the JS prototypal model, with zero risk of cross-class leakage (the proto is
+//! per-class; a plain `{x: 1}` literal sharing a class's field SHAPE never sees
+//! its methods).
+
+use cranelift_codegen::ir::{InstBuilder, types};
+use cranelift_module::Module;
+
+use crate::value::{self, abi_adapter};
+
+use crate::front::error::FrontResult;
+
+use super::lower::Lowerer;
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// For every user class: `proto = __rtsadp_class_proto_init(name, parent)`
+    /// (idempotent — the same call `new` makes), then one
+    /// `__rtsadp_obj_set(proto, name, reified-method-word)` per method. Runs
+    /// once, at the `__rtsn_main` prologue (JIT and AOT alike — `func_addr` is
+    /// relocatable). An async method (no reifiable thunk) is skipped: the
+    /// dynamic read keeps its honest `undefined` for those.
+    pub(super) fn emit_method_table_registrations(
+        &mut self,
+        module: &mut dyn Module,
+    ) -> FrontResult<()> {
+        // Collect first — the emission below re-borrows `self` mutably.
+        let mut rows: Vec<(String, Option<String>, Vec<(String, String, i64)>)> = Vec::new();
+        for desc in self.classes.descs() {
+            let mut methods: Vec<(String, String, i64)> = Vec::new();
+            for (mname, fname) in &desc.methods {
+                let Some(sig) = self.sigs.get(fname.as_str()) else {
+                    continue;
+                };
+                if sig.is_async {
+                    continue;
+                }
+                if !self.thunks.contains_key(fname) {
+                    continue;
+                }
+                methods.push((mname.clone(), fname.clone(), sig.params.len() as i64));
+            }
+            if !methods.is_empty() {
+                rows.push((desc.name.clone(), desc.parent.clone(), methods));
+            }
+        }
+        for (class, parent, methods) in rows {
+            let k = abi_adapter::intern_poly(&class);
+            let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+            let parent_word = match &parent {
+                Some(p) => {
+                    let pk = abi_adapter::intern_poly(p);
+                    self.builder.ins().iconst(types::I64, pk.raw() as i64)
+                }
+                None => self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, value::PolyValue::undefined().raw() as i64),
+            };
+            let proto = self
+                .call_runtime(module, "__rtsadp_class_proto_init", &[k_word, parent_word])?
+                .expect("__rtsadp_class_proto_init returns a word");
+            for (mname, fname, nparams) in methods {
+                let thunk_id = *self.thunks.get(&fname).expect("thunk presence checked");
+                let func_ref = module.declare_func_in_func(thunk_id, self.builder.func);
+                let addr = self.builder.ins().func_addr(types::I64, func_ref);
+                let np_v = self.builder.ins().iconst(types::I64, nparams);
+                let zero = self.builder.ins().iconst(types::I64, 0);
+                let payload = self
+                    .call_runtime(
+                        module,
+                        "__rtsadp_fn_reify_this",
+                        &[addr, np_v, zero, zero],
+                    )?
+                    .expect("__rtsadp_fn_reify_this returns a payload");
+                // Box the bare 48-bit payload as a TAG_FUNCTION PolyValue word.
+                let header = value::encode(value::TAG_FUNCTION, 0) as i64;
+                let mask = self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, value::PAYLOAD_MASK as i64);
+                let masked = self.builder.ins().band(payload, mask);
+                let header_v = self.builder.ins().iconst(types::I64, header);
+                let word = self.builder.ins().bor(masked, header_v);
+                let name_w = self.builder.ins().iconst(
+                    types::I64,
+                    abi_adapter::intern_poly(&mname).raw() as i64,
+                );
+                self.call_runtime(module, "__rtsadp_proto_set_method", &[proto, name_w, word])?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -45,6 +45,7 @@ mod globalclass;
 mod globals;
 mod loops;
 mod mathobj;
+mod methodtable;
 mod method;
 mod method_array;
 mod method_dyn;

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -884,6 +884,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64, U64],
             ret: U64,
         },
+        "__rtsadp_proto_set_method" => SymSig {
+            params: &[U64, U64, U64],
+            ret: Void,
+        },
         "__rtsadp_obj_get_own_property_descriptor" => SymSig {
             params: &[U64, U64],
             ret: U64,


### PR DESCRIPTION
## Resumo
Fecha a maior base estrutural mapeada: um método de classe lido como **valor** de um receiver Tagged (prelude json.ts, borrowed methods, `typeof v.m === "function"`) via undefined — métodos são dispatch compilado, não slots, e o prelude não conhece classes do user.

**Modelo prototípico** (o que o motor já tem): o prólogo do `__rtsn_main` emite, por classe, `proto = __rtsadp_class_proto_init(name, parent)` (a mesma chamada idempotente do `new`) e um `__rtsadp_proto_set_method(proto, name, word)` por método — obj_set + bits **non-enumerable** (métodos de classe não aparecem no for-in, que anda a proto chain; `C.prototype.m = fn` manual continua enumerável). O word é reificado this-first (`__rtsadp_fn_reify_this` + box TAG_FUNCTION); o `obj_get` já anda a proto chain no miss. `func_addr` é relocável — JIT e AOT iguais.

**Zero colisão por desenho**: proto é por classe — um `{x:1}` plano que compartilha o shape de campos de uma classe nunca vê os métodos (a 1ª tentativa, tabela por shape-id, foi descartada exatamente por esse vazamento; anti-colisão verificado empiricamente).

## Validação
- `292_json_tojson` e `377_for_in_detail` byte-a-byte com Node; `codex_parser_backtracking_tokens` passou de bônus no sweep intermediário
- Literal só-método (lit-class) também reifica; classe sem o método e literal plano dão undefined
- Suíte TS 623/623 (1688), gate verde
- Sweep: **437/609, 0 regressões**

claude-json-tojson-hook segue aberta por 2 causas próprias documentadas (dessincronia de cursor no desugar objmethod com fn-expr entre literais; toJSON expando em array).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj