### PR TITLE
feat(dom): <center> + input hidden/submit — HTML legado renderiza decente

### DIFF
--- a/crates/rts-dom/src/block.rs
+++ b/crates/rts-dom/src/block.rs
@@ -190,4 +190,9 @@ pub fn install_ua_defaults() {
             crate::style::define_style(e.tag, crate::style::SLOT_MARGIN_V, e.margin_v as i64);
         }
     }
+    // `<center>` (tag legada, viva em páginas anos-2000 — a home legada do
+    // google): bloco com text-align:center HERDÁVEL. Centralização de blocos
+    // filhos é um refino futuro; o inline-flow centrado já resolve o visual.
+    define("center", BlockDef { display: 0, indent: 0.0, prefix: PREFIX_NONE, flags: 0 });
+    crate::style::define_style("center", crate::style::SLOT_TEXT_ALIGN, 1);
 }

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -537,6 +537,21 @@ fn layout_block(
             // "conteúdo" é o texto do value/placeholder + cursor. Caminho próprio,
             // fora do fluxo de bloco genérico (que desceria em filhos inexistentes).
             if is_text_input_tag(tag) {
+                let itype = dom
+                    .node(id)
+                    .attr("type")
+                    .map(|t| t.to_ascii_lowercase())
+                    .unwrap_or_default();
+                // `type=hidden`: invisível e sem espaço (o form legado do google
+                // tem 5 — viravam caixas de texto fantasmas).
+                if itype == "hidden" {
+                    return (0.0, 0.0);
+                }
+                // `type=submit/button/reset`: BOTÃO — caixa cinza UA com o value
+                // como rótulo (não editável). O suficiente p/ o "Pesquisa Google".
+                if matches!(itype.as_str(), "submit" | "button" | "reset") {
+                    return layout_button(dom, id, &css, x, y, ctx, list);
+                }
                 return layout_input(dom, id, &css, x, y, avail_w, forced_outer_w, ctx, list);
             }
             // `<img>` com pixels decodificados: emite a imagem no rect (tamanho do CSS
@@ -1206,6 +1221,53 @@ fn layout_image(
         img_h: ih,
     });
     Some((w + margin_left + margin_right, h + margin_top + margin_bottom))
+}
+
+/// Layout de um `<input type=submit/button/reset>`: BOTÃO estilo UA — caixa
+/// cinza-clara com borda e o `value` como rótulo (shrink-to-fit no texto). O CSS
+/// do autor (bg/cor/padding) vence os defaults. Não editável, não focável (v1).
+fn layout_button(
+    dom: &Dom,
+    id: NodeIdx,
+    css: &ComputedStyle,
+    x: f32,
+    y: f32,
+    ctx: &LayoutCtx,
+    list: &mut DisplayList,
+) -> (f32, f32) {
+    let font = font_px(css, DEFAULT_FONT_SIZE - 3.0);
+    let label = dom.node(id).attr("value").unwrap_or("").to_string();
+    let tw = ctx.measurer.text_width(&label, font, false, false);
+    let lh = ctx.measurer.line_height(font);
+    let (pad_h, pad_v) = (12.0, 5.0);
+    let w = tw + 2.0 * pad_h;
+    let h = lh + 2.0 * pad_v;
+    let bg = css.bg.unwrap_or(0xF8F9FAFF); // cinza-claro UA (o do botão do google)
+    let fg = css.color.unwrap_or(0x3C4043FF);
+    list.items.push(DisplayItem::SolidRect {
+        rect: Rect::new(x, y, w, h),
+        color: bg,
+        radius: css.corner_radius.unwrap_or(4.0),
+    });
+    list.items.push(DisplayItem::Border {
+        rect: Rect::new(x, y, w, h),
+        width: css.border_width.unwrap_or(1.0),
+        color: css.border_color.unwrap_or(0xDADCE0FF),
+        radius: css.corner_radius.unwrap_or(4.0),
+    });
+    list.items.push(DisplayItem::Text {
+        x: x + pad_h,
+        y: y + pad_v,
+        text: label,
+        color: fg,
+        size: font,
+        mono: false,
+        bold: false,
+        letter_spacing: 0.0,
+        decoration: 0,
+    });
+    list.node_rects.insert(id, Rect::new(x, y, w, h));
+    (w + 6.0, h + 4.0) // margenzinha UA entre botões
 }
 
 fn layout_input(

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -53,7 +53,7 @@ pub use parse::{is_mono_family, parse_inline, parse_inline_block};
 pub use props::{
     define_style, lookup_style, ComputedStyle, SLOT_BG, SLOT_BORDER_COLOR, SLOT_BORDER_WIDTH,
     SLOT_COLOR, SLOT_CORNER_RADIUS, SLOT_FONT_SIZE, SLOT_MARGIN, SLOT_MARGIN_V, SLOT_PADDING,
-    SLOT_WIDTH,
+    SLOT_TEXT_ALIGN, SLOT_WIDTH,
 };
 pub use selector::{
     compound_matches, parse_selector, parse_selector_list, AttrOp, Combinator, ComplexSelector,

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -418,6 +418,16 @@ impl ComputedStyle {
                     v => Dimension::from_abi(v),
                 }
             }
+            // `text-align`: 0=left 1=center 2=right (a UA usa p/ <center>; o TS
+            // pode mapear o vocabulário CSS pro mesmo slot).
+            SLOT_TEXT_ALIGN => {
+                self.text_align = match val {
+                    1 => Some(crate::style::TextAlign::Center),
+                    2 => Some(crate::style::TextAlign::Right),
+                    0 => Some(crate::style::TextAlign::Left),
+                    _ => None,
+                }
+            }
             _ => {} // slot desconhecido: ignora (o TS mapeia o vocabulário CSS).
         }
     }
@@ -443,6 +453,10 @@ pub const SLOT_WIDTH: i64 = 8;
 /// `margin_v`: margem VERTICAL apenas (top/bottom), em pontos. A UA-stylesheet usa
 /// para separar blocos sem deslocar no eixo horizontal.
 pub const SLOT_MARGIN_V: i64 = 9;
+/// `text-align`: 0=left 1=center 2=right. A UA-stylesheet usa p/ `<center>`
+/// (a tag legada = text-align:center herdável, o suficiente p/ páginas
+/// anos-2000 como a home legada do google).
+pub const SLOT_TEXT_ALIGN: i64 = 10;
 
 use std::cell::RefCell;
 use std::collections::HashMap;


### PR DESCRIPTION
Fatias para a home **legada** do google (a que servem a agentes não-browser: `<center>` + tabelas + form anos-2000):

- **`<center>`**: UA-stylesheet com text-align:center herdável (novo `SLOT_TEXT_ALIGN` opaco — invariante 4 ok). 'Pesquisa avançada' saiu de x=0 para **x=432** (centro real).
- **`<input type=hidden>`**: invisível (o form do google tem 5 — viravam caixas fantasma).
- **`<input type=submit/button/reset>`**: botão UA (caixa cinza + borda + value), CSS do autor vence.

Gap documentado: botão dentro de contexto INLINE (`span>span>input`) ainda não aparece — inline-flow só coleta texto (item 8 do handoff #1793).

rts-dom 192/192 · runscripts 4/4 · gate limpo · validado com dumpLayout do google.com real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z