### PR TITLE
fix(dom): runScripts só executa JavaScript — pula type=application/json

### DIFF
--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1023,6 +1023,14 @@ function runScripts(doc: Document): number {
 function __runScriptAt(h: i64, j: number): number {
   const node = dom.getByTagAt(h, "script", j);
   if (node === __DOM_NONE) return 0;
+  // Só executa JAVASCRIPT: `type` vazio/`text|application/javascript`/`module`.
+  // `type="application/json"` (dados de config — o WhatsApp/Meta usa MUITO) e
+  // outros tipos NÃO são código; executá-los gerava `syntax error` em massa.
+  const st = dom.getAttribute(h, node, "type").toLowerCase();
+  const isJs = st.length === 0 || st === "text/javascript"
+    || st === "application/javascript" || st === "module"
+    || st === "application/x-javascript" || st === "text/ecmascript";
+  if (!isJs) return 0;
   const code = dom.getText(h, node);
   if (code.length === 0) return 0;
   // `return 0` final: o dynfn é tipado i64 e o corpo de um <script> normalmente


### PR DESCRIPTION
Testando o WhatsApp Web real, o log mostrou 52 `parse error: syntax error` — o `runScripts` tentava **executar** blocos `<script type="application/json">` (dados de config; Meta/WhatsApp usam muitos) como se fossem JS.

Agora só roda `type` vazio / `text|application/javascript` / `module` / `application/x-javascript` / `text/ecmascript`; `application/json`/`ld+json`/`importmap` = dados, pula.

Validado: 2 `<script type=json>` + 1 JS → só o JS roda, 0 syntax errors · rts-dom 199/199 · runscripts 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z