### PR TITLE
feat(dom+egui): clique real do mouse chega no addEventListener da página

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -858,6 +858,7 @@ pub extern "C" fn __RTS_FN_NS_DOM_REMOVE_STYLE_PROPERTY(h: u64, id: i64, n_ptr: 
 // esse tipo logo após. O loop TS: `n = pollEvent(); if (n>=0) { t = pollEventType(); ... }`.
 thread_local! {
     static LAST_EVENT_TYPE: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
+    static LAST_RAW_EVENT_TYPE: std::cell::RefCell<String> = const { std::cell::RefCell::new(String::new()) };
 }
 
 /// `addListener(domHandle, node, type)` → registra que o nó escuta o tipo.
@@ -968,6 +969,45 @@ pub extern "C" fn __RTS_FN_NS_DOM_POLL_EVENT(h: u64) -> i64 {
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_DOM_POLL_EVENT_TYPE(_h: u64) -> u64 {
     let t = LAST_EVENT_TYPE.with(|c| c.borrow().clone());
+    intern(&t)
+}
+
+/// `pushRawEvent(domHandle, node, type)` → empurra um evento CRU na fila do
+/// backend (o mesmo caminho do hit-test do mouse) — para eventos sintéticos e
+/// testes headless do ciclo completo.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_PUSH_RAW_EVENT(h: u64, id: i64, t_ptr: *const u8, t_len: i64) {
+    let Some(node) = NodeId::from_abi(id) else { return };
+    let t = unsafe { str_abi::from_abi(t_ptr, t_len) }.unwrap_or("").to_string();
+    with_mut(h, |dom| {
+        if let Some(idx) = dom.resolve(node) {
+            dom.push_raw_event(idx, &t);
+        }
+    });
+}
+
+/// `pollRawEvent(domHandle)` → NodeId do próximo evento CRU do backend (hit-test do
+/// mouse), ou -1. GUARDA o tipo p/ `pollRawEventType` ler em seguida. A fachada TS
+/// (`pumpEventCallbacks`) drena e faz o dispatch completo (bubbling + callbacks).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_POLL_RAW_EVENT(h: u64) -> i64 {
+    match with_mut(h, |dom| dom.poll_raw_event()) {
+        Some(Some((node, t))) => {
+            LAST_RAW_EVENT_TYPE.with(|c| *c.borrow_mut() = t);
+            node.to_abi()
+        }
+        _ => {
+            LAST_RAW_EVENT_TYPE.with(|c| c.borrow_mut().clear());
+            NODE_NONE
+        }
+    }
+}
+
+/// `pollRawEventType(domHandle)` → o tipo do evento entregue no último
+/// `pollRawEvent` ("" se nenhum). Ler imediatamente após.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_POLL_RAW_EVENT_TYPE(_h: u64) -> u64 {
+    let t = LAST_RAW_EVENT_TYPE.with(|c| c.borrow().clone());
     intern(&t)
 }
 
@@ -1819,6 +1859,29 @@ pub fn register(e: &mut Engine) {
             "pollEvent(dom: number): number",
             "next pending event's NodeId (-1 if none); stores type for pollEventType.",
             __RTS_FN_NS_DOM_POLL_EVENT as *const u8,
+        ))
+        .member(func(
+            "pushRawEvent", "__RTS_FN_NS_DOM_PUSH_RAW_EVENT",
+            Sig::new(vec![Handle, I64, StrPtr], AbiType::Void),
+            "pushRawEvent(dom: number, node: number, type: string): void",
+            "push a raw backend-style event (same path as the mouse hit-test) — \
+             synthetic events / headless tests of the full cycle.",
+            __RTS_FN_NS_DOM_PUSH_RAW_EVENT as *const u8,
+        ))
+        .member(func(
+            "pollRawEvent", "__RTS_FN_NS_DOM_POLL_RAW_EVENT",
+            Sig::new(vec![Handle], I64),
+            "pollRawEvent(dom: number): number",
+            "next backend-origin raw event's NodeId (mouse hit-test; -1 if none); \
+             stores type for pollRawEventType. pumpEventCallbacks drains this.",
+            __RTS_FN_NS_DOM_POLL_RAW_EVENT as *const u8,
+        ))
+        .member(func(
+            "pollRawEventType", "__RTS_FN_NS_DOM_POLL_RAW_EVENT_TYPE",
+            Sig::new(vec![Handle], AbiType::Handle),
+            "pollRawEventType(dom: number): string",
+            "type of the raw event delivered by the last pollRawEvent ('' if none).",
+            __RTS_FN_NS_DOM_POLL_RAW_EVENT_TYPE as *const u8,
         ))
         .member(func(
             "pollEventType", "__RTS_FN_NS_DOM_POLL_EVENT_TYPE",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -179,6 +179,12 @@ pub struct Dom {
     /// callback-word) na ordem de invocação. A camada TS copia TUDO para um array
     /// local ANTES de invocar (um callback pode re-despachar e sobrescrever isto).
     last_dispatch: Vec<(NodeIdx, i64)>,
+    /// Eventos CRUS vindos do BACKEND (hit-test do mouse): `(nó-alvo, tipo)` SEM
+    /// expansão de bubbling/listeners — o backend só empurra "clicou no nó X"; a
+    /// fachada TS drena via `pumpEventCallbacks` e faz o dispatch completo
+    /// (bubbling + callbacks + fila de polling). Padrão 1-frame-latency do
+    /// north-star §3.
+    raw_event_queue: std::collections::VecDeque<(NodeIdx, String)>,
     // ── Animação (#1776) — LOOP INTERNO ao DOM; o egui só passa o tempo ───────────
     /// As transições EM CURSO, por nó. O `Dom` é dono do loop: `advance(now_ms)`
     /// detecta mudanças de estilo, inicia/atualiza transições e grava o estilo
@@ -275,6 +281,7 @@ impl Dom {
             listeners: HashMap::new(),
             listener_cbs: HashMap::new(),
             last_dispatch: Vec::new(),
+            raw_event_queue: std::collections::VecDeque::new(),
             event_queue: std::collections::VecDeque::new(),
             active_transitions: HashMap::new(),
             prev_computed: HashMap::new(),
@@ -1007,6 +1014,21 @@ impl Dom {
         // um app antigo que só usa pumpEvents continua vendo o evento.
         self.dispatch_event(target, event_type, bubbles);
         self.last_dispatch.len() as i64
+    }
+
+    /// BACKEND → DOM: empurra um evento CRU (`(nó, tipo)`) vindo do hit-test do
+    /// mouse. Nenhuma expansão aqui — a fachada TS drena com [`Dom::poll_raw_event`]
+    /// e faz o dispatch completo (bubbling + callbacks). `idx` é o `NodeIdx` cru
+    /// que o backend tem em mãos (chave de `node_rects`).
+    pub fn push_raw_event(&mut self, idx: NodeIdx, event_type: &str) {
+        self.raw_event_queue.push_back((idx, event_type.to_string()));
+    }
+
+    /// Próximo evento CRU do backend `(NodeId versionado, tipo)`, ou `None`.
+    pub fn poll_raw_event(&mut self) -> Option<(NodeId, String)> {
+        self.raw_event_queue
+            .pop_front()
+            .map(|(idx, t)| (self.make_id(idx), t))
     }
 
     /// Nº de callbacks coletados pelo último [`Dom::dispatch_event_collect`].

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -961,6 +961,28 @@ function __loadScriptAt(h: number, j: number, baseUrl: string): number {
   return 1;
 }
 
+// Bomba de eventos do BACKEND (hit-test do mouse no egui): drena a fila de
+// eventos CRUS (`pollRawEvent` — o backend só empurra "clicou no nó X") e faz o
+// dispatch COMPLETO de cada um (bubbling + callbacks registrados + fila de
+// polling legada). Chamar UMA vez por frame no loop do app:
+//   while (win.isOpen()) { ... egui.render(...); pumpEventCallbacks(doc); }
+// Devolve quantos eventos foram despachados no frame.
+function pumpEventCallbacks(doc: Document): number {
+  const h: i64 = doc._dom;
+  let despachados = 0;
+  let guard = 0;
+  // guard: um callback pode re-despachar; 256 eventos/frame é teto sano.
+  while (guard < 256) {
+    const node = dom.pollRawEvent(h);
+    if (node === __DOM_NONE) return despachados;
+    const t = dom.pollRawEventType(h);
+    __dispatchWithCallbacks(h, node, t, 1);
+    despachados = despachados + 1;
+    guard = guard + 1;
+  }
+  return despachados;
+}
+
 // ── Execução de <script> — o "bloco JS" da página ──────────────────────────────
 //
 // `runScripts(doc)` compila e roda cada `<script>` do documento, em ordem de

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -146,6 +146,29 @@ pub struct DisplayList {
     pub scroll_regions: Vec<ScrollRegion>,
 }
 
+impl DisplayList {
+    /// HIT-TEST: o nó sob o ponto `(x, y)` em COORDENADAS DE CONTEÚDO (o backend
+    /// converte tela→conteúdo somando o offset de scroll antes de chamar). Entre
+    /// todos os `node_rects` que contêm o ponto, vence o de MENOR ÁREA — numa
+    /// árvore DOM os rects dos descendentes estão contidos nos dos ancestrais,
+    /// então menor área = nó mais profundo = top-most (o critério do north-star
+    /// §3, "ordem reversa da display list", sem depender de ordem num HashMap).
+    /// Limite documentado: irmãos sobrepostos por position/z-index podem resolver
+    /// pro rect menor em vez do maior z — aceito na v1 (raro em fluxo normal).
+    pub fn hit_test(&self, x: f32, y: f32) -> Option<NodeIdx> {
+        let mut best: Option<(NodeIdx, f32)> = None;
+        for (&idx, r) in &self.node_rects {
+            if x >= r.x && x < r.x + r.w && y >= r.y && y < r.y + r.h {
+                let area = r.w * r.h;
+                if best.map(|(_, a)| area < a).unwrap_or(true) {
+                    best = Some((idx, area));
+                }
+            }
+        }
+        best.map(|(idx, _)| idx)
+    }
+}
+
 /// Abstração de MEDIÇÃO de texto (largura/altura de uma string num tamanho/peso).
 /// Vive aqui (no `rts-dom`) e é IMPLEMENTADA pelo backend (o egui mede via galley);
 /// reimplementar largura de glifo no `rts-dom` é a armadilha que o roadmap alertou.
@@ -2357,6 +2380,32 @@ mod tests {
         let dom = parse_html_to_dom(html);
         let ctx = LayoutCtx { viewport_w: vw, viewport_h: 600.0, measurer: &ApproxMeasurer };
         layout_document(&dom, &ctx)
+    }
+
+    #[test]
+    fn hit_test_escolhe_o_no_mais_profundo() {
+        // Filho dentro do pai: clicar dentro do filho devolve o FILHO (menor
+        // área = mais profundo); clicar no pai fora do filho devolve o pai;
+        // fora de tudo devolve None.
+        def_div();
+        let dom = parse_html_to_dom(
+            "<div id=pai style='padding:50px'><div id=filho style='height:20px'>x</div></div>",
+        );
+        let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+        let list = layout_document(&dom, &ctx);
+        let pai = dom.query("#pai").unwrap();
+        let filho = dom.query("#filho").unwrap();
+        let pai_idx = dom.resolve(pai).unwrap();
+        let filho_idx = dom.resolve(filho).unwrap();
+        let fr = list.node_rects[&filho_idx];
+        let hit = list.hit_test(fr.x + fr.w / 2.0, fr.y + fr.h / 2.0);
+        assert_eq!(hit, Some(filho_idx));
+        // canto do pai (dentro do padding, fora do filho).
+        let pr = list.node_rects[&pai_idx];
+        let hit2 = list.hit_test(pr.x + 5.0, pr.y + 5.0);
+        assert_eq!(hit2, Some(pai_idx));
+        // fora de tudo.
+        assert_eq!(list.hit_test(-10.0, -10.0), None);
     }
 
     /// Primeiro `SolidRect` da lista (o fundo da 1ª caixa) — atalho de assert.

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -187,6 +187,44 @@ pub(crate) fn render_dom_scrolled(
     ui.set_clip_rect(clip);
     paint_list(ui, &list, -offset);
     ui.set_clip_rect(old_clip);
+
+    // HIT-TEST de CLIQUE (north-star §3 + handoff #1793 item 6): o egui é só o
+    // INPUT — converte tela→conteúdo (origem + offset de scroll) e pergunta ao
+    // MOTOR (`DisplayList::hit_test`, menor-área = nó mais profundo) qual nó foi
+    // clicado; o resultado vira um evento CRU na fila do Dom, que a fachada TS
+    // drena por frame (`pumpEventCallbacks` → bubbling + callbacks). O egui nunca
+    // decide semântica de evento nem invoca handler (padrão 1-frame-latency).
+    // Input CRU (não `ui.interact` — criaria um widget por cima e roubaria o drag
+    // da scrollbar registrada acima). A faixa da barra é excluída do hit-test.
+    {
+        let origin = ui.max_rect().min;
+        let clicked = ui.input(|i| i.pointer.primary_clicked());
+        let pos = ui.input(|i| i.pointer.interact_pos());
+        if clicked {
+            if let Some(pos) = pos {
+                if ui.max_rect().contains(pos) {
+                    let bar_w = if scroll_y && (max_off > 0.0 || force) {
+                        match sb.width {
+                            Some(rts_dom::scrollbar::BarWidth::Thin) => 8.0,
+                            Some(rts_dom::scrollbar::BarWidth::Px(px)) => px,
+                            _ => 12.0,
+                        }
+                    } else {
+                        0.0
+                    };
+                    let cx = pos.x - origin.x;
+                    let cy = pos.y - origin.y + offset; // tela → coords de conteúdo
+                    if cx < viewport_w - bar_w {
+                        if let Some(idx) = list.hit_test(cx, cy) {
+                            let _ = rts_dom::store::with_dom_mut(h, |d| {
+                                d.push_raw_event(idx, "click");
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
     // reserva a área visível (não a altura total — o scroll é nosso, não do egui).
     ui.allocate_space(egui::vec2(viewport_w, viewport_h));
 }

--- a/tests/claude-dom-event-callbacks.test.ts
+++ b/tests/claude-dom-event-callbacks.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "rts:test";
+import dom from "rts:dom";
 
 // Eventos com CALLBACK real (modelo do browser): addEventListener(type, fn) +
 // dispatchEvent invocando fn({type, target, currentTarget}) com bubbling.
@@ -49,6 +50,24 @@ if (b2 !== null) { b2.dispatchEvent("click"); }
 const st = doc2.getElementById("st");
 const stDepois = st === null ? "" : st.textContent;
 
+// ciclo do BACKEND (hit-test simulado): pushRawEvent → pumpEventCallbacks →
+// callback do script roda (o mesmo caminho que o clique real do mouse percorre).
+const doc3 = parseDocument(
+  "<button id='x'>x</button>" +
+  "<script>" +
+  "const b = document.getElementById('x');" +
+  "if (b !== null) { b.addEventListener('click', function(ev) { b.setAttribute('data-ok', '1'); }); }" +
+  "</script>");
+runScripts(doc3);
+const bx = doc3.getElementById("x");
+let pumped = 0;
+if (bx !== null) {
+  dom.pushRawEvent(doc3._dom, bx.nodeId, "click");
+  pumped = pumpEventCallbacks(doc3);
+}
+const bx2 = doc3.getElementById("x");
+const okAttr = bx2 === null ? "" : bx2.getAttribute("data-ok");
+
 describe("eventos com callback (modelo do browser)", () => {
   test("callback dispara com objeto de evento", () => {
     expect(cliques).toBe(2);
@@ -61,5 +80,9 @@ describe("eventos com callback (modelo do browser)", () => {
   });
   test("listener registrado por <script> de página dispara", () => {
     expect(stDepois).toBe("salvo:click");
+  });
+  test("evento do backend (hit-test) chega no callback via pump", () => {
+    expect(pumped).toBe(1);
+    expect(okAttr).toBe("1");
   });
 });


### PR DESCRIPTION
## O que faz

Quinta fatia da campanha "rodar JS de página real": **fecha o ciclo interativo** — o clique do usuário na janela chega no `addEventListener('click', fn)` registrado pelo `<script>` da página.

```
clique do mouse (egui, input cru)
  → tela→conteúdo (origem + offset de scroll)
  → DisplayList::hit_test (MOTOR, headless)
  → fila de eventos CRUS no Dom
  → pumpEventCallbacks(doc) por frame (TS)
  → bubbling + callbacks ({type, target, currentTarget})
```

### Plano congelado respeitado (li os 4 docs antes)
- **rts-dom** (headless): `hit_test` por menor-área (= nó mais profundo; o critério do north-star §3 sem depender de ordem em HashMap), fila crua `push/poll_raw_event` — o motor é dono da semântica.
- **rts-egui** continua BURRO: input cru do ponteiro (não `ui.interact` — não rouba o drag da scrollbar), exclui a faixa da barra, empurra `(nó, 'click')` e nada mais. Nunca invoca handler (padrão 1-frame-latency do north-star §3).
- ABI: `pushRawEvent` (sintético/teste) + `pollRawEvent(Type)`.

### Uso no app
```ts
while (egui.isOpen(win) !== 0) {
  egui.pump(win); egui.beginFrame(win);
  egui.render(win, doc._dom);
  egui.endFrame(win);
  pumpEventCallbacks(doc);   // ← os cliques do frame viram callbacks
}
```

## Validação
- Ciclo completo **headless**: `pushRawEvent` → pump → callback registrado por `<script>` muta o DOM (`claude-dom-event-callbacks` 4/4 — mesmo caminho de código do clique real).
- Unit `hit_test` (nó profundo vence / pai no padding / fora = None) — rts-dom **190/190**.
- Gate sem violação HARD; runscripts 4/4.
- **Pendência honesta**: validação visual com mouse real ficou pendente (a máquina estava em uso com um jogo em primeiro plano — não cliquei às cegas). Exemplo pronto: `scratchpad/janela-clique.ts`; o caminho egui usa o mesmo `hit_test` testado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z