### PR TITLE
fix(codegen): resident/AOT-safe string constants — key/name immediates honour aot_mode

### DIFF
--- a/CRANELIFT_IMPLEMENTATION.md
+++ b/CRANELIFT_IMPLEMENTATION.md
@@ -716,27 +716,86 @@ scope here.
   ON (both `707/24`, same 24 files) — my change is a pure `LoweredProgram`-preserving
   optimisation. Default (non-baked) build stays at baseline `723/8`.
 
-  > **⚠ DISCOVERY while validating Slice 3 — the resident path is NOT
-  > "731/731 byte-identical" as slice 2 above claims.** Measured on the real baked
-  > binary (`RTS_PRELUDE_DIR` build, resident ON by default): the TS suite is a
-  > STABLE `707/24` (3 identical runs — not flaky), versus `723/8` for the SAME
-  > binary with `RTS_NO_RESIDENT=1` and for the default build. So the resident
-  > prelude deterministically breaks **16 more files** than the fallback. This is
-  > PRE-EXISTING (the unchanged original code reproduces the exact same `707/24`
-  > with the identical 24-file set — it is a slice-2 property, NOT slice 3). The 24
-  > failing files cluster broadly — `reflect_*` (4), `proxy_phase3*` (2),
-  > `boolean_class`, `new_number_no_panic`, `number_valueof_receiver`,
-  > `edge_error_extends`, `function_global`, `arraybuffer_transfer_clone`, plus the
-  > crypto / `node_fs_*` / `node_stream` / `node_string_decoder` I/O family (~12).
-  > The breadth (primordials + reflect + proxy, not only allocation-heavy I/O)
-  > suggests it is MORE than the "conservative GC scan on byte-defined frames"
-  > follow-up the slice-2 notes hand-wave — it looks like a real correctness gap in
-  > the resident replay (metadata computed over prelude-ALONE in the baker vs
-  > prelude+user MERGED at run time is a prime suspect: `param_classes` /
-  > `fn_this_class` / `gcell_classes` reconciliation). **This is the true blocker to
-  > shipping baked builds and should be the next Step-10 investigation — it is
-  > higher-value than the remaining ms.** The slice-2 "731/731" line is stale; trust
-  > this measurement.
+## Step 10 — resident CORRECTNESS: the string-pool-handle-immediate bug (FIXED)
+
+**Status:** ✅ FIXED · **Effort:** medium · **Risk:** low (default JIT path byte-identical) · **The real blocker, now cleared**
+
+Validating Slice 3 exposed that the slice-2 "731/731 byte-identical resident on
+vs off" claim was STALE: the real baked binary ran a STABLE `707/24` (3 identical
+runs — not flaky) versus `723/8` for the SAME binary with `RTS_NO_RESIDENT=1` and
+for the default build. The resident prelude deterministically broke **16 more
+files** — `reflect_*` (4), `proxy_phase3*` (2), `boolean_class`,
+`new_number_no_panic`, `number_valueof_receiver`, `edge_error_extends`,
+`function_global`, `arraybuffer_transfer_clone`, plus the crypto/`node_fs_*`/
+`node_stream`/`node_string_decoder` I/O family. Symptoms were WRONG OUTPUT, not
+crashes: `new Number(42).valueOf()` → `undefined`, `new Boolean(true).valueOf()` →
+`[object Object]`, `Reflect.defineProperty`/Proxy `defineProperty` written value →
+`undefined`, `Buffer` roundtrip → the byte list `104,101,108,…` instead of the
+decoded string.
+
+### Root cause
+
+The front-end embeds **compiler-process string-pool handles as raw `iconst`
+immediates** for property keys, class/method/function names, and `typeof` result
+strings — and that path did NOT honour `aot_str::aot_mode()`. Only `HirLit::Str`
+had the guard. A `intern_poly_const(s)` handle is a SLOT INDEX into THIS process's
+string pool (`STRING_NEW` is non-deduped, slot depends on allocation order). In a
+DIFFERENT process — the resident REPLAY run (bake in one process, run in another),
+or an AOT binary — that slot holds a different string. Since slot/method resolution
+matches by key **TEXT** (`objops::resolve_slot`, `class_proto_init`/
+`proto_set_method`), the wrong text made every lookup miss → the property read /
+method dispatch silently returned `undefined` or fell to the default (Object's
+`valueOf`, array's `toString`). The 707 that passed used keys (`message`, `name`,
+`length`, …) that the run's own allocation refilled into the same slots by
+coincidence; the 24 that failed used keys UNIQUE to prelude subsystems (`__prim`,
+Reflect/Proxy descriptor flags, Buffer decode, node-fs internals) the run never
+allocated there. Deterministic because allocation order is fixed.
+
+The slice-2 in-process `resident_replay_roundtrip` test MASKED this: baker + run in
+ONE process share the pool (the keys were `intern_poly_const`-PINned during bake, so
+their slots still held the right text at run). Only a real baked binary
+(build-time baker, fresh run process) exposes it. Any honest regression test for
+resident MUST use a real baked binary, not the in-process roundtrip.
+
+### The fix (commit pending)
+
+A single AOT-safe helper `Lowerer::emit_str_const_word(module, s) -> Value`
+(`obj.rs`) mirrors `HirLit::Str`: in `aot_mode()` (baker + `rts compile`) it emits
+the bytes as a DATA object + `__RTS_FN_NS_GC_STRING_FROM_STATIC(ptr,len)` (interned
+in the RUNNING binary's OWN pool, correct text, captured/replayed by name); in JIT
+mode (default `rts run`, and user code) it is the IDENTICAL `iconst` fast path as
+before. All **33 `intern_poly_const → iconst` sites across 14 files** were routed
+through it (`HirLit::Str` too, deleting its inline duplicate); the resulting STR
+word is interchangeable with the old handle word in every consumer because they all
+read TEXT. A STR word is boxed with `JsKind::Str`.
+
+**Measured:** the baked binary went from `707/24` → **`723/8`, MATCHING the
+fallback** (`722/9` under `RTS_NO_RESIDENT=1` on the same binary — the 8 common
+files are the SAME pre-existing flaky crypto/node-fs/node-stream/GC crashes present
+in the default build; the ±1 is one flaky async file). The 16 resident-specific
+failures are GONE. The individual fixed cases verified: `number_valueof_receiver`
+5/5, `boolean_class` 2/2, `reflect_api` 15/15, `proxy_phase3` 20/20. The baked
+manifest grew from 728 → 4596 data blobs (the keys now travel as DATA, as intended).
+
+**Default-JIT safety:** with `aot_mode()` off, `emit_str_const_word` returns the
+exact `iconst(intern_poly_const(s).raw())` as before, so the common `rts run` path
+is byte-identical — confirmed by the committed-code suite (`723/8` = baseline) and
+the `RTS_NO_RESIDENT=1` suite on the baked binary (`722/9`, ±1 flaky).
+
+**AOT (`rts compile`) — a SEPARATE, deeper, PRE-EXISTING bug, NOT fixed here and
+NOT regressed here.** `rts compile` sets `aot_mode()`, so it now also emits keys via
+`string_from_static`. Measured on the same prelude-heavy program (`new Number(42)`,
+`new Boolean`, `Reflect.defineProperty`, `Object.keys`, `class extends Error`):
+`rts run` (JIT) is fully correct; the AOT binary is WRONG both before and after this
+change. This change *improves* AOT (`Object.keys` went from `,` (empty) → `a,b`
+correct) but Number/Boolean `.valueOf()` and the `catch` binding stay wrong
+(`function`/`undefined`). So AOT has a second-layer correctness bug beyond the
+key-text one — the prelude's proto-method registration (`emit_method_table_registrations`
+in the `__rtsn_main` prologue) and/or the DATA-object emission order behaves
+differently under `ObjectModule` than under JIT. It is out of scope for the resident
+fix (which targets `rts run`) and is the natural NEXT correctness target for AOT.
+The honesty floor holds: this change is neutral-to-positive on AOT, and the shipped
+default (`rts run`) is byte-identical to baseline.
 - **Slice 4 — trim merge: NOT done, deliberately deferred (design verdict).** The
   merge's real cost is `funcval::module_globals` scanning all ~1735 funcs to compute
   `written_free`/`read_free` — and that is exactly what CANNOT be skipped: it drives
@@ -769,16 +828,17 @@ documents from mis-timed resets).
 ## Ordering
 
 Original: 0 → 1 → 2 → 3 → 4 → 5 → 6 → 7.
-Done so far: 0, 1, 2, 4, 5a, 5b, 8, 10-slice1, 10-slice2, **10-slice3** (3 blocked;
-4 done by another route).
-Remaining: **10-resident-correctness → 10-slice4 → 9 → 6 → 7**.
+Done so far: 0, 1, 2, 4, 5a, 5b, 8, 10-slice1, 10-slice2, **10-slice3**,
+**10-resident-correctness** (3 blocked; 4 done by another route).
+Remaining: **10-slice4 (deferred) → 9 → 6 → 7**.
 
 If the goal is "RTS JIT should beat Bun/Node/Deno", **10 comes first** — it is the
-only step that touches the number the user actually sees. But its remaining work
-reordered: the **resident-path 24-failure correctness gap** (found validating
-slice 3, see the ⚠ box under slice 3/4) now OUTRANKS both slice 4 and the ms — a
-baked build cannot ship while it breaks 16 more files than the fallback, so the
-startup win slices 2/3 buy is unusable until that is fixed.
+only step that touches the number the user actually sees. The resident-path
+24-failure correctness gap (found validating slice 3) is now FIXED (the
+string-pool-handle-immediate bug), so a baked build is finally shippable: it matches
+the fallback suite (`723/8`) with the ~100 ms startup win of slices 2/3. Slice 4 is
+deferred (small ms, worst-class risk — see its note). Next real lever: step 9
+(userland arithmetic) or step 6/7.
 
 ### What the first four steps actually taught
 
