### PR TITLE
perf(codegen): step 10 slice 3 — skip prune when resident prelude engages

### DIFF
--- a/CRANELIFT_IMPLEMENTATION.md
+++ b/CRANELIFT_IMPLEMENTATION.md
@@ -697,8 +697,56 @@ scope here.
     (miss→hit == normal). This is "compile once, replay on repeat runs". v1 limits:
     keyed on the entry-file text (a changed IMPORT is not yet invalidated); a miss
     compiles the aot_str path.
-- **Slice 3/4** — drop pruning + trim merge from the run path once the prelude is
-  fully resident.
+- **Slice 3 — skip the prune when resident engages.** ✅ DONE. The decision
+  (`mark_resident_imports`) moved INTO `merge_programs`, right after the gcells are
+  computed (the gate reads them) but BEFORE the prune; it now returns `bool`, and
+  the prune is skipped when it returns `true`. Rationale: with resident on, the old
+  order ran `prune_prelude` (removing ~528 unreachable prelude fns) and THEN
+  `mark_resident_imports` RESTORED every one of them from the manifest — pure
+  prune-then-restore churn. Skipping is byte-identical: gcell ids are fixed before
+  the prune (immune), shape ids are seeded from the manifest, replay relocs resolve
+  by NAME (immune to func order), and the final `LoweredProgram` is the same set the
+  old restore produced. **Measured (`RTS_TIMING=1`, baked build, prelude-heavy
+  smoke): `prune prelude 9.43 ms` → GONE** (the phase disappears; `resident: prelude
+  fns defined-from-bytes 831`, machine-compile only 8 user fns). AOT and the
+  non-resident fallback are untouched (the prune runs there exactly as before — the
+  gate returns `false`). **Validated behaviour-neutral by the decisive test:** the
+  ORIGINAL (pre-Slice-3) baked binary and the Slice-3 baked binary produce a
+  BYTE-IDENTICAL suite result AND a byte-identical failing-file list under resident
+  ON (both `707/24`, same 24 files) — my change is a pure `LoweredProgram`-preserving
+  optimisation. Default (non-baked) build stays at baseline `723/8`.
+
+  > **⚠ DISCOVERY while validating Slice 3 — the resident path is NOT
+  > "731/731 byte-identical" as slice 2 above claims.** Measured on the real baked
+  > binary (`RTS_PRELUDE_DIR` build, resident ON by default): the TS suite is a
+  > STABLE `707/24` (3 identical runs — not flaky), versus `723/8` for the SAME
+  > binary with `RTS_NO_RESIDENT=1` and for the default build. So the resident
+  > prelude deterministically breaks **16 more files** than the fallback. This is
+  > PRE-EXISTING (the unchanged original code reproduces the exact same `707/24`
+  > with the identical 24-file set — it is a slice-2 property, NOT slice 3). The 24
+  > failing files cluster broadly — `reflect_*` (4), `proxy_phase3*` (2),
+  > `boolean_class`, `new_number_no_panic`, `number_valueof_receiver`,
+  > `edge_error_extends`, `function_global`, `arraybuffer_transfer_clone`, plus the
+  > crypto / `node_fs_*` / `node_stream` / `node_string_decoder` I/O family (~12).
+  > The breadth (primordials + reflect + proxy, not only allocation-heavy I/O)
+  > suggests it is MORE than the "conservative GC scan on byte-defined frames"
+  > follow-up the slice-2 notes hand-wave — it looks like a real correctness gap in
+  > the resident replay (metadata computed over prelude-ALONE in the baker vs
+  > prelude+user MERGED at run time is a prime suspect: `param_classes` /
+  > `fn_this_class` / `gcell_classes` reconciliation). **This is the true blocker to
+  > shipping baked builds and should be the next Step-10 investigation — it is
+  > higher-value than the remaining ms.** The slice-2 "731/731" line is stale; trust
+  > this measurement.
+- **Slice 4 — trim merge: NOT done, deliberately deferred (design verdict).** The
+  merge's real cost is `funcval::module_globals` scanning all ~1735 funcs to compute
+  `written_free`/`read_free` — and that is exactly what CANNOT be skipped: it drives
+  gcell numbering, and the baker computes gcells over prelude-ALONE while the run
+  computes them over prelude+user MERGED (the gcell-match gate exists precisely to
+  catch a divergence). Skipping it to trust the manifest's gcells would defeat that
+  guard — the SIGILL/miscompile class `rts-adapters/src/state.rs` documents. The
+  only safely-skippable merge work is the cheap metadata `extend`s, which are not
+  the bottleneck. Ganho projetado ~9→1-2 ms, risk = worst class. Not worth coupling
+  to Slice 3; revisit only with a dedicated design that preserves `module_globals`.
 
 ### Fallback (behaviour-neutral, permanent)
 
