### PR TITLE
feat(egui): setVsync — runtime per-window vsync opt-out (uncapped fps)

### DIFF
--- a/crates/rts-egui/src/frame/gpu.rs
+++ b/crates/rts-egui/src/frame/gpu.rs
@@ -8,13 +8,15 @@ use std::sync::Arc;
 
 use winit::window::Window;
 
-/// Present mode da surface de TODA janela. **Fifo (vsync)** é OBRIGATÓRIO, não
-/// uma preferência: o loop de render é dirigido pelo TS sem throttle próprio, e
-/// sem vsync ele gira a milhares de fps — queima CPU e, sob essa cadência, o
-/// swapchain entra em estado ruim (a janela parava de avançar após alguns
-/// milhares de frames — bug real corrigido). Fifo é garantido em todo backend e
-/// limita à taxa do monitor. NÃO troque para `Immediate`/`Mailbox` sem reintroduzir
-/// um throttle no loop; o teste `vsync_kill_gate` falha o build se isto mudar.
+/// Present mode DEFAULT da surface de toda janela. **Fifo (vsync)** é o default
+/// OBRIGATÓRIO, não uma preferência: o loop de render é dirigido pelo TS sem
+/// throttle próprio, e sem vsync ele gira a milhares de fps — queima CPU e, sob
+/// essa cadência, o swapchain entra em estado ruim (a janela parava de avançar
+/// após alguns milhares de frames — bug real corrigido). Fifo é garantido em
+/// todo backend e limita à taxa do monitor. NÃO troque este DEFAULT; o teste
+/// `vsync_kill_gate` falha o build se mudar. O OPT-OUT consciente por janela é
+/// `egui.setVsync(h, 0)` (jogos/benchmark, `frame/mod.rs`) — quem desliga
+/// assume o throttle; o default de quem não pediu nada segue protegido.
 const UI_PRESENT_MODE: wgpu::PresentMode = wgpu::PresentMode::Fifo;
 
 /// GPU compartilhada do processo (thread do TS): Instance + Adapter + Device +

--- a/crates/rts-egui/src/frame/mod.rs
+++ b/crates/rts-egui/src/frame/mod.rs
@@ -212,6 +212,34 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SNAPSHOT(h: u64, path_ptr: *const u8, path_le
     });
 }
 
+/// VSYNC por janela em runtime: `on!=0` volta ao Fifo (default OBRIGATÓRIO —
+/// ver `UI_PRESENT_MODE` e o kill-gate); `on==0` é o OPT-OUT explícito do
+/// jogo/benchmark: `AutoNoVsync` (Immediate→Mailbox→Fifo, fallback automático
+/// do wgpu por capacidade da surface). Sem vsync o loop TS roda destravado —
+/// quem desliga assume o throttle (ou o burn de CPU/GPU); o default do motor
+/// segue Fifo e o kill-gate segue protegendo o default. Reconfigura a surface
+/// na hora; o resize preserva (muta `config.present_mode`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_VSYNC(h: u64, on: i64) {
+    ctx::with_ctx(h, |c| {
+        if let Backend::Wgpu(r) = &mut c.backend {
+            let mode = if on != 0 {
+                wgpu::PresentMode::Fifo
+            } else {
+                wgpu::PresentMode::AutoNoVsync
+            };
+            if r.config.present_mode != mode {
+                r.config.present_mode = mode;
+                r.surface.configure(&r.device, &r.config);
+            }
+        }
+        #[cfg(feature = "glow-backend")]
+        if let Backend::Glow(_) = &c.backend {
+            eprintln!("rts-egui setVsync: suportado só no backend wgpu");
+        }
+    });
+}
+
 /// Drena a fila de comandos `cmds` a partir de `*idx`, emitindo cada widget no
 /// `ui` ATUAL. É RECURSIVA para tratar os escopos horizontais sem precisar
 /// guardar um `egui::Ui` entre chamadas FFI (o `ui.horizontal(...)` exige um

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -110,6 +110,14 @@ pub fn register(e: &mut Engine) {
             app::__RTS_FN_NS_EGUI_MOVE_WINDOW as *const u8,
         ))
         .member(func(
+            "setVsync",
+            "__RTS_FN_NS_EGUI_SET_VSYNC",
+            Sig::new(vec![U64, I64], AbiType::Void),
+            "setVsync(h: number, on: number): void",
+            "Runtime per-window vsync toggle. on!=0 = Fifo (the mandatory default); on==0 = explicit opt-out via AutoNoVsync (uncapped fps — the caller owns throttling/CPU burn). wgpu backend only.",
+            frame::__RTS_FN_NS_EGUI_SET_VSYNC as *const u8,
+        ))
+        .member(func(
             "mouseLock",
             "__RTS_FN_NS_EGUI_MOUSE_LOCK",
             Sig::new(vec![U64, I64], AbiType::Void),


### PR DESCRIPTION
## What

`egui.setVsync(h, on)`: runtime per-window vsync toggle. `on!=0` = Fifo (the **mandatory default — unchanged**, `vsync_kill_gate` still protects it); `on==0` = explicit opt-out via `wgpu::PresentMode::AutoNoVsync` (Immediate → Mailbox → Fifo automatic fallback by surface caps). Reconfigures the surface immediately; resizes preserve the choice.

The Fifo default exists because the TS-driven loop has no throttle (the old thousands-of-fps swapchain freeze). This opt-out is a per-window, caller-owned decision for games/benchmarks — the default path is byte-identical.

## Validation

- RTS-MINE 3D live: toggling OFF in the game menu took 60fps → **1000+fps**, present wait 16ms → 0.6ms; ~5min session, no swapchain issues; toggling back restores 60.
- TS suite at the pre-existing main baseline (same known `rts:node:*` failures, see #1968) — zero regression.
- Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tUEJtE2DhLZPgEcT5g3mz