### PR TITLE
feat(hir/codegen): fn-expr/arrow como valor — self-name, rest e default preservados

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1007,16 +1007,29 @@ impl Ctx {
         scope: &HashSet<String>,
         mutated: &HashSet<String>,
     ) -> Option<String> {
-        let HirExprKind::Arrow { params, ret, body } = &e.kind else {
+        let HirExprKind::Arrow {
+            params,
+            ret,
+            body,
+            self_name,
+        } = &e.kind
+        else {
             return None;
         };
-        // A DEFAULTED param is out of this increment's arrow subset. A VARIADIC
-        // (`...rest`) param is allowed only in LAST position (JS grammar) — the
-        // synthesized fn keeps the flag, so the sig records `rest_param` and the
-        // uniform thunk packs the overflow into it.
-        if params.iter().any(|p| p.has_default) {
-            return None;
-        }
+        // The synthesized name is minted UP FRONT so a NAMED fn-expression's
+        // self-references can be renamed to it before the free-ident analysis
+        // (the self-name is body-only scope; renamed, it resolves as this very
+        // top-level fn — recursion works). A bailed extraction just skips a
+        // counter number.
+        let name = format!("__rtsn_arrow_{}{}", self.arrow_ns, self.counter);
+        self.counter += 1;
+        let self_name = self_name.clone();
+        // A VARIADIC (`...rest`) param is allowed only in LAST position (JS
+        // grammar) — the synthesized fn keeps the flag, so the sig records
+        // `rest_param` and the uniform thunk packs the overflow into it. A
+        // DEFAULTED param is fine: the synthesized fn keeps `default_expr` and
+        // the callee-side `fill_default_params` prologue (every lowered fn
+        // gets it) replaces an `undefined` argument with the default.
         if params
             .iter()
             .enumerate()
@@ -1041,6 +1054,14 @@ impl Ctx {
         if param_names.contains("this") {
             super::class::rewrite_this_block(&mut body_stmts);
         }
+        // Bind a NAMED fn-expression's self-name: internal references become
+        // references to the synthesized top-level name (registered below), so
+        // they are neither free nor captures.
+        if let Some(sn) = &self_name {
+            if !param_names.contains(sn) {
+                rename_ident_stmts(&mut body_stmts, sn, &name);
+            }
+        }
         let mut free = HashSet::new();
         let mut bound = param_names.clone();
         for s in &body_stmts {
@@ -1057,6 +1078,7 @@ impl Ctx {
         let mut cell_caps: Vec<String> = Vec::new();
         for id in &free {
             if param_names.contains(id)
+                || id == &name
                 || GLOBALS.contains(&id.as_str())
                 || self.top_level.contains(id)
                 || self.module_globals.contains(id)
@@ -1113,8 +1135,6 @@ impl Ctx {
         // capture list, so reify and thunk agree deterministically.
         captures.sort();
 
-        let name = format!("__rtsn_arrow_{}{}", self.arrow_ns, self.counter);
-        self.counter += 1;
         self.top_level.insert(name.clone());
 
         // Record each CELL capture under BOTH the declaring function (its `let`

--- a/crates/rts-hir/src/ir.rs
+++ b/crates/rts-hir/src/ir.rs
@@ -333,6 +333,11 @@ pub enum HirExprKind {
         params: Vec<HirParam>,
         ret: HirType,
         body: HirArrowBody,
+        /// A NAMED function expression's self-name (`function s(){ … s() … }`)
+        /// — visible only inside the body. The extraction pass renames internal
+        /// references to the synthesized top-level name, making self-recursive
+        /// named fn-exprs liftable. `None` for arrows / anonymous fn-exprs.
+        self_name: Option<String>,
     },
 
     // Pre/post increment/decrement

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -268,6 +268,9 @@ fn lower_decl(decl: &swc::Decl, scope: &mut Scope, raw_text: &str) -> HirStmt {
                     params,
                     ret: ret.clone(),
                     body,
+                    // A nested `function s(){ … s() … }` is self-visible by its
+                    // declaration name — same binding rule as a named fn-expr.
+                    self_name: Some(fd.ident.sym.to_string()),
                 },
                 HirType::Function {
                     params: vec![],
@@ -570,7 +573,16 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                 // A REST param (`(...args) =>`) is variadic — the extraction and
                 // the uniform thunk pack the overflow args into it.
                 let variadic = matches!(p, swc::Pat::Rest(_));
-                HirParam { name, ty, variadic, has_default: false, optional: false, default_expr: None }
+                // A DEFAULTED param (`(n, acc = 1) =>`): keep the lowered default
+                // initializer — the synthesized fn's `fill_default_params`
+                // prologue replaces an `undefined` argument with it (dropping it
+                // here left `acc` as raw `undefined` through the uniform thunk).
+                let default_expr = match p {
+                    swc::Pat::Assign(a) => Some(Box::new(lower_swc_expr(&a.right, scope))),
+                    _ => None,
+                };
+                let has_default = default_expr.is_some();
+                HirParam { name, ty, variadic, has_default, optional: false, default_expr }
             }).collect();
             let ret = HirType::Unknown;
             let body = match &*arrow.body {
@@ -595,7 +607,7 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                 }
             };
             HirExpr::new(
-                HirExprKind::Arrow { params, ret: ret.clone(), body },
+                HirExprKind::Arrow { params, ret: ret.clone(), body, self_name: None },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )
         }
@@ -618,7 +630,17 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                 let name = extract_swc_pat_name(&p.pat);
                 let annotation = extract_ts_type_annotation(&p.pat);
                 let ty = annotation.as_deref().map(parse_type_annotation).unwrap_or(HirType::Unknown);
-                HirParam { name, ty, variadic: false, has_default: false, optional: false, default_expr: None }
+                // Same param surface as the arrow lowering: a REST param is
+                // variadic; a DEFAULTED param keeps its lowered initializer
+                // (both were silently dropped here — `function (...args)` /
+                // `function (n, acc = 0)` as VALUES mis-bound their params).
+                let variadic = matches!(p.pat, swc::Pat::Rest(_));
+                let default_expr = match &p.pat {
+                    swc::Pat::Assign(a) => Some(Box::new(lower_swc_expr(&a.right, scope))),
+                    _ => None,
+                };
+                let has_default = default_expr.is_some();
+                HirParam { name, ty, variadic, has_default, optional: false, default_expr }
             }).collect();
             let ret = HirType::Unknown;
             let body = match &func.body {
@@ -629,7 +651,12 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                 None => HirArrowBody::Block(Vec::new()),
             };
             HirExpr::new(
-                HirExprKind::Arrow { params, ret: ret.clone(), body },
+                HirExprKind::Arrow {
+                    params,
+                    ret: ret.clone(),
+                    body,
+                    self_name: fn_expr.ident.as_ref().map(|i| i.sym.to_string()),
+                },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )
         }


### PR DESCRIPTION
## Resumo
Três gaps da base "expression arrow" do histograma de rts_error:

- **Self-name de fn-expr nomeada** (`id(function fact(n) { … fact(n-1) … })`): o hir_lower carrega `Arrow.self_name`; o try_extract minta o nome sintetizado cedo e renomeia as refs internas antes da análise de frees — recursão vira chamada top-level direta. Function declaration aninhada ganha o mesmo binding.
- **fn-expr perdia `...rest` e defaults; arrow inline perdia defaults** — um `(n, acc = 1) =>` extraído recebia `acc` como undefined cru pelo uniform thunk (NaN). Ambos os lowerings preservam variadic/default_expr; o `fill_default_params` (que toda fn tem) cobre o resto.
- Gate `has_default → None` do try_extract removido (protegia contra o default perdido — corrigido na raiz).

## Validação (local)
- Repros: fn-expr nomeada recursiva como arg (120 ✓), default via thunk (6/15 ✓)
- Suíte TS 623/623 (1688), gate verde
- Sweep: **438/609, 0 regressões** (+272_symbol_iterator_custom de bônus; rts_error 99→93 — fixtures progrediram de bail para executar)

Próxima camada documentada: spread de rest capturado em closure (`fn(...args)`) retorna NaN — é o que ainda segura 386/348/420/344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj