### PR TITLE
fix(engine): string cluster — ToPrimitive on non-`+` ops, array-element coercion, dynamic localeCompare/codePointAt

### DIFF
--- a/crates/rts-adapters/src/value/dyndispatch.rs
+++ b/crates/rts-adapters/src/value/dyndispatch.rs
@@ -582,6 +582,34 @@ pub extern "C" fn __rtsadp_dyn_trim(recv: u64) -> u64 {
     undef()
 }
 
+/// `s.localeCompare(other)` — `-1`/`0`/`1` (locale order). String receiver only;
+/// other receivers → `undefined`. The `other` arg is ToString'd (JS coerces it),
+/// so `"a".localeCompare(1)` compares against `"1"`. Reuses the SAME
+/// `__RTS_FN_GL_STRING_LOCALE_COMPARE` impl the proven-string typed row calls.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_dyn_locale_compare(recv: u64, other: u64) -> u64 {
+    let v = PolyValue::from_raw(recv);
+    if v.is_string() {
+        let r = rt_gl_str::__RTS_FN_GL_STRING_LOCALE_COMPARE(str_handle(recv), str_arg_handle(other));
+        return PolyValue::from_i32(r as i32).raw();
+    }
+    undef()
+}
+
+/// `s.codePointAt(i)` — the Unicode CODE POINT starting at UTF-16 index `i`
+/// (composing a surrogate pair), or `undefined` out of range. String receiver
+/// only; other receivers → `undefined`. Returns the raw PolyValue word verbatim
+/// from `__RTS_FN_GL_STRING_CODE_POINT_AT` (a number word OR `undefined`), the
+/// SAME impl the proven-string typed row calls.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_dyn_code_point_at(recv: u64, idx: u64) -> u64 {
+    let v = PolyValue::from_raw(recv);
+    if v.is_string() {
+        return rt_gl_str::__RTS_FN_GL_STRING_CODE_POINT_AT(str_handle(recv), genops_to_i64(idx));
+    }
+    undef()
+}
+
 /// `Promise.resolve(x)` with an UNPROVEN `x` — THENABLE-aware (spec
 /// PromiseResolve): a keyed object whose `then` GETTER throws yields a
 /// REJECTED promise carrying the thrown value; a callable `then` is ADOPTED

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -511,6 +511,14 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             dyndispatch::__rtsadp_dyn_char_code_at as *const u8,
         ),
         sym(
+            "__rtsadp_dyn_code_point_at",
+            dyndispatch::__rtsadp_dyn_code_point_at as *const u8,
+        ),
+        sym(
+            "__rtsadp_dyn_locale_compare",
+            dyndispatch::__rtsadp_dyn_locale_compare as *const u8,
+        ),
+        sym(
             "__rtsadp_dyn_to_upper_case",
             dyndispatch::__rtsadp_dyn_to_upper_case as *const u8,
         ),

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -269,6 +269,40 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
         }
 
+        // ToPrimitive (issue #1447): a NON-`+` coercing op (`- * / % ** < <= > >=
+        // == !=`) where an operand is a STATICALLY-KNOWN-CLASS object that defines
+        // `toString`/`valueOf` (and did NOT opt into the operator overload above)
+        // coerces that object via its method AT LOWERING TIME, then applies the op
+        // on the resulting primitives through the generic `__rtsadp_*` path — never
+        // the whole-object bail. `obj * 2` / `obj == 3` / `obj - 5` now match
+        // Bun/Node. Plain objects, arrays, and dynamic-class objects keep the gate
+        // below (their JIT'd method — if any — is unreachable from the trampoline).
+        if Self::op_needs_object_toprimitive(op)
+            && (self.has_object_toprimitive(lhs) || self.has_object_toprimitive(rhs))
+        {
+            return self.lower_binop_object_toprimitive(module, op, lhs, rhs);
+        }
+
+        // String-concat `+` with an ARRAY-LITERAL-with-object-elements operand
+        // (issue #1499 — `"" + [both, both]`, the desugared `${[both, both]}`): the
+        // array's `String()` join renders each element via `String(element)`, so
+        // rewrite the array literal's object elements to their `toString()` /
+        // `[object Object]` HIR (the SAME rewrite `Array.join` uses) and re-lower.
+        // Only when the OTHER operand is a proven string (a real string-concat) and
+        // every object element is statically resolvable (else `None` → keep bail).
+        if matches!(op, HirBinOp::Add) {
+            if is_proven_string_expr(lhs) && self.array_arg_has_object_element(rhs) {
+                if let Some(r2) = self.array_literal_with_object_elems_to_primitives(rhs) {
+                    return self.lower_bin(module, op, lhs, &r2);
+                }
+            }
+            if is_proven_string_expr(rhs) && self.array_arg_has_object_element(lhs) {
+                if let Some(l2) = self.array_literal_with_object_elems_to_primitives(lhs) {
+                    return self.lower_bin(module, op, &l2, rhs);
+                }
+            }
+        }
+
         // STRICT equality `===`/`!==` on a whole object/array operand is pure
         // IDENTITY (reference equality) — NO ToPrimitive, so it is always sound and
         // skips the bail below (which guards the coercing ops). The operands fall

