### PR TITLE
feat(engine): async function dentro do <script> roda — fatia 2 do #207

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -997,9 +997,18 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             .get(name)
             .ok_or_else(|| Unsupported::new(format!("reify of unknown function `{name}`")))?;
         if sig.is_async {
-            return unsupported!(
-                "async/generator function `{name}` as a VALUE (it returns a Promise / suspends — a later increment)"
-            );
+            // Um async fn com shape suportado REIFICA: seu thunk uniforme faz o
+            // spawn no invoke (thunk.rs — replica o call-site spawn) e devolve a
+            // Promise pendente boxada, o contrato JS de chamar um async fn.
+            // Shapes fora do contrato do spawn (this/rest/>8 params) continuam
+            // recusando (o thunk deles ainda é o inline legado).
+            let spawn_ok =
+                !sig.has_this && sig.rest_param.is_none() && sig.params.len() <= 8;
+            if !spawn_ok {
+                return unsupported!(
+                    "async/generator function `{name}` as a VALUE (it returns a Promise / suspends — a later increment)"
+                );
+            }
         }
         // A this-first function IS reifiable now: it reifies through
         // `__rtsadp_fn_reify_this` (FunctionData.has_this_param), the METHOD-aware

--- a/crates/rts-codegen-new/src/front/run/thunk.rs
+++ b/crates/rts-codegen-new/src/front/run/thunk.rs
@@ -182,6 +182,73 @@ fn build_thunk_body(
         call_args.push(arg);
     }
 
+    // ASYNC fn-VALUE: o thunk NÃO roda o corpo inline (bloquearia o caller e
+    // devolveria o valor cru em vez da Promise). Replica o CALL-SITE spawn
+    // (`asyncspawn.rs`): empacota os args crus num Vec + kinds/meta e chama
+    // `__rtsadp_promise_spawn`, devolvendo o handle da Promise PENDENTE boxado
+    // como OBJECT word — o `.then` dinâmico e o `await` normalizam esse shape.
+    // Capturas de closure já vieram prepostas em `call_args` (viajam como args
+    // crus, captura-por-valor). Shapes fora do contrato do spawn (this/rest/>8
+    // params) mantêm o thunk inline legado — o reify continua recusando esses.
+    if sig.is_async && !sig.has_this && sig.rest_param.is_none() && sig.params.len() <= 8 {
+        let vec_h = emit_marshal::emit_call(module, fb, "__RTS_FN_NS_COLLECTIONS_VEC_NEW", &[])
+            .expect("VEC_NEW returns a handle");
+        for (v, &repr) in call_args.iter().zip(&sig.params) {
+            let slot = match repr {
+                Repr::Int32 => fb.ins().sextend(types::I64, *v),
+                Repr::Float64 => fb.ins().bitcast(
+                    types::I64,
+                    cranelift_codegen::ir::MemFlags::new(),
+                    *v,
+                ),
+                _ => *v,
+            };
+            emit_marshal::emit_call(
+                module,
+                fb,
+                "__RTS_FN_NS_COLLECTIONS_VEC_PUSH",
+                &[vec_h, slot],
+            );
+        }
+        // kinds/meta: o MESMO empacotamento do asyncspawn (0=i64, 1=f64-bits,
+        // 2=bool; meta = box_kind<<16 | nparams<<8 | ret_kind).
+        let mut kinds_packed: u64 = 0;
+        for (i, &repr) in sig.params.iter().enumerate() {
+            let k: u64 = match repr {
+                Repr::Float64 => 1,
+                Repr::Bool => 2,
+                _ => 0,
+            };
+            kinds_packed |= k << (8 * i);
+        }
+        let ret_kind: u64 = match sig.ret {
+            Some(Repr::Float64) => 1,
+            Some(Repr::Bool) => 2,
+            _ => 0,
+        };
+        let box_kind: u64 = match sig.ret {
+            Some(Repr::Float64) => 1,
+            Some(Repr::Bool) => 2,
+            Some(Repr::Int32) | Some(Repr::Int64) => 0,
+            _ => 3,
+        };
+        let meta = (box_kind << 16) | ((sig.params.len() as u64) << 8) | ret_kind;
+        let kinds_word = fb.ins().iconst(types::I64, kinds_packed as i64);
+        let meta_word = fb.ins().iconst(types::I64, meta as i64);
+        let real_ref = module.declare_func_in_func(real_id, fb.func);
+        let fn_addr = fb.ins().func_addr(types::I64, real_ref);
+        let handle = emit_marshal::emit_call(
+            module,
+            fb,
+            "__rtsadp_promise_spawn",
+            &[fn_addr, vec_h, kinds_word, meta_word],
+        )
+        .expect("__rtsadp_promise_spawn returns a handle");
+        let word = emit_marshal::emit_box_object_handle(module, fb, handle);
+        fb.ins().return_(&[word]);
+        return Ok(());
+    }
+
     // Call the real body (its signature was attached at declaration time; the
     // FuncId carries it, so no re-derivation is needed here).
     let real_ref = module.declare_func_in_func(real_id, fb.func);

