### PR TITLE
feat(serde): pickle fase 2+3 — instâncias de classe, Map/Set e funções por referência

### DIFF
--- a/crates/rts-adapters/src/shape.rs
+++ b/crates/rts-adapters/src/shape.rs
@@ -34,7 +34,8 @@ pub type SlotIdx = u32;
 // `crate::shape::*` / `rts_adapters::shape::*` path keeps working.
 pub use rts_engine::heap::shapes::{
     GLOBAL_SHAPE_BASE, GlobalShapeId, error_class_info, global_shape_count, global_shape_keys,
-    global_shape_slot_of, intern_class_shape, intern_global_shape, register_error_class, reset_global_shapes,
+    global_shape_slot_of, intern_class_shape, intern_global_shape, register_class_shape,
+    register_error_class, reset_global_shapes,
 };
 
 /// A hidden class: the layout shared by all objects built the same way. In this

--- a/crates/rts-adapters/src/value/errslot.rs
+++ b/crates/rts-adapters/src/value/errslot.rs
@@ -199,6 +199,9 @@ pub fn install_async_error_hook() {
     );
     // THENABLE probe (Promise/A+ assimilation) - same dep-direction pattern.
     rts_runtime::namespaces::promise_slot::set_thenable_hook(__rtsadp_thenable_then);
+    // Pickle class-revive: proto attachment for deserialized class instances
+    // (the proto tables live HERE, above the engine's decoder).
+    rts_engine::heap::pickle::set_class_revive_hook(super::protos::pickle_class_revive);
 }
 
 /// AOT bootstrap entry: the generated `main` shim calls this right after

--- a/crates/rts-adapters/src/value/protos.rs
+++ b/crates/rts-adapters/src/value/protos.rs
@@ -276,6 +276,17 @@ pub extern "C" fn __rtsadp_class_proto(name_str_word: u64) -> u64 {
     w
 }
 
+/// Pickle class-revive hook (installed into `rts_engine::heap::pickle` at
+/// engine bootstrap): attach the class's shared prototype to a freshly revived
+/// instance, so method dispatch through the proto walk works on it exactly as
+/// on a `new`-built one. The instance already carries the class's shape id
+/// (slot 0), so `instanceof` needs nothing from here.
+pub fn pickle_class_revive(obj_word: u64, class_name: &str) {
+    let name_word = rts_engine::heap::shapes::string_word(class_name.as_bytes());
+    let proto = __rtsadp_class_proto(name_word);
+    __rtsadp_obj_set_proto(obj_word, proto);
+}
+
 /// name → the class's shared prototype object word (see [`__rtsadp_class_proto`]).
 fn class_proto_table() -> &'static Mutex<HashMap<String, u64>> {
     static T: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();

