### PR TITLE
feat(rts-egui): texturing por UV per-vértice (substitui o triplanar)

### DIFF
--- a/crates/rts-egui/src/frame/scene3d.rs
+++ b/crates/rts-egui/src/frame/scene3d.rs
@@ -120,12 +120,14 @@ struct VOut {
   @location(2) world: vec3<f32>,
   @location(3) emissive: f32,
   @location(4) tex: f32,
+  @location(5) uv: vec2<f32>,
 };
 
 @vertex
 fn vs(
   @location(0) position: vec3<f32>,
   @location(1) normal: vec3<f32>,
+  @location(8) uv: vec2<f32>,
   @location(2) m0: vec4<f32>,
   @location(3) m1: vec4<f32>,
   @location(4) m2: vec4<f32>,
@@ -142,22 +144,17 @@ fn vs(
   o.world = world.xyz;
   o.emissive = iparams.x;
   o.tex = iparams.y;
+  o.uv = uv;
   return o;
 }
 
 @fragment
 fn fs(i: VOut) -> @location(0) vec4<f32> {
   var albedo = i.color.rgb;
-  // TRIPLANAR: amostra a textura de albedo projetando em X/Y/Z e misturando pela
-  // normal — dá UV automático sem precisar de coords per-vértice. Amostrada SEMPRE
+  // UV-CORRETO: amostra a textura de albedo pela UV per-vértice (interpolada) —
+  // mapeamento do modelo (OBJ vt / UVs geradas dos primitivos). Amostrada SEMPRE
   // (control flow uniforme p/ as derivadas do sampler); só APLICADA se tex real.
-  let bn = abs(normalize(i.normal));
-  let wsum = bn.x + bn.y + bn.z + 1e-5;
-  let sc = 0.5; // escala mundo→uv (1 tile a cada 2 unidades)
-  let cx = textureSample(albedo_tex, albedo_samp, i.world.zy * sc).rgb;
-  let cy = textureSample(albedo_tex, albedo_samp, i.world.xz * sc).rgb;
-  let cz = textureSample(albedo_tex, albedo_samp, i.world.xy * sc).rgb;
-  let texcol = (cx * bn.x + cy * bn.y + cz * bn.z) / wsum;
+  let texcol = textureSample(albedo_tex, albedo_samp, i.uv).rgb;
   // i.tex: 0=nenhuma, 1=xadrez procedural, >=2 = textura real (imagem).
   if (i.tex > 1.5) {
     albedo = albedo * texcol;
@@ -369,11 +366,12 @@ impl Scene3D {
 
         // vertex (slot 0): pos vec3 @0, normal vec3 @12 — stride 24
         let vbl = wgpu::VertexBufferLayout {
-            array_stride: 24,
+            array_stride: 32,
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &[
                 wgpu::VertexAttribute { format: wgpu::VertexFormat::Float32x3, offset: 0, shader_location: 0 },
                 wgpu::VertexAttribute { format: wgpu::VertexFormat::Float32x3, offset: 12, shader_location: 1 },
+                wgpu::VertexAttribute { format: wgpu::VertexFormat::Float32x2, offset: 24, shader_location: 8 },
             ],
         };
         // instância (slot 1): model 4×vec4 @2..5, color vec4 @6 — stride 80

--- a/crates/rts-egui/src/scene_api.rs
+++ b/crates/rts-egui/src/scene_api.rs
@@ -27,8 +27,8 @@ fn with_scene<R: Copy>(win: u64, f: impl FnOnce(&mut Scene3D, &wgpu::Device) -> 
     .unwrap_or(default)
 }
 
-/// Sobe uma mesh (verts interleaved pos+normal = 6 f32/vértice; índices u32) pra
-/// VRAM. Retorna o id da mesh (0 se a janela não é wgpu).
+/// Sobe uma mesh (verts interleaved pos+normal+uv = 8 f32/vértice; índices u32)
+/// pra VRAM. Retorna o id da mesh (0 se a janela não é wgpu).
 #[unsafe(no_mangle)]
 pub extern "C" fn __RTS_FN_NS_EGUI_MESH_UPLOAD(
     win: u64,
@@ -40,7 +40,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_MESH_UPLOAD(
     if vptr == 0 || iptr == 0 || vcount <= 0 || icount <= 0 {
         return 0;
     }
-    let verts = unsafe { std::slice::from_raw_parts(vptr as *const f32, (vcount * 6) as usize) };
+    let verts = unsafe { std::slice::from_raw_parts(vptr as *const f32, (vcount * 8) as usize) };
     let inds = unsafe { std::slice::from_raw_parts(iptr as *const u32, icount as usize) };
     with_scene(win, |s, dev| s.upload_mesh(dev, verts, inds), 0)
 }


### PR DESCRIPTION
## UV per-vértice — precisão sobre o triplanar

Segue o `egui.textureUpload` (PR #1991). Antes a textura era amostrada **triplanar** (world-space, sem UV). Agora é pela **UV per-vértice interpolada** — o mapeamento real do modelo.

- **Formato de vértice:** pos+normal+**UV** (8 f32/vértice, stride 32; era 24). Atributo `uv @location(8)` (Float32x2 @24). Os 3 pipelines (mesh/sky/shadow) consistentes; o shadow ignora o uv.
- **Shader:** `VOut.uv`; fs amostra `textureSample(albedo, i.uv)` em vez das 3 projeções triplanar. Xadrez procedural (tex==1) segue world-space.
- **Editor (rts-game, commit pareado):** upload/primitivos/loadObj emitem UV — esfera lat/long, cubo/pirâmide/octaedro planar por-face, OBJ parseia `vt` (V invertido; fallback (0,0)).

### Validação
- Build compila. **Validado via ws em janela real:** meshes sobem no formato 8f (drawn=8, zero desalinhamento), textura aplica numa esfera (tex#2) sem crash/ACCESS_VIOLATION.
- CI: o fix `dl/` (já no main) mantém cross-runtime + build verdes; ts-suite Linux tem as 11 falhas node/crypto pré-existentes (fora do escopo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)