### PR TITLE
fix(engine): numeric/coercion cluster — OrdinaryToPrimitive, Date ToNumber, sparse holes, coercion callbacks

### DIFF
--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -205,6 +205,53 @@ pub extern "C" fn __rtsadp_math_fn_value(op: u64) -> u64 {
     PolyValue::from_function_handle(h & super::PAYLOAD_MASK).raw()
 }
 
+/// Uniform-ABI thunk for a PRIMORDIAL coercion FUNCTION VALUE (`Boolean`/`Number`/
+/// `String` used as a callback — `arr.filter(Boolean)`, `arr.map(String)`). `env`
+/// carries the op (0 = `Boolean`, 1 = `Number`, 2 = `String`); it coerces the sole
+/// argument `a0` per that op — the SAME ToBoolean/ToNumber/ToString the direct
+/// `Boolean(x)`/`Number(x)`/`String(x)` call uses (no divergence).
+extern "C" fn coerce_thunk(env: u64, a0: u64, _a1: u64, _a2: u64, _a3: u64, _rest: u64) -> u64 {
+    match env {
+        1 => super::globalops::__rtsadp_g_number(a0),
+        2 => super::globalops::__rtsadp_g_string(a0),
+        _ => super::globalops::__rtsadp_g_boolean(a0),
+    }
+}
+
+/// `Boolean` / `Number` / `String` read as a first-class FUNCTION VALUE (the common
+/// `arr.filter(Boolean)` / `arr.map(String)` idiom): a real callable whose env slot
+/// carries the op (0 = `Boolean`, 1 = `Number`, 2 = `String`). These are PRIMORDIAL
+/// (the engine MAY name them); the thunk applies the exact same coercion the call
+/// form does.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_coerce_fn_value(op: u64) -> u64 {
+    let name = match op {
+        1 => "Number",
+        2 => "String",
+        _ => "Boolean",
+    };
+    let data = FunctionData {
+        fn_ptr: coerce_thunk as usize as u64,
+        arity: 1,
+        name: Box::<str>::from(name),
+        bound_this: op as i64,
+        has_bound_this: true,
+        bound_args: Vec::new(),
+        is_arrow: false,
+        has_this_param: false,
+        param_kinds: Vec::new(),
+        return_kind: 0,
+        packed_shim: 0,
+        source: None,
+        keep_alive: None,
+        prototype_handle: 0,
+        rest_param_idx: -1,
+        uniform_thunk: true,
+    };
+    let h = alloc_entry(Entry::Function(Box::new(data)));
+    PolyValue::from_function_handle(h & super::PAYLOAD_MASK).raw()
+}
+
 /// Build the `(resolve, reject)` settler FUNCTION-value pair over the promise
 /// `out_handle` (raw) — real callable `TAG_FUNCTION` words whose env carries
 /// the promise handle, exactly what a thenable's `then(res, rej)` expects.

--- a/crates/rts-adapters/src/value/genops.rs
+++ b/crates/rts-adapters/src/value/genops.rs
@@ -77,24 +77,61 @@ pub(super) fn to_string(v: PolyValue) -> String {
     "[object Object]".to_string()
 }
 
