### PR TITLE
feat(engine): new Function fala a ABI uniforme — JS sem tipos roda no <script>

### DIFF
--- a/crates/rts-codegen-new/src/front/run/dynfn.rs
+++ b/crates/rts-codegen-new/src/front/run/dynfn.rs
@@ -15,12 +15,15 @@
 //! API precisely so `new Function`/eval can compile while the outer program is
 //! live).
 //!
-//! Invoke contract: the produced `fn_ptr` is called through the LEGACY
-//! `invoke_typed` path (all-i64 `extern "C"`), so every param and the return are
-//! annotated `i64` in the synthesized source. A dynamic function is therefore
-//! integer-typed — the `new Function` subset the old engine shipped. It is NOT
-//! in the program's tail set (no `CallConv::Tail`), so the raw pointer is
-//! extern-callable.
+//! Invoke contract: the produced `fn_ptr` is the function's UNIFORM-ABI THUNK
+//! (`(env, a0..a3, rest) -> word`, PolyValue words both ways — the same shape
+//! every engine fn-value uses), flagged `uniform: true` so the Function invoke
+//! paths route it like any first-class fn. Params are synthesized UNTYPED
+//! (Tagged/`any` — real JS semantics: method calls/getters/setters on a param
+//! dispatch dynamically via the proto tables), and the return is a word (a
+//! string return survives the boundary). Fallback: if the thunk was not
+//! definable for this body, the raw pointer ships with `uniform: false`
+//! (legacy all-i64 — the pre-P5 contract).
 
 use std::sync::{Arc, Mutex};
 
@@ -45,12 +48,11 @@ pub(super) fn register_hook() {
 /// `JITModule`, and hand back the finalized code pointer + the module as the
 /// keep-alive anchor.
 fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn> {
-    let plist = params
-        .iter()
-        .map(|p| format!("{p}: i64"))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let src = format!("function {DYN_FN_NAME}({plist}): i64 {{\n{body}\n}}\n");
+    // Params UNTYPED (Tagged/`any`): real-JS semantics — a page script's
+    // `function f(el) { el.textContent = x }` dispatches dynamically. A caller
+    // MAY still pass an explicit annotation in the param string ("h: i64").
+    let plist = params.to_vec().join(", ");
+    let src = format!("function {DYN_FN_NAME}({plist}) {{\n{body}\n}}\n");
     let prog = super::build_with_includes(&src)
         .map_err(|e| anyhow::anyhow!("new Function body: {e}"))?;
     let mut module = super::module_jit::make_module();
@@ -59,6 +61,18 @@ fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn>
     module
         .finalize_definitions()
         .map_err(|e| anyhow::anyhow!("new Function finalize: {e}"))?;
+    // Prefer the fn's UNIFORM THUNK (words in/out — see the module doc): the
+    // invoke paths then treat it like any engine fn-value. The raw body pointer
+    // is the legacy fallback when the thunk wasn't definable for this body.
+    if let Some(FuncOrDataId::Func(tid)) = module.get_name(&super::thunk::thunk_name(DYN_FN_NAME)) {
+        let fn_ptr = module.get_finalized_function(tid) as u64;
+        return Ok(CompiledFn {
+            fn_ptr,
+            arity: params.len() as u8,
+            uniform: true,
+            keep_alive: Arc::new(Mutex::new(module)),
+        });
+    }
     let Some(FuncOrDataId::Func(id)) = module.get_name(DYN_FN_NAME) else {
         anyhow::bail!("new Function: compiled module lost `{DYN_FN_NAME}`");
     };
@@ -66,6 +80,7 @@ fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn>
     Ok(CompiledFn {
         fn_ptr,
         arity: params.len() as u8,
+        uniform: false,
         keep_alive: Arc::new(Mutex::new(module)),
     })
 }

--- a/crates/rts-primitives/src/function/ops.rs
+++ b/crates/rts-primitives/src/function/ops.rs
@@ -44,6 +44,11 @@ fn proxy_resolve(handle: u64) -> Option<(u64, u64)> {
 pub struct CompiledFn {
     pub fn_ptr: u64,
     pub arity: u8,
+    /// `true` quando `fn_ptr` é o THUNK de ABI uniforme do motor novo
+    /// (`(env, a0..a3, rest) -> word`, PolyValue nos dois sentidos) — o
+    /// invoke roteia como qualquer fn-value do motor. `false` = fn_ptr cru
+    /// legado all-i64.
+    pub uniform: bool,
     pub keep_alive: Arc<Mutex<dyn std::any::Any + Send>>,
 }
 
@@ -807,7 +812,7 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_NEW(params_handle: u64, body_handle: u64)
         keep_alive: Some(compiled.keep_alive),
         prototype_handle: 0,
         rest_param_idx: -1,
-        uniform_thunk: false,
+        uniform_thunk: compiled.uniform,
     })))
 }
 