@@ -721,11 +769,16 @@ documents from mis-timed resets).
 ## Ordering
 
 Original: 0 → 1 → 2 → 3 → 4 → 5 → 6 → 7.
-Done so far: 0, 1, 2, 4, 5a, 5b, 8 (3 blocked; 4 done by another route).
-Remaining: **10 → 9 → 6 → 7**.
+Done so far: 0, 1, 2, 4, 5a, 5b, 8, 10-slice1, 10-slice2, **10-slice3** (3 blocked;
+4 done by another route).
+Remaining: **10-resident-correctness → 10-slice4 → 9 → 6 → 7**.
 
 If the goal is "RTS JIT should beat Bun/Node/Deno", **10 comes first** — it is the
-only step that touches the number the user actually sees.
+only step that touches the number the user actually sees. But its remaining work
+reordered: the **resident-path 24-failure correctness gap** (found validating
+slice 3, see the ⚠ box under slice 3/4) now OUTRANKS both slice 4 and the ms — a
+baked build cannot ship while it breaks 16 more files than the fallback, so the
+startup win slices 2/3 buy is unusable until that is fixed.
 
 ### What the first four steps actually taught
 
@@ -772,7 +825,8 @@ not be used to prioritise work.
 | 7 | stack slots (escape analysis) | very high | — | not started |
 | 8 | `Intrinsic` enum → per-member `NativeEmit` | medium | enum DELETED, all 20 ops on specs | ✅ done |
 | 9 | userland arithmetic via emitters (`%`, int round-trips) | medium | userland xorshift 194 ms vs 31 ms call | after 10 |
-| 10 | the JIT's fixed ~185 ms | medium | constant across all 5 benches | **NEXT — measure phases first** |
+| 10 | the JIT's fixed ~185 ms — prelude cache/resident | medium | slice1 123→79 ms; slice2 →23 ms band; slice3 prune 9.4→0 ms | 🟡 slices 1/2/3 done; **resident 24-fail correctness gap is the blocker** |
+| 10-s3 | skip prune when resident engages | low | `prune prelude 9.43 ms` → gone; suite byte-identical to original resident | ✅ done |
 
 ### Step 5a — the allocation storm (DONE, commit 4da2ae6d)
 

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -163,12 +163,9 @@ fn build_with_includes(src: &str) -> FrontResult<LoweredProgram> {
         let prelude = build_program_for_prelude(&inc)?;
         let ambient_fns = prelude_fn_names(&prelude);
         let user = build_program_with_ambient(src, &prelude.classes, &ambient_fns)?;
-        let mut merged = merge_programs(prelude, user)?;
-        // RESIDENT prelude (slice 2): define the prelude fns from the baked machine
-        // code instead of re-compiling them, when a consistent baked prelude is
-        // installed.
-        mark_resident_imports(&mut merged, &inc, top_level);
-        Ok(merged)
+        // `merge_programs` decides resident (slice 2) internally and skips the prune
+        // when it engages (slice 3).
+        merge_programs(prelude, user, &inc, top_level)
     }
 }
 
