### PR TITLE
fix(engine): cross-runtime syntax/scoping cluster (6 fixtures)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/breakcont.rs
+++ b/crates/rts-codegen-new/src/front/run/breakcont.rs
@@ -1,0 +1,168 @@
+//! `break` / `continue` lowering, including the FINALIZER-running on an abrupt
+//! loop exit (split out of [`super::loops`] to keep it under the <500-line rule).
+//!
+//! A `break`/`continue` that ESCAPES a `try/finally` between it and its target
+//! loop must run every escaped `finally` first (innermost-first) — JS runs
+//! `finally` on abrupt loop completion too. Each loop's `LoopCtx` records the
+//! `finally_stack` depth at its entry (`finally_depth`); the jump runs every
+//! finalizer pushed after that depth.
+
+use cranelift_codegen::ir::InstBuilder;
+use cranelift_module::Module;
+
+use rts_hir::HirStmt;
+
+use crate::front::error::FrontResult;
+
+use super::lower::Lowerer;
+
+/// Whether a labeled statement's body is a construct that CONSUMES the pending
+/// label into its own `LoopCtx` (a loop or a switch — `break`/`continue label`
+/// targets). A body that does NOT consume the label (a block, an `if`, any other
+/// statement) is a `break`-only label target handled by [`Lowerer::lower_labeled_block`].
+pub(super) fn stmt_consumes_label(s: &HirStmt) -> bool {
+    matches!(
+        s,
+        HirStmt::For { .. }
+            | HirStmt::ForOf { .. }
+            | HirStmt::ForIn { .. }
+            | HirStmt::While { .. }
+            | HirStmt::DoWhile { .. }
+            | HirStmt::Switch { .. }
+    )
+}
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// Lower a labeled NON-loop statement (`label: { … break label; … }`). This is
+    /// a valid JS `break`-only target: `break label` jumps PAST the labeled
+    /// statement. Give it its own `LoopCtx` (exit = a fresh continuation block;
+    /// `continue_target` reuses `exit` — a `continue label` into a non-loop is a
+    /// syntax error tsc rejects, never reached). Both the natural end of the body
+    /// and every `break label` land at the continuation block.
+    pub(super) fn lower_labeled_block(
+        &mut self,
+        module: &mut dyn Module,
+        label: &str,
+        body: &HirStmt,
+    ) -> FrontResult<()> {
+        let exit_block = self.builder.create_block();
+        self.loop_stack.push(super::lower::LoopCtx {
+            exit: exit_block,
+            continue_target: exit_block,
+            label: Some(label.to_string()),
+            finally_depth: self.finally_stack.len(),
+        });
+        let r = self.lower_stmt(module, body);
+        self.loop_stack.pop();
+        r?;
+        if !self.block_terminated {
+            self.builder.ins().jump(exit_block, &[]);
+        }
+        self.builder.seal_block(exit_block);
+        self.builder.switch_to_block(exit_block);
+        self.block_terminated = false;
+        Ok(())
+    }
+
+    /// `break` — jump to a loop's exit. Unlabeled → the innermost loop/switch; a
+    /// `break label` → the enclosing loop carrying that label (searched outward).
+    /// A `break` outside any loop, or an unknown label, BAILS. Every `finally` the
+    /// jump ESCAPES (pushed after the target loop's `finally_depth`) runs first,
+    /// innermost-first — JS runs `finally` on an abrupt loop exit.
+    pub(super) fn lower_break(
+        &mut self,
+        module: &mut dyn Module,
+        label: Option<&str>,
+    ) -> FrontResult<()> {
+        let ctx = match label {
+            Some(l) => self
+                .loop_stack
+                .iter()
+                .rev()
+                .find(|c| c.label.as_deref() == Some(l))
+                .cloned()
+                .ok_or_else(|| {
+                    crate::front::error::Unsupported::new(format!(
+                        "`break {l}`: no enclosing loop labeled `{l}`"
+                    ))
+                })?,
+            None => self
+                .loop_stack
+                .last()
+                .cloned()
+                .ok_or_else(|| crate::front::error::Unsupported::new("`break` outside a loop"))?,
+        };
+        self.run_escaping_finalizers(module, ctx.finally_depth)?;
+        if self.block_terminated {
+            // A finalizer's own `return`/`throw` overrode the break — done.
+            return Ok(());
+        }
+        self.builder.ins().jump(ctx.exit, &[]);
+        self.block_terminated = true;
+        Ok(())
+    }
+
+    /// `continue` — jump to a loop's continue target (header / update / advance).
+    /// Unlabeled → the innermost loop; a `continue label` → the enclosing loop with
+    /// that label. A `continue` outside any loop, or an unknown label, BAILS. As
+    /// with `break`, every escaped `finally` runs first.
+    pub(super) fn lower_continue(
+        &mut self,
+        module: &mut dyn Module,
+        label: Option<&str>,
+    ) -> FrontResult<()> {
+        let ctx = match label {
+            Some(l) => self
+                .loop_stack
+                .iter()
+                .rev()
+                .find(|c| c.label.as_deref() == Some(l))
+                .cloned()
+                .ok_or_else(|| {
+                    crate::front::error::Unsupported::new(format!(
+                        "`continue {l}`: no enclosing loop labeled `{l}`"
+                    ))
+                })?,
+            None => self.loop_stack.last().cloned().ok_or_else(|| {
+                crate::front::error::Unsupported::new("`continue` outside a loop")
+            })?,
+        };
+        self.run_escaping_finalizers(module, ctx.finally_depth)?;
+        if self.block_terminated {
+            return Ok(());
+        }
+        self.builder.ins().jump(ctx.continue_target, &[]);
+        self.block_terminated = true;
+        Ok(())
+    }
+
+    /// Run every `finally` block pushed AFTER `keep_depth` (the finalizers a
+    /// `break`/`continue` escapes on its way out of a loop), innermost-first,
+    /// leaving `finally_stack` unchanged for the enclosing lowering. Each finalizer
+    /// runs with a cleared error slot (save/restore), exactly like the
+    /// return-edge finalizers in `lower_return`. If one terminates the block (its
+    /// own `return`/`throw`), it OVERRIDES the abrupt completion — the caller sees
+    /// `block_terminated` and stops.
+    fn run_escaping_finalizers(
+        &mut self,
+        module: &mut dyn Module,
+        keep_depth: usize,
+    ) -> FrontResult<()> {
+        if self.finally_stack.len() <= keep_depth {
+            return Ok(());
+        }
+        let saved = std::mem::take(&mut self.finally_stack);
+        for i in (keep_depth..saved.len()).rev() {
+            // Only the finalizers OUTER to `i` stay active while `i` lowers, so a
+            // `return`/`break` inside it runs them but not itself.
+            self.finally_stack = saved[..i].to_vec();
+            self.lower_block(module, &saved[i])?;
+            if self.block_terminated {
+                self.finally_stack = saved;
+                return Ok(());
+            }
+        }
+        self.finally_stack = saved;
+        Ok(())
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/desugar/destructure/builders.rs
+++ b/crates/rts-codegen-new/src/front/run/desugar/destructure/builders.rs
@@ -55,6 +55,43 @@ pub(super) fn prop_get(obj: HirExpr, prop: &str) -> HirExpr {
     )
 }
 
