### PR TITLE
fix(aot): seed the shape registry at binary startup — dynamic dispatch was undefined

### DIFF
--- a/CRANELIFT_IMPLEMENTATION.md
+++ b/CRANELIFT_IMPLEMENTATION.md
@@ -782,20 +782,39 @@ exact `iconst(intern_poly_const(s).raw())` as before, so the common `rts run` pa
 is byte-identical — confirmed by the committed-code suite (`723/8` = baseline) and
 the `RTS_NO_RESIDENT=1` suite on the baked binary (`722/9`, ±1 flaky).
 
-**AOT (`rts compile`) — a SEPARATE, deeper, PRE-EXISTING bug, NOT fixed here and
-NOT regressed here.** `rts compile` sets `aot_mode()`, so it now also emits keys via
-`string_from_static`. Measured on the same prelude-heavy program (`new Number(42)`,
-`new Boolean`, `Reflect.defineProperty`, `Object.keys`, `class extends Error`):
-`rts run` (JIT) is fully correct; the AOT binary is WRONG both before and after this
-change. This change *improves* AOT (`Object.keys` went from `,` (empty) → `a,b`
-correct) but Number/Boolean `.valueOf()` and the `catch` binding stay wrong
-(`function`/`undefined`). So AOT has a second-layer correctness bug beyond the
-key-text one — the prelude's proto-method registration (`emit_method_table_registrations`
-in the `__rtsn_main` prologue) and/or the DATA-object emission order behaves
-differently under `ObjectModule` than under JIT. It is out of scope for the resident
-fix (which targets `rts run`) and is the natural NEXT correctness target for AOT.
-The honesty floor holds: this change is neutral-to-positive on AOT, and the shipped
-default (`rts run`) is byte-identical to baseline.
+**AOT (`rts compile`) — the SAME class of bug, LAYER 2 (shape-id seeding), NOW
+FIXED.** After the key-text fix, `rts compile` STILL produced wrong output for
+DYNAMIC dispatch (`new Number(42).valueOf()` → `undefined`, `catch(e){e.name}` →
+`undefined`) while STATIC access worked. Root cause (agent-diagnosed, empirically
+proven): the **global shape registry** (`rts_engine::heap::shapes`) is populated at
+COMPILE time in the compiler process, and shape ids are baked as IMMEDIATES into the
+emitted code (slot 0 of every object, the compare arms of dynamic dispatch). JIT
+shares that registry with the run (same process) so `global_shape_keys(baked_id)`
+resolves; an AOT binary is a SEPARATE process whose registry starts EMPTY, so every
+dynamic shape read (`obj_get` on a Tagged/`any`/catch-bound receiver, `console.log(obj)`,
+dynamic `Object.keys`) missed and returned `undefined`. Exactly the key-text bug's
+sibling: a compile-time value baked into code that is meaningless in the AOT process.
+
+Fix (same transfer pattern): `shapes::export_seed_blob()` serializes the id→keys +
+error-class registries after `populate_module`; `compile_program_aot` embeds it as a
+`__RTS_AOT_SHAPE_SEED` DATA object and the `main` shim calls a new
+`__RTS_FN_RT_SEED_SHAPES(ptr,len)` (rts-runtime → `shapes::seed_from_blob`) FIRST,
+before any code runs. `seed_global_shapes` reproduces `id = BASE + index` by
+construction, so every baked immediate lines up; a runtime shape transition still
+`intern`s ABOVE the seeded range. **Measured:** the prelude-heavy program is now
+byte-identical to JIT (`Number.valueOf: 42`, `catch: E boom`, `Reflect.defineProperty:
+99`). JIT suite stays `723/8` (the change only adds AOT-path emission + unused-by-JIT
+functions). Also wired into `compile_replay_aot` (the `RTS_JIT_CACHE` AOT path).
+
+**AOT — LAYER 3 (still open, pre-existing, NOT this): a GC bug in loops.** With
+dynamic dispatch fixed, a deeper AOT bug is now visible: a string accumulated in a
+loop (`let a=""; for(..) a=a+"x"`) comes out EMPTY, and a `console.log` string arg
+can vanish — the conservative GC stack scan does not find loop-live string handles
+(kept in registers in the optimised AOT binary) as roots, so a GC tick (every 256
+allocs) collects them. JIT is unaffected (same conservative scan, but the run-process
+stack layout happens to keep them). This is orthogonal to shapes/strings-immediates
+and is the NEXT AOT correctness target — likely needs precise stack maps (or pinning)
+for the AOT binary. `rts run` (the shipped default) is unaffected throughout.
 - **Slice 4 — trim merge: NOT done, deliberately deferred (design verdict).** The
   merge's real cost is `funcval::module_globals` scanning all ~1735 funcs to compute
   `written_free`/`read_free` — and that is exactly what CANNOT be skipped: it drives