--- a/crates/rts-codegen-new/src/front/run/bake.rs
+++ b/crates/rts-codegen-new/src/front/run/bake.rs
@@ -88,6 +88,9 @@ pub(crate) struct PreludeManifest {
     pub shapes: Vec<Vec<String>>,
     /// The Error-class registry snapshot (`export_error_classes`).
     pub error_classes: Vec<(String, u32, Vec<String>)>,
+    /// The generic class-shape registry snapshot (`export_class_shapes`) —
+    /// name ↔ shape id for every prelude `class` (pickle revive / introspection).
+    pub class_shapes: Vec<(String, u32)>,
     /// The number of prelude gcells (`0..gcell_count`).
     pub gcell_count: u32,
     /// The pre-compiled prelude functions (machine bytes + symbolic relocs).
@@ -169,6 +172,7 @@ pub fn bake_prelude() -> FrontResult<BakedPrelude> {
         program,
         shapes: shapes::export_global_shapes(),
         error_classes: shapes::export_error_classes(),
+        class_shapes: shapes::export_class_shapes(),
         gcell_count,
         funcs,
         data,
@@ -236,6 +240,7 @@ pub(crate) fn bake_program(prog: &LoweredProgram, cache_key: u64) -> FrontResult
         program: prog.clone(),
         shapes: shapes::export_global_shapes(),
         error_classes: shapes::export_error_classes(),
+        class_shapes: shapes::export_class_shapes(),
         gcell_count,
         funcs,
         data,

--- a/crates/rts-codegen-new/src/front/run/class/synth.rs
+++ b/crates/rts-codegen-new/src/front/run/class/synth.rs
@@ -185,6 +185,8 @@ pub(super) fn build_class(
     // A UNIQUE per-class id (not key-deduped): two distinct classes with the same
     // fields must be distinguishable at runtime for `opaque instanceof C`.
     let global_shape = crate::shape::intern_class_shape(&fields);
+    // Generic name ↔ shape registry (pickle revive + shape→class introspection).
+    crate::shape::register_class_shape(&decl.name, global_shape);
 
     // PRIMORDIAL Error family: publish (shape, layout) so runtime trampolines
     // can fabricate REAL error instances for spec-mandated throws (empty

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -357,6 +357,7 @@ fn build_program_for_prelude(src: &str) -> FrontResult<LoweredProgram> {
                 if m.prelude_hash == prelude_cache::key(src) {
                     rts_engine::heap::shapes::seed_global_shapes(m.shapes.clone());
                     rts_engine::heap::shapes::seed_error_classes(m.error_classes.clone());
+                    rts_engine::heap::shapes::seed_class_shapes(m.class_shapes.clone());
                     return Ok(m.program);
                 }
             }

--- a/crates/rts-codegen-new/src/front/run/module_aot.rs
+++ b/crates/rts-codegen-new/src/front/run/module_aot.rs
@@ -65,6 +65,7 @@ pub(crate) fn compile_replay_aot(m: &super::bake::PreludeManifest) -> FrontResul
     rts_engine::heap::shapes::reset_global_shapes();
     rts_engine::heap::shapes::seed_global_shapes(m.shapes.clone());
     rts_engine::heap::shapes::seed_error_classes(m.error_classes.clone());
+    rts_engine::heap::shapes::seed_class_shapes(m.class_shapes.clone());
     let mut prog = m.program.clone();
     prog.resident_import_names = prog.funcs.iter().map(|f| f.name.clone()).collect();
     prog.resident_main = true;

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -109,6 +109,7 @@ pub(crate) fn compile_replay(m: &super::bake::PreludeManifest) -> FrontResult<Pr
     rts_engine::heap::shapes::reset_global_shapes();
     rts_engine::heap::shapes::seed_global_shapes(m.shapes.clone());
     rts_engine::heap::shapes::seed_error_classes(m.error_classes.clone());
+    rts_engine::heap::shapes::seed_class_shapes(m.class_shapes.clone());
     let mut prog = m.program.clone();
     prog.resident_import_names = prog.funcs.iter().map(|f| f.name.clone()).collect();
     prog.resident_main = true;
@@ -143,10 +144,41 @@ pub(crate) fn compile_program(prog: &super::LoweredProgram) -> FrontResult<Progr
     crate::timing::phase("finalize_definitions", || module.finalize_definitions())
         .map_err(|e| Unsupported::new(format!("finalize module: {e}")))?;
     let main = module.get_finalized_function(main_id);
+    register_pickle_fns(&module, prog);
     Ok(Program {
         _module: module,
         main,
     })
+}
+
+/// Register every TOP-LEVEL NAMED user function in the engine's pickle fn
+/// registry (function-by-reference serialization, Python's `module.qualname`
+/// analogue): the uniform-ABI thunk pointer a revived fn value invokes, plus the
+/// raw body pointer as an encode-time alias. Synthesized names (`__rts*` —
+/// arrows, ctors, thunks, dyn fns) stay out: they have no stable identity, the
+/// exact line Python draws for lambdas.
+fn register_pickle_fns(module: &JITModule, prog: &super::LoweredProgram) {
+    use cranelift_module::FuncOrDataId;
+    rts_engine::heap::pickle::reset_program_fns();
+    for f in &prog.funcs {
+        if f.name.starts_with("__rts") {
+            continue;
+        }
+        let ptr_of = |name: &str| match module.get_name(name) {
+            Some(FuncOrDataId::Func(id)) => module.get_finalized_function(id) as u64,
+            _ => 0,
+        };
+        let thunk_ptr = ptr_of(&thunk::thunk_name(&f.name));
+        if thunk_ptr != 0 {
+            let raw = ptr_of(&f.name);
+            rts_engine::heap::pickle::register_program_fn(
+                &f.name,
+                thunk_ptr,
+                f.params.len() as u8,
+                &[raw],
+            );
+        }
+    }
 }
 
 /// Declare + define every user function, `__rts_startup`, and the value/new-thunks

--- a/crates/rts-codegen-new/src/front/run/prelude_cache.rs
+++ b/crates/rts-codegen-new/src/front/run/prelude_cache.rs
@@ -35,6 +35,7 @@ struct Cached {
     program: LoweredProgram,
     shapes: Vec<Vec<String>>,
     error_classes: Vec<(String, u32, Vec<String>)>,
+    class_shapes: Vec<(String, u32)>,
 }
 
 /// The same payload borrowed, for SERIALIZE — avoids cloning the (large) lowered
@@ -44,6 +45,7 @@ struct CachedRef<'a> {
     program: &'a LoweredProgram,
     shapes: Vec<Vec<String>>,
     error_classes: Vec<(String, u32, Vec<String>)>,
+    class_shapes: Vec<(String, u32)>,
 }
 
 /// The cache is ON by default; `RTS_NO_PRELUDE_CACHE=1` disables it (an escape
@@ -93,6 +95,7 @@ pub(super) fn load(prelude_src: &str) -> Option<LoweredProgram> {
     let cached: Cached = bincode::deserialize(&bytes).ok()?;
     shapes::seed_global_shapes(cached.shapes);
     shapes::seed_error_classes(cached.error_classes);
+    shapes::seed_class_shapes(cached.class_shapes);
     Some(cached.program)
 }
 
@@ -108,6 +111,7 @@ pub(super) fn store(prelude_src: &str, program: &LoweredProgram) {
         program,
         shapes: shapes::export_global_shapes(),
         error_classes: shapes::export_error_classes(),
+        class_shapes: shapes::export_class_shapes(),
     };
     let Ok(bytes) = bincode::serialize(&cached) else {
         return;

--- a/crates/rts-engine/src/heap/pickle/decode.rs
+++ b/crates/rts-engine/src/heap/pickle/decode.rs
@@ -8,13 +8,16 @@
 
 use super::super::handles::{
     alloc_entry, pin_handle, unpin_handle, with_entry_mut, ArrayBufferBacking, ArrayBufferData,
-    BigIntData, Entry,
+    BigIntData, Entry, FunctionData,
 };
 use super::super::poly::{
     POLY_BOX_BASE, POLY_SING_HOLE, POLY_TAG_INT32, POLY_TAG_MASK, POLY_TAG_OBJECT,
     POLY_TAG_SHIFT, POLY_TAG_SINGLETON, POLY_TAG_STR, POLY_UNDEFINED,
 };
-use super::super::shapes::{alloc_shaped_object_owned, bool_word, handle_word_auto, null_word, string_word};
+use super::super::shapes::{
+    alloc_shaped_object_owned, bool_word, class_shape_of, global_shape_keys, handle_word_auto,
+    null_word, shape_id_word, string_word,
+};
 use super::*;
 
 /// Deserialize a whole `RTSP` v1 byte stream into one PolyValue word.
@@ -173,6 +176,41 @@ impl<'a> Dec<'a> {
                 });
                 Ok(word)
             }