@@ -183,11 +180,18 @@ fn build_with_includes(src: &str) -> FrontResult<LoweredProgram> {
 /// from the SAME prelude text (via the slice-1 cache), so the merged program's
 /// prelude shape ids equal the baked immediates. This only additionally guards the
 /// gcell numbering, which `merge_programs` recomputes.
+///
+/// Returns `true` iff resident ENGAGED (every prelude fn is now defined-from-bytes).
+/// The caller uses this to SKIP `prune_prelude` (slice 3): with resident on, the
+/// prune would remove ~830 prelude fns that this function immediately RESTORES from
+/// the manifest — pure wasted work. When this returns `false` (not installed, hash
+/// mismatch, nested compile, gcell mismatch) the caller runs the prune as before,
+/// so the fallback and AOT paths are byte-identical to today.
 pub(super) fn mark_resident_imports(
     merged: &mut LoweredProgram,
     prelude_src: &str,
     top_level: bool,
-) {
+) -> bool {
     // The prelude fns marked here are DEFINED from the baked machine code
     // (`define_function_bytes` into this run's JIT arena — near calls, no linking),
     // skipping their re-compile. ON by default whenever a baked manifest is
@@ -195,19 +199,19 @@ pub(super) fn mark_resident_imports(
     // `RTS_NO_RESIDENT=1` is the escape hatch (mirrors `RTS_NO_PRELUDE_CACHE`).
     // See CRANELIFT_IMPLEMENTATION.md slice 2.
     if std::env::var_os("RTS_NO_RESIDENT").is_some() {
-        return;
+        return false;
     }
     if !resident::is_installed() {
         crate::timing::note("resident: installed(0)", 0);
-        return;
+        return false;
     }
     let Some(manifest) = resident::manifest() else {
         crate::timing::note("resident: manifest-decode-fail", 0);
-        return;
+        return false;
     };
     if manifest.prelude_hash != prelude_cache::key(prelude_src) {
         crate::timing::note("resident: hash-mismatch", 0);
-        return;
+        return false;
     }
     // TOP-LEVEL ONLY. The baked machine code has the prelude's shape ids as
     // immediates assigned from the BASE (0), which holds only for the top-level
@@ -217,7 +221,7 @@ pub(super) fn mark_resident_imports(
     // there (re-lower + compile, exactly as nested does for the cache).
     if !top_level {
         crate::timing::note("resident: not-top-level", 0);
-        return;
+        return false;
     }
     // Every prelude gcell must land on the SAME id the baked code has as an
     // immediate — otherwise resident prelude code and freshly-compiled user code
@@ -225,7 +229,7 @@ pub(super) fn mark_resident_imports(
     for (name, baked_id) in &manifest.program.gcells {
         if merged.gcells.get(name) != Some(baked_id) {
             crate::timing::note("resident: gcell-mismatch", *baked_id as usize);
-            return;
+            return false;
         }
     }
     // RESTORE the WHOLE prelude that `merge_programs` PRUNED. A reachable prelude
@@ -261,6 +265,7 @@ pub(super) fn mark_resident_imports(
         manifest.program.funcs.iter().map(|f| f.name.clone()).collect();
     crate::timing::note("resident: prelude fns defined-from-bytes", names.len());
     merged.resident_import_names = names;
+    true
 }
 
 /// Arrow-name namespace for the PRELUDE build (`__rtsn_arrow_p{N}`). The prelude
@@ -402,7 +407,11 @@ pub fn render_source_with_prelude(prelude_src: &str, user_src: &str) -> FrontRes
     let prelude = build_program(&merged_prelude_src, PRELUDE_ARROW_NS)?;
     let ambient_fns = prelude_fn_names(&prelude);
     let user = build_program_with_ambient(user_src, &prelude.classes, &ambient_fns)?;
-    let merged = merge_programs(prelude, user)?;
+    // A custom test prelude never matches the baked manifest hash (and this path is
+    // never the top-level program compile in a real run), so resident cannot engage
+    // here — pass `"", false` so `mark_resident_imports` bails at the hash/top-level
+    // gate and the prune runs exactly as before.
+    let merged = merge_programs(prelude, user, "", false)?;
     let program = module_jit::compile_program(&merged)?;
     let ((), out) = crate::value::abi_adapter::with_capture(|| program.run_main());
     Ok(out)
@@ -420,7 +429,12 @@ pub fn render_source_with_prelude(prelude_src: &str, user_src: &str) -> FrontRes
 /// the single `__rtsn_main`; module-level mutable globals are recomputed over it so
 /// a prelude top-level `let` written from a prelude function (the hook setters)
 /// becomes a shared cell exactly like a user one.
-fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<LoweredProgram> {
+fn merge_programs(
+    prelude: LoweredProgram,
+    user: LoweredProgram,
+    prelude_src: &str,
+    top_level: bool,
+) -> FrontResult<LoweredProgram> {
     // ClassTable: prelude first, then user (user can override).
     let mut classes = prelude.classes;
     for desc in user.classes.iter() {
@@ -505,10 +519,25 @@ fn merge_programs(prelude: LoweredProgram, user: LoweredProgram) -> FrontResult<
         resident_import_names: std::collections::HashSet::new(),
         resident_main: false,
     };
+    // RESIDENT prelude (slice 2): define the prelude fns from the baked machine code
+    // instead of re-compiling them, when a consistent baked prelude is installed.
+    // Decided HERE — after the gcells are computed (the gate reads them) but BEFORE
+    // the prune — so slice 3 can SKIP the prune when resident engages.
+    let engaged = mark_resident_imports(&mut merged, prelude_src, top_level);
     // Drop the embedded-prelude functions this program cannot reach BEFORE the
     // Cranelift phase — the ~830 stdlib fns were the dominant FIXED startup cost
     // (see [`prune`]). Never touches user functions or `main`.
-    crate::timing::phase("prune prelude", || prune::prune_prelude(&mut merged));
+    //
+    // SLICE 3: skip the prune entirely when resident engaged. The prune would remove
+    // the unreachable prelude fns that `mark_resident_imports` just RESTORED from the
+    // manifest (every prelude fn is defined-from-bytes, so all must be present) —
+    // running it would be pure prune-then-restore churn. Skipping is byte-identical:
+    // gcell ids are already fixed above (immune to the prune), shape ids are seeded
+    // from the manifest, and replay relocs resolve by NAME (immune to func order).
+    // When resident did NOT engage (fallback / nested / AOT) the prune runs as before.
+    if !engaged {
+        crate::timing::phase("prune prelude", || prune::prune_prelude(&mut merged));
+    }
     Ok(merged)
 }
 

--- a/crates/rts-codegen-new/src/front/run/module_entry.rs
+++ b/crates/rts-codegen-new/src/front/run/module_entry.rs
@@ -203,13 +203,13 @@ fn build_path(entry: &Path) -> FrontResult<super::LoweredProgram> {
     match prelude {
         None => Ok(user),
         Some(prelude) => {
-            let mut merged =
-                crate::timing::phase("merge programs", || merge_programs(prelude, user))?;
-            // RESIDENT prelude (slice 2): define the prelude fns from the baked
-            // machine code instead of re-compiling — the disk path's twin of the
-            // string path's hook in `build_with_includes`. No-op on a non-resident
-            // build (or a nested compile).
-            super::mark_resident_imports(&mut merged, &inc, top_level);
+            // `merge_programs` decides resident (slice 2) internally and skips the
+            // prune when it engages (slice 3) — the disk path's twin of the string
+            // path's hook in `build_with_includes`. No-op on a non-resident build
+            // (or a nested compile): the prune runs as before.
+            let merged = crate::timing::phase("merge programs", || {
+                merge_programs(prelude, user, &inc, top_level)
+            })?;
             Ok(merged)
         }
     }


### PR DESCRIPTION
## What

Step 10 slice 3 of the `CRANELIFT_IMPLEMENTATION.md` campaign. The resident run-path
pruned the prelude (~528 unreachable fns) and then `mark_resident_imports` RESTORED
every one from the baked manifest — pure prune-then-restore churn. Move the resident
decision INTO `merge_programs` (after gcells are computed, before the prune), make
`mark_resident_imports` return whether it engaged, and skip `prune_prelude` when it did.

## Why it's safe (behaviour-neutral)

gcell ids are fixed before the prune (immune), shape ids are seeded from the manifest,
replay relocs resolve by NAME (immune to func order), and the final `LoweredProgram` is
the same set the old restore produced. AOT and the non-resident fallback are untouched
(the gate returns `false` → prune runs as before).

## Measured

- `RTS_TIMING=1`, baked build: the `prune prelude 9.43 ms` phase **disappears**.
- Decisive test: the ORIGINAL pre-slice-3 baked binary and this one produce a
  **byte-identical** suite result AND failing-file list under resident ON (both `707/24`,
  same 24 files). Default (non-baked) build stays at baseline `723/8`.

## Discovery (documented in the md, NOT fixed here)

Validating this slice surfaced that the resident/baked path is **not** "731/731
byte-identical" as slice 2 claimed — it deterministically fails **16 more files** than
the fallback (`707/24` vs `723/8`), pre-existing (reproduced on unchanged original code),
across reflect/proxy/primordials/node-io. That correctness gap — not slice 4 or the ms —
is the real blocker to shipping baked builds and the next step-10 investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)