### PR TITLE
feat(engine): .then/.catch/.finally sobre chamada async + flag async no Arrow do HIR

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1074,10 +1074,12 @@ impl Ctx {
             ret,
             body,
             self_name,
+            is_async,
         } = &e.kind
         else {
             return None;
         };
+        let is_async = *is_async;
         // The synthesized name is minted UP FRONT so a NAMED fn-expression's
         // self-references can be renamed to it before the free-ident analysis
         // (the self-name is body-only scope; renamed, it resolves as this very
@@ -1273,12 +1275,17 @@ impl Ctx {
         if !captures.is_empty() {
             self.captures.insert(name.clone(), captures);
         }
+        // Um `async () =>` / `async function` aninhada lifta com `is_async` — o
+        // CALL-SITE spawn (`lower_async_spawn`) faz a chamada devolver a Promise
+        // pendente, o mesmo modelo da declaração top-level. Capturas mudam a
+        // aridade real (params prepostos) — o spawn empacota args crus, então
+        // capturas por valor viajam como qualquer arg.
         self.synthesized.push(HirFunc {
             name: name.clone(),
             params: all_params,
             ret: ret.clone(),
             body: body_stmts,
-            is_async: false,
+            is_async,
             is_arrow: true,
         });
         Some(name)

--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -392,6 +392,22 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 
         let argc = args.len();
         let Some(spec) = resolve_method(class, method, argc) else {
+            // PROMISE surface on a NUMBER-typed receiver: um handle de Promise
+            // pendente viaja pela superfície NUMBER (`lower_async_spawn` — o
+            // contrato do await/promise.wait). `p.then(cb)` nesse valor caía
+            // aqui como `Number.then` e bailava; JS NUNCA tem `.then/.catch/
+            // .finally` num number genuíno, então rotear pro dispatch DINÂMICO
+            // de Promise é sound (o trampolim `promise_handle(recv)` valida o
+            // handle; um number genuíno vira `undefined`, nunca valor errado).
+            if matches!(class, RecvClass::Number)
+                && matches!(method, "then" | "catch" | "finally")
+            {
+                if let Some(val) =
+                    self.try_method_dispatch_dynamic(module, recv, method, args)?
+                {
+                    return Ok(Some(val));
+                }
+            }
             return Err(crate::front::error::Unsupported::new(format!(
                 "no Registry entry for `{class:?}.{method}({argc} args)`"
             )));

--- a/crates/rts-hir/src/ir.rs
+++ b/crates/rts-hir/src/ir.rs
@@ -338,6 +338,12 @@ pub enum HirExprKind {
         /// references to the synthesized top-level name, making self-recursive
         /// named fn-exprs liftable. `None` for arrows / anonymous fn-exprs.
         self_name: Option<String>,
+        /// `async () => …` / `async function … {}` (expression or nested decl):
+        /// the extraction pass lifts it to a top-level `HirFunc` with
+        /// `is_async = true`, and the CALL-SITE spawn (`lower_async_spawn`)
+        /// makes calls return a pending Promise — same model as a top-level
+        /// `async function` declaration.
+        is_async: bool,
     },
 
     // Pre/post increment/decrement

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -231,9 +231,11 @@ fn lower_decl(decl: &swc::Decl, scope: &mut Scope, raw_text: &str) -> HirStmt {
         // A NESTED `function f(){…}` declaration (inside another fn's body):
         // lower as `const f = <arrow>` — the same shape the fn-expression takes,
         // so the arrow-extraction pass lifts it (captures included) like any
-        // local closure. (Full var-style hoisting across the block is a later
-        // increment; the declaration-before-use corpus is covered.)
-        swc::Decl::Fn(fd) if !fd.function.is_async && !fd.function.is_generator => {
+        // local closure. An ASYNC nested decl rides the same path with the
+        // `is_async` flag — the lifted top-level fn keeps async semantics
+        // (call-site spawn). (Full var-style hoisting across the block is a
+        // later increment; the declaration-before-use corpus is covered.)
+        swc::Decl::Fn(fd) if !fd.function.is_generator => {
             let func = &fd.function;
             let params: Vec<HirParam> = func
                 .params
@@ -271,6 +273,7 @@ fn lower_decl(decl: &swc::Decl, scope: &mut Scope, raw_text: &str) -> HirStmt {
                     // A nested `function s(){ … s() … }` is self-visible by its
                     // declaration name — same binding rule as a named fn-expr.
                     self_name: Some(fd.ident.sym.to_string()),
+                    is_async: fd.function.is_async,
                 },
                 HirType::Function {
                     params: vec![],
@@ -607,7 +610,13 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                 }
             };
             HirExpr::new(
-                HirExprKind::Arrow { params, ret: ret.clone(), body, self_name: None },
+                HirExprKind::Arrow {
+                    params,
+                    ret: ret.clone(),
+                    body,
+                    self_name: None,
+                    is_async: arrow.is_async,
+                },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )
         }
@@ -623,7 +632,7 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
         // (sound) — a later increment can bind the self-name.
         swc::Expr::Fn(fn_expr) => {
             let func = &fn_expr.function;
-            if func.is_async || func.is_generator {
+            if func.is_generator {
                 return HirExpr::new(HirExprKind::Raw(format!("{:?}", e)), HirType::Unknown);
             }
             let params: Vec<HirParam> = func.params.iter().map(|p| {
@@ -656,6 +665,7 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                     ret: ret.clone(),
                     body,
                     self_name: fn_expr.ident.as_ref().map(|i| i.sym.to_string()),
+                    is_async: func.is_async,
                 },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )


### PR DESCRIPTION
## O que faz

Primeira fatia do épico #207 (async em `<script>` de página), no subset **honesto**:

### 1. `.then/.catch/.finally` funcionam sobre chamada async
O handle de Promise pendente viaja pela superfície NUMBER (contrato do `lower_async_spawn`/`await`) — `g().then(cb)` caía no Registry como `Number.then` e bailava. Agora roteia pro dispatch **dinâmico** de Promise já existente (`__rtsadp_dyn_p_then` valida o handle; JS nunca tem `.then` num number genuíno — sound).

```js
async function g() { return 9; }
g().then(function(v) { console.log('then: ' + v); });  // ✅ ordem async correta
const f = async () => 7; f().then(...);                 // ✅ (parser hoist → direct)
```

### 2. Flag `is_async` no `Arrow` do HIR (o substrato do resto do épico)
Arrow exprs, fn exprs (eram Raw-bail) e **fn decls aninhadas** (eram 'unrecognized statement') agora carregam async; a extração propaga pro `HirFunc`. Efeito imediato de honestidade: async aninhado **bailava não** — rodava SÍNCRONO devolvendo o valor cru (wrong-value vs JS). Agora baila explícito.

### O que fica para a próxima fatia (documentado em #207)
Reify de async fn-VALUE via spawn-no-thunk: o experimento funcionou estruturalmente mas mostrou bug de marshaling do valor resolvido na borda raw↔word — revertido para não shipar valor errado.

## Validação
Direcionados async/promise/function/callback/closure/timer todos verdes · funcval 16/16 (inclui o teste do bail async-as-VALUE) · closures 27/27 · dom fixtures 4/4+4/4 · rts-dom 192/192 · gate sem violação HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z