+            OP_CLASS => {
+                let class = String::from_utf8_lossy(self.c.str_block()?).into_owned();
+                let n = self.c.len()?;
+                let mut keys = Vec::with_capacity(n);
+                for _ in 0..n {
+                    keys.push(String::from_utf8_lossy(self.c.str_block()?).into_owned());
+                }
+                // The DESTINATION program's shape for this class name — that is
+                // what the baked `instanceof` shape-id compares match against.
+                let dest_shape = class_shape_of(&class).ok_or_else(|| {
+                    format!("pickle: class '{class}' is not declared in this program")
+                })?;
+                let dest_keys = global_shape_keys(dest_shape)
+                    .ok_or_else(|| format!("pickle: class '{class}' has no shape layout"))?;
+                let mut slots = vec![POLY_UNDEFINED as i64; dest_keys.len() + 1];
+                slots[0] = shape_id_word(dest_shape) as i64;
+                let h = self.alloc(Entry::Vec(Box::new(slots)));
+                let word = handle_word_auto(h);
+                self.memo.push(word);
+                // Fields matched BY KEY against the destination layout: extra
+                // stream fields drop, missing ones stay undefined (schema
+                // evolution tolerated — stricter than Python only in shape).
+                for key in &keys {
+                    let v = self.value(depth + 1)? as i64;
+                    if let Some(pos) = dest_keys.iter().position(|k| k == key) {
+                        with_entry_mut(h, |e| {
+                            if let Some(Entry::Vec(s)) = e {
+                                s[1 + pos] = v;
+                            }
+                        });
+                    }
+                }
+                class_revive(word, &class);
+                Ok(word)
+            }
             OP_BUFFER => {
                 let bytes = self.c.str_block()?.to_vec();
                 let h = self.alloc(Entry::Buffer(bytes));
@@ -257,6 +295,35 @@ impl<'a> Dec<'a> {
                 let v: serde_json::Value = serde_json::from_slice(bytes)
                     .map_err(|e| format!("pickle: corrupt JSON payload: {e}"))?;
                 let h = self.alloc(Entry::Json(Box::new(v)));
+                let word = handle_word_auto(h);
+                self.memo.push(word);
+                Ok(word)
+            }
+            OP_FN_REF => {
+                let name = String::from_utf8_lossy(self.c.str_block()?).into_owned();
+                let info = fn_info_of(&name).ok_or_else(|| {
+                    format!("pickle: function '{name}' is not declared in this program")
+                })?;
+                // A first-class fn value over the DESTINATION program's uniform
+                // thunk — same shape `new Function` produces (dynfn contract).
+                let h = self.alloc(Entry::Function(Box::new(FunctionData {
+                    fn_ptr: info.ptr,
+                    arity: info.arity,
+                    name: name.clone().into_boxed_str(),
+                    bound_this: 0,
+                    has_bound_this: false,
+                    bound_args: Vec::new(),
+                    is_arrow: false,
+                    has_this_param: false,
+                    param_kinds: Vec::new(),
+                    return_kind: 0,
+                    packed_shim: 0,
+                    source: None,
+                    keep_alive: None,
+                    prototype_handle: 0,
+                    rest_param_idx: -1,
+                    uniform_thunk: true,
+                })));
                 let word = handle_word_auto(h);
                 self.memo.push(word);
                 Ok(word)

--- a/crates/rts-engine/src/heap/pickle/encode.rs
+++ b/crates/rts-engine/src/heap/pickle/encode.rs
@@ -15,7 +15,7 @@ use super::super::poly::{
     POLY_SING_NULL, POLY_SING_TRUE, POLY_TAG_FUNCTION, POLY_TAG_INT32, POLY_TAG_MASK,
     POLY_TAG_OBJECT, POLY_TAG_SHIFT, POLY_TAG_SINGLETON, POLY_TAG_STR,
 };
-use super::super::shapes::{global_shape_keys, handle_word_auto, legacy_i64_to_word};
+use super::super::shapes::{class_name_of_shape, global_shape_keys, handle_word_auto, legacy_i64_to_word};
 use super::*;
 
 /// Serialize one PolyValue word into a fresh `RTSP` v1 byte stream.
@@ -73,10 +73,7 @@ impl Enc {
                     _ => OP_UNDEF,
                 });
             }
