### PR TITLE
feat(fetch): mini-browser se identifica como navegador (UA + Accept)

### DIFF
--- a/crates/rts-std/src/globals/fetch/instance.rs
+++ b/crates/rts-std/src/globals/fetch/instance.rs
@@ -66,6 +66,14 @@ fn map_get_headers(map_h: u64) -> Vec<(String, String)> {
 }
 
 fn do_fetch(url: &str, opts_h: u64) -> u64 {
+    do_fetch_ua(url, opts_h, false)
+}
+
+/// `browser_mode = true`: identifica-se como Chrome (UA + Accept/Accept-Language)
+/// para o servidor entregar a página humana completa (o caminho do mini-browser
+/// `fetchText`/`fetchTextAsync`). `false`: identidade RTS honesta (o `fetch()`
+/// de API). Headers explícitos em `opts.headers` vencem em ambos.
+fn do_fetch_ua(url: &str, opts_h: u64, browser_mode: bool) -> u64 {
     // Read options from Map handle (opts_h == 0 means no options → GET)
     let method = if opts_h != 0 {
         map_get_str(opts_h, "method")
@@ -83,9 +91,16 @@ fn do_fetch(url: &str, opts_h: u64) -> u64 {
 
     let mut req = ureq::request(&method, url);
 
-    // Browser-style default UA (`Rts v<version>` / `Rts development`); an
-    // explicit `headers: { "User-Agent": … }` below overrides it.
-    req = req.set("User-Agent", super::default_user_agent());
+    // UA: navegador (mini-browser) ou identidade RTS (fetch de API). Um
+    // `headers: { "User-Agent": … }` explícito nas opts vence (setado abaixo).
+    if browser_mode {
+        req = req.set("User-Agent", super::browser_user_agent());
+        for (k, v) in super::browser_headers() {
+            req = req.set(k, v);
+        }
+    } else {
+        req = req.set("User-Agent", super::default_user_agent());
+    }
 
     // headers from opts.headers map
     if opts_h != 0 {
@@ -183,7 +198,7 @@ pub extern "C" fn __RTS_FN_GL_FETCH(url_ptr: i64, url_len: i64, opts_h: u64) -> 
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_FETCH_FETCH_TEXT(url_ptr: i64, url_len: i64) -> u64 {
     let url = str_from_parts(url_ptr, url_len);
-    let resp_h = do_fetch(url, 0);
+    let resp_h = do_fetch_ua(url, 0, true);
     let body = with_response(resp_h, |r| r.body.clone()).unwrap_or_default();
     alloc_entry(Entry::String(body))
 }
@@ -218,7 +233,7 @@ pub extern "C" fn __RTS_FN_NS_FETCH_FETCH_TEXT_ASYNC(url_ptr: i64, url_len: i64)
     async_fetches().lock().unwrap().insert(ticket, None); // pendente
     std::thread::spawn(move || {
         // download síncrono NA THREAD (a UI segue livre).
-        let resp_h = do_fetch(&url, 0);
+        let resp_h = do_fetch_ua(&url, 0, true);
         let body = with_response(resp_h, |r| r.body.clone()).unwrap_or_default();
         free_handle(resp_h); // a Response já foi consumida.
         let s = String::from_utf8_lossy(&body).into_owned();
@@ -252,7 +267,10 @@ pub extern "C" fn __RTS_FN_NS_FETCH_FETCH_TAKE(ticket: u64) -> u64 {
 
 /// GET binário síncrono → Vec<u8> cru (preserva os bytes, sem UTF-8).
 fn do_fetch_bytes(url: &str) -> Vec<u8> {
-    let req = ureq::request("GET", url).set("User-Agent", super::default_user_agent());
+    let mut req = ureq::request("GET", url).set("User-Agent", super::browser_user_agent());
+    for (k, v) in super::browser_headers() {
+        req = req.set(k, v);
+    }
     match req.call() {
         Ok(resp) | Err(ureq::Error::Status(_, resp)) => {
             let mut buf = Vec::new();

--- a/crates/rts-std/src/globals/fetch/mod.rs
+++ b/crates/rts-std/src/globals/fetch/mod.rs
@@ -25,6 +25,33 @@ pub fn default_user_agent() -> &'static str {
     }
 }
 
+/// User-Agent de NAVEGADOR — usado pelo caminho do mini-browser (`fetchText`/
+/// `fetchTextAsync`/`fetchBytes`), NÃO pelo `fetch()` genérico de API. Muitos
+/// sites (google, cloudflare, etc.) servem HTML DIFERENTE por User-Agent: com
+/// um UA de bot vem uma página legada/degradada; com UA de Chrome vem a página
+/// moderna com todo o CSS inline. Como o RTS-browser É um browser, ele se
+/// identifica como um. Emparelhado com `browser_headers` (Accept/Accept-Language)
+/// que alguns servidores também exigem para servir o conteúdo completo.
+pub fn browser_user_agent() -> &'static str {
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+}
+
+/// Os cabeçalhos que um navegador manda além do User-Agent — `Accept`
+/// (prioriza HTML), `Accept-Language`. Aplicados no caminho do browser para o
+/// servidor entregar a página humana completa. (`Accept-Encoding` fica de fora:
+/// o ureq não descomprime brotli e pediríamos algo que não sabemos ler.)
+pub fn browser_headers() -> &'static [(&'static str, &'static str)] {
+    &[
+        (
+            "Accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,\
+             image/webp,image/apng,*/*;q=0.8",
+        ),
+        ("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8"),
+    ]
+}
+
 /// Membro hand-written (espelha `leak`/`leak_class` da macro). `fn_ptr` é null
 /// para membros `external` (codegen resolve pelo `symbol`).
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
**Descoberta:** o google serve HTML diferente por User-Agent — com UA de bot vem a página legada de 1999; com UA de Chrome vem a moderna com ~81KB de CSS **inline** (não bloqueado). Não era fingerprint de TLS.

O caminho do mini-browser (`fetchText`/`fetchTextAsync`/`fetchBytes`) agora manda headers de navegador (Chrome 131 + Accept/Accept-Language). O `fetch()` genérico de API mantém a identidade RTS honesta — distinção intencional.

Resultado: google.com renderiza a **página moderna** (caixa de busca 'Modo IA', tema escuro, rodapé espalhado), content_height 202→800, fiel ao Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z