--- a/crates/rts-codegen-new/src/front/run/module_aot.rs
+++ b/crates/rts-codegen-new/src/front/run/module_aot.rs
@@ -14,7 +14,7 @@
 use cranelift_codegen::ir::{AbiParam, InstBuilder, types};
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use cranelift_module::{Linkage, Module};
+use cranelift_module::{DataDescription, Linkage, Module};
 use cranelift_object::{ObjectBuilder, ObjectModule};
 
 use crate::front::error::{FrontResult, Unsupported};
@@ -33,8 +33,14 @@ pub(crate) fn compile_program_aot(prog: &super::LoweredProgram) -> FrontResult<V
         // Declare + define every user fn + __rtsn_main + thunks (the SAME path the
         // JIT uses). `__rtsn_main` is Local; the `main` shim below calls it in-object.
         let main_id = super::module_jit::populate_module(&mut module, prog)?;
-        // The CRT entry `int main(void)`: run the program, drain the event loop, exit 0.
-        emit_main_entry(&mut module, main_id)?;
+        // SHAPE SEED (AOT-only): `populate_module` interned every shape id this
+        // program bakes as an immediate; export the id→keys registry into a data
+        // object the `main` shim seeds at startup, so dynamic shape reads resolve in
+        // the separate AOT process (see `shapes::export_seed_blob`).
+        let seed = emit_shape_seed_data(&mut module)?;
+        // The CRT entry `int main(void)`: seed shapes, run the program, drain the
+        // event loop, exit 0.
+        emit_main_entry(&mut module, main_id, seed)?;
         Ok(())
     })();
     super::aot_str::set_aot_mode(false);
@@ -70,7 +76,10 @@ pub(crate) fn compile_replay_aot(m: &super::bake::PreludeManifest) -> FrontResul
         // object for the LINKER to resolve (the ±2 GB JIT far-call limit does not
         // apply — the linker + final layout handle reach).
         let main_id = super::module_jit::populate_module(&mut module, &prog)?;
-        emit_main_entry(&mut module, main_id)?;
+        // Same shape seed as the non-replay path — the produced binary is a separate
+        // process whose registry needs the (manifest-seeded) shapes at startup.
+        let seed = emit_shape_seed_data(&mut module)?;
+        emit_main_entry(&mut module, main_id, seed)?;
         Ok(())
     });
     result?;
@@ -113,11 +122,38 @@ pub(crate) fn make_object_module() -> FrontResult<ObjectModule> {
     Ok(ObjectModule::new(builder))
 }
 
