### PR TITLE
test(serde): golden freeze do formato RTSP v1 + contrato cross-process + spec

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -87,6 +87,10 @@ they were not a guide for the new engine.
   await + Promise + Function class subsystem (reference). **The new engine
   has interim SYNCHRONOUS async** (event loop / real suspension are a clean redesign,
   `#207`) — this doc describes the previous Promise-centric model.
+- [`rts:serde` — deep binary serialization (the RTS pickle)](serde-pickle.md) —
+  RTSP v1 wire format (memo back-references: cycles + shared identity), class
+  instances / Map/Set / functions-by-reference, ExtCodec + revive hooks,
+  golden-file format freeze. Shipped (PRs #2008/#2009).
 - [`.node` support (Node native addons)](node-format/README.md) — Study of the
   N-API → `HandleTable` ABI without V8. Implemented in `crates/rts-napi/`.
 - [N-API then-chained crash study](napi-then-chained-crash-study.md) — Technical

--- a/docs/specs/serde-pickle.md
+++ b/docs/specs/serde-pickle.md
@@ -1,0 +1,150 @@
+# `rts:serde` — deep binary serialization (the RTS pickle)
+
+Status: **shipped** (PRs #2008 phase 1, #2009 phases 2+3; golden format freeze
+in `tests/claude-pickle-golden.test.ts`). Wire format **RTSP v1**.
+
+## What it is
+
+Python-pickle-level deep serialization of runtime value graphs to bytes:
+
+```ts
+import { serialize, deserialize } from "rts:serde";
+
+const bytes = serialize(anyValue);   // number[] of RTSP bytes
+const back  = deserialize(bytes);    // deep copy — cycles + identity intact
+```
+
+Cyclic graphs and shared references round-trip through a memo table of
+back-references — the property `JSON.stringify` structurally cannot express.
+Two fields pointing at one object stay ONE object after a trip.
+
+## Architecture (doctrine placement)
+
+- **One native primitive** in `rts-engine/src/heap/pickle/` (`mod` format +
+  ext/fn/class registries, `encode` graph walk, `decode` cursor + revive).
+  Consumers: the `serde` namespace (rts-shared, authored with
+  `#[rtse::function]`), `node:v8` `serialize`/`deserialize`. The `.ts`
+  `structuredClone` is a future consumer (v8.md §5.7).
+- **The engine never names a non-primordial class.** Date and RegExp plug in
+  through `ExtCodec` (tag + encode/decode fn-ptrs) registered by rts-shared
+  (`serde_ns/codecs.rs`) at namespace-register time. Class-instance proto
+  attachment goes through a `ClassReviveHook` installed by rts-adapters at
+  engine bootstrap (`errslot::install_async_error_hook` →
+  `protos::pickle_class_revive`) — the proto tables live above the engine.
+- **Class identity**: the generic `name ↔ shape id` registry in
+  `rts-engine::heap::shapes` (`register_class_shape`, populated by class synth,
+  carried by every prelude snapshot: `PreludeManifest.class_shapes`,
+  `prelude_cache`, an appended seed-blob section old blobs read as empty).
+- **Function identity**: `module_jit::register_pickle_fns` (post-finalize)
+  registers every top-level named fn's uniform-ABI thunk pointer
+  (`thunk::thunk_name`, the dynfn contract) in the engine's program-fn
+  registry; cleared per program.
+
+## Wire format RTSP v1
+
+```
+magic "RTSP" | version u8 = 1 | value stream
+```
+
+Varints are LEB128 (zigzag for i32). Strings are varint len + UTF-8.
+
+| Op | Payload |
+|----|---------|
+| 0–4 | undefined / null / false / true / hole |
+| 5 F64 | 8 bytes LE (NaN canonicalized on decode) |
+| 6 I32 | zigzag varint |
+| 7 STR | len + UTF-8 |
+| 8 REF | varint memo id — back-reference (cycles / shared identity) |
+| 9 ARRAY | varint len + values |
+| 10 OBJECT | varint n + keys block + values |
+| 11 BUFFER / 12 ARRAYBUF | varint len + bytes |
+| 13 BIGINT | sign u8 + varint word-count + u64 LE words |
+| 14 ERROR | name + message + has-cause u8 + [cause value] |
+| 15–18 | Boolean box u8 / Number box f64 / String box (inner value) / FloatPrim f64 |
+| 19 EXT | tag str + varint len + codec payload (Date: i64 ms; RegExp: src+flags+lastIndex) |
+| 20 JSON | serde_json bytes |
+| 21 CLASS | class-name + varint n + keys block + values |
+| 22 FN_REF | fn-name str |
+
+**Memo discipline** (both sides, the correctness core): a heap value gets its
+memo id on FIRST VISIT, BEFORE its children — encoder inserts into the memo
+map, decoder allocates a PLACEHOLDER and registers it, then fills children in,
+so a back-edge resolves mid-construction.
+
+**Determinism**: encoding a given graph is byte-deterministic (shaped-object
+keys are ordered, `Entry::Map` is an IndexMap, memo ids follow visit order).
+The golden test asserts byte-identity — an intentional format change must bump
+`VERSION`, keep v1 decoding, and regenerate the golden bytes.
+
+## Semantics (the Python parallels)
+
+- **Class instances** (`OP_CLASS`): the WHOLE field state serializes,
+  `#`-private fields included (they are the state — Python's `__dict__`).
+  Revive allocates WITHOUT running the constructor (pickle semantics), uses the
+  DESTINATION program's shape id for the class name (so the baked shape-id
+  `instanceof` compare holds), matches fields BY KEY (extra stream fields drop,
+  missing stay undefined — schema evolution), and attaches the class proto
+  (methods/getters work). A class missing in the destination throws — Python's
+  unimportable-class error.
+- **Map/Set** ride the generic class path: `#keys`/`#vals`/`#items` are the
+  source of truth; the `#h`/`#nx`/`#mask` hash index is VALUE-based (object
+  keys hash to bucket 0 and compare by identity), so the verbatim field
+  round-trip is correct and object-keyed Maps keep working (memo preserves key
+  identity).
+- **Functions** (`OP_FN_REF`): BY REFERENCE only — a top-level named fn
+  serializes as its name and re-resolves in the destination program (Python's
+  `module.qualname`). Arrows, closures and bound fns throw — the line Python
+  draws for lambdas.
+- **Unserializable** (thrown TypeError, named): sockets, threads, pending
+  Promises, generators, Proxies, Symbols, N-API externals, detached/borrowed
+  ArrayBuffers — like Python's pickle with a socket.
+- **Security**: decode of untrusted bytes never executes user code — no
+  constructor runs, `FN_REF` only resolves fns already compiled into the
+  program, class revive only re-links already-declared classes. This is
+  strictly safer than Python's pickle (whose `__reduce__` is arbitrary code
+  execution).
+
+## Encoder/decoder implementation notes (the traps)
+
+- **Snapshot-outside-the-lock**: entry data is cloned under `with_entry`'s
+  shard lock and the recursion runs outside it — a nested `with_entry` on a
+  same-shard child deadlocks (non-reentrant Mutex).
+- **Handle-as-number**: container slots may hold a raw handle as an inline-f64
+  integer (e.g. `new Error(...)`, ABI return `Handle`). The encoder applies the
+  same liveness discipline as `element_to_handle`: finite whole f64 in
+  `[2^48, 2^53)` whose slot is live → heap reference.
+- **Null-string sentinel**: the word `STR|SLOT_MASK` (what
+  `POLY_FROM_HANDLE(0)` boxes — e.g. an unset Error `stack`) normalizes to
+  handle 0 and encodes as undefined.
+- **GC pinning on decode**: every allocated handle is pinned for the decode's
+  duration (the memo Vec lives on the Rust heap, invisible to the conservative
+  stack scanner) and unpinned before returning.
+- **Exhaustive `Entry` match**: a new `Entry` variant fails compilation in the
+  encoder's `kind_name`, forcing an explicit serialize-or-reject decision.
+- Depth ceiling 2000 on both sides (error, not stack overflow).
+
+## Known limitations (v1)
+
+- Functions by reference are **JIT-only** — an AOT binary's fn registry is
+  empty (TypeError). Class revive in AOT is wired through the seed blob +
+  bootstrap hook but not yet exercised by a test.
+- Class names are a **flat namespace** — two classes with the same name in
+  different modules collide (last registration wins).
+- `serialize` returns `number[]` (each byte an f64 word — 8× heap size while
+  in memory). Fine for correctness; a `Uint8Array`/Buffer surface is the
+  natural upgrade once the TypedArray surface is the default byte carrier.
+- Registry-backed instances (`Entry::Map` + `__rts_class`: Hash, Stats, …) and
+  `Entry::Rtse` classes without a codec throw; codecs are one `ExtCodec`
+  registration each (Date and RegExp are the templates).
+
+## Candidate next phases
+
+1. **AOT parity**: emit the fn name→thunk table into the AOT main shim; an
+   `rts compile` pickle test in the gate.
+2. **structuredClone / postMessage unification** (v8.md §5.7, threading T5):
+   make the `.ts` clone and future worker messaging consume this primitive.
+3. **By-value mode** (the cloudpickle analogue): opt-in embedding of TS SOURCE
+   for classes/fns + recompile at decode via `COMPILE_FN_HOOK`. Never the
+   default (code-from-bytes is an execution risk the base format must not
+   normalize).
+4. **Fuzzing**: a `cargo-fuzz` target over `deserialize_value`.

