### PR TITLE
feat(egui): FPS pointer-lock — egui.mouseLock + raw mouse deltas (#1871)

### DIFF
--- a/crates/rts-egui/src/app.rs
+++ b/crates/rts-egui/src/app.rs
@@ -332,8 +332,41 @@ pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(
         slider_results: Vec::new(),
         button_cursor: 0,
         slider_cursor: 0,
+        mouse_locked: false,
+        raw_dx: 0.0,
+        raw_dy: 0.0,
+        frame_dx: 0.0,
+        frame_dy: 0.0,
     };
     ctx::insert(uictx)
+}
+
+/// POINTER-LOCK FPS: `on!=0` confina o cursor à janela, esconde-o e liga o
+/// olhar por delta CRU (`DeviceEvent::MouseMotion` → `input.mouseDeltaX/Y`);
+/// `on==0` solta e mostra o cursor. Windows não implementa
+/// `CursorGrabMode::Locked` (winit) — `Confined` + raw deltas é o padrão de
+/// jogos; tenta `Locked` primeiro para os SOs que suportam.
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MOUSE_LOCK(h: u64, on: i64) {
+    use winit::window::CursorGrabMode;
+    ctx::with_ctx(h, |c| {
+        if on != 0 {
+            let locked = c.window.set_cursor_grab(CursorGrabMode::Locked);
+            if locked.is_err() {
+                let _ = c.window.set_cursor_grab(CursorGrabMode::Confined);
+            }
+            c.window.set_cursor_visible(false);
+            c.mouse_locked = true;
+            c.raw_dx = 0.0;
+            c.raw_dy = 0.0;
+            c.frame_dx = 0.0;
+            c.frame_dy = 0.0;
+        } else {
+            let _ = c.window.set_cursor_grab(CursorGrabMode::None);
+            c.window.set_cursor_visible(true);
+            c.mouse_locked = false;
+        }
+    });
 }
 
 /// Handler de runtime do pump: roteia cada evento de janela para o `UiCtx`
@@ -377,6 +410,23 @@ impl ApplicationHandler for Pumper {
                 _ => {}
             }
         });
+    }
+
+    /// Delta CRU do mouse (independente do cursor/bordas) — a fonte do olhar
+    /// FPS sob pointer-lock. Eventos de device não têm WindowId; roteia pra
+    /// janela com `mouse_locked` (a "dona" do mouse enquanto travado).
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        if let winit::event::DeviceEvent::MouseMotion { delta } = event {
+            ctx::with_locked_ctx(|c| {
+                c.raw_dx += delta.0;
+                c.raw_dy += delta.1;
+            });
+        }
     }
 }
 

--- a/crates/rts-egui/src/ctx.rs
+++ b/crates/rts-egui/src/ctx.rs
@@ -174,6 +174,18 @@ pub struct UiCtx {
     pub button_cursor: usize,
     /// Contador de `slider` já emitidos NESTE frame (casa com `slider_results`).
     pub slider_cursor: usize,
+    /// POINTER-LOCK (FPS): cursor confinado+invisível; o olhar passa a vir do
+    /// delta CRU do mouse (`DeviceEvent::MouseMotion`), imune à borda da tela.
+    /// Windows não suporta `CursorGrabMode::Locked` — usamos `Confined` + raw
+    /// deltas, o padrão dos jogos winit. Ligado por `egui.mouseLock(h, 1)`.
+    pub mouse_locked: bool,
+    /// Acumulador de delta cru entre frames (somado no `device_event` do pump).
+    pub raw_dx: f64,
+    pub raw_dy: f64,
+    /// Snapshot do acumulador feito no `beginFrame` (o que `input.mouseDeltaX/Y`
+    /// devolve neste frame quando travado; o acumulador zera no snapshot).
+    pub frame_dx: f64,
+    pub frame_dy: f64,
 }
 
 /// Aloca um novo handle e insere o `UiCtx`. Retorna o handle.
@@ -205,6 +217,16 @@ pub fn with_ctx_by_window<R>(
         m.values_mut()
             .find(|c| c.window.id() == window_id)
             .map(f)
+    })
+}
+
+/// Roda `f` no `UiCtx` com o mouse TRAVADO (se houver um). Roteia os raw
+/// deltas do `device_event` — eventos de device não têm WindowId; com lock
+/// ativo há uma janela "dona" do mouse por definição.
+pub fn with_locked_ctx<R>(f: impl FnOnce(&mut UiCtx) -> R) -> Option<R> {
+    CTXS.with(|m| {
+        let mut m = m.borrow_mut();
+        m.values_mut().find(|c| c.mouse_locked).map(f)
     })
 }
 