@@ -817,6 +822,19 @@ pub extern "C" fn __RTS_FN_GL_FUNCTION_CALL(handle: u64, this_arg: i64, args_han
     // (#218 phase2) Proxy callable: redireciona pra trap apply ou forward.
     if let Some((target, handler)) = proxy_resolve(handle) {
         return unsafe { __RTS_FN_RT_PROXY_DISPATCH_APPLY(target, handler, this_arg, args_handle) };
+    }
+    // dynfn v2: um `new Function` UNIFORME (fn_ptr = thunk de words) chamado pela
+    // superfície CRUA — boxa cada arg i64 (raw_to_word), invoca pelo caminho
+    // uniforme e decodifica o retorno (word_to_raw) pro slot i64. Sem a ponte,
+    // o thunk recebia crus como words e devolvia word cru ao caller.
+    if read_uniform_thunk(handle) {
+        let raw = read_args_vec(args_handle);
+        let words: Vec<i64> = raw.iter().map(|&a| raw_to_word(a)).collect();
+        let wh = rts_engine::heap::handles::alloc_entry(
+            rts_engine::heap::handles::Entry::Vec(Box::new(words)),
+        );
+        let r = __RTS_FN_RT_INVOKE_AUTO(handle as i64, this_arg, wh) as u64;
+        return word_to_raw(r);
     }
     // (cross-runtime #218/#354) `handle` pode ser um func_addr CRU (arrow/fn
     // passada como VALOR a um param any/function e invocada via .apply/.call —


### PR DESCRIPTION
## O que faz

Terceira fatia da campanha "rodar JS de página real": o `new Function` (o executor do bloco `<script>`) passa a falar a **ABI uniforme de words** do motor, em vez do contrato legado all-i64.

### Antes
- Todo param sintetizado como `: i64` → `function f(el) { el.textContent = x }` num script de página virava `Number.textContent` e **o corpo inteiro bailava na compilação**.
- Retorno i64 cru: string não sobrevivia à borda.

### Agora
- **dynfn.rs**: params sem anotação (Tagged/`any` — semântica JS real; método/getter/setter em param despacham dinamicamente via proto tables). O `fn_ptr` entregue é o **thunk uniforme** `(env, a0..a3, rest) → word` que o motor já gera pra todo fn. Fallback legado preservado.
- **ops.rs (rts-primitives)**: `CompiledFn.uniform` → `uniform_thunk` no `Entry::Function`; a superfície crua (`GL_FUNCTION_CALL`) ganha a ponte raw→word→raw quando o callee é uniforme.

### Resultado (validado)
```html
<script>
function addItem(lista, texto) {        // sem tipos, como qualquer site
  const li = document.createElement('li');
  li.textContent = texto;               // setter em param sem tipo
  lista.appendChild(li);
}
const l = document.getElementById('l');
if (l !== null) { addItem(l, 'um'); addItem(l, 'dois'); }
</script>
```
Funciona de ponta a ponta no motor.

### Limite que permanece (documentado no código)
Retorno STRING de `new Function` lido pela borda externa i64 vira handle numérico (dentro do script, strings funcionam plenamente — não é o contrato de um `<script>`).

## Validação
- Suite TS: **2256/2263** — as 7 falhas são o conjunto flaky pré-existente (node_fs_basic etc., idêntico ao baseline verificado no PR #1882)
- Testes de function/closure/callback/promise/new Function: todos passam isolados
- rts-dom 188/188; claude-dom-runscripts 4/4; gate `read_before_commit.sh` sem violação HARD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z