### PR TITLE
perf(codegen): step 9 — inline bitwise/%/** + fix AOT empty-string aliasing

### DIFF
--- a/CRANELIFT_IMPLEMENTATION.md
+++ b/CRANELIFT_IMPLEMENTATION.md
@@ -806,15 +806,23 @@ byte-identical to JIT (`Number.valueOf: 42`, `catch: E boom`, `Reflect.definePro
 99`). JIT suite stays `723/8` (the change only adds AOT-path emission + unused-by-JIT
 functions). Also wired into `compile_replay_aot` (the `RTS_JIT_CACHE` AOT path).
 
-**AOT — LAYER 3 (still open, pre-existing, NOT this): a GC bug in loops.** With
-dynamic dispatch fixed, a deeper AOT bug is now visible: a string accumulated in a
-loop (`let a=""; for(..) a=a+"x"`) comes out EMPTY, and a `console.log` string arg
-can vanish — the conservative GC stack scan does not find loop-live string handles
-(kept in registers in the optimised AOT binary) as roots, so a GC tick (every 256
-allocs) collects them. JIT is unaffected (same conservative scan, but the run-process
-stack layout happens to keep them). This is orthogonal to shapes/strings-immediates
-and is the NEXT AOT correctness target — likely needs precise stack maps (or pinning)
-for the AOT binary. `rts run` (the shipped default) is unaffected throughout.
+**AOT — LAYER 3 (empty-string data object aliasing): FIXED.** With dynamic dispatch
+fixed, a symptom surfaced — a string accumulated in a loop (`let a=""; for(..)
+a=a+"x"`) came out EMPTY, and `let z=""; console.log("KEEP")` printed nothing. The
+first hypothesis was GC (loop-live roots collected), but that was WRONG and disproven:
+`RTS_GC_DISABLE=1` changes nothing, the `GC_LIVE_FLOOR = 500_000` blocks any cycle in
+a small program, and the `stack_map_registry` is dead (JIT and AOT use the SAME
+conservative scanner — the CLAUDE.md "precise JIT stack maps" note is stale). The real
+cause is tiny and pointer-shaped: an EMPTY string literal `""` emits a **zero-length**
+`.rodata` DATA object (`aot_str::emit_str_data`), and the linker places a zero-length
+symbol at the SAME address as the NEXT data symbol. `__RTS_FN_NS_GC_STRING_FROM_STATIC`
+cached interned handles keyed on **`ptr` alone** (`string_pool.rs`), so `""` populated
+`cache[P] = empty_handle` and the next distinct literal sharing address `P` cache-HIT
+the empty handle → silently corrupted to `""`. JIT is immune (it bakes distinct
+immediate handles, no data object, no ptr). Fix: key the cache on **`(ptr, len)`** —
+`""` is `(P, 0)`, the colliding literal is `(P, len>0)`, distinct; reading `len` bytes
+at `P` still yields the next object's real content. One-line change; the GC framing is
+abandoned. `rts run` (default) was never affected.
 - **Slice 4 — trim merge: NOT done, deliberately deferred (design verdict).** The
   merge's real cost is `funcval::module_globals` scanning all ~1735 funcs to compute
   `written_free`/`read_free` — and that is exactly what CANNOT be skipped: it drives

--- a/crates/rts-adapters/src/value/genops_arith.rs
+++ b/crates/rts-adapters/src/value/genops_arith.rs
@@ -68,6 +68,17 @@ pub extern "C" fn __rtsadp_pow(a: u64, b: u64) -> u64 {
     arith(a, b, |x, y| x.powf(y))
 }
 
+/// SCALAR `%` on already-unboxed `f64` — the fast path for a float `%` whose
+/// operands the front-end PROVED numeric (step 9). Cranelift has no `frem`/`fmod`
+/// instruction and no fmod libcall, so `%` genuinely needs a call; but calling this
+/// on raw f64 skips the box/unbox + the generic PolyValue trampoline (`__rtsadp_mod`)
+/// + its internal ToNumber×2. Same `f64::%` semantics as `__rtsadp_mod` (sign of the
+/// dividend, `x % 0 == NaN`).
+#[unsafe(no_mangle)]
+pub extern "C" fn __rtsadp_fmod_f64(a: f64, b: f64) -> f64 {
+    a % b
+}
+
 // ===========================================================================
 // Relational comparison — `< <= > >=`, result a PolyValue bool.
 // ===========================================================================

--- a/crates/rts-codegen-new/src/adapter_symbols/list_a.rs
+++ b/crates/rts-codegen-new/src/adapter_symbols/list_a.rs
@@ -144,6 +144,10 @@ pub(super) fn symbols() -> Vec<JitSymbol> {
         sym("__rtsadp_div", genops_arith::__rtsadp_div as *const u8),
         sym("__rtsadp_mod", genops_arith::__rtsadp_mod as *const u8),
         sym("__rtsadp_pow", genops_arith::__rtsadp_pow as *const u8),
+        sym(
+            "__rtsadp_fmod_f64",
+            genops_arith::__rtsadp_fmod_f64 as *const u8,
+        ),
         sym("__rtsadp_lt", genops_arith::__rtsadp_lt as *const u8),
         sym("__rtsadp_le", genops_arith::__rtsadp_le as *const u8),
         sym("__rtsadp_gt", genops_arith::__rtsadp_gt as *const u8),

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -433,9 +433,36 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(self.poly_bool_to_bool(res))
     }
 
-    /// Bitwise/shift ops — always the generic `__rtsadp_*` trampoline (JS bitwise
-    /// semantics are ToInt32/ToUint32 + 5-bit shift-count mask, NOT a native i64
-    /// op). Result is a JS number (int32, or a double for a large `>>>`).
+    /// JS `ToInt32` of a PROVEN-numeric operand as a native i32 Cranelift value —
+    /// the inline counterpart of `genops_arith::to_int32`. Coerce to the i64
+    /// truncation (`fcvt_to_sint_sat` for a double; the register as-is for int/bool),
+    /// then `ireduce` to the low 32 bits (the modular 2^32 step, sign bit 31). A
+    /// Float64 operand additionally guards `!is_finite → 0`: `fcvt_to_sint_sat`
+    /// saturates ±Inf to i64::MAX/MIN (low32 = -1/0), but JS `ToInt32(±Inf)` is 0 —
+    /// so `select(f - f == 0, low, 0)`. Int/Bool operands are already finite, no
+    /// guard. Divergence from V8 for magnitudes ≥ 2^63 is identical to the runtime
+    /// trampoline (`trunc as i64` also saturates) — not a regression. Step 9.
+    fn emit_to_int32(&mut self, v: Val) -> FrontResult<Value> {
+        if matches!(v.repr, Repr::Float64) {
+            let f = v.v;
+            let conv = self.builder.ins().fcvt_to_sint_sat(types::I64, f);
+            let low = self.builder.ins().ireduce(types::I32, conv);
+            let diff = self.builder.ins().fsub(f, f);
+            let zero_f = self.builder.ins().f64const(0.0);
+            let finite = self.builder.ins().fcmp(FloatCC::Equal, diff, zero_f);
+            let zero_i = self.builder.ins().iconst(types::I32, 0);
+            Ok(self.builder.ins().select(finite, low, zero_i))
+        } else {
+            let i64v = self.coerce(v, Repr::Int32)?;
+            Ok(self.builder.ins().ireduce(types::I32, i64v))
+        }
+    }
+
+    /// Bitwise/shift ops. When BOTH operands are proven non-Tagged numeric, emit the
+    /// op INLINE (ToInt32 + native `band`/`ishl`/… — no extern call, no box/unbox);
+    /// the xorshift row of the bench is exactly this. A Tagged operand falls to the
+    /// generic `__rtsadp_*` trampoline. JS bitwise = ToInt32/ToUint32 + a 5-bit
+    /// shift-count mask; result is an int32 (or a uint32 double for a large `>>>`).
     pub(super) fn lower_bitwise(
         &mut self,
         module: &mut dyn Module,
@@ -443,6 +470,40 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         l: Val,
         r: Val,
     ) -> FrontResult<Val> {
+        if !is_tagged(l) && !is_tagged(r) {
+            let x = self.emit_to_int32(l)?;
+            let y = self.emit_to_int32(r)?;
+            // Shift ops mask the count to 5 bits (`& 31`); logical/arith per op. The
+            // result rides the i64 register (sign-extended) tagged Int32, EXCEPT
+            // `>>>` whose uint32 result can exceed i32::MAX → zero-extend + Int64 so
+            // it boxes as the correct positive double.
+            let (res_i32, repr) = match op {
+                HirBinOp::BitAnd => (self.builder.ins().band(x, y), Repr::Int32),
+                HirBinOp::BitOr => (self.builder.ins().bor(x, y), Repr::Int32),
+                HirBinOp::BitXor => (self.builder.ins().bxor(x, y), Repr::Int32),
+                HirBinOp::Shl => {
+                    let s = self.builder.ins().band_imm(y, 31);
+                    (self.builder.ins().ishl(x, s), Repr::Int32)
+                }
+                HirBinOp::Shr => {
+                    let s = self.builder.ins().band_imm(y, 31);
+                    (self.builder.ins().sshr(x, s), Repr::Int32)
+                }
+                HirBinOp::UShr => {
+                    let s = self.builder.ins().band_imm(y, 31);
+                    (self.builder.ins().ushr(x, s), Repr::Int64)
+                }
+                _ => return unsupported!("bitwise op {op:?}"),
+            };
+            let wide = if matches!(repr, Repr::Int64) {
+                // `>>>`: zero-extend the uint32 bit-pattern to a positive i64.
+                self.builder.ins().uextend(types::I64, res_i32)
+            } else {
+                // signed 32-bit result → sign-extend into the i64 carrier.
+                self.builder.ins().sextend(types::I64, res_i32)
+            };
+            return Ok(Val::new(wide, repr));
+        }
         let sym = match op {
             HirBinOp::BitAnd => "__rtsadp_band",
             HirBinOp::BitOr => "__rtsadp_bor",
@@ -535,10 +596,29 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 let v = self.builder.ins().fdiv(lv, rv);
                 Ok(Val::new(v, Repr::Float64))
             }
-            // Float `%` is fmod-style (sign of dividend); `**` has no native op.
-            // Route both to the generic numeric trampolines (correct, rare).
-            HirBinOp::Rem if !both_int => self.lower_generic_arith(module, op, l, r),
-            HirBinOp::Exp => self.lower_generic_arith(module, op, l, r),
+            // Float `%` is fmod-style (sign of dividend); `**` is Math.pow. Cranelift
+            // has NO `frem`/fmod instruction and no pow — both need a CALL. But the
+            // operands here are PROVEN non-Tagged numeric (the tagged case returned
+            // above), so call on RAW f64 (`__rtsadp_fmod_f64` / the existing `POW`
+            // symbol), skipping the box/unbox + the generic PolyValue trampoline and
+            // its internal ToNumber×2. Result stays native `Float64` (no re-box
+            // downstream). Step 9.
+            HirBinOp::Rem if !both_int => {
+                let lv = self.coerce(l, Repr::Float64)?;
+                let rv = self.coerce(r, Repr::Float64)?;
+                let v = self
+                    .call_runtime(module, "__rtsadp_fmod_f64", &[lv, rv])?
+                    .expect("fmod returns a value");
+                Ok(Val::new(v, Repr::Float64))
+            }
+            HirBinOp::Exp => {
+                let lv = self.coerce(l, Repr::Float64)?;
+                let rv = self.coerce(r, Repr::Float64)?;
+                let v = self
+                    .call_runtime(module, "__RTS_FN_NS_MATH_POW", &[lv, rv])?
+                    .expect("pow returns a value");
+                Ok(Val::new(v, Repr::Float64))
+            }
             // Integer `%`: native `srem` TRAPS on a zero divisor, but JS `x % 0`
             // is `NaN` (a Number). Only stay on the fast int path when the divisor
             // is a compile-time-known non-zero constant (covers `i % 2` etc.);

--- a/crates/rts-codegen-new/src/value/abi_sig.rs
+++ b/crates/rts-codegen-new/src/value/abi_sig.rs
@@ -442,6 +442,11 @@ pub fn sig_of(name: &str) -> Option<SymSig> {
                 ret: U64,
             }
         }
+        // SCALAR float `%` fast path (step 9): raw f64 in/out, no PolyValue boxing.
+        "__rtsadp_fmod_f64" => SymSig {
+            params: &[F64, F64],
+            ret: F64,
+        },
         // ---- generic unary (P4.8 + P5.6): one PolyValue word ----
         "__rtsadp_neg" | "__rtsadp_bnot" | "__rtsadp_not" | "__rtsadp_pos" => SymSig {
             params: &[U64],

--- a/crates/rts-std/src/collector/string_pool.rs
+++ b/crates/rts-std/src/collector/string_pool.rs
@@ -849,9 +849,16 @@ fn element_to_string(raw: i64) -> String {
 pub extern "C" fn __RTS_FN_NS_GC_STRING_FROM_STATIC(ptr: *const u8, len: i64) -> u64 {
     use std::collections::HashMap;
     use std::sync::{Mutex, OnceLock};
-    static CACHE: OnceLock<Mutex<HashMap<usize, u64>>> = OnceLock::new();
+    static CACHE: OnceLock<Mutex<HashMap<(usize, i64), u64>>> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let key = ptr as usize;
+    // Key on (ptr, len), NOT ptr alone: an EMPTY string literal (`""`) emits a
+    // ZERO-LENGTH `.rodata` data object, and a zero-length symbol is placed at the
+    // SAME address as the NEXT data symbol by the linker. Keying on `ptr` alone then
+    // cache-HITS the empty handle for the next distinct literal → it is silently
+    // corrupted to `""` (AOT-only: the JIT bakes distinct immediate handles, no ptr).
+    // (ptr, len) makes `""` = (P, 0) and the colliding literal = (P, len>0) distinct;
+    // reading `len` bytes at P still yields the next object's real content.
+    let key = (ptr as usize, len);
     let mut g = cache.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(&h) = g.get(&key) {
         return h;


### PR DESCRIPTION
Two changes validated together — byte-identical to Node across all cases, JIT suite **723/8 = baseline**, AOT == JIT on a broad program.

## Step 9 — userland arithmetic (the calls were the dominant cost)

- **Bitwise/shifts** (`& | ^ << >> >>>`) on proven-numeric operands emit **inline** (ToInt32 + native `band`/`ishl`/`sshr`/`ushr` — no extern call, no box/unbox). A Tagged operand still uses the generic `__rtsadp_*` trampoline. `emit_to_int32` mirrors `genops_arith::to_int32` with a `!is_finite → 0` guard for Float64 (JS `ToInt32(±Inf) = 0`, but `fcvt_to_sint_sat` saturates ±Inf). Shift count `& 31`; `>>>` zero-extends to Int64 so uint32 > i32::MAX boxes as the right positive double.
- **Float `%` / `**`** on unboxed f64: direct call to `__rtsadp_fmod_f64` (new scalar adapter) / existing `__RTS_FN_NS_MATH_POW`, skipping box/unbox + the generic trampoline.

**Measured** (Measure-Command, 10M iterations):
| bench | before | after | speedup |
|---|---|---|---|
| xorshift (headline) | 1099 ms | **288 ms** | 3.8× |
| bitwise | 1016 ms | **119 ms** | 8.5× |
| mod `%` | 345 ms | 158 ms | 2.2× |
| pow `**` | 516 ms | 270 ms | 1.9× |

Inline IR also lets the e-graph optimise through the ops (impossible across an extern call). Deferred (justified): the residual f64↔i32 `fcvt` needs typed-int locals (a Repr project), not more inline emission.

## AOT empty-string fix (a correctness bug, NOT GC)

The GC hypothesis was disproven (`RTS_GC_DISABLE` changes nothing; `GC_LIVE_FLOOR` blocks small-program cycles; `stack_map_registry` is dead). The real cause: an empty string literal `""` emits a **zero-length** `.rodata` data object, which the linker places at the **same address** as the next data symbol. `__RTS_FN_NS_GC_STRING_FROM_STATIC` cached interned handles keyed on `ptr` alone, so `""` populated `cache[P] = empty` and the next distinct literal at `P` cache-HIT the empty handle → silently corrupted to `""`. Fix: key the cache on `(ptr, len)`. JIT was immune (distinct immediate handles, no data object). This was the real cause of the "string in a loop comes out empty" AOT symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)