### PR TITLE
fix(codegen): análise de frees da arrow semeia as decls do próprio body

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1108,6 +1108,13 @@ impl Ctx {
         }
         let mut free = HashSet::new();
         let mut bound = param_names.clone();
+        // Seed with the body's OWN declarations (lexical hoisting): a nested
+        // `const step = (..) => … step(..) …` self-references FORWARD of the
+        // walk's insertion point — without the seed, `step` surfaced as a free
+        // ident outside the enclosing scope and the whole outer arrow bailed
+        // (the __awaiter executor pattern). TDZ reads aside, a body-declared
+        // name is never a capture of the OUTER scope.
+        bound.extend(declared_locals(&body_stmts));
         for s in &body_stmts {
             collect_free_stmt(s, &mut bound, &mut free);
         }


### PR DESCRIPTION
## Resumo
Camada final de **compile** da base "expression arrow" (o padrão __awaiter): fn aninhada auto-recursiva dentro de arrow — a self-ref `step` dentro do próprio init aparecia antes do ponto de inserção do walk, virava free ident fora do escopo externo e a arrow-mãe inteira bailava.

`bound` agora é semeado com `declared_locals(body)` antes do collect (nome declarado no body nunca é captura do escopo externo).

## Validação (local)
- Executor do __awaiter e repros P1/P4 compilam
- Suíte TS 623/623 (1688), gate verde
- Sweep: 449/609, **0 regressões** (neutro no placar: o 344 também depende do runtime de `new Promise(executor)`, quebrado **upstream** — issue #1862 atualizada com repro na main pura — e de `function*` como arg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AW6SAvyu6QM9AeG53VFBbj