### PR TITLE
docs: corrige a staticlib do AOT — é rts-adapters, não rts-runtime

### DIFF
--- a/.claude/rules/01-architecture.md
+++ b/.claude/rules/01-architecture.md
@@ -62,7 +62,8 @@ crates/
   rts-primitives/   — PRIMORDIAL classes
   rts-shared/       — non-primordial universal (math/num/collections/json/globals)
   rts-std/          — backend (io/net/tokio/console/promise impl)
-  rts-runtime/      — facade ("rts" + "rts:<ns>" submodules); AOT staticlib
+  rts-runtime/      — facade ("rts" + "rts:<ns>" submodules). NB: the AOT staticlib
+                      build.rs embeds is rts-adapters' (superset), not this crate's
   rts-node/         — Node.js builtin shims (fs, os, path, process, crypto, util)
   rts-egui/         — egui-based GUI / web-UI engine. Follow the FROZEN plan
                       (docs/specs/html-engine/ + egui-ui-crate-design.md) — see the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,7 +478,8 @@ crates/
                       Boolean/Number/Error+subclasses)
   rts-shared/       — non-primordial universal (math/num/collections/json/globals)
   rts-std/          — backend (io/net/tokio/console/promise impl)
-  rts-runtime/      — thin facade ("rts" + "rts:<ns>" submodules); AOT staticlib
+  rts-runtime/      — thin facade ("rts" + "rts:<ns>" submodules). NB: the AOT
+                      staticlib build.rs embeds is rts-adapters' (superset), not this
   rts-node/         — Node.js builtin shims (fs, os, path, process, crypto, util)
   rts-napi/         — N-API: Node.js native addons (.node) via libloading + the
                       engine HandleTable (ArrayBuffer/BigInt/External). 159 N-API
@@ -774,7 +775,7 @@ use).
 
 ```bash
 cargo test --lib                                              # Rust unit tests
-cargo build --release -p rts-runtime                          # AOT runtime archive (see note)
+cargo build --release -p rts-adapters                         # AOT runtime archive (see note)
 cargo build --release                                         # release build
 $env:RUST_BACKTRACE="full"; target/release/rts.exe run file.ts            # JIT
 $env:RUST_BACKTRACE="full"; target/release/rts.exe compile -p file.ts out # AOT
@@ -782,15 +783,22 @@ $env:RUST_BACKTRACE="full"; target/release/rts.exe test tests/foo.test.ts # TS s
 target/release/rts.exe apis                                   # list APIs
 ```
 
-**AOT archive is a two-step build.** `rts-runtime` is `crate-type =
-["rlib","staticlib"]`; Cargo bundles all deps + every `__RTS_*` symbol into the
-staticlib that `build.rs` embeds for AOT linking. Cargo only emits that staticlib
-when `rts-runtime` is a *direct* target, so build it first (`cargo build
--p rts-runtime`) before building `rts`. Skipping it does NOT break the build or
-JIT — `build.rs` embeds a placeholder and `rts run` works; only `rts compile`
-(AOT) errors with a "rebuild the runtime archive" message until the staticlib
-exists. The two-step replaced a fragile build.rs that hand-picked dependency
-rlibs and could not disambiguate duplicate variants on CI (serde_core/time).
+**AOT archive is a two-step build.** The staticlib `build.rs` embeds for AOT
+linking is **`rts-adapters`'s**, NOT `rts-runtime`'s: `rts-adapters` is
+`crate-type = ["rlib","staticlib"]` and DEPENDS ON `rts-runtime`, so Cargo bundles
+rts-runtime's whole rlib (every `__RTS_*` extern "C" symbol) INTO the adapters
+staticlib alongside the codegen-owned `__rtsadp_*` trampolines — one archive,
+superset of the runtime archive, no merge, no duplicate symbols. Cargo only emits
+that staticlib when `rts-adapters` is a *direct* target, so build it first
+(`cargo build -p rts-adapters`) before building `rts`. Skipping it does NOT break
+the build or JIT — `build.rs` embeds a placeholder and `rts run` works; only `rts
+compile` (AOT) errors with a "rebuild the runtime archive" message until the
+staticlib exists. NOTE: after the staticlib appears, `build.rs` only re-embeds it
+if forced to re-run (`touch build.rs`) — a plain rebuild of an already-compiled
+`rts` keeps the placeholder; a fresh build (CI) runs `build.rs` in order and
+embeds it correctly. The two-step replaced a fragile build.rs that hand-picked
+dependency rlibs and could not disambiguate duplicate variants on CI
+(serde_core/time).
 
 **Mandatory:** always set `RUST_BACKTRACE=full` before running `rts.exe`.
 Without it crashes show a shallow stack; the crash handler (`src/crash.rs`)


### PR DESCRIPTION
O `build.rs` embute a staticlib do **`rts-adapters`** (superset com o rlib inteiro do rts-runtime + trampolines `__rtsadp_*`), não a do rts-runtime. O two-step correto é `cargo build -p rts-adapters`. O CLAUDE.md/rules diziam `rts-runtime` — imprecisão que custa um ciclo de build (o `rts compile` erra com "runtime archive is a placeholder"). Também documenta a pegadinha do `build.rs` (só re-embute a staticlib se forçado a re-rodar; build limpa/CI embute certo). Descoberto ao montar o CI de AOT do rts-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)