### PR TITLE
fix(dom): JS não vaza como texto + serialize cru de <script> + browser executa scripts

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -2123,6 +2123,20 @@ impl Dom {
                 if is_void(tag) {
                     return; // void: sem filhos, sem fechamento.
                 }
+                // RAW-TEXT elements (`<script>`/`<style>`): o conteúdo é CRU —
+                // re-encodar entidades corrompia o código (`&&` → `&amp;&amp;`,
+                // que o reparse raw NÃO decodifica → syntax error no JS).
+                if self.is_raw_text_element(idx) {
+                    for &c in &self.nodes[idx].children {
+                        if let NodeKind::Text(t) = &self.nodes[c].kind {
+                            out.push_str(t);
+                        }
+                    }
+                    out.push_str("</");
+                    out.push_str(tag);
+                    out.push('>');
+                    return;
+                }
                 for &c in &self.nodes[idx].children {
                     self.serialize_node(c, out);
                 }

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -2216,7 +2216,14 @@ fn collect_runs(dom: &Dom, id: NodeIdx, parent_css: &ComputedStyle) -> Vec<Inlin
                 };
                 out.push(InlineRun { text, color: inherited_color, bold: inherited_bold });
             }
-            NodeKind::Element { .. } => {
+            NodeKind::Element { tag } => {
+                // `<script>`/`<style>`/head-etc DENTRO de um contexto inline (um
+                // script dentro de <td>/<center> — google.com faz isso): o texto
+                // cru NÃO é conteúdo renderável — sem este skip, o código JS era
+                // PINTADO na página.
+                if is_non_rendered_tag(tag) {
+                    return;
+                }
                 // a cor/text-transform/peso DESTE inline (se declarar) vence p/ os filhos.
                 let css = dom.computed_style_idx(id);
                 let color = css.as_ref().and_then(|c| c.color).unwrap_or(inherited_color);
@@ -2351,6 +2358,9 @@ fn collect_text(dom: &Dom, id: NodeIdx) -> String {
     fn collect_into(dom: &Dom, id: NodeIdx, out: &mut String) {
         match &dom.node(id).kind {
             NodeKind::Text(t) => out.push_str(t),
+            // `<script>`/`<style>` não são conteúdo renderável — o texto cru
+            // deles não entra no texto pintado (mesmo skip do collect_runs).
+            NodeKind::Element { tag } if is_non_rendered_tag(tag) => {}
             _ => {
                 for &c in &dom.node(id).children {
                     collect_into(dom, c, out);

--- a/examples/claude-browser.ts
+++ b/examples/claude-browser.ts
@@ -100,12 +100,36 @@ function extractSite(rawHtml: string, pageUrl: string): string {
     }
     j = j + 1;
   }
-  // 3) innerHTML do body.
+  // 3) <script> INLINE (head+body): preserva o fonte para o runScripts executar
+  //    depois do parse da página montada. <script src> é logado mas não baixado
+  //    (o JS externo de sites grandes é minificado além do subset — baixar
+  //    megabytes que vão bailar não vale o tempo de load; o inline roda).
+  let scripts = "";
+  const scc = dom.querySelectorAllCount(site, "script");
+  let k = 0;
+  let inlineCount = 0;
+  while (k < scc) {
+    const s = dom.querySelectorAllAt(site, "script", k);
+    const src = dom.getAttribute(site, s, "src");
+    const stype = dom.getAttribute(site, s, "type");
+    const isJs = stype.length === 0 || stype === "text/javascript" || stype === "module";
+    if (src.length > 0) {
+      io.print("[js] externo (nao baixado): " + src);
+    } else if (isJs) {
+      const code = dom.getText(site, s);
+      if (code.length > 0) {
+        scripts = scripts + "<script>" + code + "</script>";
+        inlineCount = inlineCount + 1;
+      }
+    }
+    k = k + 1;
+  }
+  // 4) innerHTML do body.
   const body = dom.querySelector(site, "body");
   const inner = body >= 0 ? dom.innerHtml(site, body) : rawHtml;
-  io.print("[site] styles_inline=" + sc + " css_baixados=" + cssCount + " body=" + inner.length + "B");
+  io.print("[site] styles_inline=" + sc + " css_baixados=" + cssCount + " scripts_inline=" + inlineCount + " body=" + inner.length + "B");
   dom.free(site);
-  return styles + inner;
+  return styles + inner + scripts;
 }
 
 // Percorre os <img> do doc já montado, baixa cada src (binário) + decodifica +
@@ -240,6 +264,9 @@ function loadingPage(cur: i64, val: string): number {
 // Abre na HOME (instantânea).
 io.print("[boot] home instantânea (digite uma URL e Enter)");
 d = localPage(d, "home");
+// Fachada Document sobre o handle corrente — o runScripts/pumpEventCallbacks
+// do prelude falam a fachada. Recriada a cada navegação (d muda).
+let docF = new Document(d);
 io.print("[boot] urlbar node=" + urlInput(d) + " inputs=" + dom.querySelectorAllCount(d, "input") + " val='" + dom.inputValue(d, urlInput(d)) + "'");
 
 let frame = 0;
@@ -263,6 +290,12 @@ while (egui.isOpen(win) !== 0) {
       dom.focusInput(d, urlInput(d));
       // baixa + decodifica as imagens do site (aparecem no render).
       if (raw.length > 0) loadImages(d, normalize(pendingUrl));
+      // EXECUTA os <script> inline da página (in-process, com `document`
+      // apontando pra este DOM). Script que não compila no subset é isolado
+      // (loga o erro e segue — como o console do browser).
+      docF = new Document(d);
+      const njs = runScripts(docF);
+      io.print("[js] scripts executados: " + njs);
     } else if (st < 0) {
       pendingTicket = 0; // ticket inválido: aborta
     }
@@ -320,9 +353,12 @@ while (egui.isOpen(win) !== 0) {
         io.print("GET (async) " + url);
         pendingTicket = fetchNs.fetchTextAsync(url);
         d = loadingPage(d, val);
+        docF = new Document(d);
       } else {
-        // página local (instantânea).
+        // página local (instantânea) — roda os <script> dela também.
         d = localPage(d, val);
+        docF = new Document(d);
+        runScripts(docF);
       }
     }
   }
@@ -330,6 +366,9 @@ while (egui.isOpen(win) !== 0) {
   egui.beginFrame(win);
   egui.render(win, d);
   egui.endFrame(win);
+  // Entrega os cliques do frame aos addEventListener registrados pelos <script>
+  // da página (hit-test do render → fila crua → callbacks, PRs #1884/#1885).
+  pumpEventCallbacks(docF);
 }
 
 dom.free(d);

--- a/site/js.html
+++ b/site/js.html
@@ -1,0 +1,45 @@
+<style>
+  .demo{background:#0c1220;border-radius:16px;padding:28px;margin:24px 0;box-shadow:0 6px 16px rgba(0,0,0,0.35)}
+  .demo h2{color:#ffffff;margin:0 0 6px 0}
+  .demo p{color:#93a0b6;margin:0 0 18px 0}
+  .btn{display:inline-block;background:#f97316;color:#1a0e03;font-weight:bold;padding:14px 28px;border-radius:10px;font-size:17px}
+  .btn:hover{background:#fdba74}
+  #contador{color:#7dd3fc;font-size:34px;font-weight:bold;margin:16px 0}
+  #status{color:#a4afc4;font-size:15px}
+  .lista{margin-top:14px}
+  .lista div{background:#10141c;color:#e6e9ef;border-radius:8px;padding:10px 14px;margin:6px 0}
+</style>
+<div class="demo">
+  <h2>JavaScript rodando no motor RTS</h2>
+  <p>Esta pagina tem um &lt;script&gt; de verdade: addEventListener, setTimeout, async function, createElement.</p>
+  <span class="btn" id="soma">Clique: +1</span>
+  <div id="contador">0</div>
+  <div id="status">aguardando o script...</div>
+  <div class="lista" id="lista"></div>
+</div>
+<script>
+let n = 0;
+const btn = document.getElementById('soma');
+if (btn !== null) {
+  btn.addEventListener('click', function(ev) {
+    n = n + 1;
+    const c = document.getElementById('contador');
+    if (c !== null) { c.textContent = '' + n; }
+    const li = document.createElement('div');
+    li.textContent = 'clique #' + n + ' em ' + ev.target.tagName;
+    const lista = document.getElementById('lista');
+    if (lista !== null) { lista.appendChild(li); }
+  });
+}
+const st = document.getElementById('status');
+if (st !== null) { st.textContent = 'script rodou! listener registrado. setTimeout em 1s...'; }
+setTimeout(function() {
+  const s2 = document.getElementById('status');
+  if (s2 !== null) { s2.textContent = 'setTimeout disparou! async agora...'; }
+}, 1000);
+async function demoAsync() { return 42; }
+demoAsync().then(function(v) {
+  const s3 = document.getElementById('status');
+  if (s3 !== null) { s3.textContent = 'tudo funcionou: listener + setTimeout + async/.then (v=' + v + ')'; }
+});
+</script>


### PR DESCRIPTION
## O que faz

Fixes achados testando **google.com de verdade** no mini-browser (o JS aparecia como texto na página e nenhum script rodava):

1. **JS pintado como texto**: `collect_runs` (inline-flow) e `collect_text` desciam em todos os filhos — um `<script>` dentro de contexto inline (script em `<td>`/`<center>`, como o google faz) tinha o código coletado e **pintado**. Skip de `is_non_rendered_tag` nos dois coletores. Validado com o dumpLayout do google.com real: 0 textos `function(` pintados (eram 4).

2. **Serialize corrompia o JS**: o filho-texto de `<script>`/`<style>` era re-encodado como entidade (`&&` → `&amp;&amp;`) — o roundtrip `innerHtml→parseHtml` do browser corrompia o código (vários 'syntax error' vinham daí). Raw-text agora serializa cru.

3. **Browser liga o pipeline de JS da campanha**: `extractSite` preserva os `<script>` inline; `runScripts(doc)` após cada navegação; `pumpEventCallbacks(doc)` no loop entrega cliques aos `addEventListener` da página. Nova página local de demo (`js` na barra): addEventListener + createElement + setTimeout + async/.then rodando no motor.

## Expectativa honesta
Os scripts do google (Closure-minificado) ainda bailam majoritariamente no subset (arrows exóticas, `this`, catch destructuring) — isolados, como erros de console. Scripts simples/inline rodam de verdade.

## Validação
rts-dom 192/192 · fixtures runscripts 4/4, event-callbacks 4/4, script-async 3/3 · gate sem violação HARD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z