### PR TITLE
feat(codegen): captura transitiva de closure + spread múltiplo em value-call — curry cai

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -1108,6 +1108,17 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     ) -> FrontResult<cranelift_codegen::ir::Value> {
         let arr = emit_marshal::emit_new_vec_object(module, self.builder);
         for cap in capture_names {
+            // A capture that is a TOP-LEVEL FUNCTION name (a transitive-closure
+            // reference — the inner arrow calls an enclosing synthesized closure):
+            // snapshot its REIFIED fn VALUE. Reifying HERE embeds ITS env from
+            // THIS scope's locals (the enclosing closure's leading capture params),
+            // so the chain nests soundly.
+            if self.local(cap).is_none() && self.sigs.contains_key(cap.as_str()) {
+                let v = self.reify_function(module, cap)?;
+                let word = self.box_value(v);
+                emit_marshal::emit_vec_push(module, self.builder, arr, word);
+                continue;
+            }
             let local = self.local(cap).ok_or_else(|| {
                 Unsupported::new(format!(
                     "closure captures `{cap}` which is not a simple local in scope"
@@ -1230,18 +1241,35 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         fn_word: Value,
         args: &[HirExpr],
     ) -> FrontResult<Val> {
-        // `f(...xs)` — a SOLE spread arg: resolve the source to an array word
-        // (array/iterable/string — the same hook array-literal spread uses) and
-        // unpack at RUNTIME via the apply trampoline (arbitrary length).
-        if args.len() == 1 {
-            if let HirExprKind::Spread(inner) = &args[0].kind {
-                let arr_word = self.spread_source_array_word(module, inner)?;
-                let res = self
-                    .call_runtime(module, "__rtsadp_fn_apply_arr", &[fn_word, arr_word])?
-                    .expect("__rtsadp_fn_apply_arr returns a value");
-                self.emit_post_call_error_check(module)?;
-                return Ok(Val::new(res, Repr::Tagged));
+        // ANY spread arg (`f(...xs)`, `f(a, ...xs)`, `f(...xs, ...ys)` — the
+        // curry pattern): build ONE runtime args array — plain args push their
+        // boxed word, each `...spread` appends its source (array/iterable/
+        // string, the same hook array-literal spread uses) — and unpack via the
+        // apply trampoline (arbitrary length).
+        if args
+            .iter()
+            .any(|a| matches!(a.kind, HirExprKind::Spread(_)))
+        {
+            let arr = emit_marshal::emit_new_vec_object(module, self.builder);
+            for a in args {
+                if let HirExprKind::Spread(inner) = &a.kind {
+                    let src_word = self.spread_source_array_word(module, inner)?;
+                    self.call_runtime(
+                        module,
+                        "__rtsadp_arr_spread_append",
+                        &[arr, src_word],
+                    )?;
+                } else {
+                    let v = self.lower_expr(module, a)?;
+                    let word = self.box_value(v);
+                    emit_marshal::emit_vec_push(module, self.builder, arr, word);
+                }
             }
+            let res = self
+                .call_runtime(module, "__rtsadp_fn_apply_arr", &[fn_word, arr])?
+                .expect("__rtsadp_fn_apply_arr returns a value");
+            self.emit_post_call_error_check(module)?;
+            return Ok(Val::new(res, Repr::Tagged));
         }
         // Box the first four positional args; missing slots are `undefined`.
         let undef = || value::PolyValue::undefined().raw() as i64;

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1114,7 +1114,11 @@ impl Ctx {
             if param_names.contains(id)
                 || id == &name
                 || GLOBALS.contains(&id.as_str())
-                || self.top_level.contains(id)
+                // A top-level CLOSURE (a synthesized fn WITH captures) is NOT
+                // skippable: its direct name cannot be called from a scope that
+                // lacks its captured locals — fall through to the capture path,
+                // which snapshots its REIFIED fn VALUE (env embedded).
+                || (self.top_level.contains(id) && !self.captures.contains_key(id))
                 || self.module_globals.contains(id)
                 // An in-scope OUTER LOCAL/PARAM SHADOWS a same-named Registry
                 // namespace/class (JS scoping): `parse(input: string)` captures
@@ -1123,6 +1127,13 @@ impl Ctx {
                 || (!scope.contains(id)
                     && (super::registry::has_namespace(id) || super::registry::has_class(id)))
             {
+                continue;
+            }
+            // A top-level closure name: capture its fn VALUE (the enclosing
+            // body reifies it — ITS captures are that body's leading params, so
+            // the env embeds transitively). Never a mutable-capture cell.
+            if self.top_level.contains(id) {
+                captures.push(id.clone());
                 continue;
             }
             // A free ident outside those sets is a CAPTURE. It must be a real outer


### PR DESCRIPTION
## Resumo
Camada 4 da base "expression arrow", em duas partes coesas (o padrão curry exige as duas):

1. **Captura transitiva**: uma arrow que referencia uma closure top-level sintetizada não pode chamá-la pelo nome (a call reconstrói o env de locais que a arrow não tem). Agora a referência vira **captura da fn word**: o `build_closure_env`, ao ver um capture que é nome de fn top-level, reifica a closure ali — seus captures são os leading params do corpo envolvente, então o env embute transitivamente.
2. **Spread múltiplo em value-call**: `curried(...args, ...more)` só cobria spread único; qualquer combinação agora monta uma array runtime (push + `arr_spread_append`) e despacha via `fn_apply_arr`.

## Validação (local)
- `348_closure_optimization` byte-a-byte com Node; curry nas 3 formas (24/24/24)
- Suíte TS 623/623 (1688), gate verde
- Sweep: **447/609, +9 ganhos** (generators 108/329, reflect_construct, algorithms, symbols custom, then-getter…)
- As 3 divergências de promise (116/167/200) são **pré-existentes na main de hoje** — reproduzidas na main pura (binário sem estas mudanças); issue #1862 aberta com a repro (bits de f64 vazando em callback de .then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj