### PR TITLE
feat(dom): unidades pt/pc

### DIFF
--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -264,6 +264,14 @@ fn parse_dimension(v: &str) -> Option<Dimension> {
     if let Some(n) = low.strip_suffix('%').and_then(num) {
         return Some(Dimension::Percent(n.clamp(0.0, 100.0)));
     }
+    // `pt` (pontos de impressão) e `pc` (paica) — absolutos, comuns em páginas
+    // legadas (o rodapé do google usa `font-size:10pt`). 1pt = 4/3 px; 1pc = 16px.
+    if let Some(n) = low.strip_suffix("pt").and_then(num) {
+        return Some(Dimension::Px(n * 4.0 / 3.0));
+    }
+    if let Some(n) = low.strip_suffix("pc").and_then(num) {
+        return Some(Dimension::Px(n * 16.0));
+    }
     // px explícito ou número puro.
     num(low.strip_suffix("px").unwrap_or(&low)).map(Dimension::Px)
 }


### PR DESCRIPTION
O rodapé do google usa `font-size:10pt`/`8pt` — 'pt'/'pc' não eram parseados, caíam no default 16px (rodapé gigante). Agora 1pt=4/3px, 1pc=16px; o inline-flow herda o font-size computado (10pt→13.3px flui pros `<a>`). rts-dom 192/192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z