### PR TITLE
fix(codegen): rename do self-name desce em arrows aninhadas — trampoline cai

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -252,6 +252,28 @@ fn rename_ident_expr(e: &mut HirExpr, from: &str, to: &str) {
             rename_ident_expr(inner, from, to);
         }
         HirExprKind::Seq(items) => items.iter_mut().for_each(|x| rename_ident_expr(x, from, to)),
+        // A NESTED arrow/fn-expression: the renamed name (a named fn-expr's
+        // self-name) is visible inside its body too — descend, unless one of the
+        // inner params SHADOWS it. Without this, `function w(n) { return () =>
+        // w(n-1); }` kept the inner `w` unrenamed → an unknown free ident → the
+        // outer extraction bailed ("expression arrow").
+        HirExprKind::Arrow {
+            params,
+            body,
+            self_name,
+            ..
+        } => {
+            let shadowed = params.iter().any(|p| p.name == from)
+                || self_name.as_deref() == Some(from);
+            if !shadowed {
+                match body {
+                    rts_hir::ir::HirArrowBody::Expr(inner) => rename_ident_expr(inner, from, to),
+                    rts_hir::ir::HirArrowBody::Block(stmts) => {
+                        rename_ident_stmts(stmts, from, to)
+                    }
+                }
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
## Resumo
Camada 3 da base "expression arrow": `rename_ident_expr` não tinha arm para `Arrow` — em `id(function w(n) { return () => w(n-1); })` a ref `w` dentro da arrow aninhada ficava sem renomear, virava free ident desconhecido e a extração da fn-expr externa bailava. O arm novo desce no body (Expr/Block), respeitando shadowing por param homônimo ou self-name próprio. O fixpoint das sintetizadas (já existente) extrai a arrow interna em seguida.

## Validação (local)
- `386_trampoline` byte-a-byte com Node (trampoline + factorial/fib/sum CPS)
- Suíte TS 623/623 (1688), gate verde
- Sweep: **441/609, 0 regressões, +2 reais** (386 + `351_obf_string_array` de bônus; encodeinto voltou = flake confirmado)

348/420/344 progrediram de camada — próximas unidades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj