### PR TITLE
feat(codegen): fns aninhadas mutuamente recursivas — forward refs via cell hoisted

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -38,6 +38,7 @@
 //! `this`/async/generator arrows are likewise left to bail.
 
 mod scan;
+pub(crate) use scan::arrow_decl_names as fn_decl_names;
 
 use std::collections::{HashMap, HashSet};
 
@@ -45,7 +46,8 @@ use rts_hir::ir::{HirArrowBody, HirExprKind};
 use rts_hir::{HirExpr, HirFunc, HirParam, HirStmt, HirType};
 
 use scan::{
-    arrow_assigned_names, arrow_free_idents, collect_free_stmt, declared_names, mutated_names,
+    arrow_assigned_names, arrow_decl_names, arrow_free_idents, collect_free_stmt, declared_names,
+    mutated_names,
 };
 
 /// MODULE-LEVEL MUTABLE GLOBALS (epic #195). Compute the set of top-level `let`
@@ -439,6 +441,7 @@ pub fn extract_arrows(
         cells: HashMap::new(),
         current_fn: String::new(),
         current_fn_lets: HashSet::new(),
+        current_fn_arrow_decls: HashSet::new(),
         self_binding: None,
         counter: 0,
         arrow_ns: arrow_ns.to_string(),
@@ -452,12 +455,14 @@ pub fn extract_arrows(
         let mutated = mutated_names(&f.body);
         ctx.current_fn = f.name.clone();
         ctx.current_fn_lets = declared_locals(&f.body);
+        ctx.current_fn_arrow_decls = arrow_decl_names(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
     }
     let main_params: HashSet<String> = main.params.iter().map(|p| p.name.clone()).collect();
     let main_mutated = mutated_names(&main.body);
     ctx.current_fn = main.name.clone();
     ctx.current_fn_lets = declared_locals(&main.body);
+    ctx.current_fn_arrow_decls = arrow_decl_names(&main.body);
     ctx.rewrite_block(&mut main.body, &main_params, &main_mutated);
 
     // The synthesized arrow bodies may THEMSELVES contain arrows; rewrite those
@@ -470,6 +475,7 @@ pub fn extract_arrows(
         let mutated = mutated_names(&f.body);
         ctx.current_fn = f.name.clone();
         ctx.current_fn_lets = declared_locals(&f.body);
+        ctx.current_fn_arrow_decls = arrow_decl_names(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
         ctx.synthesized[i] = f;
         i += 1;
@@ -795,6 +801,10 @@ struct Ctx {
     /// body — the only locals a captured-mutated name may be a cell of this
     /// increment (a deeper-block or param capture bails, kept sound).
     current_fn_lets: HashSet<String>,
+    /// Names in the CURRENT function declared with a fn-valued initializer
+    /// (`const factor = (..) => …`) — a capture of one is a CELL (mutual
+    /// forward refs read the live value; see `arrow_decl_names`).
+    current_fn_arrow_decls: HashSet<String>,
     /// The `let`/`const` NAME whose initializer is being rewritten right now —
     /// a capture of it inside an arrow is a SELF-REFERENCE (`const f = () =>
     /// … f() …`) and must be a CELL (live read), never a by-value snapshot of
@@ -1137,8 +1147,11 @@ impl Ctx {
                 continue;
             }
             // A free ident outside those sets is a CAPTURE. It must be a real outer
-            // local in scope (not an unknown name / `this`).
-            if !scope.contains(id) {
+            // local in scope (not an unknown name / `this`) — OR a fn-valued
+            // declaration of the enclosing body not yet reached by the rewrite
+            // walk (a FORWARD reference between nested fns: `a` calls `b`
+            // declared below); those are cell captures, resolved below.
+            if !scope.contains(id) && !self.current_fn_arrow_decls.contains(id.as_str()) {
                 return None; // unknown name / `this` — not a capturable local.
             }
             // A MUTATED capture (assigned by the closure body OR reassigned in the
@@ -1157,6 +1170,10 @@ impl Ctx {
             if body_assigns.contains(id)
                 || mutated.contains(id)
                 || already_cell
+                // A fn-valued declaration of the enclosing body: a FORWARD
+                // mutual reference must read the LIVE value (cell), never a
+                // reify-time snapshot (undefined before its decl runs).
+                || self.current_fn_arrow_decls.contains(id.as_str())
                 // SELF-REFERENCE (`const f = () => … f() …`): the binding is
                 // written right after the reify, so a by-value snapshot would
                 // capture undefined — a CELL reads the live fn value.

--- a/crates/rts-codegen-new/src/front/run/funcval/scan.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/scan.rs
@@ -36,6 +36,50 @@ pub(super) fn arrow_assigned_names(stmts: &[HirStmt]) -> HashSet<String> {
     mutated_names(stmts)
 }
 
+/// The names declared with a FUNCTION-VALUED initializer (`const f = (..) =>
+/// …` / a nested fn-decl lowered to that shape) anywhere in `stmts`. A capture
+/// of one of these is routed to a CELL: mutually-recursive nested fns
+/// FORWARD-reference each other (`factor` calls `expr` declared later), so a
+/// by-value snapshot at reify time would capture `undefined` — the cell reads
+/// the live fn value at call time.
+pub(crate) fn arrow_decl_names(stmts: &[HirStmt]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    collect_arrow_decls(stmts, &mut out);
+    out
+}
+
+fn collect_arrow_decls(stmts: &[HirStmt], out: &mut HashSet<String>) {
+    for s in stmts {
+        match s {
+            HirStmt::Let {
+                name,
+                init: Some(e),
+                ..
+            }
+            | HirStmt::Const { name, init: e, .. } => {
+                // Pre-rewrite the init is an inline `Arrow`; post-rewrite (the
+                // prologue's cell-hoisting scan runs on the REWRITTEN body) it
+                // is an `Ident` of the synthesized fn — accept both.
+                let is_fn_init = matches!(e.kind, HirExprKind::Arrow { .. })
+                    || matches!(&e.kind, HirExprKind::Ident(n)
+                        if n.starts_with("__rtsn_arrow_") || n.starts_with("__rtsl_"));
+                if is_fn_init {
+                    out.insert(name.clone());
+                }
+            }
+            HirStmt::If { then, else_, .. } => {
+                collect_arrow_decls(then, out);
+                if let Some(e) = else_ {
+                    collect_arrow_decls(e, out);
+                }
+            }
+            HirStmt::While { body, .. } => collect_arrow_decls(body, out),
+            HirStmt::Block(b) => collect_arrow_decls(b, out),
+            _ => {}
+        }
+    }
+}
+
 /// The names DECLARED (`let`/`const`) anywhere in `stmts` (top-level + nested
 /// blocks/if/while). Used to exclude a function's OWN locals when deciding which
 /// names it writes are FREE (module-global) writes (see `module_globals`).

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -190,6 +190,12 @@ pub(crate) struct Lowerer<'a, 'b, 'c> {
     /// [`Self::lower_function`]. The closure thunk receives the same names as its
     /// captured leading PARAMS (already holding the handle), so it shares the set.
     pub cell_locals: std::collections::HashSet<String>,
+    /// Cell-locals HOISTED by the prologue (fn-valued declarations only — the
+    /// mutual-forward-ref set). Their `let`/`const` stmt SETs into the
+    /// pre-allocated box instead of re-allocating; every other cell-local keeps
+    /// the alloc-at-decl behavior (a loop-body `let` needs a FRESH cell per
+    /// pass for the per-iteration capture semantics).
+    pub hoisted_cells: std::collections::HashSet<String>,
     /// Name → the statically-known CLASS of a local/param holding a class instance
     /// (a `new C()` result, a `: C`-annotated param, or `this` inside a method).
     /// Drives static `instance.method(args)` dispatch; absent ⇒ method calls bail.
@@ -346,6 +352,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             object_locals: std::collections::HashSet::new(),
             string_locals: std::collections::HashSet::new(),
             cell_locals,
+            hoisted_cells: std::collections::HashSet::new(),
             local_classes: HashMap::new(),
             local_class_refs: HashMap::new(),
             generator_locals: HashMap::new(),
@@ -436,6 +443,32 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // CALLEE scope (earlier params are already bound — correct JS semantics) and
         // for plain functions, methods, AND constructors (all reach here).
         ctx.fill_default_params(module, func)?;
+
+        // CELL-HOISTING prologue: allocate up front the cell of every
+        // FN-VALUED cell-local of THIS function (bound to `undefined`), so a
+        // closure reified BEFORE the declaring `const` runs (a
+        // mutually-recursive nested fn's FORWARD reference) snapshots a real
+        // cell handle — the decl later SETs the live fn into the same box.
+        // Scoped to fn-valued decls only: a plain loop-body `let` cell keeps
+        // its alloc-at-decl (fresh box per pass, the per-iteration semantics).
+        {
+            let hoist: Vec<String> = super::funcval::fn_decl_names(&func.body)
+                .intersection(&ctx.cell_locals)
+                .cloned()
+                .collect();
+            for name in hoist {
+                if ctx.local(&name).is_some() {
+                    continue; // a param of the same name owns the slot
+                }
+                let undef = ctx.builder.ins().iconst(
+                    types::I64,
+                    value::PolyValue::undefined().raw() as i64,
+                );
+                let handle = ctx.emit_cell_alloc(module, undef);
+                ctx.bind_tagged_local(&name, Val::new(handle, Repr::Tagged));
+                ctx.hoisted_cells.insert(name);
+            }
+        }
 
         // METHOD-TABLE prologue (main only): register every class method's
         // (instance shape-id, name) → thunk addr in the runtime table, so the

--- a/crates/rts-codegen-new/src/front/run/stmt_let.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_let.rs
@@ -75,16 +75,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // snapshots the HANDLE by value (shared mutable box). Shape tracking is
         // dropped (a captured-mutated var is opaque).
         if self.is_cell_local(name) {
-            // Alloc + bind the cell BEFORE lowering the initializer: a
-            // SELF-REFERENCING closure init (`const f = () => … f() …`)
-            // snapshots the cell HANDLE during its env build, and the
-            // cell-set below writes the live fn value into that same box.
-            let undef = self
-                .builder
-                .ins()
-                .iconst(types::I64, crate::value::PolyValue::undefined().raw() as i64);
-            let handle = self.emit_cell_alloc(module, undef);
-            self.bind_tagged_local(name, Val::new(handle, Repr::Tagged));
+            // A HOISTED cell (a fn-valued decl — mutual forward refs) was
+            // pre-allocated by the prologue: SET into that same box below. Any
+            // other cell-local allocs a FRESH box at each execution of its decl
+            // (a loop-body `let` gets the per-iteration binding).
+            if self.local(name).is_none() || !self.hoisted_cells.contains(name) {
+                let undef = self
+                    .builder
+                    .ins()
+                    .iconst(types::I64, crate::value::PolyValue::undefined().raw() as i64);
+                let handle = self.emit_cell_alloc(module, undef);
+                self.bind_tagged_local(name, Val::new(handle, Repr::Tagged));
+            }
             let val = self.lower_expr(module, init)?;
             let word = self.box_value(val);
             let handle = self


### PR DESCRIPTION
## Resumo
Fecha a última camada grande da base "expression arrow": o parser recursivo clássico — fns aninhadas com **forward references mútuas** capturando estado compartilhado.

Três peças:
- **try_extract**: captura de nome fn-valued do corpo envolvente ainda não alcançado pelo walk (forward ref) é aceita e roteada a **cell** (novo scan `arrow_decl_names`) — lê o valor vivo na chamada, nunca snapshot undefined.
- **Cell hoisting no prólogo**: células dos cell-locals fn-valued alocadas up-front; a decl só seta o fn vivo na mesma caixa. Escopo restrito a decls de fn — `let` de loop mantém caixa fresh por passada (per-iteration preservado via `hoisted_cells`).
- O scan pós-rewrite reconhece init `Ident(__rtsn_arrow_*)` (o rewrite já trocou o Arrow pelo nome sintetizado).

## Validação (local)
- `420_state_machine_parser` byte-a-byte com Node; repros: forward simples (11) e mútua com estado (3)
- Suíte TS 623/623 (1688) — incl. os testes de per-iteration let — gate verde
- Sweep: **449/609, +420, 0 regressões RTS** (286_setimmediate = flaky de timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj