### PR TITLE
feat(dom+egui): :hover vivo — regras :hover aplicam com o mouse de verdade

### DIFF
--- a/crates/rts-dom/src/abi.rs
+++ b/crates/rts-dom/src/abi.rs
@@ -972,6 +972,17 @@ pub extern "C" fn __RTS_FN_NS_DOM_POLL_EVENT_TYPE(_h: u64) -> u64 {
     intern(&t)
 }
 
+/// `setHovered(domHandle, node)` → informa o nó sob o cursor (`-1` = nenhum) — o
+/// estado do `:hover` vivo. O backend real chama por frame via hit-test; este
+/// membro cobre testes headless e backends alternativos.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_DOM_SET_HOVERED(h: u64, id: i64) {
+    with_mut(h, |dom| {
+        let idx = NodeId::from_abi(id).and_then(|n| dom.resolve(n));
+        dom.set_hovered(idx);
+    });
+}
+
 /// `pushRawEvent(domHandle, node, type)` → empurra um evento CRU na fila do
 /// backend (o mesmo caminho do hit-test do mouse) — para eventos sintéticos e
 /// testes headless do ciclo completo.
@@ -1859,6 +1870,14 @@ pub fn register(e: &mut Engine) {
             "pollEvent(dom: number): number",
             "next pending event's NodeId (-1 if none); stores type for pollEventType.",
             __RTS_FN_NS_DOM_POLL_EVENT as *const u8,
+        ))
+        .member(func(
+            "setHovered", "__RTS_FN_NS_DOM_SET_HOVERED",
+            Sig::new(vec![Handle, I64], AbiType::Void),
+            "setHovered(dom: number, node: number): void",
+            "set the node under the cursor (-1 = none) — live :hover state; the \
+             real backend feeds this per frame via hit-test.",
+            __RTS_FN_NS_DOM_SET_HOVERED as *const u8,
         ))
         .member(func(
             "pushRawEvent", "__RTS_FN_NS_DOM_PUSH_RAW_EVENT",

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -179,6 +179,11 @@ pub struct Dom {
     /// callback-word) na ordem de invocação. A camada TS copia TUDO para um array
     /// local ANTES de invocar (um callback pode re-despachar e sobrescrever isto).
     last_dispatch: Vec<(NodeIdx, i64)>,
+    /// O nó SOB O CURSOR (hit-test do backend, por frame) — o estado do `:hover`
+    /// vivo. `None` = ponteiro fora do conteúdo. Cell: mutável sem `&mut` (o
+    /// matcher lê durante a cascade). Setar via [`Dom::set_hovered`] (que só
+    /// invalida caches quando MUDA e quando o stylesheet tem regra `:hover`).
+    hovered: std::cell::Cell<Option<NodeIdx>>,
     /// Eventos CRUS vindos do BACKEND (hit-test do mouse): `(nó-alvo, tipo)` SEM
     /// expansão de bubbling/listeners — o backend só empurra "clicou no nó X"; a
     /// fachada TS drena via `pumpEventCallbacks` e faz o dispatch completo
@@ -282,6 +287,7 @@ impl Dom {
             listener_cbs: HashMap::new(),
             last_dispatch: Vec::new(),
             raw_event_queue: std::collections::VecDeque::new(),
+            hovered: std::cell::Cell::new(None),
             event_queue: std::collections::VecDeque::new(),
             active_transitions: HashMap::new(),
             prev_computed: HashMap::new(),
@@ -1014,6 +1020,28 @@ impl Dom {
         // um app antigo que só usa pumpEvents continua vendo o evento.
         self.dispatch_event(target, event_type, bubbles);
         self.last_dispatch.len() as i64
+    }
+
+    /// BACKEND → DOM: informa o nó SOB O CURSOR neste frame (`None` = ponteiro
+    /// fora do conteúdo). O estado alimenta o `:hover` vivo da cascade. GUARDA DE
+    /// PERF (handoff #1793): só invalida os caches (touch → re-cascade/re-layout)
+    /// quando o hovered realmente MUDA **e** o stylesheet tem alguma regra
+    /// `:hover` — mover o mouse numa página sem :hover custa zero.
+    pub fn set_hovered(&mut self, idx: Option<NodeIdx>) {
+        if self.hovered.get() == idx {
+            return;
+        }
+        self.hovered.set(idx);
+        let has_hover_rule = self.stylesheet.rules.iter().any(|r| {
+            r.selector.compounds.iter().any(|c| {
+                c.parts
+                    .iter()
+                    .any(|p| matches!(p, crate::style::SimpleSelector::Pseudo(crate::style::PseudoClass::Hover)))
+            })
+        });
+        if has_hover_rule {
+            self.touch();
+        }
     }
 
     /// BACKEND → DOM: empurra um evento CRU (`(nó, tipo)`) vindo do hit-test do
@@ -1847,6 +1875,13 @@ impl Dom {
                         "input" | "button" | "select" | "textarea" | "option" | "fieldset"));
                 is_form && self.nodes[idx].attr("disabled").is_none()
             }
+            // `:hover` VIVO: casa se o nó É o hovered ou um ANCESTRAL dele (o hover
+            // propaga — passar o mouse no <a> deixa o <li> pai também :hover, como
+            // no browser). `hovered` vem do backend (hit-test); headless = nunca.
+            P::Hover => match self.hovered.get() {
+                Some(hovered) => self.is_ancestor(idx, hovered),
+                None => false,
+            },
         }
     }
 
@@ -2680,6 +2715,49 @@ mod tests {
         let p = dom.query("p").unwrap();
         assert_eq!(dom.text_content(p).unwrap(), "novo");
         assert!(dom.query("span").is_none()); // o velho foi descartado
+    }
+
+    #[test]
+    fn hover_vivo_na_cascade() {
+        // `:hover` casa o nó sob o cursor E seus ancestrais; set_hovered só bumpa
+        // a revisão quando muda e quando há regra :hover.
+        let mut dom = parse_html_to_dom(
+            "<style>a:hover { color: #ff0000 } li:hover { color: #00ff00 }</style>\
+             <ul><li id=item><a id=link href=x>l</a></li></ul>",
+        );
+        let link = dom.query("#link").unwrap();
+        let item = dom.query("#item").unwrap();
+        let link_idx = dom.resolve(link).unwrap();
+        // sem hover: nenhum casa.
+        let c0 = dom.computed_style(link).unwrap();
+        assert_ne!(c0.color, Some(0xFF0000FF));
+        let rev0 = dom.render_revision();
+        // hovered no <a>: a regra a:hover casa o link; li:hover casa o PAI (propaga).
+        dom.set_hovered(Some(link_idx));
+        assert!(dom.render_revision() != rev0, "hover com regra :hover deve invalidar");
+        let c1 = dom.computed_style(link).unwrap();
+        assert_eq!(c1.color, Some(0xFF0000FF));
+        let c2 = dom.computed_style(item).unwrap();
+        assert_eq!(c2.color, Some(0x00FF00FF));
+        // repetir o MESMO hovered não bumpa (guarda de perf).
+        let rev1 = dom.render_revision();
+        dom.set_hovered(Some(link_idx));
+        assert_eq!(dom.render_revision(), rev1);
+        // sair: volta ao normal.
+        dom.set_hovered(None);
+        let c3 = dom.computed_style(link).unwrap();
+        assert_ne!(c3.color, Some(0xFF0000FF));
+    }
+
+    #[test]
+    fn hover_sem_regra_nao_invalida() {
+        // página SEM :hover: mover o mouse não pode custar re-layout.
+        let mut dom = parse_html_to_dom("<div id=a>x</div>");
+        let a = dom.query("#a").unwrap();
+        let idx = dom.resolve(a).unwrap();
+        let rev0 = dom.render_revision();
+        dom.set_hovered(Some(idx));
+        assert_eq!(dom.render_revision(), rev0);
     }
 
     #[test]

--- a/crates/rts-dom/src/style/selector.rs
+++ b/crates/rts-dom/src/style/selector.rs
@@ -62,6 +62,11 @@ pub enum PseudoClass {
     Enabled,
     /// `:required` — `required` presente.
     Required,
+    /// `:hover` — ESTADO VIVO: casa se o elemento é o nó sob o cursor OU um
+    /// ancestral dele (spec: hover propaga pelos ancestrais). O nó hovered vem
+    /// do backend (hit-test do mouse) via `Dom::set_hovered`; headless casa
+    /// nunca (hovered = nenhum). Especificidade 10 (classe), como no browser.
+    Hover,
 }
 
 /// O combinador ENTRE dois compounds numa cadeia (`A > B`): a relação de B com A.
@@ -341,7 +346,8 @@ fn parse_pseudo_selector(s: &str) -> Option<(SimpleSelector, &str)> {
         "disabled" => PseudoClass::Disabled,
         "enabled" => PseudoClass::Enabled,
         "required" => PseudoClass::Required,
-        _ => return None, // :hover/:focus/:not()/etc não suportados
+        "hover" => PseudoClass::Hover,
+        _ => return None, // :focus/:not()/etc não suportados
     };
     Some((SimpleSelector::Pseudo(pc), rest))
 }

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -200,6 +200,16 @@ pub(crate) fn render_dom_scrolled(
         let origin = ui.max_rect().min;
         let clicked = ui.input(|i| i.pointer.primary_clicked());
         let pos = ui.input(|i| i.pointer.interact_pos());
+        // `:hover` VIVO: informa por frame o nó sob o cursor (hit-test do motor).
+        // O `set_hovered` só invalida caches quando MUDA e há regra :hover — mover
+        // o mouse numa página sem :hover custa zero re-layout.
+        {
+            let hover_pos = ui.input(|i| i.pointer.hover_pos());
+            let hovered_idx = hover_pos
+                .filter(|p| ui.max_rect().contains(*p))
+                .and_then(|p| list.hit_test(p.x - origin.x, p.y - origin.y + offset));
+            let _ = rts_dom::store::with_dom_mut(h, |d| d.set_hovered(hovered_idx));
+        }
         if clicked {
             if let Some(pos) = pos {
                 if ui.max_rect().contains(pos) {


### PR DESCRIPTION
## O que faz

Sétima fatia da campanha "rodar página real": **`:hover` vivo** — passar o mouse sobre um elemento aplica as regras `a:hover { ... }` da página (menus, botões, dropdowns de qualquer site).

### Como
- `PseudoClass::Hover` no seletor (especificidade 10) — antes a regra inteira era descartada como pseudo desconhecida.
- Estado `hovered` no Dom, alimentado pelo backend por frame via o **mesmo `DisplayList::hit_test` do clique** (#1885). O matcher casa `:hover` no nó sob o cursor **e nos ancestrais** (propagação fiel ao browser: `li:hover` acende com o mouse no `<a>` filho).
- **Guarda de perf** (a preocupação do handoff #1793): `set_hovered` só invalida caches quando o hovered **muda** e o stylesheet **tem** regra `:hover` — mover o mouse numa página sem `:hover` custa zero re-layout.
- egui segue burro: só passa o input; ABI `setHovered` para headless/backends alternativos.

## Validação
- `hover_vivo_na_cascade`: regra casa nó + ancestral, invalida só na mudança, sai limpo ao tirar o mouse.
- `hover_sem_regra_nao_invalida`: página sem :hover → revisão intacta.
- rts-dom **192/192** · event-callbacks 4/4 · runscripts 4/4 · gate sem violação HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z