### PR TITLE
feat(fetch): headers Sec-Fetch-* (destrava WhatsApp Web) + overrides de request pelo TS

### DIFF
--- a/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_b.rs
@@ -184,6 +184,21 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
                 as *const u8,
         ),
         sym(
+            "__RTS_FN_NS_FETCH_SET_USER_AGENT",
+            rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_NS_FETCH_SET_USER_AGENT
+                as *const u8,
+        ),
+        sym(
+            "__RTS_FN_NS_FETCH_SET_HEADER",
+            rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_NS_FETCH_SET_HEADER
+                as *const u8,
+        ),
+        sym(
+            "__RTS_FN_NS_FETCH_CLEAR_OVERRIDES",
+            rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_NS_FETCH_CLEAR_OVERRIDES
+                as *const u8,
+        ),
+        sym(
             "__RTS_FN_NS_FETCH_FETCH_POLL",
             rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_NS_FETCH_FETCH_POLL
                 as *const u8,

--- a/crates/rts-std/src/globals/fetch/instance.rs
+++ b/crates/rts-std/src/globals/fetch/instance.rs
@@ -2,6 +2,81 @@ use rts_engine::heap::handles::{
     alloc_entry, free_handle, with_entry, Entry, HttpResponseData,
 };
 
+// ── OVERRIDES de request configuráveis pelo TS ───────────────────────────────
+// O mini-browser (e qualquer app) pode ajustar como o RTS se apresenta na rede:
+// trocar o User-Agent, injetar headers (Cookie/Referer/Sec-Fetch-*), sem tocar o
+// Rust. `fetch.setUserAgent(ua)` e `fetch.setHeader(nome, valor)` gravam aqui;
+// TODO caminho do browser (`do_fetch_ua` browser_mode) aplica: primeiro os
+// defaults de navegador, depois estes overrides POR CIMA (o custom vence). Um
+// valor vazio em setHeader REMOVE o override daquele header.
+use std::sync::RwLock;
+
+struct RequestOverrides {
+    user_agent: Option<String>,
+    headers: Vec<(String, String)>,
+}
+
+fn request_overrides() -> &'static RwLock<RequestOverrides> {
+    static O: OnceLock<RwLock<RequestOverrides>> = OnceLock::new();
+    O.get_or_init(|| {
+        RwLock::new(RequestOverrides {
+            user_agent: None,
+            headers: Vec::new(),
+        })
+    })
+}
+
+/// `fetch.setUserAgent(ua)` — sobrescreve o User-Agent do caminho do browser.
+/// String vazia volta ao default de navegador.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_FETCH_SET_USER_AGENT(ua_ptr: i64, ua_len: i64) {
+    let ua = str_from_parts(ua_ptr, ua_len);
+    let mut o = request_overrides().write().unwrap_or_else(|e| e.into_inner());
+    o.user_agent = if ua.is_empty() { None } else { Some(ua.to_string()) };
+}
+
+/// `fetch.setHeader(name, value)` — injeta/sobrescreve um header do caminho do
+/// browser (Cookie, Referer, X-*, o que for). Valor vazio REMOVE o override.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_FETCH_SET_HEADER(
+    name_ptr: i64,
+    name_len: i64,
+    val_ptr: i64,
+    val_len: i64,
+) {
+    let name = str_from_parts(name_ptr, name_len).to_string();
+    let val = str_from_parts(val_ptr, val_len);
+    if name.is_empty() {
+        return;
+    }
+    let mut o = request_overrides().write().unwrap_or_else(|e| e.into_inner());
+    o.headers.retain(|(k, _)| !k.eq_ignore_ascii_case(&name));
+    if !val.is_empty() {
+        o.headers.push((name, val.to_string()));
+    }
+}
+
+/// `fetch.clearOverrides()` — descarta todos os overrides (volta ao default).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_FETCH_CLEAR_OVERRIDES() {
+    let mut o = request_overrides().write().unwrap_or_else(|e| e.into_inner());
+    o.user_agent = None;
+    o.headers.clear();
+}
+
+/// Aplica os overrides do TS a uma request `ureq` (User-Agent + headers custom).
+/// Chamado APÓS os defaults de browser, então o que o TS setou VENCE.
+fn apply_overrides(mut req: ureq::Request) -> ureq::Request {
+    let o = request_overrides().read().unwrap_or_else(|e| e.into_inner());
+    if let Some(ua) = &o.user_agent {
+        req = req.set("User-Agent", ua);
+    }
+    for (k, v) in &o.headers {
+        req = req.set(k, v);
+    }
+    req
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 fn str_from_parts<'a>(ptr: i64, len: i64) -> &'a str {
@@ -98,6 +173,8 @@ fn do_fetch_ua(url: &str, opts_h: u64, browser_mode: bool) -> u64 {
         for (k, v) in super::browser_headers() {
             req = req.set(k, v);
         }
+        // Overrides do TS (setUserAgent/setHeader) VENCEM os defaults de browser.
+        req = apply_overrides(req);
     } else {
         req = req.set("User-Agent", super::default_user_agent());
     }
@@ -271,6 +348,7 @@ fn do_fetch_bytes(url: &str) -> Vec<u8> {
     for (k, v) in super::browser_headers() {
         req = req.set(k, v);
     }
+    req = apply_overrides(req);
     match req.call() {
         Ok(resp) | Err(ureq::Error::Status(_, resp)) => {
             let mut buf = Vec::new();

--- a/crates/rts-std/src/globals/fetch/mod.rs
+++ b/crates/rts-std/src/globals/fetch/mod.rs
@@ -49,6 +49,16 @@ pub fn browser_headers() -> &'static [(&'static str, &'static str)] {
              image/webp,image/apng,*/*;q=0.8",
         ),
         ("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8"),
+        // Fetch Metadata (`Sec-Fetch-*`): TODO browser moderno os manda numa
+        // navegação de topo. Sites com anti-bot (WhatsApp Web, Meta, …) RECUSAM
+        // (HTTP 400 / página de erro) a requisição sem eles — é o que separava
+        // o app real da página "Browser not supported". Valores de uma
+        // navegação de documento de topo iniciada pelo usuário.
+        ("Sec-Fetch-Dest", "document"),
+        ("Sec-Fetch-Mode", "navigate"),
+        ("Sec-Fetch-Site", "none"),
+        ("Sec-Fetch-User", "?1"),
+        ("Upgrade-Insecure-Requests", "1"),
     ]
 }
 
@@ -109,6 +119,34 @@ pub fn register(e: &mut Engine) {
             "__RTS_FN_NS_FETCH_FETCH_TEXT_ASYNC",
             "fetchTextAsync(url: string): number",
             "fetchTextAsync(url) — start a GET on a background thread; returns a ticket immediately (no UI block).",
+            false,
+        ))
+        // ── Overrides de request (o app se apresenta na rede como quiser) ──────
+        .member(m(
+            "setUserAgent",
+            MemberKind::Function,
+            Sig::new(vec![AbiType::StrPtr], AbiType::Void),
+            "__RTS_FN_NS_FETCH_SET_USER_AGENT",
+            "setUserAgent(ua: string): void",
+            "setUserAgent(ua) — override the browser-path User-Agent for all subsequent fetches ('' = default).",
+            false,
+        ))
+        .member(m(
+            "setHeader",
+            MemberKind::Function,
+            Sig::new(vec![AbiType::StrPtr, AbiType::StrPtr], AbiType::Void),
+            "__RTS_FN_NS_FETCH_SET_HEADER",
+            "setHeader(name: string, value: string): void",
+            "setHeader(name, value) — inject/override a request header (Cookie/Referer/Sec-Fetch-*/…); '' value removes it.",
+            false,
+        ))
+        .member(m(
+            "clearOverrides",
+            MemberKind::Function,
+            Sig::new(vec![], AbiType::Void),
+            "__RTS_FN_NS_FETCH_CLEAR_OVERRIDES",
+            "clearOverrides(): void",
+            "clearOverrides() — drop all setUserAgent/setHeader overrides (back to browser defaults).",
             false,
         ))
         .member(m(


### PR DESCRIPTION
## O que faz

Dois avanços rumo a **ser um browser real**:

### 1. Fetch Metadata headers (`Sec-Fetch-*`) — destrava o WhatsApp Web
`browser_headers()` agora manda `Sec-Fetch-Dest/Mode/Site/User` + `Upgrade-Insecure-Requests`, que todo browser moderno envia numa navegação de topo. Sites com anti-bot **recusavam** (HTTP 400 / 'Browser not supported') sem eles.

**Antes**: `web.whatsapp.com` → 6KB, página 'Sorry, something went wrong.'
**Agora**: → **567KB, `<title>WhatsApp Web`, o app real** (confirmado que só os Sec-Fetch bastam — sem cookie/referer).

### 2. Overrides de request pelo TS
O app se apresenta na rede como quiser, sem tocar o Rust:
```ts
import fetch from "rts:fetch";
fetch.setUserAgent("MeuBrowser/1.0");
fetch.setHeader("Cookie", "sessao=abc");   // ou Referer, Sec-*, qualquer
fetch.clearOverrides();                        // volta ao Chrome default
```
RwLock global; `apply_overrides()` roda **após** os defaults de browser (o custom vence); valor vazio em `setHeader` remove. Aplicado nos dois caminhos de browser (texto + bytes).

## Validação
setUserAgent/setHeader refletidos no httpbin, clearOverrides volta ao Chrome default, WhatsApp app real no default · rts-dom 199/199 · runscripts 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z