--- a/crates/rts-engine/src/heap/handles.rs
+++ b/crates/rts-engine/src/heap/handles.rs
@@ -881,6 +881,13 @@ pub struct PromiseSlot {
     /// .finally/await/combinador) foi anexado a esta promise. Uma rejection com
     /// `handled == false` no fim do event loop é reportada como unhandled.
     pub handled: std::sync::atomic::AtomicBool,
+    /// `true` quando `value` é uma WORD PolyValue (o settle do async-spawn do
+    /// motor novo boxa via `box_async_result` — o valor é word SEMPRE). A
+    /// entrega ao callback de then/catch/finally usa isto para NÃO re-adivinhar
+    /// o tipo (`raw_to_word` corrompia uma word de double inline — os bits ≥2^48
+    /// viravam `f64::to_bits(bits as f64)`). `false` = valor CRU da superfície
+    /// i64 legada (a ponte decodifica como antes).
+    pub value_is_word: std::sync::atomic::AtomicBool,
 }
 
 impl std::fmt::Debug for PromiseSlot {

--- a/crates/rts-std/src/globals/fetch/instance.rs
+++ b/crates/rts-std/src/globals/fetch/instance.rs
@@ -318,7 +318,8 @@ pub extern "C" fn __RTS_FN_GL_PROMISE_THEN2(promise_h: u64, on_ful: u64, on_rej:
                         fp,
                         Vec::new(),
                         value,
-                        true, // sempre invoca callback como "resolved" para
+                        true,
+                        crate::promise_slot::value_is_word(&arc), // sempre invoca callback como "resolved" para
                         // que o retorno vire resolve(result). Reject
                         // path do on_rej tambem segue spec: callback
                         // de catch recupera, resultado eh resolved.

--- a/crates/rts-std/src/globals/text_encoding/instance.rs
+++ b/crates/rts-std/src/globals/text_encoding/instance.rs
@@ -319,6 +319,9 @@ pub(crate) enum Microtask {
         bound: Vec<i64>,
         value: i64,
         fulfilled: bool,
+        /// `true` quando `value` e WORD PolyValue (settle do async-spawn) - a
+        /// entrega NAO re-adivinha o tipo pela ponte raw.
+        value_is_word: bool,
         result_slot: std::sync::Arc<rts_engine::heap::handles::PromiseSlot>,
     },
     /// promise.finally(fp) fast-path: invoca fp() sem args, preserva state/value
@@ -399,6 +402,7 @@ pub fn enqueue_microtask_settled(
     bound: Vec<i64>,
     value: i64,
     fulfilled: bool,
+    value_is_word: bool,
     result_slot: std::sync::Arc<rts_engine::heap::handles::PromiseSlot>,
 ) {
     MICROTASK_QUEUE.with(|q| {
@@ -407,6 +411,7 @@ pub fn enqueue_microtask_settled(
             bound,
             value,
             fulfilled,
+            value_is_word,
             result_slot,
         })
     });
@@ -634,8 +639,9 @@ pub fn drain_microtasks() {
                             let fulfilled = st == promise_slot::STATE_FULFILLED;
                             let runs = if is_catch { !fulfilled } else { fulfilled };
                             if runs && fn_ptr != 0 {
+                                let w = promise_slot::value_is_word(&source);
                                 let r = unsafe {
-                                    invoke_microtask_callback(fn_ptr, &bound, Some(value))
+                                    invoke_microtask_callback_w(fn_ptr, &bound, Some(value), w)
                                 };
                                 crate::promise::resolve_adopting(&result_slot, r);
                             } else if fulfilled {
@@ -675,7 +681,10 @@ pub fn drain_microtasks() {
                             let fulfilled = st == promise_slot::STATE_FULFILLED;
                             let cb = if fulfilled { on_ful } else { on_rej };
                             if cb != 0 {
-                                let r = unsafe { invoke_microtask_callback(cb, &[], Some(value)) };
+                                let w = promise_slot::value_is_word(&source);
+                                let r = unsafe {
+                                    invoke_microtask_callback_w(cb, &[], Some(value), w)
+                                };
                                 crate::promise::resolve_adopting(&result_slot, r);
                             } else if fulfilled {
                                 promise_slot::resolve(&result_slot, value);
@@ -752,14 +761,16 @@ pub fn drain_microtasks() {
                     bound,
                     value,
                     fulfilled,
+                    value_is_word,
                     result_slot,
                 } => {
                     if fulfilled {
                         if fn_ptr == 0 {
                             promise_slot::resolve(&result_slot, value);
                         } else {
-                            let r =
-                                unsafe { invoke_microtask_callback(fn_ptr, &bound, Some(value)) };
+                            let r = unsafe {
+                                invoke_microtask_callback_w(fn_ptr, &bound, Some(value), value_is_word)
+                            };
                             crate::promise::resolve_adopting(&result_slot, r);
                         }
                     } else {
@@ -810,8 +821,10 @@ pub fn drain_microtasks() {
                         // .then: roda no fulfilled; .catch: roda no rejected.
                         let runs = if is_catch { !fulfilled } else { fulfilled };
                         if runs && fn_ptr != 0 {
-                            let r =
-                                unsafe { invoke_microtask_callback(fn_ptr, &bound, Some(value)) };
+                            let w = promise_slot::value_is_word(&source);
+                            let r = unsafe {
+                                invoke_microtask_callback_w(fn_ptr, &bound, Some(value), w)
+                            };
                             crate::promise::resolve_adopting(&result_slot, r);
                         } else if fulfilled {
                             promise_slot::resolve(&result_slot, value);
@@ -871,7 +884,10 @@ pub fn drain_microtasks() {
                         if cb != 0 {
                             // .then(f) sucesso e .catch(g)/onRej recuperam:
                             // result resolved com o retorno do callback.
-                            let r = unsafe { invoke_microtask_callback(cb, &[], Some(value)) };
+                            let w = promise_slot::value_is_word(&source);
+                            let r = unsafe {
+                                invoke_microtask_callback_w(cb, &[], Some(value), w)
+                            };
                             crate::promise::resolve_adopting(&result_slot, r);
                         } else if fulfilled {
                             promise_slot::resolve(&result_slot, value);
@@ -924,6 +940,25 @@ pub fn drain_microtasks() {
 /// invoke_typed com os param_kinds reais (e normaliza args number-cru), ou
 /// invoke_n quando a fn é toda-i64 (idêntico ao transmute de antes).
 unsafe fn invoke_microtask_callback(fn_ptr: u64, bound: &[i64], extra: Option<i64>) -> i64 {
+    unsafe { invoke_microtask_callback_w(fn_ptr, bound, extra, false) }
+}
+
+/// Variante com a PROVENIENCIA do settled: `extra_is_word = true` quando o
+/// valor settled JA e WORD PolyValue (async-spawn) - invoca pela ponte com
+/// `args_are_words=true` (sem re-adivinhar o tipo; `raw_to_word` corrompia
+/// words de double inline). So quando `bound` e vazio (as pontes convertem
+/// TODOS os args por um flag so); com bound presente, mantem o caminho raw.
+unsafe fn invoke_microtask_callback_w(
+    fn_ptr: u64,
+    bound: &[i64],
+    extra: Option<i64>,
+    extra_is_word: bool,
+) -> i64 {
+    if extra_is_word && bound.is_empty() {
+        if let Some(v) = extra {
+            return rts_primitives::function::ops::invoke_callable_bridged(fn_ptr, &[v], true);
+        }
+    }
     let mut args: Vec<i64> = bound.to_vec();
     if let Some(v) = extra {
         args.push(v);

--- a/crates/rts-std/src/promise/mod.rs
+++ b/crates/rts-std/src/promise/mod.rs
@@ -439,6 +439,7 @@ pub extern "C" fn __RTS_FN_NS_PROMISE_THEN(p_handle: U64, fp: U64) -> Handle {
             bound,
             value,
             fulfilled,
+            promise_slot::value_is_word(&arc),
             result_clone,
         );
         return result_handle;
@@ -785,12 +786,15 @@ fn create_spawn(
         } else if let Some(word) = take_engine_pending_error() {
             promise_slot::reject(&result_clone, word as i64);
         } else {
+            let boxed = boxer.is_some();
             let r = match boxer {
                 Some(b) => b(fn_ptr, r),
                 None => r,
             };
             // Promise/A+: an async body returning a thenable/promise ADOPTS it.
-            resolve_assimilating(&result_clone, handle, r);
+            // Com boxer, `r` já é WORD (box_async_result) — o slot registra a
+            // proveniência p/ a entrega ao then não re-adivinhar o tipo.
+            resolve_assimilating_word(&result_clone, handle, r, boxed);
         }
         PENDING_PROMISE_TASKS.fetch_sub(1, Ordering::AcqRel);
     });
@@ -1248,6 +1252,19 @@ pub(crate) fn resolve_assimilating(
     promise_h: u64,
     value: i64,
 ) {
+    resolve_assimilating_word(arc, promise_h, value, false)
+}
+
+/// Variante com a PROVENIÊNCIA do valor: `value_is_word = true` quando `value`
+/// já é WORD PolyValue (o settle do async-spawn boxa via `box_async_result`) —
+/// o slot marca isso e a entrega ao callback de then/catch/finally NÃO
+/// re-adivinha o tipo pela ponte raw (que corrompia words de double inline).
+pub(crate) fn resolve_assimilating_word(
+    arc: &std::sync::Arc<rts_engine::heap::handles::PromiseSlot>,
+    promise_h: u64,
+    value: i64,
+    value_is_word: bool,
+) {
     // A PROMISE value (an async callback returning `Promise.resolve(x)` /
     // another chain): ADOPT its state directly — fulfil/reject through, or
     // chain a pending source via the microtask queue (fn_ptr 0 = pass-through).
@@ -1260,7 +1277,7 @@ pub(crate) fn resolve_assimilating(
         match promise_slot::current_state(&src) {
             promise_slot::STATE_FULFILLED => {
                 let inner = promise_slot::current_value(&src);
-                resolve_assimilating(arc, promise_h, inner);
+                resolve_assimilating_word(arc, promise_h, inner, promise_slot::value_is_word(&src));
             }
             promise_slot::STATE_REJECTED => {
                 promise_slot::reject(arc, promise_slot::current_value(&src));
@@ -1279,7 +1296,11 @@ pub(crate) fn resolve_assimilating(
     }
     let then_w = promise_slot::thenable_then_of(value);
     if then_w == 0 {
-        promise_slot::resolve(arc, value);
+        if value_is_word {
+            promise_slot::resolve_word(arc, value);
+        } else {
+            promise_slot::resolve(arc, value);
+        }
         return;
     }
     let res_w = settle_callable_word(promise_h, 0);

--- a/crates/rts-std/src/promise_slot.rs
+++ b/crates/rts-std/src/promise_slot.rs
@@ -85,6 +85,7 @@ pub fn new_pending() -> Arc<PromiseSlot> {
         value: std::sync::Mutex::new(0),
         waiters: std::sync::Mutex::new(Box::new(waiters)),
         handled: AtomicBool::new(false),
+        value_is_word: AtomicBool::new(false),
     })
 }
 
@@ -96,6 +97,7 @@ pub fn new_fulfilled(value: i64) -> Arc<PromiseSlot> {
         value: std::sync::Mutex::new(value),
         waiters: std::sync::Mutex::new(Box::new(waiters)),
         handled: AtomicBool::new(false),
+        value_is_word: AtomicBool::new(false),
     })
 }
 
@@ -107,6 +109,7 @@ pub fn new_rejected(error: i64) -> Arc<PromiseSlot> {
         value: std::sync::Mutex::new(error),
         waiters: std::sync::Mutex::new(Box::new(waiters)),
         handled: AtomicBool::new(false),
+        value_is_word: AtomicBool::new(false),
     });
     register_unhandled(&slot, error);
     slot
@@ -141,6 +144,20 @@ fn settle(slot: &PromiseSlot, new_state: u8, value: i64) -> bool {
 
 pub fn resolve(slot: &PromiseSlot, value: i64) -> bool {
     settle(slot, STATE_FULFILLED, value)
+}
+
+/// Resolve com um valor que JÁ é WORD PolyValue (o settle do async-spawn do
+/// motor novo): marca `value_is_word` para a entrega ao callback de then/
+/// catch/finally NÃO re-adivinhar o tipo pela ponte raw (que corrompia uma
+/// word de double inline).
+pub fn resolve_word(slot: &PromiseSlot, value: i64) -> bool {
+    slot.value_is_word.store(true, Ordering::Release);
+    settle(slot, STATE_FULFILLED, value)
+}
+
+/// `true` se o valor settled é uma WORD PolyValue (ver [`resolve_word`]).
+pub fn value_is_word(slot: &PromiseSlot) -> bool {
+    slot.value_is_word.load(Ordering::Acquire)
 }
 
 pub fn reject(slot: &PromiseSlot, error: i64) -> bool {

--- a/tests/claude-script-async.test.ts
+++ b/tests/claude-script-async.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "rts:test";
+
+// async function DENTRO do <script> da página (#207 fatia 2): declara, chama,
+// encadeia .then com o valor resolvido CORRETO (int e double — a word do
+// settle não é mais re-adivinhada pela ponte raw).
+// Pré-computado no top-level; o then roda no drain do event loop, então o
+// resultado é capturado via var de módulo checada num segundo describe... como
+// o suite roda tudo síncrono antes do drain, validamos o que É observável
+// sincronamente: compilar + disparar + o contrato do valor via await num async
+// de teste do programa principal.
+
+// 1. o script compila e roda (antes: 'unrecognized statement async function')
+const html = "<div id='t'>x</div>" +
+  "<script>" +
+  "async function carrega() { return 42; }" +
+  "carrega().then(function(v) {" +
+  "  const el = document.getElementById('t');" +
+  "  if (el !== null) { el.setAttribute('data-v', '' + v); }" +
+  "});" +
+  "</script>";
+const doc = parseDocument(html);
+const ran = runScripts(doc);
+
+// 2. valores corretos fim-a-fim (mesma maquinaria do script): int e double
+//    resolvidos via promise.wait (síncrono-observável no top-level; um gcell
+//    escrito de dentro do async não serve — o corpo roda em worker e o gcell é
+//    thread_local).
+import { promise } from "rts";
+async function intAsync(): i64 { return 8; }
+const vInt = promise.wait(intAsync());
+async function somaAsync(): f64 {
+  const b = 1.5;
+  return b + 8.0; // 9.5 — se a word do double fosse re-adivinhada, viraria lixo
+}
+// promise.wait é a superfície CRUA legada (trunca double); o double correto se
+// verifica com o await do MOTOR (que reboxa a word) — devolvendo a comparação
+// como int pela superfície crua.
+async function checaDouble(): i64 {
+  const b = await somaAsync();
+  if (b === 9.5) return 1;
+  return 0;
+}
+const vSoma = promise.wait(checaDouble());
+
+describe("async no <script> + valores corretos (#207 fatia 2)", () => {
+  test("script com async function compila e roda", () => {
+    expect(ran).toBe(1);
+  });
+  test("int resolvido correto", () => {
+    expect(vInt).toBe(8);
+  });
+  test("double resolvido correto (via await do motor)", () => {
+    expect(vSoma).toBe(1);
+  });
+});


### PR DESCRIPTION
## O que faz

**`async function` declarada dentro de um `<script>` de página agora compila, roda e encadeia `.then` com o valor resolvido CORRETO.**

```html
<script>
async function carrega() { return 42; }
carrega().then(function(v) { /* v = 42, não lixo */ });
</script>
```

### As duas peças
1. **Async fn como VALUE via thunk-spawn** (`thunk.rs`): o thunk uniforme de um fn `is_async` não roda o corpo inline — replica o call-site spawn (`asyncspawn.rs`): empacota args + kinds/meta, chama `__rtsadp_promise_spawn` e devolve a Promise pendente boxada. `call.rs` libera o reify para shapes suportados (sem this/rest, ≤8 params).
2. **Fix do marshaling por PROVENIÊNCIA** (a causa da 1ª tentativa revertida): o settle do async-spawn é sempre WORD, mas a entrega ao callback re-adivinhava o tipo pela ponte raw — uma word de **double inline** virava lixo. `PromiseSlot.value_is_word` + `resolve_word`/`resolve_assimilating_word`; a entrega (SettledThen/PendingThen/PendingThen2, fast-path e drain) usa `args_are_words=true` quando o slot marca word.

**Bônus**: conserta um bug pré-existente na main — `async function h(){return 1.5}; h().then(v => ...)` entregava lixo (word de double re-adivinhada).

### Limitação documentada (parte single-thread do #207, separada)
O CORPO async roda em worker tokio e o store do DOM é thread_local — mutação de DOM **dentro do corpo** não é visível; no `.then` (drenado na thread principal) é.

## Validação
- `tests/claude-script-async.test.ts` (novo): script com async compila+roda; int e double resolvidos corretos — 3/3
- Direcionados async/promise/then/await/microtask/function/callback/closure/timer: **todos verdes** (a mudança toca todo caminho de then)
- dom fixtures 4/4+4/4 · rts-dom 192/192 · gate sem violação HARD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z