@@ -827,6 +887,7 @@ not be used to prioritise work.
 | 9 | userland arithmetic via emitters (`%`, int round-trips) | medium | userland xorshift 194 ms vs 31 ms call | after 10 |
 | 10 | the JIT's fixed ~185 ms — prelude cache/resident | medium | slice1 123→79 ms; slice2 →23 ms band; slice3 prune 9.4→0 ms | 🟡 slices 1/2/3 done; **resident 24-fail correctness gap is the blocker** |
 | 10-s3 | skip prune when resident engages | low | `prune prelude 9.43 ms` → gone; suite byte-identical to original resident | ✅ done |
+| 10-rc | resident correctness: string-pool handle immediates → AOT-safe emitter | medium | baked **707/24 → 723/8** (matches fallback); 33 sites/14 files | ✅ done |
 
 ### Step 5a — the allocation storm (DONE, commit 4da2ae6d)
 

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -134,8 +134,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     if let Some(class) = self.enclosing_class() {
                         return self.user_instanceof(module, rhs, &class);
                     }
-                    let k = crate::value::abi_adapter::intern_poly_const(real);
-                    let key_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                    let key_word = self.emit_str_const_word(module, real)?;
                     let obj = self.lower_expr(module, rhs)?;
                     let obj_word = self.box_value(obj);
                     let res = self

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -257,11 +257,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // side-table). `C.prototype.m = v` then writes it dynamically, and every
         // instance reaches it through the dynamic-get prototype walk.
         if field == "prototype" {
-            let k = crate::value::abi_adapter::intern_poly_const(class);
-            let k_word = self
-                .builder
-                .ins()
-                .iconst(cranelift_codegen::ir::types::I64, k.raw() as i64);
+            let k_word = self.emit_str_const_word(module, class)?;
             let w = self
                 .call_runtime(module, "__rtsadp_class_proto", &[k_word])?
                 .expect("__rtsadp_class_proto returns a word");
@@ -423,8 +419,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         use cranelift_codegen::ir::condcodes::IntCC;
         let recv = self.lower_expr(module, object)?;
         let recv_word = self.box_value(recv);
-        let key = crate::value::abi_adapter::intern_poly_const(method);
-        let key_word = self.builder.ins().iconst(types::I64, key.raw() as i64);
+        let key_word = self.emit_str_const_word(module, method)?;
         let own = self
             .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
             .expect("__rtsadp_obj_get returns a value");

--- a/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/vdispatch.rs
@@ -246,8 +246,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // call from every plain object carrying an own fn of that name.
         if arg_words.len() <= 3 {
             use cranelift_codegen::ir::condcodes::IntCC;
-            let key = crate::value::abi_adapter::intern_poly_const(method);
-            let key_word = self.builder.ins().iconst(types::I64, key.raw() as i64);
+            let key_word = self.emit_str_const_word(module, method)?;
             let own = self
                 .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
                 .expect("__rtsadp_obj_get returns a value");
@@ -377,7 +376,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         self.builder.seal_block(guarded);
         let shape_word = self.read_shape_word(module, recv_word);
         self.emit_shape_arms(module, recv_word, shape_word, &targets, &[], merge)?;
-        let key_word = self.intern_key_word(prop);
+        let key_word = self.emit_str_const_word(module, prop)?;
         let data = self
             .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
             .expect("__rtsadp_obj_get returns a value");

--- a/crates/rts-codegen-new/src/front/run/expr.rs
+++ b/crates/rts-codegen-new/src/front/run/expr.rs
@@ -14,7 +14,6 @@ use rts_hir::{HirExpr, HirLit, HirUnOp};
 
 use crate::repr::Repr;
 use crate::value;
-use crate::value::abi_adapter;
 
 use crate::front::error::{FrontResult, unsupported};
 
@@ -174,27 +173,11 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 Ok(Val::new(v, Repr::Bool))
             }
             HirLit::Str(s) => {
-                // AOT: the compile-time-interned handle is invalid in the produced
-                // binary (a different process with an empty pool — it reads back as
-                // `null`). Emit the bytes as a DATA object and intern at the
-                // binary's OWN runtime via `string_from_static(ptr,len)`, boxing the
-                // returned handle into a `TAG_STR` PolyValue word.
-                if super::aot_str::aot_mode() {
-                    let (ptr, len) = super::aot_str::emit_str_data(module, self.builder, s)?;
-                    let handle = self
-                        .call_runtime(module, "__RTS_FN_NS_GC_STRING_FROM_STATIC", &[ptr, len])?
-                        .expect("string_from_static returns a handle");
-                    let word =
-                        value::emit_marshal::emit_box_real_string(module, self.builder, handle);
-                    return Ok(Val::tagged_kind(word, JsKind::Str));
-                }
-                // JIT: intern the literal in the REAL string pool at lowering time
-                // and splice the boxed string PolyValue word (48-bit payload = the
-                // real handle's slot+shard) in as a constant (Tagged, kind Str). At
-                // run time `__RTS_FN_NS_GC_POLY_TO_HANDLE(payload)` reconstructs the
-                // full handle; the slot is a normal GC reference, no side table.
-                let pv = abi_adapter::intern_poly_const(s);
-                let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                // A string literal is a boxed STR PolyValue word. `emit_str_const_word`
+                // is the single AOT-safe emitter (JIT: intern now + iconst the boxed
+                // word; AOT/baker: DATA object + `string_from_static` so the string is
+                // interned in the RUNNING binary's own pool). See its doc-comment.
+                let v = self.emit_str_const_word(module, s)?;
                 Ok(Val::tagged_kind(v, JsKind::Str))
             }
             HirLit::Null => {
@@ -305,8 +288,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // constant string; else box + `__rtsadp_typeof`. The result is a string.
         if matches!(op, HirUnOp::TypeOf) {
             if let Some(s) = static_typeof(operand) {
-                let pv = abi_adapter::intern_poly_const(s);
-                let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                let v = self.emit_str_const_word(module, s)?;
                 return Ok(Val::tagged_kind(v, JsKind::Str));
             }
             // `typeof <symbol>` is `"symbol"`. A symbol instance is carried as a
@@ -326,8 +308,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 _ => false,
             };
             if is_symbol {
-                let pv = abi_adapter::intern_poly_const("symbol");
-                let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                let v = self.emit_str_const_word(module, "symbol")?;
                 return Ok(Val::tagged_kind(v, JsKind::Str));
             }
             // `typeof <GlobalClass>` is `"function"`. A bare ident naming a
@@ -337,8 +318,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // DATA-DRIVEN registry predicate (no class-name literal).
             if let HirExprKind::Ident(name) = &operand.kind {
                 if self.local(name).is_none() && self.is_global_class_ctor(name) {
-                    let pv = abi_adapter::intern_poly_const("function");
-                    let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                    let v = self.emit_str_const_word(module, "function")?;
                     return Ok(Val::tagged_kind(v, JsKind::Str));
                 }
             }
@@ -350,8 +330,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 if let HirExprKind::Ident(n) = &object.kind {
                     if n == "Math" && self.local(n).is_none() && self.classes.get(n).is_none() {
                         let s = super::mathobj::math_member_typeof(prop);
-                        let pv = abi_adapter::intern_poly_const(s);
-                        let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                        let v = self.emit_str_const_word(module, s)?;
                         return Ok(Val::tagged_kind(v, JsKind::Str));
                     }
                 }
@@ -361,8 +340,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             if let HirExprKind::Ident(name) = &operand.kind {
                 if name == "Math" && self.local(name).is_none() && self.classes.get(name).is_none()
                 {
-                    let pv = abi_adapter::intern_poly_const("object");
-                    let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                    let v = self.emit_str_const_word(module, "object")?;
                     return Ok(Val::tagged_kind(v, JsKind::Str));
                 }
             }
@@ -379,8 +357,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     || self.classes.get(name).is_some()
                     || name == "globalThis";
                 if !bound {
-                    let pv = abi_adapter::intern_poly_const("undefined");
-                    let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                    let v = self.emit_str_const_word(module, "undefined")?;
                     return Ok(Val::tagged_kind(v, JsKind::Str));
                 }
             }

--- a/crates/rts-codegen-new/src/front/run/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/globalclass.rs
@@ -174,8 +174,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
             self.box_value(f)
         } else {
-            let pv = value::abi_adapter::intern_poly_const("");
-            self.builder.ins().iconst(types::I64, pv.raw() as i64)
+            self.emit_str_const_word(module, "")?
         };
         Ok(self
             .call_runtime(module, "__rtsadp_re_compile", &[pat_word, flags_word])?
@@ -285,7 +284,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // runtime trampoline.
             let recv = self.lower_expr(module, object)?;
             let recv_word = self.box_value(recv);
-            let key = self.intern_key_word(prop);
+            let key = self.emit_str_const_word(module, prop)?;
             let v = self
                 .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key])?
                 .expect("__rtsadp_obj_get returns a value");