+/// `obj[keyExpr]` — a COMPUTED property read for a destructuring computed key
+/// (`{ [k]: v } = src` → `const v = src[k]`). The key expression is lowered once by
+/// the caller (rts-hir) and passed in; the generic `Index` node routes to
+/// `__rtsadp_idx_get` at runtime (object key / array element), yielding `undefined`
+/// for a missing key — exactly the JS computed-property-read semantics.
+pub(super) fn index_get(obj: HirExpr, key: HirExpr) -> HirExpr {
+    HirExpr::new(
+        HirExprKind::Index {
+            object: Box::new(obj),
+            index: Box::new(key),
+        },
+        HirType::Any,
+    )
+}
+
+/// `delete obj[keyExpr];` — remove one own property named by a COMPUTED key (used
+/// to subtract a computed-key destructure target from an object-rest copy). Lowers
+/// to `__rtsadp_obj_delete` after ToString'ing the key (the engine's `lower_delete`
+/// handles the `Index` operand form).
+pub(super) fn delete_index_stmt(obj: &str, key: HirExpr) -> HirStmt {
+    let index = HirExpr::new(
+        HirExprKind::Index {
+            object: Box::new(ident(obj)),
+            index: Box::new(key),
+        },
+        HirType::Any,
+    );
+    let del = HirExpr::new(
+        HirExprKind::Unary {
+            op: HirUnOp::Delete,
+            operand: Box::new(index),
+        },
+        HirType::Any,
+    );
+    HirStmt::Expr(del)
+}
+
 /// `recv.slice(from, BIG)` — the real array slice (a fresh array) used for a rest
 /// element `...rest`. The explicit large end bound (`i32::MAX`, clamped to length by
 /// both the static `__rtsadp_arr_slice` and the dynamic `__rtsadp_dyn_slice`) lets

--- a/crates/rts-codegen-new/src/front/run/desugar/destructure/pat.rs
+++ b/crates/rts-codegen-new/src/front/run/desugar/destructure/pat.rs
@@ -5,23 +5,25 @@
 //! accesses against), and produces one `const` binding per leaf identifier reading
 //! the corresponding element (array) / property (object) off the source.
 //!
+//! A NESTED pattern element/property (`[[a], b]`, `{a: {b}}`) binds the
+//! intermediate read to a fresh temp and re-expands off it (element/property reads
+//! do not need a statically-proven shape). An OBJECT rest `{a, ...rest}` copies the
+//! source (`Object.assign({}, src)`) and `delete`s each named key. A COMPUTED
+//! object key `{[k]: v}` reads `src[k]` (and subtracts `delete rest[k]` from a
+//! rest) when `k` is a MODELED expression.
+//!
 //! Returns `None` (a total bail — the caller keeps the original statement, which
-//! itself bails at lowering) for any form outside the modeled subset:
-//! - a NESTED pattern element/property (`[[a], b]`, `{a: {b}}`): the intermediate
-//!   element read yields a shapeless `Tagged` value, so a further destructure off it
-//!   cannot resolve a static shape — bailing is sound (never a wrong value);
-//! - an OBJECT rest `{a, ...rest}` (needs a new object of the remaining keys — the
-//!   shape-minus-a transition is a later increment);
-//! - a COMPUTED object key `{[k]: v}` (the runtime-key read path is a later
-//!   increment);
+//! itself bails at lowering) only for a form still outside the modeled subset:
+//! - a non-identifier object-rest target (`{...{}}` — JS forbids it anyway);
+//! - a computed key whose expression is not fully modeled (a `Raw`/`Arrow`/`Await`);
 //! - an array rest that is not the LAST element (JS forbids it anyway).
 
 use rts_hir::HirStmt;
 
 use super::Gen;
 use super::builders::{
-    const_bind, default_ternary, delete_member_stmt, elem_at, ident, obj_assign_copy, prop_get,
-    slice_from,
+    const_bind, default_ternary, delete_index_stmt, delete_member_stmt, elem_at, ident, index_get,
+    obj_assign_copy, prop_get, slice_from,
 };
 
 /// Expand a binding `Pat` reading off source local `src`. The single recursion
@@ -114,49 +116,85 @@ pub(super) fn expand_array(
     Some(out)
 }
 