--- a/tests/claude-pickle-golden.test.ts
+++ b/tests/claude-pickle-golden.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect } from "rts:test";
+import { serialize, deserialize } from "rts:serde";
+import { writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// ── RTSP v1 FORMAT FREEZE ───────────────────────────────────────────────────
+// GOLDEN is the exact byte stream `serialize(buildGraph())` produced when the
+// v1 format shipped. Decoding it proves a stream from ANOTHER process/run
+// loads (the pickle contract); re-encoding byte-for-byte proves no silent
+// format drift. If a test here fails after an intentional format change, bump
+// the wire VERSION in rts-engine/src/heap/pickle/mod.rs, keep the v1 decode
+// path working, and regenerate GOLDEN for the new version — never just update
+// the bytes to make it pass.
+
+class GAnimal {
+  nome: string;
+  constructor(n: string) {
+    this.nome = n;
+  }
+  som(): string {
+    return "...";
+  }
+}
+class GCao extends GAnimal {
+  raca: string;
+  constructor(n: string, r: string) {
+    super(n);
+    this.raca = r;
+  }
+  som(): string {
+    return "au au";
+  }
+}
+function gDobro(x: number): number {
+  return x * 2;
+}
+
+// EXACTLY the construction order that produced GOLDEN.
+function buildGraph(): any {
+  const shared: any = { id: 42 };
+  const root: any = {
+    titulo: "golden v1",
+    n: 3.5,
+    i: 7,
+    flag: true,
+    nada: null,
+    indef: undefined,
+    lista: [1, "dois", false, shared],
+    outra: shared,
+    quando: new Date(1700000000000),
+    padrao: /ab+c/gi,
+    erro: new Error("golden boom"),
+    mapa: new Map<string, number>(),
+    conjunto: new Set<string>(),
+    pet: new GCao("Rex", "vira-lata"),
+    fn: gDobro,
+  };
+  root.mapa.set("a", 1);
+  root.mapa.set("b", 2);
+  root.conjunto.add("x");
+  root.conjunto.add("y");
+  root.ciclo = root;
+  return root;
+}
+
+const GOLDEN: number[] = [82,84,83,80,1,10,16,6,116,105,116,117,108,111,1,110,1,105,4,102,108,97,103,4,110,97,100,97,5,105,110,100,101,102,5,108,105,115,116,97,5,111,117,116,114,97,6,113,117,97,110,100,111,6,112,97,100,114,97,111,4,101,114,114,111,4,109,97,112,97,8,99,111,110,106,117,110,116,111,3,112,101,116,2,102,110,5,99,105,99,108,111,7,9,103,111,108,100,101,110,32,118,49,5,0,0,0,0,0,0,12,64,5,0,0,0,0,0,0,28,64,3,1,0,9,4,5,0,0,0,0,0,0,240,63,7,4,100,111,105,115,2,10,1,2,105,100,5,0,0,0,0,0,0,69,64,8,4,19,4,68,97,116,101,8,0,104,229,207,139,1,0,0,19,6,82,101,103,69,120,112,22,4,0,0,0,97,98,43,99,2,0,0,0,103,105,0,0,0,0,0,0,0,0,21,5,69,114,114,111,114,4,7,109,101,115,115,97,103,101,4,110,97,109,101,5,115,116,97,99,107,5,99,97,117,115,101,7,11,103,111,108,100,101,110,32,98,111,111,109,7,5,69,114,114,111,114,0,0,21,3,77,97,112,5,5,35,107,101,121,115,5,35,118,97,108,115,2,35,104,3,35,110,120,5,35,109,97,115,107,9,2,7,1,97,7,1,98,9,2,5,0,0,0,0,0,0,240,63,5,0,0,0,0,0,0,0,64,9,8,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,0,0,6,2,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,9,2,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,28,64,21,3,83,101,116,4,6,35,105,116,101,109,115,2,35,104,3,35,110,120,5,35,109,97,115,107,9,2,7,1,120,7,1,121,9,8,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,6,2,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,0,0,9,2,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,240,191,5,0,0,0,0,0,0,28,64,21,4,71,67,97,111,2,4,110,111,109,101,4,114,97,99,97,7,3,82,101,120,7,9,118,105,114,97,45,108,97,116,97,22,6,103,68,111,98,114,111,8,0];
+
+// (a) format freeze: fresh serialize reproduces the golden bytes exactly.
+const fresh: any = serialize(buildGraph());
+let sameLen = fresh.length === GOLDEN.length;
+let firstDiff = -1;
+if (sameLen) {
+  for (let i = 0; i < GOLDEN.length; i++) {
+    if (fresh[i] !== GOLDEN[i]) {
+      firstDiff = i;
+      break;
+    }
+  }
+}
+
+// (b) cross-process contract: the golden stream (produced by an EARLIER
+// process) revives completely here.
+const g: any = deserialize(GOLDEN);
+
+// (c) disk round-trip: serialize → file → read → deserialize.
+const diskPath = tmpdir() + "\\claude-pickle-golden.rtsp";
+writeFileSync(diskPath, serialize(buildGraph()) as any);
+const fromDisk: any = deserialize(readFileSync(diskPath) as any);
+
+describe("rts:serde RTSP v1 golden (format freeze + cross-process)", () => {
+  test("fresh serialize is byte-identical to golden", () => {
+    expect(sameLen).toBe(true);
+    expect(firstDiff).toBe(-1);
+  });
+
+  test("golden: primitives", () => {
+    expect(g.titulo).toBe("golden v1");
+    expect(g.n).toBe(3.5);
+    expect(g.i).toBe(7);
+    expect(g.flag).toBe(true);
+    expect(g.nada).toBe(null);
+    expect(g.indef).toBe(undefined);
+  });
+
+  test("golden: array + shared identity + cycle", () => {
+    expect(g.lista.length).toBe(4);
+    expect(g.lista[1]).toBe("dois");
+    expect(g.lista[3] === g.outra).toBe(true);
+    expect(g.outra.id).toBe(42);
+    expect(g.ciclo === g).toBe(true);
+  });
+
+  test("golden: Date + RegExp + Error", () => {
+    expect(g.quando.getTime()).toBe(1700000000000);
+    expect(g.padrao.source).toBe("ab+c");
+    expect(g.padrao.flags).toBe("gi");
+    expect(g.erro.message).toBe("golden boom");
+  });
+
+  test("golden: Map + Set revive", () => {
+    expect(g.mapa instanceof Map).toBe(true);
+    expect(g.mapa.get("b")).toBe(2);
+    expect(g.conjunto instanceof Set).toBe(true);
+    expect(g.conjunto.has("y")).toBe(true);
+  });
+
+  test("golden: class instance + inheritance + fn by reference", () => {
+    expect(g.pet instanceof GCao).toBe(true);
+    expect(g.pet instanceof GAnimal).toBe(true);
+    expect(g.pet.som()).toBe("au au");
+    expect(g.fn(21)).toBe(42);
+  });
+
+  test("disk round-trip via node:fs", () => {
+    expect(fromDisk.titulo).toBe("golden v1");
+    expect(fromDisk.ciclo === fromDisk).toBe(true);
+    expect(fromDisk.pet instanceof GCao).toBe(true);
+    expect(fromDisk.mapa.get("a")).toBe(1);
+  });
+});


### PR DESCRIPTION
## O que é

A fatia que faltava pro pickle ser confiável **fora do processo**:

- **Golden format freeze**: um stream RTSP de 587 bytes (classes, Map/Set, Date/RegExp/Error, ciclo, identidade compartilhada, função por referência) commitado no teste. O serialize fresco reproduz os bytes **byte-a-byte** (encoding determinístico provado) — qualquer drift silencioso do formato agora quebra um teste. Mudança intencional de formato = bump de VERSION + manter decode v1 + regenerar golden (instrução no próprio teste).
- **Contrato cross-process**: o golden foi produzido por um processo ANTERIOR — deserializar e validar tudo (instanceof, métodos, ciclo, fn) prova o contrato real do pickle, que os testes same-process nunca exercitavam.
- **Round-trip por disco**: serialize → `writeFileSync` → `readFileSync` → deserialize (o fluxo save/load real).
- **Spec**: `docs/specs/serde-pickle.md` — tabela do formato, disciplina de memo, colocação na doutrina, postura de segurança (decode nunca executa código — mais estrito que o pickle do Python), armadilhas do encoder e fases candidatas.

Sem mudança de engine nesta fatia (testes + docs). Suite completa: mesmas 9 falhas pré-existentes/flaky da baseline, zero regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcJTt9H7nSVknbRZQHW7LL