--- a/crates/rts-codegen-new/src/front/run/globals.rs
+++ b/crates/rts-codegen-new/src/front/run/globals.rs
@@ -559,8 +559,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         if args.is_empty() {
             // `String.fromCharCode()` → "" (the empty string).
-            let pv = crate::value::abi_adapter::intern_poly_const("");
-            let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+            let v = self.emit_str_const_word(module, "")?;
             return Ok(Val::tagged_kind(v, JsKind::Str));
         }
         // `String.fromCharCode(...codes)` (P5.6): a SINGLE spread of a proven array

--- a/crates/rts-codegen-new/src/front/run/method_dyn.rs
+++ b/crates/rts-codegen-new/src/front/run/method_dyn.rs
@@ -394,8 +394,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(None);
         }
         let recv_word = self.box_value(recv);
-        let key = crate::value::abi_adapter::intern_poly_const(method);
-        let key_w = self.builder.ins().iconst(types::I64, key.raw() as i64);
+        let key_w = self.emit_str_const_word(module, method)?;
         let undef = || crate::value::PolyValue::undefined().raw() as i64;
         let mut slots = [self.builder.ins().iconst(types::I64, undef()); 3];
         for (i, a) in args.iter().enumerate() {

--- a/crates/rts-codegen-new/src/front/run/methodtable.rs
+++ b/crates/rts-codegen-new/src/front/run/methodtable.rs
@@ -11,7 +11,7 @@
 use cranelift_codegen::ir::{InstBuilder, types};
 use cranelift_module::Module;
 
-use crate::value::{self, abi_adapter};
+use crate::value;
 
 use crate::front::error::FrontResult;
 
@@ -72,13 +72,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
         }
         for (class, parent, methods) in rows {
-            let k = abi_adapter::intern_poly_const(&class);
-            let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+            let k_word = self.emit_str_const_word(module, &class)?;
             let parent_word = match &parent {
-                Some(p) => {
-                    let pk = abi_adapter::intern_poly_const(p);
-                    self.builder.ins().iconst(types::I64, pk.raw() as i64)
-                }
+                Some(p) => self.emit_str_const_word(module, p)?,
                 None => self
                     .builder
                     .ins()
@@ -105,10 +101,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let masked = self.builder.ins().band(payload, mask);
                 let header_v = self.builder.ins().iconst(types::I64, header);
                 let word = self.builder.ins().bor(masked, header_v);
-                let name_w = self.builder.ins().iconst(
-                    types::I64,
-                    abi_adapter::intern_poly_const(&mname).raw() as i64,
-                );
+                let name_w = self.emit_str_const_word(module, &mname)?;
                 self.call_runtime(module, "__rtsadp_proto_set_method", &[proto, name_w, word])?;
             }
         }