-/// Expand an OBJECT pattern `{a, b: c, d = 5}` reading off source local `src`.
-/// Returns `None` for a rest property or a computed key; a nested value pattern is
-/// bound to a temp and recursed.
+/// A property key the pattern pulled out — subtracted from a trailing `...rest`
+/// shallow copy. A STATIC key deletes by name (`delete rest.k`); a COMPUTED key
+/// `{ [expr]: v }` deletes by the SAME re-lowered key expression (`delete
+/// rest[expr]`). (A computed key expr is proven side-effect-free by
+/// `rebuild_default`'s modeled gate below, so re-evaluating it in the delete is
+/// observationally identical to the single JS evaluation.)
+enum RemovedKey {
+    Static(String),
+    Computed(rts_hir::HirExpr),
+}
+
+/// Expand an OBJECT pattern `{a, b: c, d = 5, [k]: v, ...rest}` reading off source
+/// local `src`. Returns `None` only for a non-ident rest target or an unmodeled
+/// computed-key expression; a nested value pattern is bound to a temp and recursed.
 pub(super) fn expand_object(
     src: &str,
     pat: &swc_ecma_ast::ObjectPat,
     g: &mut Gen,
 ) -> Option<Vec<HirStmt>> {
     let mut out = Vec::new();
-    // Static keys named explicitly — subtracted from a trailing `...rest` copy.
-    let mut named_keys: Vec<String> = Vec::new();
+    // Keys named explicitly — subtracted from a trailing `...rest` copy.
+    let mut named_keys: Vec<RemovedKey> = Vec::new();
     for prop in &pat.props {
         match prop {
             // `{ a, b, ...rest }` — JS-guaranteed LAST. Bind `rest` to a shallow copy
             // of the source (`Object.assign({}, src)`) minus every explicitly-named
-            // key (`delete rest.<key>` each). A non-ident rest target bails (JS forbids
-            // it anyway). A computed/nested key earlier would have bailed at its own
-            // arm (so `named_keys` covers every property already pulled out).
+            // key (`delete rest.<key>` / `delete rest[expr]` each). A non-ident rest
+            // target bails (JS forbids it anyway).
             swc_ecma_ast::ObjectPatProp::Rest(rest) => {
                 let name = leaf_name(&rest.arg)?;
                 out.push(const_bind(&name, obj_assign_copy(src)));
                 for key in &named_keys {
-                    out.push(delete_member_stmt(&name, key));
+                    match key {
+                        RemovedKey::Static(k) => out.push(delete_member_stmt(&name, k)),
+                        RemovedKey::Computed(e) => {
+                            out.push(delete_index_stmt(&name, e.clone()))
+                        }
+                    }
                 }
             }
-            // `{ key: value_pat }` — including `{ a: b }` rename. The VALUE pat may be
-            // a plain ident, `ident = default`, or a nested pattern (temp + recurse).
+            // `{ key: value_pat }` — including `{ a: b }` rename and `{ [k]: v }`
+            // computed key. The VALUE pat may be a plain ident, `ident = default`, or
+            // a nested pattern (temp + recurse).
             swc_ecma_ast::ObjectPatProp::KeyValue(kv) => {
-                let key = static_key(&kv.key)?;
-                named_keys.push(key.clone());
+                // A COMPUTED key `[expr]` reads `src[expr]`; a static key reads
+                // `src.k`. Track the removed key in the right form for `...rest`.
+                let (access_of, removed): (Box<dyn Fn() -> rts_hir::HirExpr>, RemovedKey) =
+                    match computed_key(&kv.key) {
+                        Some(key_expr) => {
+                            let ke = key_expr.clone();
+                            let s = src.to_string();
+                            (
+                                Box::new(move || index_get(ident(&s), ke.clone())),
+                                RemovedKey::Computed(key_expr),
+                            )
+                        }
+                        None => {
+                            let key = static_key(&kv.key)?;
+                            let s = src.to_string();
+                            let k = key.clone();
+                            (
+                                Box::new(move || prop_get(ident(&s), &k)),
+                                RemovedKey::Static(key),
+                            )
+                        }
+                    };
+                named_keys.push(removed);
                 match kv.value.as_ref() {
                     swc_ecma_ast::Pat::Ident(id) => {
                         let name = id.id.sym.to_string();
-                        out.push(const_bind(&name, prop_get(ident(src), &key)));
+                        out.push(const_bind(&name, access_of()));
                     }
                     swc_ecma_ast::Pat::Assign(assign) => {
                         let default = rebuild_default(&assign.right)?;
-                        let access = prop_get(ident(src), &key);
-                        let value = default_ternary(access, default);
+                        let value = default_ternary(access_of(), default);
                         expand_assign_target(&assign.left, value, g, &mut out)?;
                     }
                     nested @ (swc_ecma_ast::Pat::Array(_) | swc_ecma_ast::Pat::Object(_)) => {
-                        expand_nested(prop_get(ident(src), &key), nested, g, &mut out)?;
+                        expand_nested(access_of(), nested, g, &mut out)?;
                     }
                     _ => return None,
                 }
@@ -164,7 +202,7 @@ pub(super) fn expand_object(
             // `{ a }` shorthand, or `{ a = 5 }` shorthand-with-default.
             swc_ecma_ast::ObjectPatProp::Assign(a) => {
                 let name = a.key.sym.to_string();
-                named_keys.push(name.clone());
+                named_keys.push(RemovedKey::Static(name.clone()));
                 let access = prop_get(ident(src), &name);
                 match &a.value {
                     Some(default_expr) => {
@@ -188,15 +226,28 @@ fn leaf_name(pat: &swc_ecma_ast::Pat) -> Option<String> {
     }
 }
 
-/// A STATIC object-pattern key (`a`, `"a"`, `0`). A computed key `[k]` bails.
+/// A STATIC object-pattern key (`a`, `"a"`, `0`). A computed key `[k]` yields
+/// `None` here (handled by [`computed_key`]).
 fn static_key(key: &swc_ecma_ast::PropName) -> Option<String> {
     match key {
         swc_ecma_ast::PropName::Ident(id) => Some(id.sym.to_string()),
         swc_ecma_ast::PropName::Str(s) => Some(s.value.to_string_lossy().into_owned()),
         swc_ecma_ast::PropName::Num(n) => Some(format!("{}", n.value)),
-        // Computed / BigInt keys need the runtime-key path → bail.
+        // Computed / BigInt keys are not static names.
         _ => None,
     }
+}
+
+/// A COMPUTED object-pattern key `{ [expr]: v }` → the re-lowered HIR of `expr`,
+/// used for BOTH the property read (`src[expr]`) and the `...rest` subtraction
+/// (`delete rest[expr]`). Accepts only a fully MODELED key expression (same gate as
+/// a default RHS — no `Raw`/`Arrow`/`Await`), so an unmodeled key bails the whole
+/// pattern (never a silently wrong binding). `None` for a non-computed key.
+fn computed_key(key: &swc_ecma_ast::PropName) -> Option<rts_hir::HirExpr> {
+    let swc_ecma_ast::PropName::Computed(c) = key else {
+        return None;
+    };
+    rebuild_default(&c.expr)
 }
 
 /// Lower a default expression (the RHS of `= default`) to HIR via rts-hir's real

--- a/crates/rts-codegen-new/src/front/run/fnhoist.rs
+++ b/crates/rts-codegen-new/src/front/run/fnhoist.rs
@@ -1,0 +1,65 @@
+//! Function-DECLARATION hoisting — a pre-pass over a function/module body.
+//!
+//! JS hoists a `function f(){…}` DECLARATION fully — both the NAME and its
+//! VALUE — to the top of the enclosing scope, so a call `f()` textually BEFORE
+//! the declaration resolves. This differs from `var` hoisting (name only,
+//! value `undefined` until the assignment) and from `const f = () => …` /
+//! `const f = function g(){}` (a plain binding, NOT hoisted).
+//!
+//! rts-hir lowers a nested `function f(){…}` declaration to
+//! `HirStmt::Let { name: f, init: Arrow { self_name: Some(f), … } }` (see
+//! `lower_decl`'s `Decl::Fn` arm) — the marker `self_name == name` identifies a
+//! DECLARATION (a named fn-EXPRESSION assigned to a `const`/`let` lowers to a
+//! `Const`, or to a `Let` whose `self_name != name`). This pass moves every such
+//! direct-body statement to the FRONT of the body, preserving their relative
+//! order, so the value is bound before any earlier statement runs.
+//!
+//! Scope: only DIRECT body statements are hoisted (a function declared inside a
+//! nested `{ }` block is block-scoped in a strict/module context — TS is always
+//! strict — so it must NOT leak to the function top). Nested fn/arrow bodies are
+//! separate `HirFunc`s handled on their own.
+
+use rts_hir::ir::{HirExprKind, HirStmt};
+
+/// Whether `s` is a direct function DECLARATION (`function f(){…}`), identified
+/// by the `self_name == name` marker rts-hir stamps on the lowered arrow.
+fn is_fn_decl(s: &HirStmt) -> bool {
+    if let HirStmt::Let {
+        name,
+        init: Some(init),
+        ..
+    } = s
+    {
+        if let HirExprKind::Arrow {
+            self_name: Some(sn),
+            ..
+        } = &init.kind
+        {
+            return sn == name;
+        }
+    }
+    false
+}
+
+/// Move every direct function-declaration statement in `body` to the FRONT,
+/// preserving the relative order of both the declarations and the remaining
+/// statements (a stable partition). A no-op when the body has no declarations or
+/// they are already all leading.
+pub(crate) fn hoist_fn_decls(body: &mut Vec<HirStmt>) {
+    if !body.iter().any(is_fn_decl) {
+        return;
+    }
+    // Stable partition: declarations first (in source order), then the rest.
+    let taken = std::mem::take(body);
+    let mut decls = Vec::new();
+    let mut rest = Vec::new();
+    for s in taken {
+        if is_fn_decl(&s) {
+            decls.push(s);
+        } else {
+            rest.push(s);
+        }
+    }
+    decls.extend(rest);
+    *body = decls;
+}

--- a/crates/rts-codegen-new/src/front/run/fnhoist.rs
+++ b/crates/rts-codegen-new/src/front/run/fnhoist.rs
@@ -10,20 +10,30 @@
 //! `HirStmt::Let { name: f, init: Arrow { self_name: Some(f), … } }` (see
 //! `lower_decl`'s `Decl::Fn` arm) — the marker `self_name == name` identifies a
 //! DECLARATION (a named fn-EXPRESSION assigned to a `const`/`let` lowers to a
-//! `Const`, or to a `Let` whose `self_name != name`). This pass moves every such
-//! direct-body statement to the FRONT of the body, preserving their relative
-//! order, so the value is bound before any earlier statement runs.
+//! `Const`, or to a `Let` whose `self_name != name`).
 //!
-//! Scope: only DIRECT body statements are hoisted (a function declared inside a
-//! nested `{ }` block is block-scoped in a strict/module context — TS is always
-//! strict — so it must NOT leak to the function top). Nested fn/arrow bodies are
-//! separate `HirFunc`s handled on their own.
+//! ## Only FORWARD references are hoisted, and only as far as needed
+//! Moving every declaration to the very top would place it BEFORE a `let`/`const`
+//! it captures (the arrow-extraction then sees an undeclared capture and bails).
+//! So this pass hoists a declaration ONLY when it is referenced by a statement
+//! that comes BEFORE it, and moves it to just BEFORE that first referencing
+//! statement — never earlier. In a VALID program every variable the function
+//! captures is already declared before that first use (reaching it earlier would
+//! be a TDZ error), so the moved declaration never jumps ahead of a live capture.
+//! A declaration with no forward reference is left exactly where it was — the
+//! common `function f(){…}; … f()` case is untouched.
+//!
+//! Scope: only DIRECT body statements are considered (a function declared inside
+//! a nested `{ }` block is block-scoped in a strict/module context — TS is always
+//! strict). Nested fn/arrow bodies are separate `HirFunc`s handled on their own.
 
+use rts_hir::HirExpr;
 use rts_hir::ir::{HirExprKind, HirStmt};
 
-/// Whether `s` is a direct function DECLARATION (`function f(){…}`), identified
-/// by the `self_name == name` marker rts-hir stamps on the lowered arrow.
-fn is_fn_decl(s: &HirStmt) -> bool {
+/// The declaration NAME of a direct function DECLARATION (`function f(){…}`),
+/// identified by the `self_name == name` marker rts-hir stamps on the lowered
+/// arrow. `None` for any other statement (incl. `const f = () => …`).
+fn fn_decl_name(s: &HirStmt) -> Option<&str> {
     if let HirStmt::Let {
         name,
         init: Some(init),
@@ -35,31 +45,196 @@ fn is_fn_decl(s: &HirStmt) -> bool {
             ..
         } = &init.kind
         {
-            return sn == name;
+            if sn == name {
+                return Some(name);
+            }
         }
     }
-    false
+    None
 }
 
-/// Move every direct function-declaration statement in `body` to the FRONT,
-/// preserving the relative order of both the declarations and the remaining
-/// statements (a stable partition). A no-op when the body has no declarations or
-/// they are already all leading.
+/// Hoist each FORWARD-referenced function declaration to just before its first
+/// referencing statement. Leaves every other statement (incl. declarations used
+/// only after their line) exactly in place.
 pub(crate) fn hoist_fn_decls(body: &mut Vec<HirStmt>) {
-    if !body.iter().any(is_fn_decl) {
+    // Positions of the direct fn declarations, by name.
+    let decls: Vec<(usize, String)> = body
+        .iter()
+        .enumerate()
+        .filter_map(|(i, s)| fn_decl_name(s).map(|n| (i, n.to_string())))
+        .collect();
+    if decls.is_empty() {
         return;
     }
-    // Stable partition: declarations first (in source order), then the rest.
+
+    // For each declaration, the FIRST statement index that references its name.
+    // A declaration whose first reference is BEFORE it must be hoisted to that
+    // index; one referenced only after its line (or not at all) stays put
+    // (`target == None`). Reference scan ignores the declaration's OWN statement
+    // (self-recursion is not a forward reference).
+    let hoist_target: Vec<Option<usize>> = decls
+        .iter()
+        .map(|(decl_i, name)| {
+            (0..*decl_i)
+                .find(|&j| stmt_references(&body[j], name))
+                .filter(|&first| first < *decl_i)
+        })
+        .collect();
+    if hoist_target.iter().all(Option::is_none) {
+        return;
+    }
+
+    // Rebuild the body in one pass: at each position, emit every to-be-hoisted
+    // declaration whose target is this position (in declaration source order),
+    // then the position's own statement UNLESS it is a declaration already
+    // hoisted here. A stable, index-shift-free reconstruction.
+    let decl_at: std::collections::HashMap<usize, usize> = decls
+        .iter()
+        .enumerate()
+        .map(|(k, (i, _))| (*i, k))
+        .collect();
+    let mut out: Vec<HirStmt> = Vec::with_capacity(body.len());
     let taken = std::mem::take(body);
-    let mut decls = Vec::new();
-    let mut rest = Vec::new();
-    for s in taken {
-        if is_fn_decl(&s) {
-            decls.push(s);
-        } else {
-            rest.push(s);
+    // Move the declarations out so we can re-place them; keep others in `slots`.
+    let mut slots: Vec<Option<HirStmt>> = taken.into_iter().map(Some).collect();
+    for pos in 0..slots.len() {
+        // Emit any hoisted declaration targeted at `pos`, in source order.
+        for (k, (decl_i, _)) in decls.iter().enumerate() {
+            if hoist_target[k] == Some(pos) {
+                if let Some(stmt) = slots[*decl_i].take() {
+                    out.push(stmt);
+                }
+            }
+        }
+        // Emit this position's own statement unless it was a hoisted declaration
+        // already emitted above.
+        let is_hoisted_decl = decl_at
+            .get(&pos)
+            .is_some_and(|&k| hoist_target[k].is_some());
+        if !is_hoisted_decl {
+            if let Some(stmt) = slots[pos].take() {
+                out.push(stmt);
+            }
         }
     }
-    decls.extend(rest);
-    *body = decls;
+    *body = out;
+}
+
+/// Whether statement `s` references the identifier `name` anywhere in its
+/// expressions or nested statement bodies (NOT descending into a nested fn/arrow
+/// body — that is a separate scope whose free `name` is resolved as a capture, not
+/// a same-body reference that would force a hoist).
+fn stmt_references(s: &HirStmt, name: &str) -> bool {
+    match s {
+        HirStmt::Expr(e) | HirStmt::Throw(e) => expr_references(e, name),
+        HirStmt::Return(Some(e)) => expr_references(e, name),
+        HirStmt::Return(None) | HirStmt::Break(_) | HirStmt::Continue(_) | HirStmt::Raw(_) => false,
+        HirStmt::Let { init, .. } => init.as_ref().is_some_and(|e| expr_references(e, name)),
+        HirStmt::Const { init, .. } => expr_references(init, name),
+        HirStmt::If { cond, then, else_ } => {
+            expr_references(cond, name)
+                || then.iter().any(|s| stmt_references(s, name))
+                || else_
+                    .as_ref()
+                    .is_some_and(|e| e.iter().any(|s| stmt_references(s, name)))
+        }
+        HirStmt::While { cond, body } | HirStmt::DoWhile { body, cond } => {
+            expr_references(cond, name) || body.iter().any(|s| stmt_references(s, name))
+        }
+        HirStmt::For {
+            init,
+            cond,
+            update,
+            body,
+        } => {
+            init.as_ref().is_some_and(|s| stmt_references(s, name))
+                || cond.as_ref().is_some_and(|e| expr_references(e, name))
+                || update.as_ref().is_some_and(|e| expr_references(e, name))
+                || body.iter().any(|s| stmt_references(s, name))
+        }
+        HirStmt::ForOf { iterable, body, .. } => {
+            expr_references(iterable, name) || body.iter().any(|s| stmt_references(s, name))
+        }
+        HirStmt::ForIn { object, body, .. } => {
+            expr_references(object, name) || body.iter().any(|s| stmt_references(s, name))
+        }
+        HirStmt::Block(b) => b.iter().any(|s| stmt_references(s, name)),
+        HirStmt::Labeled { body, .. } => stmt_references(body, name),
+        HirStmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            body.iter().any(|s| stmt_references(s, name))
+                || catch
+                    .as_ref()
+                    .is_some_and(|c| c.body.iter().any(|s| stmt_references(s, name)))
+                || finally
+                    .as_ref()
+                    .is_some_and(|f| f.iter().any(|s| stmt_references(s, name)))
+        }
+        HirStmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            expr_references(discriminant, name)
+                || cases.iter().any(|c| {
+                    c.test.as_ref().is_some_and(|e| expr_references(e, name))
+                        || c.body.iter().any(|s| stmt_references(s, name))
+                })
+        }
+    }
+}
+
+/// Whether expression `e` references the identifier `name`. Descends into every
+/// sub-expression BUT NOT into a nested `Arrow` body (a separate scope). A bare
+/// `Ident(name)` — a call target, an argument, an operand — counts.
+fn expr_references(e: &HirExpr, name: &str) -> bool {
+    use HirExprKind::*;
+    match &e.kind {
+        Ident(n) => n == name,
+        Lit(_) | Raw(_) => false,
+        // A nested arrow/fn body is a separate scope — do not descend (a free
+        // `name` there is a capture, resolved once the value is bound, not a
+        // same-body forward reference).
+        Arrow { .. } => false,
+        Bin { lhs, rhs, .. }
+        | Index {
+            object: lhs,
+            index: rhs,
+        }
+        | Assign {
+            target: lhs,
+            value: rhs,
+        }
+        | AssignOp {
+            target: lhs,
+            value: rhs,
+            ..
+        } => expr_references(lhs, name) || expr_references(rhs, name),
+        Unary { operand, .. }
+        | Cast { expr: operand, .. }
+        | Member { object: operand, .. }
+        | Spread(operand)
+        | PreInc(operand)
+        | PreDec(operand)
+        | PostInc(operand)
+        | PostDec(operand)
+        | Await(operand) => expr_references(operand, name),
+        Call { callee, args } => {
+            expr_references(callee, name) || args.iter().any(|a| expr_references(a, name))
+        }
+        MethodCall { object, args, .. } => {
+            expr_references(object, name) || args.iter().any(|a| expr_references(a, name))
+        }
+        New { args, .. } => args.iter().any(|a| expr_references(a, name)),
+        Array(els) => els.iter().any(|a| expr_references(a, name)),
+        Object(fields) => fields.iter().any(|(_, v)| expr_references(v, name)),
+        Ternary { cond, then, else_ } => {
+            expr_references(cond, name)
+                || expr_references(then, name)
+                || expr_references(else_, name)
+        }
+        Seq(es) => es.iter().any(|e| expr_references(e, name)),
+    }
 }

--- a/crates/rts-codegen-new/src/front/run/globals.rs
+++ b/crates/rts-codegen-new/src/front/run/globals.rs
@@ -298,20 +298,35 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// single-numeric-arg form is supported; `Array(a, b, …)` (an element list) is
     /// `Array.of`-shaped and BAILS here (a later increment). Result kind Array.
     fn array_ctor_call(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Val> {
-        // `Array(a, b, …)` / `Array()` — the element-list form (JS: 0 or 2+ args
-        // never mean a size): lower exactly like the array literal `[a, b, …]`.
-        if args.len() != 1 {
-            let arr_expr = HirExpr::new(
-                HirExprKind::Array(args.to_vec()),
-                rts_hir::HirType::Unknown,
-            );
-            return self.lower_expr(module, &arr_expr);
+        // A single SPREAD of a LITERAL array (`new Array(...[1,2,3])`) is
+        // statically the argument list `[1,2,3]` — re-dispatch on those real args
+        // so JS's own arity rule applies: `Array(...[10])` becomes `Array(10)` (a
+        // SIZED array of 10 holes, NOT `[10]`), `Array(...[1,2,3])` an element
+        // list, `Array(...[])` empty. Only a literal source can be expanded at
+        // lowering time; a runtime spread (`Array(...someVar)`) stays a bail.
+        if args.len() == 1 {
+            if let HirExprKind::Spread(inner) = &args[0].kind {
+                if let HirExprKind::Array(elems) = &inner.kind {
+                    // A hole inside the literal (`[, 1]`) would change the argument
+                    // count in a way the flat element-list re-dispatch cannot model
+                    // (`Array(undefined, 1)`); only expand a hole-free literal.
+                    if elems.iter().all(|e| !matches!(e.kind, HirExprKind::Spread(_))) {
+                        let expanded = elems.clone();
+                        return self.array_ctor_call(module, &expanded);
+                    }
+                }
+            }
         }
-        // `Array(...arr)` (spread, flattened to a single array arg by the HIR) is
-        // NOT the sized form — bail rather than treat the array's `length` coercion
-        // as `n`.
-        if self.is_array_valued(&args[0]) {
-            return unsupported!("Array(...spread) — a spread argument is a later increment");
+        // The ELEMENT-LIST form (lower exactly like the array literal `[a, b, …]`):
+        // 0 or 2+ args (JS: never a size); any remaining non-literal SPREAD; or a
+        // single bare array value `Array(arr)` (the JS single-element form `[arr]`,
+        // NOT a size). Only a single NON-array, NON-spread scalar falls through to
+        // the sized `Array(n)` path below.
+        let has_spread = args.iter().any(|a| matches!(a.kind, HirExprKind::Spread(_)));
+        if has_spread || args.len() != 1 || self.is_array_valued(&args[0]) {
+            let arr_expr =
+                HirExpr::new(HirExprKind::Array(args.to_vec()), rts_hir::HirType::Unknown);
+            return self.lower_expr(module, &arr_expr);
         }
         let n = self.lower_expr(module, &args[0])?;
         let n_word = self.box_value(n);

--- a/crates/rts-codegen-new/src/front/run/loops.rs
+++ b/crates/rts-codegen-new/src/front/run/loops.rs
@@ -85,6 +85,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: exit_block,
             continue_target: update_block,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         self.lower_block(module, body)?;
         self.loop_stack.pop();
@@ -258,6 +259,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: break_block,
             continue_target: header,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         self.lower_block(module, body)?;
         self.loop_stack.pop();
@@ -503,6 +505,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: exit_block,
             continue_target: advance_block,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         self.lower_block(module, body)?;
         self.loop_stack.pop();
@@ -527,55 +530,4 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(())
     }
 
-    /// `break` — jump to a loop's exit. Unlabeled → the innermost loop/switch; a
-    /// `break label` → the enclosing loop carrying that label (searched outward).
-    /// A `break` outside any loop, or an unknown label, BAILS.
-    pub(super) fn lower_break(&mut self, label: Option<&str>) -> FrontResult<()> {
-        let exit = match label {
-            Some(l) => self
-                .loop_stack
-                .iter()
-                .rev()
-                .find(|c| c.label.as_deref() == Some(l))
-                .map(|c| c.exit)
-                .ok_or_else(|| {
-                    crate::front::error::Unsupported::new(format!(
-                        "`break {l}`: no enclosing loop labeled `{l}`"
-                    ))
-                })?,
-            None => self
-                .loop_stack
-                .last()
-                .map(|c| c.exit)
-                .ok_or_else(|| crate::front::error::Unsupported::new("`break` outside a loop"))?,
-        };
-        self.builder.ins().jump(exit, &[]);
-        self.block_terminated = true;
-        Ok(())
-    }
-
-    /// `continue` — jump to a loop's continue target (header / update / advance).
-    /// Unlabeled → the innermost loop; a `continue label` → the enclosing loop with
-    /// that label. A `continue` outside any loop, or an unknown label, BAILS.
-    pub(super) fn lower_continue(&mut self, label: Option<&str>) -> FrontResult<()> {
-        let target = match label {
-            Some(l) => self
-                .loop_stack
-                .iter()
-                .rev()
-                .find(|c| c.label.as_deref() == Some(l))
-                .map(|c| c.continue_target)
-                .ok_or_else(|| {
-                    crate::front::error::Unsupported::new(format!(
-                        "`continue {l}`: no enclosing loop labeled `{l}`"
-                    ))
-                })?,
-            None => self.loop_stack.last().map(|c| c.continue_target).ok_or_else(|| {
-                crate::front::error::Unsupported::new("`continue` outside a loop")
-            })?,
-        };
-        self.builder.ins().jump(target, &[]);
-        self.block_terminated = true;
-        Ok(())
-    }
 }

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -126,6 +126,11 @@ pub(crate) struct LoopCtx {
     /// The source LABEL of this loop (`outer: for …`), if any — the target of a
     /// `break label` / `continue label`. `None` for an unlabeled loop/switch.
     pub label: Option<String>,
+    /// The `finally_stack` depth at the point this loop's body starts. A `break`/
+    /// `continue` targeting this loop must run every `finally` pushed AFTER this
+    /// depth (the finalizers of `try/finally` blocks the jump escapes), innermost
+    /// first, before jumping — JS runs `finally` on an abrupt loop exit too.
+    pub finally_depth: usize,
 }
 
 /// One active enclosing `try` (P5.13): the block a pending error routes to. For a

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -26,7 +26,9 @@ mod argsobj;
 mod assign;
 mod asyncspawn;
 mod binop;
+mod breakcont;
 mod dynfn;
+mod fnhoist;
 mod floatscan;
 mod binop_eq;
 mod ctorfn;
@@ -499,6 +501,11 @@ fn build_from_program(
                 varhoist::rewrite_var_decls_to_assigns(&mut f.body, &names);
                 f.body.splice(0..0, hoists);
             }
+            // Function-DECLARATION hoisting: a `function inner(){…}` declared in
+            // the body is visible (name + value) from the top, so a call textually
+            // before it resolves. Runs AFTER the var-hoist splice so the fn decls
+            // lead the whole body. See `fnhoist`.
+            fnhoist::hoist_fn_decls(&mut f.body);
             funcs.push(f);
         }
     }
@@ -528,6 +535,9 @@ fn build_from_program(
         varhoist::rewrite_var_decls_to_assigns(&mut body, &names);
         body.splice(0..0, top_var_hoists);
     }
+    // Function-DECLARATION hoisting at MODULE scope: a top-level `function f(){…}`
+    // used before its line resolves (name + value hoisted to the head of main).
+    fnhoist::hoist_fn_decls(&mut body);
 
     // STATIC fields + `static {}` init blocks: every static FIELD of a user class
     // lives in a WRITABLE module-global cell named by the synth convention

--- a/crates/rts-codegen-new/src/front/run/optchain_lower.rs
+++ b/crates/rts-codegen-new/src/front/run/optchain_lower.rs
@@ -193,7 +193,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // sentinel). Emit `undefined` instead of bailing the whole program.
         self.builder.switch_to_block(else_blk);
         self.builder.seal_block(else_blk);
-        let resolvable = self.static_instance_class(object).is_some()
+        // A method is resolvable in the present branch when its dispatch reaches a
+        // real body: a statically-known class instance, some user/ambient class
+        // declaring it, OR a PRIMITIVE receiver whose builtin methods the engine
+        // owns — a proven ARRAY (`arr?.join(",")`) or a proven STRING
+        // (`s?.toUpperCase()`). Without these the guarded call would fall to
+        // `undefined` even for a present receiver, dropping a legitimate result.
+        let primitive_receiver =
+            self.is_array_valued(object) || matches!(object.ty, rts_hir::HirType::Str);
+        let resolvable = primitive_receiver
+            || self.static_instance_class(object).is_some()
             || self.classes.iter().any(|d| {
                 !d.name.starts_with("__rtsl_")
                     && (d.method_fn(&method).is_some() || d.accessor(&method).is_some())

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -57,13 +57,17 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 object,
                 body,
             } => self.lower_for_in(module, binding, object, body),
-            HirStmt::Break(label) => self.lower_break(label.as_deref()),
-            HirStmt::Continue(label) => self.lower_continue(label.as_deref()),
-            // `outer: <loop>` — record the label so the immediately-following loop
-            // (or switch) `take`s it into its `LoopCtx`, making `break outer` /
-            // `continue outer` target it. A labeled NON-loop statement leaves the
-            // pending label unconsumed; clear it after so it never leaks to a later
-            // loop (a `break label` into a plain block is then a clean bail).
+            HirStmt::Break(label) => self.lower_break(module, label.as_deref()),
+            HirStmt::Continue(label) => self.lower_continue(module, label.as_deref()),
+            // A labeled NON-loop statement (`block1: { … break block1; … }`) is a
+            // valid JS `break`-only target — lowered with its own break-target
+            // `LoopCtx` (see `lower_labeled_block`).
+            HirStmt::Labeled { label, body } if !super::breakcont::stmt_consumes_label(body) => {
+                self.lower_labeled_block(module, label, body)
+            }
+            // A labeled LOOP/SWITCH: the construct itself `take`s the pending label
+            // into its own `LoopCtx`. Clear it after so it never leaks to a later
+            // loop.
             HirStmt::Labeled { label, body } => {
                 self.pending_label = Some(label.clone());
                 self.lower_stmt(module, body)?;
@@ -329,6 +333,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: exit_block,
             continue_target: header,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         self.lower_block(module, body)?;
         self.loop_stack.pop();
@@ -367,6 +372,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: exit_block,
             continue_target: cond_block,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         self.lower_block(module, body)?;
         self.loop_stack.pop();

--- a/crates/rts-codegen-new/src/front/run/switch.rs
+++ b/crates/rts-codegen-new/src/front/run/switch.rs
@@ -83,6 +83,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             exit: exit_block,
             continue_target,
             label,
+            finally_depth: self.finally_stack.len(),
         });
         for (i, case) in cases.iter().enumerate() {
             self.builder.seal_block(body_blocks[i]);

--- a/crates/rts-hir/src/type_refine.rs
+++ b/crates/rts-hir/src/type_refine.rs
@@ -246,6 +246,44 @@ fn stmt_has_nullish_return(stmt: &HirStmt) -> bool {
     }
 }
 
+/// Merge two `return`-statement types for return-type inference. Two NUMERIC
+/// types promote through [`numeric_promotion`] (the winning unboxed numeric
+/// path). The surgical fix over calling `numeric_promotion` DIRECTLY: two EQUAL
+/// non-numeric types (`Str + Str`, `Bool + Bool`) keep that type, and a non-numeric
+/// MISMATCH (`Str` vs `Bool`, `Str` vs `I64`) is `Any` (genuinely polymorphic).
+/// Without this, `numeric_promotion` collapsed `Str + Str` to `Number` (its
+/// `_ => Number` default), turning a string-returning
+/// `try { return "a" } finally { return "b" }` into an f64 fn that coerced the
+/// strings to `NaN`.
+///
+/// A side involving `Unknown`/`Any` keeps the ORIGINAL `numeric_promotion`
+/// behaviour (deliberately — `refine_func_ret` treats a resulting `Number` no
+/// differently from a resulting `Any`/`Unknown` when the OTHER returns are
+/// un-inferable, so preserving it avoids perturbing any established numeric path).
+fn merge_return_types(a: HirType, b: HirType) -> HirType {
+    use HirType::*;
+    let is_numeric = |t: &HirType| {
+        matches!(
+            t,
+            I8 | I16 | I32 | I64 | I128 | U8 | U16 | U32 | U64 | U128 | F32 | F64 | Number
+        )
+    };
+    // Both sides a CONCRETE (non-Unknown/Any) type: apply the corrected merge.
+    if !matches!(a, Unknown | Any) && !matches!(b, Unknown | Any) {
+        if a == b {
+            return a;
+        }
+        if is_numeric(&a) && is_numeric(&b) {
+            return numeric_promotion(a, b);
+        }
+        // A non-numeric mismatch is genuinely polymorphic — stay Tagged, never a
+        // bogus numeric collapse.
+        return Any;
+    }
+    // An un-inferable side: unchanged from the historical behaviour.
+    numeric_promotion(a, b)
+}
+
 /// Walk a stmt block and merge the type of every `return` expression found.
 fn collect_return_types(stmts: &[HirStmt], scope: &Scope, acc: &mut Option<HirType>) {
     for stmt in stmts {
@@ -258,7 +296,7 @@ fn collect_return_types_in_stmt(stmt: &HirStmt, scope: &Scope, acc: &mut Option<
         HirStmt::Return(Some(expr)) => {
             let ty = refine_type_from_init(expr, scope);
             *acc = Some(match acc.take() {
-                Some(prev) => numeric_promotion(prev, ty),
+                Some(prev) => merge_return_types(prev, ty),
                 None => ty,
             });
         }


### PR DESCRIPTION
## What

Fixes six cross-runtime **"syntax"/scoping** fixtures that diverged from Bun/Node. Every fix is a **root-cause fix in the front-end lowering** — no fixture hardcoding, no input special-casing.

| Fixture | Issue | Root cause → fix |
|---|---|---|
| `331_labeled_statements` | #1677 | A labeled NON-loop block (`b: { … break b }`) bailed. Now lowered with its own break-target `LoopCtx`, so `break label` jumps past the block. |
| `343_optional_chaining` | #1683 | `arr?.join(",")` returned `undefined`. The guarded optional-method-call gate only treated user/ambient classes as resolvable; now a proven **array/string** receiver is too. |
| `251_array_constructor_spread` | — | `new Array(...[10])` was a `__RUNTIME_ERROR__`. A single spread of a **literal** array is re-dispatched on its real elements, so JS's arity rule applies (`...[10]` → sized `Array(10)`, `...[1,2,3]` → element list). |
| `398_destructure_rest_computed_keys` | #1508 | `{ [k]: v, ...rest }` bailed. The destructure desugar now models a **computed object key** (`src[k]` read + `delete rest[k]` from the rest copy). |
| `claude-var-and-fn-hoisting` | #1418 | `hoisted()` called before its `function hoisted(){}` decl errored. Added **function-declaration hoisting** (name+value hoisted to the head of the body). `var` hoisting already worked. |
| `codex_try_finally_control_flow` | #1725 | (a) `break`/`continue` escaping a `try/finally` didn't run the `finally`. Now `LoopCtx` records the finally-stack depth at loop entry and the jump runs the escaped finalizers first. (b) Return-type inference collapsed `Str + Str` to `Number` (the `numeric_promotion` `_ => Number` default), typing a string-returning `try{return "a"}finally{return "b"}` as f64 → `NaN`. New `merge_return_types` keeps two equal non-numeric returns' type and sends non-numeric mismatches to Tagged; the Unknown/Any path is unchanged. |

## Layout

- New `crates/rts-codegen-new/src/front/run/breakcont.rs` (break/continue + finalizer-on-abrupt-exit + labeled-block helper) — `loops.rs` shrinks 581→533.
- New `crates/rts-codegen-new/src/front/run/fnhoist.rs` (function-declaration hoist pass).

## Testing

- **TS suite: 623/623 files, 1688/1688 tests pass** — no regression.
- All 6 target fixtures now match Node/Bun byte-for-byte.
- `read_before_commit.sh`: **no HARD violation**; no new >500-line offender (the pre-existing offenders `loops.rs` shrank; `stmt.rs`/`globals.rs` net-neutral after extracting helpers).

## Not fixed in this PR (documented, out of scope as pointed bugs)

These need larger features (mutable-closure/env-record, TDZ tracking, Symbol.toPrimitive, `this`-in-IIFE, real `eval` scope), left open:
`codex_tdz_typeof_let` (#1522), `claude-let-vs-var-loop-closures` (#1413), `codex_for_in_shadowed_var_closure` (#1519), `399_default_param_temporal_order` (#1509), `402_template_toPrimitive_order` (#1503), `400_eval_scope_edges` (#1510), `417_nested_optional_call_this_binding` (#1686), plus `300_this_strict_top_level` and `360_obf_iife_scope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er9ksRgLQdNDMZE6CgZcn1
