### PR TITLE
feat(dom+engine): bloco <script> da página executa in-process + setters dinâmicos

### DIFF
--- a/crates/rts-codegen-new/src/front/run/methodtable.rs
+++ b/crates/rts-codegen-new/src/front/run/methodtable.rs
@@ -44,6 +44,29 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 }
                 methods.push((mname.clone(), fname.clone(), sig.params.len() as i64));
             }
+            // ACCESSORS on the proto too, under the `__get_<key>`/`__set_<key>`
+            // convention the dynamic paths already dispatch (`__rtsadp_obj_get`
+            // invokes a chain `__get_x` on own-slot miss; `__rtsadp_obj_set`
+            // mirrors with `__set_x`) — so a TAGGED receiver (an `any` local, a
+            // `new Function` body, a union-typed return) reaches class getters/
+            // setters exactly like literal/defineProperty accessors. The STATIC
+            // known-class dispatch is untouched (it resolves at compile time and
+            // never consults the proto).
+            for (aname, acc) in &desc.accessors {
+                for (fname, key) in [
+                    (acc.getter.as_ref(), format!("__get_{aname}")),
+                    (acc.setter.as_ref(), format!("__set_{aname}")),
+                ] {
+                    let Some(fname) = fname else { continue };
+                    let Some(sig) = self.sigs.get(fname.as_str()) else {
+                        continue;
+                    };
+                    if sig.is_async || !self.thunks.contains_key(fname) {
+                        continue;
+                    }
+                    methods.push((key, fname.clone(), sig.params.len() as i64));
+                }
+            }
             if !methods.is_empty() {
                 rows.push((desc.name.clone(), desc.parent.clone(), methods));
             }

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -940,9 +940,9 @@ function __loadScriptAt(h: number, j: number, baseUrl: string): number {
 // classes Document/Element existem lá com a mesma API.
 //
 // Limites HONESTOS do subset dinâmico (documentados, não silenciosos):
-//   • SETTER de propriedade não despacha no dynfn (`el.textContent = x` cria campo
-//     morto). O script deve usar MÉTODOS: `setInnerHTML`, `setAttribute`,
-//     `classListAdd`... (mesma restrição já anotada no `set innerHTML` acima).
+//   • GETTER/SETTER de classe despacham também no caminho dinâmico (o prólogo do
+//     motor registra `__get_/__set_<prop>` no proto — `el.textContent = x` chama o
+//     setter REAL, como no browser).
 //   • O retorno do dynfn é i64 — devolver string do script não sobrevive à borda.
 //     Efeitos no DOM (o caso real de <script>) funcionam; "return de valor" não é
 //     o contrato de um bloco de página mesmo.

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -915,13 +915,8 @@ function __loadLinkAt(h: number, i: number, baseUrl: string): number {
 
 // Carrega o fonte do j-ésimo `<script src>` e o injeta no DOM como texto do nó
 // `<script>` (fica acessível via `el.textContent`), via `dom.runScript`. Devolve 1/0.
-//
-// ⚠️ NÃO há EXECUÇÃO de script no motor novo ainda: o namespace `runtime` (eval) não
-// está registrado no codegen novo, e o único eval disponível (`__RTS_FN_NS_RUNTIME_EVAL`)
-// roda num SUBPROCESSO isolado que não enxerga este DOM — inútil para `<script>`.
-// Então `dom.runScript` apenas materializa o fonte no nó (carregar ≠ executar). A
-// execução real entra quando o motor expuser um eval in-process com acesso ao DOM.
-// Regressão explícita do escopo "executar via eval", justificada pelo bloqueador.
+// Carregar ≠ executar: a execução é a fase seguinte, `runScripts(doc)` (abaixo),
+// que compila cada `<script>` in-process via `new Function` (o eval do motor novo).
 function __loadScriptAt(h: number, j: number, baseUrl: string): number {
   const node = dom.getByTagAt(h, "script", j);
   if (node === __DOM_NONE) return 0;
@@ -932,4 +927,60 @@ function __loadScriptAt(h: number, j: number, baseUrl: string): number {
   if (code.length === 0) return 0;
   dom.runScript(h, node, code);
   return 1;
+}
+
+// ── Execução de <script> — o "bloco JS" da página ──────────────────────────────
+//
+// `runScripts(doc)` compila e roda cada `<script>` do documento, em ordem de
+// documento, IN-PROCESS: o corpo vai pelo `new Function` (pipeline swc→HIR→JIT do
+// motor, hook COMPILE_FN_HOOK/dynfn.rs) e roda na MESMA thread — o store de DOMs é
+// thread_local no Rust, então o script enxerga o MESMO documento. A ponte é 100%
+// dados: prefixamos `const document = new Document(__h)` no corpo e passamos o
+// handle como argumento. O programa aninhado inclui os mesmos preludes, então as
+// classes Document/Element existem lá com a mesma API.
+//
+// Limites HONESTOS do subset dinâmico (documentados, não silenciosos):
+//   • SETTER de propriedade não despacha no dynfn (`el.textContent = x` cria campo
+//     morto). O script deve usar MÉTODOS: `setInnerHTML`, `setAttribute`,
+//     `classListAdd`... (mesma restrição já anotada no `set innerHTML` acima).
+//   • O retorno do dynfn é i64 — devolver string do script não sobrevive à borda.
+//     Efeitos no DOM (o caso real de <script>) funcionam; "return de valor" não é
+//     o contrato de um bloco de página mesmo.
+//   • Sem `async`/`await` no corpo (limite do new Function herdado do motor).
+// Erro de compilação/execução de um script NÃO derruba os demais (isolamento por
+// try/catch, como no browser). Devolve quantos scripts rodaram com sucesso.
+function runScripts(doc: Document): number {
+  // `: i64` no handle e no param da helper: handle via param `number` corrompe
+  // (fcvt vs bitcast — issue #1870 do motor).
+  const h: i64 = doc._dom;
+  let ran = 0;
+  const scriptCount = dom.getByTagCount(h, "script");
+  let j = 0;
+  while (j < scriptCount) {
+    ran = ran + __runScriptAt(h, j);
+    j = j + 1;
+  }
+  return ran;
+}
+
+// Roda o j-ésimo `<script>`: inline usa o texto do nó; externo usa o fonte que o
+// `loadResources` materializou no nó (mesmo caminho). Devolve 1 (rodou) ou 0.
+function __runScriptAt(h: i64, j: number): number {
+  const node = dom.getByTagAt(h, "script", j);
+  if (node === __DOM_NONE) return 0;
+  const code = dom.getText(h, node);
+  if (code.length === 0) return 0;
+  // `return 0` final: o dynfn é tipado i64 e o corpo de um <script> normalmente
+  // não tem return — garantimos um. (Um return do próprio script vence, este vira
+  // código morto.)
+  const body = "const document = new Document(__h);\n" + code + "\nreturn 0;";
+  let ok = 1;
+  try {
+    const f = new Function("__h", body);
+    f(h);
+  } catch (e) {
+    // Script quebrado não derruba a página (comportamento do browser).
+    ok = 0;
+  }
+  return ok;
 }

--- a/tests/claude-dom-runscripts.test.ts
+++ b/tests/claude-dom-runscripts.test.ts
@@ -22,6 +22,10 @@ const html = "<div id='app'><h1 id='t'>antes</h1><ul id='list'></ul></div>" +
   "<script>" +
   "const t2 = document.getElementById('t');" +
   "if (t2 !== null) { t2.setAttribute('data-seq', 'terceiro'); }" +
+  "</script>" +
+  "<script>" +
+  "const t3 = document.getElementById('t');" +
+  "if (t3 !== null) { t3.textContent = 'via setter'; }" +
   "</script>";
 
 const doc = parseDocument(html);
@@ -36,10 +40,10 @@ const ultimo = nLis === 3 ? lis[2].textContent : "";
 
 describe("runScripts — bloco <script> da página", () => {
   test("scripts válidos rodam; o quebrado é isolado", () => {
-    expect(ran).toBe(2);
+    expect(ran).toBe(3);
   });
-  test("script muta o DOM via método", () => {
-    expect(textoDepois).toBe("mudado");
+  test("script muta o DOM via SETTER de propriedade (como no browser)", () => {
+    expect(textoDepois).toBe("via setter");
   });
   test("script cria elementos dinamicamente", () => {
     expect(nLis).toBe(3);

--- a/tests/claude-dom-runscripts.test.ts
+++ b/tests/claude-dom-runscripts.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "rts:test";
+
+// Bloco <script> da página: runScripts compila cada <script> in-process (new
+// Function) e roda com `document` apontando pro MESMO DOM (store thread_local).
+// Pré-computado no top-level (regra do projeto: chamadas de método dentro de
+// test() podem perder handle pro GC).
+
+const html = "<div id='app'><h1 id='t'>antes</h1><ul id='list'></ul></div>" +
+  "<script>" +
+  "const el = document.getElementById('t');" +
+  "if (el !== null) { el.setInnerHTML('mudado'); }" +
+  "let i = 0;" +
+  "while (i < 3) {" +
+  "  const li = document.createElement('li');" +
+  "  li.setInnerHTML('item ' + i);" +
+  "  const list = document.getElementById('list');" +
+  "  if (list !== null) { list.appendChild(li); }" +
+  "  i = i + 1;" +
+  "}" +
+  "</script>" +
+  "<script>tem erro de sintaxe {{{</script>" +
+  "<script>" +
+  "const t2 = document.getElementById('t');" +
+  "if (t2 !== null) { t2.setAttribute('data-seq', 'terceiro'); }" +
+  "</script>";
+
+const doc = parseDocument(html);
+const ran = runScripts(doc);
+
+const t = doc.getElementById("t");
+const textoDepois = t === null ? "" : t.textContent;
+const attrDepois = t === null ? "" : t.getAttribute("data-seq");
+const lis = doc.querySelectorAll("#list li");
+const nLis = lis.length;
+const ultimo = nLis === 3 ? lis[2].textContent : "";
+
+describe("runScripts — bloco <script> da página", () => {
+  test("scripts válidos rodam; o quebrado é isolado", () => {
+    expect(ran).toBe(2);
+  });
+  test("script muta o DOM via método", () => {
+    expect(textoDepois).toBe("mudado");
+  });
+  test("script cria elementos dinamicamente", () => {
+    expect(nLis).toBe(3);
+    expect(ultimo).toBe("item 2");
+  });
+  test("script após o quebrado ainda roda", () => {
+    expect(attrDepois).toBe("terceiro");
+  });
+});


### PR DESCRIPTION
## O que faz

Duas fatias que destravam **rodar o JS de páginas web** no motor:

### 1. `runScripts(doc)` — o bloco `<script>` executa (crates/rts-dom/src/dom.ts)
- Compila cada `<script>` (inline ou src materializado pelo `loadResources`) **in-process** via `new Function` (pipeline swc→HIR→JIT já existente, COMPILE_FN_HOOK/dynfn.rs) — sem tocar o motor pra isso.
- O corpo é prefixado com `const document = new Document(__h)`; o programa aninhado inclui os mesmos preludes (classes Document/Element) e roda na MESMA thread → o store thread_local entrega o MESMO DOM.
- Script quebrado é isolado por try/catch (não derruba os demais, como no browser).
- Handle anotado `: i64` no prelude por causa do #1870.

### 2. Getters/setters de classe no caminho DINÂMICO (crates/rts-codegen-new)
- O prólogo de proto-methods (`methodtable.rs`) agora registra também os **acessores** sob a convenção `__get_/__set_<prop>` que `__rtsadp_obj_get/obj_set` já despacham para literais/defineProperty.
- Resultado: `el.textContent = 'x'` num `<script>` de página (receiver Tagged) chama o setter REAL e muta o DOM — antes criava campo morto silencioso.
- Dispatch estático de classe conhecida intocado.

## Validação
- `tests/claude-dom-runscripts.test.ts` (novo — primeiro teste da suite usando rts:dom): mutação via setter, criação dinâmica de elementos, isolamento de script quebrado, ordem de execução — 4/4.
- rts-dom 188/188; closures do codegen 27/27; gate `read_before_commit.sh` sem violação HARD.

## Regressões conhecidas: NENHUMA (verificado contra baseline)
Falhas PRÉ-EXISTENTES confirmadas idênticas no baseline sem estas mudanças: `node_fs_basic` (2 casos, falha isolado nos dois binários), flakiness de carga na suite completa (`node_dns_full`/`node_querystring_full` passam isolados), hang da suite `--lib` completa do rts-codegen-new (débito da campanha suite-100).

## Limites honestos (documentados no código)
- Retorno string do dynfn não sobrevive à borda i64 (efeitos no DOM funcionam; não é o contrato de um `<script>`).
- Sem `async`/`await` no corpo do script (limite herdado do `new Function`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z