--- a/crates/rts-codegen-new/src/front/run/newexpr.rs
+++ b/crates/rts-codegen-new/src/front/run/newexpr.rs
@@ -145,13 +145,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         //          prototype walk (own-key reads never touch this). The one-time
         //          init also wires `constructor.name` + the extends chain up to
         //          the Object.prototype root. ----
-        let k = crate::value::abi_adapter::intern_poly_const(class);
-        let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+        let k_word = self.emit_str_const_word(module, class)?;
         let parent_word = match &desc.parent {
-            Some(p) => {
-                let pk = crate::value::abi_adapter::intern_poly_const(p);
-                self.builder.ins().iconst(types::I64, pk.raw() as i64)
-            }
+            Some(p) => self.emit_str_const_word(module, p)?,
             None => self
                 .builder
                 .ins()
@@ -185,8 +181,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             for (slot, fn_name) in wk {
                 let f = self.reify_method(module, &fn_name)?;
                 let fw = self.box_value(f);
-                let key = crate::value::abi_adapter::intern_poly_const(&slot);
-                let key_w = self.builder.ins().iconst(types::I64, key.raw() as i64);
+                let key_w = self.emit_str_const_word(module, &slot)?;
                 self.call_runtime(module, "__rtsadp_obj_set", &[proto, key_w, fw])?;
             }
         }

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -196,8 +196,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let k = self.lower_expr(module, key_expr)?;
                 (self.box_value(k), value_expr)
             } else {
-                let k = abi_adapter::intern_poly_const(key);
-                let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                let k_word = self.emit_str_const_word(module, key)?;
                 (k_word, expr)
             };
             let v = self.lower_expr(module, value_expr)?;