-            POLY_TAG_STR | POLY_TAG_OBJECT => self.heap(word, depth)?,
-            POLY_TAG_FUNCTION => {
-                return Err("pickle: cannot serialize a function".into());
-            }
+            POLY_TAG_STR | POLY_TAG_OBJECT | POLY_TAG_FUNCTION => self.heap(word, depth)?,
             other => return Err(format!("pickle: unserializable value tag {other}")),
         }
         Ok(())
@@ -129,6 +126,17 @@ impl Enc {
                     self.value(w, depth + 1)?;
                 }
             }
+            Snap::ClassInst { class, keys, values } => {
+                self.out.push(OP_CLASS);
+                put_str(&mut self.out, class.as_bytes());
+                put_varint(&mut self.out, keys.len() as u64);
+                for k in &keys {
+                    put_str(&mut self.out, k.as_bytes());
+                }
+                for v in values {
+                    self.value(v as u64, depth + 1)?;
+                }
+            }
             Snap::Buffer(bytes) => {
                 self.out.push(OP_BUFFER);
                 put_str(&mut self.out, &bytes);
@@ -176,6 +184,10 @@ impl Enc {
                 self.out.push(OP_JSON);
                 put_str(&mut self.out, &bytes);
             }
+            Snap::FnRef(name) => {
+                self.out.push(OP_FN_REF);
+                put_str(&mut self.out, name.as_bytes());
+            }
             Snap::Ext(tag, payload) => {
                 self.out.push(OP_EXT);
                 put_str(&mut self.out, tag.as_bytes());
@@ -204,6 +216,7 @@ enum Snap {
     Str(Vec<u8>),
     Array(Vec<i64>),
     Object { keys: Vec<String>, values: Vec<i64>, normalize: bool },
+    ClassInst { class: String, keys: Vec<String>, values: Vec<i64> },
     Buffer(Vec<u8>),
     ArrayBuf(Vec<u8>),
     BigInt { negative: bool, words: Vec<u64> },
@@ -213,6 +226,7 @@ enum Snap {
     StrBox(u64),
     FloatPrim(f64),
     Json(Vec<u8>),
+    FnRef(String),
     Ext(&'static str, Vec<u8>),
 }
 
@@ -253,6 +267,20 @@ fn snapshot(h: u64) -> Result<Snap, String> {
             Entry::Json(v) => {
                 serde_json::to_vec(v.as_ref()).map(Snap::Json).map_err(|e| format!("pickle: JSON snapshot failed: {e}"))
             }
+            // Function BY REFERENCE — Python's rule: only a top-level named fn
+            // (resolvable in the program fn registry) serializes; a closure /
+            // arrow / bound fn is state the reference cannot carry.
+            Entry::Function(f) => {
+                if f.has_bound_this || !f.bound_args.is_empty() {
+                    return Err("pickle: cannot serialize a bound function or closure".into());
+                }
+                fn_name_of_ptr(f.fn_ptr).map(Snap::FnRef).ok_or_else(|| {
+                    format!(
+                        "pickle: cannot serialize function '{}' (only top-level named functions serialize, by reference)",
+                        f.name
+                    )
+                })
+            }
             // Everything else: an extension codec (Date, RegExp, … registered
             // by the class's owner crate) or an honest, named error.
             other => ext_encode(other)
@@ -274,8 +302,21 @@ fn snap_vec(slots: &[i64]) -> Result<Snap, String> {
             let shape_id = (w0 & POLY_PAYLOAD_MASK) as u32;
             if let Some(keys) = global_shape_keys(shape_id) {
                 if keys.len() + 1 == slots.len() {
-                    // A `#`-private field / accessor / symbol key marks a class
-                    // instance or exotic object — phase 2, not silently lossy.
+                    // A shape owned by a `class` declaration → CLASS_INST with
+                    // the WHOLE field state, `#`-private fields included (they
+                    // are the instance's state — Python pickles __dict__ the
+                    // same way). Methods/accessors live on the shared proto,
+                    // not in slots, and are re-attached at revive.
+                    if let Some(class) = class_name_of_shape(shape_id) {
+                        return Ok(Snap::ClassInst {
+                            class,
+                            keys,
+                            values: slots[1..].to_vec(),
+                        });
+                    }
+                    // Not a class shape: an accessor / symbol key marks an
+                    // exotic literal (defineProperty getter etc.) — explicit
+                    // error, not silently lossy.
                     if let Some(k) = keys.iter().find(|k| {
                         k.starts_with('#')
                             || k.starts_with("__get_")
@@ -283,7 +324,7 @@ fn snap_vec(slots: &[i64]) -> Result<Snap, String> {
                             || k.starts_with("@@sym:")
                     }) {
                         return Err(format!(
-                            "pickle: cannot serialize an object with key '{k}' (class instance / accessor / symbol key — unsupported in v1)"
+                            "pickle: cannot serialize an object with key '{k}' (accessor / symbol / private key on a non-class shape)"
                         ));
                     }
                     return Ok(Snap::Object {

--- a/crates/rts-engine/src/heap/pickle/mod.rs
+++ b/crates/rts-engine/src/heap/pickle/mod.rs
@@ -75,6 +75,21 @@ pub(crate) const OP_FLOATPRIM: u8 = 18;
 pub(crate) const OP_EXT: u8 = 19;
 /// `Entry::Json` boxed value: varint len + serde_json bytes.
 pub(crate) const OP_JSON: u8 = 20;
+/// User-class instance: class-name str + varint field-count + keys block +
+/// values. Revives with the DESTINATION program's shape id for that class name
+/// (so `instanceof` — a baked shape-id compare — holds), fields matched BY KEY
+/// (extra stream fields dropped, missing ones stay undefined), then the
+/// class-revive hook attaches the class proto. The class must be declared in
+/// the destination program — otherwise a TypeError, like Python's pickle with
+/// an unimportable class.
+pub(crate) const OP_CLASS: u8 = 21;
+/// Function BY REFERENCE (Python's `module.qualname` analogue): fn-name str.
+/// Only a TOP-LEVEL NAMED function resolves — the decoder looks the name up in
+/// the destination program's fn registry ([`register_program_fn`]) and rebuilds
+/// a first-class fn value over its uniform-ABI thunk. Arrows, closures, bound
+/// functions and class methods do NOT serialize (a TypeError — exactly the line
+/// Python draws for lambdas/locals).
+pub(crate) const OP_FN_REF: u8 = 22;
 
 /// Recursion ceiling for encode AND decode — a nesting deeper than this errors
 /// instead of overflowing the Rust stack (Python's pickle errors likewise).
@@ -149,4 +164,86 @@ pub(crate) fn ext_encode(entry: &Entry) -> Option<(&'static str, Vec<u8>)> {
 pub(crate) fn ext_decode(tag: &str, payload: &[u8]) -> Option<u64> {
     let g = ext_codecs().read().unwrap_or_else(|e| e.into_inner());
     g.iter().find(|c| c.tag == tag).and_then(|c| (c.decode)(payload))
+}
+
+// ── Class-revive hook (proto attachment lives ABOVE the engine) ─────────────
+
+/// Attach the class prototype to a freshly revived instance (`obj_word`,
+/// `class_name`). The proto tables live in rts-adapters (`__rtsadp_class_proto`
+/// / `__rtsadp_obj_set_proto`), a crate ABOVE this one — installed at engine
+/// bootstrap, the same dep-direction pattern as `SHAPED_OBJ_HOOK` /
+/// `install_gc_hook`. Absent hook (a bare-engine unit test) → the instance
+/// still has the right shape id (`instanceof` works); only proto-resolved
+/// method dispatch would miss.
+pub type ClassReviveHook = fn(obj_word: u64, class_name: &str);
+
+static CLASS_REVIVE_HOOK: OnceLock<ClassReviveHook> = OnceLock::new();
+
+/// Install the class-revive hook (idempotent; first install wins).
+pub fn set_class_revive_hook(f: ClassReviveHook) {
+    let _ = CLASS_REVIVE_HOOK.set(f);
+}
+
+pub(crate) fn class_revive(obj_word: u64, class_name: &str) {
+    if let Some(f) = CLASS_REVIVE_HOOK.get() {
+        f(obj_word, class_name);
+    }
+}
+
+// ── Program fn registry (functions BY REFERENCE, Python-style) ──────────────
+
+/// One top-level function of the LIVE program, registered by the JIT after
+/// finalize: the uniform-ABI thunk pointer (words in/out — the same convention
+/// every engine fn-value uses) + arity.
+#[derive(Clone, Copy)]
+pub struct FnInfo {
+    pub ptr: u64,
+    pub arity: u8,
+}
+
+struct FnRegistry {
+    by_name: std::collections::HashMap<String, FnInfo>,
+    /// Any pointer identifying the fn (thunk AND raw body) → its name, so the
+    /// encoder can match whatever pointer a reified fn value carries.
+    by_ptr: std::collections::HashMap<u64, String>,
+}
+
+fn fn_registry() -> &'static RwLock<FnRegistry> {
+    static T: OnceLock<RwLock<FnRegistry>> = OnceLock::new();
+    T.get_or_init(|| {
+        RwLock::new(FnRegistry {
+            by_name: std::collections::HashMap::new(),
+            by_ptr: std::collections::HashMap::new(),
+        })
+    })
+}
+
+/// Clear the fn registry at a program boundary (stale pointers from a dropped
+/// JIT module must never resolve).
+pub fn reset_program_fns() {
+    let mut g = fn_registry().write().unwrap_or_else(|e| e.into_inner());
+    g.by_name.clear();
+    g.by_ptr.clear();
+}
+
+/// Register one top-level program function: `thunk_ptr` is what a revived fn
+/// value invokes (uniform ABI); `alias_ptrs` are additional pointers (the raw
+/// body) that identify the same fn at encode time.
+pub fn register_program_fn(name: &str, thunk_ptr: u64, arity: u8, alias_ptrs: &[u64]) {
+    let mut g = fn_registry().write().unwrap_or_else(|e| e.into_inner());
+    g.by_name.insert(name.to_string(), FnInfo { ptr: thunk_ptr, arity });
+    g.by_ptr.insert(thunk_ptr, name.to_string());
+    for &p in alias_ptrs {
+        if p != 0 {
+            g.by_ptr.insert(p, name.to_string());
+        }
+    }
+}
+
+pub(crate) fn fn_name_of_ptr(ptr: u64) -> Option<String> {
+    fn_registry().read().unwrap_or_else(|e| e.into_inner()).by_ptr.get(&ptr).cloned()
+}
+
+pub(crate) fn fn_info_of(name: &str) -> Option<FnInfo> {
+    fn_registry().read().unwrap_or_else(|e| e.into_inner()).by_name.get(name).copied()
 }

--- a/crates/rts-engine/src/heap/shapes.rs
+++ b/crates/rts-engine/src/heap/shapes.rs
@@ -77,6 +77,10 @@ pub fn reset_global_shapes() {
     if let Ok(mut t) = error_classes().lock() {
         t.clear();
     }
+    if let Ok(mut t) = class_shapes().lock() {
+        t.by_name.clear();
+        t.by_id.clear();
+    }
 }
 
 /// PRIMORDIAL error-class registry: `name` → (instance shape-id, flattened
@@ -98,6 +102,74 @@ pub fn register_error_class(name: &str, shape: GlobalShapeId, fields: &[String])
 /// not lowered in this process — e.g. an AOT binary).
 pub fn error_class_info(name: &str) -> Option<(GlobalShapeId, Vec<String>)> {
     error_classes().lock().ok()?.get(name).cloned()
+}
+
+/// GENERIC class-shape registry: `class name ↔ instance shape id`, for every
+/// user/prelude `class` declaration (the Error-family table above predates this
+/// and stays — it also carries the field layout error trampolines need). The
+/// consumer is the pickle (`heap::pickle`): the encoder asks "which class is
+/// this shape?" ([`class_name_of_shape`]) and the decoder asks "which shape does
+/// this class have HERE?" ([`class_shape_of`]) — reviving with the DESTINATION
+/// program's shape id is what makes `instanceof` (a baked shape-id compare)
+/// work on a revived instance.
+struct ClassShapes {
+    by_name: HashMap<String, GlobalShapeId>,
+    by_id: HashMap<GlobalShapeId, String>,
+}
+
+fn class_shapes() -> &'static Mutex<ClassShapes> {
+    static T: OnceLock<Mutex<ClassShapes>> = OnceLock::new();
+    T.get_or_init(|| {
+        Mutex::new(ClassShapes {
+            by_name: HashMap::new(),
+            by_id: HashMap::new(),
+        })
+    })
+}
+
+/// Record one `class` declaration's name ↔ instance-shape pair. Last
+/// declaration wins by name (flat name space — a duplicated class name across
+/// modules revives as the LAST one registered, a documented limitation).
+pub fn register_class_shape(name: &str, shape: GlobalShapeId) {
+    if name.is_empty() {
+        return;
+    }
+    if let Ok(mut t) = class_shapes().lock() {
+        t.by_name.insert(name.to_string(), shape);
+        t.by_id.insert(shape, name.to_string());
+    }
+}
+
+/// The instance shape id of class `name` in THIS process, or `None` when no
+/// such class was lowered here.
+pub fn class_shape_of(name: &str) -> Option<GlobalShapeId> {
+    class_shapes().lock().ok()?.by_name.get(name).copied()
+}
+
+/// The class name owning shape `id`, or `None` for a plain object-literal shape.
+pub fn class_name_of_shape(id: GlobalShapeId) -> Option<String> {
+    class_shapes().lock().ok()?.by_id.get(&id).cloned()
+}
+
+/// Snapshot the class-shape registry for the prelude cache. Paired with
+/// [`seed_class_shapes`].
+pub fn export_class_shapes() -> Vec<(String, GlobalShapeId)> {
+    class_shapes()
+        .lock()
+        .map(|t| t.by_name.iter().map(|(n, id)| (n.clone(), *id)).collect())
+        .unwrap_or_default()
+}
+
+/// Re-seed the class-shape registry from an [`export_class_shapes`] snapshot.
+pub fn seed_class_shapes(snapshot: Vec<(String, GlobalShapeId)>) {
+    if let Ok(mut t) = class_shapes().lock() {
+        t.by_name.clear();
+        t.by_id.clear();
+        for (name, id) in snapshot {
+            t.by_id.insert(id, name.clone());
+            t.by_name.insert(name, id);
+        }
+    }
 }
 
 /// The number of interned global shapes (leak-test probe).
@@ -229,6 +301,15 @@ pub fn export_seed_blob() -> Vec<u8> {
             wr_str(&mut out, f);
         }
     }
+    // Class-shape section (appended AFTER the original two — a blob written by
+    // an older binary simply ends here, and `seed_from_blob` treats the missing
+    // section as empty instead of misparsing).
+    let classes = export_class_shapes();
+    wr_u32(&mut out, classes.len() as u32);
+    for (name, id) in &classes {
+        wr_str(&mut out, name);
+        wr_u32(&mut out, *id);
+    }
     out
 }
 
@@ -261,9 +342,21 @@ pub fn seed_from_blob(bytes: &[u8]) {
         }
         errs.push((name, id, fields));
     }
+    // Class-shape section — absent in a blob written before it existed.
+    let mut classes: Vec<(String, GlobalShapeId)> = Vec::new();
+    if p + 4 <= bytes.len() {
+        let num_classes = rd_u32(bytes, &mut p) as usize;
+        classes.reserve(num_classes);
+        for _ in 0..num_classes {
+            let name = rd_str(bytes, &mut p);
+            let id = rd_u32(bytes, &mut p);
+            classes.push((name, id));
+        }
+    }
     reset_global_shapes();
     seed_global_shapes(shapes);
     seed_error_classes(errs);
+    seed_class_shapes(classes);
 }
 
 /// The ordered keys of a [`GlobalShapeId`], or `None` if the id was never

--- a/tests/claude-pickle.test.ts
+++ b/tests/claude-pickle.test.ts
@@ -53,6 +53,105 @@ try {
 // 10. special numbers survive (NaN via isNaN, ±Infinity, -0)
 const nums: any = deserialize(serialize([NaN, Infinity, -Infinity, -0, 1e300]));
 
+// ── phase 2: class instances ──
+class PkPessoa {
+  nome: string;
+  idade: number;
+  constructor(n: string, i: number) {
+    this.nome = n;
+    this.idade = i;
+  }
+  saudacao(): string {
+    return "oi " + this.nome;
+  }
+}
+class PkConta {
+  #saldo: number;
+  dono: PkPessoa;
+  constructor(d: PkPessoa, s: number) {
+    this.dono = d;
+    this.#saldo = s;
+  }
+  get saldo(): number {
+    return this.#saldo;
+  }
+  depositar(v: number): void {
+    this.#saldo = this.#saldo + v;
+  }
+}
+class PkAnimal {
+  nome: string;
+  constructor(n: string) {
+    this.nome = n;
+  }
+  som(): string {
+    return "...";
+  }
+}
+class PkCao extends PkAnimal {
+  raca: string;
+  constructor(n: string, r: string) {
+    super(n);
+    this.raca = r;
+  }
+  som(): string {
+    return "au au";
+  }
+}
+class PkNode {
+  val: number;
+  next: PkNode | null;
+  constructor(v: number) {
+    this.val = v;
+    this.next = null;
+  }
+}
+
+const inst: any = deserialize(serialize(new PkPessoa("Ana", 30)));
+const conta: any = deserialize(serialize(new PkConta(new PkPessoa("Bia", 20), 100)));
+conta.depositar(50);
+const dog: any = deserialize(serialize(new PkCao("Rex", "vira-lata")));
+const na = new PkNode(1);
+const nb = new PkNode(2);
+na.next = nb;
+nb.next = na;
+const cycNode: any = deserialize(serialize(na));
+
+// ── phase 2: Map/Set ──
+const srcMap = new Map<string, number>();
+srcMap.set("a", 1);
+srcMap.set("b", 2);
+const rMap: any = deserialize(serialize(srcMap));
+rMap.set("c", 3);
+const srcSet = new Set<number>();
+srcSet.add(10);
+srcSet.add(20);
+const rSet: any = deserialize(serialize(srcSet));
+const keyObj: any = { k: 1 };
+const objMap = new Map<any, string>();
+objMap.set(keyObj, "valor");
+const rObjMap: any = deserialize(serialize({ map: objMap, key: keyObj }));
+
+// ── phase 3: functions by reference ──
+function pkDobro(x: number): number {
+  return x * 2;
+}
+const rFn: any = deserialize(serialize(pkDobro));
+const rFnObj: any = deserialize(serialize({ handler: pkDobro }));
+let arrowThrew = false;
+try {
+  const k = 7;
+  serialize((x: number) => x + k);
+} catch (e) {
+  arrowThrew = true;
+}
+let boundThrew = false;
+try {
+  serialize(pkDobro.bind(null, 5));
+} catch (e) {
+  boundThrew = true;
+}
+
 describe("rts:serde pickle", () => {
   test("plain object + array round-trip", () => {
     expect(r1.name).toBe("root");
@@ -114,5 +213,60 @@ describe("rts:serde pickle", () => {
     expect(nums[1]).toBe(Infinity);
     expect(nums[2]).toBe(-Infinity);
     expect(nums[4]).toBe(1e300);
+  });
+
+  test("class instance: fields + instanceof + method", () => {
+    expect(inst.nome).toBe("Ana");
+    expect(inst.idade).toBe(30);
+    expect(inst instanceof PkPessoa).toBe(true);
+    expect(inst.saudacao()).toBe("oi Ana");
+  });
+
+  test("class instance: #private + getter + nested instance", () => {
+    expect(conta.saldo).toBe(150);
+    expect(conta.dono instanceof PkPessoa).toBe(true);
+    expect(conta.dono.saudacao()).toBe("oi Bia");
+  });
+
+  test("class inheritance: instanceof chain + override", () => {
+    expect(dog instanceof PkCao).toBe(true);
+    expect(dog instanceof PkAnimal).toBe(true);
+    expect(dog.nome).toBe("Rex");
+    expect(dog.som()).toBe("au au");
+  });
+
+  test("cycle through class instances", () => {
+    expect(cycNode.val).toBe(1);
+    expect(cycNode.next.val).toBe(2);
+    expect(cycNode.next.next === cycNode).toBe(true);
+    expect(cycNode.next instanceof PkNode).toBe(true);
+  });
+
+  test("Map round-trip + mutation after revive", () => {
+    expect(rMap instanceof Map).toBe(true);
+    expect(rMap.size).toBe(3);
+    expect(rMap.get("a")).toBe(1);
+    expect(rMap.get("c")).toBe(3);
+  });
+
+  test("Set round-trip", () => {
+    expect(rSet instanceof Set).toBe(true);
+    expect(rSet.size).toBe(2);
+    expect(rSet.has(10)).toBe(true);
+    expect(rSet.has(99)).toBe(false);
+  });
+
+  test("Map with object key keeps identity", () => {
+    expect(rObjMap.map.get(rObjMap.key)).toBe("valor");
+  });
+
+  test("function by reference", () => {
+    expect(rFn(21)).toBe(42);
+    expect(rFnObj.handler(5)).toBe(10);
+  });
+
+  test("arrow/bound functions throw", () => {
+    expect(arrowThrew).toBe(true);
+    expect(boundThrew).toBe(true);
   });
 });


### PR DESCRIPTION
## O que é

O pickle do RTS chega ao nível do Python: **instâncias de classe de usuário, Map/Set e funções top-level** agora round-trippam por `rts:serde` (e `node:v8`).

```ts
class Pessoa {
  constructor(public nome: string) {}
  saudacao() { return "oi " + this.nome; }
}
const p2: any = deserialize(serialize(new Pessoa("Ana")));
p2 instanceof Pessoa; // true
p2.saudacao();        // "oi Ana" — métodos funcionam (proto religado)
```

## Como

- **Registro genérico nome ↔ shape** no engine (o gap ao lado do registry da família Error): populado pelo synth de classe e carregado por TODOS os caminhos de snapshot do prelude (PreludeManifest, prelude_cache, seed blob — seção appendada, blob antigo lê como vazio) — Map/Set do prelude baked resolvem também.
- **`OP_CLASS`**: estado completo dos campos (`#`-privados inclusos — são o estado, como o `__dict__` do Python), revive com o shape id **do programa destino** (o `instanceof` baked compara shape-id → funciona de graça), campos casados por chave (evolução de schema tolerada), proto religado via hook instalado pelo rts-adapters (mesmo padrão dep-direction do `SHAPED_OBJ_HOOK`). Classe ausente no destino = TypeError, como classe não-importável no Python.
- **Map/Set caem no caminho genérico**: `#keys/#vals/#items` são a fonte da verdade e o índice hash (`#h/#nx/#mask`) é por VALOR (chave-objeto = bucket 0 + comparação de identidade) — o round-trip verbatim é correto, e Map com chave-objeto funciona porque o memo preserva identidade.
- **`OP_FN_REF`**: funções POR REFERÊNCIA (análogo do `module.qualname`). O JIT registra cada fn top-level nomeada pós-finalize (ponteiro do thunk uniforme — o contrato do dynfn); encode casa o fn_ptr reificado, decode reconstrói o fn-value sobre o thunk do destino. Arrows/closures/bound = TypeError (a mesma linha que o Python traça pra lambdas). JIT-only por ora (AOT → TypeError).

## Testes

- `tests/claude-pickle.test.ts` **20/20** (era 11): classes (campos, instanceof, herança com override, #privado+getter, aninhada, ciclo entre instâncias), Map/Set (mutação pós-revive, chave-objeto com identidade), funções (ref direta, dentro de objeto, arrow/bound recusadas)
- Suite completa **2510 passed / 10 failed** — os arquivos que falham são os MESMOS 9 pré-existentes/flaky da baseline pré-mudança; zero regressão
- `read_before_commit.sh`: verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcJTt9H7nSVknbRZQHW7LL