### PR TITLE
fix(engine): let-locals truncate fractional reassignment when init is int-valued float (#1869)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/floatscan.rs
+++ b/crates/rts-codegen-new/src/front/run/floatscan.rs
@@ -1,20 +1,34 @@
-//! Pre-scan: numeric ACCUMULATOR locals that must bind as `Float64`.
+//! Pre-scan: numeric locals that must bind as `Float64`.
 //!
-//! `let s = 0; for (const p of ps) { s = s + p.age; }` — the init proves `Int64`,
-//! but a later accumulation folds in a heap-read number (`p.age`, a `number`
-//! field, F64 at runtime). Binding `s` as `Int64` makes the assign's coerce
-//! TRUNCATE every fractional carry (`72.7` became `72`). This scan walks a
-//! function body BEFORE lowering and collects every local that is the target of
-//! an arithmetic self-accumulation whose value tree contains a heap read
-//! (member/index/call — a value the front cannot prove integral). The `let`
-//! numeric tail then binds such a local as `Float64` from the start — JS numbers
-//! are f64, so this is always semantically sound; only reprs that WOULD have
-//! been `Int*` are widened (a string/object/Tagged binding is untouched).
+//! A `let` initialized with an integer-valued literal proves `Int64` (swc lowers
+//! `0`/`0.0`/`20.0` — no fractional part — to an integer literal, see
+//! `rts-hir::lower::lower_lit`). If that same local is later ASSIGNED a value the
+//! front cannot prove is integral, binding it `Int64` makes the assign's coerce
+//! TRUNCATE the fraction (`fcvt_to_sint_sat`), silently losing it. Two shapes hit
+//! this:
+//!
+//!   1. accumulation of a heap-read number —
+//!      `let s = 0; for (const p of ps) { s = s + p.age; }` (`p.age` is a
+//!      `number` field, F64 at runtime; `72.7` became `72`);
+//!   2. assignment of a fractional value —
+//!      `let vy = 0.0; vy = vy - 0.272;` (the literal `0.272` is fractional; `vy`
+//!      printed `0` instead of `-0.272` — issue #1869).
+//!
+//! This scan walks a function body BEFORE lowering and collects every local that
+//! is the target of an assignment (`=` or `op=`) whose value tree REQUIRES float
+//! — it contains a heap read (member/index the front cannot prove integral) OR a
+//! genuinely fractional numeric literal. The `let` numeric tail then binds such a
+//! local as `Float64` from the start. JS numbers are f64, so widening an
+//! int-inferred local to `Float64` is ALWAYS semantically sound; only reprs that
+//! WOULD have been `Int*` are widened (a string/object/Tagged binding is
+//! untouched). A local only ever assigned integer-valued literals/locals is NOT
+//! promoted — a Fibonacci-style `let a = 0.0; a = a + 1.0;` loop keeps its native
+//! unboxed `Int64` fast path.
 
 use std::collections::HashSet;
 
 use rts_hir::HirExpr;
-use rts_hir::ir::{HirBinOp, HirExprKind, HirStmt};
+use rts_hir::ir::{HirBinOp, HirExprKind, HirLit, HirStmt};
 
 /// Collect the names needing a `Float64` binding (see module doc).
 pub(super) fn float_promoted_locals(body: &[HirStmt]) -> HashSet<String> {
@@ -103,18 +117,23 @@ fn walk_stmt(stmt: &HirStmt, out: &mut HashSet<String>) {
 
 fn walk_expr(e: &HirExpr, out: &mut HashSet<String>) {
     match &e.kind {
-        // `s = s <op> …heapRead…` / `s <op>= …heapRead…` — the accumulator shape.
+        // `x = …` — promote `x` when the assigned value REQUIRES float: it folds
+        // in a heap read (`s = s + p.age`, an F64 field) OR a genuinely fractional
+        // literal (`vy = vy - 0.272`). Either would truncate against an `Int*`
+        // slot. A pure integer-valued tree (`a = b + 1`) leaves `x` unpromoted.
         HirExprKind::Assign { target, value } => {
             if let HirExprKind::Ident(name) = &target.kind {
-                if is_arith_self_accum(name, value) && tree_has_heap_read(value) {
+                if tree_requires_float(value) {
                     out.insert(name.clone());
                 }
             }
             walk_expr(value, out);
         }
+        // `x op= …` — same rule; `op=` desugars to `x = x op value`, so a
+        // fractional/heap-read RHS forces `x` to `Float64` (`vy -= 0.272`).
         HirExprKind::AssignOp { op, target, value } => {
             if let HirExprKind::Ident(name) = &target.kind {
-                if is_arith_op(*op) && tree_has_heap_read(value) {
+                if is_arith_op(*op) && tree_requires_float(value) {
                     out.insert(name.clone());
                 }
             }
@@ -146,35 +165,20 @@ fn walk_expr(e: &HirExpr, out: &mut HashSet<String>) {
     }
 }
 
-/// `value` is an arithmetic tree that REFERENCES `name` (the `s = s + x` shape).
-fn is_arith_self_accum(name: &str, value: &HirExpr) -> bool {
-    match &value.kind {
-        HirExprKind::Bin { op, lhs, rhs } if is_arith_op(*op) => {
-            tree_refs_ident(name, lhs) || tree_refs_ident(name, rhs)
-        }
-        _ => false,
-    }
-}
-
-fn tree_refs_ident(name: &str, e: &HirExpr) -> bool {
-    match &e.kind {
-        HirExprKind::Ident(n) => n == name,
-        HirExprKind::Bin { lhs, rhs, .. } => {
-            tree_refs_ident(name, lhs) || tree_refs_ident(name, rhs)
-        }
-        HirExprKind::Unary { operand, .. } => tree_refs_ident(name, operand),
-        _ => false,
-    }
-}
-
-/// The value tree contains a HEAP READ the front cannot prove integral (a
-/// member/index read — a `number` field is F64 at runtime). A pure literal /
-/// local-only tree stays out (int counters keep their unboxed `Int64`).
-fn tree_has_heap_read(e: &HirExpr) -> bool {
+/// The value tree REQUIRES a float slot — the front cannot prove it integral, so
+/// truncating it into an `Int*` slot would drop a fraction. True when the tree
+/// contains EITHER:
+///   - a HEAP READ (member/index — a `number` field is F64 at runtime), or
+///   - a genuinely FRACTIONAL numeric literal (`2.7`, `0.272`; a `.fract() != 0`
+///     `Number`/`Float`). Integer-valued literals (`1.0`, which swc already
+///     lowered to `Int`; or a `Number(3.0)`) do NOT force a float — a pure
+///     integer tree keeps its unboxed `Int64` fast path.
+fn tree_requires_float(e: &HirExpr) -> bool {
     match &e.kind {
         HirExprKind::Member { .. } | HirExprKind::Index { .. } => true,
-        HirExprKind::Bin { lhs, rhs, .. } => tree_has_heap_read(lhs) || tree_has_heap_read(rhs),
-        HirExprKind::Unary { operand, .. } => tree_has_heap_read(operand),
+        HirExprKind::Lit(HirLit::Number(v) | HirLit::Float(v)) => v.fract() != 0.0,
+        HirExprKind::Bin { lhs, rhs, .. } => tree_requires_float(lhs) || tree_requires_float(rhs),
+        HirExprKind::Unary { operand, .. } => tree_requires_float(operand),
         _ => false,
     }
 }

--- a/tests/cross-runtime/numeric/claude-let-float-literal-reassign.ts
+++ b/tests/cross-runtime/numeric/claude-let-float-literal-reassign.ts
@@ -1,0 +1,41 @@
+// Cross-runtime: a `let` initialized with an int-valued float literal (0.0/20.0)
+// must not truncate later fractional reassignments (issue #1869).
+
+// direct fractional reassign
+let py = 20.0;
+py = 10 + 2.7;
+console.log("py=" + py);
+
+// self-referential fractional op (sign must survive too)
+let vy = 0.0;
+vy = vy - 0.272;
+console.log("vy=" + vy);
+
+// compound assignment with a fractional literal
+let acc = 0.0;
+acc += 0.5;
+acc -= 0.1;
+console.log("acc=" + acc);
+
+// annotated control
+let ok: number = 20.0;
+ok = 10 + 2.7;
+console.log("ok=" + ok);
+
+// non-integer initializer (Float from the start)
+let yaw = 0.7;
+yaw = yaw + 0.05;
+console.log("yaw=" + yaw);
+
+// integer-only loop must STAY integer (no regression to the fast path):
+// only integer-valued literals are ever assigned, so no float promotion.
+let a = 0.0;
+let b = 1.0;
+let i = 0.0;
+while (i < 10.0) {
+  let t = a + b;
+  a = b;
+  b = t;
+  i = i + 1.0;
+}
+console.log("fib=" + a);


### PR DESCRIPTION
Fixes #1869.

## Problem

A `let` initialized with an integer-valued float literal (`let vy = 0.0;`, `let py = 20.0;`) was classified with an **`Int64`** repr. swc lowers `0.0`/`20.0` (no fractional part) to an integer literal, so `rts-hir::lower::lower_lit` types the binding `I64`. A later fractional reassignment (`vy = vy - 0.272;`) was then coerced back to int via `fcvt_to_sint_sat`, **silently truncating** the fraction:

```ts
let py = 20.0;  py = 10 + 2.7;   // printed 12   (expected 12.7)
let vy = 0.0;   vy = vy - 0.272; // printed 0    (expected -0.272; sign lost too)
```

Silent-wrong-value with no error anywhere (found while building a game — physics velocity stayed `0` forever).

## Fix

The `floatscan` pre-scan already promoted a local to `Float64` when it was the target of a heap-read self-accumulation (`s = s + p.age`). This broadens it: promote on **any** assignment (`=` / `op=`) whose value tree **requires float** — it contains a heap read (existing) **OR** a genuinely fractional numeric literal (`.fract() != 0`).

Per design Pilar 2, JS `number` is one f64 type, so widening an int-inferred local to `Float64` is always semantically sound; only reprs that would have been `Int*` are widened (string/object/Tagged bindings untouched).

Change is contained to one file (`crates/rts-codegen-new/src/front/run/floatscan.rs`), reusing the existing pre-scan mechanism.

## No regression to the integer fast path

A Fibonacci-style loop that only ever assigns **integer-valued** literals (`a = a + 1.0`) contains no fractional literal, so it is **not** promoted and keeps its native unboxed `Int64` lowering. The `fib_loop_int64` lib test stays green.

## Verification

- Exact issue repro fixed: `py=12.7`, `vy=-0.272`, `ok=12.7`, `yaw=0.75`.
- New cross-runtime fixture `tests/cross-runtime/numeric/claude-let-float-literal-reassign.ts` — output identical across **rts / bun / node**.
- Full cross-runtime suite: **456/609, 0 regressions** (no fixture went pass → fail).
- Lib tests: `front::tests` (incl. `fib_loop_int64`), `precision`, `poly`, `loops`, `number_class`, `toprimitive`, `template` — all pass.
- `read_before_commit.sh` gate: no hard violation; no warnings from the change.

## Follow-up (out of scope, filed separately)

A sibling bug: a **function return** truncates a float when the return type was inferred `i64` from an int-valued-float-initialized local (`function f(): number { let s = 0.0; s = s + 1.5; return s; }` returns `1`, not `1.5`). That is return-type inference, not local promotion — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)