### PR TITLE
feat(dom): CSS Grid real — track-sizing + auto-placement + cell align

### DIFF
--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -804,16 +804,15 @@ fn layout_block(
         d if d == crate::block::DISPLAY_HORIZONTAL => {
             layout_children_horizontal(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, false, None, ctx, list)
         }
-        // wrap (inline-block flow): lado a lado E QUEBRA linha quando enche. GRID
-        // (`display:grid`) também vem aqui, com o Nº de colunas → cada item ganha
-        // largura fixa de coluna e quebra a cada N.
+        // GRID REAL: track-sizing (px/fr/auto/%) + auto-placement row-by-row +
+        // alinhamento de célula (align-items/justify-items). Só quando é
+        // `display:grid` de fato; senão o wrap horizontal (inline-block flow).
+        _ if css.effective_display() == Some(crate::style::DisplayKind::Grid) => {
+            layout_children_grid(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, ctx, list)
+        }
+        // wrap (inline-block flow): lado a lado E QUEBRA linha quando enche.
         d if d == crate::block::DISPLAY_WRAP => {
-            let grid_cols = if css.effective_display() == Some(crate::style::DisplayKind::Grid) {
-                Some(css.grid_columns.unwrap_or(1).max(1))
-            } else {
-                None
-            };
-            layout_children_horizontal(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, true, grid_cols, ctx, list)
+            layout_children_horizontal(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, true, None, ctx, list)
         }
         // vertical (block): empilha.
         _ => layout_children_vertical(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, ctx, list),
@@ -2064,6 +2063,220 @@ fn layout_children_horizontal(
 /// ⚠️ Cortes: `column-reverse` dispõe como `column` (sem inverter); `flex-wrap` em
 /// column (multi-coluna) trata como coluna única; `flex-grow/shrink/basis` ainda
 /// fora (fatia própria).
+/// GRID real (css-grid track-sizing simplificado): resolve as trilhas de coluna
+/// (px/%/fr/auto) e de linha, faz auto-placement dos itens célula-a-célula
+/// (row-by-row), e posiciona cada item na sua célula com `justify-items`
+/// (horizontal) / `align-items` (vertical). Suporta o subset do MDN:
+/// grid-template-columns/rows, grid-auto-rows, gap, repeat(N,...), minmax(→max),
+/// fr. NÃO suporta: grid-column/row-span explícito, areas, auto-fill/fit reais,
+/// dense. Um item sem placement explícito preenche a próxima célula livre.
+#[allow(clippy::too_many_arguments)]
+fn layout_children_grid(
+    dom: &Dom,
+    id: NodeIdx,
+    content_x: f32,
+    content_y: f32,
+    content_w: f32,
+    container_content_h: Option<f32>,
+    css: &ComputedStyle,
+    font_size: f32,
+    ctx: &LayoutCtx,
+    list: &mut DisplayList,
+) -> f32 {
+    let resolve = ResolveCtx {
+        parent_content_w: content_w,
+        node_font_size: font_size,
+        root_font_size: DEFAULT_FONT_SIZE,
+        viewport_w: ctx.viewport_w,
+        viewport_h: ctx.viewport_h,
+    };
+    let col_gap = css.gap.or(css.row_gap).and_then(|d| d.resolve(&resolve)).unwrap_or(0.0).max(0.0);
+    let row_gap = css.row_gap.or(css.gap).and_then(|d| d.resolve(&resolve)).unwrap_or(0.0).max(0.0);
+
+    // ── COLUNAS: resolve as trilhas ──────────────────────────────────────────────
+    // Sem grid-template-columns explícito → 1 coluna 1fr (o container-do-logo do
+    // google: single-column grid). Com N colunas do grid_columns legado (repeat) →
+    // N trilhas 1fr.
+    let col_tracks: Vec<crate::style::GridTrack> = match &css.grid_template_columns {
+        Some(t) => (**t).clone(),
+        None => {
+            let n = css.grid_columns.unwrap_or(1).max(1) as usize;
+            vec![crate::style::GridTrack::Fr(1.0); n]
+        }
+    };
+    let col_sizes = resolve_tracks(&col_tracks, content_w, col_gap, &resolve);
+    let ncols = col_sizes.len().max(1);
+
+    // ── ITENS: os filhos renderizáveis (auto-placement row-by-row) ───────────────
+    let mut children: Vec<NodeIdx> = Vec::new();
+    for &child in &dom.node(id).children {
+        if let NodeKind::Element { tag } = &dom.node(child).kind {
+            if is_non_rendered_tag(tag) {
+                continue;
+            }
+        }
+        if is_out_of_flow(dom, child) {
+            continue;
+        }
+        if !is_block_level(dom, child) && collect_text(dom, child).trim().is_empty() {
+            continue;
+        }
+        children.push(child);
+    }
+    if children.is_empty() {
+        return 0.0;
+    }
+    let nrows = children.len().div_ceil(ncols);
+
+    // ── LINHAS: altura de cada linha ─────────────────────────────────────────────
+    // grid-template-rows explícito (px/%/fr/auto), senão grid-auto-rows, senão a
+    // altura do conteúdo mais alto da linha. `fr`/`%` de linha precisam da altura
+    // do container (container_content_h).
+    let explicit_rows: Vec<crate::style::GridTrack> = css
+        .grid_template_rows
+        .as_ref()
+        .map(|t| (**t).clone())
+        .unwrap_or_default();
+    // mede a altura de conteúdo de cada linha (o item mais alto medido em shrink).
+    let mut content_row_h = vec![0.0f32; nrows];
+    for (i, &child) in children.iter().enumerate() {
+        let r = i / ncols;
+        let ci = i % ncols;
+        let cw = col_sizes[ci.min(col_sizes.len() - 1)];
+        let mut scratch = DisplayList::default();
+        let (_, h) = layout_block(dom, child, 0.0, 0.0, cw, container_content_h, None, None, true, ctx, &mut scratch);
+        content_row_h[r] = content_row_h[r].max(h);
+    }
+    let auto_row = css.grid_auto_rows;
+    let has_explicit_row_track = |r: usize| {
+        explicit_rows.get(r).is_some() || auto_row.is_some()
+    };
+    let mut row_sizes: Vec<f32> = (0..nrows)
+        .map(|r| {
+            let track = explicit_rows.get(r).copied().or(auto_row);
+            match track {
+                Some(crate::style::GridTrack::Fixed(d)) => resolve_height(Some(d), container_content_h, &resolve).unwrap_or(content_row_h[r]),
+                _ => content_row_h[r], // Auto/None/Fr → conteúdo por ora (ajuste abaixo)
+            }
+        })
+        .collect();
+    // Se o container tem ALTURA definida e as linhas NÃO têm track explícita (auto),
+    // as linhas DIVIDEM a altura do container (uma row auto num grid de altura fixa
+    // preenche o espaço — é o que dá a track de 240 pro logo centrar). Distribui o
+    // espaço livre igualmente entre as linhas auto (aproximação; fr real seria por
+    // peso — mas grid sem template-rows usa 1fr implícito quando há altura).
+    if let Some(ch) = container_content_h {
+        let auto_rows: Vec<usize> = (0..nrows).filter(|&r| !has_explicit_row_track(r)).collect();
+        if !auto_rows.is_empty() {
+            let fixed: f32 = (0..nrows).filter(|r| has_explicit_row_track(*r)).map(|r| row_sizes[r]).sum();
+            let total_gap = (nrows.saturating_sub(1)) as f32 * row_gap;
+            let free = (ch - fixed - total_gap).max(0.0);
+            let each = free / auto_rows.len() as f32;
+            for r in auto_rows {
+                row_sizes[r] = row_sizes[r].max(each);
+            }
+        }
+    }
+
+    // ── POSICIONA cada item na sua célula ────────────────────────────────────────
+    let justify = css.grid_justify_items.unwrap_or(crate::style::AlignItems::Stretch);
+    let align = css.align_items.unwrap_or(crate::style::AlignItems::Stretch);
+    // x acumulado de cada coluna, y de cada linha.
+    let mut col_x = vec![content_x; ncols + 1];
+    for c in 0..ncols {
+        col_x[c + 1] = col_x[c] + col_sizes[c.min(col_sizes.len() - 1)] + col_gap;
+    }
+    let mut row_y = vec![content_y; nrows + 1];
+    for r in 0..nrows {
+        row_y[r + 1] = row_y[r] + row_sizes[r] + row_gap;
+    }
+    for (i, &child) in children.iter().enumerate() {
+        let r = i / ncols;
+        let c = i % ncols;
+        let cell_x = col_x[c];
+        let cell_y = row_y[r];
+        let cell_w = col_sizes[c.min(col_sizes.len() - 1)];
+        let cell_h = row_sizes[r];
+        // mede o tamanho natural do item (shrink) p/ o alinhamento não-stretch.
+        let stretch_x = justify == crate::style::AlignItems::Stretch;
+        let stretch_y = align == crate::style::AlignItems::Stretch;
+        let mut scratch = DisplayList::default();
+        let (nat_w, nat_h) = layout_block(dom, child, 0.0, 0.0, cell_w, Some(cell_h), None, None, true, ctx, &mut scratch);
+        let iw = if stretch_x { cell_w } else { nat_w.min(cell_w) };
+        let ih = if stretch_y { cell_h } else { nat_h.min(cell_h) };
+        let x = cell_x + cell_align_offset(justify, cell_w, iw);
+        let y = cell_y + cell_align_offset(align, cell_h, ih);
+        // pinta o item: stretch no eixo → forced size; senão shrink-to-fit.
+        let forced_w = if stretch_x { None } else { Some(iw) };
+        let forced_h = if stretch_y { Some(cell_h) } else { None };
+        layout_block(dom, child, x, y, cell_w, Some(cell_h), forced_w, forced_h, !stretch_x, ctx, list);
+    }
+    // altura total = soma das linhas + gaps.
+    let total_h: f32 = row_sizes.iter().sum::<f32>() + (nrows.saturating_sub(1)) as f32 * row_gap;
+    total_h.max(0.0)
+}
+
+/// Resolve os tamanhos px de uma lista de trilhas dado o tamanho do container no
+/// eixo e o gap: px/%/auto resolvem direto; o espaço livre restante é dividido
+/// pelas trilhas `fr` na proporção dos pesos (css-grid track sizing simplificado).
+fn resolve_tracks(
+    tracks: &[crate::style::GridTrack],
+    container: f32,
+    gap: f32,
+    ctx: &ResolveCtx,
+) -> Vec<f32> {
+    let n = tracks.len().max(1);
+    let total_gap = (n.saturating_sub(1)) as f32 * gap;
+    // 1ª passada: resolve px/%/auto; soma o consumido e os pesos fr.
+    let mut sizes = vec![0.0f32; tracks.len()];
+    let mut used = 0.0f32;
+    let mut sum_fr = 0.0f32;
+    for (i, t) in tracks.iter().enumerate() {
+        match t {
+            crate::style::GridTrack::Fixed(d) => {
+                // % de trilha resolve contra o container (largura p/ colunas).
+                let v = match d {
+                    crate::style::Dimension::Percent(p) => container * p / 100.0,
+                    other => other.resolve(ctx).unwrap_or(0.0),
+                };
+                sizes[i] = v.max(0.0);
+                used += sizes[i];
+            }
+            crate::style::GridTrack::Fr(f) => sum_fr += f.max(0.0),
+            crate::style::GridTrack::Auto => {} // auto: 0 na v1 (conteúdo dita a linha, não a coluna)
+        }
+    }
+    // 2ª passada: distribui o espaço livre pelas trilhas fr.
+    let free = (container - used - total_gap).max(0.0);
+    if sum_fr > 0.0 {
+        for (i, t) in tracks.iter().enumerate() {
+            if let crate::style::GridTrack::Fr(f) = t {
+                sizes[i] = free * f.max(0.0) / sum_fr;
+            }
+        }
+    } else {
+        // sem fr: uma trilha `auto` sozinha ocupa o espaço livre (single-column).
+        let autos: Vec<usize> = tracks.iter().enumerate()
+            .filter(|(_, t)| matches!(t, crate::style::GridTrack::Auto))
+            .map(|(i, _)| i).collect();
+        if !autos.is_empty() {
+            let each = free / autos.len() as f32;
+            for i in autos { sizes[i] = each; }
+        }
+    }
+    sizes
+}
+
+/// Offset de alinhamento de um item de tamanho `item` dentro de uma célula de
+/// tamanho `cell` (start=0, center=(cell-item)/2, end=cell-item; stretch=0).
+fn cell_align_offset(a: crate::style::AlignItems, cell: f32, item: f32) -> f32 {
+    match a {
+        crate::style::AlignItems::Center => ((cell - item) / 2.0).max(0.0),
+        crate::style::AlignItems::FlexEnd => (cell - item).max(0.0),
+        _ => 0.0, // FlexStart / Stretch
+    }
+}
+
 fn layout_children_column(
     dom: &Dom,
     id: NodeIdx,
@@ -3089,6 +3302,42 @@ mod tests {
         // "y" à direita → x ≈ 400-8 = 392.
         let rx = texts.iter().find(|(t, _)| t == "y").unwrap().1;
         assert!((rx - 392.0).abs() < 2.0, "right: {rx}");
+    }
+
+    #[test]
+    fn grid_fr_track_sizing() {
+        // grid-template-columns: 200px 1fr 2fr num container 620 → 200/140/280.
+        let dom = parse_html_to_dom(
+            "<div style='display:grid;grid-template-columns:200px 1fr 2fr;width:620px'>\
+             <div id=a>A</div><div id=b>B</div><div id=c>C</div></div>",
+        );
+        let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 800.0, measurer: &ApproxMeasurer };
+        let list = layout_document(&dom, &ctx);
+        let rect = |sel: &str| {
+            let idx = dom.resolve(dom.query(sel).unwrap()).unwrap();
+            list.node_rects[&idx]
+        };
+        let a = rect("#a"); let b = rect("#b"); let c = rect("#c");
+        assert!((a.w - 200.0).abs() < 1.0, "col px: {}", a.w);
+        assert!((b.w - 140.0).abs() < 1.0, "col 1fr: {}", b.w); // (620-200)/3
+        assert!((c.w - 280.0).abs() < 1.0, "col 2fr: {}", c.w); // 2×140
+        assert!((b.x - 200.0).abs() < 1.0 && (c.x - 340.0).abs() < 1.0, "posições");
+    }
+
+    #[test]
+    fn grid_align_items_center_centraliza_na_celula() {
+        // single-column grid de altura fixa + align-items:center → o item de
+        // altura menor centraliza verticalmente na track (o logo do google).
+        let dom = parse_html_to_dom(
+            "<div style='display:grid;align-items:center;height:240px'>\
+             <div id=logo style='height:92px'>x</div></div>",
+        );
+        let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 800.0, measurer: &ApproxMeasurer };
+        let list = layout_document(&dom, &ctx);
+        let idx = dom.resolve(dom.query("#logo").unwrap()).unwrap();
+        let r = list.node_rects[&idx];
+        assert!((r.y - 74.0).abs() < 2.0, "y centralizado: {} (esperado 74=(240-92)/2)", r.y);
+        assert!((r.h - 92.0).abs() < 2.0, "altura preservada: {}", r.h);
     }
 
     #[test]

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -61,7 +61,7 @@ pub use selector::{
 };
 pub use stylesheet::{parse_rules, DeclBlock, MediaQuery, Rule, Stylesheet};
 pub use values::{
-    clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection, FloatSide,
+    clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection, FloatSide, GridTrack,
     JustifyContent, LineHeight, Position, ResolveCtx, Rgba, Side, TextAlign, TextTransform,
     WhiteSpace, DIM_BASE_EM, DIM_BASE_PERCENT, DIM_BASE_PX, DIM_BASE_REM, DIM_BASE_VH,
     DIM_BASE_VW, DIM_RANGE,

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -60,7 +60,32 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
                 }
             }
             "box-shadow" => css.box_shadow = crate::style::effects::BoxShadow::parse(val),
