### PR TITLE
feat(dom+engine): addEventListener com callback real — modelo de eventos do browser

### DIFF
--- a/crates/rts-adapters/src/value/funcops.rs
+++ b/crates/rts-adapters/src/value/funcops.rs
@@ -984,6 +984,41 @@ pub extern "C" fn __rtsadp_fn_apply_this(fn_word: u64, this_word: u64, arr_word:
     __rtsadp_fn_invoke_method(fn_word, this_word, elem(0), elem(1), elem(2), rest)
 }
 
+/// `engine.invoke_cb(cb, a0)` — invoca um CALLBACK guardado opaco fora do mundo
+/// de words (os listeners do DOM guardam o fn pela borda I64 da ABI de
+/// namespace, então ele pode chegar aqui como word de função, como HANDLE cru
+/// ou como um double-word do valor do handle). Normaliza para word de função e
+/// invoca com `this = undefined`, um argumento. Não-função ⇒ `undefined`.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_invoke_cb(cb: u64, a0: u64) -> u64 {
+    use rts_engine::heap::poly as p;
+    let undef = PolyValue::undefined().raw();
+    let v = PolyValue::from_raw(cb);
+    let fn_word = if v.is_function() {
+        cb
+    } else {
+        // Decodifica o valor numérico (double inline ou i64 cru) de volta ao
+        // handle e re-taggeia. Exato até 2^53 — a mesma janela da ponte
+        // raw_to_word (gen do handle ≤ 32).
+        let raw = if (cb & p::POLY_BOX_BASE) == p::POLY_BOX_BASE {
+            match PolyValue::from_raw(cb) {
+                w if w.is_int32() => w.as_i32() as i64 as u64,
+                _ => return undef,
+            }
+        } else {
+            f64::from_bits(cb) as u64
+        };
+        let is_fn = with_entry(raw, |e| matches!(e, Some(Entry::Function(_))));
+        if !is_fn {
+            return undef;
+        }
+        let slot =
+            rts_runtime::namespaces::gc::handles::__RTS_FN_NS_GC_POLY_FROM_HANDLE(raw);
+        PolyValue::from_function_handle(slot).raw()
+    };
+    __rtsadp_fn_invoke_method(fn_word, undef, a0, undef, undef, 0)
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn __rtsadp_fn_invoke_method(
     fn_word: u64,

--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -325,6 +325,7 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
         sym("__rtsadp_fn_reify", funcops::__rtsadp_fn_reify as *const u8),
         sym("__rtsadp_fn_reify_this", funcops::__rtsadp_fn_reify_this as *const u8),
         sym("__rtsadp_fn_invoke_method", funcops::__rtsadp_fn_invoke_method as *const u8),
+        sym("__rtsadp_invoke_cb", funcops::__rtsadp_invoke_cb as *const u8),
         sym(
             "__rtsadp_fn_invoke",
             funcops::__rtsadp_fn_invoke as *const u8,

--- a/crates/rts-codegen-new/src/front/run/engineobj.rs
+++ b/crates/rts-codegen-new/src/front/run/engineobj.rs
@@ -182,6 +182,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if method == "queue_microtask" {
             return self.lower_engine_descriptor(module, args, "__rtsadp_queue_microtask", 1, Repr::Tagged);
         }
+        // `invoke_cb(cb, a0)` — invoca um callback guardado OPACO (word de fn,
+        // handle cru ou double do handle — os listeners do DOM): a fachada
+        // dispatchEvent do prelude usa para chamar os handlers registrados.
+        if method == "invoke_cb" {
+            return self.lower_engine_descriptor(module, args, "__rtsadp_invoke_cb", 2, Repr::Tagged);
+        }
         if method == "set_immediate" {
             return self.lower_engine_descriptor(module, args, "__rtsadp_set_immediate", 1, Repr::Tagged);
         }

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -970,7 +970,7 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
             ret: I64,
         },
         "__rtsadp_construct" | "__rtsadp_class_proto_init" | "__rtsadp_class_proto_set"
-        | "__rtsadp_set_timeout" | "__rtsadp_set_interval" => SymSig {
+        | "__rtsadp_set_timeout" | "__rtsadp_set_interval" | "__rtsadp_invoke_cb" => SymSig {
             params: &[U64, U64],
             ret: U64,
         },

--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -868,6 +868,60 @@ pub extern "C" fn __RTS_FN_NS_DOM_ADD_LISTENER(h: u64, id: i64, t_ptr: *const u8
     with_mut(h, |dom| dom.add_event_listener(node, &t));
 }
 
+/// `addListenerCb(domHandle, node, type, cb)` → registra o tipo E o callback
+/// (word/handle i64 da Function, guardado OPACO — quem invoca é a fachada TS).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_ADD_LISTENER_CB(
+    h: u64,
+    id: i64,
+    t_ptr: *const u8,
+    t_len: i64,
+    cb: i64,
+) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.add_event_listener_cb(node, &t, cb));
+}
+
+/// `dispatchCollect(domHandle, target, type, bubbles)` → dispara COLETANDO os
+/// callbacks (alvo → bubbling) no scratch do Dom; devolve quantos coletou. A
+/// fachada TS lê com `dispatchCbAt`/`dispatchCbNode` e COPIA antes de invocar.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_DISPATCH_COLLECT(
+    h: u64,
+    id: i64,
+    t_ptr: *const u8,
+    t_len: i64,
+    bubbles: i64,
+) -> i64 {
+    let Some(node) = NodeId::from_abi(id) else { return 0 };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| dom.dispatch_event_collect(node, &t, bubbles != 0)).unwrap_or(0)
+}
+
+/// `dispatchCbAt(domHandle, i)` → o i-ésimo callback-word coletado (0 fora do range).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_DISPATCH_CB_AT(h: u64, i: i64) -> i64 {
+    with(h, |dom| {
+        dom.last_dispatch_at(i.max(0) as usize)
+            .map(|(_, cb)| cb)
+            .unwrap_or(0)
+    })
+    .unwrap_or(0)
+}
+
+/// `dispatchCbNode(domHandle, i)` → o NodeId do nó que escuta no i-ésimo par
+/// coletado (-1 fora do range) — vira o `currentTarget` do handler na fachada.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_DISPATCH_CB_NODE(h: u64, i: i64) -> i64 {
+    with(h, |dom| {
+        dom.last_dispatch_at(i.max(0) as usize)
+            .map(|(n, _)| n.to_abi())
+            .unwrap_or(NODE_NONE)
+    })
+    .unwrap_or(NODE_NONE)
+}
+
 /// `removeListener(domHandle, node, type)` → para de escutar o tipo.
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_LISTENER(h: u64, id: i64, t_ptr: *const u8, t_len: i64) {
@@ -1705,6 +1759,38 @@ pub fn register(e: &mut Engine) {
             "addListener(dom: number, node: number, type: string): void",
             "element.addEventListener(type): register the node as listening for type.",
             __RTS_FN_NS_DOM_ADD_LISTENER as *const u8,
+        ))
+        .member(func(
+            "addListenerCb", "__RTS_FN_NS_DOM_ADD_LISTENER_CB",
+            Sig::new(vec![Handle, I64, StrPtr, I64], AbiType::Void),
+            "addListenerCb(dom: number, node: number, type: string, cb: number): void",
+            "element.addEventListener(type, fn): register type AND the callback \
+             (Function word/handle, stored opaque — the TS facade invokes it).",
+            __RTS_FN_NS_DOM_ADD_LISTENER_CB as *const u8,
+        ))
+        .member(func(
+            "dispatchCollect", "__RTS_FN_NS_DOM_DISPATCH_COLLECT",
+            Sig::new(vec![Handle, I64, StrPtr, I64], I64),
+            "dispatchCollect(dom: number, target: number, type: string, bubbles: number): number",
+            "dispatch collecting callbacks (target then bubbling) into the Dom \
+             scratch; returns how many. Read with dispatchCbAt/dispatchCbNode and \
+             COPY before invoking (a callback may re-dispatch).",
+            __RTS_FN_NS_DOM_DISPATCH_COLLECT as *const u8,
+        ))
+        .member(func(
+            "dispatchCbAt", "__RTS_FN_NS_DOM_DISPATCH_CB_AT",
+            Sig::new(vec![Handle, I64], I64),
+            "dispatchCbAt(dom: number, i: number): number",
+            "i-th collected callback word (0 if out of range).",
+            __RTS_FN_NS_DOM_DISPATCH_CB_AT as *const u8,
+        ))
+        .member(func(
+            "dispatchCbNode", "__RTS_FN_NS_DOM_DISPATCH_CB_NODE",
+            Sig::new(vec![Handle, I64], I64),
+            "dispatchCbNode(dom: number, i: number): number",
+            "NodeId of the listening node in the i-th collected pair (-1 if out of \
+             range) — the handler's currentTarget.",
+            __RTS_FN_NS_DOM_DISPATCH_CB_NODE as *const u8,
         ))
         .member(func(
             "removeListener", "__RTS_FN_NS_DOM_REMOVE_LISTENER",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -163,13 +163,22 @@ pub struct Dom {
     /// DERIVADO do HTML, fora do `PartialEq`.
     raw_css: String,
     /// Eventos (#1760, modelo de POLLING — F3): que TIPOS cada nó escuta
-    /// (`addEventListener`). Os callbacks vivem no TS (o motor não guarda fn-handles
-    /// de forma confiável — limite #195); aqui só registramos o tipo p/ saber se um
+    /// (`addEventListener`). Aqui só registramos o tipo p/ saber se um
     /// `dispatchEvent` deve notificar o nó. `NodeIdx → tipos`. DERIVADO, fora do Eq.
     listeners: HashMap<NodeIdx, Vec<String>>,
+    /// CALLBACKS por (nó, tipo) — `el.addEventListener('click', fn)` com fn de
+    /// verdade. O Dom guarda o WORD/handle i64 da Function OPACO (nunca o invoca —
+    /// o rts-dom é headless e livre de runtime; quem invoca é a camada TS via
+    /// `dispatch_event_collect`). Guardar fn-handles ficou confiável com o motor
+    /// novo (Entry::Function com keep_alive; o antigo limite #195 caiu).
+    listener_cbs: HashMap<(NodeIdx, String), Vec<i64>>,
     /// Fila de eventos PENDENTES a entregar ao loop TS via `pollEvent`. Cada entrada
     /// é `(nó-alvo a notificar, tipo)` — já expandida pelo bubbling no `dispatch`.
     event_queue: std::collections::VecDeque<(NodeIdx, String)>,
+    /// Scratch da ÚLTIMA coleta de `dispatch_event_collect`: pares (nó-alvo,
+    /// callback-word) na ordem de invocação. A camada TS copia TUDO para um array
+    /// local ANTES de invocar (um callback pode re-despachar e sobrescrever isto).
+    last_dispatch: Vec<(NodeIdx, i64)>,
     // ── Animação (#1776) — LOOP INTERNO ao DOM; o egui só passa o tempo ───────────
     /// As transições EM CURSO, por nó. O `Dom` é dono do loop: `advance(now_ms)`
     /// detecta mudanças de estilo, inicia/atualiza transições e grava o estilo
@@ -264,6 +273,8 @@ impl Dom {
             stylesheet: crate::style::Stylesheet::new(),
             raw_css: String::new(),
             listeners: HashMap::new(),
+            listener_cbs: HashMap::new(),
+            last_dispatch: Vec::new(),
             event_queue: std::collections::VecDeque::new(),
             active_transitions: HashMap::new(),
             prev_computed: HashMap::new(),
@@ -900,12 +911,29 @@ impl Dom {
         }
     }
 
+    /// `element.addEventListener(type, fn)` com CALLBACK: registra o tipo (como
+    /// acima) e guarda o word/handle i64 da Function, opaco. Duplicatas do MESMO
+    /// callback são ignoradas (spec DOM: registrar o mesmo par duas vezes é no-op).
+    pub fn add_event_listener_cb(&mut self, id: NodeId, event_type: &str, cb: i64) {
+        let Some(idx) = self.resolve(id) else { return };
+        self.add_event_listener(id, event_type);
+        let cbs = self
+            .listener_cbs
+            .entry((idx, event_type.to_string()))
+            .or_default();
+        if !cbs.contains(&cb) {
+            cbs.push(cb);
+        }
+    }
+
     /// `element.removeEventListener(type)`: para de escutar `type` neste nó.
+    /// (Remove também os callbacks registrados do tipo.)
     pub fn remove_event_listener(&mut self, id: NodeId, event_type: &str) {
         let Some(idx) = self.resolve(id) else { return };
         if let Some(types) = self.listeners.get_mut(&idx) {
             types.retain(|x| x != event_type);
         }
+        self.listener_cbs.remove(&(idx, event_type.to_string()));
     }
 
     /// `true` se o nó escuta o tipo de evento dado (case-sensitive).
@@ -944,6 +972,54 @@ impl Dom {
     /// callback certo (que vive no TS, indexado por nó+tipo). O NodeId é versionado.
     pub fn poll_event(&mut self) -> Option<(NodeId, String)> {
         self.event_queue.pop_front().map(|(idx, t)| (self.make_id(idx), t))
+    }
+
+    /// `dispatchEvent` com COLETA de callbacks: mesmo caminhamento (alvo → bubbling
+    /// pelos ancestrais), mas além de enfileirar no polling, coleta em
+    /// `last_dispatch` os pares (nó-que-escuta, callback-word) na ordem de invocação
+    /// DOM (alvo primeiro, depois os ancestrais). O rts-dom NUNCA invoca — a camada
+    /// TS lê via [`Dom::last_dispatch_len`]/[`Dom::last_dispatch_at`], COPIA tudo e
+    /// só então invoca (um callback pode re-despachar e sobrescrever o scratch).
+    /// Devolve quantos callbacks foram coletados.
+    pub fn dispatch_event_collect(
+        &mut self,
+        target: NodeId,
+        event_type: &str,
+        bubbles: bool,
+    ) -> i64 {
+        self.last_dispatch.clear();
+        let mut cur = Some(target);
+        let mut first = true;
+        while let Some(node) = cur {
+            let Some(idx) = self.resolve(node) else { break };
+            if let Some(cbs) = self.listener_cbs.get(&(idx, event_type.to_string())) {
+                for &cb in cbs {
+                    self.last_dispatch.push((idx, cb));
+                }
+            }
+            if !bubbles && first {
+                break;
+            }
+            first = false;
+            cur = self.parent_of(node);
+        }
+        // Mantém o contrato do polling também (contadores/fila do modelo #1760):
+        // um app antigo que só usa pumpEvents continua vendo o evento.
+        self.dispatch_event(target, event_type, bubbles);
+        self.last_dispatch.len() as i64
+    }
+
+    /// Nº de callbacks coletados pelo último [`Dom::dispatch_event_collect`].
+    pub fn last_dispatch_len(&self) -> i64 {
+        self.last_dispatch.len() as i64
+    }
+
+    /// O i-ésimo par coletado: `(NodeId versionado do nó que escuta, callback-word)`.
+    /// `None` se fora do range.
+    pub fn last_dispatch_at(&self, i: usize) -> Option<(NodeId, i64)> {
+        self.last_dispatch
+            .get(i)
+            .map(|&(idx, cb)| (self.make_id(idx), cb))
     }
 
     // ── Animação (#1776) — o LOOP INTERNO ao DOM ─────────────────────────────────
@@ -2582,6 +2658,27 @@ mod tests {
         let p = dom.query("p").unwrap();
         assert_eq!(dom.text_content(p).unwrap(), "novo");
         assert!(dom.query("span").is_none()); // o velho foi descartado
+    }
+
+    #[test]
+    fn listener_cb_registra_e_coleta_com_bubbling() {
+        // addEventListener(type, fn): o Dom guarda o word opaco; dispatch_event_collect
+        // devolve os pares (nó, cb) na ordem DOM (alvo → ancestrais).
+        let mut dom = parse_html_to_dom("<div id=pai><button id=b>x</button></div>");
+        let pai = dom.query("#pai").unwrap();
+        let b = dom.query("#b").unwrap();
+        dom.add_event_listener_cb(b, "click", 111);
+        dom.add_event_listener_cb(pai, "click", 222);
+        // duplicata do MESMO cb é no-op (spec DOM).
+        dom.add_event_listener_cb(b, "click", 111);
+        assert_eq!(dom.dispatch_event_collect(b, "click", true), 2);
+        assert_eq!(dom.last_dispatch_at(0).unwrap().1, 111); // alvo primeiro
+        assert_eq!(dom.last_dispatch_at(1).unwrap().1, 222); // depois o pai
+        // sem bubbling: só o alvo.
+        assert_eq!(dom.dispatch_event_collect(b, "click", false), 1);
+        // removeEventListener limpa os callbacks do tipo.
+        dom.remove_event_listener(b, "click");
+        assert_eq!(dom.dispatch_event_collect(b, "click", false), 0);
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -15,6 +15,35 @@
 
 const __DOM_NONE = -1;
 
+// Despacho de evento com CALLBACKS: coleta os pares (nó, fn-word) do Rust
+// (`dispatchCollect` — alvo primeiro, depois bubbling), COPIA tudo para arrays
+// locais (um callback pode re-despachar e sobrescrever o scratch do Dom) e invoca
+// cada fn com um objeto de evento `{type, target, currentTarget}` (subset do Event
+// do browser). Devolve o total notificado (callbacks coletados; a fila de polling
+// legada também é alimentada pelo mesmo dispatchCollect).
+function __dispatchWithCallbacks(h: i64, node: number, type: string, bubbles: number): number {
+  const n = dom.dispatchCollect(h, node, type, bubbles);
+  if (n === 0) return 0;
+  const cbs: number[] = [];
+  const nodes: number[] = [];
+  let i = 0;
+  while (i < n) {
+    cbs.push(dom.dispatchCbAt(h, i));
+    nodes.push(dom.dispatchCbNode(h, i));
+    i = i + 1;
+  }
+  const target = new Element(h, node);
+  let j = 0;
+  while (j < n) {
+    const cur = new Element(h, nodes[j]);
+    // engine.invoke_cb: o cb atravessou a borda I64 da ABI (vira número); a
+    // bridge re-taggeia para função e invoca com 1 argumento (o objeto Event).
+    engine.invoke_cb(cbs[j], { type: type, target: target, currentTarget: cur });
+    j = j + 1;
+  }
+  return n;
+}
+
 // camelCase → kebab-case para o açúcar de `dataset` (`userId` → `user-id`).
 function __camelToKebab(s: string): string {
   let out = "";
@@ -305,29 +334,32 @@ class Element {
     return dom.computedProperty(this._dom, this._node, __camelToKebab(name));
   }
 
-  // ── Eventos (#1760) — modelo de POLLING (limite do motor: callbacks vivem no TS) ─
-  // `el.addEventListener(type)` — registra que o nó escuta o tipo. ⚠️ O motor não
-  // guarda fn-handles de forma confiável (#195), então NÃO recebe o callback aqui;
-  // o loop chama `pumpEvents()` por frame e despacha via getEventTargetId()/Type().
-  // O padrão de uso:
-  //   el.addEventListener("click");
-  //   ... // num laço por frame:
-  //   while (pumpEvents(d) !== -1) { if (getEventTargetId() === el.nodeId) { ... } }
-  addEventListener(type: string): void {
-    dom.addListener(this._dom, this._node, type);
+  // ── Eventos — callbacks REAIS + polling legado (#1760) ───────────────────────
+  // `el.addEventListener(type, fn)` — como no browser: registra o callback; um
+  // `dispatchEvent` invoca fn({type, target, currentTarget}) na ordem DOM (alvo →
+  // bubbling). O Dom guarda o fn-word opaco (o antigo limite #195 caiu — Function
+  // values são estáveis). A forma de 1 argumento continua valendo para o modelo de
+  // POLLING legado (pumpEvents/getEventTargetId por frame).
+  addEventListener(type: string, cb?: any): void {
+    if (cb === undefined) {
+      dom.addListener(this._dom, this._node, type);
+      return;
+    }
+    dom.addListenerCb(this._dom, this._node, type, cb);
   }
   removeEventListener(type: string): void {
     dom.removeListener(this._dom, this._node, type);
   }
   // `el.dispatchEvent(type)` — dispara COM BUBBLING (como `new Event(t, {bubbles:
-  // true})`). Devolve quantos listeners foram enfileirados.
+  // true})`): invoca os callbacks registrados (alvo → ancestrais) e alimenta a fila
+  // de polling legada. Devolve quantos listeners (callbacks + polling) notificou.
   dispatchEvent(type: string): number {
-    return dom.dispatchEvent(this._dom, this._node, type, 1);
+    return __dispatchWithCallbacks(this._dom, this._node, type, 1);
   }
   // `el.dispatchEventNoBubble(type)` — dispara SÓ no alvo (como `new Event(t)`, que
   // é bubbles:false por padrão; focus/blur/mouseenter não borbulham).
   dispatchEventNoBubble(type: string): number {
-    return dom.dispatchEvent(this._dom, this._node, type, 0);
+    return __dispatchWithCallbacks(this._dom, this._node, type, 0);
   }
   // `el.nodeId` — o NodeId cru deste elemento (p/ comparar no switch do polling).
   get nodeId(): number {

--- a/tests/claude-dom-event-callbacks.test.ts
+++ b/tests/claude-dom-event-callbacks.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "rts:test";
+
+// Eventos com CALLBACK real (modelo do browser): addEventListener(type, fn) +
+// dispatchEvent invocando fn({type, target, currentTarget}) com bubbling.
+// Pré-computado no top-level (regra do projeto).
+
+const doc = parseDocument("<div id='pai'><button id='b'>x</button></div>");
+const btn = doc.getElementById("b");
+const pai = doc.getElementById("pai");
+
+let cliques = 0;
+let tipoVisto = "";
+let alvoTag = "";
+let bubbleCurrent = "";
+
+if (btn !== null) {
+  btn.addEventListener("click", (ev: any) => {
+    cliques = cliques + 1;
+    tipoVisto = ev.type;
+    alvoTag = ev.target.tagName;
+  });
+}
+if (pai !== null) {
+  pai.addEventListener("click", (ev: any) => {
+    bubbleCurrent = ev.currentTarget.tagName;
+  });
+}
+let notificados = 0;
+if (btn !== null) {
+  notificados = btn.dispatchEvent("click");
+  btn.dispatchEvent("click");
+}
+
+// listener registrado por um <script> de página
+const html2 = "<button id='salvar'>s</button><div id='st'>antes</div>" +
+  "<script>" +
+  "const b = document.getElementById('salvar');" +
+  "if (b !== null) {" +
+  "  b.addEventListener('click', function(ev) {" +
+  "    const s = document.getElementById('st');" +
+  "    if (s !== null) { s.textContent = 'salvo:' + ev.type; }" +
+  "  });" +
+  "}" +
+  "</script>";
+const doc2 = parseDocument(html2);
+runScripts(doc2);
+const b2 = doc2.getElementById("salvar");
+if (b2 !== null) { b2.dispatchEvent("click"); }
+const st = doc2.getElementById("st");
+const stDepois = st === null ? "" : st.textContent;
+
+describe("eventos com callback (modelo do browser)", () => {
+  test("callback dispara com objeto de evento", () => {
+    expect(cliques).toBe(2);
+    expect(tipoVisto).toBe("click");
+    expect(alvoTag).toBe("BUTTON");
+  });
+  test("bubbling notifica o pai com currentTarget correto", () => {
+    expect(bubbleCurrent).toBe("DIV");
+    expect(notificados).toBe(2); // alvo + pai
+  });
+  test("listener registrado por <script> de página dispara", () => {
+    expect(stDepois).toBe("salvo:click");
+  });
+});


### PR DESCRIPTION
## O que faz

Quarta fatia da campanha "rodar JS de página real": **`el.addEventListener('click', fn)` funciona como no browser** — callback de verdade, objeto de evento, bubbling.

### Validado de ponta a ponta
```html
<script>
const b = document.getElementById('salvar');
b.addEventListener('click', function(ev) {
  document.getElementById('st').textContent = 'salvo:' + ev.type;
});
</script>
```
Um `dispatchEvent('click')` invoca o handler com `{type, target, currentTarget}`, na ordem DOM (alvo → bubbling pelos ancestrais).

### Como
- **rts-dom** (headless preservado): `listener_cbs` guarda o fn-word **opaco** por (nó, tipo) — o crate nunca invoca; `dispatch_event_collect` coleta os pares na ordem DOM num scratch que a fachada **copia antes de invocar** (um callback pode re-despachar). O polling legado (#1760) continua alimentado.
- **ABI `rts:dom`**: `addListenerCb` / `dispatchCollect` / `dispatchCbAt` / `dispatchCbNode`.
- **`engine.invoke_cb`** (bridge nova, `__rtsadp_invoke_cb` em rts-adapters): invoca um callback que atravessou a borda I64 da ABI de namespace (re-taggeia handle→função; `this=undefined`, 1 arg).
- **dom.ts**: `addEventListener(type, cb?)` — 2 args registra o callback; 1 arg mantém o polling legado. `dispatchEvent` invoca os handlers.

O antigo limite "#195 — motor não guarda fn-handles" caiu (Function values estáveis com keep_alive); comentários atualizados.

### Próxima fatia
Hit-test do mouse no egui alimentando `dispatchCollect` (fatia própria — exige a leitura do plano congelado do html-engine).

## Validação
- `tests/claude-dom-event-callbacks.test.ts` (novo): callback+objeto de evento, bubbling com currentTarget, listener registrado por `<script>` — 3/3
- rts-dom 189/189 (novo unit `listener_cb_registra_e_coleta_com_bubbling`); runscripts 4/4; direcionados function/callback/closure/promise verdes; gate sem violação HARD
- Suite completa: presa no hang flaky pré-existente (`node_child_process_full` — passa isolado; família do deadlock `net_tcp_echo` já documentada); 1314 ✓ / 1 crash flaky até o ponto do hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z