-/// Emit `extern "C" int main(void)` that calls the lowered top-level
-/// (`__rtsn_main`, `rtsn_main_id`), then `__RTS_FN_RT_RUN_EVENT_LOOP`, returning 0.
+/// A codegen-emitted shape-seed data object: its id + byte length, so the `main`
+/// shim can pass `(ptr, len)` to `__RTS_FN_RT_SEED_SHAPES`.
+struct ShapeSeed {
+    data: cranelift_module::DataId,
+    len: usize,
+}
+
+/// Serialize the compile-time global-shape + error-class registries (populated by
+/// the just-completed `populate_module`) into a `Local` data object. Empty blob
+/// (no shapes) still emits a valid 4-byte header, so the seed call is unconditional
+/// and harmless.
+fn emit_shape_seed_data(module: &mut ObjectModule) -> FrontResult<ShapeSeed> {
+    let blob = rts_engine::heap::shapes::export_seed_blob();
+    let len = blob.len();
+    let data = module
+        .declare_data("__RTS_AOT_SHAPE_SEED", Linkage::Local, false, false)
+        .map_err(|e| Unsupported::new(format!("declare shape-seed data: {e}")))?;
+    let mut desc = DataDescription::new();
+    desc.define(blob.into_boxed_slice());
+    module
+        .define_data(data, &desc)
+        .map_err(|e| Unsupported::new(format!("define shape-seed data: {e}")))?;
+    Ok(ShapeSeed { data, len })
+}
+
+/// Emit `extern "C" int main(void)` that SEEDS the shape registry, calls the
+/// lowered top-level (`__rtsn_main`, `rtsn_main_id`), then
+/// `__RTS_FN_RT_RUN_EVENT_LOOP`, returning 0.
 fn emit_main_entry(
     module: &mut ObjectModule,
     rtsn_main_id: cranelift_module::FuncId,
+    seed: ShapeSeed,
 ) -> FrontResult<()> {
     // Runtime bootstrap, resolved at link time (ONE generic `RT`-scope symbol, no
     // non-primordial name in the engine). It wires the GC tick hook + main-thread
@@ -151,6 +187,16 @@ fn emit_main_entry(
         .declare_function("__RTS_FN_RT_RUN_EVENT_LOOP", Linkage::Import, &evloop_sig)
         .map_err(|e| Unsupported::new(format!("declare event-loop drain: {e}")))?;
 
+    // The shape-registry seeder: `(ptr, len) -> ()`. Resolved at link time against
+    // rts-runtime. Called FIRST in main so the baked shape ids resolve before any
+    // program (or bootstrap) code performs a dynamic shape read.
+    let mut seed_sig = module.make_signature();
+    seed_sig.params.push(AbiParam::new(types::I64)); // ptr
+    seed_sig.params.push(AbiParam::new(types::I64)); // len
+    let seed_id = module
+        .declare_function("__RTS_FN_RT_SEED_SHAPES", Linkage::Import, &seed_sig)
+        .map_err(|e| Unsupported::new(format!("declare shape seed: {e}")))?;
+
     let mut main_sig = module.make_signature();
     main_sig.returns.push(AbiParam::new(types::I32));
     let main_id = module
@@ -166,6 +212,15 @@ fn emit_main_entry(
         fb.append_block_params_for_function_params(blk);
         fb.switch_to_block(blk);
         fb.seal_block(blk);
+
+        // SEED the shape registry FIRST — before any code (bootstrap or program)
+        // can perform a dynamic shape read on a baked id. `(ptr, len)` of the
+        // embedded seed blob.
+        let seed_gv = module.declare_data_in_func(seed.data, fb.func);
+        let seed_ptr = fb.ins().global_value(types::I64, seed_gv);
+        let seed_len = fb.ins().iconst(types::I64, seed.len as i64);
+        let seed_ref = module.declare_func_in_func(seed_id, fb.func);
+        fb.ins().call(seed_ref, &[seed_ptr, seed_len]);
 
         // Bootstrap BEFORE the program (GC hook + main thread + UI backend, all
         // behind the one generic `__RTS_FN_RT_INIT`).

--- a/crates/rts-engine/src/heap/shapes.rs
+++ b/crates/rts-engine/src/heap/shapes.rs
@@ -168,6 +168,104 @@ pub fn seed_error_classes(snapshot: Vec<(String, GlobalShapeId, Vec<String>)>) {
     }
 }
 
+// ---- AOT seed blob (compiler ↔ runtime, in-process for JIT, cross-process for AOT) ----
+//
+// The global shape registry is populated at COMPILE time in the compiler process,
+// and shape ids are baked as IMMEDIATES into the emitted code (slot-0 of every
+// object, the compare arms of dynamic dispatch). The JIT shares the registry with
+// the run (same process), so `global_shape_keys(baked_id)` resolves. An AOT binary
+// is a SEPARATE process whose registry starts EMPTY — every DYNAMIC shape read
+// (`__rtsadp_obj_get` on a Tagged/`any`/catch-bound receiver, `console.log(obj)`,
+// dynamic `Object.keys`) then misses and returns `undefined`. This is the same
+// class of bug as the string-pool handles (fixed by making key immediates
+// AOT-safe): a compile-time value baked into code that means nothing in the AOT
+// process. Here the fix transfers the id→keys registry itself: the AOT `main` shim
+// embeds this blob and calls `__RTS_FN_RT_SEED_SHAPES` before `__rtsn_main`.
+//
+// Format (little-endian, length-prefixed; a PRIVATE contract — both sides are this
+// module): u32 num_shapes, then per shape { u32 num_keys, per key { u32 len, bytes }};
+// u32 num_errs, then per err { u32 name_len, name_bytes, u32 shape_id, u32
+// num_fields, per field { u32 len, bytes } }.
+
+fn wr_u32(out: &mut Vec<u8>, n: u32) {
+    out.extend_from_slice(&n.to_le_bytes());
+}
+fn wr_str(out: &mut Vec<u8>, s: &str) {
+    wr_u32(out, s.len() as u32);
+    out.extend_from_slice(s.as_bytes());
+}
+fn rd_u32(b: &[u8], p: &mut usize) -> u32 {
+    let v = u32::from_le_bytes([b[*p], b[*p + 1], b[*p + 2], b[*p + 3]]);
+    *p += 4;
+    v
+}
+fn rd_str(b: &[u8], p: &mut usize) -> String {
+    let len = rd_u32(b, p) as usize;
+    let s = String::from_utf8_lossy(&b[*p..*p + len]).into_owned();
+    *p += len;
+    s
+}
+
+/// Serialize the current global-shape + error-class registries into a flat byte
+/// blob the AOT binary re-seeds at startup ([`seed_from_blob`]). Call AFTER the
+/// whole program is lowered (every shape interned). See the module note above.
+pub fn export_seed_blob() -> Vec<u8> {
+    let shapes = export_global_shapes();
+    let errs = export_error_classes();
+    let mut out = Vec::new();
+    wr_u32(&mut out, shapes.len() as u32);
+    for keys in &shapes {
+        wr_u32(&mut out, keys.len() as u32);
+        for k in keys {
+            wr_str(&mut out, k);
+        }
+    }
+    wr_u32(&mut out, errs.len() as u32);
+    for (name, id, fields) in &errs {
+        wr_str(&mut out, name);
+        wr_u32(&mut out, *id);
+        wr_u32(&mut out, fields.len() as u32);
+        for f in fields {
+            wr_str(&mut out, f);
+        }
+    }
+    out
+}
+
+/// Re-seed both registries from an [`export_seed_blob`] blob. Resets first, so the
+/// seeded ids reproduce the baked immediates exactly (`seed_global_shapes` asserts
+/// an empty registry — the reset guarantees it even if something interned earlier).
+/// A later runtime `intern_global_shape` (a dynamic shape transition) mints ABOVE
+/// the seeded range, consistent with the compile-time numbering.
+pub fn seed_from_blob(bytes: &[u8]) {
+    let mut p = 0usize;
+    let num_shapes = rd_u32(bytes, &mut p) as usize;
+    let mut shapes: Vec<Vec<String>> = Vec::with_capacity(num_shapes);
+    for _ in 0..num_shapes {
+        let num_keys = rd_u32(bytes, &mut p) as usize;
+        let mut keys = Vec::with_capacity(num_keys);
+        for _ in 0..num_keys {
+            keys.push(rd_str(bytes, &mut p));
+        }
+        shapes.push(keys);
+    }
+    let num_errs = rd_u32(bytes, &mut p) as usize;
+    let mut errs: Vec<(String, GlobalShapeId, Vec<String>)> = Vec::with_capacity(num_errs);
+    for _ in 0..num_errs {
+        let name = rd_str(bytes, &mut p);
+        let id = rd_u32(bytes, &mut p);
+        let num_fields = rd_u32(bytes, &mut p) as usize;
+        let mut fields = Vec::with_capacity(num_fields);
+        for _ in 0..num_fields {
+            fields.push(rd_str(bytes, &mut p));
+        }
+        errs.push((name, id, fields));
+    }
+    reset_global_shapes();
+    seed_global_shapes(shapes);
+    seed_error_classes(errs);
+}
+
 /// The ordered keys of a [`GlobalShapeId`], or `None` if the id was never
 /// interned.
 pub fn global_shape_keys(id: GlobalShapeId) -> Option<Vec<String>> {

--- a/crates/rts-runtime/src/lib.rs
+++ b/crates/rts-runtime/src/lib.rs
@@ -90,3 +90,23 @@ pub extern "C" fn __RTS_FN_RT_INIT() {
     runtime_init();
 }
 
+/// Seed the AOT binary's global shape + error-class registries from the blob the
+/// codegen embedded (`rts_engine::heap::shapes::export_seed_blob`). Called by the
+/// AOT `main` shim BEFORE `__rtsn_main`. Without it the registry is EMPTY in the
+/// separate AOT process and every DYNAMIC shape read (`obj_get` on a Tagged/`any`
+/// receiver, `console.log(obj)`, catch-bound `e.name`, `new Number(x).valueOf()`)
+/// misses on its baked shape id and returns `undefined`. JIT does not need this —
+/// it shares the compile-time registry in-process. Safe: `ptr`/`len` name a
+/// codegen-emitted, linker-placed data object (never user input).
+///
+/// # Safety
+/// `ptr` must point at `len` valid bytes produced by `export_seed_blob`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __RTS_FN_RT_SEED_SHAPES(ptr: *const u8, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+    rts_engine::heap::shapes::seed_from_blob(bytes);
+}
+


### PR DESCRIPTION
## The bug

Second layer of the same class the resident/AOT string-immediate fix (#1972) addressed: a compile-time value baked into code that is meaningless in the separate AOT process. The global shape registry (`rts_engine::heap::shapes`) is populated at **compile** time and shape ids are baked as immediates (slot 0 of every object, the compare arms of dynamic dispatch). JIT shares that registry with the run in-process; an AOT binary starts with an **empty** registry, so every DYNAMIC shape read (`obj_get` on a Tagged/`any`/catch-bound receiver, `console.log(obj)`, dynamic `Object.keys`) missed on its baked id and returned `undefined`. Static access worked (compile-time slot), which hid this behind the earlier layers.

## The fix

Mirrors the existing bake/replay seed: `shapes::export_seed_blob()` serializes the id→keys + error-class registries after `populate_module`; `compile_program_aot` embeds it as the `__RTS_AOT_SHAPE_SEED` data object and the `main` shim calls a new `__RTS_FN_RT_SEED_SHAPES(ptr,len)` (rts-runtime → `shapes::seed_from_blob`) **first**, before any code runs. `seed_global_shapes` reproduces `id = BASE + index` by construction, so every baked immediate lines up; a runtime shape transition still interns above the seeded range. Also wired into `compile_replay_aot` (the `RTS_JIT_CACHE` AOT path).

## Measured

The prelude-heavy program (`new Number/Boolean`, `Reflect.defineProperty`, `class extends Error` + throw/catch, `Object.keys`) is now **byte-identical to JIT** under AOT (`Number.valueOf: 42`, `catch: E boom`, `Reflect.defineProperty: 99`). JIT suite stays **723/8** (the change only adds AOT-path emission + functions unused by JIT).

## Still open (pre-existing, NOT this)

An AOT GC bug: a string accumulated in a loop is collected (the conservative stack scan misses register-held loop-live handles). Documented in `CRANELIFT_IMPLEMENTATION.md` as the next AOT target. `rts run` (the shipped default) is unaffected throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)