### PR TITLE
feat(dom): runScripts executa <script src=data:...> (base64/texto)

### DIFF
--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1031,7 +1031,19 @@ function __runScriptAt(h: i64, j: number): number {
     || st === "application/javascript" || st === "module"
     || st === "application/x-javascript" || st === "text/ecmascript";
   if (!isJs) return 0;
-  const code = dom.getText(h, node);
+  // O CÓDIGO vem do texto inline OU de um `src=data:...;base64,<b64>` (o
+  // WhatsApp/Meta embutem quase todo o JS assim). data-URI base64 é decodificado
+  // via `atob`; data-URI de texto puro (`data:...,<code>`) usa o payload direto.
+  // `src=http(s)` externo NÃO é baixado aqui (o extractSite do browser decide).
+  let code = dom.getText(h, node);
+  const src = dom.getAttribute(h, node, "src");
+  if (src.length > 5 && src.substring(0, 5) === "data:") {
+    const comma = src.indexOf(",");
+    if (comma < 0) return 0;
+    const meta = src.substring(0, comma);
+    const payload = src.substring(comma + 1);
+    code = meta.indexOf("base64") >= 0 ? atob(payload) : decodeURIComponent(payload);
+  }
   if (code.length === 0) return 0;
   // `return 0` final: o dynfn é tipado i64 e o corpo de um <script> normalmente
   // não tem return — garantimos um. (Um return do próprio script vence, este vira

--- a/tests/claude-dom-runscripts.test.ts
+++ b/tests/claude-dom-runscripts.test.ts
@@ -38,6 +38,15 @@ const lis = doc.querySelectorAll("#list li");
 const nLis = lis.length;
 const ultimo = nLis === 3 ? lis[2].textContent : "";
 
+// <script src="data:...;base64,..."> — o WhatsApp/Meta embutem quase todo o JS
+// assim. base64 de: const el=document.getElementById('d'); if(el!==null){el.setInnerHTML('data-uri ok');}
+const b64 = "Y29uc3QgZWw9ZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQoJ2QnKTsgaWYoZWwhPT1udWxsKXtlbC5zZXRJbm5lckhUTUwoJ2RhdGEtdXJpIG9rJyk7fQ==";
+const htmlData = "<div id='d'>x</div><script src='data:application/x-javascript;base64," + b64 + "'></script>";
+const docData = parseDocument(htmlData);
+const ranData = runScripts(docData);
+const dEl = docData.getElementById("d");
+const dataResult = dEl === null ? "" : dEl.textContent;
+
 describe("runScripts — bloco <script> da página", () => {
   test("scripts válidos rodam; o quebrado é isolado", () => {
     expect(ran).toBe(3);
@@ -51,5 +60,9 @@ describe("runScripts — bloco <script> da página", () => {
   });
   test("script após o quebrado ainda roda", () => {
     expect(attrDepois).toBe("terceiro");
+  });
+  test("script src=data:base64 é decodificado e executado", () => {
+    expect(ranData).toBe(1);
+    expect(dataResult).toBe("data-uri ok");
   });
 });


### PR DESCRIPTION
O WhatsApp/Meta (e muitos sites) embutem quase todo o JS como `<script src="data:application/x-javascript;base64,...">` em vez de inline. Antes ignorávamos — perdendo a maioria dos scripts.

Agora o data-URI é decodificado: `;base64,` → `atob`, texto puro → `decodeURIComponent`. `src=http(s)` externo continua não baixado aqui (o extractSite do browser decide).

**Efeito**: os scripts embutidos chegam decodificados ao compilador em vez de descartados. No WhatsApp isso expõe o próximo limite honesto (batem em `requireLazy`/`window`/`_btldr` — o sistema de módulos + `window` deles, que não temos), mas sites com JS data-URI comum rodam.

Validado: `<script src=data:base64>` decodifica e muta o DOM (novo teste, 5/5); `atob` confirmado decodificando payload real do WhatsApp. rts-dom 199/199 · gate sem violação HARD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5nCb1fbdSb3Lr7KFrvT5z