--- a/crates/rts-codegen-new/src/front/run/method_array.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array.rs
@@ -116,11 +116,17 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // `[obj].join(..)` ToStrings each element in the runtime trampoline, which
         // renders a method-bearing OBJECT element as the default `[object Object]`
         // (it cannot call the JIT'd `toString`) — a wrong value vs bun's element
-        // ToPrimitive. Bail rather than diverge (array-of-object ToPrimitive is a
-        // later increment). Only the array-LITERAL-with-object case is statically
-        // detectable here; an opaque array's elements can only become objects via
-        // paths that already bail.
+        // ToPrimitive. When the receiver is an array LITERAL whose object elements
+        // are ALL statically-known-class objects with a usable `toString`/`valueOf`
+        // (issue #1499), rewrite each such element to a lowering-time
+        // `ToString(ToPrimitive(el, string))` HIR (`join` calls `String(element)`),
+        // then dispatch join over the resulting string-element array — exactly
+        // Bun/Node. If ANY object element lacks a usable primitive method, bail
+        // (the runtime trampoline's `[object Object]` would diverge).
         if method == "join" && self.array_arg_has_object_element(object) {
+            if let Some(rewritten) = self.array_literal_with_object_elems_to_primitives(object) {
+                return self.try_array_dispatch(module, &rewritten, method, args);
+            }
             return Err(crate::front::error::Unsupported::new(
                 "Array.join on an array containing an object element \
                  (element ToPrimitive is a later increment)"

--- a/crates/rts-codegen-new/src/front/run/method_dyn.rs
+++ b/crates/rts-codegen-new/src/front/run/method_dyn.rs
@@ -241,6 +241,20 @@ const DYN_METHODS: &[DynMethod] = &[
         ret_kind: JsKind::Number,
     },
     DynMethod {
+        // `codePointAt` returns a number OR `undefined` (out of range); the word
+        // is opaque here (the trampoline returns the raw PolyValue), so `Unknown`.
+        name: "codePointAt",
+        argc: 1,
+        symbol: "__rtsadp_dyn_code_point_at",
+        ret_kind: JsKind::Unknown,
+    },
+    DynMethod {
+        name: "localeCompare",
+        argc: 1,
+        symbol: "__rtsadp_dyn_locale_compare",
+        ret_kind: JsKind::Number,
+    },
+    DynMethod {
         name: "split",
         argc: 1,
         symbol: "__rtsadp_dyn_split",

--- a/crates/rts-codegen-new/src/front/run/toprimitive.rs
+++ b/crates/rts-codegen-new/src/front/run/toprimitive.rs
@@ -164,6 +164,54 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         false
     }
 
+    /// Rewrite an ARRAY LITERAL whose object elements are all STATICALLY-KNOWN-CLASS
+    /// objects into a new array literal where each object element is replaced by its
+    /// JS `String(element)` HIR (issue #1499): a `toString`-bearing object → a
+    /// `element.toString()` method call; a `toString`-free object → the string
+    /// literal `"[object Object]"` (the inherited `Object.prototype.toString`).
+    /// Non-object elements are kept verbatim. Returns `None` when `object` is not an
+    /// array literal, or when an object element's class is NOT statically resolvable
+    /// (its `String()` can't be run at lowering time → the caller keeps its bail).
+    /// Used by `Array.join` (which calls `String(element)` on each element).
+    pub(super) fn array_literal_with_object_elems_to_primitives(
+        &self,
+        object: &HirExpr,
+    ) -> Option<HirExpr> {
+        use rts_hir::ir::{HirExprKind, HirLit};
+        let HirExprKind::Array(elems) = &object.kind else {
+            return None;
+        };
+        let mut out = Vec::with_capacity(elems.len());
+        for el in elems {
+            if self.is_whole_object_value(el) {
+                // The element must be a statically-known class to run its `String()`
+                // here; otherwise decline (keep the bail — never a wrong value).
+                let class = self.static_instance_class(el)?;
+                if self.primitive_method_of(&class, Hint::String).is_some() {
+                    // Has (own) `toString`: `String(el)` == `el.toString()`.
+                    out.push(HirExpr::new(
+                        HirExprKind::MethodCall {
+                            object: Box::new(el.clone()),
+                            method: "toString".to_string(),
+                            args: Vec::new(),
+                        },
+                        rts_hir::HirType::Str,
+                    ));
+                } else {
+                    // No own `toString` (only `valueOf`, or method-free): the
+                    // inherited `Object.prototype.toString` → "[object Object]".
+                    out.push(HirExpr::new(
+                        HirExprKind::Lit(HirLit::Str("[object Object]".to_string())),
+                        rts_hir::HirType::Str,
+                    ));
+                }
+            } else {
+                out.push(el.clone());
+            }
+        }
+        Some(HirExpr::new(HirExprKind::Array(out), object.ty.clone()))
+    }
+
     /// Lower a `+` where at least one operand is a known-class object with a usable
     /// `ToPrimitive` (issue #304). Each operand is reduced to a PolyValue word: an
     /// object-with-primitive operand via its `valueOf`/`toString` (JS `+` uses the
@@ -188,10 +236,104 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     /// Reduce one `+` operand to a PolyValue word, applying `ToPrimitive` (default
     /// hint) when the operand is a known-class object; otherwise ordinary lower+box.
     fn add_operand_word(&mut self, module: &mut dyn Module, expr: &HirExpr) -> FrontResult<Value> {
-        if let Some(word) = self.coerce_object_to_primitive_word(module, expr, Hint::Default)? {
+        self.operand_word_with_toprimitive(module, expr, Hint::Default)
+    }
+
+    /// Reduce one operand to a PolyValue word, applying `ToPrimitive(hint)` when it
+    /// is a known-class object with a usable `valueOf`/`toString`; otherwise
+    /// ordinary lower + box. Shared by `+` ([`Self::add_operand_word`]) and the
+    /// other coercing operators ([`Self::lower_binop_object_toprimitive`]).
+    pub(super) fn operand_word_with_toprimitive(
+        &mut self,
+        module: &mut dyn Module,
+        expr: &HirExpr,
+        hint: Hint,
+    ) -> FrontResult<Value> {
+        if let Some(word) = self.coerce_object_to_primitive_word(module, expr, hint)? {
             return Ok(word);
         }
         let v = self.lower_expr(module, expr)?;
         Ok(self.box_value(v))
+    }
+
+    /// Whether `<op>` is a NON-`+` coercing binary op whose object operands need JS
+    /// `ToPrimitive` (issue #304 / #1447): the arithmetic ops `- * / % **`, the
+    /// relational ops `< <= > >=`, and loose `== !=`. `+` has its own dedicated
+    /// path ([`Self::lower_add_with_toprimitive`], string-concat aware); strict
+    /// `=== !==` is reference identity (NO ToPrimitive); bitwise/`in`/`instanceof`
+    /// are not routed here.
+    pub(super) fn op_needs_object_toprimitive(op: rts_hir::HirBinOp) -> bool {
+        use rts_hir::HirBinOp::*;
+        matches!(
+            op,
+            Sub | Mul | Div | Rem | Exp | Lt | Le | Gt | Ge | Eq | Ne
+        )
+    }
+
+    /// Lower a NON-`+` coercing binary op (`- * / % ** < <= > >= == !=`) where at
+    /// least one operand is a STATICALLY-KNOWN-CLASS object with a usable
+    /// `valueOf`/`toString` (issue #1447). Each object operand is reduced to its
+    /// primitive PolyValue word via `ToPrimitive` (JS uses the "number"/"default"
+    /// hint here — `valueOf` first); every other operand is ordinary lower + box.
+    /// The two primitive words then go through the SAME generic `__rtsadp_*`
+    /// trampoline the Tagged path uses (which re-dispatches on the resulting
+    /// primitive tags — exactly JS after `ToPrimitive`). Returns the op's result.
+    pub(super) fn lower_binop_object_toprimitive(
+        &mut self,
+        module: &mut dyn Module,
+        op: rts_hir::HirBinOp,
+        lhs: &HirExpr,
+        rhs: &HirExpr,
+    ) -> FrontResult<super::lower::Val> {
+        use rts_hir::HirBinOp::*;
+        // Both operands → primitive words (object operands via valueOf/toString).
+        let a = self.operand_word_with_toprimitive(module, lhs, Hint::Default)?;
+        let b = self.operand_word_with_toprimitive(module, rhs, Hint::Default)?;
+        // Arithmetic → the matching `__rtsadp_*` (a JS number, except `%`/`**`).
+        let arith_sym = match op {
+            Sub => Some("__rtsadp_sub"),
+            Mul => Some("__rtsadp_mul"),
+            Div => Some("__rtsadp_div"),
+            Rem => Some("__rtsadp_mod"),
+            Exp => Some("__rtsadp_pow"),
+            _ => None,
+        };
+        if let Some(sym) = arith_sym {
+            let res = self
+                .call_runtime(module, sym, &[a, b])?
+                .expect("generic arithmetic returns a value");
+            return Ok(super::lower::Val {
+                v: res,
+                repr: crate::repr::Repr::Tagged,
+                kind: super::lower::JsKind::Number,
+            });
+        }
+        // Relational → `__rtsadp_{lt,le,gt,ge}` (a bool word → i64 0/1).
+        let rel_sym = match op {
+            Lt => Some("__rtsadp_lt"),
+            Le => Some("__rtsadp_le"),
+            Gt => Some("__rtsadp_gt"),
+            Ge => Some("__rtsadp_ge"),
+            _ => None,
+        };
+        if let Some(sym) = rel_sym {
+            let res = self
+                .call_runtime(module, sym, &[a, b])?
+                .expect("relational returns a value");
+            return Ok(self.poly_bool_to_bool(res));
+        }
+        // Loose equality `==`/`!=` → the JS Abstract Equality trampoline. It runs
+        // ToPrimitive on an object side itself, but here the object was already
+        // reduced to its primitive word (its JIT'd method is unreachable from the
+        // trampoline), so it compares the primitives — exactly `obj == 3`.
+        let sym = if matches!(op, Ne) {
+            "__rtsadp_loose_neq"
+        } else {
+            "__rtsadp_loose_eq"
+        };
+        let res = self
+            .call_runtime(module, sym, &[a, b])?
+            .expect("loose eq returns a value");
+        Ok(self.poly_bool_to_bool(res))
     }
 }

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -834,6 +834,8 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
         | "__rtsadp_dyn_push"
         | "__rtsadp_dyn_char_at"
         | "__rtsadp_dyn_char_code_at"
+        | "__rtsadp_dyn_code_point_at"
+        | "__rtsadp_dyn_locale_compare"
         | "__rtsadp_dyn_split"
         | "__rtsadp_dyn_starts_with"
         | "__rtsadp_dyn_ends_with"


### PR DESCRIPTION
## What

Fixes three cross-runtime **"string" cluster** fixtures that diverged from Bun/Node by **pointed semantic bugs** (not missing features). Every fix is a root-cause fix in the engine lowering / dynamic-dispatch — no fixture hardcoding, no input special-casing.

| Fixture | Issue | Was | Now |
|---|---|---|---|
| `claude-toprimitive-valueof-vs-tostring` | #1447 | `rts_error` (bail on `obj * 2`) | ✅ passes |
| `claude-tostring-vs-valueof-hint` | #1499 | `rts_error` (bail on `[obj].join`) | ✅ passes |
| `203_string_localecompare_numeric` | — | `rts_error` (throws in `.sort` comparator) | ✅ passes |

## Root causes & fixes

**1. ToPrimitive on non-`+` operators (#1447).** `obj * 2` / `obj - 5` / `obj == 3` / `obj < 10` on a statically-known-class object with `valueOf`/`toString` bailed with *"binary `Mul` on a whole object/array operand"*. The lowering-time ToPrimitive path only existed for `+` (`lower_add_with_toprimitive`). Generalized to `- * / % ** < <= > >= == !=`: each object operand is reduced to its primitive PolyValue word via `valueOf`/`toString` (default hint) at lowering time (its JIT'd method is unreachable from the runtime trampoline), then the op runs on the primitives through the SAME generic `__rtsadp_*` path. Strict `===`/`!==` stays reference identity; operator-overload classes still take their `.add`/`.mul` method first.

**2. Object-element ToPrimitive in `Array.join` / string-concat (#1499).** `[both].join("-")` and `` `${[both, both]}` `` rendered method-bearing object elements as `[object Object]` (the runtime join can't call a JIT'd `toString`). An array **literal** with statically-known-class object elements is now rewritten at lowering time so each object element becomes its JS `String(element)` HIR: `element.toString()` when it has an own `toString`, else the inherited `Object.prototype.toString` → `"[object Object]"` (exactly JS `String(obj)`). Applied by both `Array.join` and the string-concat `+`.

**3. `localeCompare` / `codePointAt` on an untyped receiver (203).** `.sort((a, b) => a.localeCompare(b))` threw *"uncaught exception: [object Object]"*. Both methods lived ONLY in the proven-string typed-row table, so on an untyped arrow param they fell to the generic proto-chain and TypeError'd. Added both to the dynamic dispatch table (`DYN_METHODS`) with two new `__rtsadp_dyn_*` trampolines that tag-dispatch on the receiver (string → the SAME `__RTS_FN_GL_STRING_*` impl the typed row calls; other → `undefined`). The proven-string path is unchanged (checked first).

## Side effect (bonus, not a full fix)

`claude-lone-surrogate-iteration` (#1495) no longer **crashes** thanks to the `codePointAt` dynamic-dispatch fix (`[...s].map(c => c.codePointAt(0))`); it went from `rts_error` to `rts_diverge` (2 lines still off). Its exact lone-surrogate values remain wrong — see below.

## Not fixed — blocked by UTF-8 string storage (out of scope)

RTS stores strings as Rust UTF-8 and **loses lone surrogates at parse** (SWC `to_string_lossy` replaces `\uD83D` with U+FFFD). Making these pass needs WTF-8 string storage end-to-end (parser + pool + every reader) — a subsystem change, not a pointed bug fix:

- `claude-padstart-unicode` (#1496) — pad-fill truncation splits a surrogate pair; `charCodeAt` on the resulting lone surrogate can't return the half.
- `claude-at-negative-index` (#1493) — `.at(1).length` requires holding a lone high surrogate.
- `claude-lone-surrogate-iteration` (#1495) — exact `codePointAt` values need the surrogate preserved.
- `91_string_wellformed` — `"\uD83D".isWellFormed()` can't see a surrogate that parse already replaced.

## Testing

- **TS suite: 623/623 files, 1688/1688 tests pass.**
- `cargo test -p rts-codegen-new --lib` green single-threaded. (3 closure `map`/`reduce` tests flake only under full parallel GC contention — pass single-threaded and in isolation; logically disconnected from these changes, which touch only binop / dynamic-dispatch / join.)
- No cross-runtime regressions. (`160_string_fromcharcode`'s NUL byte is a report-capture artifact — the capture pipeline strips NUL from all runtimes; `String.fromCharCode(0)` output is unchanged from main.)
- `scripts/read_before_commit.sh`: no HARD violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er9ksRgLQdNDMZE6CgZcn1