-/// JS `ToPrimitive(v, hint)` OBJECT step: when `v` is a keyed object carrying an
-/// own `[Symbol.toPrimitive](hint)` method (the object-literal desugar recovers
-/// it as the `@@toPrimitive` own-prop fn slot — see `desugar::objmethod`),
-/// invoke it with the hint string and return the PRIMITIVE result. `None` = no
-/// such method, or the method returned a non-primitive (spec: TypeError; here
-/// the caller keeps its default coercion — never a wrong recursion).
+/// JS `ToPrimitive(v, hint)` OBJECT step: when `v` is a keyed object, run the spec
+/// ToPrimitive algorithm.
+///
+/// 1. An own `[Symbol.toPrimitive](hint)` method (the object-literal desugar
+///    recovers it as the `@@toPrimitive` own-prop fn slot — see `desugar::objmethod`)
+///    takes precedence: invoke it with the hint string and return the PRIMITIVE
+///    result.
+/// 2. Otherwise OrdinaryToPrimitive: with hint `"string"` try `toString` then
+///    `valueOf`; with hint `"number"`/`"default"` try `valueOf` then `toString`.
+///    Each own method that IS a function is called with no args; the first one to
+///    return a primitive wins.
+///
+/// `None` = not a keyed object, no usable method found, or every method returned a
+/// non-primitive (spec: TypeError; here the caller keeps its default coercion —
+/// never a wrong recursion).
 pub(super) fn to_primitive_via_method(v: PolyValue, hint: &str) -> Option<PolyValue> {
     if !v.is_object() || !crate::value::inspect::looks_like_object(v) {
         return None;
     }
-    let key = abi_adapter::intern_poly("@@toPrimitive").raw();
+    // 1. `[Symbol.toPrimitive]` (canonicalized to the `@@toPrimitive` own slot).
+    if let Some(p) = invoke_prim_method(v, "@@toPrimitive", Some(hint)) {
+        return Some(p);
+    }
+    // 2. OrdinaryToPrimitive: the method order depends on the hint. `"string"`
+    //    tries `toString` first; every other hint (`"number"`/`"default"`) tries
+    //    `valueOf` first.
+    let order: [&str; 2] = if hint == "string" {
+        ["toString", "valueOf"]
+    } else {
+        ["valueOf", "toString"]
+    };
+    for name in order {
+        if let Some(p) = invoke_prim_method(v, name, None) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Fetch the own method `name` on keyed object `v`; if it is a function, invoke it
+/// (with `hint` as the sole argument when `Some`, else no args) and return the
+/// result IFF it is a primitive. `None` when the slot is absent / not a function /
+/// the call produced a non-primitive.
+fn invoke_prim_method(v: PolyValue, name: &str, hint: Option<&str>) -> Option<PolyValue> {
+    let key = abi_adapter::intern_poly(name).raw();
     let f = super::objops::__rtsadp_obj_get(v.raw(), key);
     if !PolyValue::from_raw(f).is_function() {
         return None;
     }
-    let hint_w = abi_adapter::intern_poly(hint).raw();
     let undef = PolyValue::undefined().raw();
-    let r = super::funcops::__rtsadp_fn_invoke_method(f, v.raw(), hint_w, undef, undef, undef);
+    let a0 = match hint {
+        Some(h) => abi_adapter::intern_poly(h).raw(),
+        None => undef,
+    };
+    let r = super::funcops::__rtsadp_fn_invoke_method(f, v.raw(), a0, undef, undef, undef);
     let p = PolyValue::from_raw(r);
     if p.is_object() || p.is_function() {
         return None;
@@ -176,9 +213,19 @@ pub(super) fn to_number(v: PolyValue) -> f64 {
     if let Some(p) = to_primitive_via_method(v, "number") {
         return to_number(p);
     }
-    // An ARRAY (no toPrimitive method): ToPrimitive falls to its ToString (the
-    // element join) and re-parses — `-[]` → -0, `+[5]` → 5, `+[1,2]` → NaN.
+    // An opaque runtime entry (Date / RegExp / array / …): ToPrimitive with hint
+    // "number" runs `valueOf` FIRST. A `Date` exposes a NUMERIC `valueOf` (its time
+    // value), so `+date` / `date < date` use the timestamp — dispatched by ENTRY
+    // KIND in the runtime layer (`OPAQUE_HAS_NUMBER`/`OPAQUE_TO_NUMBER`), no class
+    // name here. Everything else (arrays, RegExp) has no numeric `valueOf` and
+    // falls to ToString then re-parse — `-[]` → -0, `+[5]` → 5, `+[1,2]` → NaN,
+    // `+/re/` → NaN.
     if v.is_object() && !super::inspect::looks_like_object(v) {
+        use rts_runtime::namespaces::globals::date::instance as rt_date;
+        let h = abi_adapter::real_handle_of(v);
+        if rt_date::__RTS_FN_RT_OPAQUE_HAS_NUMBER(h) != 0 {
+            return rt_date::__RTS_FN_RT_OPAQUE_TO_NUMBER(h);
+        }
         return string_to_number(&to_string(v));
     }
     // undefined, object, function, hole, empty → NaN.

--- a/crates/rts-adapters/src/value/objops.rs
+++ b/crates/rts-adapters/src/value/objops.rs
@@ -141,6 +141,33 @@ fn resolve_slot(obj_word: u64, key_str_handle: u64) -> Option<(u64, i64)> {
     Some((handle, idx))
 }
 
+/// JS ToPropertyKey normalization for a key that may be an OBJECT with a
+/// side-effecting `toString`/`valueOf`: coerce it to a STRING word ONCE and return
+/// that interned string word (so the internal `key_text` probes never re-fire the
+/// method). A string / symbol / number / bool / undefined / null key is already
+/// side-effect-free and returns unchanged. A SYMBOL key stays a symbol word (it is
+/// a valid non-string property key, handled by `key_text`'s symbol arm).
+fn canonical_property_key(key_word: u64) -> u64 {
+    let k = PolyValue::from_raw(key_word);
+    // Only a genuine keyed/opaque OBJECT can carry a coercing method. Everything
+    // else (string/int/double/bool/undefined/null/function) — and a SYMBOL, which
+    // is its own key — is returned as-is.
+    if !k.is_object() {
+        return key_word;
+    }
+    {
+        // A SYMBOL primitive is a valid property key on its own; do NOT stringify it.
+        let h = rt_handles::__RTS_FN_NS_GC_POLY_TO_HANDLE(k.as_handle());
+        if rt_handles::with_entry(h, |e| matches!(e, Some(rt_handles::Entry::Symbol { .. }))) {
+            return key_word;
+        }
+    }
+    // Run ToString (the toString/valueOf ToPrimitive chain, hint "string") once via
+    // the engine's generic stringify, which returns a STRING PolyValue word already
+    // interned in the real pool. That word is a stable, side-effect-free key.
+    super::genops::__rtsadp_to_string(key_word)
+}
+
 /// The UTF-8 text of a key PolyValue. A string PolyValue is read from the real
 /// pool; a non-string (a defensively-passed number/bool) is rendered through the
 /// engine's own ToString so a numeric computed key (`o["0"]` vs `o[0]`) coerces
@@ -188,6 +215,12 @@ fn key_text(key_str_handle: u64) -> String {
 /// array / primitive). The lowering routes here only proven-object receivers.
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_obj_get(obj_word: u64, key_str_handle: u64) -> u64 {
+    // ToPropertyKey must run the key's coercion EXACTLY ONCE (JS 13.3.12): a key
+    // OBJECT with a side-effecting `toString`/`valueOf` (`obj[keyObj]`) would
+    // otherwise fire its method per internal `key_text` probe below. Canonicalize an
+    // OBJECT key to an interned STRING word up front; strings/symbols/numbers are
+    // already side-effect-free and pass through unchanged.
+    let key_str_handle = canonical_property_key(key_str_handle);
     // PROXY (#218): a proxy receiver routes through its `get` trap. Checked first —
     // a proxy is not a keyed Vec object, so `resolve_slot` would read `undefined`.
     if let Some((target, handler)) = proxy_parts(obj_word) {
@@ -395,8 +428,12 @@ pub extern "C" fn __rtsadp_obj_set(obj_word: u64, key_str_handle: u64, val_word:
     }
     // An ARRAY receiver + NUMERIC key (`v[i] = x` through the dynamic path —
     // the receiver was an `any` param/local): element write. `i == len`
-    // appends; `i > len` fills the gap with `undefined` (no holes in the
-    // model) then appends — JS growth semantics.
+    // appends; `i > len` grows the array, filling the skipped slots with the
+    // HOLE singleton (a SPARSE array — JS creates holes at the gap, NOT
+    // `undefined` values). Holes read back as `undefined` but are skipped by
+    // `Object.keys` / `hasOwnProperty` / enumeration (see the hole guards in
+    // `__rtsadp_obj_has` / `__rtsadp_has_own`), matching JS `arr[7] = x` on a
+    // length-3 array (`Object.keys` → `0,1,2,7`, not `0..7`).
     {
         let obj = PolyValue::from_raw(obj_word);
         if obj.is_object() && !looks_like_object(obj) {
@@ -410,9 +447,9 @@ pub extern "C" fn __rtsadp_obj_set(obj_word: u64, key_str_handle: u64, val_word:
                     if i < len {
                         rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_SET(handle, i, val_word as i64);
                     } else {
-                        let undef = PolyValue::undefined().raw() as i64;
+                        let hole = PolyValue::hole().raw() as i64;
                         for _ in len..i {
-                            rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle, undef);
+                            rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle, hole);
                         }
                         rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(handle, val_word as i64);
                     }

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -228,6 +228,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
             funcops::__rtsadp_math_fn_value as *const u8,
         ),
         sym(
+            "__rtsadp_coerce_fn_value",
+            funcops::__rtsadp_coerce_fn_value as *const u8,
+        ),
+        sym(
             "__rtsadp_fn_apply_this",
             funcops::__rtsadp_fn_apply_this as *const u8,
         ),

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -37,34 +37,29 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         self.sigs.get(&fn_name)?.ret_class.clone()
     }
 
-    /// Whether `e`, as a `+` operand, is EXACT through the runtime generic `+`'s
-    /// ToPrimitive: a non-object operand always is; an OBJECT operand is when
-    /// its statically-known class defines no custom `toString`/`valueOf` (those
-    /// are unreachable from the trampoline → wrong value, keep the bail). A
-    /// `[Symbol.toPrimitive]` method (`@@toPrimitive` slot) is fine — the
-    /// generic path consults it; a method-free object renders the spec
-    /// `[object Object]`.
+    /// Whether `e`, as a coercing-op operand, is EXACT through the runtime generic
+    /// path's ToPrimitive. Safe when: it is not an object; the object has no custom
+    /// `toString`/`valueOf` (renders the spec `[object Object]`); it carries a
+    /// `[Symbol.toPrimitive]`; or it is an OBJECT-LITERAL instance (inline or a var of
+    /// a `__rtsl_lit_*` class) — those materialize methods as OWN slots the runtime
+    /// `to_primitive_via_method` reaches via `__rtsadp_obj_get` (the real
+    /// OrdinaryToPrimitive chain). A general class instance with a custom
+    /// `toString`/`valueOf` stays a conservative bail.
     fn add_operand_to_primitive_safe(&self, e: &HirExpr) -> bool {
         if !self.is_whole_object_value(e) {
             return true;
         }
-        // An INLINE literal carries its recovered class in the marker field.
-        let class = match &e.kind {
-            rts_hir::ir::HirExprKind::Object(fields) => fields
-                .iter()
-                .find(|(k, _)| k == crate::front::run::desugar::LIT_CLASS_MARKER)
-                .and_then(|(_, v)| match &v.kind {
-                    rts_hir::ir::HirExprKind::Lit(rts_hir::ir::HirLit::Str(s)) => Some(s.clone()),
-                    _ => None,
-                }),
-            _ => self.static_instance_class(e),
-        };
-        match class {
+        // Any INLINE literal reaching here is safe (an unsupported-member literal bails
+        // earlier in `lower_object_literal`; a recovered/plain one has own-slot methods).
+        if matches!(&e.kind, rts_hir::ir::HirExprKind::Object(_)) {
+            return true;
+        }
+        match self.static_instance_class(e) {
+            // A LITERAL class instance (`const o = { valueOf(){…} }`) — own-slot methods.
+            Some(class) if class.starts_with("__rtsl_lit_") => true,
             Some(class) => self.classes.get(&class).is_none_or(|d| {
                 !d.methods.contains_key("toString") && !d.methods.contains_key("valueOf")
             }),
-            // An anonymous plain shape (no class ⇒ no methods) renders the spec
-            // `[object Object]` — exact.
             None => true,
         }
     }

--- a/crates/rts-codegen-new/src/front/run/method_array.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array.rs
@@ -430,13 +430,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // `__rtsadp_dyn_*` path, not here.
             return Ok(None);
         };
-        // The callback must be a reifiable function value (a synthesized non-
-        // capturing arrow ident, or a function ident). A capturing arrow stays an
-        // `Arrow` node — decline so the caller bails with the closure message
-        // (#195), never a wrong value.
-        if !matches!(&args[0].kind,
-            HirExprKind::Ident(name) if self.sigs.contains_key(name))
-        {
+        // The callback must be a reifiable function value: a function ident, OR a
+        // PRIMORDIAL coercion global (`Boolean`/`Number`/`String`, not shadowed). A
+        // capturing arrow stays an `Arrow` node — decline so the caller bails with the
+        // closure message (#195), never a wrong value.
+        let is_reifiable = matches!(&args[0].kind,
+            HirExprKind::Ident(name)
+                if self.sigs.contains_key(name) || self.coerce_fn_op_for(name).is_some());
+        if !is_reifiable {
             return Ok(None);
         }
         let arr_word = self.box_value(recv);
@@ -526,6 +527,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             HirExprKind::Ident(name) if self.sigs.contains_key(name) => {
                 let f = self.reify_function(module, name)?;
                 Ok(f.v)
+            }
+            // A PRIMORDIAL coercion global as a callback (`filter(Boolean)`,
+            // `map(String)`, `map(Number)`) — reify it to a real coercion FUNCTION
+            // VALUE (Boolean/Number/String are PRIMORDIAL; the engine may name them).
+            HirExprKind::Ident(name) if self.coerce_fn_op_for(name).is_some() => {
+                let op = self.coerce_fn_op_for(name).expect("guarded");
+                self.emit_coerce_fn_value(module, op)
             }
             HirExprKind::Arrow { .. } => Err(crate::front::error::Unsupported::new(format!(
                 "Array.{method}() with a CAPTURING callback (closures are a later increment)"

--- a/crates/rts-codegen-new/src/front/run/method_array_coerce.rs
+++ b/crates/rts-codegen-new/src/front/run/method_array_coerce.rs
@@ -1,0 +1,46 @@
+//! Reifying a PRIMORDIAL coercion global (`Boolean`/`Number`/`String`) as a
+//! first-class callback FUNCTION VALUE — the `arr.filter(Boolean)` /
+//! `arr.map(String)` / `arr.map(Number)` idiom.
+//!
+//! `Boolean`/`Number`/`String` are PRIMORDIAL (the engine MAY name them). Used as
+//! an Array callback the name must become a real callable word; this reifies it
+//! through the runtime `__rtsadp_coerce_fn_value(op)` reifier (op: 0 = Boolean,
+//! 1 = Number, 2 = String), whose thunk applies the SAME ToBoolean/ToNumber/ToString
+//! the direct `Boolean(x)`/`Number(x)`/`String(x)` call uses.
+
+use cranelift_codegen::ir::{InstBuilder, Value, types};
+use cranelift_module::Module;
+
+use crate::front::error::FrontResult;
+
+use super::lower::Lowerer;
+
+impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
+    /// The `__rtsadp_coerce_fn_value` op if `name` is an UNSHADOWED PRIMORDIAL
+    /// coercion global (`Boolean`/`Number`/`String`), else `None`. A same-named local
+    /// or user function shadows it (both resolve on their own paths).
+    pub(super) fn coerce_fn_op_for(&self, name: &str) -> Option<i64> {
+        if self.local(name).is_some() || self.sigs.contains_key(name) {
+            return None;
+        }
+        match name {
+            "Boolean" => Some(0),
+            "Number" => Some(1),
+            "String" => Some(2),
+            _ => None,
+        }
+    }
+
+    /// Emit a coercion FUNCTION-value word (`op`: 0 = Boolean, 1 = Number, 2 = String)
+    /// via the runtime `__rtsadp_coerce_fn_value` reifier.
+    pub(super) fn emit_coerce_fn_value(
+        &mut self,
+        module: &mut dyn Module,
+        op: i64,
+    ) -> FrontResult<Value> {
+        let op_v = self.builder.ins().iconst(types::I64, op);
+        Ok(self
+            .call_runtime(module, "__rtsadp_coerce_fn_value", &[op_v])?
+            .expect("__rtsadp_coerce_fn_value returns a fn word"))
+    }
+}

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -48,6 +48,7 @@ mod mathobj;
 mod methodtable;
 mod method;
 mod method_array;
+mod method_array_coerce;
 mod method_dyn;
 mod module_aot;
 mod module_entry;

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -344,6 +344,10 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             params: &[U64],
             ret: U64,
         },
+        "__rtsadp_coerce_fn_value" => SymSig {
+            params: &[U64],
+            ret: U64,
+        },
         "__rtsadp_fn_apply_this" => SymSig {
             params: &[U64, U64, U64],
             ret: U64,

--- a/crates/rts-shared/src/globals/date/instance.rs
+++ b/crates/rts-shared/src/globals/date/instance.rs
@@ -540,3 +540,33 @@ pub extern "C" fn __RTS_FN_RT_OPAQUE_TO_STRING(handle: u64) -> u64 {
         _ => 0,
     }
 }
+
+/// Does this OPAQUE heap-entry expose a NUMERIC ToPrimitive value (a `valueOf` that
+/// returns a number)? `1` = yes (a `Date` — its `valueOf` is the time value), `0` =
+/// no (a `RegExp` / anything else coerces to a number only through its string). The
+/// engine's generic `ToNumber` probes this BEFORE the string-based fallback so
+/// `+date` / `date < date` use the timestamp, while `+/re/` still goes via the
+/// string (→ `NaN`). Dispatch by ENTRY KIND — no class name in the engine.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_OPAQUE_HAS_NUMBER(handle: u64) -> i64 {
+    with_entry(handle, |e| match e {
+        Some(Entry::DateMs(_)) => 1i64,
+        _ => 0,
+    })
+}
+
+/// The NUMERIC ToPrimitive value of an OPAQUE heap-entry that has one (see
+/// `__RTS_FN_RT_OPAQUE_HAS_NUMBER`). For a `Date` it is the time value in ms (`NaN`
+/// for an Invalid Date, matching `+new Date(NaN)`). Only meaningful when the probe
+/// returned `1`; other kinds return `NaN`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_RT_OPAQUE_TO_NUMBER(handle: u64) -> f64 {
+    let kind = with_entry(handle, |e| match e {
+        Some(Entry::DateMs(_)) => 1u8,
+        _ => 0,
+    });
+    match kind {
+        1 => __RTS_FN_GL_DATE_VALUE_OF(handle),
+        _ => f64::NAN,
+    }
+}

--- a/tests/cross-runtime/numeric/claude-object-toprimitive-chain.ts
+++ b/tests/cross-runtime/numeric/claude-object-toprimitive-chain.ts
@@ -1,0 +1,31 @@
+// Cross-runtime: OrdinaryToPrimitive (valueOf/toString chain) for plain objects,
+// Date numeric coercion (valueOf), and sparse-array holes vs Object.keys.
+
+// A plain object with a numeric valueOf coerces via valueOf for number hints.
+const n: any = { valueOf() { return 3; } };
+console.log(n < 4);        // true  (valueOf → 3)
+console.log(n - 1);        // 2
+console.log(n * 2);        // 6
+
+// A plain object with a string toString coerces via toString for string hints
+// (property key coercion uses ToString).
+const k: any = { toString() { return "hi"; } };
+const bag: any = { hi: "found" };
+console.log(bag[k]);       // "found"
+
+// Date numeric coercion prefers valueOf (the time value) for +/-/< , but the
+// string form for `+` with a string sibling.
+const d: any = new Date(0);
+console.log(+d);           // 0
+console.log(d < new Date(5)); // true
+
+// Sparse array via an object-valued index whose toString names a far slot: the
+// skipped indices are HOLES, skipped by Object.keys (only 0,1,5 enumerate).
+const far: any = { toString() { return "5"; } };
+const arr: any[] = ["a", "b"];
+arr[far] = "z";
+console.log(arr.length);              // 6
+console.log(Object.keys(arr).join(",")); // "0,1,5"
+
+// filter(Boolean) drops every falsy element (Boolean as a callback).
+console.log([0, "", null, undefined, NaN, false, 1, "x"].filter(Boolean).length); // 2


### PR DESCRIPTION
## What

Fixes a cluster of cross-runtime **numeric/coercion** fixtures where RTS diverged from Bun/Node. All fixes make the generic runtime **ToPrimitive** path faithful to the JS spec, and are **doctrine-clean** (no non-primordial class name in the engine; Date/RegExp coercion dispatches by entry-kind in the runtime layer).

## Root causes & fixes

| Area | Root cause | Fix |
|---|---|---|
| **OrdinaryToPrimitive** | `to_primitive_via_method` only consulted `[Symbol.toPrimitive]`, never the ordinary `valueOf`/`toString` chain | Run the chain in hint order (string → `toString` first; number/default → `valueOf` first), reaching an object literal's OWN method slots via `__rtsadp_obj_get` |
| **ToPropertyKey twice** | `__rtsadp_obj_get` probed `key_text` ~8× → a key object's side-effecting `toString` fired N times | Canonicalize an OBJECT key to an interned string word **once** at entry (`canonical_property_key`) |
| **Sparse-array holes** | an out-of-range index write filled the gap with `undefined` (enumerable) | Fill with the HOLE singleton → `Object.keys` skips the gap (`arr[7]=x` on len-3 → `0,1,2,7`) |
| **Date numeric coercion** | `+date` / `date < date` stringified the Date then re-parsed → `NaN` | ToNumber consults a runtime `OPAQUE_HAS_NUMBER`/`OPAQUE_TO_NUMBER` (entry-kind dispatch in rts-shared): Date → time value; RegExp/array → string path (`+/re/` → NaN) |
| **Coercion callbacks** | `arr.filter(Boolean)` / `map(Number)` / `map(String)` bailed | Reify Boolean/Number/String (PRIMORDIAL) as a coercion function value via `__rtsadp_coerce_fn_value` |

Front-end guard `add_operand_to_primitive_safe` no longer bails on an object **literal** with a custom `toString`/`valueOf` (its methods are own-slot-reachable now); a general class instance stays conservative.

## Fixtures fully passing after this PR
- `codex_date_toprimitive_addition` — **#1451**
- `396_property_key_coercion` — **#1453**
- `367_coercion_traps` — **#1623**

Added `tests/cross-runtime/numeric/claude-object-toprimitive-chain.ts` as a focused regression fixture.

## Explicitly NOT fixed (blocked by larger features — no hack forced)
- **`codex_numeric_relational_coercion` (#1452):** 7/8 lines now pass (incl. `obj < 4` coercion). The last line `2n === 2` must be `false`, but that needs **real BigInt as a distinct type (#219)** — today `typeof 2n === "number"`, so strict-eq can't distinguish the types.
- **`198_number_parseint_parsefloat`:** the `Number.parseInt === parseInt` identity lines need **builtin-function reification with identity** (a bare `parseInt` value is currently an unbound ident). The parseInt/parseFloat *calls* already work.

## Testing
- TS suite: **1688/1688 pass** (clean run; one earlier failure was a known JIT-parallelism flake — the same test passes isolated/single-threaded).
- Targeted codegen unit tests (obj/binop/array): **110/110 pass**.
- `scripts/read_before_commit.sh`: green (no HARD violation; `binop.rs` shrank, the bulk of new code is in a new focused `method_array_coerce.rs` module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er9ksRgLQdNDMZE6CgZcn1