--- a/crates/rts-egui/src/frame/mod.rs
+++ b/crates/rts-egui/src/frame/mod.rs
@@ -46,6 +46,14 @@ pub extern "C" fn __RTS_FN_NS_EGUI_BEGIN_FRAME(h: u64) {
         // size_in_pixels / ppp == screen_rect lógico em qualquer DPI.
         let raw_input = c.egui_state.take_egui_input(&c.window);
 
+        // POINTER-LOCK: snapshot dos raw deltas acumulados desde o último frame
+        // (o que `input.mouseDeltaX/Y` devolve com o mouse travado) e zera o
+        // acumulador pro próximo intervalo de pump.
+        c.frame_dx = c.raw_dx;
+        c.frame_dy = c.raw_dy;
+        c.raw_dx = 0.0;
+        c.raw_dy = 0.0;
+
         c.egui_ctx.begin_pass(raw_input);
         c.frame_active = true;
         c.cmds.clear();

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -110,6 +110,14 @@ pub fn register(e: &mut Engine) {
             app::__RTS_FN_NS_EGUI_MOVE_WINDOW as *const u8,
         ))
         .member(func(
+            "mouseLock",
+            "__RTS_FN_NS_EGUI_MOUSE_LOCK",
+            Sig::new(vec![U64, I64], AbiType::Void),
+            "mouseLock(h: number, on: number): void",
+            "FPS pointer-lock: on!=0 confines+hides the cursor and switches input.mouseDeltaX/Y to RAW device deltas (edge-immune); on==0 releases. Windows uses Confined+raw (winit has no Locked there).",
+            app::__RTS_FN_NS_EGUI_MOUSE_LOCK as *const u8,
+        ))
+        .member(func(
             "setNextWindowPos",
             "__RTS_FN_NS_EGUI_SET_NEXT_POS",
             Sig::new(vec![I64, I64], AbiType::Void),

--- a/crates/rts-egui/src/render_backend.rs
+++ b/crates/rts-egui/src/render_backend.rs
@@ -190,6 +190,12 @@ impl InputSource for EguiRenderer {
 
     fn mouse_delta(&self, target: u64) -> (f32, f32) {
         ctx::with_ctx(target, |c| {
+            // POINTER-LOCK: com o mouse travado o delta vem CRU do device
+            // (snapshot do beginFrame) — o delta do egui deriva da POSIÇÃO do
+            // cursor, que confinado para de andar na borda (olhar "engasga").
+            if c.mouse_locked {
+                return (c.frame_dx as f32, c.frame_dy as f32);
+            }
             c.egui_ctx.input(|i| {
                 let d = i.pointer.delta();
                 (d.x, d.y)


### PR DESCRIPTION
## What

New primitive **`egui.mouseLock(h, on)`**: confines + hides the cursor and switches `input.mouseDeltaX/Y` to **raw device deltas** (`DeviceEvent::MouseMotion`) — edge-immune free look for FPS games. `on=0` releases and restores the cursor. Closes #1871.

## How

- **Windows has no `CursorGrabMode::Locked`** in winit → tries `Locked` first (macOS/other), falls back to `Confined` + raw deltas — the standard winit game pattern.
- Raw deltas accumulate in `Pumper::device_event` (device events carry no `WindowId`; they route to the window owning the lock via `with_locked_ctx`). `beginFrame` snapshots + zeroes the accumulator, so `input.mouseDeltaX/Y` keeps its per-frame contract.
- While locked, the egui pointer delta would stall at window edges (it derives from cursor *position*) — the `InputSource::mouse_delta` impl returns the raw snapshot instead. Unlocked behavior is byte-identical to before.

## Validation

- Live-played in RTS-MINE 3D (external voxel game on the new gpu3d pipeline): free 360° mouse-look at 60fps, Esc menu releases the cursor, returning re-locks; ~2min40s real session, no crash.
- TS suite 723/731 — identical to the pre-existing main baseline (the 8 failures are the known `rts:node:*` resolution regressions, see #1968, unrelated).
- `cargo build --release` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tUEJtE2DhLZPgEcT5g3mz