-            "grid-template-columns" => css.grid_columns = parse_grid_columns(val),
+            "grid-template-columns" => {
+                css.grid_columns = parse_grid_columns(val);
+                css.grid_template_columns =
+                    crate::style::GridTrack::parse_list(val).map(std::sync::Arc::new);
+            }
+            "grid-template-rows" => {
+                css.grid_template_rows =
+                    crate::style::GridTrack::parse_list(val).map(std::sync::Arc::new);
+            }
+            "grid-auto-rows" => {
+                css.grid_auto_rows = crate::style::GridTrack::parse_one(val);
+            }
+            "justify-items" => {
+                css.grid_justify_items = crate::style::AlignItems::parse(val);
+            }
+            "grid" | "grid-template" => {
+                // shorthand `grid-template: rows / columns` (forma comum
+                // `"areas" rows / cols` não modelada — v1 pega rows/cols).
+                if let Some((rows, cols)) = val.split_once('/') {
+                    css.grid_template_rows =
+                        crate::style::GridTrack::parse_list(rows).map(std::sync::Arc::new);
+                    css.grid_template_columns =
+                        crate::style::GridTrack::parse_list(cols).map(std::sync::Arc::new);
+                    css.grid_columns = parse_grid_columns(cols);
+                }
+            }
             "transform" => css.transform = crate::style::effects::Transform::parse(val),
             "aspect-ratio" => css.aspect_ratio = parse_aspect_ratio(val),
             "opacity" => {
@@ -235,6 +260,11 @@ fn parse_px(v: &str) -> Option<f32> {
 /// `280`/`280px` → Px. Unidades relativas resolvem TARDE no render (risco 5).
 /// Número inválido / unidade desconhecida → `None`. Ordem do match importa: testa
 /// sufixos de 3/2 letras (`rem`) ANTES dos de 1 (`%`) e do px implícito.
+/// Público p/ o parse de trilhas de grid (`GridTrack::parse_one`).
+pub(crate) fn parse_dimension_pub(v: &str) -> Option<Dimension> {
+    parse_dimension(v)
+}
+
 fn parse_dimension(v: &str) -> Option<Dimension> {
     let v = v.trim();
     if v.eq_ignore_ascii_case("auto") {

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -60,6 +60,24 @@ macro_rules! css_props {
             /// BUILT-IN da macro (herança/merge próprios; não anima).
             pub custom_props:
                 Option<std::sync::Arc<std::collections::HashMap<String, String>>>,
+            /// GRID: as trilhas de COLUNA (`grid-template-columns`) parseadas —
+            /// px/fr/auto/%. `None` = não é grid explícito. Campo built-in (Vec não
+            /// cabe na macro simples); herança N/A (grid não herda). O layout roda
+            /// o track-sizing sobre isto.
+            pub grid_template_columns:
+                Option<std::sync::Arc<Vec<crate::style::GridTrack>>>,
+            /// GRID: trilhas de LINHA (`grid-template-rows`). `None` = linhas
+            /// implícitas (via `grid_auto_rows`).
+            pub grid_template_rows:
+                Option<std::sync::Arc<Vec<crate::style::GridTrack>>>,
+            /// GRID: tamanho das linhas IMPLÍCITAS (`grid-auto-rows`) — uma trilha
+            /// aplicada a toda linha não coberta por `grid-template-rows`. `None` =
+            /// auto (altura do conteúdo).
+            pub grid_auto_rows: Option<crate::style::GridTrack>,
+            /// GRID: `justify-items` — alinhamento HORIZONTAL do item na célula
+            /// (start/center/end/stretch). `None` = stretch. Reusa AlignItems como
+            /// vocabulário (start=FlexStart etc.).
+            pub grid_justify_items: Option<crate::style::AlignItems>,
         }
 
         impl ComputedStyle {
@@ -69,6 +87,20 @@ macro_rules! css_props {
             pub fn merge_over(&mut self, other: &ComputedStyle) {
                 $( if other.$ofield.is_some() { self.$ofield = other.$ofield.clone(); } )*
                 $( self.$efield.merge_over(&other.$efield); )*
+                // GRID: os campos built-in (Vec/track) — `other` vence quando setado
+                // (mesma precedência dos campos da macro; grid não herda).
+                if other.grid_template_columns.is_some() {
+                    self.grid_template_columns = other.grid_template_columns.clone();
+                }
+                if other.grid_template_rows.is_some() {
+                    self.grid_template_rows = other.grid_template_rows.clone();
+                }
+                if other.grid_auto_rows.is_some() {
+                    self.grid_auto_rows = other.grid_auto_rows;
+                }
+                if other.grid_justify_items.is_some() {
+                    self.grid_justify_items = other.grid_justify_items;
+                }
                 // custom props: as de `other` vencem POR NOME (união CoW).
                 if let Some(theirs) = &other.custom_props {
                     self.custom_props = Some(match self.custom_props.take() {

--- a/crates/rts-dom/src/style/values.rs
+++ b/crates/rts-dom/src/style/values.rs
@@ -380,6 +380,101 @@ impl AlignItems {
     }
 }
 
+/// Uma TRILHA de grid (`grid-template-columns`/`-rows`, `grid-auto-rows`): o
+/// tamanho de uma coluna/linha. `Px` fixo, `Fr` fração do espaço livre, `Auto`
+/// dimensiona pelo conteúdo, `Percent` do container. A resolução (px → fr → auto)
+/// vive no layout (algoritmo de track sizing). Egui-free.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum GridTrack {
+    /// `100px`, `2rem`… — tamanho absoluto (já resolvido a px no parse quando
+    /// possível; `em`/`rem`/`vw` resolvem no layout via a Dimension).
+    Fixed(Dimension),
+    /// `1fr`, `2fr` — fração do espaço livre (após px/auto). O nº é o peso.
+    Fr(f32),
+    /// `auto`/`min-content`/`max-content` — dimensiona pelo conteúdo (v1: trata
+    /// como o maior conteúdo dos itens da trilha; sem distinção min/max).
+    Auto,
+}
+
+impl GridTrack {
+    /// Parseia UMA trilha: `100px`/`50%`/`1fr`/`auto`/`minmax(a,b)` (minmax → o
+    /// MÁXIMO, aproximação v1). `None` se não reconhece.
+    pub fn parse_one(v: &str) -> Option<GridTrack> {
+        let v = v.trim();
+        let low = v.to_ascii_lowercase();
+        if low == "auto" || low == "min-content" || low == "max-content" {
+            return Some(GridTrack::Auto);
+        }
+        if let Some(n) = low.strip_suffix("fr") {
+            return n.trim().parse::<f32>().ok().map(GridTrack::Fr);
+        }
+        // minmax(min, max) → usa o max (a trilha cresce até ele).
+        if let Some(inner) = low.strip_prefix("minmax(").and_then(|s| s.strip_suffix(')')) {
+            let parts: Vec<&str> = inner.splitn(2, ',').collect();
+            if parts.len() == 2 {
+                return GridTrack::parse_one(parts[1]);
+            }
+        }
+        // fit-content(x) → x fixo (aproximação).
+        if let Some(inner) = low.strip_prefix("fit-content(").and_then(|s| s.strip_suffix(')')) {
+            return GridTrack::parse_one(inner);
+        }
+        super::parse::parse_dimension_pub(v).map(GridTrack::Fixed)
+    }
+
+    /// Parseia uma LISTA de trilhas (`grid-template-columns`), expandindo
+    /// `repeat(N, tracks…)`. Devolve o Vec de trilhas na ordem. Vazio → None.
+    pub fn parse_list(v: &str) -> Option<Vec<GridTrack>> {
+        let v = v.trim();
+        if v.is_empty() || v.eq_ignore_ascii_case("none") {
+            return None;
+        }
+        let mut out = Vec::new();
+        // tokeniza respeitando parênteses (repeat/minmax têm vírgulas internas).
+        for tok in split_top_level(v) {
+            let t = tok.trim();
+            let low = t.to_ascii_lowercase();
+            if let Some(inner) = low.strip_prefix("repeat(").and_then(|s| s.strip_suffix(')')) {
+                // repeat(N, tracks) — N vezes as trilhas internas.
+                let mut parts = inner.splitn(2, ',');
+                let count = parts.next().unwrap_or("").trim();
+                let tracks = parts.next().unwrap_or("").trim();
+                // `auto-fill`/`auto-fit`: v1 usa 1 repetição (sem cálculo de quantas
+                // cabem — aproximação; a maioria das páginas usa repeat(N,...) fixo).
+                let n: usize = count.parse().unwrap_or(1);
+                if let Some(inner_tracks) = GridTrack::parse_list(tracks) {
+                    for _ in 0..n.max(1) {
+                        out.extend(inner_tracks.iter().copied());
+                    }
+                }
+            } else if let Some(track) = GridTrack::parse_one(t) {
+                out.push(track);
+            }
+        }
+        (!out.is_empty()).then_some(out)
+    }
+}
+
+/// Tokeniza uma lista separada por espaços RESPEITANDO parênteses (para não
+/// quebrar `repeat(3, 1fr)` / `minmax(0, 1fr)` na vírgula/espaço internos).
+fn split_top_level(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut cur = String::new();
+    for ch in s.chars() {
+        match ch {
+            '(' => { depth += 1; cur.push(ch); }
+            ')' => { depth -= 1; cur.push(ch); }
+            c if c.is_whitespace() && depth == 0 => {
+                if !cur.is_empty() { out.push(std::mem::take(&mut cur)); }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() { out.push(cur); }
+    out
+}
+
 /// `flex-direction` — qual eixo é o principal. Default `Row`. Egui-free.
 /// ⚠️ CORTE: o layout hoje SÓ honra `Row`. `Column`/`RowReverse`/`ColumnReverse`
 /// são parseados e mesclados (cascade pronta) mas o `layout_block` dispõe sempre em


### PR DESCRIPTION
Grid de verdade (consultei a spec css-grid do MDN), substituindo a emulação por colunas horizontais. Subset comum:

- **GridTrack**: Fixed/Fr/Auto; parse com `repeat(N,...)`, `minmax(→max)`, `fit-content`, `auto`.
- **props**: grid_template_columns/rows, grid_auto_rows, justify_items (+ shorthand).
- **layout_children_grid**: track-sizing (px/% direto; espaço livre ÷ fr por peso), auto-placement row-by-row, altura de linha (linha auto num container de altura fixa divide a altura), cell align (justify-items X / align-items Y).

Validado número-a-número: `200px 1fr 2fr`@620 → 200/140/280; Tailwind `repeat(3,minmax(0,1fr))` gap16 → 3×323; `align-items:center` h=240 → logo centraliza y=74. rts-dom 198/198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z