@@ -355,8 +354,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 if self.local(fname).is_none() {
                     if let Some(sig) = self.sigs.get(fname.as_str()) {
                         if prop == "name" {
-                            let pv = crate::value::abi_adapter::intern_poly_const(fname);
-                            let v = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                            let v = self.emit_str_const_word(module, fname)?;
                             return Ok(Val::tagged_kind(v, JsKind::Str));
                         }
                         let n = sig.params.len() as i64
@@ -415,8 +413,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if prop == "prototype" {
             if let HirExprKind::Ident(g) = &object.kind {
                 if matches!(g.as_str(), "Array" | "Object") && self.local(g).is_none() {
-                    let k = crate::value::abi_adapter::intern_poly_const(g);
-                    let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                    let k_word = self.emit_str_const_word(module, g)?;
                     let w = self
                         .call_runtime(module, "__rtsadp_class_proto", &[k_word])?
                         .expect("__rtsadp_class_proto returns a word");
@@ -472,15 +469,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // elevation / `new F()` observe one object.
             if prop == "prototype" {
                 if let HirExprKind::Ident(name) = &object.kind {
-                    let k = abi_adapter::intern_poly_const(name);
-                    let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                    let k_word = self.emit_str_const_word(module, name)?;
                     let w = self
                         .call_runtime(module, "__rtsadp_class_proto", &[k_word])?
                         .expect("__rtsadp_class_proto returns a word");
                     return Ok(Val::tagged_kind(w, JsKind::Object));
                 }
             }
-            let key_word = self.intern_key_word(prop);
+            let key_word = self.emit_str_const_word(module, prop)?;
             let word = self
                 .call_runtime(module, "__rtsadp_fn_get_prop", &[fn_word, key_word])?
                 .expect("__rtsadp_fn_get_prop returns a value");
@@ -863,8 +859,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if let Some(class) = self.class_name_receiver(object) {
             // `C.prototype = obj` — replace the class's shared prototype object.
             if prop == "prototype" {
-                let k = abi_adapter::intern_poly_const(&class);
-                let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                let k_word = self.emit_str_const_word(module, &class)?;
                 let v = self.lower_expr(module, value)?;
                 let word = self.box_value(v);
                 self.call_runtime(module, "__rtsadp_class_proto_set", &[k_word, word])?;
@@ -924,15 +919,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // same `class_proto(name)`).
             if prop == "prototype" {
                 if let HirExprKind::Ident(name) = &object.kind {
-                    let k = abi_adapter::intern_poly_const(name);
-                    let k_word = self.builder.ins().iconst(types::I64, k.raw() as i64);
+                    let k_word = self.emit_str_const_word(module, name)?;
                     let v = self.lower_expr(module, value)?;
                     let word = self.box_value(v);
                     self.call_runtime(module, "__rtsadp_class_proto_set", &[k_word, word])?;
                     return Ok(Val::new(word, Repr::Tagged));
                 }
             }
-            let key_word = self.intern_key_word(prop);
+            let key_word = self.emit_str_const_word(module, prop)?;
             let v = self.lower_expr(module, value)?;
             let word = self.box_value(v);
             let ret = self
@@ -970,7 +964,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // non-ident receiver (no local to demote) still routes the dynamic set.
             let v = self.lower_expr(module, value)?;
             let word = self.box_value(v);
-            let key_word = self.intern_key_word(prop);
+            let key_word = self.emit_str_const_word(module, prop)?;
             self.call_runtime(module, "__rtsadp_obj_set", &[recv_word, key_word, word])?;
             self.emit_post_call_error_check(module)?; // Proxy set trap / setter can THROW
             if let HirExprKind::Ident(name) = &object.kind {
@@ -1001,7 +995,8 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             HirExprKind::Member { object, prop } => {
                 let obj = self.lower_expr(module, object)?;
                 let obj_word = self.box_value(obj);
-                (object.as_ref(), obj_word, self.intern_key_word(prop))
+                let key = self.emit_str_const_word(module, prop)?;
+                (object.as_ref(), obj_word, key)
             }
             HirExprKind::Index { object, index } => {
                 let obj = self.lower_expr(module, object)?;
@@ -1366,7 +1361,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         name: &str,
         prop: &str,
     ) -> FrontResult<Val> {
-        let key_word = self.intern_key_word(prop);
+        let key_word = self.emit_str_const_word(module, prop)?;
         let obj_word = self.load_local_word(name);
         let word = self
             .call_runtime(module, "__rtsadp_obj_get", &[obj_word, key_word])?
@@ -1384,7 +1379,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         prop: &str,
         value: &HirExpr,
     ) -> FrontResult<Val> {
-        let key_word = self.intern_key_word(prop);
+        let key_word = self.emit_str_const_word(module, prop)?;
         let v = self.lower_expr(module, value)?;
         let word = self.box_value(v);
         let obj_word = self.load_local_word(name);
@@ -1421,7 +1416,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
         let recv = self.lower_expr(module, object)?;
         let recv_word = self.box_value(recv);
-        let key_word = self.intern_key_word(prop);
+        let key_word = self.emit_str_const_word(module, prop)?;
         let word = self
             .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
             .expect("__rtsadp_obj_get returns a value");
@@ -1447,7 +1442,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
         let recv = self.lower_expr(module, object)?;
         let recv_word = self.box_value(recv);
-        let key_word = self.intern_key_word(prop);
+        let key_word = self.emit_str_const_word(module, prop)?;
         let v = self.lower_expr(module, value)?;
         let word = self.box_value(v);
         self.call_runtime(module, "__rtsadp_obj_set", &[recv_word, key_word, word])?;
@@ -1465,12 +1460,46 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(self.box_value(v))
     }
 
-    /// Intern a STATIC property name as a string-PolyValue key word (an i64
-    /// constant — the literal is interned in the real pool at lowering time, like
-    /// every string literal).
-    pub(super) fn intern_key_word(&mut self, prop: &str) -> Value {
-        let pv = abi_adapter::intern_poly_const(prop);
-        self.builder.ins().iconst(types::I64, pv.raw() as i64)
+    /// Emit a STRING CONSTANT as a boxed STR PolyValue WORD (an i64 `Value`),
+    /// AOT-safe. The canonical helper for EVERY synthesized string the front-end
+    /// splices as a constant — property keys, class/method/function names used for
+    /// dispatch, `typeof` result strings — mirroring the `HirLit::Str` lowering.
+    ///
+    /// It MUST honor AOT/baker mode exactly like `HirLit::Str` does. A
+    /// compile-time-interned pool handle (`intern_poly_const`) is a SLOT INDEX into
+    /// THIS compiler process's string pool. In a DIFFERENT process — an AOT binary,
+    /// or a resident-prelude REPLAY run (`bake` then a fresh run) — that slot holds a
+    /// different string, so a raw immediate makes every key/name text-compare against
+    /// the WRONG string. Since slot resolution (`objops::resolve_slot`) and method
+    /// dispatch match by key TEXT, the miss surfaces as a property read / method call
+    /// silently returning `undefined` or falling to the default — the resident 24-file
+    /// bug (see `CRANELIFT_IMPLEMENTATION.md` step 10). The old `intern_key_word` and
+    /// ~30 sibling sites skipped this guard; only `HirLit::Str` had it.
+    ///
+    /// - AOT/baker mode: emit the bytes as a DATA object + `string_from_static` so the
+    ///   string is interned in the RUNNING binary's OWN pool (correct text), reusing
+    ///   the capture/replay machinery (`emit_str_data` + `CAPTURE_DATA`).
+    /// - JIT mode (default `rts run`, and user code — `aot_mode()` is off): the fast
+    ///   path, IDENTICAL to before — intern now, splice the boxed word as an immediate.
+    pub(super) fn emit_str_const_word(
+        &mut self,
+        module: &mut dyn Module,
+        s: &str,
+    ) -> FrontResult<Value> {
+        if super::aot_str::aot_mode() {
+            let (ptr, len) = super::aot_str::emit_str_data(module, self.builder, s)?;
+            let handle = self
+                .call_runtime(module, "__RTS_FN_NS_GC_STRING_FROM_STATIC", &[ptr, len])?
+                .expect("string_from_static returns a handle");
+            Ok(crate::value::emit_marshal::emit_box_real_string(
+                module,
+                self.builder,
+                handle,
+            ))
+        } else {
+            let pv = abi_adapter::intern_poly_const(s);
+            Ok(self.builder.ins().iconst(types::I64, pv.raw() as i64))
+        }
     }
 
     /// Lower a COMPUTED index expression to a string-PolyValue key WORD for the

--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -19,7 +19,7 @@ use rts_hir::HirExpr;
 use rts_hir::ir::HirExprKind;
 
 use crate::repr::Repr;
-use crate::value::{abi_adapter, emit_marshal};
+use crate::value::emit_marshal;
 
 use crate::front::error::{FrontResult, unsupported};
 
@@ -360,8 +360,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let (_obj, keys) = self.receiver(module, args)?;
         let arr = emit_marshal::emit_new_vec_object(module, self.builder);
         for i in crate::value::iterops::enum_key_order(&keys) {
-            let pv = abi_adapter::intern_poly_const(&keys[i]);
-            let word = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+            let word = self.emit_str_const_word(module, &keys[i])?;
             emit_marshal::emit_vec_push(module, self.builder, arr, word);
         }
         Ok(Val::tagged_kind(arr, JsKind::Array))
@@ -396,8 +395,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             let idx = self.builder.ins().iconst(types::I64, 1 + i as i64);
             let value_word = emit_marshal::emit_vec_get(module, self.builder, obj, idx);
             // key as a string word.
-            let pv = abi_adapter::intern_poly_const(k);
-            let key_word = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+            let key_word = self.emit_str_const_word(module, k)?;
             // inner = [key, value].
             let inner = emit_marshal::emit_new_vec_object(module, self.builder);
             emit_marshal::emit_vec_push(module, self.builder, inner, key_word);

--- a/crates/rts-codegen-new/src/front/run/regex.rs
+++ b/crates/rts-codegen-new/src/front/run/regex.rs
@@ -23,13 +23,12 @@
 //! Bails (the honesty floor): a function replacer; capture-group `.exec`
 //! extraction; a dynamic (non-literal, non-recorded) regex receiver.
 
-use cranelift_codegen::ir::{InstBuilder, types};
+use cranelift_codegen::ir::InstBuilder;
 use cranelift_module::Module;
 
 use rts_hir::HirExpr;
 use rts_hir::ir::HirExprKind;
 
-use crate::value::abi_adapter;
 
 use crate::front::error::FrontResult;
 
@@ -71,10 +70,8 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         pattern: &str,
         flags: &str,
     ) -> FrontResult<Val> {
-        let pat_pv = abi_adapter::intern_poly_const(pattern);
-        let flags_pv = abi_adapter::intern_poly_const(flags);
-        let pat_w = self.builder.ins().iconst(types::I64, pat_pv.raw() as i64);
-        let flags_w = self.builder.ins().iconst(types::I64, flags_pv.raw() as i64);
+        let pat_w = self.emit_str_const_word(module, pattern)?;
+        let flags_w = self.emit_str_const_word(module, flags)?;
         let word = self
             .call_runtime(module, "__rtsadp_re_compile", &[pat_w, flags_w])?
             .expect("regex compile returns a value");

--- a/crates/rts-codegen-new/src/front/run/registry_call.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_call.rs
@@ -80,8 +80,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 // StrPtr slot - `new URLSearchParams()`): the EMPTY string, not
                 // the "undefined" text ToString would render.
                 if matches!(val.kind, JsKind::Undefined) {
-                    let pv = crate::value::abi_adapter::intern_poly_const("");
-                    let w = self.builder.ins().iconst(types::I64, pv.raw() as i64);
+                    let w = self.emit_str_const_word(module, "")?;
                     let handle = value::emit_marshal::emit_table_load(module, self.builder, w);
                     let (ptr, len) =
                         value::emit_marshal::emit_string_ptr_len(module, self.builder, handle);

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -547,8 +547,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // the METHOD variant yields the `undefined` sentinel.
         match data_read_key {
             Some(prop) => {
-                let key = crate::value::abi_adapter::intern_poly_const(prop);
-                let key_word = self.builder.ins().iconst(types::I64, key.raw() as i64);
+                let key_word = self.emit_str_const_word(module, prop)?;
                 let data = self
                     .call_runtime(module, "__rtsadp_obj_get", &[recv_word, key_word])?
                     .expect("__rtsadp_obj_get returns a value");


### PR DESCRIPTION
## The bug

The front-end embedded compiler-process string-pool handles as raw `iconst` immediates for property keys, class/method/function names, and `typeof` result strings — and that path did NOT honour `aot_str::aot_mode()`. Only `HirLit::Str` had the guard.

A `intern_poly_const(s)` handle is a SLOT INDEX into THIS process's string pool (`STRING_NEW` is non-deduped; the slot depends on allocation order). In a **different process** — the resident-prelude REPLAY run (bake in one process, run in another) or an AOT binary — that slot holds a different string. Since slot resolution (`objops::resolve_slot`) and method dispatch (`class_proto_init`/`proto_set_method`) match by key **TEXT**, the miss surfaced as property reads / method dispatch silently returning `undefined` or falling to the default (`Object.valueOf`, array `toString`).

This was the resident 24-file correctness gap discovered validating step-10 slice 3 (the slice-2 "731/731 byte-identical" claim was stale — the real baked binary ran a stable `707/24`). Symptoms: `new Number(42).valueOf()` → `undefined`, `new Boolean(true).valueOf()` → `[object Object]`, `Reflect`/Proxy `defineProperty` written value → `undefined`, `Buffer` roundtrip → the byte list instead of the decoded string.

## The fix

A single AOT-safe helper `Lowerer::emit_str_const_word(module, s)` mirrors `HirLit::Str`: in `aot_mode()` emit a DATA object + `string_from_static` (interned in the running binary's own pool, captured/replayed by name); in JIT mode the **identical** `iconst` fast path as before. All **33 `intern_poly_const → iconst` sites across 14 files** route through it (`HirLit::Str` too, deleting its inline duplicate).

## Measured

- Baked binary: **707/24 → 723/8**, matching the fallback (`722/9` under `RTS_NO_RESIDENT=1` on the same binary — the 8 common are pre-existing flaky crypto/node-fs/GC crashes, the ±1 is one flaky async file). The 16 resident-specific failures are gone: `number_valueof_receiver` 5/5, `boolean_class` 2/2, `reflect_api` 15/15, `proxy_phase3` 20/20.
- Default `rts run` suite: **723/8 = baseline** (the JIT branch is byte-identical to before).
- Baked manifest 728 → 4596 data blobs (keys now travel as DATA, as intended).

## AOT note

`rts compile` has a **separate, deeper, pre-existing** correctness bug (proto-method registration under `ObjectModule`). This change does not regress it — it improves it (`Object.keys` `,` → `a,b`) but Number/Boolean `.valueOf()` stay wrong. Documented as the next AOT target. Out of scope for this resident fix.

**Lesson:** any string the front-end turns into an `iconst` immediate MUST pass the `aot_mode()` guard, or it breaks both AOT and resident replay (each a distinct process from the compiler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)