### PR TITLE
feat(dom): JS de página com escopo global compartilhado + estado migrado para Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4121,6 +4121,7 @@ name = "rts-dom"
 version = "0.1.0"
 dependencies = [
  "rts-engine",
+ "rts-macro",
 ]
 
 [[package]]

--- a/crates/rts-codegen-new/src/front/run/binop.rs
+++ b/crates/rts-codegen-new/src/front/run/binop.rs
@@ -193,12 +193,42 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
 
         // `x instanceof C` (P5.3). swc collapses `instanceof`/`in`/etc onto
-        // `HirBinOp::Unsupported`; we only treat it as instanceof when the RHS is a
-        // bare identifier naming a class the engine can check (a user class, or a
-        // runtime/Registry class Map/Set/Error-family/Array). That keeps `"k" in o`
-        // (rhs not a class ident) safely bailed — never a wrong instanceof.
+        // `HirBinOp::Unsupported`; we only treat it as instanceof when the RHS NAMES
+        // a class the engine can check (a user class, or a runtime/Registry class
+        // Map/Set/Error-family/Array) — either as a bare identifier or through an
+        // unshadowed global object (`window.C`). That keeps `"k" in o` (rhs not a
+        // class name) safely bailed — never a wrong instanceof.
         if matches!(op, HirBinOp::Unsupported) {
-            if let rts_hir::ir::HirExprKind::Ident(class) = &rhs.kind {
+            // The RHS names a class either DIRECTLY (`x instanceof Map`) or through
+            // the global object (`x instanceof window.DOMStringMap` — the form page
+            // scripts use when they feature-detect a DOM class). `window`/`self`/
+            // `globalThis`/`top`/`parent` all denote the global object, on which a
+            // global class is reachable by its own name, so `<global>.C` resolves to
+            // the very same class as a bare `C`. Anything else stays bailed — the
+            // check below never guesses at an arbitrary expression.
+            let class_name: Option<&str> = match &rhs.kind {
+                rts_hir::ir::HirExprKind::Ident(class) => Some(class.as_str()),
+                rts_hir::ir::HirExprKind::Member { object, prop } => {
+                    match &object.kind {
+                        // Only when the base is NOT a local in scope: a user
+                        // `const window = {DOMStringMap: somethingElse}` shadows the
+                        // global object, and resolving `window.C` to the class `C`
+                        // would then be plainly wrong. A shadowed base falls through
+                        // to the honest bail.
+                        rts_hir::ir::HirExprKind::Ident(base)
+                            if matches!(
+                                base.as_str(),
+                                "window" | "globalThis" | "self" | "top" | "parent"
+                            ) && self.local(base).is_none() =>
+                        {
+                            Some(prop.as_str())
+                        }
+                        _ => None,
+                    }
+                }
+                _ => None,
+            };
+            if let Some(class) = class_name {
                 if let Some(val) = self.try_instanceof(module, lhs, class)? {
                     return Ok(val);
                 }

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1164,11 +1164,16 @@ impl Ctx {
             body,
             self_name,
             is_async,
+            is_real_arrow,
         } = &e.kind
         else {
             return None;
         };
         let is_async = *is_async;
+        // Propagado até o `HirFunc`: só uma ARROW de verdade não tem `arguments`
+        // próprio. Uma function-expression tem, e o `argsobj` o materializa —
+        // sem isto ela seria pulada e o `arguments` ficaria unbound.
+        let is_real_arrow = *is_real_arrow;
         // The synthesized name is minted UP FRONT so a NAMED fn-expression's
         // self-references can be renamed to it before the free-ident analysis
         // (the self-name is body-only scope; renamed, it resolves as this very
@@ -1239,6 +1244,13 @@ impl Ctx {
         for id in &free {
             if param_names.contains(id)
                 || id == &name
+                // `arguments` é binding PRÓPRIO de uma função não-arrow, não uma
+                // captura do escopo externo. Sem isto ele surgia como ident livre
+                // desconhecido e a extração abortava ("expression arrow"), o que
+                // obrigava a reescrevê-lo por fora, no `.ts`. O `argsobj` (que já
+                // materializa `arguments` como rest param / prólogo) roda DEPOIS
+                // do lifting e resolve — ver `expand_arguments_object`.
+                || (!is_async && id == "arguments")
                 || GLOBALS.contains(&id.as_str())
                 // A top-level CLOSURE (a synthesized fn WITH captures) is NOT
                 // skippable: its direct name cannot be called from a scope that
@@ -1375,7 +1387,7 @@ impl Ctx {
             ret: ret.clone(),
             body: body_stmts,
             is_async,
-            is_arrow: true,
+            is_arrow: is_real_arrow,
         });
         Some(name)
     }

--- a/crates/rts-codegen-new/src/front/run/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/mod.rs
@@ -901,6 +901,14 @@ fn build_from_program(
     );
     funcs.extend(extracted.funcs);
 
+    // `arguments` de NOVO, agora sobre as funções que o lifting acabou de
+    // sintetizar: uma função-EXPRESSÃO (`f = function(){ … arguments … }`) só
+    // existe como `HirFunc` depois de `extract_arrows`, então a passada da
+    // linha ~622 (que vê apenas `Item::Function` de topo) não a alcança. É o
+    // mesmo pass, idempotente — uma fn já materializada tem um param
+    // `arguments` e é pulada.
+    argsobj::expand_arguments_object(&mut funcs);
+
     // Module-level mutable globals (#195): function-written top lets + the
     // captured-and-mutated top lets force-promoted above.
     let gcells = funcval::module_globals(&funcs, &main, &forced_globals);

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -191,6 +191,7 @@ pub(super) static REGISTER: &[fn(&mut Engine)] = &[
     // arrayBuffer/slice stay hand-written (F8 doesn't cover `Vec<i64>`/`Self`
     // returns). `File` embeds a `Blob` + forwards (composition, `extends =
     // "Blob"` for `instanceof`).
+    ns::dom::scriptscope::register,
     ns::globals::node_constants::register,
     ns::globals::storage::register,
     ns::globals::blob::register_blob_class_spec,

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -191,6 +191,7 @@ pub(super) static REGISTER: &[fn(&mut Engine)] = &[
     // arrayBuffer/slice stay hand-written (F8 doesn't cover `Vec<i64>`/`Self`
     // returns). `File` embeds a `Blob` + forwards (composition, `extends =
     // "Blob"` for `instanceof`).
+    ns::globals::node_constants::register,
     ns::globals::storage::register,
     ns::globals::blob::register_blob_class_spec,
     ns::globals::blob::register_file_class_spec,

--- a/crates/rts-codegen-new/src/front/run/registry_build.rs
+++ b/crates/rts-codegen-new/src/front/run/registry_build.rs
@@ -191,6 +191,7 @@ pub(super) static REGISTER: &[fn(&mut Engine)] = &[
     // arrayBuffer/slice stay hand-written (F8 doesn't cover `Vec<i64>`/`Self`
     // returns). `File` embeds a `Blob` + forwards (composition, `extends =
     // "Blob"` for `instanceof`).
+    ns::globals::storage::register,
     ns::globals::blob::register_blob_class_spec,
     ns::globals::blob::register_file_class_spec,
     // `FormData` — backend/Registry class (#72): case-sensitive multimap,

--- a/crates/rts-dom/Cargo.toml
+++ b/crates/rts-dom/Cargo.toml
@@ -17,3 +17,4 @@ edition = "2024"
 
 [dependencies]
 rts-engine = { path = "../rts-engine" }
+rtse = { package = "rts-macro", path = "../rts-macro" }

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1069,7 +1069,7 @@ function __runScriptAt(h: i64, j: number, url: string): number {
   // é qualificado para `__G.<nome>` neste script também — é o que faz o loader
   // criado pelo script 2 estar disponível para o script 30.
   const known = __globalNames(h, url, 1000, 800);
-  const created = __scanImplicitGlobals(__splitTopLevelSequences(__rewriteArguments(code)));
+  const created = __scanImplicitGlobals(__normalizeScript(code));
   const body = prologue + __bindGlobals(code, known) + "\nreturn 0;";
   let ok = 1;
   try {

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1055,19 +1055,41 @@ function __runScriptAt(h: i64, j: number, url: string): number {
   // storage/timers) + `document` (do window) + os aliases globais que os scripts
   // esperam (self/globalThis/top/parent === window). `return 0` final garante o
   // dynfn tipado i64 (o corpo de um <script> normalmente não tem return).
-  const prologue = "const window = __makeWindow(__h, __url, 1000, 800);\n"
+  //
+  // O `window` vem de `__winFor` (PERSISTENTE por documento) e `__G` é o SACO DE
+  // GLOBAIS compartilhado — os dois é que fazem um <script> enxergar o que o
+  // anterior definiu, como no browser. Ver `window.ts`.
+  const prologue = "const window = __winFor(__h, __url, 1000, 800);\n"
+    + "const __G = __globalsFor(__h, __url, 1000, 800);\n"
     + "const document = window.document;\n"
     + "const self = window; const globalThis = window; const top = window; const parent = window;\n"
     + "const location = window.location; const navigator = window.navigator;\n"
     + "const history = window.history; const localStorage = window.localStorage;\n";
-  const body = prologue + code + "\nreturn 0;";
+  // Escopo global COMPARTILHADO: o que scripts anteriores publicaram (`known`)
+  // é qualificado para `__G.<nome>` neste script também — é o que faz o loader
+  // criado pelo script 2 estar disponível para o script 30.
+  const known = __globalNames(h, url, 1000, 800);
+  const created = __scanImplicitGlobals(__splitTopLevelSequences(__rewriteArguments(code)));
+  const body = prologue + __bindGlobals(code, known) + "\nreturn 0;";
   let ok = 1;
   try {
     const f = new Function("__h", "__url", body);
     f(h, url);
+    // Só depois de RODAR é que os nomes viram "publicados" (um script que falhou
+    // não deixa seus globais no escopo — como no browser).
+    let i = 0;
+    while (i < created.length) {
+      const nm = created[i];
+      let dup = 0;
+      let k = 0;
+      while (k < known.length) { if (known[k] === nm) dup = 1; k = k + 1; }
+      if (dup === 0) known.push(nm);
+      i = i + 1;
+    }
   } catch (e) {
     // Script quebrado não derruba a página (comportamento do browser).
     ok = 0;
   }
   return ok;
 }
+

--- a/crates/rts-dom/src/lib.rs
+++ b/crates/rts-dom/src/lib.rs
@@ -19,6 +19,7 @@
 //! `u64` (extern "C") através de [`register`]; a camada ergonômica
 //! (`Document`/`Element`) é TS. Depende só de `rts-engine`.
 
+pub mod scriptscope;
 pub mod abi;
 mod dom;
 mod html;

--- a/crates/rts-dom/src/lib.rs
+++ b/crates/rts-dom/src/lib.rs
@@ -60,5 +60,15 @@ pub use abi::register;
 /// `Engine::include` na tabela `PRELUDE_TS` — DEPOIS do registro do ns `dom`.
 /// O `window.ts` é CONCATENADO na mesma unidade (usa `Document`/`Element` do
 /// `dom.ts` em escopo): o objeto `window` de browser (location/navigator/
-/// history/storage/timers) que o `runScripts` injeta em cada `<script>`.
-pub const DOM_TS: &str = concat!(include_str!("dom.ts"), "\n", include_str!("window.ts"));
+/// history/storage/timers) que o `runScripts` injeta em cada `<script>`, mais o
+/// ESCOPO GLOBAL compartilhado entre os `<script>` do mesmo documento.
+/// O `scriptscope.ts` traz o pré-passo que adapta o JS de página ao subset que o
+/// compilador aceita (global implícito → `__G.x`, `arguments` → rest, sequência
+/// com função → statements).
+pub const DOM_TS: &str = concat!(
+    include_str!("dom.ts"),
+    "\n",
+    include_str!("scriptscope.ts"),
+    "\n",
+    include_str!("window.ts")
+);

--- a/crates/rts-dom/src/scriptscope.rs
+++ b/crates/rts-dom/src/scriptscope.rs
@@ -1,0 +1,133 @@
+//! Saco de globais de cada documento — o objeto global que todos os `<script>`
+//! de uma página compartilham.
+//!
+//! Vive em Rust (num `thread_local` chaveado pelo handle do DOM) porque precisa
+//! ser COMPARTILHADO ENTRE PROGRAMAS: cada `new Function` compila um programa
+//! novo, então um saco escrito em `.ts` seria por-programa e o script N+1 não
+//! veria o do script N. Guardá-lo em arrays globais de prelude é pior — vira
+//! gcell (estado do programa) e já travou um teste sem relação nesta sessão.
+//!
+//! O valor guardado é `Poly` — a WORD TAGUEADA, o tipo que atravessa a borda
+//! SEM coerção. Com `f64` o round-trip devolve `undefined`; com `Poly` uma
+//! string volta string e uma função volta CHAMÁVEL (medido).
+//!
+//! O lado `.ts` expõe isto como um Proxy cujas traps `get`/`set` caem aqui.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use rts_engine::abi::ty::{Handle, Poly};
+
+#[derive(Default)]
+struct Scope {
+    globals: HashMap<String, u64>,
+    order: Vec<String>,
+}
+
+thread_local! {
+    static SCOPES: RefCell<HashMap<u64, Scope>> = RefCell::new(HashMap::new());
+}
+
+fn s_count(h: u64) -> i64 {
+    SCOPES.with(|s| s.borrow().get(&h).map(|x| x.order.len() as i64).unwrap_or(0))
+}
+
+fn s_name_at(h: u64, n: i64) -> String {
+    if n < 0 {
+        return String::new();
+    }
+    SCOPES.with(|s| {
+        s.borrow()
+            .get(&h)
+            .and_then(|x| x.order.get(n as usize).cloned())
+            .unwrap_or_default()
+    })
+}
+
+fn s_get(h: u64, name: &str) -> u64 {
+    SCOPES.with(|s| {
+        s.borrow()
+            .get(&h)
+            .and_then(|x| x.globals.get(name).copied())
+            .unwrap_or(0)
+    })
+}
+
+fn s_set(h: u64, name: &str, w: u64) {
+    SCOPES.with(|s| {
+        let mut s = s.borrow_mut();
+        let sc = s.entry(h).or_default();
+        if !sc.globals.contains_key(name) {
+            sc.order.push(name.to_string());
+        }
+        sc.globals.insert(name.to_string(), w);
+    });
+}
+
+fn s_has(h: u64, name: &str) -> i64 {
+    SCOPES.with(|s| {
+        s.borrow()
+            .get(&h)
+            .map(|x| i64::from(x.globals.contains_key(name)))
+            .unwrap_or(0)
+    })
+}
+
+fn s_drop(h: u64) {
+    SCOPES.with(|s| {
+        s.borrow_mut().remove(&h);
+    });
+}
+
+/// Portador do saco de globais por documento. Só membros estáticos.
+///
+/// Classe (e não `#[rtse::function]` livre) porque o `rts-symbol-baker` ainda
+/// não escaneia funções livres — o símbolo não entraria na tabela.
+#[rtse::class("DomScope")]
+#[derive(Clone, Default)]
+pub struct DomScope {}
+
+#[rtse::class("DomScope")]
+impl DomScope {
+    /// Quantos globais este documento publicou.
+    #[rtse::statical]
+    fn count(h: Handle) -> f64 {
+        s_count(h) as f64
+    }
+
+    /// O n-ésimo nome publicado ("" fora de faixa).
+    #[rtse::statical]
+    fn nameAt(h: Handle, n: f64) -> String {
+        s_name_at(h, n as i64)
+    }
+
+    /// O VALOR do global (`undefined` se não existe). `Poly` para atravessar
+    /// sem coerção — com `f64` a função vira `undefined`.
+    #[rtse::statical]
+    fn get(h: Handle, name: &str) -> Poly {
+        let w = s_get(h, name);
+        if w == 0 {
+            rts_engine::heap::poly::POLY_UNDEFINED
+        } else {
+            w
+        }
+    }
+
+    /// Guarda o VALOR sob `name`.
+    #[rtse::statical]
+    fn set(h: Handle, name: &str, value: Poly) {
+        s_set(h, name, value);
+    }
+
+    /// `1` se o global existe.
+    #[rtse::statical]
+    fn has(h: Handle, name: &str) -> f64 {
+        s_has(h, name) as f64
+    }
+
+    /// Descarta o saco deste documento.
+    #[rtse::statical]
+    fn drop(h: Handle) {
+        s_drop(h);
+    }
+}

--- a/crates/rts-dom/src/scriptscope.ts
+++ b/crates/rts-dom/src/scriptscope.ts
@@ -451,10 +451,64 @@ function __filterDeclared(names: string[], src: string): string[] {
   return out;
 }
 
+// ── `x instanceof window.C` → `x instanceof C` ───────────────────────────────
+//
+// `instanceof` no motor resolve o lado direito por NOME de classe. Um script de
+// página escreve a mesma checagem via objeto global (`e.dataset instanceof
+// window.DOMStringMap` — feature-detect de classe do DOM), e a forma com membro
+// não resolvia, derrubando o script inteiro.
+//
+// `window`/`self`/`globalThis`/`top`/`parent` denotam o objeto global, e uma
+// classe global é alcançável pelo próprio nome — então as duas formas são a
+// MESMA checagem, e tirar o prefixo é fiel. Quando a classe não existe no motor,
+// o `instanceof` responde `false`, que é a resposta certa para um feature-detect
+// (e era o que o browser daria num motor sem aquela classe).
+//
+// Só age imediatamente depois do token `instanceof`; qualquer outro `window.x`
+// do script fica intacto.
+function __unqualifyInstanceof(src: string): string {
+  if (src.indexOf("instanceof") < 0) return src;
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    if (src.substring(i, i + 10) === "instanceof") {
+      // precisa ser o token inteiro (não sufixo de um identificador maior)
+      const antes = i > 0 ? src.substring(i - 1, i) : "";
+      const depois = i + 10 < n ? src.substring(i + 10, i + 11) : "";
+      if (!__isIdPart(antes) && !__isIdPart(depois)) {
+        let j = i + 10;
+        while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+        const baseStart = j;
+        while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
+        const base = src.substring(baseStart, j);
+        const ehGlobal = base === "window" || base === "globalThis"
+          || base === "self" || base === "top" || base === "parent";
+        if (ehGlobal && j < n && src.substring(j, j + 1) === ".") {
+          // `instanceof window.Classe` → mantém só `Classe`
+          out = out + src.substring(i, i + 10) + " ";
+          i = j + 1;
+          continue;
+        }
+      }
+    }
+    out = out + src.substring(i, i + 1);
+    i = i + 1;
+  }
+  return out;
+}
+
+// TODA a normalização sintática, num lugar só — o `runScripts` e o `__bindGlobals`
+// precisam enxergar exatamente o mesmo texto (os nomes detectados têm de bater
+// com o texto que vai ser compilado).
+function __normalizeScript(code: string): string {
+  return __unqualifyInstanceof(__splitTopLevelSequences(__rewriteArguments(code)));
+}
+
 function __bindGlobals(code: string, known: string[]): string {
   // Normaliza PRIMEIRO e só então varre: o split de sequência transforma
   // `a=1,b=2` em `a=1;b=2`, e é sobre essa forma que os nomes são detectados.
-  const normalized = __splitTopLevelSequences(__rewriteArguments(code));
+  const normalized = __normalizeScript(code);
   const names = __filterDeclared(__scanImplicitGlobals(normalized), normalized);
   // Acrescenta os já publicados que aparecem neste script — MENOS os que este
   // script declara localmente (shadowing: um `const requireLazy = …` local ganha

--- a/crates/rts-dom/src/scriptscope.ts
+++ b/crates/rts-dom/src/scriptscope.ts
@@ -1,0 +1,477 @@
+// Adaptação do JS de PÁGINA à semântica que o compilador do RTS aceita — o
+// pré-passo que roda em todo `<script>` antes de compilar (`runScripts`).
+//
+// ## Por que existe
+// O corpo de um `<script>` é compilado pelo pipeline do próprio RTS (swc→HIR→JIT,
+// via `new Function`). Esse pipeline é um COMPILADOR DE TS, e trata como erro
+// coisas que uma página faz o tempo todo:
+//
+//   1. GLOBAL IMPLÍCITO — `requireLazy = function(){…}` sem `var/let/const`.
+//      Em JS sloppy isso CRIA um global; para o compilador é "assignment to
+//      unbound". Não afrouxamos o motor (para código RTS a recusa está certa):
+//      traduzimos aqui, na borda que já tem semântica de browser, reescrevendo
+//      para o SACO DE GLOBAIS compartilhado do documento (`__G`, ver window.ts).
+//
+//   2. `arguments` — o motor não tem o objeto; um ident livre desconhecido faz a
+//      extração da função abortar. Mas SUPORTA rest, e para o uso dominante em
+//      loaders (repassar args adiante) as duas formas são equivalentes.
+//
+//   3. SEQUÊNCIA com função — o motor aceita o operador vírgula e aceita
+//      `function` como valor, mas não a combinação `x=…, y=function(){…}` numa só
+//      expressão; minificadores geram isso o tempo todo.
+//
+// ## O que este módulo NÃO é
+// Não é um parser de JS. É um conjunto de reescritas TEXTUAIS conservadoras que
+// pulam string/comentário e só agem em padrões inequívocos. Onde não tem certeza,
+// deixa como está — falha honesta do compilador em vez de resultado errado.
+//
+// Concatenado na mesma unidade de `dom.ts` (ver `lib.rs::DOM_TS`).
+
+// ── GLOBAL IMPLÍCITO (`x = 1` sem var/let/const) ──────────────────────────────
+//
+// Em JS *sloppy mode* atribuir a um nome não declarado CRIA um global. É como o
+// loader da Meta se instala (`requireLazy=function(){…}`) e como quase todo
+// bundle antigo publica sua API. O compilador do RTS — corretamente, para código
+// RTS — recusa: "assignment to unbound `x`". Não relaxamos isso no motor (seria
+// enfraquecer a linguagem inteira por causa de uma página); resolvemos AQUI, na
+// borda que já é "semântica de browser": um pré-passo reescreve o script para
+// falar com o saco de globais compartilhado.
+//
+//   requireLazy = function(){…}   →   __G.requireLazy = function(){…}
+//   requireLazy([...], cb)        →   __G.requireLazy([...], cb)
+//
+// `__bindGlobals` faz as duas metades: acha os nomes atribuídos sem declaração
+// (`__scanImplicitGlobals`) e reescreve TODAS as ocorrências livres desses nomes
+// para `__G.<nome>` (`__qualify`). Nomes já declarados no próprio script, campos
+// (`a.x`), chaves de objeto (`{x:…}`) e conteúdo de string/comentário não são
+// tocados.
+
+function __isIdStart(c: string): boolean {
+  return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c === "$";
+}
+function __isIdPart(c: string): boolean {
+  return __isIdStart(c) || (c >= "0" && c <= "9");
+}
+function __isSpace(c: string): boolean {
+  return c === " " || c === "\n" || c === "\t" || c === "\r";
+}
+
+// Nomes DECLARADOS em qualquer ponto do script: `var/let/const X`, `function X`,
+// `class X`, parâmetros de função e `catch (X)`. Um nome daqui NUNCA é global
+// implícito, mesmo que seja reatribuído adiante (`let i = 0; … i = i + 1`) — sem
+// esta lista o `i` do segundo statement parece um global e o script quebra.
+function __scanDeclared(src: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src.substring(i, i + 1);
+    // pula comentário e string (um `var` dentro de texto não declara nada)
+    if (c === "/" && i + 1 < n) {
+      const c2 = src.substring(i + 1, i + 2);
+      if (c2 === "/") { while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1; continue; }
+      if (c2 === "*") {
+        i = i + 2;
+        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        i = i + 2;
+        continue;
+      }
+    }
+    if (c === "\"" || c === "'" || c === "`") {
+      const q = c;
+      i = i + 1;
+      while (i < n) {
+        const d = src.substring(i, i + 1);
+        if (d === "\\") { i = i + 2; continue; }
+        if (d === q) { i = i + 1; break; }
+        i = i + 1;
+      }
+      continue;
+    }
+    if (__isIdStart(c)) {
+      const s = i;
+      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
+      const w = src.substring(s, i);
+      const isDecl = w === "var" || w === "let" || w === "const";
+      const isFn = w === "function" || w === "class" || w === "catch";
+      if (isDecl || isFn) {
+        // `var a = 1, b = 2` → captura a lista inteira até `;` ou `)`.
+        let j = i;
+        let guard = 0;
+        while (j < n && guard < 4096) {
+          while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+          if (j < n && __isIdStart(src.substring(j, j + 1))) {
+            const s2 = j;
+            while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
+            const nm = src.substring(s2, j);
+            let dup = 0;
+            let k = 0;
+            while (k < out.length) { if (out[k] === nm) dup = 1; k = k + 1; }
+            if (dup === 0) out.push(nm);
+          }
+          // parâmetros: `function f(a, b)` — anda até `)` coletando nomes
+          while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+          const ch = j < n ? src.substring(j, j + 1) : "";
+          if (ch === "," ) { j = j + 1; guard = guard + 1; continue; }
+          if (ch === "(") { j = j + 1; guard = guard + 1; continue; }
+          if (ch === ")") { j = j + 1; break; }
+          if (ch === "=") {
+            // pula o inicializador até `,` ou `;` de profundidade 0
+            let p = 0; let b = 0; let br = 0;
+            while (j < n) {
+              const d = src.substring(j, j + 1);
+              if (d === "(") p = p + 1; else if (d === ")") { if (p === 0) break; p = p - 1; }
+              else if (d === "[") b = b + 1; else if (d === "]") b = b - 1;
+              else if (d === "{") br = br + 1; else if (d === "}") br = br - 1;
+              else if ((d === "," || d === ";") && p === 0 && b === 0 && br === 0) break;
+              j = j + 1;
+            }
+            if (j < n && src.substring(j, j + 1) === ",") { j = j + 1; guard = guard + 1; continue; }
+            break;
+          }
+          break;
+        }
+        i = j;
+        continue;
+      }
+      continue;
+    }
+    i = i + 1;
+  }
+  return out;
+}
+
+// Varre `src` pulando comentário e string, e devolve os nomes que aparecem como
+// `NOME =` (mas não `==`, `===`, `=>`, `>=`, `<=`, `!=`) sem `var`/`let`/`const`
+// imediatamente antes e sem `.` antes (que seria campo).
+function __scanImplicitGlobals(src: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src.substring(i, i + 1);
+    // comentário de linha / bloco
+    if (c === "/" && i + 1 < n) {
+      const c2 = src.substring(i + 1, i + 2);
+      if (c2 === "/") {
+        while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1;
+        continue;
+      }
+      if (c2 === "*") {
+        i = i + 2;
+        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        i = i + 2;
+        continue;
+      }
+    }
+    // string / template
+    if (c === "\"" || c === "'" || c === "`") {
+      const q = c;
+      i = i + 1;
+      while (i < n) {
+        const d = src.substring(i, i + 1);
+        if (d === "\\") { i = i + 2; continue; }
+        if (d === q) { i = i + 1; break; }
+        i = i + 1;
+      }
+      continue;
+    }
+    if (__isIdStart(c)) {
+      const start = i;
+      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
+      const word = src.substring(start, i);
+      // `.nome` é campo, não global
+      let p = start - 1;
+      while (p >= 0 && __isSpace(src.substring(p, p + 1))) p = p - 1;
+      const prevCh = p >= 0 ? src.substring(p, p + 1) : "";
+      if (prevCh === ".") continue;
+      // procura o `=` adiante
+      let j = i;
+      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+      if (j < n && src.substring(j, j + 1) === "=") {
+        const nx = j + 1 < n ? src.substring(j + 1, j + 2) : "";
+        // `==`/`===`/`=>` não são atribuição
+        if (nx !== "=" && nx !== ">" && prevCh !== "=" && prevCh !== "!"
+          && prevCh !== "<" && prevCh !== ">") {
+          // palavra-chave declarante imediatamente antes?
+          let we = p + 1;
+          let ws = we;
+          while (ws > 0 && __isIdPart(src.substring(ws - 1, ws))) ws = ws - 1;
+          const kw = src.substring(ws, we);
+          if (kw !== "var" && kw !== "let" && kw !== "const" && kw !== "function"
+            && kw !== "class" && kw !== "case" && kw !== "return") {
+            let dup = 0;
+            let k = 0;
+            while (k < out.length) { if (out[k] === word) dup = 1; k = k + 1; }
+            if (dup === 0) out.push(word);
+          }
+        }
+      }
+      continue;
+    }
+    i = i + 1;
+  }
+  return out;
+}
+
+// Reescreve toda ocorrência LIVRE de cada nome de `names` para `__G.<nome>`,
+// pulando string/comentário e não tocando em `a.nome` (campo) nem `{nome:` (chave).
+function __qualify(src: string, names: string[]): string {
+  if (names.length === 0) return src;
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src.substring(i, i + 1);
+    if (c === "/" && i + 1 < n) {
+      const c2 = src.substring(i + 1, i + 2);
+      if (c2 === "/") {
+        const s = i;
+        while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1;
+        out = out + src.substring(s, i);
+        continue;
+      }
+      if (c2 === "*") {
+        const s = i;
+        i = i + 2;
+        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        i = i + 2;
+        out = out + src.substring(s, i);
+        continue;
+      }
+    }
+    if (c === "\"" || c === "'" || c === "`") {
+      const q = c;
+      const s = i;
+      i = i + 1;
+      while (i < n) {
+        const d = src.substring(i, i + 1);
+        if (d === "\\") { i = i + 2; continue; }
+        if (d === q) { i = i + 1; break; }
+        i = i + 1;
+      }
+      out = out + src.substring(s, i);
+      continue;
+    }
+    if (__isIdStart(c)) {
+      const start = i;
+      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
+      const word = src.substring(start, i);
+      let hit = 0;
+      let k = 0;
+      while (k < names.length) { if (names[k] === word) hit = 1; k = k + 1; }
+      if (hit === 1) {
+        // `.nome` = campo → não qualifica
+        let p = start - 1;
+        while (p >= 0 && __isSpace(src.substring(p, p + 1))) p = p - 1;
+        const prevCh = p >= 0 ? src.substring(p, p + 1) : "";
+        // `nome:` = chave de objeto ou label → não qualifica
+        let j = i;
+        while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+        const nextCh = j < n ? src.substring(j, j + 1) : "";
+        if (prevCh === "." || nextCh === ":") out = out + word;
+        else out = out + "__G." + word;
+      } else {
+        out = out + word;
+      }
+      continue;
+    }
+    out = out + c;
+    i = i + 1;
+  }
+  return out;
+}
+
+// Pré-passo aplicado a todo `<script>` antes de compilar. Qualifica DUAS classes
+// de nome:
+//   (a) os que ESTE script cria sem declarar (`requireLazy = …`) — senão o
+//       compilador recusa com "assignment to unbound";
+//   (b) os que um script ANTERIOR já publicou no saco (`known`) e este apenas
+//       LÊ/CHAMA (`requireLazy([...], cb)`) — senão seria "unknown function".
+// (b) é o que transforma 33 ilhas num escopo só, como no browser.
+// ── `arguments` → rest param ──────────────────────────────────────────────────
+//
+// O motor não tem o objeto `arguments` (um ident livre desconhecido faz a
+// extração da função abortar — o erro sai como "expression arrow"). Mas SUPORTA
+// rest (`function(...a){}`). Para o uso dominante em loaders — repassar os args
+// adiante, `f=function(){stub.push(arguments)}` — as duas formas são
+// equivalentes, então reescrevemos:
+//
+//   function(){ … arguments … }   →   function(...__rtsargs){ … __rtsargs … }
+//
+// Só age em `function()` de lista de parâmetros VAZIA cujo corpo menciona
+// `arguments` (com parâmetros nomeados a equivalência não vale e deixamos como
+// está — falha honesta em vez de resultado errado). `arguments` é reservado como
+// NOME de parâmetro, daí o `__rtsargs`.
+function __rewriteArguments(src: string): string {
+  if (src.indexOf("arguments") < 0) return src;
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    // `function` seguido de `(` `)` vazio
+    if (src.substring(i, i + 8) === "function") {
+      let j = i + 8;
+      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+      // pula um nome opcional (function foo(){})
+      while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
+      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
+      if (j < n && src.substring(j, j + 1) === "(") {
+        let k = j + 1;
+        while (k < n && __isSpace(src.substring(k, k + 1))) k = k + 1;
+        if (k < n && src.substring(k, k + 1) === ")") {
+          // lista vazia: o corpo até a chave de fechamento menciona `arguments`?
+          const bodyStart = k + 1;
+          let b = bodyStart;
+          while (b < n && src.substring(b, b + 1) !== "{") b = b + 1;
+          let depth = 0;
+          let e = b;
+          while (e < n) {
+            const ch = src.substring(e, e + 1);
+            if (ch === "{") depth = depth + 1;
+            else if (ch === "}") { depth = depth - 1; if (depth === 0) break; }
+            e = e + 1;
+          }
+          const bodyTxt = src.substring(b, e + 1);
+          if (bodyTxt.indexOf("arguments") >= 0) {
+            // `src[i..j]` = "function[ nome]", depois abrimos a lista nós mesmos:
+            // `(...__rtsargs)` — o `)` original está em `k` e é descartado.
+            out = out + src.substring(i, j) + "(...__rtsargs)";
+            out = out + __replaceIdent(bodyTxt, "arguments", "__rtsargs");
+            i = e + 1;
+            continue;
+          }
+        }
+      }
+    }
+    out = out + src.substring(i, i + 1);
+    i = i + 1;
+  }
+  return out;
+}
+
+// Troca ocorrências do identificador `from` por `to` (só identificador inteiro,
+// não `.from` nem dentro de outro nome).
+function __replaceIdent(src: string, from: string, to: string): string {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src.substring(i, i + 1);
+    if (__isIdStart(c)) {
+      const s = i;
+      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
+      const w = src.substring(s, i);
+      let p = s - 1;
+      while (p >= 0 && __isSpace(src.substring(p, p + 1))) p = p - 1;
+      const prevCh = p >= 0 ? src.substring(p, p + 1) : "";
+      out = out + (w === from && prevCh !== "." ? to : w);
+      continue;
+    }
+    out = out + c;
+    i = i + 1;
+  }
+  return out;
+}
+
+// ── SEQUÊNCIA (`a=1, b=function(){}`) → statements ────────────────────────────
+//
+// O motor aceita o operador vírgula, e aceita `function` como valor — mas NÃO a
+// combinação `x=…, y=function(){…}` numa só expressão (a extração da função
+// aborta). Minificadores geram isso o tempo todo. Como no topo do script a
+// sequência é só "faça isto, depois aquilo", trocar a vírgula separadora por `;`
+// preserva a semântica. Só quebra vírgulas em profundidade ZERO de (), [], {} e
+// fora de string — as vírgulas de argumento/array/objeto ficam intactas.
+function __splitTopLevelSequences(src: string): string {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  let par = 0;
+  let brk = 0;
+  let brc = 0;
+  while (i < n) {
+    const c = src.substring(i, i + 1);
+    if (c === "/" && i + 1 < n) {
+      const c2 = src.substring(i + 1, i + 2);
+      if (c2 === "/") {
+        const s = i;
+        while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1;
+        out = out + src.substring(s, i);
+        continue;
+      }
+      if (c2 === "*") {
+        const s = i;
+        i = i + 2;
+        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        i = i + 2;
+        out = out + src.substring(s, i);
+        continue;
+      }
+    }
+    if (c === "\"" || c === "'" || c === "`") {
+      const q = c;
+      const s = i;
+      i = i + 1;
+      while (i < n) {
+        const d = src.substring(i, i + 1);
+        if (d === "\\") { i = i + 2; continue; }
+        if (d === q) { i = i + 1; break; }
+        i = i + 1;
+      }
+      out = out + src.substring(s, i);
+      continue;
+    }
+    if (c === "(") par = par + 1;
+    else if (c === ")") par = par - 1;
+    else if (c === "[") brk = brk + 1;
+    else if (c === "]") brk = brk - 1;
+    else if (c === "{") brc = brc + 1;
+    else if (c === "}") brc = brc - 1;
+    // vírgula separadora de sequência no topo → `;`
+    if (c === "," && par === 0 && brk === 0 && brc === 0) out = out + ";";
+    else out = out + c;
+    i = i + 1;
+  }
+  return out;
+}
+
+// Remove de `names` tudo que o script DECLARA (var/let/const/function/param).
+function __filterDeclared(names: string[], src: string): string[] {
+  if (names.length === 0) return names;
+  const decl = __scanDeclared(src);
+  const out: string[] = [];
+  let i = 0;
+  while (i < names.length) {
+    let hit = 0;
+    let k = 0;
+    while (k < decl.length) { if (decl[k] === names[i]) hit = 1; k = k + 1; }
+    if (hit === 0) out.push(names[i]);
+    i = i + 1;
+  }
+  return out;
+}
+
+function __bindGlobals(code: string, known: string[]): string {
+  // Normaliza PRIMEIRO e só então varre: o split de sequência transforma
+  // `a=1,b=2` em `a=1;b=2`, e é sobre essa forma que os nomes são detectados.
+  const normalized = __splitTopLevelSequences(__rewriteArguments(code));
+  const names = __filterDeclared(__scanImplicitGlobals(normalized), normalized);
+  // Acrescenta os já publicados que aparecem neste script — MENOS os que este
+  // script declara localmente (shadowing: um `const requireLazy = …` local ganha
+  // do global, como no browser).
+  const declared = __scanDeclared(normalized);
+  let i = 0;
+  while (i < known.length) {
+    const kn = known[i];
+    let dup = 0;
+    let k = 0;
+    while (k < names.length) { if (names[k] === kn) dup = 1; k = k + 1; }
+    let shadow = 0;
+    let s = 0;
+    while (s < declared.length) { if (declared[s] === kn) shadow = 1; s = s + 1; }
+    if (dup === 0 && shadow === 0) names.push(kn);
+    i = i + 1;
+  }
+  if (names.length === 0) return normalized;
+  return __qualify(normalized, names);
+}

--- a/crates/rts-dom/src/scriptscope.ts
+++ b/crates/rts-dom/src/scriptscope.ts
@@ -12,13 +12,16 @@
 //      traduzimos aqui, na borda que já tem semântica de browser, reescrevendo
 //      para o SACO DE GLOBAIS compartilhado do documento (`__G`, ver window.ts).
 //
-//   2. `arguments` — o motor não tem o objeto; um ident livre desconhecido faz a
-//      extração da função abortar. Mas SUPORTA rest, e para o uso dominante em
-//      loaders (repassar args adiante) as duas formas são equivalentes.
-//
-//   3. SEQUÊNCIA com função — o motor aceita o operador vírgula e aceita
+//   2. SEQUÊNCIA com função — o motor aceita o operador vírgula e aceita
 //      `function` como valor, mas não a combinação `x=…, y=function(){…}` numa só
 //      expressão; minificadores geram isso o tempo todo.
+//
+// `arguments` NÃO está mais aqui: o motor materializa o objeto sozinho, também em
+// função-EXPRESSÃO (`f = function(){ … arguments … }`) — `argsobj.rs` roda depois
+// do lifting de closures e `HirExprKind::Arrow.is_real_arrow` distingue uma arrow
+// de verdade (que não tem `arguments` próprio) de uma fn-expr (que tem). A
+// reescrita textual que existia aqui foi DELETADA: reimplementar por fora o que o
+// motor faz com AST é frágil e era o custo dominante de RAM (issue #2019).
 //
 // ## O que este módulo NÃO é
 // Não é um parser de JS. É um conjunto de reescritas TEXTUAIS conservadoras que
@@ -46,6 +49,55 @@
 // (`a.x`), chaves de objeto (`{x:…}`) e conteúdo de string/comentário não são
 // tocados.
 
+// ── Leitura de caractere SEM ALOCAR ──────────────────────────────────────────
+//
+// `src.substring(i, i + 1)` aloca uma STRING NOVA por caractere: varrer 200 KB
+// assim cria 200 mil handles, e o GC periódico não os recolhe (gatilho é
+// `GC_LIVE_FLOOR = 500_000` handles vivos). `charCodeAt` devolve um NÚMERO e
+// aloca ZERO — medido. Era o custo dominante deste pré-passo (issue #2019).
+const __CH_TAB = 9;
+const __CH_LF = 10;
+const __CH_CR = 13;
+const __CH_SPACE = 32;
+const __CH_BANG = 33;
+const __CH_QUOTE = 34;
+const __CH_DOLLAR = 36;
+const __CH_APOS = 39;
+const __CH_LPAREN = 40;
+const __CH_RPAREN = 41;
+const __CH_STAR = 42;
+const __CH_COMMA = 44;
+const __CH_DOT = 46;
+const __CH_SLASH = 47;
+const __CH_0 = 48;
+const __CH_9 = 57;
+const __CH_SEMI = 59;
+const __CH_LT = 60;
+const __CH_EQ = 61;
+const __CH_GT = 62;
+const __CH_A_UP = 65;
+const __CH_Z_UP = 90;
+const __CH_LBRACK = 91;
+const __CH_BACKSLASH = 92;
+const __CH_RBRACK = 93;
+const __CH_UNDER = 95;
+const __CH_BACKTICK = 96;
+const __CH_A_LO = 97;
+const __CH_Z_LO = 122;
+const __CH_LBRACE = 123;
+const __CH_RBRACE = 125;
+
+function __isIdStartCode(k: number): boolean {
+  return (k >= __CH_A_LO && k <= __CH_Z_LO) || (k >= __CH_A_UP && k <= __CH_Z_UP)
+    || k === __CH_UNDER || k === __CH_DOLLAR;
+}
+function __isIdPartCode(k: number): boolean {
+  return __isIdStartCode(k) || (k >= __CH_0 && k <= __CH_9);
+}
+function __isSpaceCode(k: number): boolean {
+  return k === __CH_SPACE || k === __CH_LF || k === __CH_TAB || k === __CH_CR;
+}
+
 function __isIdStart(c: string): boolean {
   return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c === "$";
 }
@@ -65,33 +117,33 @@ function __scanDeclared(src: string): string[] {
   let i = 0;
   const n = src.length;
   while (i < n) {
-    const c = src.substring(i, i + 1);
+    const c = src.charCodeAt(i);
     // pula comentário e string (um `var` dentro de texto não declara nada)
-    if (c === "/" && i + 1 < n) {
-      const c2 = src.substring(i + 1, i + 2);
-      if (c2 === "/") { while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1; continue; }
-      if (c2 === "*") {
+    if (c === __CH_SLASH && i + 1 < n) {
+      const c2 = src.charCodeAt(i + 1);
+      if (c2 === __CH_SLASH) { while (i < n && src.charCodeAt(i) !== __CH_LF) i = i + 1; continue; }
+      if (c2 === __CH_STAR) {
         i = i + 2;
-        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        while (i + 1 < n && !(src.charCodeAt(i) === __CH_STAR && src.charCodeAt(i + 1) === __CH_SLASH)) i = i + 1;
         i = i + 2;
         continue;
       }
     }
-    if (c === "\"" || c === "'" || c === "`") {
+    if (c === __CH_QUOTE || c === __CH_APOS || c === __CH_BACKTICK) {
       const q = c;
       i = i + 1;
       while (i < n) {
-        const d = src.substring(i, i + 1);
-        if (d === "\\") { i = i + 2; continue; }
+        const d = src.charCodeAt(i);
+        if (d === __CH_BACKSLASH) { i = i + 2; continue; }
         if (d === q) { i = i + 1; break; }
         i = i + 1;
       }
       continue;
     }
-    if (__isIdStart(c)) {
-      const s = i;
-      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
-      const w = src.substring(s, i);
+    if (__isIdStartCode(c)) {
+      const s0 = i;
+      while (i < n && __isIdPartCode(src.charCodeAt(i))) i = i + 1;
+      const w = src.substring(s0, i);
       const isDecl = w === "var" || w === "let" || w === "const";
       const isFn = w === "function" || w === "class" || w === "catch";
       if (isDecl || isFn) {
@@ -99,10 +151,10 @@ function __scanDeclared(src: string): string[] {
         let j = i;
         let guard = 0;
         while (j < n && guard < 4096) {
-          while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-          if (j < n && __isIdStart(src.substring(j, j + 1))) {
+          while (j < n && __isSpaceCode(src.charCodeAt(j))) j = j + 1;
+          if (j < n && __isIdStartCode(src.charCodeAt(j))) {
             const s2 = j;
-            while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
+            while (j < n && __isIdPartCode(src.charCodeAt(j))) j = j + 1;
             const nm = src.substring(s2, j);
             let dup = 0;
             let k = 0;
@@ -110,23 +162,23 @@ function __scanDeclared(src: string): string[] {
             if (dup === 0) out.push(nm);
           }
           // parâmetros: `function f(a, b)` — anda até `)` coletando nomes
-          while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-          const ch = j < n ? src.substring(j, j + 1) : "";
-          if (ch === "," ) { j = j + 1; guard = guard + 1; continue; }
-          if (ch === "(") { j = j + 1; guard = guard + 1; continue; }
-          if (ch === ")") { j = j + 1; break; }
-          if (ch === "=") {
+          while (j < n && __isSpaceCode(src.charCodeAt(j))) j = j + 1;
+          const ch = j < n ? src.charCodeAt(j) : 0;
+          if (ch === __CH_COMMA) { j = j + 1; guard = guard + 1; continue; }
+          if (ch === __CH_LPAREN) { j = j + 1; guard = guard + 1; continue; }
+          if (ch === __CH_RPAREN) { j = j + 1; break; }
+          if (ch === __CH_EQ) {
             // pula o inicializador até `,` ou `;` de profundidade 0
             let p = 0; let b = 0; let br = 0;
             while (j < n) {
-              const d = src.substring(j, j + 1);
-              if (d === "(") p = p + 1; else if (d === ")") { if (p === 0) break; p = p - 1; }
-              else if (d === "[") b = b + 1; else if (d === "]") b = b - 1;
-              else if (d === "{") br = br + 1; else if (d === "}") br = br - 1;
-              else if ((d === "," || d === ";") && p === 0 && b === 0 && br === 0) break;
+              const d = src.charCodeAt(j);
+              if (d === __CH_LPAREN) p = p + 1; else if (d === __CH_RPAREN) { if (p === 0) break; p = p - 1; }
+              else if (d === __CH_LBRACK) b = b + 1; else if (d === __CH_RBRACK) b = b - 1;
+              else if (d === __CH_LBRACE) br = br + 1; else if (d === __CH_RBRACE) br = br - 1;
+              else if ((d === __CH_COMMA || d === __CH_SEMI) && p === 0 && b === 0 && br === 0) break;
               j = j + 1;
             }
-            if (j < n && src.substring(j, j + 1) === ",") { j = j + 1; guard = guard + 1; continue; }
+            if (j < n && src.charCodeAt(j) === __CH_COMMA) { j = j + 1; guard = guard + 1; continue; }
             break;
           }
           break;
@@ -149,54 +201,54 @@ function __scanImplicitGlobals(src: string): string[] {
   let i = 0;
   const n = src.length;
   while (i < n) {
-    const c = src.substring(i, i + 1);
+    const c = src.charCodeAt(i);
     // comentário de linha / bloco
-    if (c === "/" && i + 1 < n) {
-      const c2 = src.substring(i + 1, i + 2);
-      if (c2 === "/") {
-        while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1;
+    if (c === __CH_SLASH && i + 1 < n) {
+      const c2 = src.charCodeAt(i + 1);
+      if (c2 === __CH_SLASH) {
+        while (i < n && src.charCodeAt(i) !== __CH_LF) i = i + 1;
         continue;
       }
-      if (c2 === "*") {
+      if (c2 === __CH_STAR) {
         i = i + 2;
-        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        while (i + 1 < n && !(src.charCodeAt(i) === __CH_STAR && src.charCodeAt(i + 1) === __CH_SLASH)) i = i + 1;
         i = i + 2;
         continue;
       }
     }
     // string / template
-    if (c === "\"" || c === "'" || c === "`") {
+    if (c === __CH_QUOTE || c === __CH_APOS || c === __CH_BACKTICK) {
       const q = c;
       i = i + 1;
       while (i < n) {
-        const d = src.substring(i, i + 1);
-        if (d === "\\") { i = i + 2; continue; }
+        const d = src.charCodeAt(i);
+        if (d === __CH_BACKSLASH) { i = i + 2; continue; }
         if (d === q) { i = i + 1; break; }
         i = i + 1;
       }
       continue;
     }
-    if (__isIdStart(c)) {
+    if (__isIdStartCode(c)) {
       const start = i;
-      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
+      while (i < n && __isIdPartCode(src.charCodeAt(i))) i = i + 1;
       const word = src.substring(start, i);
       // `.nome` é campo, não global
       let p = start - 1;
-      while (p >= 0 && __isSpace(src.substring(p, p + 1))) p = p - 1;
-      const prevCh = p >= 0 ? src.substring(p, p + 1) : "";
-      if (prevCh === ".") continue;
+      while (p >= 0 && __isSpaceCode(src.charCodeAt(p))) p = p - 1;
+      const prevCh = p >= 0 ? src.charCodeAt(p) : 0;
+      if (prevCh === __CH_DOT) continue;
       // procura o `=` adiante
       let j = i;
-      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-      if (j < n && src.substring(j, j + 1) === "=") {
-        const nx = j + 1 < n ? src.substring(j + 1, j + 2) : "";
+      while (j < n && __isSpaceCode(src.charCodeAt(j))) j = j + 1;
+      if (j < n && src.charCodeAt(j) === __CH_EQ) {
+        const nx = j + 1 < n ? src.charCodeAt(j + 1) : 0;
         // `==`/`===`/`=>` não são atribuição
-        if (nx !== "=" && nx !== ">" && prevCh !== "=" && prevCh !== "!"
-          && prevCh !== "<" && prevCh !== ">") {
+        if (nx !== __CH_EQ && nx !== __CH_GT && prevCh !== __CH_EQ && prevCh !== __CH_BANG
+          && prevCh !== __CH_LT && prevCh !== __CH_GT) {
           // palavra-chave declarante imediatamente antes?
           let we = p + 1;
           let ws = we;
-          while (ws > 0 && __isIdPart(src.substring(ws - 1, ws))) ws = ws - 1;
+          while (ws > 0 && __isIdPartCode(src.charCodeAt(ws - 1))) ws = ws - 1;
           const kw = src.substring(ws, we);
           if (kw !== "var" && kw !== "let" && kw !== "const" && kw !== "function"
             && kw !== "class" && kw !== "case" && kw !== "return") {
@@ -289,90 +341,6 @@ function __qualify(src: string, names: string[]): string {
 //   (b) os que um script ANTERIOR já publicou no saco (`known`) e este apenas
 //       LÊ/CHAMA (`requireLazy([...], cb)`) — senão seria "unknown function".
 // (b) é o que transforma 33 ilhas num escopo só, como no browser.
-// ── `arguments` → rest param ──────────────────────────────────────────────────
-//
-// O motor não tem o objeto `arguments` (um ident livre desconhecido faz a
-// extração da função abortar — o erro sai como "expression arrow"). Mas SUPORTA
-// rest (`function(...a){}`). Para o uso dominante em loaders — repassar os args
-// adiante, `f=function(){stub.push(arguments)}` — as duas formas são
-// equivalentes, então reescrevemos:
-//
-//   function(){ … arguments … }   →   function(...__rtsargs){ … __rtsargs … }
-//
-// Só age em `function()` de lista de parâmetros VAZIA cujo corpo menciona
-// `arguments` (com parâmetros nomeados a equivalência não vale e deixamos como
-// está — falha honesta em vez de resultado errado). `arguments` é reservado como
-// NOME de parâmetro, daí o `__rtsargs`.
-function __rewriteArguments(src: string): string {
-  if (src.indexOf("arguments") < 0) return src;
-  let out = "";
-  let i = 0;
-  const n = src.length;
-  while (i < n) {
-    // `function` seguido de `(` `)` vazio
-    if (src.substring(i, i + 8) === "function") {
-      let j = i + 8;
-      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-      // pula um nome opcional (function foo(){})
-      while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
-      while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-      if (j < n && src.substring(j, j + 1) === "(") {
-        let k = j + 1;
-        while (k < n && __isSpace(src.substring(k, k + 1))) k = k + 1;
-        if (k < n && src.substring(k, k + 1) === ")") {
-          // lista vazia: o corpo até a chave de fechamento menciona `arguments`?
-          const bodyStart = k + 1;
-          let b = bodyStart;
-          while (b < n && src.substring(b, b + 1) !== "{") b = b + 1;
-          let depth = 0;
-          let e = b;
-          while (e < n) {
-            const ch = src.substring(e, e + 1);
-            if (ch === "{") depth = depth + 1;
-            else if (ch === "}") { depth = depth - 1; if (depth === 0) break; }
-            e = e + 1;
-          }
-          const bodyTxt = src.substring(b, e + 1);
-          if (bodyTxt.indexOf("arguments") >= 0) {
-            // `src[i..j]` = "function[ nome]", depois abrimos a lista nós mesmos:
-            // `(...__rtsargs)` — o `)` original está em `k` e é descartado.
-            out = out + src.substring(i, j) + "(...__rtsargs)";
-            out = out + __replaceIdent(bodyTxt, "arguments", "__rtsargs");
-            i = e + 1;
-            continue;
-          }
-        }
-      }
-    }
-    out = out + src.substring(i, i + 1);
-    i = i + 1;
-  }
-  return out;
-}
-
-// Troca ocorrências do identificador `from` por `to` (só identificador inteiro,
-// não `.from` nem dentro de outro nome).
-function __replaceIdent(src: string, from: string, to: string): string {
-  let out = "";
-  let i = 0;
-  const n = src.length;
-  while (i < n) {
-    const c = src.substring(i, i + 1);
-    if (__isIdStart(c)) {
-      const s = i;
-      while (i < n && __isIdPart(src.substring(i, i + 1))) i = i + 1;
-      const w = src.substring(s, i);
-      let p = s - 1;
-      while (p >= 0 && __isSpace(src.substring(p, p + 1))) p = p - 1;
-      const prevCh = p >= 0 ? src.substring(p, p + 1) : "";
-      out = out + (w === from && prevCh !== "." ? to : w);
-      continue;
-    }
-    out = out + c;
-    i = i + 1;
-  }
-  return out;
-}
 
 // ── SEQUÊNCIA (`a=1, b=function(){}`) → statements ────────────────────────────
 //
@@ -383,62 +351,69 @@ function __replaceIdent(src: string, from: string, to: string): string {
 // preserva a semântica. Só quebra vírgulas em profundidade ZERO de (), [], {} e
 // fora de string — as vírgulas de argumento/array/objeto ficam intactas.
 function __splitTopLevelSequences(src: string): string {
+  // Saída rápida: sem vírgula NENHUMA não há sequência a quebrar, e reconstruir
+  // o texto só para devolvê-lo igual seria lixo puro no heap (issue #2019).
+  if (src.indexOf(",") < 0) return src;
   let out = "";
   let i = 0;
+  let copiado = 0;   // tudo em [copiado, …) ainda não foi para `out`
   const n = src.length;
   let par = 0;
   let brk = 0;
   let brc = 0;
   while (i < n) {
-    const c = src.substring(i, i + 1);
-    if (c === "/" && i + 1 < n) {
-      const c2 = src.substring(i + 1, i + 2);
-      if (c2 === "/") {
-        const s = i;
-        while (i < n && src.substring(i, i + 1) !== "\n") i = i + 1;
-        out = out + src.substring(s, i);
+    const c = src.charCodeAt(i);
+    if (c === __CH_SLASH && i + 1 < n) {
+      const c2 = src.charCodeAt(i + 1);
+      if (c2 === __CH_SLASH) {
+        while (i < n && src.charCodeAt(i) !== __CH_LF) i = i + 1;
         continue;
       }
-      if (c2 === "*") {
-        const s = i;
+      if (c2 === __CH_STAR) {
         i = i + 2;
-        while (i + 1 < n && !(src.substring(i, i + 1) === "*" && src.substring(i + 1, i + 2) === "/")) i = i + 1;
+        while (i + 1 < n && !(src.charCodeAt(i) === __CH_STAR && src.charCodeAt(i + 1) === __CH_SLASH)) i = i + 1;
         i = i + 2;
-        out = out + src.substring(s, i);
         continue;
       }
     }
-    if (c === "\"" || c === "'" || c === "`") {
+    if (c === __CH_QUOTE || c === __CH_APOS || c === __CH_BACKTICK) {
       const q = c;
-      const s = i;
       i = i + 1;
       while (i < n) {
-        const d = src.substring(i, i + 1);
-        if (d === "\\") { i = i + 2; continue; }
+        const d = src.charCodeAt(i);
+        if (d === __CH_BACKSLASH) { i = i + 2; continue; }
         if (d === q) { i = i + 1; break; }
         i = i + 1;
       }
-      out = out + src.substring(s, i);
       continue;
     }
-    if (c === "(") par = par + 1;
-    else if (c === ")") par = par - 1;
-    else if (c === "[") brk = brk + 1;
-    else if (c === "]") brk = brk - 1;
-    else if (c === "{") brc = brc + 1;
-    else if (c === "}") brc = brc - 1;
-    // vírgula separadora de sequência no topo → `;`
-    if (c === "," && par === 0 && brk === 0 && brc === 0) out = out + ";";
-    else out = out + c;
+    if (c === __CH_LPAREN) par = par + 1;
+    else if (c === __CH_RPAREN) par = par - 1;
+    else if (c === __CH_LBRACK) brk = brk + 1;
+    else if (c === __CH_RBRACK) brk = brk - 1;
+    else if (c === __CH_LBRACE) brc = brc + 1;
+    else if (c === __CH_RBRACE) brc = brc - 1;
+    // vírgula separadora de sequência no topo → `;`. Só AQUI o texto muda:
+    // descarrega em BLOCO o trecho intocado e emite `;` no lugar da vírgula.
+    if (c === __CH_COMMA && par === 0 && brk === 0 && brc === 0) {
+      out = out + src.substring(copiado, i) + ";";
+      copiado = i + 1;
+    }
     i = i + 1;
   }
-  return out;
+  return out + src.substring(copiado, n);
 }
 
 // Remove de `names` tudo que o script DECLARA (var/let/const/function/param).
 function __filterDeclared(names: string[], src: string): string[] {
   if (names.length === 0) return names;
-  const decl = __scanDeclared(src);
+  return __filterComDeclarados(names, __scanDeclared(src));
+}
+
+// Como `__filterDeclared`, mas com a lista de declarados JÁ pronta — evita
+// varrer o mesmo texto de novo.
+function __filterComDeclarados(names: string[], decl: string[]): string[] {
+  if (names.length === 0) return names;
   const out: string[] = [];
   let i = 0;
   while (i < names.length) {
@@ -468,52 +443,67 @@ function __filterDeclared(names: string[], src: string): string[] {
 // do script fica intacto.
 function __unqualifyInstanceof(src: string): string {
   if (src.indexOf("instanceof") < 0) return src;
+  // Só age em `instanceof <global>.Classe`. Ter um `instanceof` qualquer não
+  // basta: sem o nome de um objeto global adiante, varrer reconstruiria o texto
+  // para devolvê-lo IGUAL. Num bundle real `instanceof` é comum e a forma com
+  // objeto global é rara (issue #2019).
+  if (src.indexOf("window.") < 0 && src.indexOf("globalThis.") < 0
+    && src.indexOf("self.") < 0 && src.indexOf("top.") < 0
+    && src.indexOf("parent.") < 0) {
+    return src;
+  }
   let out = "";
   let i = 0;
+  let copiado = 0;   // tudo em [copiado, …) ainda não foi para `out`
   const n = src.length;
   while (i < n) {
-    if (src.substring(i, i + 10) === "instanceof") {
-      // precisa ser o token inteiro (não sufixo de um identificador maior)
-      const antes = i > 0 ? src.substring(i - 1, i) : "";
-      const depois = i + 10 < n ? src.substring(i + 10, i + 11) : "";
-      if (!__isIdPart(antes) && !__isIdPart(depois)) {
-        let j = i + 10;
-        while (j < n && __isSpace(src.substring(j, j + 1))) j = j + 1;
-        const baseStart = j;
-        while (j < n && __isIdPart(src.substring(j, j + 1))) j = j + 1;
-        const base = src.substring(baseStart, j);
-        const ehGlobal = base === "window" || base === "globalThis"
-          || base === "self" || base === "top" || base === "parent";
-        if (ehGlobal && j < n && src.substring(j, j + 1) === ".") {
-          // `instanceof window.Classe` → mantém só `Classe`
-          out = out + src.substring(i, i + 10) + " ";
-          i = j + 1;
-          continue;
-        }
+    // Salta direto para o próximo `instanceof`; o texto entre um e outro sai
+    // depois num bloco só — copiar char-a-char era o custo dominante.
+    const t = src.indexOf("instanceof", i);
+    if (t < 0) break;
+    i = t;
+    // precisa ser o token inteiro (não sufixo de um identificador maior)
+    const antes = i > 0 ? src.charCodeAt(i - 1) : 0;
+    const depois = i + 10 < n ? src.charCodeAt(i + 10) : 0;
+    if (!__isIdPartCode(antes) && !__isIdPartCode(depois)) {
+      let j = i + 10;
+      while (j < n && __isSpaceCode(src.charCodeAt(j))) j = j + 1;
+      const baseStart = j;
+      while (j < n && __isIdPartCode(src.charCodeAt(j))) j = j + 1;
+      const base = src.substring(baseStart, j);
+      const ehGlobal = base === "window" || base === "globalThis"
+        || base === "self" || base === "top" || base === "parent";
+      if (ehGlobal && j < n && src.charCodeAt(j) === __CH_DOT) {
+        // `instanceof window.Classe` → mantém só `Classe`
+        out = out + src.substring(copiado, i + 10) + " ";
+        i = j + 1;
+        copiado = i;
+        continue;
       }
     }
-    out = out + src.substring(i, i + 1);
-    i = i + 1;
+    i = i + 10;
   }
-  return out;
+  return out + src.substring(copiado, n);
 }
 
 // TODA a normalização sintática, num lugar só — o `runScripts` e o `__bindGlobals`
 // precisam enxergar exatamente o mesmo texto (os nomes detectados têm de bater
 // com o texto que vai ser compilado).
 function __normalizeScript(code: string): string {
-  return __unqualifyInstanceof(__splitTopLevelSequences(__rewriteArguments(code)));
+  return __unqualifyInstanceof(__splitTopLevelSequences(code));
 }
 
 function __bindGlobals(code: string, known: string[]): string {
   // Normaliza PRIMEIRO e só então varre: o split de sequência transforma
   // `a=1,b=2` em `a=1;b=2`, e é sobre essa forma que os nomes são detectados.
   const normalized = __normalizeScript(code);
-  const names = __filterDeclared(__scanImplicitGlobals(normalized), normalized);
+  // `__scanDeclared` roda UMA vez e serve aos dois usos (o filtro abaixo e o
+  // shadowing): varrer o mesmo texto duas vezes era custo puro em JS minificado.
+  const declared = __scanDeclared(normalized);
   // Acrescenta os já publicados que aparecem neste script — MENOS os que este
   // script declara localmente (shadowing: um `const requireLazy = …` local ganha
   // do global, como no browser).
-  const declared = __scanDeclared(normalized);
+  const names = __filterComDeclarados(__scanImplicitGlobals(normalized), declared);
   let i = 0;
   while (i < known.length) {
     const kn = known[i];

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -261,3 +261,81 @@ class WindowImpl {
 function __makeWindow(domHandle: i64, url: string, vw: number, vh: number): WindowImpl {
   return new WindowImpl(domHandle, url, vw, vh);
 }
+
+// ── ESCOPO GLOBAL COMPARTILHADO ENTRE OS <script> DO MESMO DOCUMENTO ──────────
+//
+// Num browser, TODOS os <script> de uma página compartilham UM único objeto
+// global: o script A define `requireLazy = ...` e o script B, compilado depois,
+// enxerga. Sem isso cada <script> é uma ilha — foi exatamente o que reprovou o
+// boot do WhatsApp/Meta (1 de 33 scripts rodava: o loader `requireLazy` nascia
+// no script 2 e morria com ele, e os 28 seguintes caíam em "unknown function").
+//
+// O modelo aqui: um `window` VIVO por documento (`__winFor`) + um SACO DE
+// GLOBAIS (`__G`) que é um objeto simples — o motor aceita propriedade dinâmica
+// num objeto literal (`g.foo = fn` e `g.foo()` despacham), então o saco carrega
+// o que os scripts criam em tempo de execução, que é o que uma classe `WindowImpl`
+// (shape fixo) não consegue carregar.
+//
+// Os dois vivem enquanto o documento viver, chaveados pelo handle do DOM.
+
+// `handle do DOM → window vivo`. Arrays paralelos (o motor lida melhor com
+// arrays de primitivo/handle do que com Map de objeto neste caminho dinâmico).
+const __winKeys: i64[] = [];
+const __winVals: any[] = [];
+const __gVals: any[] = [];
+// Nomes já PUBLICADOS no saco por scripts anteriores do mesmo documento (um
+// array de nomes por documento). É o que permite ao script N+1 CHAMAR o que o
+// script N criou: `__bindGlobals` qualifica essas leituras para `__G.<nome>`.
+const __gNames: any[] = [];
+
+// Índice do documento `h` nas tabelas acima; -1 se ainda não tem.
+function __winIndex(h: i64): number {
+  let i = 0;
+  while (i < __winKeys.length) {
+    if (__winKeys[i] === h) return i;
+    i = i + 1;
+  }
+  return -1;
+}
+
+// `window` PERSISTENTE do documento `h` — criado na primeira chamada e REUSADO
+// por todos os <script> seguintes (é o que faz `window.x = 1` num script ser
+// visível no próximo, como no browser).
+function __winFor(h: i64, url: string, vw: number, vh: number): WindowImpl {
+  const idx = __winIndex(h);
+  if (idx >= 0) return __winVals[idx];
+  const w = new WindowImpl(h, url, vw, vh);
+  __winKeys.push(h);
+  __winVals.push(w);
+  __gVals.push({});
+  __gNames.push([]);
+  return w;
+}
+
+// Os nomes globais já publicados no documento `h` (lista viva; `runScripts`
+// acrescenta os que cada script cria).
+function __globalNames(h: i64, url: string, vw: number, vh: number): string[] {
+  const idx = __winIndex(h);
+  if (idx >= 0) return __gNames[idx];
+  __winFor(h, url, vw, vh);
+  return __gNames[__winIndex(h)];
+}
+
+// O SACO DE GLOBAIS do documento `h` (o objeto onde moram os globais que os
+// scripts criam em runtime: `requireLazy`, `__d`, `_btldr`, …).
+function __globalsFor(h: i64, url: string, vw: number, vh: number): any {
+  const idx = __winIndex(h);
+  if (idx >= 0) return __gVals[idx];
+  __winFor(h, url, vw, vh);
+  return __gVals[__winIndex(h)];
+}
+
+// Descarta o escopo global do documento `h` (chamado no `free` do documento).
+function __dropWindow(h: i64): void {
+  const idx = __winIndex(h);
+  if (idx < 0) return;
+  __winKeys.splice(idx, 1);
+  __winVals.splice(idx, 1);
+  __gVals.splice(idx, 1);
+  __gNames.splice(idx, 1);
+}

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -256,26 +256,11 @@ class WindowImpl {
   queueMicrotask(cb: any): void { queueMicrotask(cb); }
 }
 
-// `Node` — as CONSTANTES de nodeType do DOM. Scripts de boot fazem
-// `if (n.nodeType !== Node.ELEMENT_NODE) return` antes de tocar num nó; sem a
-// classe o script inteiro morria em "unbound identifier `Node`". Os valores são
-// os da spec, e batem com o que `el.nodeType` devolve.
-// Membros ESTÁTICOS (não uma instância global): `const Node = new …` viraria um
-// singleton promovido a gcell, e o gcell é estado do PROGRAMA — entre duas
-// compilações dinâmicas (dois `runScripts` de documentos diferentes) ele vazava
-// e embaralhava o programa seguinte. `static` é a forma correta aqui de qualquer
-// modo: no browser `Node.ELEMENT_NODE` é propriedade da própria classe.
-class Node {
-  static get ELEMENT_NODE(): number { return 1; }
-  static get ATTRIBUTE_NODE(): number { return 2; }
-  static get TEXT_NODE(): number { return 3; }
-  static get CDATA_SECTION_NODE(): number { return 4; }
-  static get PROCESSING_INSTRUCTION_NODE(): number { return 7; }
-  static get COMMENT_NODE(): number { return 8; }
-  static get DOCUMENT_NODE(): number { return 9; }
-  static get DOCUMENT_TYPE_NODE(): number { return 10; }
-  static get DOCUMENT_FRAGMENT_NODE(): number { return 11; }
-}
+// `Node` (as constantes de nodeType) vive em RUST: `rts-shared/src/globals/
+// node_constants`, declarado com `#[rtse::constant(global = "Node")]`. Constante
+// numérica atravessa a borda sem problema, então não há razão para ficar aqui.
+// (O `MutationObserver` abaixo guarda um CALLBACK — objeto JS vivo, que não
+// atravessa — e por isso continua no `.ts`.)
 
 // `MutationObserver` — observa mutações da árvore. Implementação HONESTA e
 // PARCIAL: registra o callback e `observe`/`disconnect`/`takeRecords` existem

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -358,13 +358,31 @@ function __globalNames(h: i64, url: string, vw: number, vh: number): string[] {
   return __gNames[__winIndex(h)];
 }
 
-// O SACO DE GLOBAIS do documento `h` (o objeto onde moram os globais que os
-// scripts criam em runtime: `requireLazy`, `__d`, `_btldr`, …).
+// O SACO DE GLOBAIS do documento `h` — onde moram os globais que os scripts
+// criam em runtime (`requireLazy`, `__d`, `_btldr`, …).
 function __globalsFor(h: i64, url: string, vw: number, vh: number): any {
-  const idx = __winIndex(h);
-  if (idx >= 0) return __gVals[idx];
-  __winFor(h, url, vw, vh);
-  return __gVals[__winIndex(h)];
+  // O saco vive em RUST (`scriptscope.rs`), num `thread_local` compartilhado
+  // ENTRE PROGRAMAS — cada `new Function` é um programa novo, então um saco
+  // `.ts` seria por-programa e o script N+1 não veria o do script N. Aqui ele é
+  // um Proxy cujas traps caem direto no registro; o valor viaja como `Poly`
+  // (word tagueada, sem coerção — com `f64` uma função vira `undefined`).
+  //
+  // O handle é CAPTURADO léxicamente (`const doc = h`), nunca repassado como
+  // parâmetro para outra função `.ts`: handle via parâmetro corrompe (#1870 —
+  // medido aqui: `DomScope.count(h)` direto devolve 1, via param devolve 0).
+  const doc: i64 = h;
+  return new Proxy({}, {
+    get: function (alvo: any, chave: any) {
+      return DomScope.get(doc, "" + chave);
+    },
+    set: function (alvo: any, chave: any, valor: any) {
+      DomScope.set(doc, "" + chave, valor);
+      return true;
+    },
+    has: function (alvo: any, chave: any) {
+      return DomScope.has(doc, "" + chave) === 1;
+    },
+  });
 }
 
 // Descarta o escopo global do documento `h` (chamado no `free` do documento).

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -256,6 +256,58 @@ class WindowImpl {
   queueMicrotask(cb: any): void { queueMicrotask(cb); }
 }
 
+// `Node` — as CONSTANTES de nodeType do DOM. Scripts de boot fazem
+// `if (n.nodeType !== Node.ELEMENT_NODE) return` antes de tocar num nó; sem a
+// classe o script inteiro morria em "unbound identifier `Node`". Os valores são
+// os da spec, e batem com o que `el.nodeType` devolve.
+// Membros ESTÁTICOS (não uma instância global): `const Node = new …` viraria um
+// singleton promovido a gcell, e o gcell é estado do PROGRAMA — entre duas
+// compilações dinâmicas (dois `runScripts` de documentos diferentes) ele vazava
+// e embaralhava o programa seguinte. `static` é a forma correta aqui de qualquer
+// modo: no browser `Node.ELEMENT_NODE` é propriedade da própria classe.
+class Node {
+  static get ELEMENT_NODE(): number { return 1; }
+  static get ATTRIBUTE_NODE(): number { return 2; }
+  static get TEXT_NODE(): number { return 3; }
+  static get CDATA_SECTION_NODE(): number { return 4; }
+  static get PROCESSING_INSTRUCTION_NODE(): number { return 7; }
+  static get COMMENT_NODE(): number { return 8; }
+  static get DOCUMENT_NODE(): number { return 9; }
+  static get DOCUMENT_TYPE_NODE(): number { return 10; }
+  static get DOCUMENT_FRAGMENT_NODE(): number { return 11; }
+}
+
+// `MutationObserver` — observa mutações da árvore. Implementação HONESTA e
+// PARCIAL: registra o callback e `observe`/`disconnect`/`takeRecords` existem
+// com a assinatura certa, mas NÃO há entrega automática de mutações (o DOM não
+// emite notificação de mudança ainda).
+//
+// Por que existe assim: o padrão dominante no boot de uma página é
+// `new MutationObserver(cb); o.observe(html, {...})` para reagir a nós FUTUROS.
+// Sem a classe, o `new` derruba o script inteiro — e com ele todo o resto do
+// bootstrap, que não tem nada a ver com mutação. Com o stub, o script roda e só
+// a reação a mutação futura fica inerte. É a mesma escolha do browser para uma
+// página sem mutações: o callback simplesmente não dispara.
+//
+// Quando o DOM ganhar notificação de mutação, `__deliver` é o ponto de entrada:
+// o resto da API já está no lugar.
+class MutationObserver {
+  _cb: any;
+  _alvos: number[];
+  constructor(cb: any) {
+    this._cb = cb;
+    this._alvos = [];
+  }
+  // `observe(target, options)` — registra o alvo. As opções (childList/subtree/
+  // attributes) são aceitas e guardadas implicitamente pelo registro.
+  observe(target: any, options: any): void {
+    this._alvos.push(1);
+  }
+  disconnect(): void { this._alvos = []; }
+  // Sem fila de mutação ainda: nunca há registro pendente.
+  takeRecords(): any[] { return []; }
+}
+
 // Fábrica usada pelo `runScripts` para injetar o window num <script>. `vw/vh` são
 // o viewport (o host passa; default 1000x800 quando não sabe).
 function __makeWindow(domHandle: i64, url: string, vw: number, vh: number): WindowImpl {

--- a/crates/rts-hir/src/ir.rs
+++ b/crates/rts-hir/src/ir.rs
@@ -338,6 +338,13 @@ pub enum HirExprKind {
         /// references to the synthesized top-level name, making self-recursive
         /// named fn-exprs liftable. `None` for arrows / anonymous fn-exprs.
         self_name: Option<String>,
+        /// `true` só para uma ARROW de verdade (`() => …`); `false` para uma
+        /// function-expression (`function(){…}`) e para uma `function` aninhada.
+        /// A distinção importa porque uma arrow NÃO tem `arguments` próprio (lê o
+        /// da função envolvente), enquanto uma fn-expr tem — e é o que permite ao
+        /// `argsobj` materializá-lo em vez de o pré-passo do DOM reescrever o
+        /// texto por fora.
+        is_real_arrow: bool,
         /// `async () => …` / `async function … {}` (expression or nested decl):
         /// the extraction pass lifts it to a top-level `HirFunc` with
         /// `is_async = true`, and the CALL-SITE spawn (`lower_async_spawn`)

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -274,6 +274,7 @@ fn lower_decl(decl: &swc::Decl, scope: &mut Scope, raw_text: &str) -> HirStmt {
                     // declaration name — same binding rule as a named fn-expr.
                     self_name: Some(fd.ident.sym.to_string()),
                     is_async: fd.function.is_async,
+                    is_real_arrow: false,
                 },
                 HirType::Function {
                     params: vec![],
@@ -616,6 +617,7 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                     body,
                     self_name: None,
                     is_async: arrow.is_async,
+                    is_real_arrow: true,
                 },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )
@@ -666,6 +668,7 @@ pub fn lower_swc_expr(e: &swc::Expr, scope: &Scope) -> HirExpr {
                     body,
                     self_name: fn_expr.ident.as_ref().map(|i| i.sym.to_string()),
                     is_async: func.is_async,
+                    is_real_arrow: false,
                 },
                 HirType::Function { params: vec![], ret: Box::new(ret) },
             )

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -22,6 +22,7 @@ pub use rts_std::globals::events;
 pub use rts_std::globals::fetch;
 pub use rts_std::globals::form_data;
 pub use rts_std::globals::headers;
+pub use rts_std::globals::storage;
 pub use rts_std::globals::streams;
 pub use rts_primitives::finalization_registry;
 pub use rts_primitives::function;

--- a/crates/rts-runtime/src/namespaces/globals/mod.rs
+++ b/crates/rts-runtime/src/namespaces/globals/mod.rs
@@ -9,6 +9,7 @@ pub use rts_primitives::boolean;
 pub use rts_std::globals::console;
 pub use rts_shared::globals::date;
 pub use rts_shared::globals::dom_exception;
+pub use rts_shared::globals::node_constants;
 pub use rts_shared::globals::point;
 pub use rts_shared::globals::point3;
 pub use rts_primitives::number;

--- a/crates/rts-shared/src/globals/mod.rs
+++ b/crates/rts-shared/src/globals/mod.rs
@@ -11,6 +11,7 @@
 // bigint: register_bigint_class_spec removido (DRAIN_MOTOR) — nunca chamado;
 // BigInt real é PRIMORDIAL via rts_runtime::adapters::value::taops (registry_build.rs).
 // number → PRIMORDIAL: movido p/ `rts-primitives` (Fase 2).
+pub mod node_constants;
 pub mod date;
 pub mod point;
 pub mod point3;

--- a/crates/rts-shared/src/globals/node_constants/mod.rs
+++ b/crates/rts-shared/src/globals/node_constants/mod.rs
@@ -1,0 +1,77 @@
+//! `Node` — as constantes de `nodeType` do DOM (Web IDL `Node.ELEMENT_NODE` …).
+//!
+//! Um script de boot faz `if (n.nodeType !== Node.ELEMENT_NODE) return` antes de
+//! tocar num nó; sem a classe o script inteiro morre em "unbound identifier
+//! `Node`" — e com ele todo o resto do bootstrap, que nada tem a ver com isso.
+//!
+//! ## Por que em Rust
+//!
+//! Isto era um `class Node { static get … }` no prelude `.ts` do `rts-dom`.
+//! Migrou para cá pelo padrão vigente (`docs/specs/rts-macro-single-source.md`):
+//! `#[rtse::class]` declara, o símbolo é DERIVADO da assinatura Rust e o
+//! `rts-symbol-baker` bakeia a tabela — nada escrito à mão.
+//!
+//! É constante numérica pura, então atravessa a borda Rust↔JS sem problema.
+//! (Um objeto JS vivo NÃO atravessa — foi por isso que o `MutationObserver`,
+//! que guarda um callback, continua no `.ts`.)
+//!
+//! Vive em `rts-shared` porque é superfície universal não-primordial: não faz
+//! I/O, não depende de backend, e a árvore DOM em si é outro crate. Os valores
+//! são os da spec e batem com o que `el.nodeType` devolve.
+
+/// Um elemento (`<div>`) — o caso que os guardas de boot testam.
+#[rtse::constant(global = "Node", value = "ELEMENT_NODE")]
+pub const ELEMENT_NODE: f64 = 1.0;
+
+/// Um atributo (legado; `Attr` não é mais um nó filho na spec atual).
+#[rtse::constant(global = "Node", value = "ATTRIBUTE_NODE")]
+pub const ATTRIBUTE_NODE: f64 = 2.0;
+
+/// Um nó de texto.
+#[rtse::constant(global = "Node", value = "TEXT_NODE")]
+pub const TEXT_NODE: f64 = 3.0;
+
+/// Uma seção CDATA (`<![CDATA[…]]>`, só em XML).
+#[rtse::constant(global = "Node", value = "CDATA_SECTION_NODE")]
+pub const CDATA_SECTION_NODE: f64 = 4.0;
+
+/// Uma processing instruction (`<?xml-stylesheet …?>`).
+#[rtse::constant(global = "Node", value = "PROCESSING_INSTRUCTION_NODE")]
+pub const PROCESSING_INSTRUCTION_NODE: f64 = 7.0;
+
+/// Um comentário (`<!-- … -->`).
+#[rtse::constant(global = "Node", value = "COMMENT_NODE")]
+pub const COMMENT_NODE: f64 = 8.0;
+
+/// O próprio documento.
+#[rtse::constant(global = "Node", value = "DOCUMENT_NODE")]
+pub const DOCUMENT_NODE: f64 = 9.0;
+
+/// O doctype (`<!DOCTYPE html>`).
+#[rtse::constant(global = "Node", value = "DOCUMENT_TYPE_NODE")]
+pub const DOCUMENT_TYPE_NODE: f64 = 10.0;
+
+/// Um `DocumentFragment`.
+#[rtse::constant(global = "Node", value = "DOCUMENT_FRAGMENT_NODE")]
+pub const DOCUMENT_FRAGMENT_NODE: f64 = 11.0;
+
+/// Registra a classe `Node` com as constantes de `nodeType`.
+///
+/// São `#[rtse::constant]` e não métodos estáticos: um script de página escreve
+/// `Node.ELEMENT_NODE` como PROPRIEDADE, não como chamada. `MemberKind::Constant`
+/// é exatamente isso no engine — um getter que o codegen chama onde o nome
+/// aparece sem parênteses —, então a forma da spec é preservada.
+pub fn register(e: &mut rts_engine::Engine) {
+    e.class("Node")
+        .doc("Node — nodeType constants (Web IDL).")
+        .member(element_node_member())
+        .member(attribute_node_member())
+        .member(text_node_member())
+        .member(cdata_section_node_member())
+        .member(processing_instruction_node_member())
+        .member(comment_node_member())
+        .member(document_node_member())
+        .member(document_type_node_member())
+        .member(document_fragment_node_member())
+        .done();
+}

--- a/crates/rts-std/src/globals/mod.rs
+++ b/crates/rts-std/src/globals/mod.rs
@@ -32,6 +32,7 @@ pub mod form_data;
 pub mod performance;
 pub mod events;
 pub mod headers;
+pub mod storage;
 pub mod streams;
 pub mod text_encoding;
 pub mod timers;

--- a/crates/rts-std/src/globals/storage/mod.rs
+++ b/crates/rts-std/src/globals/storage/mod.rs
@@ -1,0 +1,225 @@
+//! `Storage` — `localStorage` / `sessionStorage` (Web Storage API), em Rust.
+//!
+//! ## Por que em Rust e não `.ts`
+//!
+//! A primeira implementação foi um prelude `.ts` (`rts-dom/src/window.ts`).
+//! Medido: acrescentar as ~68 linhas ao prelude fazia
+//! `tests/node_util_parseargs.test.ts` — um teste de `node:util`, sem NENHUMA
+//! relação — travar (CPU parada = bloqueio, não laço). Bisseção binária
+//! (68 → 18 → 11 → 2 linhas) isolou o gatilho em DUAS linhas:
+//!
+//! ```ts
+//! const __lsStores: any[] = [];
+//! const __lsPaths: string[] = [];
+//! ```
+//!
+//! Dois arrays globais VAZIOS, que ninguém lia nem escrevia. Estado global de
+//! módulo num prelude vira gcell, e gcell é estado do PROGRAMA — o mesmo
+//! mecanismo que na mesma sessão fez `const Node = new NodeConstants()` vazar
+//! entre programas. Aqui o estado mora na struct e no HandleTable: não há
+//! global de prelude, e a classe inteira de problema desaparece.
+//!
+//! Segue o padrão vigente (`docs/specs/rts-macro-single-source.md` +
+//! `docs/specs/namespace-creation-guide.md`): declarado com `#[rtse::class]`,
+//! símbolo e assinatura DERIVADOS da declaração Rust, tabela bakeada pelo
+//! `rts-symbol-baker`. Nada escrito à mão.
+//!
+//! ## Persistência: PICKLE, não texto
+//!
+//! `persistTo(path)` liga o storage a um arquivo; toda mutação regrava. O
+//! formato é o pickle do RTS (`rts_engine::heap::pickle`), não texto:
+//!
+//! - guarda ESTRUTURA E TIPO — um valor com `\n` ou com o separador dentro
+//!   quebraria um "k=v por linha", e isso é conteúdo comum;
+//! - é o mesmo mecanismo do resto do projeto, sem um parser novo só aqui;
+//! - produz um bloco de bytes OPACO, que é exatamente o que se cifra quando a
+//!   criptografia entrar — o ponto de entrada é [`encode`]/[`decode`], hoje a
+//!   identidade (bytes crus em disco).
+//!
+//! A API pública segue a spec (string-only): `setItem` coage a string e
+//! `getItem` devolve `string | null`.
+
+use rts_engine::abi::ty::Handle;
+use rts_engine::heap::handles::{alloc_entry, alloc_rtse, with_entry, Entry};
+use rts_engine::heap::pickle;
+
+/// Um storage Web: pares chave→valor em ordem de inserção (a spec expõe
+/// `key(n)` por índice), opcionalmente ligados a um arquivo.
+#[rtse::class("Storage")]
+#[derive(Clone, Default)]
+pub struct Storage {
+    keys: Vec<String>,
+    vals: Vec<String>,
+    /// Arquivo ligado por `persistTo`; vazio = em-memória (o padrão).
+    path: String,
+}
+
+#[rtse::class("Storage")]
+impl Storage {
+    /// `new Storage()` — vazio e em-memória.
+    #[rtse::ctor]
+    fn new() -> Self {
+        Storage::default()
+    }
+
+    /// `storage.length` — quantos pares há.
+    #[rtse::getter]
+    fn length(self: &Storage) -> f64 {
+        self.keys.len() as f64
+    }
+
+    /// `storage.getItem(key)` — o valor, ou `null` se a chave não existe.
+    #[rtse::method]
+    fn getItem(self: &Storage, key: &str) -> Option<String> {
+        self.index_of(key).map(|i| self.vals[i].clone())
+    }
+
+    /// `storage.setItem(key, value)` — insere ou sobrescreve, e persiste.
+    #[rtse::method]
+    fn setItem(self: &mut Storage, key: &str, value: &str) {
+        match self.index_of(key) {
+            Some(i) => self.vals[i] = value.to_string(),
+            None => {
+                self.keys.push(key.to_string());
+                self.vals.push(value.to_string());
+            }
+        }
+        self.flush();
+    }
+
+    /// `storage.removeItem(key)` — remove o par (no-op se ausente) e persiste.
+    #[rtse::method]
+    fn removeItem(self: &mut Storage, key: &str) {
+        if let Some(i) = self.index_of(key) {
+            self.keys.remove(i);
+            self.vals.remove(i);
+            self.flush();
+        }
+    }
+
+    /// `storage.clear()` — esvazia e persiste.
+    #[rtse::method]
+    fn clear(self: &mut Storage) {
+        self.keys.clear();
+        self.vals.clear();
+        self.flush();
+    }
+
+    /// `storage.key(n)` — a n-ésima chave em ordem de inserção, ou `null`.
+    #[rtse::method]
+    fn key(self: &Storage, n: f64) -> Option<String> {
+        if n < 0.0 {
+            return None;
+        }
+        self.keys.get(n as usize).cloned()
+    }
+
+    /// Liga este storage a um ARQUIVO e carrega o que já houver nele.
+    ///
+    /// Superfície do HOST, não da página: um site não escolhe onde seu
+    /// `localStorage` mora — por isso não existe no `Storage` de um browser.
+    #[rtse::method]
+    fn persistTo(self: &mut Storage, path: &str) {
+        self.path = path.to_string();
+        self.load();
+    }
+}
+
+impl Storage {
+    /// Índice da chave, se existir.
+    fn index_of(&self, key: &str) -> Option<usize> {
+        self.keys.iter().position(|k| k == key)
+    }
+
+    /// Regrava o storage no arquivo ligado. No-op quando não há arquivo — o
+    /// caso padrão (em-memória).
+    fn flush(&self) {
+        if self.path.is_empty() {
+            return;
+        }
+        if let Some(bytes) = self.to_pickle() {
+            let _ = std::fs::write(&self.path, encode(&bytes));
+        }
+    }
+
+    /// Recarrega do arquivo, substituindo o conteúdo em memória. Arquivo
+    /// ausente/ilegível/corrompido deixa o storage como está em vez de
+    /// derrubar a página — é dado de cache, nunca vale quebrar o boot por ele.
+    fn load(&mut self) {
+        if self.path.is_empty() {
+            return;
+        }
+        let Ok(raw) = std::fs::read(&self.path) else { return };
+        let Ok(word) = pickle::deserialize_value(&decode(&raw)) else { return };
+        if let Some((keys, vals)) = read_pair(word) {
+            self.keys = keys;
+            self.vals = vals;
+        }
+    }
+
+    /// Serializa `[keys, vals]` como um grafo de valores do RTS.
+    fn to_pickle(&self) -> Option<Vec<u8>> {
+        let pair = alloc_entry(Entry::Vec(Box::new(vec![
+            string_array(&self.keys) as i64,
+            string_array(&self.vals) as i64,
+        ])));
+        pickle::serialize_value(pair).ok()
+    }
+}
+
+/// Aloca um `Vec` de strings do RTS e devolve seu handle.
+fn string_array(items: &[String]) -> u64 {
+    let words: Vec<i64> = items
+        .iter()
+        .map(|s| alloc_entry(Entry::String(s.as_bytes().to_vec())) as i64)
+        .collect();
+    alloc_entry(Entry::Vec(Box::new(words)))
+}
+
+/// Lê de volta o `[keys, vals]` produzido por [`Storage::to_pickle`].
+/// `None` quando o stream não tem essa forma (arquivo de outra origem).
+fn read_pair(word: u64) -> Option<(Vec<String>, Vec<String>)> {
+    let (kw, vw) = with_entry(word, |e| match e {
+        Some(Entry::Vec(v)) if v.len() == 2 => Some((v[0] as u64, v[1] as u64)),
+        _ => None,
+    })?;
+    Some((read_string_array(kw)?, read_string_array(vw)?))
+}
+
+/// Lê um `Vec` de strings do RTS para `Vec<String>`.
+fn read_string_array(handle: u64) -> Option<Vec<String>> {
+    // COPIA as words ANTES de tocar em cada uma: `with_entry` segura o lock do
+    // shard enquanto roda o corpo, e ler outro handle lá dentro pode cair no
+    // MESMO shard — auto-deadlock. Soltar o lock primeiro é o padrão correto.
+    let words: Vec<i64> = with_entry(handle, |e| match e {
+        Some(Entry::Vec(v)) => Some(v.as_ref().clone()),
+        _ => None,
+    })?;
+    let mut out = Vec::with_capacity(words.len());
+    for w in words {
+        let s = with_entry(w as u64, |e| match e {
+            Some(Entry::String(b)) => Some(String::from_utf8_lossy(b).into_owned()),
+            _ => None,
+        })?;
+        out.push(s);
+    }
+    Some(out)
+}
+
+/// Bytes do pickle → bytes do arquivo. Identidade hoje; é AQUI que a
+/// criptografia entra quando for a hora (cifrar antes de gravar e decifrar em
+/// [`decode`]), sem tocar em mais nada do storage.
+fn encode(bytes: &[u8]) -> Vec<u8> {
+    bytes.to_vec()
+}
+
+/// Bytes do arquivo → bytes do pickle.
+fn decode(raw: &[u8]) -> Vec<u8> {
+    raw.to_vec()
+}
+
+/// Um `Storage` novo e vazio, como handle — o que o host usa para montar o
+/// `localStorage`/`sessionStorage` de um documento.
+pub fn new_storage() -> Handle {
+    alloc_rtse("Storage", Storage::default())
+}

--- a/crates/rts-symbol-baker/generated/symbol_table.rs
+++ b/crates/rts-symbol-baker/generated/symbol_table.rs
@@ -7,7 +7,7 @@
 // symbol name, so lookup is a binary search and every scope (`__rtsa_`,
 // `__rtsm_node_fs_`, …) is ONE contiguous range. See `rts_abi::table`.
 //
-// 2159 symbols.
+// 2167 symbols.
 
 // Addresses are taken through the LINKER name, not a Rust module path: that
 // reaches every `#[no_mangle]` symbol regardless of Rust visibility, and makes
@@ -3433,914 +3433,930 @@ unsafe extern "C" {
     fn __rts_sym_1703();
     #[link_name = "__rtsm_global_stats_uid"]
     fn __rts_sym_1704();
-    #[link_name = "__rtsm_global_string_at"]
+    #[link_name = "__rtsm_global_storage_clear"]
     fn __rts_sym_1705();
-    #[link_name = "__rtsm_global_string_char_at"]
+    #[link_name = "__rtsm_global_storage_getItem"]
     fn __rts_sym_1706();
-    #[link_name = "__rtsm_global_string_char_code_at"]
+    #[link_name = "__rtsm_global_storage_key"]
     fn __rts_sym_1707();
-    #[link_name = "__rtsm_global_string_code_point_at"]
+    #[link_name = "__rtsm_global_storage_length"]
     fn __rts_sym_1708();
-    #[link_name = "__rtsm_global_string_concat"]
+    #[link_name = "__rtsm_global_storage_new"]
     fn __rts_sym_1709();
-    #[link_name = "__rtsm_global_string_ends_with"]
+    #[link_name = "__rtsm_global_storage_persistTo"]
     fn __rts_sym_1710();
-    #[link_name = "__rtsm_global_string_includes"]
+    #[link_name = "__rtsm_global_storage_removeItem"]
     fn __rts_sym_1711();
-    #[link_name = "__rtsm_global_string_index_of"]
+    #[link_name = "__rtsm_global_storage_setItem"]
     fn __rts_sym_1712();
-    #[link_name = "__rtsm_global_string_is_well_formed"]
+    #[link_name = "__rtsm_global_string_at"]
     fn __rts_sym_1713();
-    #[link_name = "__rtsm_global_string_last_index_of"]
+    #[link_name = "__rtsm_global_string_char_at"]
     fn __rts_sym_1714();
-    #[link_name = "__rtsm_global_string_length"]
+    #[link_name = "__rtsm_global_string_char_code_at"]
     fn __rts_sym_1715();
-    #[link_name = "__rtsm_global_string_locale_compare"]
+    #[link_name = "__rtsm_global_string_code_point_at"]
     fn __rts_sym_1716();
-    #[link_name = "__rtsm_global_string_new"]
+    #[link_name = "__rtsm_global_string_concat"]
     fn __rts_sym_1717();
-    #[link_name = "__rtsm_global_string_normalize"]
+    #[link_name = "__rtsm_global_string_ends_with"]
     fn __rts_sym_1718();
-    #[link_name = "__rtsm_global_string_pad_end"]
+    #[link_name = "__rtsm_global_string_includes"]
     fn __rts_sym_1719();
-    #[link_name = "__rtsm_global_string_pad_start"]
+    #[link_name = "__rtsm_global_string_index_of"]
     fn __rts_sym_1720();
-    #[link_name = "__rtsm_global_string_repeat"]
+    #[link_name = "__rtsm_global_string_is_well_formed"]
     fn __rts_sym_1721();
-    #[link_name = "__rtsm_global_string_replace"]
+    #[link_name = "__rtsm_global_string_last_index_of"]
     fn __rts_sym_1722();
-    #[link_name = "__rtsm_global_string_replace_all"]
+    #[link_name = "__rtsm_global_string_length"]
     fn __rts_sym_1723();
-    #[link_name = "__rtsm_global_string_slice"]
+    #[link_name = "__rtsm_global_string_locale_compare"]
     fn __rts_sym_1724();
-    #[link_name = "__rtsm_global_string_starts_with"]
+    #[link_name = "__rtsm_global_string_new"]
     fn __rts_sym_1725();
-    #[link_name = "__rtsm_global_string_substr"]
+    #[link_name = "__rtsm_global_string_normalize"]
     fn __rts_sym_1726();
-    #[link_name = "__rtsm_global_string_substring"]
+    #[link_name = "__rtsm_global_string_pad_end"]
     fn __rts_sym_1727();
-    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
+    #[link_name = "__rtsm_global_string_pad_start"]
     fn __rts_sym_1728();
-    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
+    #[link_name = "__rtsm_global_string_repeat"]
     fn __rts_sym_1729();
-    #[link_name = "__rtsm_global_string_to_lower_case"]
+    #[link_name = "__rtsm_global_string_replace"]
     fn __rts_sym_1730();
-    #[link_name = "__rtsm_global_string_to_string"]
+    #[link_name = "__rtsm_global_string_replace_all"]
     fn __rts_sym_1731();
-    #[link_name = "__rtsm_global_string_to_upper_case"]
+    #[link_name = "__rtsm_global_string_slice"]
     fn __rts_sym_1732();
-    #[link_name = "__rtsm_global_string_to_well_formed"]
+    #[link_name = "__rtsm_global_string_starts_with"]
     fn __rts_sym_1733();
-    #[link_name = "__rtsm_global_string_trim"]
+    #[link_name = "__rtsm_global_string_substr"]
     fn __rts_sym_1734();
-    #[link_name = "__rtsm_global_string_trim_end"]
+    #[link_name = "__rtsm_global_string_substring"]
     fn __rts_sym_1735();
-    #[link_name = "__rtsm_global_string_trim_left"]
+    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
     fn __rts_sym_1736();
-    #[link_name = "__rtsm_global_string_trim_right"]
+    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
     fn __rts_sym_1737();
-    #[link_name = "__rtsm_global_string_trim_start"]
+    #[link_name = "__rtsm_global_string_to_lower_case"]
     fn __rts_sym_1738();
-    #[link_name = "__rtsm_global_string_value_of"]
+    #[link_name = "__rtsm_global_string_to_string"]
     fn __rts_sym_1739();
-    #[link_name = "__rtsm_global_stringdecoder_encoding"]
+    #[link_name = "__rtsm_global_string_to_upper_case"]
     fn __rts_sym_1740();
-    #[link_name = "__rtsm_global_stringdecoder_end"]
+    #[link_name = "__rtsm_global_string_to_well_formed"]
     fn __rts_sym_1741();
-    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
+    #[link_name = "__rtsm_global_string_trim"]
     fn __rts_sym_1742();
-    #[link_name = "__rtsm_global_stringdecoder_new"]
+    #[link_name = "__rtsm_global_string_trim_end"]
     fn __rts_sym_1743();
-    #[link_name = "__rtsm_global_stringdecoder_text"]
+    #[link_name = "__rtsm_global_string_trim_left"]
     fn __rts_sym_1744();
-    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
+    #[link_name = "__rtsm_global_string_trim_right"]
     fn __rts_sym_1745();
-    #[link_name = "__rtsm_global_stringdecoder_write"]
+    #[link_name = "__rtsm_global_string_trim_start"]
     fn __rts_sym_1746();
-    #[link_name = "__rtsm_global_symbol_description"]
+    #[link_name = "__rtsm_global_string_value_of"]
     fn __rts_sym_1747();
-    #[link_name = "__rtsm_global_symbol_for_key"]
+    #[link_name = "__rtsm_global_stringdecoder_encoding"]
     fn __rts_sym_1748();
-    #[link_name = "__rtsm_global_symbol_js_to_string"]
+    #[link_name = "__rtsm_global_stringdecoder_end"]
     fn __rts_sym_1749();
-    #[link_name = "__rtsm_global_symbol_key_for"]
+    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
     fn __rts_sym_1750();
-    #[link_name = "__rtsm_global_symbol_new"]
+    #[link_name = "__rtsm_global_stringdecoder_new"]
     fn __rts_sym_1751();
-    #[link_name = "__rtsm_global_textdecoder_decode"]
+    #[link_name = "__rtsm_global_stringdecoder_text"]
     fn __rts_sym_1752();
-    #[link_name = "__rtsm_global_textdecoder_new"]
+    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
     fn __rts_sym_1753();
-    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
+    #[link_name = "__rtsm_global_stringdecoder_write"]
     fn __rts_sym_1754();
-    #[link_name = "__rtsm_global_textdecoderstream_new"]
+    #[link_name = "__rtsm_global_symbol_description"]
     fn __rts_sym_1755();
-    #[link_name = "__rtsm_global_textdecoderstream_readable"]
+    #[link_name = "__rtsm_global_symbol_for_key"]
     fn __rts_sym_1756();
-    #[link_name = "__rtsm_global_textdecoderstream_writable"]
+    #[link_name = "__rtsm_global_symbol_js_to_string"]
     fn __rts_sym_1757();
-    #[link_name = "__rtsm_global_textencoder_encode"]
+    #[link_name = "__rtsm_global_symbol_key_for"]
     fn __rts_sym_1758();
-    #[link_name = "__rtsm_global_textencoder_encode_into"]
+    #[link_name = "__rtsm_global_symbol_new"]
     fn __rts_sym_1759();
-    #[link_name = "__rtsm_global_textencoder_new"]
+    #[link_name = "__rtsm_global_textdecoder_decode"]
     fn __rts_sym_1760();
-    #[link_name = "__rtsm_global_textencoderstream_encoding"]
+    #[link_name = "__rtsm_global_textdecoder_new"]
     fn __rts_sym_1761();
-    #[link_name = "__rtsm_global_textencoderstream_new"]
+    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
     fn __rts_sym_1762();
-    #[link_name = "__rtsm_global_textencoderstream_readable"]
+    #[link_name = "__rtsm_global_textdecoderstream_new"]
     fn __rts_sym_1763();
-    #[link_name = "__rtsm_global_textencoderstream_writable"]
+    #[link_name = "__rtsm_global_textdecoderstream_readable"]
     fn __rts_sym_1764();
-    #[link_name = "__rtsm_global_transformstream_new"]
+    #[link_name = "__rtsm_global_textdecoderstream_writable"]
     fn __rts_sym_1765();
-    #[link_name = "__rtsm_global_transformstream_readable"]
+    #[link_name = "__rtsm_global_textencoder_encode"]
     fn __rts_sym_1766();
-    #[link_name = "__rtsm_global_transformstream_writable"]
+    #[link_name = "__rtsm_global_textencoder_encode_into"]
     fn __rts_sym_1767();
-    #[link_name = "__rtsm_global_url_can_parse"]
+    #[link_name = "__rtsm_global_textencoder_new"]
     fn __rts_sym_1768();
-    #[link_name = "__rtsm_global_url_can_parse_base"]
+    #[link_name = "__rtsm_global_textencoderstream_encoding"]
     fn __rts_sym_1769();
-    #[link_name = "__rtsm_global_url_hash"]
+    #[link_name = "__rtsm_global_textencoderstream_new"]
     fn __rts_sym_1770();
-    #[link_name = "__rtsm_global_url_host"]
+    #[link_name = "__rtsm_global_textencoderstream_readable"]
     fn __rts_sym_1771();
-    #[link_name = "__rtsm_global_url_hostname"]
+    #[link_name = "__rtsm_global_textencoderstream_writable"]
     fn __rts_sym_1772();
-    #[link_name = "__rtsm_global_url_href"]
+    #[link_name = "__rtsm_global_transformstream_new"]
     fn __rts_sym_1773();
-    #[link_name = "__rtsm_global_url_new"]
+    #[link_name = "__rtsm_global_transformstream_readable"]
     fn __rts_sym_1774();
-    #[link_name = "__rtsm_global_url_new_with_base"]
+    #[link_name = "__rtsm_global_transformstream_writable"]
     fn __rts_sym_1775();
-    #[link_name = "__rtsm_global_url_origin"]
+    #[link_name = "__rtsm_global_url_can_parse"]
     fn __rts_sym_1776();
-    #[link_name = "__rtsm_global_url_password"]
+    #[link_name = "__rtsm_global_url_can_parse_base"]
     fn __rts_sym_1777();
-    #[link_name = "__rtsm_global_url_pathname"]
+    #[link_name = "__rtsm_global_url_hash"]
     fn __rts_sym_1778();
-    #[link_name = "__rtsm_global_url_port"]
+    #[link_name = "__rtsm_global_url_host"]
     fn __rts_sym_1779();
-    #[link_name = "__rtsm_global_url_protocol"]
+    #[link_name = "__rtsm_global_url_hostname"]
     fn __rts_sym_1780();
-    #[link_name = "__rtsm_global_url_search"]
+    #[link_name = "__rtsm_global_url_href"]
     fn __rts_sym_1781();
-    #[link_name = "__rtsm_global_url_search_params"]
+    #[link_name = "__rtsm_global_url_new"]
     fn __rts_sym_1782();
-    #[link_name = "__rtsm_global_url_set_hash"]
+    #[link_name = "__rtsm_global_url_new_with_base"]
     fn __rts_sym_1783();
-    #[link_name = "__rtsm_global_url_set_host"]
+    #[link_name = "__rtsm_global_url_origin"]
     fn __rts_sym_1784();
-    #[link_name = "__rtsm_global_url_set_hostname"]
+    #[link_name = "__rtsm_global_url_password"]
     fn __rts_sym_1785();
-    #[link_name = "__rtsm_global_url_set_href"]
+    #[link_name = "__rtsm_global_url_pathname"]
     fn __rts_sym_1786();
-    #[link_name = "__rtsm_global_url_set_password"]
+    #[link_name = "__rtsm_global_url_port"]
     fn __rts_sym_1787();
-    #[link_name = "__rtsm_global_url_set_pathname"]
+    #[link_name = "__rtsm_global_url_protocol"]
     fn __rts_sym_1788();
-    #[link_name = "__rtsm_global_url_set_port"]
+    #[link_name = "__rtsm_global_url_search"]
     fn __rts_sym_1789();
-    #[link_name = "__rtsm_global_url_set_protocol"]
+    #[link_name = "__rtsm_global_url_search_params"]
     fn __rts_sym_1790();
-    #[link_name = "__rtsm_global_url_set_search"]
+    #[link_name = "__rtsm_global_url_set_hash"]
     fn __rts_sym_1791();
-    #[link_name = "__rtsm_global_url_set_username"]
+    #[link_name = "__rtsm_global_url_set_host"]
     fn __rts_sym_1792();
-    #[link_name = "__rtsm_global_url_to_json"]
+    #[link_name = "__rtsm_global_url_set_hostname"]
     fn __rts_sym_1793();
-    #[link_name = "__rtsm_global_url_to_string"]
+    #[link_name = "__rtsm_global_url_set_href"]
     fn __rts_sym_1794();
-    #[link_name = "__rtsm_global_url_username"]
+    #[link_name = "__rtsm_global_url_set_password"]
     fn __rts_sym_1795();
-    #[link_name = "__rtsm_global_urlsearchparams_append"]
+    #[link_name = "__rtsm_global_url_set_pathname"]
     fn __rts_sym_1796();
-    #[link_name = "__rtsm_global_urlsearchparams_delete"]
+    #[link_name = "__rtsm_global_url_set_port"]
     fn __rts_sym_1797();
-    #[link_name = "__rtsm_global_urlsearchparams_get"]
+    #[link_name = "__rtsm_global_url_set_protocol"]
     fn __rts_sym_1798();
-    #[link_name = "__rtsm_global_urlsearchparams_has"]
+    #[link_name = "__rtsm_global_url_set_search"]
     fn __rts_sym_1799();
-    #[link_name = "__rtsm_global_urlsearchparams_new"]
+    #[link_name = "__rtsm_global_url_set_username"]
     fn __rts_sym_1800();
-    #[link_name = "__rtsm_global_urlsearchparams_set"]
+    #[link_name = "__rtsm_global_url_to_json"]
     fn __rts_sym_1801();
-    #[link_name = "__rtsm_global_urlsearchparams_size"]
+    #[link_name = "__rtsm_global_url_to_string"]
     fn __rts_sym_1802();
-    #[link_name = "__rtsm_global_urlsearchparams_sort"]
+    #[link_name = "__rtsm_global_url_username"]
     fn __rts_sym_1803();
-    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
+    #[link_name = "__rtsm_global_urlsearchparams_append"]
     fn __rts_sym_1804();
-    #[link_name = "__rtsm_global_weakref_deref"]
+    #[link_name = "__rtsm_global_urlsearchparams_delete"]
     fn __rts_sym_1805();
-    #[link_name = "__rtsm_global_weakref_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_get"]
     fn __rts_sym_1806();
-    #[link_name = "__rtsm_global_writablestream_locked__get"]
+    #[link_name = "__rtsm_global_urlsearchparams_has"]
     fn __rts_sym_1807();
-    #[link_name = "__rtsm_global_writablestream_locked__set"]
+    #[link_name = "__rtsm_global_urlsearchparams_new"]
     fn __rts_sym_1808();
-    #[link_name = "__rtsm_global_writablestream_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_set"]
     fn __rts_sym_1809();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
+    #[link_name = "__rtsm_global_urlsearchparams_size"]
     fn __rts_sym_1810();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
+    #[link_name = "__rtsm_global_urlsearchparams_sort"]
     fn __rts_sym_1811();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
+    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
     fn __rts_sym_1812();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
+    #[link_name = "__rtsm_global_weakref_deref"]
     fn __rts_sym_1813();
-    #[link_name = "__rtsm_node_assert_deepEqual"]
+    #[link_name = "__rtsm_global_weakref_new"]
     fn __rts_sym_1814();
-    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
+    #[link_name = "__rtsm_global_writablestream_locked__get"]
     fn __rts_sym_1815();
-    #[link_name = "__rtsm_node_assert_doesNotMatch"]
+    #[link_name = "__rtsm_global_writablestream_locked__set"]
     fn __rts_sym_1816();
-    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
+    #[link_name = "__rtsm_global_writablestream_new"]
     fn __rts_sym_1817();
-    #[link_name = "__rtsm_node_assert_doesNotThrow"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
     fn __rts_sym_1818();
-    #[link_name = "__rtsm_node_assert_equal"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
     fn __rts_sym_1819();
-    #[link_name = "__rtsm_node_assert_fail"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
     fn __rts_sym_1820();
-    #[link_name = "__rtsm_node_assert_fail_msg"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
     fn __rts_sym_1821();
-    #[link_name = "__rtsm_node_assert_ifError"]
+    #[link_name = "__rtsm_node_assert_deepEqual"]
     fn __rts_sym_1822();
-    #[link_name = "__rtsm_node_assert_match"]
+    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
     fn __rts_sym_1823();
-    #[link_name = "__rtsm_node_assert_match_msg"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch"]
     fn __rts_sym_1824();
-    #[link_name = "__rtsm_node_assert_notDeepEqual"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
     fn __rts_sym_1825();
-    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
+    #[link_name = "__rtsm_node_assert_doesNotThrow"]
     fn __rts_sym_1826();
-    #[link_name = "__rtsm_node_assert_notEqual"]
+    #[link_name = "__rtsm_node_assert_equal"]
     fn __rts_sym_1827();
-    #[link_name = "__rtsm_node_assert_notStrictEqual"]
+    #[link_name = "__rtsm_node_assert_fail"]
     fn __rts_sym_1828();
-    #[link_name = "__rtsm_node_assert_ok"]
+    #[link_name = "__rtsm_node_assert_fail_msg"]
     fn __rts_sym_1829();
-    #[link_name = "__rtsm_node_assert_ok_msg"]
+    #[link_name = "__rtsm_node_assert_ifError"]
     fn __rts_sym_1830();
-    #[link_name = "__rtsm_node_assert_strictEqual"]
+    #[link_name = "__rtsm_node_assert_match"]
     fn __rts_sym_1831();
-    #[link_name = "__rtsm_node_assert_throws"]
+    #[link_name = "__rtsm_node_assert_match_msg"]
     fn __rts_sym_1832();
-    #[link_name = "__rtsm_node_buffer_atob"]
+    #[link_name = "__rtsm_node_assert_notDeepEqual"]
     fn __rts_sym_1833();
-    #[link_name = "__rtsm_node_buffer_btoa"]
+    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
     fn __rts_sym_1834();
-    #[link_name = "__rtsm_node_crypto_createCipheriv"]
+    #[link_name = "__rtsm_node_assert_notEqual"]
     fn __rts_sym_1835();
-    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
+    #[link_name = "__rtsm_node_assert_notStrictEqual"]
     fn __rts_sym_1836();
-    #[link_name = "__rtsm_node_crypto_createHash"]
+    #[link_name = "__rtsm_node_assert_ok"]
     fn __rts_sym_1837();
-    #[link_name = "__rtsm_node_crypto_createHmac"]
+    #[link_name = "__rtsm_node_assert_ok_msg"]
     fn __rts_sym_1838();
-    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
+    #[link_name = "__rtsm_node_assert_strictEqual"]
     fn __rts_sym_1839();
-    #[link_name = "__rtsm_node_crypto_getHashes"]
+    #[link_name = "__rtsm_node_assert_throws"]
     fn __rts_sym_1840();
-    #[link_name = "__rtsm_node_crypto_hash"]
+    #[link_name = "__rtsm_node_buffer_atob"]
     fn __rts_sym_1841();
-    #[link_name = "__rtsm_node_crypto_hash_enc"]
+    #[link_name = "__rtsm_node_buffer_btoa"]
     fn __rts_sym_1842();
-    #[link_name = "__rtsm_node_crypto_hkdfSync"]
+    #[link_name = "__rtsm_node_crypto_createCipheriv"]
     fn __rts_sym_1843();
-    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
+    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
     fn __rts_sym_1844();
-    #[link_name = "__rtsm_node_crypto_randomBytes"]
+    #[link_name = "__rtsm_node_crypto_createHash"]
     fn __rts_sym_1845();
-    #[link_name = "__rtsm_node_crypto_randomFillSync"]
+    #[link_name = "__rtsm_node_crypto_createHmac"]
     fn __rts_sym_1846();
-    #[link_name = "__rtsm_node_crypto_randomInt"]
+    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
     fn __rts_sym_1847();
-    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
+    #[link_name = "__rtsm_node_crypto_getHashes"]
     fn __rts_sym_1848();
-    #[link_name = "__rtsm_node_crypto_randomUUID"]
+    #[link_name = "__rtsm_node_crypto_hash"]
     fn __rts_sym_1849();
-    #[link_name = "__rtsm_node_crypto_scryptSync"]
+    #[link_name = "__rtsm_node_crypto_hash_enc"]
     fn __rts_sym_1850();
-    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
+    #[link_name = "__rtsm_node_crypto_hkdfSync"]
     fn __rts_sym_1851();
-    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
+    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
     fn __rts_sym_1852();
-    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
+    #[link_name = "__rtsm_node_crypto_randomBytes"]
     fn __rts_sym_1853();
-    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
+    #[link_name = "__rtsm_node_crypto_randomFillSync"]
     fn __rts_sym_1854();
-    #[link_name = "__rtsm_node_dgram_createSocket"]
+    #[link_name = "__rtsm_node_crypto_randomInt"]
     fn __rts_sym_1855();
-    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
+    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
     fn __rts_sym_1856();
-    #[link_name = "__rtsm_node_dns_lookup"]
+    #[link_name = "__rtsm_node_crypto_randomUUID"]
     fn __rts_sym_1857();
-    #[link_name = "__rtsm_node_dns_resolve4"]
+    #[link_name = "__rtsm_node_crypto_scryptSync"]
     fn __rts_sym_1858();
-    #[link_name = "__rtsm_node_dns_resolve6"]
+    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
     fn __rts_sym_1859();
-    #[link_name = "__rtsm_node_fs_access"]
+    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
     fn __rts_sym_1860();
-    #[link_name = "__rtsm_node_fs_accessSync"]
+    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
     fn __rts_sym_1861();
-    #[link_name = "__rtsm_node_fs_appendFile"]
+    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
     fn __rts_sym_1862();
-    #[link_name = "__rtsm_node_fs_appendFileSync"]
+    #[link_name = "__rtsm_node_dgram_createSocket"]
     fn __rts_sym_1863();
-    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
+    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
     fn __rts_sym_1864();
-    #[link_name = "__rtsm_node_fs_chmod"]
+    #[link_name = "__rtsm_node_dns_lookup"]
     fn __rts_sym_1865();
-    #[link_name = "__rtsm_node_fs_chmodSync"]
+    #[link_name = "__rtsm_node_dns_resolve4"]
     fn __rts_sym_1866();
-    #[link_name = "__rtsm_node_fs_chownSync"]
+    #[link_name = "__rtsm_node_dns_resolve6"]
     fn __rts_sym_1867();
-    #[link_name = "__rtsm_node_fs_closeSync"]
+    #[link_name = "__rtsm_node_fs_access"]
     fn __rts_sym_1868();
-    #[link_name = "__rtsm_node_fs_copyFile"]
+    #[link_name = "__rtsm_node_fs_accessSync"]
     fn __rts_sym_1869();
-    #[link_name = "__rtsm_node_fs_copyFileSync"]
+    #[link_name = "__rtsm_node_fs_appendFile"]
     fn __rts_sym_1870();
-    #[link_name = "__rtsm_node_fs_cpSync"]
+    #[link_name = "__rtsm_node_fs_appendFileSync"]
     fn __rts_sym_1871();
-    #[link_name = "__rtsm_node_fs_cpSync_opts"]
+    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
     fn __rts_sym_1872();
-    #[link_name = "__rtsm_node_fs_exists"]
+    #[link_name = "__rtsm_node_fs_chmod"]
     fn __rts_sym_1873();
-    #[link_name = "__rtsm_node_fs_existsSync"]
+    #[link_name = "__rtsm_node_fs_chmodSync"]
     fn __rts_sym_1874();
-    #[link_name = "__rtsm_node_fs_fchmodSync"]
+    #[link_name = "__rtsm_node_fs_chownSync"]
     fn __rts_sym_1875();
-    #[link_name = "__rtsm_node_fs_fchownSync"]
+    #[link_name = "__rtsm_node_fs_closeSync"]
     fn __rts_sym_1876();
-    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
+    #[link_name = "__rtsm_node_fs_copyFile"]
     fn __rts_sym_1877();
-    #[link_name = "__rtsm_node_fs_fstatSync"]
+    #[link_name = "__rtsm_node_fs_copyFileSync"]
     fn __rts_sym_1878();
-    #[link_name = "__rtsm_node_fs_fsyncSync"]
+    #[link_name = "__rtsm_node_fs_cpSync"]
     fn __rts_sym_1879();
-    #[link_name = "__rtsm_node_fs_ftruncateSync"]
+    #[link_name = "__rtsm_node_fs_cpSync_opts"]
     fn __rts_sym_1880();
-    #[link_name = "__rtsm_node_fs_futimesSync"]
+    #[link_name = "__rtsm_node_fs_exists"]
     fn __rts_sym_1881();
-    #[link_name = "__rtsm_node_fs_globSync"]
+    #[link_name = "__rtsm_node_fs_existsSync"]
     fn __rts_sym_1882();
-    #[link_name = "__rtsm_node_fs_lchmodSync"]
+    #[link_name = "__rtsm_node_fs_fchmodSync"]
     fn __rts_sym_1883();
-    #[link_name = "__rtsm_node_fs_lchownSync"]
+    #[link_name = "__rtsm_node_fs_fchownSync"]
     fn __rts_sym_1884();
-    #[link_name = "__rtsm_node_fs_linkSync"]
+    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
     fn __rts_sym_1885();
-    #[link_name = "__rtsm_node_fs_lstat"]
+    #[link_name = "__rtsm_node_fs_fstatSync"]
     fn __rts_sym_1886();
-    #[link_name = "__rtsm_node_fs_lstatSync"]
+    #[link_name = "__rtsm_node_fs_fsyncSync"]
     fn __rts_sym_1887();
-    #[link_name = "__rtsm_node_fs_mkdir"]
+    #[link_name = "__rtsm_node_fs_ftruncateSync"]
     fn __rts_sym_1888();
-    #[link_name = "__rtsm_node_fs_mkdirSync"]
+    #[link_name = "__rtsm_node_fs_futimesSync"]
     fn __rts_sym_1889();
-    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_globSync"]
     fn __rts_sym_1890();
-    #[link_name = "__rtsm_node_fs_mkdtempSync"]
+    #[link_name = "__rtsm_node_fs_lchmodSync"]
     fn __rts_sym_1891();
-    #[link_name = "__rtsm_node_fs_openSync"]
+    #[link_name = "__rtsm_node_fs_lchownSync"]
     fn __rts_sym_1892();
-    #[link_name = "__rtsm_node_fs_opendirSync"]
+    #[link_name = "__rtsm_node_fs_linkSync"]
     fn __rts_sym_1893();
-    #[link_name = "__rtsm_node_fs_promises_access"]
+    #[link_name = "__rtsm_node_fs_lstat"]
     fn __rts_sym_1894();
-    #[link_name = "__rtsm_node_fs_promises_appendFile"]
+    #[link_name = "__rtsm_node_fs_lstatSync"]
     fn __rts_sym_1895();
-    #[link_name = "__rtsm_node_fs_promises_copyFile"]
+    #[link_name = "__rtsm_node_fs_mkdir"]
     fn __rts_sym_1896();
-    #[link_name = "__rtsm_node_fs_promises_lstat"]
+    #[link_name = "__rtsm_node_fs_mkdirSync"]
     fn __rts_sym_1897();
-    #[link_name = "__rtsm_node_fs_promises_mkdir"]
+    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
     fn __rts_sym_1898();
-    #[link_name = "__rtsm_node_fs_promises_open"]
+    #[link_name = "__rtsm_node_fs_mkdtempSync"]
     fn __rts_sym_1899();
-    #[link_name = "__rtsm_node_fs_promises_readFile"]
+    #[link_name = "__rtsm_node_fs_openSync"]
     fn __rts_sym_1900();
-    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_opendirSync"]
     fn __rts_sym_1901();
-    #[link_name = "__rtsm_node_fs_promises_readdir"]
+    #[link_name = "__rtsm_node_fs_promises_access"]
     fn __rts_sym_1902();
-    #[link_name = "__rtsm_node_fs_promises_readlink"]
+    #[link_name = "__rtsm_node_fs_promises_appendFile"]
     fn __rts_sym_1903();
-    #[link_name = "__rtsm_node_fs_promises_realpath"]
+    #[link_name = "__rtsm_node_fs_promises_copyFile"]
     fn __rts_sym_1904();
-    #[link_name = "__rtsm_node_fs_promises_rename"]
+    #[link_name = "__rtsm_node_fs_promises_lstat"]
     fn __rts_sym_1905();
-    #[link_name = "__rtsm_node_fs_promises_rm"]
+    #[link_name = "__rtsm_node_fs_promises_mkdir"]
     fn __rts_sym_1906();
-    #[link_name = "__rtsm_node_fs_promises_rmdir"]
+    #[link_name = "__rtsm_node_fs_promises_open"]
     fn __rts_sym_1907();
-    #[link_name = "__rtsm_node_fs_promises_stat"]
+    #[link_name = "__rtsm_node_fs_promises_readFile"]
     fn __rts_sym_1908();
-    #[link_name = "__rtsm_node_fs_promises_truncate"]
+    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
     fn __rts_sym_1909();
-    #[link_name = "__rtsm_node_fs_promises_unlink"]
+    #[link_name = "__rtsm_node_fs_promises_readdir"]
     fn __rts_sym_1910();
-    #[link_name = "__rtsm_node_fs_promises_writeFile"]
+    #[link_name = "__rtsm_node_fs_promises_readlink"]
     fn __rts_sym_1911();
-    #[link_name = "__rtsm_node_fs_readFile"]
+    #[link_name = "__rtsm_node_fs_promises_realpath"]
     fn __rts_sym_1912();
-    #[link_name = "__rtsm_node_fs_readFileSync"]
+    #[link_name = "__rtsm_node_fs_promises_rename"]
     fn __rts_sym_1913();
-    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_promises_rm"]
     fn __rts_sym_1914();
-    #[link_name = "__rtsm_node_fs_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_promises_rmdir"]
     fn __rts_sym_1915();
-    #[link_name = "__rtsm_node_fs_readSync"]
+    #[link_name = "__rtsm_node_fs_promises_stat"]
     fn __rts_sym_1916();
-    #[link_name = "__rtsm_node_fs_readdir"]
+    #[link_name = "__rtsm_node_fs_promises_truncate"]
     fn __rts_sym_1917();
-    #[link_name = "__rtsm_node_fs_readdirSync"]
+    #[link_name = "__rtsm_node_fs_promises_unlink"]
     fn __rts_sym_1918();
-    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_promises_writeFile"]
     fn __rts_sym_1919();
-    #[link_name = "__rtsm_node_fs_readlinkSync"]
+    #[link_name = "__rtsm_node_fs_readFile"]
     fn __rts_sym_1920();
-    #[link_name = "__rtsm_node_fs_readvSync"]
+    #[link_name = "__rtsm_node_fs_readFileSync"]
     fn __rts_sym_1921();
-    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
+    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
     fn __rts_sym_1922();
-    #[link_name = "__rtsm_node_fs_realpath"]
+    #[link_name = "__rtsm_node_fs_readFile_enc"]
     fn __rts_sym_1923();
-    #[link_name = "__rtsm_node_fs_realpathSync"]
+    #[link_name = "__rtsm_node_fs_readSync"]
     fn __rts_sym_1924();
-    #[link_name = "__rtsm_node_fs_rename"]
+    #[link_name = "__rtsm_node_fs_readdir"]
     fn __rts_sym_1925();
-    #[link_name = "__rtsm_node_fs_renameSync"]
+    #[link_name = "__rtsm_node_fs_readdirSync"]
     fn __rts_sym_1926();
-    #[link_name = "__rtsm_node_fs_rm"]
+    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
     fn __rts_sym_1927();
-    #[link_name = "__rtsm_node_fs_rmSync"]
+    #[link_name = "__rtsm_node_fs_readlinkSync"]
     fn __rts_sym_1928();
-    #[link_name = "__rtsm_node_fs_rmSync_opts"]
+    #[link_name = "__rtsm_node_fs_readvSync"]
     fn __rts_sym_1929();
-    #[link_name = "__rtsm_node_fs_rmdir"]
+    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
     fn __rts_sym_1930();
-    #[link_name = "__rtsm_node_fs_rmdirSync"]
+    #[link_name = "__rtsm_node_fs_realpath"]
     fn __rts_sym_1931();
-    #[link_name = "__rtsm_node_fs_stat"]
+    #[link_name = "__rtsm_node_fs_realpathSync"]
     fn __rts_sym_1932();
-    #[link_name = "__rtsm_node_fs_statSync"]
+    #[link_name = "__rtsm_node_fs_rename"]
     fn __rts_sym_1933();
-    #[link_name = "__rtsm_node_fs_statfsSync"]
+    #[link_name = "__rtsm_node_fs_renameSync"]
     fn __rts_sym_1934();
-    #[link_name = "__rtsm_node_fs_symlinkSync"]
+    #[link_name = "__rtsm_node_fs_rm"]
     fn __rts_sym_1935();
-    #[link_name = "__rtsm_node_fs_truncateSync"]
+    #[link_name = "__rtsm_node_fs_rmSync"]
     fn __rts_sym_1936();
-    #[link_name = "__rtsm_node_fs_unlink"]
+    #[link_name = "__rtsm_node_fs_rmSync_opts"]
     fn __rts_sym_1937();
-    #[link_name = "__rtsm_node_fs_unlinkSync"]
+    #[link_name = "__rtsm_node_fs_rmdir"]
     fn __rts_sym_1938();
-    #[link_name = "__rtsm_node_fs_unwatchFile"]
+    #[link_name = "__rtsm_node_fs_rmdirSync"]
     fn __rts_sym_1939();
-    #[link_name = "__rtsm_node_fs_utimesSync"]
+    #[link_name = "__rtsm_node_fs_stat"]
     fn __rts_sym_1940();
-    #[link_name = "__rtsm_node_fs_watch"]
+    #[link_name = "__rtsm_node_fs_statSync"]
     fn __rts_sym_1941();
-    #[link_name = "__rtsm_node_fs_watchFile"]
+    #[link_name = "__rtsm_node_fs_statfsSync"]
     fn __rts_sym_1942();
-    #[link_name = "__rtsm_node_fs_watchFile_interval"]
+    #[link_name = "__rtsm_node_fs_symlinkSync"]
     fn __rts_sym_1943();
-    #[link_name = "__rtsm_node_fs_writeFile"]
+    #[link_name = "__rtsm_node_fs_truncateSync"]
     fn __rts_sym_1944();
-    #[link_name = "__rtsm_node_fs_writeFileSync"]
+    #[link_name = "__rtsm_node_fs_unlink"]
     fn __rts_sym_1945();
-    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_unlinkSync"]
     fn __rts_sym_1946();
-    #[link_name = "__rtsm_node_fs_writeSync"]
+    #[link_name = "__rtsm_node_fs_unwatchFile"]
     fn __rts_sym_1947();
-    #[link_name = "__rtsm_node_fs_writevSync"]
+    #[link_name = "__rtsm_node_fs_utimesSync"]
     fn __rts_sym_1948();
-    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
+    #[link_name = "__rtsm_node_fs_watch"]
     fn __rts_sym_1949();
-    #[link_name = "__rtsm_node_http_METHODS"]
+    #[link_name = "__rtsm_node_fs_watchFile"]
     fn __rts_sym_1950();
-    #[link_name = "__rtsm_node_http_STATUS_CODES"]
+    #[link_name = "__rtsm_node_fs_watchFile_interval"]
     fn __rts_sym_1951();
-    #[link_name = "__rtsm_node_module_builtinModules"]
+    #[link_name = "__rtsm_node_fs_writeFile"]
     fn __rts_sym_1952();
-    #[link_name = "__rtsm_node_module_isBuiltin"]
+    #[link_name = "__rtsm_node_fs_writeFileSync"]
     fn __rts_sym_1953();
-    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
+    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
     fn __rts_sym_1954();
-    #[link_name = "__rtsm_node_module_wrap"]
+    #[link_name = "__rtsm_node_fs_writeSync"]
     fn __rts_sym_1955();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_fs_writevSync"]
     fn __rts_sym_1956();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
     fn __rts_sym_1957();
-    #[link_name = "__rtsm_node_net_isIP"]
+    #[link_name = "__rtsm_node_http_METHODS"]
     fn __rts_sym_1958();
-    #[link_name = "__rtsm_node_net_isIPv4"]
+    #[link_name = "__rtsm_node_http_STATUS_CODES"]
     fn __rts_sym_1959();
-    #[link_name = "__rtsm_node_net_isIPv6"]
+    #[link_name = "__rtsm_node_module_builtinModules"]
     fn __rts_sym_1960();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_module_isBuiltin"]
     fn __rts_sym_1961();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
     fn __rts_sym_1962();
-    #[link_name = "__rtsm_node_os_EOL"]
+    #[link_name = "__rtsm_node_module_wrap"]
     fn __rts_sym_1963();
-    #[link_name = "__rtsm_node_os_arch"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
     fn __rts_sym_1964();
-    #[link_name = "__rtsm_node_os_availableParallelism"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1965();
-    #[link_name = "__rtsm_node_os_cpus"]
+    #[link_name = "__rtsm_node_net_isIP"]
     fn __rts_sym_1966();
-    #[link_name = "__rtsm_node_os_endianness"]
+    #[link_name = "__rtsm_node_net_isIPv4"]
     fn __rts_sym_1967();
-    #[link_name = "__rtsm_node_os_freemem"]
+    #[link_name = "__rtsm_node_net_isIPv6"]
     fn __rts_sym_1968();
-    #[link_name = "__rtsm_node_os_getPriority"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
     fn __rts_sym_1969();
-    #[link_name = "__rtsm_node_os_getPriority_pid"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1970();
-    #[link_name = "__rtsm_node_os_homedir"]
+    #[link_name = "__rtsm_node_os_EOL"]
     fn __rts_sym_1971();
-    #[link_name = "__rtsm_node_os_hostname"]
+    #[link_name = "__rtsm_node_os_arch"]
     fn __rts_sym_1972();
-    #[link_name = "__rtsm_node_os_loadavg"]
+    #[link_name = "__rtsm_node_os_availableParallelism"]
     fn __rts_sym_1973();
-    #[link_name = "__rtsm_node_os_machine"]
+    #[link_name = "__rtsm_node_os_cpus"]
     fn __rts_sym_1974();
-    #[link_name = "__rtsm_node_os_networkInterfaces"]
+    #[link_name = "__rtsm_node_os_endianness"]
     fn __rts_sym_1975();
-    #[link_name = "__rtsm_node_os_platform"]
+    #[link_name = "__rtsm_node_os_freemem"]
     fn __rts_sym_1976();
-    #[link_name = "__rtsm_node_os_release"]
+    #[link_name = "__rtsm_node_os_getPriority"]
     fn __rts_sym_1977();
-    #[link_name = "__rtsm_node_os_setPriority"]
+    #[link_name = "__rtsm_node_os_getPriority_pid"]
     fn __rts_sym_1978();
-    #[link_name = "__rtsm_node_os_setPriority_pid"]
+    #[link_name = "__rtsm_node_os_homedir"]
     fn __rts_sym_1979();
-    #[link_name = "__rtsm_node_os_tmpdir"]
+    #[link_name = "__rtsm_node_os_hostname"]
     fn __rts_sym_1980();
-    #[link_name = "__rtsm_node_os_totalmem"]
+    #[link_name = "__rtsm_node_os_loadavg"]
     fn __rts_sym_1981();
-    #[link_name = "__rtsm_node_os_type"]
+    #[link_name = "__rtsm_node_os_machine"]
     fn __rts_sym_1982();
-    #[link_name = "__rtsm_node_os_uptime"]
+    #[link_name = "__rtsm_node_os_networkInterfaces"]
     fn __rts_sym_1983();
-    #[link_name = "__rtsm_node_os_userInfo"]
+    #[link_name = "__rtsm_node_os_platform"]
     fn __rts_sym_1984();
-    #[link_name = "__rtsm_node_os_version"]
+    #[link_name = "__rtsm_node_os_release"]
     fn __rts_sym_1985();
-    #[link_name = "__rtsm_node_path_posix_basename"]
+    #[link_name = "__rtsm_node_os_setPriority"]
     fn __rts_sym_1986();
-    #[link_name = "__rtsm_node_path_posix_dirname"]
+    #[link_name = "__rtsm_node_os_setPriority_pid"]
     fn __rts_sym_1987();
-    #[link_name = "__rtsm_node_path_posix_extname"]
+    #[link_name = "__rtsm_node_os_tmpdir"]
     fn __rts_sym_1988();
-    #[link_name = "__rtsm_node_path_posix_format"]
+    #[link_name = "__rtsm_node_os_totalmem"]
     fn __rts_sym_1989();
-    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
+    #[link_name = "__rtsm_node_os_type"]
     fn __rts_sym_1990();
-    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
+    #[link_name = "__rtsm_node_os_uptime"]
     fn __rts_sym_1991();
-    #[link_name = "__rtsm_node_path_posix_normalize"]
+    #[link_name = "__rtsm_node_os_userInfo"]
     fn __rts_sym_1992();
-    #[link_name = "__rtsm_node_path_posix_parse"]
+    #[link_name = "__rtsm_node_os_version"]
     fn __rts_sym_1993();
-    #[link_name = "__rtsm_node_path_posix_relative"]
+    #[link_name = "__rtsm_node_path_posix_basename"]
     fn __rts_sym_1994();
-    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_posix_dirname"]
     fn __rts_sym_1995();
-    #[link_name = "__rtsm_node_path_win32_basename"]
+    #[link_name = "__rtsm_node_path_posix_extname"]
     fn __rts_sym_1996();
-    #[link_name = "__rtsm_node_path_win32_dirname"]
+    #[link_name = "__rtsm_node_path_posix_format"]
     fn __rts_sym_1997();
-    #[link_name = "__rtsm_node_path_win32_extname"]
+    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
     fn __rts_sym_1998();
-    #[link_name = "__rtsm_node_path_win32_format"]
+    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
     fn __rts_sym_1999();
-    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
+    #[link_name = "__rtsm_node_path_posix_normalize"]
     fn __rts_sym_2000();
-    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
+    #[link_name = "__rtsm_node_path_posix_parse"]
     fn __rts_sym_2001();
-    #[link_name = "__rtsm_node_path_win32_normalize"]
+    #[link_name = "__rtsm_node_path_posix_relative"]
     fn __rts_sym_2002();
-    #[link_name = "__rtsm_node_path_win32_parse"]
+    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
     fn __rts_sym_2003();
-    #[link_name = "__rtsm_node_path_win32_relative"]
+    #[link_name = "__rtsm_node_path_win32_basename"]
     fn __rts_sym_2004();
-    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_win32_dirname"]
     fn __rts_sym_2005();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
+    #[link_name = "__rtsm_node_path_win32_extname"]
     fn __rts_sym_2006();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
+    #[link_name = "__rtsm_node_path_win32_format"]
     fn __rts_sym_2007();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
+    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
     fn __rts_sym_2008();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
+    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
     fn __rts_sym_2009();
-    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
+    #[link_name = "__rtsm_node_path_win32_normalize"]
     fn __rts_sym_2010();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
+    #[link_name = "__rtsm_node_path_win32_parse"]
     fn __rts_sym_2011();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
+    #[link_name = "__rtsm_node_path_win32_relative"]
     fn __rts_sym_2012();
-    #[link_name = "__rtsm_node_perf_hooks_mark"]
+    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
     fn __rts_sym_2013();
-    #[link_name = "__rtsm_node_perf_hooks_measure"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
     fn __rts_sym_2014();
-    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
     fn __rts_sym_2015();
-    #[link_name = "__rtsm_node_perf_hooks_now"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
     fn __rts_sym_2016();
-    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
     fn __rts_sym_2017();
-    #[link_name = "__rtsm_node_process_abort"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
     fn __rts_sym_2018();
-    #[link_name = "__rtsm_node_process_arch"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
     fn __rts_sym_2019();
-    #[link_name = "__rtsm_node_process_argv"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
     fn __rts_sym_2020();
-    #[link_name = "__rtsm_node_process_argv0"]
+    #[link_name = "__rtsm_node_perf_hooks_mark"]
     fn __rts_sym_2021();
-    #[link_name = "__rtsm_node_process_availableMemory"]
+    #[link_name = "__rtsm_node_perf_hooks_measure"]
     fn __rts_sym_2022();
-    #[link_name = "__rtsm_node_process_chdir"]
+    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
     fn __rts_sym_2023();
-    #[link_name = "__rtsm_node_process_constrainedMemory"]
+    #[link_name = "__rtsm_node_perf_hooks_now"]
     fn __rts_sym_2024();
-    #[link_name = "__rtsm_node_process_cpuUsage"]
+    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
     fn __rts_sym_2025();
-    #[link_name = "__rtsm_node_process_cwd"]
+    #[link_name = "__rtsm_node_process_abort"]
     fn __rts_sym_2026();
-    #[link_name = "__rtsm_node_process_env"]
+    #[link_name = "__rtsm_node_process_arch"]
     fn __rts_sym_2027();
-    #[link_name = "__rtsm_node_process_execPath"]
+    #[link_name = "__rtsm_node_process_argv"]
     fn __rts_sym_2028();
-    #[link_name = "__rtsm_node_process_exit"]
+    #[link_name = "__rtsm_node_process_argv0"]
     fn __rts_sym_2029();
-    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
+    #[link_name = "__rtsm_node_process_availableMemory"]
     fn __rts_sym_2030();
-    #[link_name = "__rtsm_node_process_hrtime"]
+    #[link_name = "__rtsm_node_process_chdir"]
     fn __rts_sym_2031();
-    #[link_name = "__rtsm_node_process_hrtime_prev"]
+    #[link_name = "__rtsm_node_process_constrainedMemory"]
     fn __rts_sym_2032();
-    #[link_name = "__rtsm_node_process_kill"]
+    #[link_name = "__rtsm_node_process_cpuUsage"]
     fn __rts_sym_2033();
-    #[link_name = "__rtsm_node_process_memoryUsage"]
+    #[link_name = "__rtsm_node_process_cwd"]
     fn __rts_sym_2034();
-    #[link_name = "__rtsm_node_process_pid"]
+    #[link_name = "__rtsm_node_process_env"]
     fn __rts_sym_2035();
-    #[link_name = "__rtsm_node_process_platform"]
+    #[link_name = "__rtsm_node_process_execPath"]
     fn __rts_sym_2036();
-    #[link_name = "__rtsm_node_process_resourceUsage"]
+    #[link_name = "__rtsm_node_process_exit"]
     fn __rts_sym_2037();
-    #[link_name = "__rtsm_node_process_title"]
+    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
     fn __rts_sym_2038();
-    #[link_name = "__rtsm_node_process_uptime"]
+    #[link_name = "__rtsm_node_process_hrtime"]
     fn __rts_sym_2039();
-    #[link_name = "__rtsm_node_process_version"]
+    #[link_name = "__rtsm_node_process_hrtime_prev"]
     fn __rts_sym_2040();
-    #[link_name = "__rtsm_node_process_versions"]
+    #[link_name = "__rtsm_node_process_kill"]
     fn __rts_sym_2041();
-    #[link_name = "__rtsm_node_punycode_decode"]
+    #[link_name = "__rtsm_node_process_memoryUsage"]
     fn __rts_sym_2042();
-    #[link_name = "__rtsm_node_punycode_encode"]
+    #[link_name = "__rtsm_node_process_pid"]
     fn __rts_sym_2043();
-    #[link_name = "__rtsm_node_punycode_toASCII"]
+    #[link_name = "__rtsm_node_process_platform"]
     fn __rts_sym_2044();
-    #[link_name = "__rtsm_node_punycode_toUnicode"]
+    #[link_name = "__rtsm_node_process_resourceUsage"]
     fn __rts_sym_2045();
-    #[link_name = "__rtsm_node_querystring_decode"]
+    #[link_name = "__rtsm_node_process_title"]
     fn __rts_sym_2046();
-    #[link_name = "__rtsm_node_querystring_encode"]
+    #[link_name = "__rtsm_node_process_uptime"]
     fn __rts_sym_2047();
-    #[link_name = "__rtsm_node_querystring_escape"]
+    #[link_name = "__rtsm_node_process_version"]
     fn __rts_sym_2048();
-    #[link_name = "__rtsm_node_querystring_parse"]
+    #[link_name = "__rtsm_node_process_versions"]
     fn __rts_sym_2049();
-    #[link_name = "__rtsm_node_querystring_stringify"]
+    #[link_name = "__rtsm_node_punycode_decode"]
     fn __rts_sym_2050();
-    #[link_name = "__rtsm_node_querystring_unescape"]
+    #[link_name = "__rtsm_node_punycode_encode"]
     fn __rts_sym_2051();
-    #[link_name = "__rtsm_node_tls_getCiphers"]
+    #[link_name = "__rtsm_node_punycode_toASCII"]
     fn __rts_sym_2052();
-    #[link_name = "__rtsm_node_tls_getCurves"]
+    #[link_name = "__rtsm_node_punycode_toUnicode"]
     fn __rts_sym_2053();
-    #[link_name = "__rtsm_node_tty_getColorDepth"]
+    #[link_name = "__rtsm_node_querystring_decode"]
     fn __rts_sym_2054();
-    #[link_name = "__rtsm_node_tty_hasColors"]
+    #[link_name = "__rtsm_node_querystring_encode"]
     fn __rts_sym_2055();
-    #[link_name = "__rtsm_node_tty_isatty"]
+    #[link_name = "__rtsm_node_querystring_escape"]
     fn __rts_sym_2056();
-    #[link_name = "__rtsm_node_url_domainToASCII"]
+    #[link_name = "__rtsm_node_querystring_parse"]
     fn __rts_sym_2057();
-    #[link_name = "__rtsm_node_url_domainToUnicode"]
+    #[link_name = "__rtsm_node_querystring_stringify"]
     fn __rts_sym_2058();
-    #[link_name = "__rtsm_node_url_fileURLToPath"]
+    #[link_name = "__rtsm_node_querystring_unescape"]
     fn __rts_sym_2059();
-    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
+    #[link_name = "__rtsm_node_tls_getCiphers"]
     fn __rts_sym_2060();
-    #[link_name = "__rtsm_node_url_format"]
+    #[link_name = "__rtsm_node_tls_getCurves"]
     fn __rts_sym_2061();
-    #[link_name = "__rtsm_node_url_parse"]
+    #[link_name = "__rtsm_node_tty_getColorDepth"]
     fn __rts_sym_2062();
-    #[link_name = "__rtsm_node_url_pathToFileURL"]
+    #[link_name = "__rtsm_node_tty_hasColors"]
     fn __rts_sym_2063();
-    #[link_name = "__rtsm_node_url_resolve"]
+    #[link_name = "__rtsm_node_tty_isatty"]
     fn __rts_sym_2064();
-    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
+    #[link_name = "__rtsm_node_url_domainToASCII"]
     fn __rts_sym_2065();
-    #[link_name = "__rtsm_node_util_format"]
+    #[link_name = "__rtsm_node_url_domainToUnicode"]
     fn __rts_sym_2066();
-    #[link_name = "__rtsm_node_util_formatWithOptions"]
+    #[link_name = "__rtsm_node_url_fileURLToPath"]
     fn __rts_sym_2067();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
+    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
     fn __rts_sym_2068();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
+    #[link_name = "__rtsm_node_url_format"]
     fn __rts_sym_2069();
-    #[link_name = "__rtsm_node_util_format_a1"]
+    #[link_name = "__rtsm_node_url_parse"]
     fn __rts_sym_2070();
-    #[link_name = "__rtsm_node_util_format_a2"]
+    #[link_name = "__rtsm_node_url_pathToFileURL"]
     fn __rts_sym_2071();
-    #[link_name = "__rtsm_node_util_format_a3"]
+    #[link_name = "__rtsm_node_url_resolve"]
     fn __rts_sym_2072();
-    #[link_name = "__rtsm_node_util_format_a4"]
+    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
     fn __rts_sym_2073();
-    #[link_name = "__rtsm_node_util_getSystemErrorName"]
+    #[link_name = "__rtsm_node_util_format"]
     fn __rts_sym_2074();
-    #[link_name = "__rtsm_node_util_inspect"]
+    #[link_name = "__rtsm_node_util_formatWithOptions"]
     fn __rts_sym_2075();
-    #[link_name = "__rtsm_node_util_inspect_opts"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
     fn __rts_sym_2076();
-    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
     fn __rts_sym_2077();
-    #[link_name = "__rtsm_node_util_parseArgs"]
+    #[link_name = "__rtsm_node_util_format_a1"]
     fn __rts_sym_2078();
-    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
+    #[link_name = "__rtsm_node_util_format_a2"]
     fn __rts_sym_2079();
-    #[link_name = "__rtsm_node_util_styleText"]
+    #[link_name = "__rtsm_node_util_format_a3"]
     fn __rts_sym_2080();
-    #[link_name = "__rtsm_node_util_toUSVString"]
+    #[link_name = "__rtsm_node_util_format_a4"]
     fn __rts_sym_2081();
-    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
+    #[link_name = "__rtsm_node_util_getSystemErrorName"]
     fn __rts_sym_2082();
-    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
+    #[link_name = "__rtsm_node_util_inspect"]
     fn __rts_sym_2083();
-    #[link_name = "__rtsm_node_zlib_crc32"]
+    #[link_name = "__rtsm_node_util_inspect_opts"]
     fn __rts_sym_2084();
-    #[link_name = "__rtsm_node_zlib_crc32_prev"]
+    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
     fn __rts_sym_2085();
-    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
+    #[link_name = "__rtsm_node_util_parseArgs"]
     fn __rts_sym_2086();
-    #[link_name = "__rtsm_node_zlib_deflateSync"]
+    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
     fn __rts_sym_2087();
-    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
+    #[link_name = "__rtsm_node_util_styleText"]
     fn __rts_sym_2088();
-    #[link_name = "__rtsm_node_zlib_gunzipSync"]
+    #[link_name = "__rtsm_node_util_toUSVString"]
     fn __rts_sym_2089();
-    #[link_name = "__rtsm_node_zlib_gzipSync"]
+    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
     fn __rts_sym_2090();
-    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
+    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
     fn __rts_sym_2091();
-    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
+    #[link_name = "__rtsm_node_zlib_crc32"]
     fn __rts_sym_2092();
-    #[link_name = "__rtsm_node_zlib_inflateSync"]
+    #[link_name = "__rtsm_node_zlib_crc32_prev"]
     fn __rts_sym_2093();
-    #[link_name = "__rtsm_node_zlib_unzipSync"]
+    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
     fn __rts_sym_2094();
-    #[link_name = "__rtsm_serde_deserialize"]
+    #[link_name = "__rtsm_node_zlib_deflateSync"]
     fn __rts_sym_2095();
-    #[link_name = "__rtsm_serde_serialize"]
+    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
     fn __rts_sym_2096();
-    #[link_name = "__rtsn_agen_new"]
+    #[link_name = "__rtsm_node_zlib_gunzipSync"]
     fn __rts_sym_2097();
-    #[link_name = "__rtsn_agen_next"]
+    #[link_name = "__rtsm_node_zlib_gzipSync"]
     fn __rts_sym_2098();
-    #[link_name = "__rtsn_async_sm_awaited"]
+    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
     fn __rts_sym_2099();
-    #[link_name = "__rtsn_async_sm_new"]
+    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
     fn __rts_sym_2100();
-    #[link_name = "__rtsn_async_sm_resolve"]
+    #[link_name = "__rtsm_node_zlib_inflateSync"]
     fn __rts_sym_2101();
-    #[link_name = "__rtsn_async_sm_resume"]
+    #[link_name = "__rtsm_node_zlib_unzipSync"]
     fn __rts_sym_2102();
-    #[link_name = "__rtsn_async_sm_start"]
+    #[link_name = "__rtsm_serde_deserialize"]
     fn __rts_sym_2103();
-    #[link_name = "__rtsn_async_sm_suspend"]
+    #[link_name = "__rtsm_serde_serialize"]
     fn __rts_sym_2104();
-    #[link_name = "__rtsn_collect"]
+    #[link_name = "__rtsn_agen_new"]
     fn __rts_sym_2105();
-    #[link_name = "__rtsn_collect_debt"]
+    #[link_name = "__rtsn_agen_next"]
     fn __rts_sym_2106();
-    #[link_name = "__rtsn_error_clear"]
+    #[link_name = "__rtsn_async_sm_awaited"]
     fn __rts_sym_2107();
-    #[link_name = "__rtsn_error_get"]
+    #[link_name = "__rtsn_async_sm_new"]
     fn __rts_sym_2108();
-    #[link_name = "__rtsn_error_get_stack"]
+    #[link_name = "__rtsn_async_sm_resolve"]
     fn __rts_sym_2109();
-    #[link_name = "__rtsn_error_set"]
+    #[link_name = "__rtsn_async_sm_resume"]
     fn __rts_sym_2110();
-    #[link_name = "__rtsn_gcell_get"]
+    #[link_name = "__rtsn_async_sm_start"]
     fn __rts_sym_2111();
-    #[link_name = "__rtsn_gcell_set"]
+    #[link_name = "__rtsn_async_sm_suspend"]
     fn __rts_sym_2112();
-    #[link_name = "__rtsn_gen_delegate_done"]
+    #[link_name = "__rtsn_collect"]
     fn __rts_sym_2113();
-    #[link_name = "__rtsn_gen_delegate_next"]
+    #[link_name = "__rtsn_collect_debt"]
     fn __rts_sym_2114();
-    #[link_name = "__rtsn_gen_delegate_start"]
+    #[link_name = "__rtsn_error_clear"]
     fn __rts_sym_2115();
-    #[link_name = "__rtsn_gen_sm_caught"]
+    #[link_name = "__rtsn_error_get"]
     fn __rts_sym_2116();
-    #[link_name = "__rtsn_gen_sm_done"]
+    #[link_name = "__rtsn_error_get_stack"]
     fn __rts_sym_2117();
-    #[link_name = "__rtsn_gen_sm_drain"]
+    #[link_name = "__rtsn_error_set"]
     fn __rts_sym_2118();
-    #[link_name = "__rtsn_gen_sm_end_finally"]
+    #[link_name = "__rtsn_gcell_get"]
     fn __rts_sym_2119();
-    #[link_name = "__rtsn_gen_sm_enter_try"]
+    #[link_name = "__rtsn_gcell_set"]
     fn __rts_sym_2120();
-    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
+    #[link_name = "__rtsn_gen_delegate_done"]
     fn __rts_sym_2121();
-    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
+    #[link_name = "__rtsn_gen_delegate_next"]
     fn __rts_sym_2122();
-    #[link_name = "__rtsn_gen_sm_fget"]
+    #[link_name = "__rtsn_gen_delegate_start"]
     fn __rts_sym_2123();
-    #[link_name = "__rtsn_gen_sm_fset"]
+    #[link_name = "__rtsn_gen_sm_caught"]
     fn __rts_sym_2124();
-    #[link_name = "__rtsn_gen_sm_is"]
+    #[link_name = "__rtsn_gen_sm_done"]
     fn __rts_sym_2125();
-    #[link_name = "__rtsn_gen_sm_new"]
+    #[link_name = "__rtsn_gen_sm_drain"]
     fn __rts_sym_2126();
-    #[link_name = "__rtsn_gen_sm_next"]
+    #[link_name = "__rtsn_gen_sm_end_finally"]
     fn __rts_sym_2127();
-    #[link_name = "__rtsn_gen_sm_return"]
+    #[link_name = "__rtsn_gen_sm_enter_try"]
     fn __rts_sym_2128();
-    #[link_name = "__rtsn_gen_sm_sent"]
+    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
     fn __rts_sym_2129();
-    #[link_name = "__rtsn_gen_sm_setstate"]
+    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
     fn __rts_sym_2130();
-    #[link_name = "__rtsn_gen_sm_state"]
+    #[link_name = "__rtsn_gen_sm_fget"]
     fn __rts_sym_2131();
-    #[link_name = "__rtsn_gen_sm_throw"]
+    #[link_name = "__rtsn_gen_sm_fset"]
     fn __rts_sym_2132();
-    #[link_name = "__rtsn_gen_sm_yield"]
+    #[link_name = "__rtsn_gen_sm_is"]
     fn __rts_sym_2133();
-    #[link_name = "__rtsn_generator_get_ret"]
+    #[link_name = "__rtsn_gen_sm_new"]
     fn __rts_sym_2134();
-    #[link_name = "__rtsn_generator_next"]
+    #[link_name = "__rtsn_gen_sm_next"]
     fn __rts_sym_2135();
-    #[link_name = "__rtsn_generator_next_sent"]
+    #[link_name = "__rtsn_gen_sm_return"]
     fn __rts_sym_2136();
-    #[link_name = "__rtsn_generator_return"]
+    #[link_name = "__rtsn_gen_sm_sent"]
     fn __rts_sym_2137();
-    #[link_name = "__rtsn_generator_set_ret"]
+    #[link_name = "__rtsn_gen_sm_setstate"]
     fn __rts_sym_2138();
-    #[link_name = "__rtsn_generator_throw"]
+    #[link_name = "__rtsn_gen_sm_state"]
     fn __rts_sym_2139();
-    #[link_name = "__rtsn_inspect"]
+    #[link_name = "__rtsn_gen_sm_throw"]
     fn __rts_sym_2140();
-    #[link_name = "__rtsn_iter_done"]
+    #[link_name = "__rtsn_gen_sm_yield"]
     fn __rts_sym_2141();
-    #[link_name = "__rtsn_iter_value"]
+    #[link_name = "__rtsn_generator_get_ret"]
     fn __rts_sym_2142();
-    #[link_name = "__rtsn_live_count"]
+    #[link_name = "__rtsn_generator_next"]
     fn __rts_sym_2143();
-    #[link_name = "__rtsn_object_to_string"]
+    #[link_name = "__rtsn_generator_next_sent"]
     fn __rts_sym_2144();
-    #[link_name = "__rtsn_poly_from_handle"]
+    #[link_name = "__rtsn_generator_return"]
     fn __rts_sym_2145();
-    #[link_name = "__rtsn_poly_to_handle"]
+    #[link_name = "__rtsn_generator_set_ret"]
     fn __rts_sym_2146();
-    #[link_name = "__rtsn_report_uncaught"]
+    #[link_name = "__rtsn_generator_throw"]
     fn __rts_sym_2147();
-    #[link_name = "__rtsn_spread_into_vec"]
+    #[link_name = "__rtsn_inspect"]
     fn __rts_sym_2148();
-    #[link_name = "__rtsn_stack_depth"]
+    #[link_name = "__rtsn_iter_done"]
     fn __rts_sym_2149();
-    #[link_name = "__rtsn_stack_pop"]
+    #[link_name = "__rtsn_iter_value"]
     fn __rts_sym_2150();
-    #[link_name = "__rtsn_stack_push"]
+    #[link_name = "__rtsn_live_count"]
     fn __rts_sym_2151();
-    #[link_name = "__rtsn_string_from_f64"]
+    #[link_name = "__rtsn_object_to_string"]
     fn __rts_sym_2152();
-    #[link_name = "__rtsn_symbol_iterator_of"]
+    #[link_name = "__rtsn_poly_from_handle"]
     fn __rts_sym_2153();
-    #[link_name = "__rtsn_vec_get_by_payload"]
+    #[link_name = "__rtsn_poly_to_handle"]
     fn __rts_sym_2154();
-    #[link_name = "__rtsn_vec_len_by_payload"]
+    #[link_name = "__rtsn_report_uncaught"]
     fn __rts_sym_2155();
-    #[link_name = "__rtsn_vec_new_object"]
+    #[link_name = "__rtsn_spread_into_vec"]
     fn __rts_sym_2156();
-    #[link_name = "__rtsn_vec_push_by_payload"]
+    #[link_name = "__rtsn_stack_depth"]
     fn __rts_sym_2157();
-    #[link_name = "__rtsn_vec_set_by_payload"]
+    #[link_name = "__rtsn_stack_pop"]
     fn __rts_sym_2158();
+    #[link_name = "__rtsn_stack_push"]
+    fn __rts_sym_2159();
+    #[link_name = "__rtsn_string_from_f64"]
+    fn __rts_sym_2160();
+    #[link_name = "__rtsn_symbol_iterator_of"]
+    fn __rts_sym_2161();
+    #[link_name = "__rtsn_vec_get_by_payload"]
+    fn __rts_sym_2162();
+    #[link_name = "__rtsn_vec_len_by_payload"]
+    fn __rts_sym_2163();
+    #[link_name = "__rtsn_vec_new_object"]
+    fn __rts_sym_2164();
+    #[link_name = "__rtsn_vec_push_by_payload"]
+    fn __rts_sym_2165();
+    #[link_name = "__rtsn_vec_set_by_payload"]
+    fn __rts_sym_2166();
 }
 
 /// Every RTS symbol with its address, for `JITBuilder::symbol`.
@@ -4348,7 +4364,7 @@ unsafe extern "C" {
 /// Sorted ascending by name; `#[cfg]`-gated rows drop out on platforms where
 /// they do not exist, which preserves the order of the rows that remain.
 pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
-    let mut out = ::std::vec::Vec::with_capacity(2159);
+    let mut out = ::std::vec::Vec::with_capacity(2167);
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT", ptr: __rts_sym_0 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY", ptr: __rts_sym_1 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT", ptr: __rts_sym_2 as *const u8 });
@@ -6054,467 +6070,475 @@ pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_rdev", ptr: __rts_sym_1702 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_size", ptr: __rts_sym_1703 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_uid", ptr: __rts_sym_1704 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1705 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1706 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1707 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1708 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1709 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1710 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1711 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1712 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1713 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1714 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1715 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1716 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1717 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1718 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1719 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1720 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1721 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1722 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1723 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1724 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1725 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1726 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1727 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1728 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1729 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1730 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1731 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1732 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1733 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1734 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1735 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1736 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1737 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1738 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1739 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1740 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1741 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1742 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1743 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1744 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1745 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1746 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1747 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1748 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1749 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1750 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1751 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1752 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1753 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1754 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1755 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1756 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1757 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1758 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1759 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1760 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1761 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1762 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1763 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1764 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1765 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1766 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1767 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1768 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1769 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1770 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1771 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1772 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1773 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1774 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1775 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1776 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1777 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1778 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1779 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1780 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1781 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1782 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1783 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1784 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1785 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1786 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1787 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1788 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1789 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1790 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1791 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1792 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1793 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1794 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1795 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1796 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1797 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1798 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1799 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1800 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1801 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1802 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1803 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1804 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1805 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1806 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1807 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1808 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1809 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1810 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1811 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1812 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1813 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1814 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1815 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1816 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1817 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1818 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1819 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1820 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1821 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1822 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1823 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1824 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1825 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1826 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1827 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1828 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1829 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1830 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1831 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1832 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1833 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1834 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1835 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1836 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1837 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1838 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1839 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1840 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1841 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1842 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1843 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1844 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1845 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1846 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1847 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1848 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1849 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1850 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1851 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1852 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1853 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1854 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1855 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1856 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1857 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1858 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1859 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1860 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1861 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1862 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1863 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1864 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1865 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1866 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1867 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1868 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1869 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1870 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1871 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1872 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1873 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1874 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1875 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1876 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1877 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1878 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1879 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1880 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1881 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1882 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1883 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1884 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1885 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1886 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1887 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1888 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1889 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1890 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1891 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1892 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1893 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1894 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1895 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1896 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1897 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1898 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1899 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1900 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1901 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1902 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1903 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1904 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1905 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1906 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1907 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1908 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1909 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1910 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1911 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1912 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1913 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1914 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1915 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1916 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1917 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1918 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1919 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1920 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1921 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1922 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1923 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1924 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1925 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1926 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1927 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1928 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1929 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1930 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1931 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1932 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1933 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1934 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1935 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1936 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1937 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1938 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1939 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1940 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1941 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1942 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1943 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1944 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1945 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1946 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1947 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1948 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1949 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1950 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1951 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1952 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1953 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1954 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1955 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1956 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1957 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1958 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1959 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1960 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1961 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1962 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1963 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1964 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1965 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1966 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1967 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1968 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1969 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1970 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1971 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1972 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1973 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1974 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1975 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1976 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_1977 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_1978 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_1979 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_1980 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_1981 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_1982 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_1983 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_1984 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_1985 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_1986 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_1987 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_1988 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_1989 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_1990 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_1991 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_1992 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_1993 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_1994 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_1995 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_1996 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_1997 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_1998 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_1999 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2000 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2001 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2002 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2003 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2004 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2005 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2006 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2007 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2008 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2009 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2010 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2011 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2012 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2013 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2014 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2015 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2016 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2017 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2018 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2019 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2020 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2021 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2022 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2023 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2024 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2025 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2026 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2027 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2028 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2029 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2030 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2031 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2032 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2033 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2034 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2035 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2036 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2037 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2038 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2039 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2040 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2041 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2042 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2043 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2044 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2045 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2046 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2047 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2048 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2049 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2050 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2051 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2052 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2053 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2054 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2055 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2056 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2057 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2058 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2059 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2060 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2061 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2062 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2063 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2064 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2065 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2066 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2067 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2068 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2069 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2070 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2071 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2072 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2073 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2074 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2075 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2076 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2077 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2078 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2079 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2080 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2081 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2082 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2083 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2084 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2085 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2086 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2087 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2088 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2089 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2090 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2091 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2092 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2093 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2094 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2095 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2096 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2097 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2098 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2099 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2100 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2101 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2102 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2103 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2104 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2105 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2106 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2107 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2108 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2109 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2110 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2111 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2112 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2113 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2114 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2115 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2116 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2117 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2118 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2119 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2120 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2121 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2122 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2123 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2124 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2125 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2126 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2127 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2128 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2129 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2130 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2131 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2132 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2133 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2134 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2135 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2136 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2137 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2138 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2139 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2140 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2141 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2142 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2143 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2144 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2145 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2146 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2147 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2148 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2149 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2150 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2151 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2152 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2153 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2154 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2155 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2156 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2157 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2158 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_clear", ptr: __rts_sym_1705 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_getItem", ptr: __rts_sym_1706 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_key", ptr: __rts_sym_1707 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_length", ptr: __rts_sym_1708 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_new", ptr: __rts_sym_1709 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_persistTo", ptr: __rts_sym_1710 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_removeItem", ptr: __rts_sym_1711 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_setItem", ptr: __rts_sym_1712 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1713 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1714 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1715 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1716 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1717 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1718 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1719 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1720 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1721 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1722 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1723 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1724 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1725 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1726 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1727 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1728 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1729 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1730 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1731 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1732 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1733 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1734 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1735 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1736 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1737 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1738 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1739 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1740 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1741 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1742 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1743 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1744 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1745 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1746 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1747 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1748 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1749 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1750 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1751 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1752 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1753 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1754 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1755 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1756 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1757 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1758 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1759 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1760 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1761 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1762 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1763 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1764 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1765 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1766 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1767 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1768 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1769 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1770 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1771 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1772 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1773 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1774 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1775 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1776 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1777 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1778 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1779 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1780 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1781 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1782 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1783 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1784 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1785 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1786 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1787 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1788 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1789 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1790 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1791 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1792 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1793 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1794 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1795 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1796 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1797 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1798 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1799 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1800 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1801 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1802 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1803 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1804 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1805 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1806 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1807 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1808 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1809 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1810 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1811 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1812 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1813 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1814 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1815 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1816 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1817 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1818 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1819 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1820 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1821 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1822 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1823 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1824 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1825 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1826 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1827 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1828 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1829 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1830 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1831 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1832 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1833 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1834 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1835 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1836 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1837 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1838 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1839 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1840 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1841 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1842 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1843 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1844 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1845 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1846 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1847 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1848 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1849 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1850 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1851 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1852 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1853 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1854 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1855 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1856 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1857 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1858 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1859 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1860 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1861 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1862 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1863 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1864 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1865 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1866 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1867 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1868 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1869 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1870 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1871 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1872 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1873 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1874 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1875 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1876 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1877 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1878 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1879 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1880 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1881 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1882 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1883 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1884 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1885 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1886 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1887 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1888 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1889 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1890 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1891 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1892 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1893 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1894 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1895 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1896 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1897 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1898 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1899 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1900 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1901 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1902 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1903 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1904 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1905 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1906 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1907 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1908 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1909 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1910 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1911 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1912 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1913 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1914 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1915 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1916 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1917 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1918 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1919 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1920 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1921 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1922 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1923 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1924 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1925 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1926 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1927 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1928 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1929 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1930 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1931 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1932 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1933 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1934 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1935 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1936 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1937 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1938 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1939 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1940 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1941 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1942 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1943 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1944 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1945 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1946 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1947 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1948 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1949 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1950 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1951 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1952 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1953 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1954 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1955 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1956 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1957 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1958 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1959 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1960 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1961 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1962 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1963 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1964 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1965 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1966 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1967 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1968 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1969 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1970 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1971 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1972 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1973 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1974 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1975 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1976 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1977 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1978 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1979 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1980 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1981 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1982 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1983 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1984 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_1985 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_1986 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_1987 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_1988 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_1989 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_1990 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_1991 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_1992 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_1993 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_1994 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_1995 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_1996 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_1997 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_1998 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_1999 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_2000 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_2001 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_2002 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_2003 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_2004 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_2005 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_2006 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_2007 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2008 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2009 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2010 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2011 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2012 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2013 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2014 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2015 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2016 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2017 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2018 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2019 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2020 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2021 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2022 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2023 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2024 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2025 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2026 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2027 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2028 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2029 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2030 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2031 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2032 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2033 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2034 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2035 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2036 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2037 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2038 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2039 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2040 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2041 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2042 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2043 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2044 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2045 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2046 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2047 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2048 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2049 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2050 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2051 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2052 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2053 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2054 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2055 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2056 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2057 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2058 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2059 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2060 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2061 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2062 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2063 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2064 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2065 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2066 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2067 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2068 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2069 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2070 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2071 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2072 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2073 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2074 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2075 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2076 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2077 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2078 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2079 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2080 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2081 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2082 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2083 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2084 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2085 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2086 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2087 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2088 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2089 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2090 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2091 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2092 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2093 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2094 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2095 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2096 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2097 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2098 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2099 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2100 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2101 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2102 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2103 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2104 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2105 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2106 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2107 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2108 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2109 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2110 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2111 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2112 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2113 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2114 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2115 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2116 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2117 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2118 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2119 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2120 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2121 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2122 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2123 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2124 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2125 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2126 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2127 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2128 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2129 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2130 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2131 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2132 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2133 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2134 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2135 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2136 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2137 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2138 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2139 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2140 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2141 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2142 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2143 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2144 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2145 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2146 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2147 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2148 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2149 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2150 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2151 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2152 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2153 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2154 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2155 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2156 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2157 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2158 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2159 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2160 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2161 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2162 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2163 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2164 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2165 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2166 as *const u8 });
     out
 }
 
 /// The same symbols as names only, for the AOT object module's declaration
 /// list. Same order, same `#[cfg]` gating — the two paths cannot diverge.
 pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
-    let mut out = ::std::vec::Vec::with_capacity(2159);
+    let mut out = ::std::vec::Vec::with_capacity(2167);
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT");
@@ -8220,6 +8244,14 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
     out.push("__rtsm_global_stats_rdev");
     out.push("__rtsm_global_stats_size");
     out.push("__rtsm_global_stats_uid");
+    out.push("__rtsm_global_storage_clear");
+    out.push("__rtsm_global_storage_getItem");
+    out.push("__rtsm_global_storage_key");
+    out.push("__rtsm_global_storage_length");
+    out.push("__rtsm_global_storage_new");
+    out.push("__rtsm_global_storage_persistTo");
+    out.push("__rtsm_global_storage_removeItem");
+    out.push("__rtsm_global_storage_setItem");
     out.push("__rtsm_global_string_at");
     out.push("__rtsm_global_string_char_at");
     out.push("__rtsm_global_string_char_code_at");
@@ -8680,7 +8712,7 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
 /// ABI signatures derived from the Rust signatures of `#[rtse::abi]` fns.
 ///
 /// Sorted ascending by name, like the symbol table, so a lookup is a binary
-/// search. 607 of 2159 symbols carry one; the rest are not yet declared with
+/// search. 607 of 2167 symbols carry one; the rest are not yet declared with
 /// `#[rtse::abi]`.
 pub fn signatures() -> ::std::vec::Vec<(&'static str, &'static [::rts_abi::AbiType], ::rts_abi::AbiType)> {
     // The element type is spelled out: without it the `&[]` of a zero-arg

--- a/crates/rts-symbol-baker/generated/symbol_table.rs
+++ b/crates/rts-symbol-baker/generated/symbol_table.rs
@@ -7,7 +7,7 @@
 // symbol name, so lookup is a binary search and every scope (`__rtsa_`,
 // `__rtsm_node_fs_`, …) is ONE contiguous range. See `rts_abi::table`.
 //
-// 2167 symbols.
+// 2176 symbols.
 
 // Addresses are taken through the LINKER name, not a Rust module path: that
 // reaches every `#[no_mangle]` symbol regardless of Rust visibility, and makes
@@ -3261,1102 +3261,1120 @@ unsafe extern "C" {
     fn __rts_sym_1617();
     #[link_name = "__rtsm_global_iterator_to_array"]
     fn __rts_sym_1618();
-    #[link_name = "__rtsm_global_number_EPSILON"]
+    #[link_name = "__rtsm_global_node_ATTRIBUTE_NODE"]
     fn __rts_sym_1619();
-    #[link_name = "__rtsm_global_number_MAX_SAFE_INTEGER"]
+    #[link_name = "__rtsm_global_node_CDATA_SECTION_NODE"]
     fn __rts_sym_1620();
-    #[link_name = "__rtsm_global_number_MAX_VALUE"]
+    #[link_name = "__rtsm_global_node_COMMENT_NODE"]
     fn __rts_sym_1621();
-    #[link_name = "__rtsm_global_number_MIN_SAFE_INTEGER"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE"]
     fn __rts_sym_1622();
-    #[link_name = "__rtsm_global_number_MIN_VALUE"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_NODE"]
     fn __rts_sym_1623();
-    #[link_name = "__rtsm_global_number_NEGATIVE_INFINITY"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_TYPE_NODE"]
     fn __rts_sym_1624();
-    #[link_name = "__rtsm_global_number_NaN"]
+    #[link_name = "__rtsm_global_node_ELEMENT_NODE"]
     fn __rts_sym_1625();
-    #[link_name = "__rtsm_global_number_POSITIVE_INFINITY"]
+    #[link_name = "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE"]
     fn __rts_sym_1626();
-    #[link_name = "__rtsm_global_number_is_finite"]
+    #[link_name = "__rtsm_global_node_TEXT_NODE"]
     fn __rts_sym_1627();
-    #[link_name = "__rtsm_global_number_is_integer"]
+    #[link_name = "__rtsm_global_number_EPSILON"]
     fn __rts_sym_1628();
-    #[link_name = "__rtsm_global_number_is_nan"]
+    #[link_name = "__rtsm_global_number_MAX_SAFE_INTEGER"]
     fn __rts_sym_1629();
-    #[link_name = "__rtsm_global_number_is_safe_integer"]
+    #[link_name = "__rtsm_global_number_MAX_VALUE"]
     fn __rts_sym_1630();
-    #[link_name = "__rtsm_global_number_new"]
+    #[link_name = "__rtsm_global_number_MIN_SAFE_INTEGER"]
     fn __rts_sym_1631();
-    #[link_name = "__rtsm_global_number_parse_float"]
+    #[link_name = "__rtsm_global_number_MIN_VALUE"]
     fn __rts_sym_1632();
-    #[link_name = "__rtsm_global_number_parse_int"]
+    #[link_name = "__rtsm_global_number_NEGATIVE_INFINITY"]
     fn __rts_sym_1633();
-    #[link_name = "__rtsm_global_number_to_exponential"]
+    #[link_name = "__rtsm_global_number_NaN"]
     fn __rts_sym_1634();
-    #[link_name = "__rtsm_global_number_to_fixed"]
+    #[link_name = "__rtsm_global_number_POSITIVE_INFINITY"]
     fn __rts_sym_1635();
-    #[link_name = "__rtsm_global_number_to_locale_string"]
+    #[link_name = "__rtsm_global_number_is_finite"]
     fn __rts_sym_1636();
-    #[link_name = "__rtsm_global_number_to_precision"]
+    #[link_name = "__rtsm_global_number_is_integer"]
     fn __rts_sym_1637();
-    #[link_name = "__rtsm_global_number_to_string"]
+    #[link_name = "__rtsm_global_number_is_nan"]
     fn __rts_sym_1638();
-    #[link_name = "__rtsm_global_number_value_of"]
+    #[link_name = "__rtsm_global_number_is_safe_integer"]
     fn __rts_sym_1639();
-    #[link_name = "__rtsm_global_proxy_new"]
+    #[link_name = "__rtsm_global_number_new"]
     fn __rts_sym_1640();
-    #[link_name = "__rtsm_global_readablestream_get_reader"]
+    #[link_name = "__rtsm_global_number_parse_float"]
     fn __rts_sym_1641();
-    #[link_name = "__rtsm_global_readablestream_locked__get"]
+    #[link_name = "__rtsm_global_number_parse_int"]
     fn __rts_sym_1642();
-    #[link_name = "__rtsm_global_readablestream_locked__set"]
+    #[link_name = "__rtsm_global_number_to_exponential"]
     fn __rts_sym_1643();
-    #[link_name = "__rtsm_global_readablestream_new"]
+    #[link_name = "__rtsm_global_number_to_fixed"]
     fn __rts_sym_1644();
-    #[link_name = "__rtsm_global_readablestream_pipe_through"]
+    #[link_name = "__rtsm_global_number_to_locale_string"]
     fn __rts_sym_1645();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_close"]
+    #[link_name = "__rtsm_global_number_to_precision"]
     fn __rts_sym_1646();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_desired_size"]
+    #[link_name = "__rtsm_global_number_to_string"]
     fn __rts_sym_1647();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_enqueue"]
+    #[link_name = "__rtsm_global_number_value_of"]
     fn __rts_sym_1648();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_error"]
+    #[link_name = "__rtsm_global_proxy_new"]
     fn __rts_sym_1649();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_new"]
+    #[link_name = "__rtsm_global_readablestream_get_reader"]
     fn __rts_sym_1650();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_cancel"]
+    #[link_name = "__rtsm_global_readablestream_locked__get"]
     fn __rts_sym_1651();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_read"]
+    #[link_name = "__rtsm_global_readablestream_locked__set"]
     fn __rts_sym_1652();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_release_lock"]
+    #[link_name = "__rtsm_global_readablestream_new"]
     fn __rts_sym_1653();
-    #[link_name = "__rtsm_global_rtsepoint3_new"]
+    #[link_name = "__rtsm_global_readablestream_pipe_through"]
     fn __rts_sym_1654();
-    #[link_name = "__rtsm_global_rtsepoint3_sum3"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_close"]
     fn __rts_sym_1655();
-    #[link_name = "__rtsm_global_rtsepoint_at0"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_desired_size"]
     fn __rts_sym_1656();
-    #[link_name = "__rtsm_global_rtsepoint_at1"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_enqueue"]
     fn __rts_sym_1657();
-    #[link_name = "__rtsm_global_rtsepoint_bump"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_error"]
     fn __rts_sym_1658();
-    #[link_name = "__rtsm_global_rtsepoint_info"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_new"]
     fn __rts_sym_1659();
-    #[link_name = "__rtsm_global_rtsepoint_label"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_cancel"]
     fn __rts_sym_1660();
-    #[link_name = "__rtsm_global_rtsepoint_label_async"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_read"]
     fn __rts_sym_1661();
-    #[link_name = "__rtsm_global_rtsepoint_new"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_release_lock"]
     fn __rts_sym_1662();
-    #[link_name = "__rtsm_global_rtsepoint_pairs"]
+    #[link_name = "__rtsm_global_rtsepoint3_new"]
     fn __rts_sym_1663();
-    #[link_name = "__rtsm_global_rtsepoint_parts"]
+    #[link_name = "__rtsm_global_rtsepoint3_sum3"]
     fn __rts_sym_1664();
-    #[link_name = "__rtsm_global_rtsepoint_scaled"]
+    #[link_name = "__rtsm_global_rtsepoint_at0"]
     fn __rts_sym_1665();
-    #[link_name = "__rtsm_global_rtsepoint_scaled_or1"]
+    #[link_name = "__rtsm_global_rtsepoint_at1"]
     fn __rts_sym_1666();
-    #[link_name = "__rtsm_global_rtsepoint_self_ref"]
+    #[link_name = "__rtsm_global_rtsepoint_bump"]
     fn __rts_sym_1667();
-    #[link_name = "__rtsm_global_rtsepoint_set_tag"]
+    #[link_name = "__rtsm_global_rtsepoint_info"]
     fn __rts_sym_1668();
-    #[link_name = "__rtsm_global_rtsepoint_sum"]
+    #[link_name = "__rtsm_global_rtsepoint_label"]
     fn __rts_sym_1669();
-    #[link_name = "__rtsm_global_rtsepoint_tag"]
+    #[link_name = "__rtsm_global_rtsepoint_label_async"]
     fn __rts_sym_1670();
-    #[link_name = "__rtsm_global_rtsepoint_tagged"]
+    #[link_name = "__rtsm_global_rtsepoint_new"]
     fn __rts_sym_1671();
-    #[link_name = "__rtsm_global_rtsepoint_unit"]
+    #[link_name = "__rtsm_global_rtsepoint_pairs"]
     fn __rts_sym_1672();
-    #[link_name = "__rtsm_global_rtsepoint_with_x"]
+    #[link_name = "__rtsm_global_rtsepoint_parts"]
     fn __rts_sym_1673();
-    #[link_name = "__rtsm_global_rtsepoint_x__get"]
+    #[link_name = "__rtsm_global_rtsepoint_scaled"]
     fn __rts_sym_1674();
-    #[link_name = "__rtsm_global_rtsepoint_x__set"]
+    #[link_name = "__rtsm_global_rtsepoint_scaled_or1"]
     fn __rts_sym_1675();
-    #[link_name = "__rtsm_global_rtsepoint_y__get"]
+    #[link_name = "__rtsm_global_rtsepoint_self_ref"]
     fn __rts_sym_1676();
-    #[link_name = "__rtsm_global_socketaddress_address"]
+    #[link_name = "__rtsm_global_rtsepoint_set_tag"]
     fn __rts_sym_1677();
-    #[link_name = "__rtsm_global_socketaddress_family"]
+    #[link_name = "__rtsm_global_rtsepoint_sum"]
     fn __rts_sym_1678();
-    #[link_name = "__rtsm_global_socketaddress_flowlabel"]
+    #[link_name = "__rtsm_global_rtsepoint_tag"]
     fn __rts_sym_1679();
-    #[link_name = "__rtsm_global_socketaddress_new"]
+    #[link_name = "__rtsm_global_rtsepoint_tagged"]
     fn __rts_sym_1680();
-    #[link_name = "__rtsm_global_socketaddress_parse"]
+    #[link_name = "__rtsm_global_rtsepoint_unit"]
     fn __rts_sym_1681();
-    #[link_name = "__rtsm_global_socketaddress_port"]
+    #[link_name = "__rtsm_global_rtsepoint_with_x"]
     fn __rts_sym_1682();
-    #[link_name = "__rtsm_global_socketaddress_with_options"]
+    #[link_name = "__rtsm_global_rtsepoint_x__get"]
     fn __rts_sym_1683();
-    #[link_name = "__rtsm_global_stats_atime_ms"]
+    #[link_name = "__rtsm_global_rtsepoint_x__set"]
     fn __rts_sym_1684();
-    #[link_name = "__rtsm_global_stats_birthtime_ms"]
+    #[link_name = "__rtsm_global_rtsepoint_y__get"]
     fn __rts_sym_1685();
-    #[link_name = "__rtsm_global_stats_blksize"]
+    #[link_name = "__rtsm_global_socketaddress_address"]
     fn __rts_sym_1686();
-    #[link_name = "__rtsm_global_stats_blocks"]
+    #[link_name = "__rtsm_global_socketaddress_family"]
     fn __rts_sym_1687();
-    #[link_name = "__rtsm_global_stats_ctime_ms"]
+    #[link_name = "__rtsm_global_socketaddress_flowlabel"]
     fn __rts_sym_1688();
-    #[link_name = "__rtsm_global_stats_dev"]
+    #[link_name = "__rtsm_global_socketaddress_new"]
     fn __rts_sym_1689();
-    #[link_name = "__rtsm_global_stats_gid"]
+    #[link_name = "__rtsm_global_socketaddress_parse"]
     fn __rts_sym_1690();
-    #[link_name = "__rtsm_global_stats_ino"]
+    #[link_name = "__rtsm_global_socketaddress_port"]
     fn __rts_sym_1691();
-    #[link_name = "__rtsm_global_stats_is_block"]
+    #[link_name = "__rtsm_global_socketaddress_with_options"]
     fn __rts_sym_1692();
-    #[link_name = "__rtsm_global_stats_is_char"]
+    #[link_name = "__rtsm_global_stats_atime_ms"]
     fn __rts_sym_1693();
-    #[link_name = "__rtsm_global_stats_is_directory"]
+    #[link_name = "__rtsm_global_stats_birthtime_ms"]
     fn __rts_sym_1694();
-    #[link_name = "__rtsm_global_stats_is_fifo"]
+    #[link_name = "__rtsm_global_stats_blksize"]
     fn __rts_sym_1695();
-    #[link_name = "__rtsm_global_stats_is_file"]
+    #[link_name = "__rtsm_global_stats_blocks"]
     fn __rts_sym_1696();
-    #[link_name = "__rtsm_global_stats_is_socket"]
+    #[link_name = "__rtsm_global_stats_ctime_ms"]
     fn __rts_sym_1697();
-    #[link_name = "__rtsm_global_stats_is_symlink"]
+    #[link_name = "__rtsm_global_stats_dev"]
     fn __rts_sym_1698();
-    #[link_name = "__rtsm_global_stats_mode"]
+    #[link_name = "__rtsm_global_stats_gid"]
     fn __rts_sym_1699();
-    #[link_name = "__rtsm_global_stats_mtime_ms"]
+    #[link_name = "__rtsm_global_stats_ino"]
     fn __rts_sym_1700();
-    #[link_name = "__rtsm_global_stats_nlink"]
+    #[link_name = "__rtsm_global_stats_is_block"]
     fn __rts_sym_1701();
-    #[link_name = "__rtsm_global_stats_rdev"]
+    #[link_name = "__rtsm_global_stats_is_char"]
     fn __rts_sym_1702();
-    #[link_name = "__rtsm_global_stats_size"]
+    #[link_name = "__rtsm_global_stats_is_directory"]
     fn __rts_sym_1703();
-    #[link_name = "__rtsm_global_stats_uid"]
+    #[link_name = "__rtsm_global_stats_is_fifo"]
     fn __rts_sym_1704();
-    #[link_name = "__rtsm_global_storage_clear"]
+    #[link_name = "__rtsm_global_stats_is_file"]
     fn __rts_sym_1705();
-    #[link_name = "__rtsm_global_storage_getItem"]
+    #[link_name = "__rtsm_global_stats_is_socket"]
     fn __rts_sym_1706();
-    #[link_name = "__rtsm_global_storage_key"]
+    #[link_name = "__rtsm_global_stats_is_symlink"]
     fn __rts_sym_1707();
-    #[link_name = "__rtsm_global_storage_length"]
+    #[link_name = "__rtsm_global_stats_mode"]
     fn __rts_sym_1708();
-    #[link_name = "__rtsm_global_storage_new"]
+    #[link_name = "__rtsm_global_stats_mtime_ms"]
     fn __rts_sym_1709();
-    #[link_name = "__rtsm_global_storage_persistTo"]
+    #[link_name = "__rtsm_global_stats_nlink"]
     fn __rts_sym_1710();
-    #[link_name = "__rtsm_global_storage_removeItem"]
+    #[link_name = "__rtsm_global_stats_rdev"]
     fn __rts_sym_1711();
-    #[link_name = "__rtsm_global_storage_setItem"]
+    #[link_name = "__rtsm_global_stats_size"]
     fn __rts_sym_1712();
-    #[link_name = "__rtsm_global_string_at"]
+    #[link_name = "__rtsm_global_stats_uid"]
     fn __rts_sym_1713();
-    #[link_name = "__rtsm_global_string_char_at"]
+    #[link_name = "__rtsm_global_storage_clear"]
     fn __rts_sym_1714();
-    #[link_name = "__rtsm_global_string_char_code_at"]
+    #[link_name = "__rtsm_global_storage_getItem"]
     fn __rts_sym_1715();
-    #[link_name = "__rtsm_global_string_code_point_at"]
+    #[link_name = "__rtsm_global_storage_key"]
     fn __rts_sym_1716();
-    #[link_name = "__rtsm_global_string_concat"]
+    #[link_name = "__rtsm_global_storage_length"]
     fn __rts_sym_1717();
-    #[link_name = "__rtsm_global_string_ends_with"]
+    #[link_name = "__rtsm_global_storage_new"]
     fn __rts_sym_1718();
-    #[link_name = "__rtsm_global_string_includes"]
+    #[link_name = "__rtsm_global_storage_persistTo"]
     fn __rts_sym_1719();
-    #[link_name = "__rtsm_global_string_index_of"]
+    #[link_name = "__rtsm_global_storage_removeItem"]
     fn __rts_sym_1720();
-    #[link_name = "__rtsm_global_string_is_well_formed"]
+    #[link_name = "__rtsm_global_storage_setItem"]
     fn __rts_sym_1721();
-    #[link_name = "__rtsm_global_string_last_index_of"]
+    #[link_name = "__rtsm_global_string_at"]
     fn __rts_sym_1722();
-    #[link_name = "__rtsm_global_string_length"]
+    #[link_name = "__rtsm_global_string_char_at"]
     fn __rts_sym_1723();
-    #[link_name = "__rtsm_global_string_locale_compare"]
+    #[link_name = "__rtsm_global_string_char_code_at"]
     fn __rts_sym_1724();
-    #[link_name = "__rtsm_global_string_new"]
+    #[link_name = "__rtsm_global_string_code_point_at"]
     fn __rts_sym_1725();
-    #[link_name = "__rtsm_global_string_normalize"]
+    #[link_name = "__rtsm_global_string_concat"]
     fn __rts_sym_1726();
-    #[link_name = "__rtsm_global_string_pad_end"]
+    #[link_name = "__rtsm_global_string_ends_with"]
     fn __rts_sym_1727();
-    #[link_name = "__rtsm_global_string_pad_start"]
+    #[link_name = "__rtsm_global_string_includes"]
     fn __rts_sym_1728();
-    #[link_name = "__rtsm_global_string_repeat"]
+    #[link_name = "__rtsm_global_string_index_of"]
     fn __rts_sym_1729();
-    #[link_name = "__rtsm_global_string_replace"]
+    #[link_name = "__rtsm_global_string_is_well_formed"]
     fn __rts_sym_1730();
-    #[link_name = "__rtsm_global_string_replace_all"]
+    #[link_name = "__rtsm_global_string_last_index_of"]
     fn __rts_sym_1731();
-    #[link_name = "__rtsm_global_string_slice"]
+    #[link_name = "__rtsm_global_string_length"]
     fn __rts_sym_1732();
-    #[link_name = "__rtsm_global_string_starts_with"]
+    #[link_name = "__rtsm_global_string_locale_compare"]
     fn __rts_sym_1733();
-    #[link_name = "__rtsm_global_string_substr"]
+    #[link_name = "__rtsm_global_string_new"]
     fn __rts_sym_1734();
-    #[link_name = "__rtsm_global_string_substring"]
+    #[link_name = "__rtsm_global_string_normalize"]
     fn __rts_sym_1735();
-    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
+    #[link_name = "__rtsm_global_string_pad_end"]
     fn __rts_sym_1736();
-    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
+    #[link_name = "__rtsm_global_string_pad_start"]
     fn __rts_sym_1737();
-    #[link_name = "__rtsm_global_string_to_lower_case"]
+    #[link_name = "__rtsm_global_string_repeat"]
     fn __rts_sym_1738();
-    #[link_name = "__rtsm_global_string_to_string"]
+    #[link_name = "__rtsm_global_string_replace"]
     fn __rts_sym_1739();
-    #[link_name = "__rtsm_global_string_to_upper_case"]
+    #[link_name = "__rtsm_global_string_replace_all"]
     fn __rts_sym_1740();
-    #[link_name = "__rtsm_global_string_to_well_formed"]
+    #[link_name = "__rtsm_global_string_slice"]
     fn __rts_sym_1741();
-    #[link_name = "__rtsm_global_string_trim"]
+    #[link_name = "__rtsm_global_string_starts_with"]
     fn __rts_sym_1742();
-    #[link_name = "__rtsm_global_string_trim_end"]
+    #[link_name = "__rtsm_global_string_substr"]
     fn __rts_sym_1743();
-    #[link_name = "__rtsm_global_string_trim_left"]
+    #[link_name = "__rtsm_global_string_substring"]
     fn __rts_sym_1744();
-    #[link_name = "__rtsm_global_string_trim_right"]
+    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
     fn __rts_sym_1745();
-    #[link_name = "__rtsm_global_string_trim_start"]
+    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
     fn __rts_sym_1746();
-    #[link_name = "__rtsm_global_string_value_of"]
+    #[link_name = "__rtsm_global_string_to_lower_case"]
     fn __rts_sym_1747();
-    #[link_name = "__rtsm_global_stringdecoder_encoding"]
+    #[link_name = "__rtsm_global_string_to_string"]
     fn __rts_sym_1748();
-    #[link_name = "__rtsm_global_stringdecoder_end"]
+    #[link_name = "__rtsm_global_string_to_upper_case"]
     fn __rts_sym_1749();
-    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
+    #[link_name = "__rtsm_global_string_to_well_formed"]
     fn __rts_sym_1750();
-    #[link_name = "__rtsm_global_stringdecoder_new"]
+    #[link_name = "__rtsm_global_string_trim"]
     fn __rts_sym_1751();
-    #[link_name = "__rtsm_global_stringdecoder_text"]
+    #[link_name = "__rtsm_global_string_trim_end"]
     fn __rts_sym_1752();
-    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
+    #[link_name = "__rtsm_global_string_trim_left"]
     fn __rts_sym_1753();
-    #[link_name = "__rtsm_global_stringdecoder_write"]
+    #[link_name = "__rtsm_global_string_trim_right"]
     fn __rts_sym_1754();
-    #[link_name = "__rtsm_global_symbol_description"]
+    #[link_name = "__rtsm_global_string_trim_start"]
     fn __rts_sym_1755();
-    #[link_name = "__rtsm_global_symbol_for_key"]
+    #[link_name = "__rtsm_global_string_value_of"]
     fn __rts_sym_1756();
-    #[link_name = "__rtsm_global_symbol_js_to_string"]
+    #[link_name = "__rtsm_global_stringdecoder_encoding"]
     fn __rts_sym_1757();
-    #[link_name = "__rtsm_global_symbol_key_for"]
+    #[link_name = "__rtsm_global_stringdecoder_end"]
     fn __rts_sym_1758();
-    #[link_name = "__rtsm_global_symbol_new"]
+    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
     fn __rts_sym_1759();
-    #[link_name = "__rtsm_global_textdecoder_decode"]
+    #[link_name = "__rtsm_global_stringdecoder_new"]
     fn __rts_sym_1760();
-    #[link_name = "__rtsm_global_textdecoder_new"]
+    #[link_name = "__rtsm_global_stringdecoder_text"]
     fn __rts_sym_1761();
-    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
+    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
     fn __rts_sym_1762();
-    #[link_name = "__rtsm_global_textdecoderstream_new"]
+    #[link_name = "__rtsm_global_stringdecoder_write"]
     fn __rts_sym_1763();
-    #[link_name = "__rtsm_global_textdecoderstream_readable"]
+    #[link_name = "__rtsm_global_symbol_description"]
     fn __rts_sym_1764();
-    #[link_name = "__rtsm_global_textdecoderstream_writable"]
+    #[link_name = "__rtsm_global_symbol_for_key"]
     fn __rts_sym_1765();
-    #[link_name = "__rtsm_global_textencoder_encode"]
+    #[link_name = "__rtsm_global_symbol_js_to_string"]
     fn __rts_sym_1766();
-    #[link_name = "__rtsm_global_textencoder_encode_into"]
+    #[link_name = "__rtsm_global_symbol_key_for"]
     fn __rts_sym_1767();
-    #[link_name = "__rtsm_global_textencoder_new"]
+    #[link_name = "__rtsm_global_symbol_new"]
     fn __rts_sym_1768();
-    #[link_name = "__rtsm_global_textencoderstream_encoding"]
+    #[link_name = "__rtsm_global_textdecoder_decode"]
     fn __rts_sym_1769();
-    #[link_name = "__rtsm_global_textencoderstream_new"]
+    #[link_name = "__rtsm_global_textdecoder_new"]
     fn __rts_sym_1770();
-    #[link_name = "__rtsm_global_textencoderstream_readable"]
+    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
     fn __rts_sym_1771();
-    #[link_name = "__rtsm_global_textencoderstream_writable"]
+    #[link_name = "__rtsm_global_textdecoderstream_new"]
     fn __rts_sym_1772();
-    #[link_name = "__rtsm_global_transformstream_new"]
+    #[link_name = "__rtsm_global_textdecoderstream_readable"]
     fn __rts_sym_1773();
-    #[link_name = "__rtsm_global_transformstream_readable"]
+    #[link_name = "__rtsm_global_textdecoderstream_writable"]
     fn __rts_sym_1774();
-    #[link_name = "__rtsm_global_transformstream_writable"]
+    #[link_name = "__rtsm_global_textencoder_encode"]
     fn __rts_sym_1775();
-    #[link_name = "__rtsm_global_url_can_parse"]
+    #[link_name = "__rtsm_global_textencoder_encode_into"]
     fn __rts_sym_1776();
-    #[link_name = "__rtsm_global_url_can_parse_base"]
+    #[link_name = "__rtsm_global_textencoder_new"]
     fn __rts_sym_1777();
-    #[link_name = "__rtsm_global_url_hash"]
+    #[link_name = "__rtsm_global_textencoderstream_encoding"]
     fn __rts_sym_1778();
-    #[link_name = "__rtsm_global_url_host"]
+    #[link_name = "__rtsm_global_textencoderstream_new"]
     fn __rts_sym_1779();
-    #[link_name = "__rtsm_global_url_hostname"]
+    #[link_name = "__rtsm_global_textencoderstream_readable"]
     fn __rts_sym_1780();
-    #[link_name = "__rtsm_global_url_href"]
+    #[link_name = "__rtsm_global_textencoderstream_writable"]
     fn __rts_sym_1781();
-    #[link_name = "__rtsm_global_url_new"]
+    #[link_name = "__rtsm_global_transformstream_new"]
     fn __rts_sym_1782();
-    #[link_name = "__rtsm_global_url_new_with_base"]
+    #[link_name = "__rtsm_global_transformstream_readable"]
     fn __rts_sym_1783();
-    #[link_name = "__rtsm_global_url_origin"]
+    #[link_name = "__rtsm_global_transformstream_writable"]
     fn __rts_sym_1784();
-    #[link_name = "__rtsm_global_url_password"]
+    #[link_name = "__rtsm_global_url_can_parse"]
     fn __rts_sym_1785();
-    #[link_name = "__rtsm_global_url_pathname"]
+    #[link_name = "__rtsm_global_url_can_parse_base"]
     fn __rts_sym_1786();
-    #[link_name = "__rtsm_global_url_port"]
+    #[link_name = "__rtsm_global_url_hash"]
     fn __rts_sym_1787();
-    #[link_name = "__rtsm_global_url_protocol"]
+    #[link_name = "__rtsm_global_url_host"]
     fn __rts_sym_1788();
-    #[link_name = "__rtsm_global_url_search"]
+    #[link_name = "__rtsm_global_url_hostname"]
     fn __rts_sym_1789();
-    #[link_name = "__rtsm_global_url_search_params"]
+    #[link_name = "__rtsm_global_url_href"]
     fn __rts_sym_1790();
-    #[link_name = "__rtsm_global_url_set_hash"]
+    #[link_name = "__rtsm_global_url_new"]
     fn __rts_sym_1791();
-    #[link_name = "__rtsm_global_url_set_host"]
+    #[link_name = "__rtsm_global_url_new_with_base"]
     fn __rts_sym_1792();
-    #[link_name = "__rtsm_global_url_set_hostname"]
+    #[link_name = "__rtsm_global_url_origin"]
     fn __rts_sym_1793();
-    #[link_name = "__rtsm_global_url_set_href"]
+    #[link_name = "__rtsm_global_url_password"]
     fn __rts_sym_1794();
-    #[link_name = "__rtsm_global_url_set_password"]
+    #[link_name = "__rtsm_global_url_pathname"]
     fn __rts_sym_1795();
-    #[link_name = "__rtsm_global_url_set_pathname"]
+    #[link_name = "__rtsm_global_url_port"]
     fn __rts_sym_1796();
-    #[link_name = "__rtsm_global_url_set_port"]
+    #[link_name = "__rtsm_global_url_protocol"]
     fn __rts_sym_1797();
-    #[link_name = "__rtsm_global_url_set_protocol"]
+    #[link_name = "__rtsm_global_url_search"]
     fn __rts_sym_1798();
-    #[link_name = "__rtsm_global_url_set_search"]
+    #[link_name = "__rtsm_global_url_search_params"]
     fn __rts_sym_1799();
-    #[link_name = "__rtsm_global_url_set_username"]
+    #[link_name = "__rtsm_global_url_set_hash"]
     fn __rts_sym_1800();
-    #[link_name = "__rtsm_global_url_to_json"]
+    #[link_name = "__rtsm_global_url_set_host"]
     fn __rts_sym_1801();
-    #[link_name = "__rtsm_global_url_to_string"]
+    #[link_name = "__rtsm_global_url_set_hostname"]
     fn __rts_sym_1802();
-    #[link_name = "__rtsm_global_url_username"]
+    #[link_name = "__rtsm_global_url_set_href"]
     fn __rts_sym_1803();
-    #[link_name = "__rtsm_global_urlsearchparams_append"]
+    #[link_name = "__rtsm_global_url_set_password"]
     fn __rts_sym_1804();
-    #[link_name = "__rtsm_global_urlsearchparams_delete"]
+    #[link_name = "__rtsm_global_url_set_pathname"]
     fn __rts_sym_1805();
-    #[link_name = "__rtsm_global_urlsearchparams_get"]
+    #[link_name = "__rtsm_global_url_set_port"]
     fn __rts_sym_1806();
-    #[link_name = "__rtsm_global_urlsearchparams_has"]
+    #[link_name = "__rtsm_global_url_set_protocol"]
     fn __rts_sym_1807();
-    #[link_name = "__rtsm_global_urlsearchparams_new"]
+    #[link_name = "__rtsm_global_url_set_search"]
     fn __rts_sym_1808();
-    #[link_name = "__rtsm_global_urlsearchparams_set"]
+    #[link_name = "__rtsm_global_url_set_username"]
     fn __rts_sym_1809();
-    #[link_name = "__rtsm_global_urlsearchparams_size"]
+    #[link_name = "__rtsm_global_url_to_json"]
     fn __rts_sym_1810();
-    #[link_name = "__rtsm_global_urlsearchparams_sort"]
+    #[link_name = "__rtsm_global_url_to_string"]
     fn __rts_sym_1811();
-    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
+    #[link_name = "__rtsm_global_url_username"]
     fn __rts_sym_1812();
-    #[link_name = "__rtsm_global_weakref_deref"]
+    #[link_name = "__rtsm_global_urlsearchparams_append"]
     fn __rts_sym_1813();
-    #[link_name = "__rtsm_global_weakref_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_delete"]
     fn __rts_sym_1814();
-    #[link_name = "__rtsm_global_writablestream_locked__get"]
+    #[link_name = "__rtsm_global_urlsearchparams_get"]
     fn __rts_sym_1815();
-    #[link_name = "__rtsm_global_writablestream_locked__set"]
+    #[link_name = "__rtsm_global_urlsearchparams_has"]
     fn __rts_sym_1816();
-    #[link_name = "__rtsm_global_writablestream_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_new"]
     fn __rts_sym_1817();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
+    #[link_name = "__rtsm_global_urlsearchparams_set"]
     fn __rts_sym_1818();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
+    #[link_name = "__rtsm_global_urlsearchparams_size"]
     fn __rts_sym_1819();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
+    #[link_name = "__rtsm_global_urlsearchparams_sort"]
     fn __rts_sym_1820();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
+    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
     fn __rts_sym_1821();
-    #[link_name = "__rtsm_node_assert_deepEqual"]
+    #[link_name = "__rtsm_global_weakref_deref"]
     fn __rts_sym_1822();
-    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
+    #[link_name = "__rtsm_global_weakref_new"]
     fn __rts_sym_1823();
-    #[link_name = "__rtsm_node_assert_doesNotMatch"]
+    #[link_name = "__rtsm_global_writablestream_locked__get"]
     fn __rts_sym_1824();
-    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
+    #[link_name = "__rtsm_global_writablestream_locked__set"]
     fn __rts_sym_1825();
-    #[link_name = "__rtsm_node_assert_doesNotThrow"]
+    #[link_name = "__rtsm_global_writablestream_new"]
     fn __rts_sym_1826();
-    #[link_name = "__rtsm_node_assert_equal"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
     fn __rts_sym_1827();
-    #[link_name = "__rtsm_node_assert_fail"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
     fn __rts_sym_1828();
-    #[link_name = "__rtsm_node_assert_fail_msg"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
     fn __rts_sym_1829();
-    #[link_name = "__rtsm_node_assert_ifError"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
     fn __rts_sym_1830();
-    #[link_name = "__rtsm_node_assert_match"]
+    #[link_name = "__rtsm_node_assert_deepEqual"]
     fn __rts_sym_1831();
-    #[link_name = "__rtsm_node_assert_match_msg"]
+    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
     fn __rts_sym_1832();
-    #[link_name = "__rtsm_node_assert_notDeepEqual"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch"]
     fn __rts_sym_1833();
-    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
     fn __rts_sym_1834();
-    #[link_name = "__rtsm_node_assert_notEqual"]
+    #[link_name = "__rtsm_node_assert_doesNotThrow"]
     fn __rts_sym_1835();
-    #[link_name = "__rtsm_node_assert_notStrictEqual"]
+    #[link_name = "__rtsm_node_assert_equal"]
     fn __rts_sym_1836();
-    #[link_name = "__rtsm_node_assert_ok"]
+    #[link_name = "__rtsm_node_assert_fail"]
     fn __rts_sym_1837();
-    #[link_name = "__rtsm_node_assert_ok_msg"]
+    #[link_name = "__rtsm_node_assert_fail_msg"]
     fn __rts_sym_1838();
-    #[link_name = "__rtsm_node_assert_strictEqual"]
+    #[link_name = "__rtsm_node_assert_ifError"]
     fn __rts_sym_1839();
-    #[link_name = "__rtsm_node_assert_throws"]
+    #[link_name = "__rtsm_node_assert_match"]
     fn __rts_sym_1840();
-    #[link_name = "__rtsm_node_buffer_atob"]
+    #[link_name = "__rtsm_node_assert_match_msg"]
     fn __rts_sym_1841();
-    #[link_name = "__rtsm_node_buffer_btoa"]
+    #[link_name = "__rtsm_node_assert_notDeepEqual"]
     fn __rts_sym_1842();
-    #[link_name = "__rtsm_node_crypto_createCipheriv"]
+    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
     fn __rts_sym_1843();
-    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
+    #[link_name = "__rtsm_node_assert_notEqual"]
     fn __rts_sym_1844();
-    #[link_name = "__rtsm_node_crypto_createHash"]
+    #[link_name = "__rtsm_node_assert_notStrictEqual"]
     fn __rts_sym_1845();
-    #[link_name = "__rtsm_node_crypto_createHmac"]
+    #[link_name = "__rtsm_node_assert_ok"]
     fn __rts_sym_1846();
-    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
+    #[link_name = "__rtsm_node_assert_ok_msg"]
     fn __rts_sym_1847();
-    #[link_name = "__rtsm_node_crypto_getHashes"]
+    #[link_name = "__rtsm_node_assert_strictEqual"]
     fn __rts_sym_1848();
-    #[link_name = "__rtsm_node_crypto_hash"]
+    #[link_name = "__rtsm_node_assert_throws"]
     fn __rts_sym_1849();
-    #[link_name = "__rtsm_node_crypto_hash_enc"]
+    #[link_name = "__rtsm_node_buffer_atob"]
     fn __rts_sym_1850();
-    #[link_name = "__rtsm_node_crypto_hkdfSync"]
+    #[link_name = "__rtsm_node_buffer_btoa"]
     fn __rts_sym_1851();
-    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
+    #[link_name = "__rtsm_node_crypto_createCipheriv"]
     fn __rts_sym_1852();
-    #[link_name = "__rtsm_node_crypto_randomBytes"]
+    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
     fn __rts_sym_1853();
-    #[link_name = "__rtsm_node_crypto_randomFillSync"]
+    #[link_name = "__rtsm_node_crypto_createHash"]
     fn __rts_sym_1854();
-    #[link_name = "__rtsm_node_crypto_randomInt"]
+    #[link_name = "__rtsm_node_crypto_createHmac"]
     fn __rts_sym_1855();
-    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
+    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
     fn __rts_sym_1856();
-    #[link_name = "__rtsm_node_crypto_randomUUID"]
+    #[link_name = "__rtsm_node_crypto_getHashes"]
     fn __rts_sym_1857();
-    #[link_name = "__rtsm_node_crypto_scryptSync"]
+    #[link_name = "__rtsm_node_crypto_hash"]
     fn __rts_sym_1858();
-    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
+    #[link_name = "__rtsm_node_crypto_hash_enc"]
     fn __rts_sym_1859();
-    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
+    #[link_name = "__rtsm_node_crypto_hkdfSync"]
     fn __rts_sym_1860();
-    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
+    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
     fn __rts_sym_1861();
-    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
+    #[link_name = "__rtsm_node_crypto_randomBytes"]
     fn __rts_sym_1862();
-    #[link_name = "__rtsm_node_dgram_createSocket"]
+    #[link_name = "__rtsm_node_crypto_randomFillSync"]
     fn __rts_sym_1863();
-    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
+    #[link_name = "__rtsm_node_crypto_randomInt"]
     fn __rts_sym_1864();
-    #[link_name = "__rtsm_node_dns_lookup"]
+    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
     fn __rts_sym_1865();
-    #[link_name = "__rtsm_node_dns_resolve4"]
+    #[link_name = "__rtsm_node_crypto_randomUUID"]
     fn __rts_sym_1866();
-    #[link_name = "__rtsm_node_dns_resolve6"]
+    #[link_name = "__rtsm_node_crypto_scryptSync"]
     fn __rts_sym_1867();
-    #[link_name = "__rtsm_node_fs_access"]
+    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
     fn __rts_sym_1868();
-    #[link_name = "__rtsm_node_fs_accessSync"]
+    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
     fn __rts_sym_1869();
-    #[link_name = "__rtsm_node_fs_appendFile"]
+    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
     fn __rts_sym_1870();
-    #[link_name = "__rtsm_node_fs_appendFileSync"]
+    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
     fn __rts_sym_1871();
-    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
+    #[link_name = "__rtsm_node_dgram_createSocket"]
     fn __rts_sym_1872();
-    #[link_name = "__rtsm_node_fs_chmod"]
+    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
     fn __rts_sym_1873();
-    #[link_name = "__rtsm_node_fs_chmodSync"]
+    #[link_name = "__rtsm_node_dns_lookup"]
     fn __rts_sym_1874();
-    #[link_name = "__rtsm_node_fs_chownSync"]
+    #[link_name = "__rtsm_node_dns_resolve4"]
     fn __rts_sym_1875();
-    #[link_name = "__rtsm_node_fs_closeSync"]
+    #[link_name = "__rtsm_node_dns_resolve6"]
     fn __rts_sym_1876();
-    #[link_name = "__rtsm_node_fs_copyFile"]
+    #[link_name = "__rtsm_node_fs_access"]
     fn __rts_sym_1877();
-    #[link_name = "__rtsm_node_fs_copyFileSync"]
+    #[link_name = "__rtsm_node_fs_accessSync"]
     fn __rts_sym_1878();
-    #[link_name = "__rtsm_node_fs_cpSync"]
+    #[link_name = "__rtsm_node_fs_appendFile"]
     fn __rts_sym_1879();
-    #[link_name = "__rtsm_node_fs_cpSync_opts"]
+    #[link_name = "__rtsm_node_fs_appendFileSync"]
     fn __rts_sym_1880();
-    #[link_name = "__rtsm_node_fs_exists"]
+    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
     fn __rts_sym_1881();
-    #[link_name = "__rtsm_node_fs_existsSync"]
+    #[link_name = "__rtsm_node_fs_chmod"]
     fn __rts_sym_1882();
-    #[link_name = "__rtsm_node_fs_fchmodSync"]
+    #[link_name = "__rtsm_node_fs_chmodSync"]
     fn __rts_sym_1883();
-    #[link_name = "__rtsm_node_fs_fchownSync"]
+    #[link_name = "__rtsm_node_fs_chownSync"]
     fn __rts_sym_1884();
-    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
+    #[link_name = "__rtsm_node_fs_closeSync"]
     fn __rts_sym_1885();
-    #[link_name = "__rtsm_node_fs_fstatSync"]
+    #[link_name = "__rtsm_node_fs_copyFile"]
     fn __rts_sym_1886();
-    #[link_name = "__rtsm_node_fs_fsyncSync"]
+    #[link_name = "__rtsm_node_fs_copyFileSync"]
     fn __rts_sym_1887();
-    #[link_name = "__rtsm_node_fs_ftruncateSync"]
+    #[link_name = "__rtsm_node_fs_cpSync"]
     fn __rts_sym_1888();
-    #[link_name = "__rtsm_node_fs_futimesSync"]
+    #[link_name = "__rtsm_node_fs_cpSync_opts"]
     fn __rts_sym_1889();
-    #[link_name = "__rtsm_node_fs_globSync"]
+    #[link_name = "__rtsm_node_fs_exists"]
     fn __rts_sym_1890();
-    #[link_name = "__rtsm_node_fs_lchmodSync"]
+    #[link_name = "__rtsm_node_fs_existsSync"]
     fn __rts_sym_1891();
-    #[link_name = "__rtsm_node_fs_lchownSync"]
+    #[link_name = "__rtsm_node_fs_fchmodSync"]
     fn __rts_sym_1892();
-    #[link_name = "__rtsm_node_fs_linkSync"]
+    #[link_name = "__rtsm_node_fs_fchownSync"]
     fn __rts_sym_1893();
-    #[link_name = "__rtsm_node_fs_lstat"]
+    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
     fn __rts_sym_1894();
-    #[link_name = "__rtsm_node_fs_lstatSync"]
+    #[link_name = "__rtsm_node_fs_fstatSync"]
     fn __rts_sym_1895();
-    #[link_name = "__rtsm_node_fs_mkdir"]
+    #[link_name = "__rtsm_node_fs_fsyncSync"]
     fn __rts_sym_1896();
-    #[link_name = "__rtsm_node_fs_mkdirSync"]
+    #[link_name = "__rtsm_node_fs_ftruncateSync"]
     fn __rts_sym_1897();
-    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_futimesSync"]
     fn __rts_sym_1898();
-    #[link_name = "__rtsm_node_fs_mkdtempSync"]
+    #[link_name = "__rtsm_node_fs_globSync"]
     fn __rts_sym_1899();
-    #[link_name = "__rtsm_node_fs_openSync"]
+    #[link_name = "__rtsm_node_fs_lchmodSync"]
     fn __rts_sym_1900();
-    #[link_name = "__rtsm_node_fs_opendirSync"]
+    #[link_name = "__rtsm_node_fs_lchownSync"]
     fn __rts_sym_1901();
-    #[link_name = "__rtsm_node_fs_promises_access"]
+    #[link_name = "__rtsm_node_fs_linkSync"]
     fn __rts_sym_1902();
-    #[link_name = "__rtsm_node_fs_promises_appendFile"]
+    #[link_name = "__rtsm_node_fs_lstat"]
     fn __rts_sym_1903();
-    #[link_name = "__rtsm_node_fs_promises_copyFile"]
+    #[link_name = "__rtsm_node_fs_lstatSync"]
     fn __rts_sym_1904();
-    #[link_name = "__rtsm_node_fs_promises_lstat"]
+    #[link_name = "__rtsm_node_fs_mkdir"]
     fn __rts_sym_1905();
-    #[link_name = "__rtsm_node_fs_promises_mkdir"]
+    #[link_name = "__rtsm_node_fs_mkdirSync"]
     fn __rts_sym_1906();
-    #[link_name = "__rtsm_node_fs_promises_open"]
+    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
     fn __rts_sym_1907();
-    #[link_name = "__rtsm_node_fs_promises_readFile"]
+    #[link_name = "__rtsm_node_fs_mkdtempSync"]
     fn __rts_sym_1908();
-    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_openSync"]
     fn __rts_sym_1909();
-    #[link_name = "__rtsm_node_fs_promises_readdir"]
+    #[link_name = "__rtsm_node_fs_opendirSync"]
     fn __rts_sym_1910();
-    #[link_name = "__rtsm_node_fs_promises_readlink"]
+    #[link_name = "__rtsm_node_fs_promises_access"]
     fn __rts_sym_1911();
-    #[link_name = "__rtsm_node_fs_promises_realpath"]
+    #[link_name = "__rtsm_node_fs_promises_appendFile"]
     fn __rts_sym_1912();
-    #[link_name = "__rtsm_node_fs_promises_rename"]
+    #[link_name = "__rtsm_node_fs_promises_copyFile"]
     fn __rts_sym_1913();
-    #[link_name = "__rtsm_node_fs_promises_rm"]
+    #[link_name = "__rtsm_node_fs_promises_lstat"]
     fn __rts_sym_1914();
-    #[link_name = "__rtsm_node_fs_promises_rmdir"]
+    #[link_name = "__rtsm_node_fs_promises_mkdir"]
     fn __rts_sym_1915();
-    #[link_name = "__rtsm_node_fs_promises_stat"]
+    #[link_name = "__rtsm_node_fs_promises_open"]
     fn __rts_sym_1916();
-    #[link_name = "__rtsm_node_fs_promises_truncate"]
+    #[link_name = "__rtsm_node_fs_promises_readFile"]
     fn __rts_sym_1917();
-    #[link_name = "__rtsm_node_fs_promises_unlink"]
+    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
     fn __rts_sym_1918();
-    #[link_name = "__rtsm_node_fs_promises_writeFile"]
+    #[link_name = "__rtsm_node_fs_promises_readdir"]
     fn __rts_sym_1919();
-    #[link_name = "__rtsm_node_fs_readFile"]
+    #[link_name = "__rtsm_node_fs_promises_readlink"]
     fn __rts_sym_1920();
-    #[link_name = "__rtsm_node_fs_readFileSync"]
+    #[link_name = "__rtsm_node_fs_promises_realpath"]
     fn __rts_sym_1921();
-    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_promises_rename"]
     fn __rts_sym_1922();
-    #[link_name = "__rtsm_node_fs_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_promises_rm"]
     fn __rts_sym_1923();
-    #[link_name = "__rtsm_node_fs_readSync"]
+    #[link_name = "__rtsm_node_fs_promises_rmdir"]
     fn __rts_sym_1924();
-    #[link_name = "__rtsm_node_fs_readdir"]
+    #[link_name = "__rtsm_node_fs_promises_stat"]
     fn __rts_sym_1925();
-    #[link_name = "__rtsm_node_fs_readdirSync"]
+    #[link_name = "__rtsm_node_fs_promises_truncate"]
     fn __rts_sym_1926();
-    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_promises_unlink"]
     fn __rts_sym_1927();
-    #[link_name = "__rtsm_node_fs_readlinkSync"]
+    #[link_name = "__rtsm_node_fs_promises_writeFile"]
     fn __rts_sym_1928();
-    #[link_name = "__rtsm_node_fs_readvSync"]
+    #[link_name = "__rtsm_node_fs_readFile"]
     fn __rts_sym_1929();
-    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
+    #[link_name = "__rtsm_node_fs_readFileSync"]
     fn __rts_sym_1930();
-    #[link_name = "__rtsm_node_fs_realpath"]
+    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
     fn __rts_sym_1931();
-    #[link_name = "__rtsm_node_fs_realpathSync"]
+    #[link_name = "__rtsm_node_fs_readFile_enc"]
     fn __rts_sym_1932();
-    #[link_name = "__rtsm_node_fs_rename"]
+    #[link_name = "__rtsm_node_fs_readSync"]
     fn __rts_sym_1933();
-    #[link_name = "__rtsm_node_fs_renameSync"]
+    #[link_name = "__rtsm_node_fs_readdir"]
     fn __rts_sym_1934();
-    #[link_name = "__rtsm_node_fs_rm"]
+    #[link_name = "__rtsm_node_fs_readdirSync"]
     fn __rts_sym_1935();
-    #[link_name = "__rtsm_node_fs_rmSync"]
+    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
     fn __rts_sym_1936();
-    #[link_name = "__rtsm_node_fs_rmSync_opts"]
+    #[link_name = "__rtsm_node_fs_readlinkSync"]
     fn __rts_sym_1937();
-    #[link_name = "__rtsm_node_fs_rmdir"]
+    #[link_name = "__rtsm_node_fs_readvSync"]
     fn __rts_sym_1938();
-    #[link_name = "__rtsm_node_fs_rmdirSync"]
+    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
     fn __rts_sym_1939();
-    #[link_name = "__rtsm_node_fs_stat"]
+    #[link_name = "__rtsm_node_fs_realpath"]
     fn __rts_sym_1940();
-    #[link_name = "__rtsm_node_fs_statSync"]
+    #[link_name = "__rtsm_node_fs_realpathSync"]
     fn __rts_sym_1941();
-    #[link_name = "__rtsm_node_fs_statfsSync"]
+    #[link_name = "__rtsm_node_fs_rename"]
     fn __rts_sym_1942();
-    #[link_name = "__rtsm_node_fs_symlinkSync"]
+    #[link_name = "__rtsm_node_fs_renameSync"]
     fn __rts_sym_1943();
-    #[link_name = "__rtsm_node_fs_truncateSync"]
+    #[link_name = "__rtsm_node_fs_rm"]
     fn __rts_sym_1944();
-    #[link_name = "__rtsm_node_fs_unlink"]
+    #[link_name = "__rtsm_node_fs_rmSync"]
     fn __rts_sym_1945();
-    #[link_name = "__rtsm_node_fs_unlinkSync"]
+    #[link_name = "__rtsm_node_fs_rmSync_opts"]
     fn __rts_sym_1946();
-    #[link_name = "__rtsm_node_fs_unwatchFile"]
+    #[link_name = "__rtsm_node_fs_rmdir"]
     fn __rts_sym_1947();
-    #[link_name = "__rtsm_node_fs_utimesSync"]
+    #[link_name = "__rtsm_node_fs_rmdirSync"]
     fn __rts_sym_1948();
-    #[link_name = "__rtsm_node_fs_watch"]
+    #[link_name = "__rtsm_node_fs_stat"]
     fn __rts_sym_1949();
-    #[link_name = "__rtsm_node_fs_watchFile"]
+    #[link_name = "__rtsm_node_fs_statSync"]
     fn __rts_sym_1950();
-    #[link_name = "__rtsm_node_fs_watchFile_interval"]
+    #[link_name = "__rtsm_node_fs_statfsSync"]
     fn __rts_sym_1951();
-    #[link_name = "__rtsm_node_fs_writeFile"]
+    #[link_name = "__rtsm_node_fs_symlinkSync"]
     fn __rts_sym_1952();
-    #[link_name = "__rtsm_node_fs_writeFileSync"]
+    #[link_name = "__rtsm_node_fs_truncateSync"]
     fn __rts_sym_1953();
-    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_unlink"]
     fn __rts_sym_1954();
-    #[link_name = "__rtsm_node_fs_writeSync"]
+    #[link_name = "__rtsm_node_fs_unlinkSync"]
     fn __rts_sym_1955();
-    #[link_name = "__rtsm_node_fs_writevSync"]
+    #[link_name = "__rtsm_node_fs_unwatchFile"]
     fn __rts_sym_1956();
-    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
+    #[link_name = "__rtsm_node_fs_utimesSync"]
     fn __rts_sym_1957();
-    #[link_name = "__rtsm_node_http_METHODS"]
+    #[link_name = "__rtsm_node_fs_watch"]
     fn __rts_sym_1958();
-    #[link_name = "__rtsm_node_http_STATUS_CODES"]
+    #[link_name = "__rtsm_node_fs_watchFile"]
     fn __rts_sym_1959();
-    #[link_name = "__rtsm_node_module_builtinModules"]
+    #[link_name = "__rtsm_node_fs_watchFile_interval"]
     fn __rts_sym_1960();
-    #[link_name = "__rtsm_node_module_isBuiltin"]
+    #[link_name = "__rtsm_node_fs_writeFile"]
     fn __rts_sym_1961();
-    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
+    #[link_name = "__rtsm_node_fs_writeFileSync"]
     fn __rts_sym_1962();
-    #[link_name = "__rtsm_node_module_wrap"]
+    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
     fn __rts_sym_1963();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_fs_writeSync"]
     fn __rts_sym_1964();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_fs_writevSync"]
     fn __rts_sym_1965();
-    #[link_name = "__rtsm_node_net_isIP"]
+    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
     fn __rts_sym_1966();
-    #[link_name = "__rtsm_node_net_isIPv4"]
+    #[link_name = "__rtsm_node_http_METHODS"]
     fn __rts_sym_1967();
-    #[link_name = "__rtsm_node_net_isIPv6"]
+    #[link_name = "__rtsm_node_http_STATUS_CODES"]
     fn __rts_sym_1968();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_module_builtinModules"]
     fn __rts_sym_1969();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_module_isBuiltin"]
     fn __rts_sym_1970();
-    #[link_name = "__rtsm_node_os_EOL"]
+    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
     fn __rts_sym_1971();
-    #[link_name = "__rtsm_node_os_arch"]
+    #[link_name = "__rtsm_node_module_wrap"]
     fn __rts_sym_1972();
-    #[link_name = "__rtsm_node_os_availableParallelism"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
     fn __rts_sym_1973();
-    #[link_name = "__rtsm_node_os_cpus"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1974();
-    #[link_name = "__rtsm_node_os_endianness"]
+    #[link_name = "__rtsm_node_net_isIP"]
     fn __rts_sym_1975();
-    #[link_name = "__rtsm_node_os_freemem"]
+    #[link_name = "__rtsm_node_net_isIPv4"]
     fn __rts_sym_1976();
-    #[link_name = "__rtsm_node_os_getPriority"]
+    #[link_name = "__rtsm_node_net_isIPv6"]
     fn __rts_sym_1977();
-    #[link_name = "__rtsm_node_os_getPriority_pid"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
     fn __rts_sym_1978();
-    #[link_name = "__rtsm_node_os_homedir"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1979();
-    #[link_name = "__rtsm_node_os_hostname"]
+    #[link_name = "__rtsm_node_os_EOL"]
     fn __rts_sym_1980();
-    #[link_name = "__rtsm_node_os_loadavg"]
+    #[link_name = "__rtsm_node_os_arch"]
     fn __rts_sym_1981();
-    #[link_name = "__rtsm_node_os_machine"]
+    #[link_name = "__rtsm_node_os_availableParallelism"]
     fn __rts_sym_1982();
-    #[link_name = "__rtsm_node_os_networkInterfaces"]
+    #[link_name = "__rtsm_node_os_cpus"]
     fn __rts_sym_1983();
-    #[link_name = "__rtsm_node_os_platform"]
+    #[link_name = "__rtsm_node_os_endianness"]
     fn __rts_sym_1984();
-    #[link_name = "__rtsm_node_os_release"]
+    #[link_name = "__rtsm_node_os_freemem"]
     fn __rts_sym_1985();
-    #[link_name = "__rtsm_node_os_setPriority"]
+    #[link_name = "__rtsm_node_os_getPriority"]
     fn __rts_sym_1986();
-    #[link_name = "__rtsm_node_os_setPriority_pid"]
+    #[link_name = "__rtsm_node_os_getPriority_pid"]
     fn __rts_sym_1987();
-    #[link_name = "__rtsm_node_os_tmpdir"]
+    #[link_name = "__rtsm_node_os_homedir"]
     fn __rts_sym_1988();
-    #[link_name = "__rtsm_node_os_totalmem"]
+    #[link_name = "__rtsm_node_os_hostname"]
     fn __rts_sym_1989();
-    #[link_name = "__rtsm_node_os_type"]
+    #[link_name = "__rtsm_node_os_loadavg"]
     fn __rts_sym_1990();
-    #[link_name = "__rtsm_node_os_uptime"]
+    #[link_name = "__rtsm_node_os_machine"]
     fn __rts_sym_1991();
-    #[link_name = "__rtsm_node_os_userInfo"]
+    #[link_name = "__rtsm_node_os_networkInterfaces"]
     fn __rts_sym_1992();
-    #[link_name = "__rtsm_node_os_version"]
+    #[link_name = "__rtsm_node_os_platform"]
     fn __rts_sym_1993();
-    #[link_name = "__rtsm_node_path_posix_basename"]
+    #[link_name = "__rtsm_node_os_release"]
     fn __rts_sym_1994();
-    #[link_name = "__rtsm_node_path_posix_dirname"]
+    #[link_name = "__rtsm_node_os_setPriority"]
     fn __rts_sym_1995();
-    #[link_name = "__rtsm_node_path_posix_extname"]
+    #[link_name = "__rtsm_node_os_setPriority_pid"]
     fn __rts_sym_1996();
-    #[link_name = "__rtsm_node_path_posix_format"]
+    #[link_name = "__rtsm_node_os_tmpdir"]
     fn __rts_sym_1997();
-    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
+    #[link_name = "__rtsm_node_os_totalmem"]
     fn __rts_sym_1998();
-    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
+    #[link_name = "__rtsm_node_os_type"]
     fn __rts_sym_1999();
-    #[link_name = "__rtsm_node_path_posix_normalize"]
+    #[link_name = "__rtsm_node_os_uptime"]
     fn __rts_sym_2000();
-    #[link_name = "__rtsm_node_path_posix_parse"]
+    #[link_name = "__rtsm_node_os_userInfo"]
     fn __rts_sym_2001();
-    #[link_name = "__rtsm_node_path_posix_relative"]
+    #[link_name = "__rtsm_node_os_version"]
     fn __rts_sym_2002();
-    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_posix_basename"]
     fn __rts_sym_2003();
-    #[link_name = "__rtsm_node_path_win32_basename"]
+    #[link_name = "__rtsm_node_path_posix_dirname"]
     fn __rts_sym_2004();
-    #[link_name = "__rtsm_node_path_win32_dirname"]
+    #[link_name = "__rtsm_node_path_posix_extname"]
     fn __rts_sym_2005();
-    #[link_name = "__rtsm_node_path_win32_extname"]
+    #[link_name = "__rtsm_node_path_posix_format"]
     fn __rts_sym_2006();
-    #[link_name = "__rtsm_node_path_win32_format"]
+    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
     fn __rts_sym_2007();
-    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
+    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
     fn __rts_sym_2008();
-    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
+    #[link_name = "__rtsm_node_path_posix_normalize"]
     fn __rts_sym_2009();
-    #[link_name = "__rtsm_node_path_win32_normalize"]
+    #[link_name = "__rtsm_node_path_posix_parse"]
     fn __rts_sym_2010();
-    #[link_name = "__rtsm_node_path_win32_parse"]
+    #[link_name = "__rtsm_node_path_posix_relative"]
     fn __rts_sym_2011();
-    #[link_name = "__rtsm_node_path_win32_relative"]
+    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
     fn __rts_sym_2012();
-    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_win32_basename"]
     fn __rts_sym_2013();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
+    #[link_name = "__rtsm_node_path_win32_dirname"]
     fn __rts_sym_2014();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
+    #[link_name = "__rtsm_node_path_win32_extname"]
     fn __rts_sym_2015();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
+    #[link_name = "__rtsm_node_path_win32_format"]
     fn __rts_sym_2016();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
+    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
     fn __rts_sym_2017();
-    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
+    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
     fn __rts_sym_2018();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
+    #[link_name = "__rtsm_node_path_win32_normalize"]
     fn __rts_sym_2019();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
+    #[link_name = "__rtsm_node_path_win32_parse"]
     fn __rts_sym_2020();
-    #[link_name = "__rtsm_node_perf_hooks_mark"]
+    #[link_name = "__rtsm_node_path_win32_relative"]
     fn __rts_sym_2021();
-    #[link_name = "__rtsm_node_perf_hooks_measure"]
+    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
     fn __rts_sym_2022();
-    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
     fn __rts_sym_2023();
-    #[link_name = "__rtsm_node_perf_hooks_now"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
     fn __rts_sym_2024();
-    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
     fn __rts_sym_2025();
-    #[link_name = "__rtsm_node_process_abort"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
     fn __rts_sym_2026();
-    #[link_name = "__rtsm_node_process_arch"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
     fn __rts_sym_2027();
-    #[link_name = "__rtsm_node_process_argv"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
     fn __rts_sym_2028();
-    #[link_name = "__rtsm_node_process_argv0"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
     fn __rts_sym_2029();
-    #[link_name = "__rtsm_node_process_availableMemory"]
+    #[link_name = "__rtsm_node_perf_hooks_mark"]
     fn __rts_sym_2030();
-    #[link_name = "__rtsm_node_process_chdir"]
+    #[link_name = "__rtsm_node_perf_hooks_measure"]
     fn __rts_sym_2031();
-    #[link_name = "__rtsm_node_process_constrainedMemory"]
+    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
     fn __rts_sym_2032();
-    #[link_name = "__rtsm_node_process_cpuUsage"]
+    #[link_name = "__rtsm_node_perf_hooks_now"]
     fn __rts_sym_2033();
-    #[link_name = "__rtsm_node_process_cwd"]
+    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
     fn __rts_sym_2034();
-    #[link_name = "__rtsm_node_process_env"]
+    #[link_name = "__rtsm_node_process_abort"]
     fn __rts_sym_2035();
-    #[link_name = "__rtsm_node_process_execPath"]
+    #[link_name = "__rtsm_node_process_arch"]
     fn __rts_sym_2036();
-    #[link_name = "__rtsm_node_process_exit"]
+    #[link_name = "__rtsm_node_process_argv"]
     fn __rts_sym_2037();
-    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
+    #[link_name = "__rtsm_node_process_argv0"]
     fn __rts_sym_2038();
-    #[link_name = "__rtsm_node_process_hrtime"]
+    #[link_name = "__rtsm_node_process_availableMemory"]
     fn __rts_sym_2039();
-    #[link_name = "__rtsm_node_process_hrtime_prev"]
+    #[link_name = "__rtsm_node_process_chdir"]
     fn __rts_sym_2040();
-    #[link_name = "__rtsm_node_process_kill"]
+    #[link_name = "__rtsm_node_process_constrainedMemory"]
     fn __rts_sym_2041();
-    #[link_name = "__rtsm_node_process_memoryUsage"]
+    #[link_name = "__rtsm_node_process_cpuUsage"]
     fn __rts_sym_2042();
-    #[link_name = "__rtsm_node_process_pid"]
+    #[link_name = "__rtsm_node_process_cwd"]
     fn __rts_sym_2043();
-    #[link_name = "__rtsm_node_process_platform"]
+    #[link_name = "__rtsm_node_process_env"]
     fn __rts_sym_2044();
-    #[link_name = "__rtsm_node_process_resourceUsage"]
+    #[link_name = "__rtsm_node_process_execPath"]
     fn __rts_sym_2045();
-    #[link_name = "__rtsm_node_process_title"]
+    #[link_name = "__rtsm_node_process_exit"]
     fn __rts_sym_2046();
-    #[link_name = "__rtsm_node_process_uptime"]
+    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
     fn __rts_sym_2047();
-    #[link_name = "__rtsm_node_process_version"]
+    #[link_name = "__rtsm_node_process_hrtime"]
     fn __rts_sym_2048();
-    #[link_name = "__rtsm_node_process_versions"]
+    #[link_name = "__rtsm_node_process_hrtime_prev"]
     fn __rts_sym_2049();
-    #[link_name = "__rtsm_node_punycode_decode"]
+    #[link_name = "__rtsm_node_process_kill"]
     fn __rts_sym_2050();
-    #[link_name = "__rtsm_node_punycode_encode"]
+    #[link_name = "__rtsm_node_process_memoryUsage"]
     fn __rts_sym_2051();
-    #[link_name = "__rtsm_node_punycode_toASCII"]
+    #[link_name = "__rtsm_node_process_pid"]
     fn __rts_sym_2052();
-    #[link_name = "__rtsm_node_punycode_toUnicode"]
+    #[link_name = "__rtsm_node_process_platform"]
     fn __rts_sym_2053();
-    #[link_name = "__rtsm_node_querystring_decode"]
+    #[link_name = "__rtsm_node_process_resourceUsage"]
     fn __rts_sym_2054();
-    #[link_name = "__rtsm_node_querystring_encode"]
+    #[link_name = "__rtsm_node_process_title"]
     fn __rts_sym_2055();
-    #[link_name = "__rtsm_node_querystring_escape"]
+    #[link_name = "__rtsm_node_process_uptime"]
     fn __rts_sym_2056();
-    #[link_name = "__rtsm_node_querystring_parse"]
+    #[link_name = "__rtsm_node_process_version"]
     fn __rts_sym_2057();
-    #[link_name = "__rtsm_node_querystring_stringify"]
+    #[link_name = "__rtsm_node_process_versions"]
     fn __rts_sym_2058();
-    #[link_name = "__rtsm_node_querystring_unescape"]
+    #[link_name = "__rtsm_node_punycode_decode"]
     fn __rts_sym_2059();
-    #[link_name = "__rtsm_node_tls_getCiphers"]
+    #[link_name = "__rtsm_node_punycode_encode"]
     fn __rts_sym_2060();
-    #[link_name = "__rtsm_node_tls_getCurves"]
+    #[link_name = "__rtsm_node_punycode_toASCII"]
     fn __rts_sym_2061();
-    #[link_name = "__rtsm_node_tty_getColorDepth"]
+    #[link_name = "__rtsm_node_punycode_toUnicode"]
     fn __rts_sym_2062();
-    #[link_name = "__rtsm_node_tty_hasColors"]
+    #[link_name = "__rtsm_node_querystring_decode"]
     fn __rts_sym_2063();
-    #[link_name = "__rtsm_node_tty_isatty"]
+    #[link_name = "__rtsm_node_querystring_encode"]
     fn __rts_sym_2064();
-    #[link_name = "__rtsm_node_url_domainToASCII"]
+    #[link_name = "__rtsm_node_querystring_escape"]
     fn __rts_sym_2065();
-    #[link_name = "__rtsm_node_url_domainToUnicode"]
+    #[link_name = "__rtsm_node_querystring_parse"]
     fn __rts_sym_2066();
-    #[link_name = "__rtsm_node_url_fileURLToPath"]
+    #[link_name = "__rtsm_node_querystring_stringify"]
     fn __rts_sym_2067();
-    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
+    #[link_name = "__rtsm_node_querystring_unescape"]
     fn __rts_sym_2068();
-    #[link_name = "__rtsm_node_url_format"]
+    #[link_name = "__rtsm_node_tls_getCiphers"]
     fn __rts_sym_2069();
-    #[link_name = "__rtsm_node_url_parse"]
+    #[link_name = "__rtsm_node_tls_getCurves"]
     fn __rts_sym_2070();
-    #[link_name = "__rtsm_node_url_pathToFileURL"]
+    #[link_name = "__rtsm_node_tty_getColorDepth"]
     fn __rts_sym_2071();
-    #[link_name = "__rtsm_node_url_resolve"]
+    #[link_name = "__rtsm_node_tty_hasColors"]
     fn __rts_sym_2072();
-    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
+    #[link_name = "__rtsm_node_tty_isatty"]
     fn __rts_sym_2073();
-    #[link_name = "__rtsm_node_util_format"]
+    #[link_name = "__rtsm_node_url_domainToASCII"]
     fn __rts_sym_2074();
-    #[link_name = "__rtsm_node_util_formatWithOptions"]
+    #[link_name = "__rtsm_node_url_domainToUnicode"]
     fn __rts_sym_2075();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
+    #[link_name = "__rtsm_node_url_fileURLToPath"]
     fn __rts_sym_2076();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
+    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
     fn __rts_sym_2077();
-    #[link_name = "__rtsm_node_util_format_a1"]
+    #[link_name = "__rtsm_node_url_format"]
     fn __rts_sym_2078();
-    #[link_name = "__rtsm_node_util_format_a2"]
+    #[link_name = "__rtsm_node_url_parse"]
     fn __rts_sym_2079();
-    #[link_name = "__rtsm_node_util_format_a3"]
+    #[link_name = "__rtsm_node_url_pathToFileURL"]
     fn __rts_sym_2080();
-    #[link_name = "__rtsm_node_util_format_a4"]
+    #[link_name = "__rtsm_node_url_resolve"]
     fn __rts_sym_2081();
-    #[link_name = "__rtsm_node_util_getSystemErrorName"]
+    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
     fn __rts_sym_2082();
-    #[link_name = "__rtsm_node_util_inspect"]
+    #[link_name = "__rtsm_node_util_format"]
     fn __rts_sym_2083();
-    #[link_name = "__rtsm_node_util_inspect_opts"]
+    #[link_name = "__rtsm_node_util_formatWithOptions"]
     fn __rts_sym_2084();
-    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
     fn __rts_sym_2085();
-    #[link_name = "__rtsm_node_util_parseArgs"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
     fn __rts_sym_2086();
-    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
+    #[link_name = "__rtsm_node_util_format_a1"]
     fn __rts_sym_2087();
-    #[link_name = "__rtsm_node_util_styleText"]
+    #[link_name = "__rtsm_node_util_format_a2"]
     fn __rts_sym_2088();
-    #[link_name = "__rtsm_node_util_toUSVString"]
+    #[link_name = "__rtsm_node_util_format_a3"]
     fn __rts_sym_2089();
-    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
+    #[link_name = "__rtsm_node_util_format_a4"]
     fn __rts_sym_2090();
-    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
+    #[link_name = "__rtsm_node_util_getSystemErrorName"]
     fn __rts_sym_2091();
-    #[link_name = "__rtsm_node_zlib_crc32"]
+    #[link_name = "__rtsm_node_util_inspect"]
     fn __rts_sym_2092();
-    #[link_name = "__rtsm_node_zlib_crc32_prev"]
+    #[link_name = "__rtsm_node_util_inspect_opts"]
     fn __rts_sym_2093();
-    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
+    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
     fn __rts_sym_2094();
-    #[link_name = "__rtsm_node_zlib_deflateSync"]
+    #[link_name = "__rtsm_node_util_parseArgs"]
     fn __rts_sym_2095();
-    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
+    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
     fn __rts_sym_2096();
-    #[link_name = "__rtsm_node_zlib_gunzipSync"]
+    #[link_name = "__rtsm_node_util_styleText"]
     fn __rts_sym_2097();
-    #[link_name = "__rtsm_node_zlib_gzipSync"]
+    #[link_name = "__rtsm_node_util_toUSVString"]
     fn __rts_sym_2098();
-    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
+    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
     fn __rts_sym_2099();
-    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
+    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
     fn __rts_sym_2100();
-    #[link_name = "__rtsm_node_zlib_inflateSync"]
+    #[link_name = "__rtsm_node_zlib_crc32"]
     fn __rts_sym_2101();
-    #[link_name = "__rtsm_node_zlib_unzipSync"]
+    #[link_name = "__rtsm_node_zlib_crc32_prev"]
     fn __rts_sym_2102();
-    #[link_name = "__rtsm_serde_deserialize"]
+    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
     fn __rts_sym_2103();
-    #[link_name = "__rtsm_serde_serialize"]
+    #[link_name = "__rtsm_node_zlib_deflateSync"]
     fn __rts_sym_2104();
-    #[link_name = "__rtsn_agen_new"]
+    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
     fn __rts_sym_2105();
-    #[link_name = "__rtsn_agen_next"]
+    #[link_name = "__rtsm_node_zlib_gunzipSync"]
     fn __rts_sym_2106();
-    #[link_name = "__rtsn_async_sm_awaited"]
+    #[link_name = "__rtsm_node_zlib_gzipSync"]
     fn __rts_sym_2107();
-    #[link_name = "__rtsn_async_sm_new"]
+    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
     fn __rts_sym_2108();
-    #[link_name = "__rtsn_async_sm_resolve"]
+    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
     fn __rts_sym_2109();
-    #[link_name = "__rtsn_async_sm_resume"]
+    #[link_name = "__rtsm_node_zlib_inflateSync"]
     fn __rts_sym_2110();
-    #[link_name = "__rtsn_async_sm_start"]
+    #[link_name = "__rtsm_node_zlib_unzipSync"]
     fn __rts_sym_2111();
-    #[link_name = "__rtsn_async_sm_suspend"]
+    #[link_name = "__rtsm_serde_deserialize"]
     fn __rts_sym_2112();
-    #[link_name = "__rtsn_collect"]
+    #[link_name = "__rtsm_serde_serialize"]
     fn __rts_sym_2113();
-    #[link_name = "__rtsn_collect_debt"]
+    #[link_name = "__rtsn_agen_new"]
     fn __rts_sym_2114();
-    #[link_name = "__rtsn_error_clear"]
+    #[link_name = "__rtsn_agen_next"]
     fn __rts_sym_2115();
-    #[link_name = "__rtsn_error_get"]
+    #[link_name = "__rtsn_async_sm_awaited"]
     fn __rts_sym_2116();
-    #[link_name = "__rtsn_error_get_stack"]
+    #[link_name = "__rtsn_async_sm_new"]
     fn __rts_sym_2117();
-    #[link_name = "__rtsn_error_set"]
+    #[link_name = "__rtsn_async_sm_resolve"]
     fn __rts_sym_2118();
-    #[link_name = "__rtsn_gcell_get"]
+    #[link_name = "__rtsn_async_sm_resume"]
     fn __rts_sym_2119();
-    #[link_name = "__rtsn_gcell_set"]
+    #[link_name = "__rtsn_async_sm_start"]
     fn __rts_sym_2120();
-    #[link_name = "__rtsn_gen_delegate_done"]
+    #[link_name = "__rtsn_async_sm_suspend"]
     fn __rts_sym_2121();
-    #[link_name = "__rtsn_gen_delegate_next"]
+    #[link_name = "__rtsn_collect"]
     fn __rts_sym_2122();
-    #[link_name = "__rtsn_gen_delegate_start"]
+    #[link_name = "__rtsn_collect_debt"]
     fn __rts_sym_2123();
-    #[link_name = "__rtsn_gen_sm_caught"]
+    #[link_name = "__rtsn_error_clear"]
     fn __rts_sym_2124();
-    #[link_name = "__rtsn_gen_sm_done"]
+    #[link_name = "__rtsn_error_get"]
     fn __rts_sym_2125();
-    #[link_name = "__rtsn_gen_sm_drain"]
+    #[link_name = "__rtsn_error_get_stack"]
     fn __rts_sym_2126();
-    #[link_name = "__rtsn_gen_sm_end_finally"]
+    #[link_name = "__rtsn_error_set"]
     fn __rts_sym_2127();
-    #[link_name = "__rtsn_gen_sm_enter_try"]
+    #[link_name = "__rtsn_gcell_get"]
     fn __rts_sym_2128();
-    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
+    #[link_name = "__rtsn_gcell_set"]
     fn __rts_sym_2129();
-    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
+    #[link_name = "__rtsn_gen_delegate_done"]
     fn __rts_sym_2130();
-    #[link_name = "__rtsn_gen_sm_fget"]
+    #[link_name = "__rtsn_gen_delegate_next"]
     fn __rts_sym_2131();
-    #[link_name = "__rtsn_gen_sm_fset"]
+    #[link_name = "__rtsn_gen_delegate_start"]
     fn __rts_sym_2132();
-    #[link_name = "__rtsn_gen_sm_is"]
+    #[link_name = "__rtsn_gen_sm_caught"]
     fn __rts_sym_2133();
-    #[link_name = "__rtsn_gen_sm_new"]
+    #[link_name = "__rtsn_gen_sm_done"]
     fn __rts_sym_2134();
-    #[link_name = "__rtsn_gen_sm_next"]
+    #[link_name = "__rtsn_gen_sm_drain"]
     fn __rts_sym_2135();
-    #[link_name = "__rtsn_gen_sm_return"]
+    #[link_name = "__rtsn_gen_sm_end_finally"]
     fn __rts_sym_2136();
-    #[link_name = "__rtsn_gen_sm_sent"]
+    #[link_name = "__rtsn_gen_sm_enter_try"]
     fn __rts_sym_2137();
-    #[link_name = "__rtsn_gen_sm_setstate"]
+    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
     fn __rts_sym_2138();
-    #[link_name = "__rtsn_gen_sm_state"]
+    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
     fn __rts_sym_2139();
-    #[link_name = "__rtsn_gen_sm_throw"]
+    #[link_name = "__rtsn_gen_sm_fget"]
     fn __rts_sym_2140();
-    #[link_name = "__rtsn_gen_sm_yield"]
+    #[link_name = "__rtsn_gen_sm_fset"]
     fn __rts_sym_2141();
-    #[link_name = "__rtsn_generator_get_ret"]
+    #[link_name = "__rtsn_gen_sm_is"]
     fn __rts_sym_2142();
-    #[link_name = "__rtsn_generator_next"]
+    #[link_name = "__rtsn_gen_sm_new"]
     fn __rts_sym_2143();
-    #[link_name = "__rtsn_generator_next_sent"]
+    #[link_name = "__rtsn_gen_sm_next"]
     fn __rts_sym_2144();
-    #[link_name = "__rtsn_generator_return"]
+    #[link_name = "__rtsn_gen_sm_return"]
     fn __rts_sym_2145();
-    #[link_name = "__rtsn_generator_set_ret"]
+    #[link_name = "__rtsn_gen_sm_sent"]
     fn __rts_sym_2146();
-    #[link_name = "__rtsn_generator_throw"]
+    #[link_name = "__rtsn_gen_sm_setstate"]
     fn __rts_sym_2147();
-    #[link_name = "__rtsn_inspect"]
+    #[link_name = "__rtsn_gen_sm_state"]
     fn __rts_sym_2148();
-    #[link_name = "__rtsn_iter_done"]
+    #[link_name = "__rtsn_gen_sm_throw"]
     fn __rts_sym_2149();
-    #[link_name = "__rtsn_iter_value"]
+    #[link_name = "__rtsn_gen_sm_yield"]
     fn __rts_sym_2150();
-    #[link_name = "__rtsn_live_count"]
+    #[link_name = "__rtsn_generator_get_ret"]
     fn __rts_sym_2151();
-    #[link_name = "__rtsn_object_to_string"]
+    #[link_name = "__rtsn_generator_next"]
     fn __rts_sym_2152();
-    #[link_name = "__rtsn_poly_from_handle"]
+    #[link_name = "__rtsn_generator_next_sent"]
     fn __rts_sym_2153();
-    #[link_name = "__rtsn_poly_to_handle"]
+    #[link_name = "__rtsn_generator_return"]
     fn __rts_sym_2154();
-    #[link_name = "__rtsn_report_uncaught"]
+    #[link_name = "__rtsn_generator_set_ret"]
     fn __rts_sym_2155();
-    #[link_name = "__rtsn_spread_into_vec"]
+    #[link_name = "__rtsn_generator_throw"]
     fn __rts_sym_2156();
-    #[link_name = "__rtsn_stack_depth"]
+    #[link_name = "__rtsn_inspect"]
     fn __rts_sym_2157();
-    #[link_name = "__rtsn_stack_pop"]
+    #[link_name = "__rtsn_iter_done"]
     fn __rts_sym_2158();
-    #[link_name = "__rtsn_stack_push"]
+    #[link_name = "__rtsn_iter_value"]
     fn __rts_sym_2159();
-    #[link_name = "__rtsn_string_from_f64"]
+    #[link_name = "__rtsn_live_count"]
     fn __rts_sym_2160();
-    #[link_name = "__rtsn_symbol_iterator_of"]
+    #[link_name = "__rtsn_object_to_string"]
     fn __rts_sym_2161();
-    #[link_name = "__rtsn_vec_get_by_payload"]
+    #[link_name = "__rtsn_poly_from_handle"]
     fn __rts_sym_2162();
-    #[link_name = "__rtsn_vec_len_by_payload"]
+    #[link_name = "__rtsn_poly_to_handle"]
     fn __rts_sym_2163();
-    #[link_name = "__rtsn_vec_new_object"]
+    #[link_name = "__rtsn_report_uncaught"]
     fn __rts_sym_2164();
-    #[link_name = "__rtsn_vec_push_by_payload"]
+    #[link_name = "__rtsn_spread_into_vec"]
     fn __rts_sym_2165();
-    #[link_name = "__rtsn_vec_set_by_payload"]
+    #[link_name = "__rtsn_stack_depth"]
     fn __rts_sym_2166();
+    #[link_name = "__rtsn_stack_pop"]
+    fn __rts_sym_2167();
+    #[link_name = "__rtsn_stack_push"]
+    fn __rts_sym_2168();
+    #[link_name = "__rtsn_string_from_f64"]
+    fn __rts_sym_2169();
+    #[link_name = "__rtsn_symbol_iterator_of"]
+    fn __rts_sym_2170();
+    #[link_name = "__rtsn_vec_get_by_payload"]
+    fn __rts_sym_2171();
+    #[link_name = "__rtsn_vec_len_by_payload"]
+    fn __rts_sym_2172();
+    #[link_name = "__rtsn_vec_new_object"]
+    fn __rts_sym_2173();
+    #[link_name = "__rtsn_vec_push_by_payload"]
+    fn __rts_sym_2174();
+    #[link_name = "__rtsn_vec_set_by_payload"]
+    fn __rts_sym_2175();
 }
 
 /// Every RTS symbol with its address, for `JITBuilder::symbol`.
@@ -4364,7 +4382,7 @@ unsafe extern "C" {
 /// Sorted ascending by name; `#[cfg]`-gated rows drop out on platforms where
 /// they do not exist, which preserves the order of the rows that remain.
 pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
-    let mut out = ::std::vec::Vec::with_capacity(2167);
+    let mut out = ::std::vec::Vec::with_capacity(2176);
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT", ptr: __rts_sym_0 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY", ptr: __rts_sym_1 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT", ptr: __rts_sym_2 as *const u8 });
@@ -5984,561 +6002,570 @@ pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_values", ptr: __rts_sym_1616 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_from", ptr: __rts_sym_1617 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_to_array", ptr: __rts_sym_1618 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_EPSILON", ptr: __rts_sym_1619 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_SAFE_INTEGER", ptr: __rts_sym_1620 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_VALUE", ptr: __rts_sym_1621 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_SAFE_INTEGER", ptr: __rts_sym_1622 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_VALUE", ptr: __rts_sym_1623 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NEGATIVE_INFINITY", ptr: __rts_sym_1624 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NaN", ptr: __rts_sym_1625 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_POSITIVE_INFINITY", ptr: __rts_sym_1626 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_finite", ptr: __rts_sym_1627 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_integer", ptr: __rts_sym_1628 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_nan", ptr: __rts_sym_1629 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_safe_integer", ptr: __rts_sym_1630 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_new", ptr: __rts_sym_1631 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_float", ptr: __rts_sym_1632 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_int", ptr: __rts_sym_1633 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_exponential", ptr: __rts_sym_1634 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_fixed", ptr: __rts_sym_1635 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_locale_string", ptr: __rts_sym_1636 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_precision", ptr: __rts_sym_1637 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_string", ptr: __rts_sym_1638 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_value_of", ptr: __rts_sym_1639 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_proxy_new", ptr: __rts_sym_1640 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_get_reader", ptr: __rts_sym_1641 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__get", ptr: __rts_sym_1642 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__set", ptr: __rts_sym_1643 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_new", ptr: __rts_sym_1644 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_pipe_through", ptr: __rts_sym_1645 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_close", ptr: __rts_sym_1646 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_desired_size", ptr: __rts_sym_1647 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_enqueue", ptr: __rts_sym_1648 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_error", ptr: __rts_sym_1649 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_new", ptr: __rts_sym_1650 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_cancel", ptr: __rts_sym_1651 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_read", ptr: __rts_sym_1652 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_release_lock", ptr: __rts_sym_1653 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_new", ptr: __rts_sym_1654 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_sum3", ptr: __rts_sym_1655 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at0", ptr: __rts_sym_1656 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at1", ptr: __rts_sym_1657 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_bump", ptr: __rts_sym_1658 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_info", ptr: __rts_sym_1659 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label", ptr: __rts_sym_1660 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label_async", ptr: __rts_sym_1661 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_new", ptr: __rts_sym_1662 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_pairs", ptr: __rts_sym_1663 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_parts", ptr: __rts_sym_1664 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled", ptr: __rts_sym_1665 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled_or1", ptr: __rts_sym_1666 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_self_ref", ptr: __rts_sym_1667 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_set_tag", ptr: __rts_sym_1668 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_sum", ptr: __rts_sym_1669 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tag", ptr: __rts_sym_1670 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tagged", ptr: __rts_sym_1671 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_unit", ptr: __rts_sym_1672 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_with_x", ptr: __rts_sym_1673 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__get", ptr: __rts_sym_1674 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__set", ptr: __rts_sym_1675 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_y__get", ptr: __rts_sym_1676 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_address", ptr: __rts_sym_1677 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_family", ptr: __rts_sym_1678 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_flowlabel", ptr: __rts_sym_1679 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_new", ptr: __rts_sym_1680 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_parse", ptr: __rts_sym_1681 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_port", ptr: __rts_sym_1682 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_with_options", ptr: __rts_sym_1683 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_atime_ms", ptr: __rts_sym_1684 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_birthtime_ms", ptr: __rts_sym_1685 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blksize", ptr: __rts_sym_1686 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blocks", ptr: __rts_sym_1687 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ctime_ms", ptr: __rts_sym_1688 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_dev", ptr: __rts_sym_1689 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_gid", ptr: __rts_sym_1690 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ino", ptr: __rts_sym_1691 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_block", ptr: __rts_sym_1692 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_char", ptr: __rts_sym_1693 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_directory", ptr: __rts_sym_1694 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_fifo", ptr: __rts_sym_1695 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_file", ptr: __rts_sym_1696 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_socket", ptr: __rts_sym_1697 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_symlink", ptr: __rts_sym_1698 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mode", ptr: __rts_sym_1699 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mtime_ms", ptr: __rts_sym_1700 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_nlink", ptr: __rts_sym_1701 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_rdev", ptr: __rts_sym_1702 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_size", ptr: __rts_sym_1703 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_uid", ptr: __rts_sym_1704 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_clear", ptr: __rts_sym_1705 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_getItem", ptr: __rts_sym_1706 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_key", ptr: __rts_sym_1707 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_length", ptr: __rts_sym_1708 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_new", ptr: __rts_sym_1709 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_persistTo", ptr: __rts_sym_1710 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_removeItem", ptr: __rts_sym_1711 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_setItem", ptr: __rts_sym_1712 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1713 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1714 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1715 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1716 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1717 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1718 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1719 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1720 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1721 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1722 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1723 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1724 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1725 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1726 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1727 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1728 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1729 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1730 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1731 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1732 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1733 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1734 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1735 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1736 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1737 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1738 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1739 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1740 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1741 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1742 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1743 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1744 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1745 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1746 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1747 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1748 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1749 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1750 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1751 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1752 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1753 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1754 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1755 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1756 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1757 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1758 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1759 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1760 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1761 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1762 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1763 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1764 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1765 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1766 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1767 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1768 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1769 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1770 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1771 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1772 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1773 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1774 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1775 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1776 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1777 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1778 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1779 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1780 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1781 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1782 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1783 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1784 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1785 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1786 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1787 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1788 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1789 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1790 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1791 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1792 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1793 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1794 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1795 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1796 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1797 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1798 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1799 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1800 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1801 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1802 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1803 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1804 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1805 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1806 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1807 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1808 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1809 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1810 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1811 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1812 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1813 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1814 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1815 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1816 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1817 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1818 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1819 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1820 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1821 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1822 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1823 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1824 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1825 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1826 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1827 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1828 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1829 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1830 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1831 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1832 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1833 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1834 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1835 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1836 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1837 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1838 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1839 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1840 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1841 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1842 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1843 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1844 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1845 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1846 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1847 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1848 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1849 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1850 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1851 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1852 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1853 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1854 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1855 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1856 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1857 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1858 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1859 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1860 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1861 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1862 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1863 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1864 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1865 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1866 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1867 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1868 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1869 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1870 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1871 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1872 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1873 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1874 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1875 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1876 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1877 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1878 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1879 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1880 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1881 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1882 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1883 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1884 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1885 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1886 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1887 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1888 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1889 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1890 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1891 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1892 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1893 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1894 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1895 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1896 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1897 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1898 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1899 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1900 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1901 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1902 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1903 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1904 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1905 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1906 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1907 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1908 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1909 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1910 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1911 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1912 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1913 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1914 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1915 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1916 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1917 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1918 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1919 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1920 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1921 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1922 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1923 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1924 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1925 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1926 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1927 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1928 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1929 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1930 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1931 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1932 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1933 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1934 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1935 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1936 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1937 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1938 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1939 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1940 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1941 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1942 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1943 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1944 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1945 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1946 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1947 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1948 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1949 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1950 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1951 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1952 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1953 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1954 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1955 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1956 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1957 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1958 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1959 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1960 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1961 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1962 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1963 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1964 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1965 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1966 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1967 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1968 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1969 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1970 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1971 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1972 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1973 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1974 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1975 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1976 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1977 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1978 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1979 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1980 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1981 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1982 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1983 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1984 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_1985 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_1986 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_1987 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_1988 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_1989 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_1990 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_1991 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_1992 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_1993 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_1994 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_1995 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_1996 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_1997 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_1998 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_1999 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_2000 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_2001 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_2002 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_2003 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_2004 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_2005 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_2006 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_2007 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2008 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2009 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2010 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2011 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2012 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2013 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2014 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2015 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2016 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2017 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2018 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2019 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2020 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2021 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2022 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2023 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2024 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2025 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2026 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2027 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2028 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2029 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2030 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2031 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2032 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2033 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2034 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2035 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2036 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2037 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2038 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2039 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2040 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2041 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2042 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2043 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2044 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2045 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2046 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2047 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2048 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2049 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2050 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2051 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2052 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2053 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2054 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2055 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2056 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2057 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2058 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2059 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2060 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2061 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2062 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2063 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2064 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2065 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2066 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2067 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2068 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2069 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2070 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2071 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2072 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2073 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2074 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2075 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2076 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2077 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2078 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2079 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2080 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2081 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2082 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2083 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2084 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2085 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2086 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2087 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2088 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2089 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2090 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2091 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2092 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2093 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2094 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2095 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2096 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2097 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2098 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2099 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2100 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2101 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2102 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2103 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2104 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2105 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2106 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2107 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2108 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2109 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2110 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2111 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2112 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2113 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2114 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2115 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2116 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2117 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2118 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2119 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2120 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2121 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2122 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2123 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2124 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2125 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2126 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2127 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2128 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2129 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2130 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2131 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2132 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2133 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2134 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2135 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2136 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2137 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2138 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2139 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2140 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2141 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2142 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2143 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2144 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2145 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2146 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2147 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2148 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2149 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2150 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2151 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2152 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2153 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2154 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2155 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2156 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2157 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2158 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2159 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2160 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2161 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2162 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2163 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2164 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2165 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2166 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ATTRIBUTE_NODE", ptr: __rts_sym_1619 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_CDATA_SECTION_NODE", ptr: __rts_sym_1620 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_COMMENT_NODE", ptr: __rts_sym_1621 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE", ptr: __rts_sym_1622 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_NODE", ptr: __rts_sym_1623 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_TYPE_NODE", ptr: __rts_sym_1624 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ELEMENT_NODE", ptr: __rts_sym_1625 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE", ptr: __rts_sym_1626 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_TEXT_NODE", ptr: __rts_sym_1627 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_EPSILON", ptr: __rts_sym_1628 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_SAFE_INTEGER", ptr: __rts_sym_1629 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_VALUE", ptr: __rts_sym_1630 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_SAFE_INTEGER", ptr: __rts_sym_1631 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_VALUE", ptr: __rts_sym_1632 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NEGATIVE_INFINITY", ptr: __rts_sym_1633 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NaN", ptr: __rts_sym_1634 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_POSITIVE_INFINITY", ptr: __rts_sym_1635 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_finite", ptr: __rts_sym_1636 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_integer", ptr: __rts_sym_1637 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_nan", ptr: __rts_sym_1638 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_safe_integer", ptr: __rts_sym_1639 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_new", ptr: __rts_sym_1640 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_float", ptr: __rts_sym_1641 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_int", ptr: __rts_sym_1642 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_exponential", ptr: __rts_sym_1643 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_fixed", ptr: __rts_sym_1644 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_locale_string", ptr: __rts_sym_1645 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_precision", ptr: __rts_sym_1646 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_string", ptr: __rts_sym_1647 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_value_of", ptr: __rts_sym_1648 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_proxy_new", ptr: __rts_sym_1649 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_get_reader", ptr: __rts_sym_1650 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__get", ptr: __rts_sym_1651 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__set", ptr: __rts_sym_1652 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_new", ptr: __rts_sym_1653 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_pipe_through", ptr: __rts_sym_1654 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_close", ptr: __rts_sym_1655 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_desired_size", ptr: __rts_sym_1656 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_enqueue", ptr: __rts_sym_1657 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_error", ptr: __rts_sym_1658 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_new", ptr: __rts_sym_1659 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_cancel", ptr: __rts_sym_1660 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_read", ptr: __rts_sym_1661 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_release_lock", ptr: __rts_sym_1662 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_new", ptr: __rts_sym_1663 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_sum3", ptr: __rts_sym_1664 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at0", ptr: __rts_sym_1665 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at1", ptr: __rts_sym_1666 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_bump", ptr: __rts_sym_1667 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_info", ptr: __rts_sym_1668 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label", ptr: __rts_sym_1669 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label_async", ptr: __rts_sym_1670 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_new", ptr: __rts_sym_1671 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_pairs", ptr: __rts_sym_1672 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_parts", ptr: __rts_sym_1673 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled", ptr: __rts_sym_1674 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled_or1", ptr: __rts_sym_1675 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_self_ref", ptr: __rts_sym_1676 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_set_tag", ptr: __rts_sym_1677 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_sum", ptr: __rts_sym_1678 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tag", ptr: __rts_sym_1679 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tagged", ptr: __rts_sym_1680 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_unit", ptr: __rts_sym_1681 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_with_x", ptr: __rts_sym_1682 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__get", ptr: __rts_sym_1683 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__set", ptr: __rts_sym_1684 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_y__get", ptr: __rts_sym_1685 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_address", ptr: __rts_sym_1686 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_family", ptr: __rts_sym_1687 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_flowlabel", ptr: __rts_sym_1688 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_new", ptr: __rts_sym_1689 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_parse", ptr: __rts_sym_1690 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_port", ptr: __rts_sym_1691 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_with_options", ptr: __rts_sym_1692 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_atime_ms", ptr: __rts_sym_1693 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_birthtime_ms", ptr: __rts_sym_1694 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blksize", ptr: __rts_sym_1695 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blocks", ptr: __rts_sym_1696 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ctime_ms", ptr: __rts_sym_1697 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_dev", ptr: __rts_sym_1698 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_gid", ptr: __rts_sym_1699 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ino", ptr: __rts_sym_1700 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_block", ptr: __rts_sym_1701 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_char", ptr: __rts_sym_1702 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_directory", ptr: __rts_sym_1703 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_fifo", ptr: __rts_sym_1704 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_file", ptr: __rts_sym_1705 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_socket", ptr: __rts_sym_1706 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_symlink", ptr: __rts_sym_1707 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mode", ptr: __rts_sym_1708 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mtime_ms", ptr: __rts_sym_1709 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_nlink", ptr: __rts_sym_1710 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_rdev", ptr: __rts_sym_1711 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_size", ptr: __rts_sym_1712 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_uid", ptr: __rts_sym_1713 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_clear", ptr: __rts_sym_1714 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_getItem", ptr: __rts_sym_1715 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_key", ptr: __rts_sym_1716 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_length", ptr: __rts_sym_1717 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_new", ptr: __rts_sym_1718 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_persistTo", ptr: __rts_sym_1719 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_removeItem", ptr: __rts_sym_1720 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_setItem", ptr: __rts_sym_1721 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1722 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1723 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1724 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1725 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1726 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1727 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1728 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1729 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1730 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1731 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1732 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1733 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1734 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1735 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1736 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1737 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1738 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1739 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1740 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1741 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1742 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1743 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1744 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1745 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1746 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1747 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1748 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1749 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1750 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1751 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1752 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1753 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1754 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1755 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1756 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1757 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1758 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1759 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1760 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1761 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1762 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1763 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1764 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1765 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1766 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1767 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1768 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1769 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1770 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1771 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1772 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1773 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1774 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1775 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1776 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1777 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1778 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1779 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1780 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1781 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1782 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1783 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1784 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1785 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1786 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1787 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1788 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1789 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1790 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1791 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1792 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1793 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1794 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1795 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1796 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1797 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1798 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1799 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1800 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1801 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1802 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1803 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1804 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1805 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1806 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1807 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1808 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1809 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1810 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1811 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1812 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1813 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1814 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1815 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1816 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1817 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1818 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1819 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1820 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1821 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1822 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1823 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1824 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1825 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1826 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1827 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1828 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1829 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1830 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1831 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1832 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1833 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1834 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1835 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1836 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1837 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1838 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1839 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1840 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1841 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1842 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1843 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1844 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1845 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1846 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1847 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1848 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1849 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1850 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1851 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1852 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1853 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1854 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1855 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1856 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1857 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1858 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1859 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1860 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1861 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1862 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1863 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1864 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1865 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1866 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1867 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1868 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1869 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1870 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1871 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1872 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1873 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1874 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1875 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1876 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1877 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1878 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1879 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1880 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1881 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1882 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1883 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1884 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1885 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1886 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1887 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1888 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1889 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1890 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1891 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1892 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1893 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1894 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1895 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1896 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1897 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1898 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1899 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1900 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1901 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1902 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1903 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1904 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1905 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1906 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1907 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1908 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1909 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1910 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1911 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1912 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1913 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1914 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1915 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1916 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1917 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1918 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1919 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1920 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1921 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1922 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1923 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1924 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1925 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1926 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1927 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1928 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1929 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1930 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1931 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1932 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1933 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1934 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1935 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1936 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1937 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1938 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1939 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1940 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1941 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1942 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1943 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1944 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1945 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1946 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1947 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1948 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1949 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1950 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1951 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1952 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1953 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1954 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1955 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1956 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1957 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1958 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1959 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1960 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1961 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1962 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1963 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1964 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1965 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1966 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1967 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1968 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1969 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1970 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1971 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1972 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1973 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1974 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1975 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1976 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1977 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1978 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1979 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1980 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1981 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1982 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1983 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1984 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1985 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1986 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1987 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1988 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1989 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1990 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1991 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1992 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1993 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_1994 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_1995 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_1996 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_1997 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_1998 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_1999 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_2000 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_2001 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_2002 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_2003 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_2004 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_2005 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_2006 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_2007 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_2008 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_2009 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_2010 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_2011 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_2012 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_2013 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_2014 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_2015 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_2016 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2017 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2018 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2019 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2020 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2021 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2022 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2023 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2024 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2025 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2026 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2027 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2028 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2029 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2030 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2031 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2032 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2033 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2034 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2035 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2036 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2037 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2038 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2039 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2040 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2041 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2042 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2043 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2044 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2045 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2046 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2047 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2048 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2049 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2050 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2051 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2052 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2053 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2054 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2055 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2056 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2057 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2058 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2059 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2060 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2061 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2062 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2063 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2064 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2065 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2066 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2067 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2068 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2069 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2070 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2071 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2072 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2073 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2074 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2075 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2076 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2077 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2078 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2079 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2080 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2081 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2082 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2083 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2084 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2085 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2086 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2087 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2088 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2089 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2090 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2091 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2092 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2093 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2094 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2095 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2096 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2097 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2098 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2099 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2100 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2101 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2102 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2103 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2104 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2105 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2106 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2107 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2108 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2109 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2110 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2111 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2112 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2113 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2114 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2115 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2116 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2117 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2118 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2119 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2120 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2121 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2122 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2123 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2124 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2125 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2126 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2127 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2128 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2129 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2130 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2131 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2132 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2133 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2134 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2135 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2136 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2137 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2138 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2139 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2140 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2141 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2142 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2143 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2144 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2145 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2146 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2147 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2148 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2149 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2150 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2151 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2152 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2153 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2154 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2155 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2156 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2157 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2158 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2159 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2160 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2161 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2162 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2163 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2164 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2165 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2166 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2167 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2168 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2169 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2170 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2171 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2172 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2173 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2174 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2175 as *const u8 });
     out
 }
 
 /// The same symbols as names only, for the AOT object module's declaration
 /// list. Same order, same `#[cfg]` gating — the two paths cannot diverge.
 pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
-    let mut out = ::std::vec::Vec::with_capacity(2167);
+    let mut out = ::std::vec::Vec::with_capacity(2176);
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT");
@@ -8158,6 +8185,15 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
     out.push("__rtsm_global_headers_values");
     out.push("__rtsm_global_iterator_from");
     out.push("__rtsm_global_iterator_to_array");
+    out.push("__rtsm_global_node_ATTRIBUTE_NODE");
+    out.push("__rtsm_global_node_CDATA_SECTION_NODE");
+    out.push("__rtsm_global_node_COMMENT_NODE");
+    out.push("__rtsm_global_node_DOCUMENT_FRAGMENT_NODE");
+    out.push("__rtsm_global_node_DOCUMENT_NODE");
+    out.push("__rtsm_global_node_DOCUMENT_TYPE_NODE");
+    out.push("__rtsm_global_node_ELEMENT_NODE");
+    out.push("__rtsm_global_node_PROCESSING_INSTRUCTION_NODE");
+    out.push("__rtsm_global_node_TEXT_NODE");
     out.push("__rtsm_global_number_EPSILON");
     out.push("__rtsm_global_number_MAX_SAFE_INTEGER");
     out.push("__rtsm_global_number_MAX_VALUE");
@@ -8712,7 +8748,7 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
 /// ABI signatures derived from the Rust signatures of `#[rtse::abi]` fns.
 ///
 /// Sorted ascending by name, like the symbol table, so a lookup is a binary
-/// search. 607 of 2167 symbols carry one; the rest are not yet declared with
+/// search. 607 of 2176 symbols carry one; the rest are not yet declared with
 /// `#[rtse::abi]`.
 pub fn signatures() -> ::std::vec::Vec<(&'static str, &'static [::rts_abi::AbiType], ::rts_abi::AbiType)> {
     // The element type is spelled out: without it the `&[]` of a zero-arg

--- a/crates/rts-symbol-baker/generated/symbol_table.rs
+++ b/crates/rts-symbol-baker/generated/symbol_table.rs
@@ -7,7 +7,7 @@
 // symbol name, so lookup is a binary search and every scope (`__rtsa_`,
 // `__rtsm_node_fs_`, …) is ONE contiguous range. See `rts_abi::table`.
 //
-// 2176 symbols.
+// 2182 symbols.
 
 // Addresses are taken through the LINKER name, not a Rust module path: that
 // reaches every `#[no_mangle]` symbol regardless of Rust visibility, and makes
@@ -3117,1264 +3117,1276 @@ unsafe extern "C" {
     fn __rts_sym_1545();
     #[link_name = "__rtsm_global_domexception_to_string"]
     fn __rts_sym_1546();
-    #[link_name = "__rtsm_global_encode_uri"]
+    #[link_name = "__rtsm_global_domscope_count"]
     fn __rts_sym_1547();
-    #[link_name = "__rtsm_global_encode_uri_component"]
+    #[link_name = "__rtsm_global_domscope_drop"]
     fn __rts_sym_1548();
-    #[link_name = "__rtsm_global_event_bubbles__get"]
+    #[link_name = "__rtsm_global_domscope_get"]
     fn __rts_sym_1549();
-    #[link_name = "__rtsm_global_event_cancelable__get"]
+    #[link_name = "__rtsm_global_domscope_has"]
     fn __rts_sym_1550();
-    #[link_name = "__rtsm_global_event_current_target_get"]
+    #[link_name = "__rtsm_global_domscope_nameAt"]
     fn __rts_sym_1551();
-    #[link_name = "__rtsm_global_event_default_prevented__get"]
+    #[link_name = "__rtsm_global_domscope_set"]
     fn __rts_sym_1552();
-    #[link_name = "__rtsm_global_event_js_type"]
+    #[link_name = "__rtsm_global_encode_uri"]
     fn __rts_sym_1553();
-    #[link_name = "__rtsm_global_event_new"]
+    #[link_name = "__rtsm_global_encode_uri_component"]
     fn __rts_sym_1554();
-    #[link_name = "__rtsm_global_event_prevent_default"]
+    #[link_name = "__rtsm_global_event_bubbles__get"]
     fn __rts_sym_1555();
-    #[link_name = "__rtsm_global_event_stop_immediate_propagation"]
+    #[link_name = "__rtsm_global_event_cancelable__get"]
     fn __rts_sym_1556();
-    #[link_name = "__rtsm_global_event_stop_propagation"]
+    #[link_name = "__rtsm_global_event_current_target_get"]
     fn __rts_sym_1557();
-    #[link_name = "__rtsm_global_event_target"]
+    #[link_name = "__rtsm_global_event_default_prevented__get"]
     fn __rts_sym_1558();
-    #[link_name = "__rtsm_global_eventemitter_add_listener"]
+    #[link_name = "__rtsm_global_event_js_type"]
     fn __rts_sym_1559();
-    #[link_name = "__rtsm_global_eventemitter_emit0"]
+    #[link_name = "__rtsm_global_event_new"]
     fn __rts_sym_1560();
-    #[link_name = "__rtsm_global_eventemitter_emit1"]
+    #[link_name = "__rtsm_global_event_prevent_default"]
     fn __rts_sym_1561();
-    #[link_name = "__rtsm_global_eventemitter_emit2"]
+    #[link_name = "__rtsm_global_event_stop_immediate_propagation"]
     fn __rts_sym_1562();
-    #[link_name = "__rtsm_global_eventemitter_emit3"]
+    #[link_name = "__rtsm_global_event_stop_propagation"]
     fn __rts_sym_1563();
-    #[link_name = "__rtsm_global_eventemitter_emit_handle"]
+    #[link_name = "__rtsm_global_event_target"]
     fn __rts_sym_1564();
-    #[link_name = "__rtsm_global_eventemitter_event_names"]
+    #[link_name = "__rtsm_global_eventemitter_add_listener"]
     fn __rts_sym_1565();
-    #[link_name = "__rtsm_global_eventemitter_free"]
+    #[link_name = "__rtsm_global_eventemitter_emit0"]
     fn __rts_sym_1566();
-    #[link_name = "__rtsm_global_eventemitter_get_max_listeners"]
+    #[link_name = "__rtsm_global_eventemitter_emit1"]
     fn __rts_sym_1567();
-    #[link_name = "__rtsm_global_eventemitter_listener_count"]
+    #[link_name = "__rtsm_global_eventemitter_emit2"]
     fn __rts_sym_1568();
-    #[link_name = "__rtsm_global_eventemitter_listeners"]
+    #[link_name = "__rtsm_global_eventemitter_emit3"]
     fn __rts_sym_1569();
-    #[link_name = "__rtsm_global_eventemitter_new"]
+    #[link_name = "__rtsm_global_eventemitter_emit_handle"]
     fn __rts_sym_1570();
-    #[link_name = "__rtsm_global_eventemitter_new_async"]
+    #[link_name = "__rtsm_global_eventemitter_event_names"]
     fn __rts_sym_1571();
-    #[link_name = "__rtsm_global_eventemitter_off"]
+    #[link_name = "__rtsm_global_eventemitter_free"]
     fn __rts_sym_1572();
-    #[link_name = "__rtsm_global_eventemitter_on"]
+    #[link_name = "__rtsm_global_eventemitter_get_max_listeners"]
     fn __rts_sym_1573();
-    #[link_name = "__rtsm_global_eventemitter_once"]
+    #[link_name = "__rtsm_global_eventemitter_listener_count"]
     fn __rts_sym_1574();
-    #[link_name = "__rtsm_global_eventemitter_prepend_listener"]
+    #[link_name = "__rtsm_global_eventemitter_listeners"]
     fn __rts_sym_1575();
-    #[link_name = "__rtsm_global_eventemitter_prepend_once_listener"]
+    #[link_name = "__rtsm_global_eventemitter_new"]
     fn __rts_sym_1576();
-    #[link_name = "__rtsm_global_eventemitter_raw_listeners"]
+    #[link_name = "__rtsm_global_eventemitter_new_async"]
     fn __rts_sym_1577();
-    #[link_name = "__rtsm_global_eventemitter_remove_all_listeners"]
+    #[link_name = "__rtsm_global_eventemitter_off"]
     fn __rts_sym_1578();
-    #[link_name = "__rtsm_global_eventemitter_remove_listener"]
+    #[link_name = "__rtsm_global_eventemitter_on"]
     fn __rts_sym_1579();
-    #[link_name = "__rtsm_global_eventemitter_set_max_listeners"]
+    #[link_name = "__rtsm_global_eventemitter_once"]
     fn __rts_sym_1580();
-    #[link_name = "__rtsm_global_eventtarget_add_event_listener"]
+    #[link_name = "__rtsm_global_eventemitter_prepend_listener"]
     fn __rts_sym_1581();
-    #[link_name = "__rtsm_global_eventtarget_new"]
+    #[link_name = "__rtsm_global_eventemitter_prepend_once_listener"]
     fn __rts_sym_1582();
-    #[link_name = "__rtsm_global_eventtarget_remove_event_listener"]
+    #[link_name = "__rtsm_global_eventemitter_raw_listeners"]
     fn __rts_sym_1583();
-    #[link_name = "__rtsm_global_file_kind"]
+    #[link_name = "__rtsm_global_eventemitter_remove_all_listeners"]
     fn __rts_sym_1584();
-    #[link_name = "__rtsm_global_file_last_modified__get"]
+    #[link_name = "__rtsm_global_eventemitter_remove_listener"]
     fn __rts_sym_1585();
-    #[link_name = "__rtsm_global_file_name"]
+    #[link_name = "__rtsm_global_eventemitter_set_max_listeners"]
     fn __rts_sym_1586();
-    #[link_name = "__rtsm_global_file_new"]
+    #[link_name = "__rtsm_global_eventtarget_add_event_listener"]
     fn __rts_sym_1587();
-    #[link_name = "__rtsm_global_file_size"]
+    #[link_name = "__rtsm_global_eventtarget_new"]
     fn __rts_sym_1588();
-    #[link_name = "__rtsm_global_file_text"]
+    #[link_name = "__rtsm_global_eventtarget_remove_event_listener"]
     fn __rts_sym_1589();
-    #[link_name = "__rtsm_global_finalizationregistry_new"]
+    #[link_name = "__rtsm_global_file_kind"]
     fn __rts_sym_1590();
-    #[link_name = "__rtsm_global_finalizationregistry_register"]
+    #[link_name = "__rtsm_global_file_last_modified__get"]
     fn __rts_sym_1591();
-    #[link_name = "__rtsm_global_finalizationregistry_unregister"]
+    #[link_name = "__rtsm_global_file_name"]
     fn __rts_sym_1592();
-    #[link_name = "__rtsm_global_formdata_append"]
+    #[link_name = "__rtsm_global_file_new"]
     fn __rts_sym_1593();
-    #[link_name = "__rtsm_global_formdata_delete"]
+    #[link_name = "__rtsm_global_file_size"]
     fn __rts_sym_1594();
-    #[link_name = "__rtsm_global_formdata_get"]
+    #[link_name = "__rtsm_global_file_text"]
     fn __rts_sym_1595();
-    #[link_name = "__rtsm_global_formdata_get_all"]
+    #[link_name = "__rtsm_global_finalizationregistry_new"]
     fn __rts_sym_1596();
-    #[link_name = "__rtsm_global_formdata_has"]
+    #[link_name = "__rtsm_global_finalizationregistry_register"]
     fn __rts_sym_1597();
-    #[link_name = "__rtsm_global_formdata_keys"]
+    #[link_name = "__rtsm_global_finalizationregistry_unregister"]
     fn __rts_sym_1598();
-    #[link_name = "__rtsm_global_formdata_new"]
+    #[link_name = "__rtsm_global_formdata_append"]
     fn __rts_sym_1599();
-    #[link_name = "__rtsm_global_formdata_set"]
+    #[link_name = "__rtsm_global_formdata_delete"]
     fn __rts_sym_1600();
-    #[link_name = "__rtsm_global_formdata_values"]
+    #[link_name = "__rtsm_global_formdata_get"]
     fn __rts_sym_1601();
-    #[link_name = "__rtsm_global_hash_copy"]
+    #[link_name = "__rtsm_global_formdata_get_all"]
     fn __rts_sym_1602();
-    #[link_name = "__rtsm_global_hash_digest"]
+    #[link_name = "__rtsm_global_formdata_has"]
     fn __rts_sym_1603();
-    #[link_name = "__rtsm_global_hash_digest_enc"]
+    #[link_name = "__rtsm_global_formdata_keys"]
     fn __rts_sym_1604();
-    #[link_name = "__rtsm_global_hash_update"]
+    #[link_name = "__rtsm_global_formdata_new"]
     fn __rts_sym_1605();
-    #[link_name = "__rtsm_global_hash_update_enc"]
+    #[link_name = "__rtsm_global_formdata_set"]
     fn __rts_sym_1606();
-    #[link_name = "__rtsm_global_headers_append"]
+    #[link_name = "__rtsm_global_formdata_values"]
     fn __rts_sym_1607();
-    #[link_name = "__rtsm_global_headers_delete"]
+    #[link_name = "__rtsm_global_hash_copy"]
     fn __rts_sym_1608();
-    #[link_name = "__rtsm_global_headers_get"]
+    #[link_name = "__rtsm_global_hash_digest"]
     fn __rts_sym_1609();
-    #[link_name = "__rtsm_global_headers_get_set_cookie"]
+    #[link_name = "__rtsm_global_hash_digest_enc"]
     fn __rts_sym_1610();
-    #[link_name = "__rtsm_global_headers_has"]
+    #[link_name = "__rtsm_global_hash_update"]
     fn __rts_sym_1611();
-    #[link_name = "__rtsm_global_headers_keys"]
+    #[link_name = "__rtsm_global_hash_update_enc"]
     fn __rts_sym_1612();
-    #[link_name = "__rtsm_global_headers_new"]
+    #[link_name = "__rtsm_global_headers_append"]
     fn __rts_sym_1613();
-    #[link_name = "__rtsm_global_headers_new_from"]
+    #[link_name = "__rtsm_global_headers_delete"]
     fn __rts_sym_1614();
-    #[link_name = "__rtsm_global_headers_set"]
+    #[link_name = "__rtsm_global_headers_get"]
     fn __rts_sym_1615();
-    #[link_name = "__rtsm_global_headers_values"]
+    #[link_name = "__rtsm_global_headers_get_set_cookie"]
     fn __rts_sym_1616();
-    #[link_name = "__rtsm_global_iterator_from"]
+    #[link_name = "__rtsm_global_headers_has"]
     fn __rts_sym_1617();
-    #[link_name = "__rtsm_global_iterator_to_array"]
+    #[link_name = "__rtsm_global_headers_keys"]
     fn __rts_sym_1618();
-    #[link_name = "__rtsm_global_node_ATTRIBUTE_NODE"]
+    #[link_name = "__rtsm_global_headers_new"]
     fn __rts_sym_1619();
-    #[link_name = "__rtsm_global_node_CDATA_SECTION_NODE"]
+    #[link_name = "__rtsm_global_headers_new_from"]
     fn __rts_sym_1620();
-    #[link_name = "__rtsm_global_node_COMMENT_NODE"]
+    #[link_name = "__rtsm_global_headers_set"]
     fn __rts_sym_1621();
-    #[link_name = "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE"]
+    #[link_name = "__rtsm_global_headers_values"]
     fn __rts_sym_1622();
-    #[link_name = "__rtsm_global_node_DOCUMENT_NODE"]
+    #[link_name = "__rtsm_global_iterator_from"]
     fn __rts_sym_1623();
-    #[link_name = "__rtsm_global_node_DOCUMENT_TYPE_NODE"]
+    #[link_name = "__rtsm_global_iterator_to_array"]
     fn __rts_sym_1624();
-    #[link_name = "__rtsm_global_node_ELEMENT_NODE"]
+    #[link_name = "__rtsm_global_node_ATTRIBUTE_NODE"]
     fn __rts_sym_1625();
-    #[link_name = "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE"]
+    #[link_name = "__rtsm_global_node_CDATA_SECTION_NODE"]
     fn __rts_sym_1626();
-    #[link_name = "__rtsm_global_node_TEXT_NODE"]
+    #[link_name = "__rtsm_global_node_COMMENT_NODE"]
     fn __rts_sym_1627();
-    #[link_name = "__rtsm_global_number_EPSILON"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE"]
     fn __rts_sym_1628();
-    #[link_name = "__rtsm_global_number_MAX_SAFE_INTEGER"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_NODE"]
     fn __rts_sym_1629();
-    #[link_name = "__rtsm_global_number_MAX_VALUE"]
+    #[link_name = "__rtsm_global_node_DOCUMENT_TYPE_NODE"]
     fn __rts_sym_1630();
-    #[link_name = "__rtsm_global_number_MIN_SAFE_INTEGER"]
+    #[link_name = "__rtsm_global_node_ELEMENT_NODE"]
     fn __rts_sym_1631();
-    #[link_name = "__rtsm_global_number_MIN_VALUE"]
+    #[link_name = "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE"]
     fn __rts_sym_1632();
-    #[link_name = "__rtsm_global_number_NEGATIVE_INFINITY"]
+    #[link_name = "__rtsm_global_node_TEXT_NODE"]
     fn __rts_sym_1633();
-    #[link_name = "__rtsm_global_number_NaN"]
+    #[link_name = "__rtsm_global_number_EPSILON"]
     fn __rts_sym_1634();
-    #[link_name = "__rtsm_global_number_POSITIVE_INFINITY"]
+    #[link_name = "__rtsm_global_number_MAX_SAFE_INTEGER"]
     fn __rts_sym_1635();
-    #[link_name = "__rtsm_global_number_is_finite"]
+    #[link_name = "__rtsm_global_number_MAX_VALUE"]
     fn __rts_sym_1636();
-    #[link_name = "__rtsm_global_number_is_integer"]
+    #[link_name = "__rtsm_global_number_MIN_SAFE_INTEGER"]
     fn __rts_sym_1637();
-    #[link_name = "__rtsm_global_number_is_nan"]
+    #[link_name = "__rtsm_global_number_MIN_VALUE"]
     fn __rts_sym_1638();
-    #[link_name = "__rtsm_global_number_is_safe_integer"]
+    #[link_name = "__rtsm_global_number_NEGATIVE_INFINITY"]
     fn __rts_sym_1639();
-    #[link_name = "__rtsm_global_number_new"]
+    #[link_name = "__rtsm_global_number_NaN"]
     fn __rts_sym_1640();
-    #[link_name = "__rtsm_global_number_parse_float"]
+    #[link_name = "__rtsm_global_number_POSITIVE_INFINITY"]
     fn __rts_sym_1641();
-    #[link_name = "__rtsm_global_number_parse_int"]
+    #[link_name = "__rtsm_global_number_is_finite"]
     fn __rts_sym_1642();
-    #[link_name = "__rtsm_global_number_to_exponential"]
+    #[link_name = "__rtsm_global_number_is_integer"]
     fn __rts_sym_1643();
-    #[link_name = "__rtsm_global_number_to_fixed"]
+    #[link_name = "__rtsm_global_number_is_nan"]
     fn __rts_sym_1644();
-    #[link_name = "__rtsm_global_number_to_locale_string"]
+    #[link_name = "__rtsm_global_number_is_safe_integer"]
     fn __rts_sym_1645();
-    #[link_name = "__rtsm_global_number_to_precision"]
+    #[link_name = "__rtsm_global_number_new"]
     fn __rts_sym_1646();
-    #[link_name = "__rtsm_global_number_to_string"]
+    #[link_name = "__rtsm_global_number_parse_float"]
     fn __rts_sym_1647();
-    #[link_name = "__rtsm_global_number_value_of"]
+    #[link_name = "__rtsm_global_number_parse_int"]
     fn __rts_sym_1648();
-    #[link_name = "__rtsm_global_proxy_new"]
+    #[link_name = "__rtsm_global_number_to_exponential"]
     fn __rts_sym_1649();
-    #[link_name = "__rtsm_global_readablestream_get_reader"]
+    #[link_name = "__rtsm_global_number_to_fixed"]
     fn __rts_sym_1650();
-    #[link_name = "__rtsm_global_readablestream_locked__get"]
+    #[link_name = "__rtsm_global_number_to_locale_string"]
     fn __rts_sym_1651();
-    #[link_name = "__rtsm_global_readablestream_locked__set"]
+    #[link_name = "__rtsm_global_number_to_precision"]
     fn __rts_sym_1652();
-    #[link_name = "__rtsm_global_readablestream_new"]
+    #[link_name = "__rtsm_global_number_to_string"]
     fn __rts_sym_1653();
-    #[link_name = "__rtsm_global_readablestream_pipe_through"]
+    #[link_name = "__rtsm_global_number_value_of"]
     fn __rts_sym_1654();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_close"]
+    #[link_name = "__rtsm_global_proxy_new"]
     fn __rts_sym_1655();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_desired_size"]
+    #[link_name = "__rtsm_global_readablestream_get_reader"]
     fn __rts_sym_1656();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_enqueue"]
+    #[link_name = "__rtsm_global_readablestream_locked__get"]
     fn __rts_sym_1657();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_error"]
+    #[link_name = "__rtsm_global_readablestream_locked__set"]
     fn __rts_sym_1658();
-    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_new"]
+    #[link_name = "__rtsm_global_readablestream_new"]
     fn __rts_sym_1659();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_cancel"]
+    #[link_name = "__rtsm_global_readablestream_pipe_through"]
     fn __rts_sym_1660();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_read"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_close"]
     fn __rts_sym_1661();
-    #[link_name = "__rtsm_global_readablestreamdefaultreader_release_lock"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_desired_size"]
     fn __rts_sym_1662();
-    #[link_name = "__rtsm_global_rtsepoint3_new"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_enqueue"]
     fn __rts_sym_1663();
-    #[link_name = "__rtsm_global_rtsepoint3_sum3"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_error"]
     fn __rts_sym_1664();
-    #[link_name = "__rtsm_global_rtsepoint_at0"]
+    #[link_name = "__rtsm_global_readablestreamdefaultcontroller_new"]
     fn __rts_sym_1665();
-    #[link_name = "__rtsm_global_rtsepoint_at1"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_cancel"]
     fn __rts_sym_1666();
-    #[link_name = "__rtsm_global_rtsepoint_bump"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_read"]
     fn __rts_sym_1667();
-    #[link_name = "__rtsm_global_rtsepoint_info"]
+    #[link_name = "__rtsm_global_readablestreamdefaultreader_release_lock"]
     fn __rts_sym_1668();
-    #[link_name = "__rtsm_global_rtsepoint_label"]
+    #[link_name = "__rtsm_global_rtsepoint3_new"]
     fn __rts_sym_1669();
-    #[link_name = "__rtsm_global_rtsepoint_label_async"]
+    #[link_name = "__rtsm_global_rtsepoint3_sum3"]
     fn __rts_sym_1670();
-    #[link_name = "__rtsm_global_rtsepoint_new"]
+    #[link_name = "__rtsm_global_rtsepoint_at0"]
     fn __rts_sym_1671();
-    #[link_name = "__rtsm_global_rtsepoint_pairs"]
+    #[link_name = "__rtsm_global_rtsepoint_at1"]
     fn __rts_sym_1672();
-    #[link_name = "__rtsm_global_rtsepoint_parts"]
+    #[link_name = "__rtsm_global_rtsepoint_bump"]
     fn __rts_sym_1673();
-    #[link_name = "__rtsm_global_rtsepoint_scaled"]
+    #[link_name = "__rtsm_global_rtsepoint_info"]
     fn __rts_sym_1674();
-    #[link_name = "__rtsm_global_rtsepoint_scaled_or1"]
+    #[link_name = "__rtsm_global_rtsepoint_label"]
     fn __rts_sym_1675();
-    #[link_name = "__rtsm_global_rtsepoint_self_ref"]
+    #[link_name = "__rtsm_global_rtsepoint_label_async"]
     fn __rts_sym_1676();
-    #[link_name = "__rtsm_global_rtsepoint_set_tag"]
+    #[link_name = "__rtsm_global_rtsepoint_new"]
     fn __rts_sym_1677();
-    #[link_name = "__rtsm_global_rtsepoint_sum"]
+    #[link_name = "__rtsm_global_rtsepoint_pairs"]
     fn __rts_sym_1678();
-    #[link_name = "__rtsm_global_rtsepoint_tag"]
+    #[link_name = "__rtsm_global_rtsepoint_parts"]
     fn __rts_sym_1679();
-    #[link_name = "__rtsm_global_rtsepoint_tagged"]
+    #[link_name = "__rtsm_global_rtsepoint_scaled"]
     fn __rts_sym_1680();
-    #[link_name = "__rtsm_global_rtsepoint_unit"]
+    #[link_name = "__rtsm_global_rtsepoint_scaled_or1"]
     fn __rts_sym_1681();
-    #[link_name = "__rtsm_global_rtsepoint_with_x"]
+    #[link_name = "__rtsm_global_rtsepoint_self_ref"]
     fn __rts_sym_1682();
-    #[link_name = "__rtsm_global_rtsepoint_x__get"]
+    #[link_name = "__rtsm_global_rtsepoint_set_tag"]
     fn __rts_sym_1683();
-    #[link_name = "__rtsm_global_rtsepoint_x__set"]
+    #[link_name = "__rtsm_global_rtsepoint_sum"]
     fn __rts_sym_1684();
-    #[link_name = "__rtsm_global_rtsepoint_y__get"]
+    #[link_name = "__rtsm_global_rtsepoint_tag"]
     fn __rts_sym_1685();
-    #[link_name = "__rtsm_global_socketaddress_address"]
+    #[link_name = "__rtsm_global_rtsepoint_tagged"]
     fn __rts_sym_1686();
-    #[link_name = "__rtsm_global_socketaddress_family"]
+    #[link_name = "__rtsm_global_rtsepoint_unit"]
     fn __rts_sym_1687();
-    #[link_name = "__rtsm_global_socketaddress_flowlabel"]
+    #[link_name = "__rtsm_global_rtsepoint_with_x"]
     fn __rts_sym_1688();
-    #[link_name = "__rtsm_global_socketaddress_new"]
+    #[link_name = "__rtsm_global_rtsepoint_x__get"]
     fn __rts_sym_1689();
-    #[link_name = "__rtsm_global_socketaddress_parse"]
+    #[link_name = "__rtsm_global_rtsepoint_x__set"]
     fn __rts_sym_1690();
-    #[link_name = "__rtsm_global_socketaddress_port"]
+    #[link_name = "__rtsm_global_rtsepoint_y__get"]
     fn __rts_sym_1691();
-    #[link_name = "__rtsm_global_socketaddress_with_options"]
+    #[link_name = "__rtsm_global_socketaddress_address"]
     fn __rts_sym_1692();
-    #[link_name = "__rtsm_global_stats_atime_ms"]
+    #[link_name = "__rtsm_global_socketaddress_family"]
     fn __rts_sym_1693();
-    #[link_name = "__rtsm_global_stats_birthtime_ms"]
+    #[link_name = "__rtsm_global_socketaddress_flowlabel"]
     fn __rts_sym_1694();
-    #[link_name = "__rtsm_global_stats_blksize"]
+    #[link_name = "__rtsm_global_socketaddress_new"]
     fn __rts_sym_1695();
-    #[link_name = "__rtsm_global_stats_blocks"]
+    #[link_name = "__rtsm_global_socketaddress_parse"]
     fn __rts_sym_1696();
-    #[link_name = "__rtsm_global_stats_ctime_ms"]
+    #[link_name = "__rtsm_global_socketaddress_port"]
     fn __rts_sym_1697();
-    #[link_name = "__rtsm_global_stats_dev"]
+    #[link_name = "__rtsm_global_socketaddress_with_options"]
     fn __rts_sym_1698();
-    #[link_name = "__rtsm_global_stats_gid"]
+    #[link_name = "__rtsm_global_stats_atime_ms"]
     fn __rts_sym_1699();
-    #[link_name = "__rtsm_global_stats_ino"]
+    #[link_name = "__rtsm_global_stats_birthtime_ms"]
     fn __rts_sym_1700();
-    #[link_name = "__rtsm_global_stats_is_block"]
+    #[link_name = "__rtsm_global_stats_blksize"]
     fn __rts_sym_1701();
-    #[link_name = "__rtsm_global_stats_is_char"]
+    #[link_name = "__rtsm_global_stats_blocks"]
     fn __rts_sym_1702();
-    #[link_name = "__rtsm_global_stats_is_directory"]
+    #[link_name = "__rtsm_global_stats_ctime_ms"]
     fn __rts_sym_1703();
-    #[link_name = "__rtsm_global_stats_is_fifo"]
+    #[link_name = "__rtsm_global_stats_dev"]
     fn __rts_sym_1704();
-    #[link_name = "__rtsm_global_stats_is_file"]
+    #[link_name = "__rtsm_global_stats_gid"]
     fn __rts_sym_1705();
-    #[link_name = "__rtsm_global_stats_is_socket"]
+    #[link_name = "__rtsm_global_stats_ino"]
     fn __rts_sym_1706();
-    #[link_name = "__rtsm_global_stats_is_symlink"]
+    #[link_name = "__rtsm_global_stats_is_block"]
     fn __rts_sym_1707();
-    #[link_name = "__rtsm_global_stats_mode"]
+    #[link_name = "__rtsm_global_stats_is_char"]
     fn __rts_sym_1708();
-    #[link_name = "__rtsm_global_stats_mtime_ms"]
+    #[link_name = "__rtsm_global_stats_is_directory"]
     fn __rts_sym_1709();
-    #[link_name = "__rtsm_global_stats_nlink"]
+    #[link_name = "__rtsm_global_stats_is_fifo"]
     fn __rts_sym_1710();
-    #[link_name = "__rtsm_global_stats_rdev"]
+    #[link_name = "__rtsm_global_stats_is_file"]
     fn __rts_sym_1711();
-    #[link_name = "__rtsm_global_stats_size"]
+    #[link_name = "__rtsm_global_stats_is_socket"]
     fn __rts_sym_1712();
-    #[link_name = "__rtsm_global_stats_uid"]
+    #[link_name = "__rtsm_global_stats_is_symlink"]
     fn __rts_sym_1713();
-    #[link_name = "__rtsm_global_storage_clear"]
+    #[link_name = "__rtsm_global_stats_mode"]
     fn __rts_sym_1714();
-    #[link_name = "__rtsm_global_storage_getItem"]
+    #[link_name = "__rtsm_global_stats_mtime_ms"]
     fn __rts_sym_1715();
-    #[link_name = "__rtsm_global_storage_key"]
+    #[link_name = "__rtsm_global_stats_nlink"]
     fn __rts_sym_1716();
-    #[link_name = "__rtsm_global_storage_length"]
+    #[link_name = "__rtsm_global_stats_rdev"]
     fn __rts_sym_1717();
-    #[link_name = "__rtsm_global_storage_new"]
+    #[link_name = "__rtsm_global_stats_size"]
     fn __rts_sym_1718();
-    #[link_name = "__rtsm_global_storage_persistTo"]
+    #[link_name = "__rtsm_global_stats_uid"]
     fn __rts_sym_1719();
-    #[link_name = "__rtsm_global_storage_removeItem"]
+    #[link_name = "__rtsm_global_storage_clear"]
     fn __rts_sym_1720();
-    #[link_name = "__rtsm_global_storage_setItem"]
+    #[link_name = "__rtsm_global_storage_getItem"]
     fn __rts_sym_1721();
-    #[link_name = "__rtsm_global_string_at"]
+    #[link_name = "__rtsm_global_storage_key"]
     fn __rts_sym_1722();
-    #[link_name = "__rtsm_global_string_char_at"]
+    #[link_name = "__rtsm_global_storage_length"]
     fn __rts_sym_1723();
-    #[link_name = "__rtsm_global_string_char_code_at"]
+    #[link_name = "__rtsm_global_storage_new"]
     fn __rts_sym_1724();
-    #[link_name = "__rtsm_global_string_code_point_at"]
+    #[link_name = "__rtsm_global_storage_persistTo"]
     fn __rts_sym_1725();
-    #[link_name = "__rtsm_global_string_concat"]
+    #[link_name = "__rtsm_global_storage_removeItem"]
     fn __rts_sym_1726();
-    #[link_name = "__rtsm_global_string_ends_with"]
+    #[link_name = "__rtsm_global_storage_setItem"]
     fn __rts_sym_1727();
-    #[link_name = "__rtsm_global_string_includes"]
+    #[link_name = "__rtsm_global_string_at"]
     fn __rts_sym_1728();
-    #[link_name = "__rtsm_global_string_index_of"]
+    #[link_name = "__rtsm_global_string_char_at"]
     fn __rts_sym_1729();
-    #[link_name = "__rtsm_global_string_is_well_formed"]
+    #[link_name = "__rtsm_global_string_char_code_at"]
     fn __rts_sym_1730();
-    #[link_name = "__rtsm_global_string_last_index_of"]
+    #[link_name = "__rtsm_global_string_code_point_at"]
     fn __rts_sym_1731();
-    #[link_name = "__rtsm_global_string_length"]
+    #[link_name = "__rtsm_global_string_concat"]
     fn __rts_sym_1732();
-    #[link_name = "__rtsm_global_string_locale_compare"]
+    #[link_name = "__rtsm_global_string_ends_with"]
     fn __rts_sym_1733();
-    #[link_name = "__rtsm_global_string_new"]
+    #[link_name = "__rtsm_global_string_includes"]
     fn __rts_sym_1734();
-    #[link_name = "__rtsm_global_string_normalize"]
+    #[link_name = "__rtsm_global_string_index_of"]
     fn __rts_sym_1735();
-    #[link_name = "__rtsm_global_string_pad_end"]
+    #[link_name = "__rtsm_global_string_is_well_formed"]
     fn __rts_sym_1736();
-    #[link_name = "__rtsm_global_string_pad_start"]
+    #[link_name = "__rtsm_global_string_last_index_of"]
     fn __rts_sym_1737();
-    #[link_name = "__rtsm_global_string_repeat"]
+    #[link_name = "__rtsm_global_string_length"]
     fn __rts_sym_1738();
-    #[link_name = "__rtsm_global_string_replace"]
+    #[link_name = "__rtsm_global_string_locale_compare"]
     fn __rts_sym_1739();
-    #[link_name = "__rtsm_global_string_replace_all"]
+    #[link_name = "__rtsm_global_string_new"]
     fn __rts_sym_1740();
-    #[link_name = "__rtsm_global_string_slice"]
+    #[link_name = "__rtsm_global_string_normalize"]
     fn __rts_sym_1741();
-    #[link_name = "__rtsm_global_string_starts_with"]
+    #[link_name = "__rtsm_global_string_pad_end"]
     fn __rts_sym_1742();
-    #[link_name = "__rtsm_global_string_substr"]
+    #[link_name = "__rtsm_global_string_pad_start"]
     fn __rts_sym_1743();
-    #[link_name = "__rtsm_global_string_substring"]
+    #[link_name = "__rtsm_global_string_repeat"]
     fn __rts_sym_1744();
-    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
+    #[link_name = "__rtsm_global_string_replace"]
     fn __rts_sym_1745();
-    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
+    #[link_name = "__rtsm_global_string_replace_all"]
     fn __rts_sym_1746();
-    #[link_name = "__rtsm_global_string_to_lower_case"]
+    #[link_name = "__rtsm_global_string_slice"]
     fn __rts_sym_1747();
-    #[link_name = "__rtsm_global_string_to_string"]
+    #[link_name = "__rtsm_global_string_starts_with"]
     fn __rts_sym_1748();
-    #[link_name = "__rtsm_global_string_to_upper_case"]
+    #[link_name = "__rtsm_global_string_substr"]
     fn __rts_sym_1749();
-    #[link_name = "__rtsm_global_string_to_well_formed"]
+    #[link_name = "__rtsm_global_string_substring"]
     fn __rts_sym_1750();
-    #[link_name = "__rtsm_global_string_trim"]
+    #[link_name = "__rtsm_global_string_to_locale_lower_case"]
     fn __rts_sym_1751();
-    #[link_name = "__rtsm_global_string_trim_end"]
+    #[link_name = "__rtsm_global_string_to_locale_upper_case"]
     fn __rts_sym_1752();
-    #[link_name = "__rtsm_global_string_trim_left"]
+    #[link_name = "__rtsm_global_string_to_lower_case"]
     fn __rts_sym_1753();
-    #[link_name = "__rtsm_global_string_trim_right"]
+    #[link_name = "__rtsm_global_string_to_string"]
     fn __rts_sym_1754();
-    #[link_name = "__rtsm_global_string_trim_start"]
+    #[link_name = "__rtsm_global_string_to_upper_case"]
     fn __rts_sym_1755();
-    #[link_name = "__rtsm_global_string_value_of"]
+    #[link_name = "__rtsm_global_string_to_well_formed"]
     fn __rts_sym_1756();
-    #[link_name = "__rtsm_global_stringdecoder_encoding"]
+    #[link_name = "__rtsm_global_string_trim"]
     fn __rts_sym_1757();
-    #[link_name = "__rtsm_global_stringdecoder_end"]
+    #[link_name = "__rtsm_global_string_trim_end"]
     fn __rts_sym_1758();
-    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
+    #[link_name = "__rtsm_global_string_trim_left"]
     fn __rts_sym_1759();
-    #[link_name = "__rtsm_global_stringdecoder_new"]
+    #[link_name = "__rtsm_global_string_trim_right"]
     fn __rts_sym_1760();
-    #[link_name = "__rtsm_global_stringdecoder_text"]
+    #[link_name = "__rtsm_global_string_trim_start"]
     fn __rts_sym_1761();
-    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
+    #[link_name = "__rtsm_global_string_value_of"]
     fn __rts_sym_1762();
-    #[link_name = "__rtsm_global_stringdecoder_write"]
+    #[link_name = "__rtsm_global_stringdecoder_encoding"]
     fn __rts_sym_1763();
-    #[link_name = "__rtsm_global_symbol_description"]
+    #[link_name = "__rtsm_global_stringdecoder_end"]
     fn __rts_sym_1764();
-    #[link_name = "__rtsm_global_symbol_for_key"]
+    #[link_name = "__rtsm_global_stringdecoder_end_buf"]
     fn __rts_sym_1765();
-    #[link_name = "__rtsm_global_symbol_js_to_string"]
+    #[link_name = "__rtsm_global_stringdecoder_new"]
     fn __rts_sym_1766();
-    #[link_name = "__rtsm_global_symbol_key_for"]
+    #[link_name = "__rtsm_global_stringdecoder_text"]
     fn __rts_sym_1767();
-    #[link_name = "__rtsm_global_symbol_new"]
+    #[link_name = "__rtsm_global_stringdecoder_with_encoding"]
     fn __rts_sym_1768();
-    #[link_name = "__rtsm_global_textdecoder_decode"]
+    #[link_name = "__rtsm_global_stringdecoder_write"]
     fn __rts_sym_1769();
-    #[link_name = "__rtsm_global_textdecoder_new"]
+    #[link_name = "__rtsm_global_symbol_description"]
     fn __rts_sym_1770();
-    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
+    #[link_name = "__rtsm_global_symbol_for_key"]
     fn __rts_sym_1771();
-    #[link_name = "__rtsm_global_textdecoderstream_new"]
+    #[link_name = "__rtsm_global_symbol_js_to_string"]
     fn __rts_sym_1772();
-    #[link_name = "__rtsm_global_textdecoderstream_readable"]
+    #[link_name = "__rtsm_global_symbol_key_for"]
     fn __rts_sym_1773();
-    #[link_name = "__rtsm_global_textdecoderstream_writable"]
+    #[link_name = "__rtsm_global_symbol_new"]
     fn __rts_sym_1774();
-    #[link_name = "__rtsm_global_textencoder_encode"]
+    #[link_name = "__rtsm_global_textdecoder_decode"]
     fn __rts_sym_1775();
-    #[link_name = "__rtsm_global_textencoder_encode_into"]
+    #[link_name = "__rtsm_global_textdecoder_new"]
     fn __rts_sym_1776();
-    #[link_name = "__rtsm_global_textencoder_new"]
+    #[link_name = "__rtsm_global_textdecoderstream_encoding"]
     fn __rts_sym_1777();
-    #[link_name = "__rtsm_global_textencoderstream_encoding"]
+    #[link_name = "__rtsm_global_textdecoderstream_new"]
     fn __rts_sym_1778();
-    #[link_name = "__rtsm_global_textencoderstream_new"]
+    #[link_name = "__rtsm_global_textdecoderstream_readable"]
     fn __rts_sym_1779();
-    #[link_name = "__rtsm_global_textencoderstream_readable"]
+    #[link_name = "__rtsm_global_textdecoderstream_writable"]
     fn __rts_sym_1780();
-    #[link_name = "__rtsm_global_textencoderstream_writable"]
+    #[link_name = "__rtsm_global_textencoder_encode"]
     fn __rts_sym_1781();
-    #[link_name = "__rtsm_global_transformstream_new"]
+    #[link_name = "__rtsm_global_textencoder_encode_into"]
     fn __rts_sym_1782();
-    #[link_name = "__rtsm_global_transformstream_readable"]
+    #[link_name = "__rtsm_global_textencoder_new"]
     fn __rts_sym_1783();
-    #[link_name = "__rtsm_global_transformstream_writable"]
+    #[link_name = "__rtsm_global_textencoderstream_encoding"]
     fn __rts_sym_1784();
-    #[link_name = "__rtsm_global_url_can_parse"]
+    #[link_name = "__rtsm_global_textencoderstream_new"]
     fn __rts_sym_1785();
-    #[link_name = "__rtsm_global_url_can_parse_base"]
+    #[link_name = "__rtsm_global_textencoderstream_readable"]
     fn __rts_sym_1786();
-    #[link_name = "__rtsm_global_url_hash"]
+    #[link_name = "__rtsm_global_textencoderstream_writable"]
     fn __rts_sym_1787();
-    #[link_name = "__rtsm_global_url_host"]
+    #[link_name = "__rtsm_global_transformstream_new"]
     fn __rts_sym_1788();
-    #[link_name = "__rtsm_global_url_hostname"]
+    #[link_name = "__rtsm_global_transformstream_readable"]
     fn __rts_sym_1789();
-    #[link_name = "__rtsm_global_url_href"]
+    #[link_name = "__rtsm_global_transformstream_writable"]
     fn __rts_sym_1790();
-    #[link_name = "__rtsm_global_url_new"]
+    #[link_name = "__rtsm_global_url_can_parse"]
     fn __rts_sym_1791();
-    #[link_name = "__rtsm_global_url_new_with_base"]
+    #[link_name = "__rtsm_global_url_can_parse_base"]
     fn __rts_sym_1792();
-    #[link_name = "__rtsm_global_url_origin"]
+    #[link_name = "__rtsm_global_url_hash"]
     fn __rts_sym_1793();
-    #[link_name = "__rtsm_global_url_password"]
+    #[link_name = "__rtsm_global_url_host"]
     fn __rts_sym_1794();
-    #[link_name = "__rtsm_global_url_pathname"]
+    #[link_name = "__rtsm_global_url_hostname"]
     fn __rts_sym_1795();
-    #[link_name = "__rtsm_global_url_port"]
+    #[link_name = "__rtsm_global_url_href"]
     fn __rts_sym_1796();
-    #[link_name = "__rtsm_global_url_protocol"]
+    #[link_name = "__rtsm_global_url_new"]
     fn __rts_sym_1797();
-    #[link_name = "__rtsm_global_url_search"]
+    #[link_name = "__rtsm_global_url_new_with_base"]
     fn __rts_sym_1798();
-    #[link_name = "__rtsm_global_url_search_params"]
+    #[link_name = "__rtsm_global_url_origin"]
     fn __rts_sym_1799();
-    #[link_name = "__rtsm_global_url_set_hash"]
+    #[link_name = "__rtsm_global_url_password"]
     fn __rts_sym_1800();
-    #[link_name = "__rtsm_global_url_set_host"]
+    #[link_name = "__rtsm_global_url_pathname"]
     fn __rts_sym_1801();
-    #[link_name = "__rtsm_global_url_set_hostname"]
+    #[link_name = "__rtsm_global_url_port"]
     fn __rts_sym_1802();
-    #[link_name = "__rtsm_global_url_set_href"]
+    #[link_name = "__rtsm_global_url_protocol"]
     fn __rts_sym_1803();
-    #[link_name = "__rtsm_global_url_set_password"]
+    #[link_name = "__rtsm_global_url_search"]
     fn __rts_sym_1804();
-    #[link_name = "__rtsm_global_url_set_pathname"]
+    #[link_name = "__rtsm_global_url_search_params"]
     fn __rts_sym_1805();
-    #[link_name = "__rtsm_global_url_set_port"]
+    #[link_name = "__rtsm_global_url_set_hash"]
     fn __rts_sym_1806();
-    #[link_name = "__rtsm_global_url_set_protocol"]
+    #[link_name = "__rtsm_global_url_set_host"]
     fn __rts_sym_1807();
-    #[link_name = "__rtsm_global_url_set_search"]
+    #[link_name = "__rtsm_global_url_set_hostname"]
     fn __rts_sym_1808();
-    #[link_name = "__rtsm_global_url_set_username"]
+    #[link_name = "__rtsm_global_url_set_href"]
     fn __rts_sym_1809();
-    #[link_name = "__rtsm_global_url_to_json"]
+    #[link_name = "__rtsm_global_url_set_password"]
     fn __rts_sym_1810();
-    #[link_name = "__rtsm_global_url_to_string"]
+    #[link_name = "__rtsm_global_url_set_pathname"]
     fn __rts_sym_1811();
-    #[link_name = "__rtsm_global_url_username"]
+    #[link_name = "__rtsm_global_url_set_port"]
     fn __rts_sym_1812();
-    #[link_name = "__rtsm_global_urlsearchparams_append"]
+    #[link_name = "__rtsm_global_url_set_protocol"]
     fn __rts_sym_1813();
-    #[link_name = "__rtsm_global_urlsearchparams_delete"]
+    #[link_name = "__rtsm_global_url_set_search"]
     fn __rts_sym_1814();
-    #[link_name = "__rtsm_global_urlsearchparams_get"]
+    #[link_name = "__rtsm_global_url_set_username"]
     fn __rts_sym_1815();
-    #[link_name = "__rtsm_global_urlsearchparams_has"]
+    #[link_name = "__rtsm_global_url_to_json"]
     fn __rts_sym_1816();
-    #[link_name = "__rtsm_global_urlsearchparams_new"]
+    #[link_name = "__rtsm_global_url_to_string"]
     fn __rts_sym_1817();
-    #[link_name = "__rtsm_global_urlsearchparams_set"]
+    #[link_name = "__rtsm_global_url_username"]
     fn __rts_sym_1818();
-    #[link_name = "__rtsm_global_urlsearchparams_size"]
+    #[link_name = "__rtsm_global_urlsearchparams_append"]
     fn __rts_sym_1819();
-    #[link_name = "__rtsm_global_urlsearchparams_sort"]
+    #[link_name = "__rtsm_global_urlsearchparams_delete"]
     fn __rts_sym_1820();
-    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
+    #[link_name = "__rtsm_global_urlsearchparams_get"]
     fn __rts_sym_1821();
-    #[link_name = "__rtsm_global_weakref_deref"]
+    #[link_name = "__rtsm_global_urlsearchparams_has"]
     fn __rts_sym_1822();
-    #[link_name = "__rtsm_global_weakref_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_new"]
     fn __rts_sym_1823();
-    #[link_name = "__rtsm_global_writablestream_locked__get"]
+    #[link_name = "__rtsm_global_urlsearchparams_set"]
     fn __rts_sym_1824();
-    #[link_name = "__rtsm_global_writablestream_locked__set"]
+    #[link_name = "__rtsm_global_urlsearchparams_size"]
     fn __rts_sym_1825();
-    #[link_name = "__rtsm_global_writablestream_new"]
+    #[link_name = "__rtsm_global_urlsearchparams_sort"]
     fn __rts_sym_1826();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
+    #[link_name = "__rtsm_global_urlsearchparams_to_string"]
     fn __rts_sym_1827();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
+    #[link_name = "__rtsm_global_weakref_deref"]
     fn __rts_sym_1828();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
+    #[link_name = "__rtsm_global_weakref_new"]
     fn __rts_sym_1829();
-    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
+    #[link_name = "__rtsm_global_writablestream_locked__get"]
     fn __rts_sym_1830();
-    #[link_name = "__rtsm_node_assert_deepEqual"]
+    #[link_name = "__rtsm_global_writablestream_locked__set"]
     fn __rts_sym_1831();
-    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
+    #[link_name = "__rtsm_global_writablestream_new"]
     fn __rts_sym_1832();
-    #[link_name = "__rtsm_node_assert_doesNotMatch"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_abort"]
     fn __rts_sym_1833();
-    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_close"]
     fn __rts_sym_1834();
-    #[link_name = "__rtsm_node_assert_doesNotThrow"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_release_lock"]
     fn __rts_sym_1835();
-    #[link_name = "__rtsm_node_assert_equal"]
+    #[link_name = "__rtsm_global_writablestreamdefaultwriter_write"]
     fn __rts_sym_1836();
-    #[link_name = "__rtsm_node_assert_fail"]
+    #[link_name = "__rtsm_node_assert_deepEqual"]
     fn __rts_sym_1837();
-    #[link_name = "__rtsm_node_assert_fail_msg"]
+    #[link_name = "__rtsm_node_assert_deepStrictEqual"]
     fn __rts_sym_1838();
-    #[link_name = "__rtsm_node_assert_ifError"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch"]
     fn __rts_sym_1839();
-    #[link_name = "__rtsm_node_assert_match"]
+    #[link_name = "__rtsm_node_assert_doesNotMatch_msg"]
     fn __rts_sym_1840();
-    #[link_name = "__rtsm_node_assert_match_msg"]
+    #[link_name = "__rtsm_node_assert_doesNotThrow"]
     fn __rts_sym_1841();
-    #[link_name = "__rtsm_node_assert_notDeepEqual"]
+    #[link_name = "__rtsm_node_assert_equal"]
     fn __rts_sym_1842();
-    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
+    #[link_name = "__rtsm_node_assert_fail"]
     fn __rts_sym_1843();
-    #[link_name = "__rtsm_node_assert_notEqual"]
+    #[link_name = "__rtsm_node_assert_fail_msg"]
     fn __rts_sym_1844();
-    #[link_name = "__rtsm_node_assert_notStrictEqual"]
+    #[link_name = "__rtsm_node_assert_ifError"]
     fn __rts_sym_1845();
-    #[link_name = "__rtsm_node_assert_ok"]
+    #[link_name = "__rtsm_node_assert_match"]
     fn __rts_sym_1846();
-    #[link_name = "__rtsm_node_assert_ok_msg"]
+    #[link_name = "__rtsm_node_assert_match_msg"]
     fn __rts_sym_1847();
-    #[link_name = "__rtsm_node_assert_strictEqual"]
+    #[link_name = "__rtsm_node_assert_notDeepEqual"]
     fn __rts_sym_1848();
-    #[link_name = "__rtsm_node_assert_throws"]
+    #[link_name = "__rtsm_node_assert_notDeepStrictEqual"]
     fn __rts_sym_1849();
-    #[link_name = "__rtsm_node_buffer_atob"]
+    #[link_name = "__rtsm_node_assert_notEqual"]
     fn __rts_sym_1850();
-    #[link_name = "__rtsm_node_buffer_btoa"]
+    #[link_name = "__rtsm_node_assert_notStrictEqual"]
     fn __rts_sym_1851();
-    #[link_name = "__rtsm_node_crypto_createCipheriv"]
+    #[link_name = "__rtsm_node_assert_ok"]
     fn __rts_sym_1852();
-    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
+    #[link_name = "__rtsm_node_assert_ok_msg"]
     fn __rts_sym_1853();
-    #[link_name = "__rtsm_node_crypto_createHash"]
+    #[link_name = "__rtsm_node_assert_strictEqual"]
     fn __rts_sym_1854();
-    #[link_name = "__rtsm_node_crypto_createHmac"]
+    #[link_name = "__rtsm_node_assert_throws"]
     fn __rts_sym_1855();
-    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
+    #[link_name = "__rtsm_node_buffer_atob"]
     fn __rts_sym_1856();
-    #[link_name = "__rtsm_node_crypto_getHashes"]
+    #[link_name = "__rtsm_node_buffer_btoa"]
     fn __rts_sym_1857();
-    #[link_name = "__rtsm_node_crypto_hash"]
+    #[link_name = "__rtsm_node_crypto_createCipheriv"]
     fn __rts_sym_1858();
-    #[link_name = "__rtsm_node_crypto_hash_enc"]
+    #[link_name = "__rtsm_node_crypto_createDecipheriv"]
     fn __rts_sym_1859();
-    #[link_name = "__rtsm_node_crypto_hkdfSync"]
+    #[link_name = "__rtsm_node_crypto_createHash"]
     fn __rts_sym_1860();
-    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
+    #[link_name = "__rtsm_node_crypto_createHmac"]
     fn __rts_sym_1861();
-    #[link_name = "__rtsm_node_crypto_randomBytes"]
+    #[link_name = "__rtsm_node_crypto_generateX25519KeyPair"]
     fn __rts_sym_1862();
-    #[link_name = "__rtsm_node_crypto_randomFillSync"]
+    #[link_name = "__rtsm_node_crypto_getHashes"]
     fn __rts_sym_1863();
-    #[link_name = "__rtsm_node_crypto_randomInt"]
+    #[link_name = "__rtsm_node_crypto_hash"]
     fn __rts_sym_1864();
-    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
+    #[link_name = "__rtsm_node_crypto_hash_enc"]
     fn __rts_sym_1865();
-    #[link_name = "__rtsm_node_crypto_randomUUID"]
+    #[link_name = "__rtsm_node_crypto_hkdfSync"]
     fn __rts_sym_1866();
-    #[link_name = "__rtsm_node_crypto_scryptSync"]
+    #[link_name = "__rtsm_node_crypto_pbkdf2Sync"]
     fn __rts_sym_1867();
-    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
+    #[link_name = "__rtsm_node_crypto_randomBytes"]
     fn __rts_sym_1868();
-    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
+    #[link_name = "__rtsm_node_crypto_randomFillSync"]
     fn __rts_sym_1869();
-    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
+    #[link_name = "__rtsm_node_crypto_randomInt"]
     fn __rts_sym_1870();
-    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
+    #[link_name = "__rtsm_node_crypto_randomInt_minmax"]
     fn __rts_sym_1871();
-    #[link_name = "__rtsm_node_dgram_createSocket"]
+    #[link_name = "__rtsm_node_crypto_randomUUID"]
     fn __rts_sym_1872();
-    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
+    #[link_name = "__rtsm_node_crypto_scryptSync"]
     fn __rts_sym_1873();
-    #[link_name = "__rtsm_node_dns_lookup"]
+    #[link_name = "__rtsm_node_crypto_scryptSync_params"]
     fn __rts_sym_1874();
-    #[link_name = "__rtsm_node_dns_resolve4"]
+    #[link_name = "__rtsm_node_crypto_timingSafeEqual"]
     fn __rts_sym_1875();
-    #[link_name = "__rtsm_node_dns_resolve6"]
+    #[link_name = "__rtsm_node_crypto_x25519DiffieHellman"]
     fn __rts_sym_1876();
-    #[link_name = "__rtsm_node_fs_access"]
+    #[link_name = "__rtsm_node_crypto_x25519PublicKey"]
     fn __rts_sym_1877();
-    #[link_name = "__rtsm_node_fs_accessSync"]
+    #[link_name = "__rtsm_node_dgram_createSocket"]
     fn __rts_sym_1878();
-    #[link_name = "__rtsm_node_fs_appendFile"]
+    #[link_name = "__rtsm_node_dgram_createSocket_cb"]
     fn __rts_sym_1879();
-    #[link_name = "__rtsm_node_fs_appendFileSync"]
+    #[link_name = "__rtsm_node_dns_lookup"]
     fn __rts_sym_1880();
-    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
+    #[link_name = "__rtsm_node_dns_resolve4"]
     fn __rts_sym_1881();
-    #[link_name = "__rtsm_node_fs_chmod"]
+    #[link_name = "__rtsm_node_dns_resolve6"]
     fn __rts_sym_1882();
-    #[link_name = "__rtsm_node_fs_chmodSync"]
+    #[link_name = "__rtsm_node_fs_access"]
     fn __rts_sym_1883();
-    #[link_name = "__rtsm_node_fs_chownSync"]
+    #[link_name = "__rtsm_node_fs_accessSync"]
     fn __rts_sym_1884();
-    #[link_name = "__rtsm_node_fs_closeSync"]
+    #[link_name = "__rtsm_node_fs_appendFile"]
     fn __rts_sym_1885();
-    #[link_name = "__rtsm_node_fs_copyFile"]
+    #[link_name = "__rtsm_node_fs_appendFileSync"]
     fn __rts_sym_1886();
-    #[link_name = "__rtsm_node_fs_copyFileSync"]
+    #[link_name = "__rtsm_node_fs_appendFileSync_enc"]
     fn __rts_sym_1887();
-    #[link_name = "__rtsm_node_fs_cpSync"]
+    #[link_name = "__rtsm_node_fs_chmod"]
     fn __rts_sym_1888();
-    #[link_name = "__rtsm_node_fs_cpSync_opts"]
+    #[link_name = "__rtsm_node_fs_chmodSync"]
     fn __rts_sym_1889();
-    #[link_name = "__rtsm_node_fs_exists"]
+    #[link_name = "__rtsm_node_fs_chownSync"]
     fn __rts_sym_1890();
-    #[link_name = "__rtsm_node_fs_existsSync"]
+    #[link_name = "__rtsm_node_fs_closeSync"]
     fn __rts_sym_1891();
-    #[link_name = "__rtsm_node_fs_fchmodSync"]
+    #[link_name = "__rtsm_node_fs_copyFile"]
     fn __rts_sym_1892();
-    #[link_name = "__rtsm_node_fs_fchownSync"]
+    #[link_name = "__rtsm_node_fs_copyFileSync"]
     fn __rts_sym_1893();
-    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
+    #[link_name = "__rtsm_node_fs_cpSync"]
     fn __rts_sym_1894();
-    #[link_name = "__rtsm_node_fs_fstatSync"]
+    #[link_name = "__rtsm_node_fs_cpSync_opts"]
     fn __rts_sym_1895();
-    #[link_name = "__rtsm_node_fs_fsyncSync"]
+    #[link_name = "__rtsm_node_fs_exists"]
     fn __rts_sym_1896();
-    #[link_name = "__rtsm_node_fs_ftruncateSync"]
+    #[link_name = "__rtsm_node_fs_existsSync"]
     fn __rts_sym_1897();
-    #[link_name = "__rtsm_node_fs_futimesSync"]
+    #[link_name = "__rtsm_node_fs_fchmodSync"]
     fn __rts_sym_1898();
-    #[link_name = "__rtsm_node_fs_globSync"]
+    #[link_name = "__rtsm_node_fs_fchownSync"]
     fn __rts_sym_1899();
-    #[link_name = "__rtsm_node_fs_lchmodSync"]
+    #[link_name = "__rtsm_node_fs_fdatasyncSync"]
     fn __rts_sym_1900();
-    #[link_name = "__rtsm_node_fs_lchownSync"]
+    #[link_name = "__rtsm_node_fs_fstatSync"]
     fn __rts_sym_1901();
-    #[link_name = "__rtsm_node_fs_linkSync"]
+    #[link_name = "__rtsm_node_fs_fsyncSync"]
     fn __rts_sym_1902();
-    #[link_name = "__rtsm_node_fs_lstat"]
+    #[link_name = "__rtsm_node_fs_ftruncateSync"]
     fn __rts_sym_1903();
-    #[link_name = "__rtsm_node_fs_lstatSync"]
+    #[link_name = "__rtsm_node_fs_futimesSync"]
     fn __rts_sym_1904();
-    #[link_name = "__rtsm_node_fs_mkdir"]
+    #[link_name = "__rtsm_node_fs_globSync"]
     fn __rts_sym_1905();
-    #[link_name = "__rtsm_node_fs_mkdirSync"]
+    #[link_name = "__rtsm_node_fs_lchmodSync"]
     fn __rts_sym_1906();
-    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_lchownSync"]
     fn __rts_sym_1907();
-    #[link_name = "__rtsm_node_fs_mkdtempSync"]
+    #[link_name = "__rtsm_node_fs_linkSync"]
     fn __rts_sym_1908();
-    #[link_name = "__rtsm_node_fs_openSync"]
+    #[link_name = "__rtsm_node_fs_lstat"]
     fn __rts_sym_1909();
-    #[link_name = "__rtsm_node_fs_opendirSync"]
+    #[link_name = "__rtsm_node_fs_lstatSync"]
     fn __rts_sym_1910();
-    #[link_name = "__rtsm_node_fs_promises_access"]
+    #[link_name = "__rtsm_node_fs_mkdir"]
     fn __rts_sym_1911();
-    #[link_name = "__rtsm_node_fs_promises_appendFile"]
+    #[link_name = "__rtsm_node_fs_mkdirSync"]
     fn __rts_sym_1912();
-    #[link_name = "__rtsm_node_fs_promises_copyFile"]
+    #[link_name = "__rtsm_node_fs_mkdirSync_opts"]
     fn __rts_sym_1913();
-    #[link_name = "__rtsm_node_fs_promises_lstat"]
+    #[link_name = "__rtsm_node_fs_mkdtempSync"]
     fn __rts_sym_1914();
-    #[link_name = "__rtsm_node_fs_promises_mkdir"]
+    #[link_name = "__rtsm_node_fs_openSync"]
     fn __rts_sym_1915();
-    #[link_name = "__rtsm_node_fs_promises_open"]
+    #[link_name = "__rtsm_node_fs_opendirSync"]
     fn __rts_sym_1916();
-    #[link_name = "__rtsm_node_fs_promises_readFile"]
+    #[link_name = "__rtsm_node_fs_promises_access"]
     fn __rts_sym_1917();
-    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_promises_appendFile"]
     fn __rts_sym_1918();
-    #[link_name = "__rtsm_node_fs_promises_readdir"]
+    #[link_name = "__rtsm_node_fs_promises_copyFile"]
     fn __rts_sym_1919();
-    #[link_name = "__rtsm_node_fs_promises_readlink"]
+    #[link_name = "__rtsm_node_fs_promises_lstat"]
     fn __rts_sym_1920();
-    #[link_name = "__rtsm_node_fs_promises_realpath"]
+    #[link_name = "__rtsm_node_fs_promises_mkdir"]
     fn __rts_sym_1921();
-    #[link_name = "__rtsm_node_fs_promises_rename"]
+    #[link_name = "__rtsm_node_fs_promises_open"]
     fn __rts_sym_1922();
-    #[link_name = "__rtsm_node_fs_promises_rm"]
+    #[link_name = "__rtsm_node_fs_promises_readFile"]
     fn __rts_sym_1923();
-    #[link_name = "__rtsm_node_fs_promises_rmdir"]
+    #[link_name = "__rtsm_node_fs_promises_readFile_enc"]
     fn __rts_sym_1924();
-    #[link_name = "__rtsm_node_fs_promises_stat"]
+    #[link_name = "__rtsm_node_fs_promises_readdir"]
     fn __rts_sym_1925();
-    #[link_name = "__rtsm_node_fs_promises_truncate"]
+    #[link_name = "__rtsm_node_fs_promises_readlink"]
     fn __rts_sym_1926();
-    #[link_name = "__rtsm_node_fs_promises_unlink"]
+    #[link_name = "__rtsm_node_fs_promises_realpath"]
     fn __rts_sym_1927();
-    #[link_name = "__rtsm_node_fs_promises_writeFile"]
+    #[link_name = "__rtsm_node_fs_promises_rename"]
     fn __rts_sym_1928();
-    #[link_name = "__rtsm_node_fs_readFile"]
+    #[link_name = "__rtsm_node_fs_promises_rm"]
     fn __rts_sym_1929();
-    #[link_name = "__rtsm_node_fs_readFileSync"]
+    #[link_name = "__rtsm_node_fs_promises_rmdir"]
     fn __rts_sym_1930();
-    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_promises_stat"]
     fn __rts_sym_1931();
-    #[link_name = "__rtsm_node_fs_readFile_enc"]
+    #[link_name = "__rtsm_node_fs_promises_truncate"]
     fn __rts_sym_1932();
-    #[link_name = "__rtsm_node_fs_readSync"]
+    #[link_name = "__rtsm_node_fs_promises_unlink"]
     fn __rts_sym_1933();
-    #[link_name = "__rtsm_node_fs_readdir"]
+    #[link_name = "__rtsm_node_fs_promises_writeFile"]
     fn __rts_sym_1934();
-    #[link_name = "__rtsm_node_fs_readdirSync"]
+    #[link_name = "__rtsm_node_fs_readFile"]
     fn __rts_sym_1935();
-    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
+    #[link_name = "__rtsm_node_fs_readFileSync"]
     fn __rts_sym_1936();
-    #[link_name = "__rtsm_node_fs_readlinkSync"]
+    #[link_name = "__rtsm_node_fs_readFileSync_enc"]
     fn __rts_sym_1937();
-    #[link_name = "__rtsm_node_fs_readvSync"]
+    #[link_name = "__rtsm_node_fs_readFile_enc"]
     fn __rts_sym_1938();
-    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
+    #[link_name = "__rtsm_node_fs_readSync"]
     fn __rts_sym_1939();
-    #[link_name = "__rtsm_node_fs_realpath"]
+    #[link_name = "__rtsm_node_fs_readdir"]
     fn __rts_sym_1940();
-    #[link_name = "__rtsm_node_fs_realpathSync"]
+    #[link_name = "__rtsm_node_fs_readdirSync"]
     fn __rts_sym_1941();
-    #[link_name = "__rtsm_node_fs_rename"]
+    #[link_name = "__rtsm_node_fs_readdirSync_opts"]
     fn __rts_sym_1942();
-    #[link_name = "__rtsm_node_fs_renameSync"]
+    #[link_name = "__rtsm_node_fs_readlinkSync"]
     fn __rts_sym_1943();
-    #[link_name = "__rtsm_node_fs_rm"]
+    #[link_name = "__rtsm_node_fs_readvSync"]
     fn __rts_sym_1944();
-    #[link_name = "__rtsm_node_fs_rmSync"]
+    #[link_name = "__rtsm_node_fs_readvSync_nopos"]
     fn __rts_sym_1945();
-    #[link_name = "__rtsm_node_fs_rmSync_opts"]
+    #[link_name = "__rtsm_node_fs_realpath"]
     fn __rts_sym_1946();
-    #[link_name = "__rtsm_node_fs_rmdir"]
+    #[link_name = "__rtsm_node_fs_realpathSync"]
     fn __rts_sym_1947();
-    #[link_name = "__rtsm_node_fs_rmdirSync"]
+    #[link_name = "__rtsm_node_fs_rename"]
     fn __rts_sym_1948();
-    #[link_name = "__rtsm_node_fs_stat"]
+    #[link_name = "__rtsm_node_fs_renameSync"]
     fn __rts_sym_1949();
-    #[link_name = "__rtsm_node_fs_statSync"]
+    #[link_name = "__rtsm_node_fs_rm"]
     fn __rts_sym_1950();
-    #[link_name = "__rtsm_node_fs_statfsSync"]
+    #[link_name = "__rtsm_node_fs_rmSync"]
     fn __rts_sym_1951();
-    #[link_name = "__rtsm_node_fs_symlinkSync"]
+    #[link_name = "__rtsm_node_fs_rmSync_opts"]
     fn __rts_sym_1952();
-    #[link_name = "__rtsm_node_fs_truncateSync"]
+    #[link_name = "__rtsm_node_fs_rmdir"]
     fn __rts_sym_1953();
-    #[link_name = "__rtsm_node_fs_unlink"]
+    #[link_name = "__rtsm_node_fs_rmdirSync"]
     fn __rts_sym_1954();
-    #[link_name = "__rtsm_node_fs_unlinkSync"]
+    #[link_name = "__rtsm_node_fs_stat"]
     fn __rts_sym_1955();
-    #[link_name = "__rtsm_node_fs_unwatchFile"]
+    #[link_name = "__rtsm_node_fs_statSync"]
     fn __rts_sym_1956();
-    #[link_name = "__rtsm_node_fs_utimesSync"]
+    #[link_name = "__rtsm_node_fs_statfsSync"]
     fn __rts_sym_1957();
-    #[link_name = "__rtsm_node_fs_watch"]
+    #[link_name = "__rtsm_node_fs_symlinkSync"]
     fn __rts_sym_1958();
-    #[link_name = "__rtsm_node_fs_watchFile"]
+    #[link_name = "__rtsm_node_fs_truncateSync"]
     fn __rts_sym_1959();
-    #[link_name = "__rtsm_node_fs_watchFile_interval"]
+    #[link_name = "__rtsm_node_fs_unlink"]
     fn __rts_sym_1960();
-    #[link_name = "__rtsm_node_fs_writeFile"]
+    #[link_name = "__rtsm_node_fs_unlinkSync"]
     fn __rts_sym_1961();
-    #[link_name = "__rtsm_node_fs_writeFileSync"]
+    #[link_name = "__rtsm_node_fs_unwatchFile"]
     fn __rts_sym_1962();
-    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
+    #[link_name = "__rtsm_node_fs_utimesSync"]
     fn __rts_sym_1963();
-    #[link_name = "__rtsm_node_fs_writeSync"]
+    #[link_name = "__rtsm_node_fs_watch"]
     fn __rts_sym_1964();
-    #[link_name = "__rtsm_node_fs_writevSync"]
+    #[link_name = "__rtsm_node_fs_watchFile"]
     fn __rts_sym_1965();
-    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
+    #[link_name = "__rtsm_node_fs_watchFile_interval"]
     fn __rts_sym_1966();
-    #[link_name = "__rtsm_node_http_METHODS"]
+    #[link_name = "__rtsm_node_fs_writeFile"]
     fn __rts_sym_1967();
-    #[link_name = "__rtsm_node_http_STATUS_CODES"]
+    #[link_name = "__rtsm_node_fs_writeFileSync"]
     fn __rts_sym_1968();
-    #[link_name = "__rtsm_node_module_builtinModules"]
+    #[link_name = "__rtsm_node_fs_writeFileSync_enc"]
     fn __rts_sym_1969();
-    #[link_name = "__rtsm_node_module_isBuiltin"]
+    #[link_name = "__rtsm_node_fs_writeSync"]
     fn __rts_sym_1970();
-    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
+    #[link_name = "__rtsm_node_fs_writevSync"]
     fn __rts_sym_1971();
-    #[link_name = "__rtsm_node_module_wrap"]
+    #[link_name = "__rtsm_node_fs_writevSync_nopos"]
     fn __rts_sym_1972();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_http_METHODS"]
     fn __rts_sym_1973();
-    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_http_STATUS_CODES"]
     fn __rts_sym_1974();
-    #[link_name = "__rtsm_node_net_isIP"]
+    #[link_name = "__rtsm_node_module_builtinModules"]
     fn __rts_sym_1975();
-    #[link_name = "__rtsm_node_net_isIPv4"]
+    #[link_name = "__rtsm_node_module_isBuiltin"]
     fn __rts_sym_1976();
-    #[link_name = "__rtsm_node_net_isIPv6"]
+    #[link_name = "__rtsm_node_module_syncBuiltinESMExports"]
     fn __rts_sym_1977();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
+    #[link_name = "__rtsm_node_module_wrap"]
     fn __rts_sym_1978();
-    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamily"]
     fn __rts_sym_1979();
-    #[link_name = "__rtsm_node_os_EOL"]
+    #[link_name = "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1980();
-    #[link_name = "__rtsm_node_os_arch"]
+    #[link_name = "__rtsm_node_net_isIP"]
     fn __rts_sym_1981();
-    #[link_name = "__rtsm_node_os_availableParallelism"]
+    #[link_name = "__rtsm_node_net_isIPv4"]
     fn __rts_sym_1982();
-    #[link_name = "__rtsm_node_os_cpus"]
+    #[link_name = "__rtsm_node_net_isIPv6"]
     fn __rts_sym_1983();
-    #[link_name = "__rtsm_node_os_endianness"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamily"]
     fn __rts_sym_1984();
-    #[link_name = "__rtsm_node_os_freemem"]
+    #[link_name = "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout"]
     fn __rts_sym_1985();
-    #[link_name = "__rtsm_node_os_getPriority"]
+    #[link_name = "__rtsm_node_os_EOL"]
     fn __rts_sym_1986();
-    #[link_name = "__rtsm_node_os_getPriority_pid"]
+    #[link_name = "__rtsm_node_os_arch"]
     fn __rts_sym_1987();
-    #[link_name = "__rtsm_node_os_homedir"]
+    #[link_name = "__rtsm_node_os_availableParallelism"]
     fn __rts_sym_1988();
-    #[link_name = "__rtsm_node_os_hostname"]
+    #[link_name = "__rtsm_node_os_cpus"]
     fn __rts_sym_1989();
-    #[link_name = "__rtsm_node_os_loadavg"]
+    #[link_name = "__rtsm_node_os_endianness"]
     fn __rts_sym_1990();
-    #[link_name = "__rtsm_node_os_machine"]
+    #[link_name = "__rtsm_node_os_freemem"]
     fn __rts_sym_1991();
-    #[link_name = "__rtsm_node_os_networkInterfaces"]
+    #[link_name = "__rtsm_node_os_getPriority"]
     fn __rts_sym_1992();
-    #[link_name = "__rtsm_node_os_platform"]
+    #[link_name = "__rtsm_node_os_getPriority_pid"]
     fn __rts_sym_1993();
-    #[link_name = "__rtsm_node_os_release"]
+    #[link_name = "__rtsm_node_os_homedir"]
     fn __rts_sym_1994();
-    #[link_name = "__rtsm_node_os_setPriority"]
+    #[link_name = "__rtsm_node_os_hostname"]
     fn __rts_sym_1995();
-    #[link_name = "__rtsm_node_os_setPriority_pid"]
+    #[link_name = "__rtsm_node_os_loadavg"]
     fn __rts_sym_1996();
-    #[link_name = "__rtsm_node_os_tmpdir"]
+    #[link_name = "__rtsm_node_os_machine"]
     fn __rts_sym_1997();
-    #[link_name = "__rtsm_node_os_totalmem"]
+    #[link_name = "__rtsm_node_os_networkInterfaces"]
     fn __rts_sym_1998();
-    #[link_name = "__rtsm_node_os_type"]
+    #[link_name = "__rtsm_node_os_platform"]
     fn __rts_sym_1999();
-    #[link_name = "__rtsm_node_os_uptime"]
+    #[link_name = "__rtsm_node_os_release"]
     fn __rts_sym_2000();
-    #[link_name = "__rtsm_node_os_userInfo"]
+    #[link_name = "__rtsm_node_os_setPriority"]
     fn __rts_sym_2001();
-    #[link_name = "__rtsm_node_os_version"]
+    #[link_name = "__rtsm_node_os_setPriority_pid"]
     fn __rts_sym_2002();
-    #[link_name = "__rtsm_node_path_posix_basename"]
+    #[link_name = "__rtsm_node_os_tmpdir"]
     fn __rts_sym_2003();
-    #[link_name = "__rtsm_node_path_posix_dirname"]
+    #[link_name = "__rtsm_node_os_totalmem"]
     fn __rts_sym_2004();
-    #[link_name = "__rtsm_node_path_posix_extname"]
+    #[link_name = "__rtsm_node_os_type"]
     fn __rts_sym_2005();
-    #[link_name = "__rtsm_node_path_posix_format"]
+    #[link_name = "__rtsm_node_os_uptime"]
     fn __rts_sym_2006();
-    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
+    #[link_name = "__rtsm_node_os_userInfo"]
     fn __rts_sym_2007();
-    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
+    #[link_name = "__rtsm_node_os_version"]
     fn __rts_sym_2008();
-    #[link_name = "__rtsm_node_path_posix_normalize"]
+    #[link_name = "__rtsm_node_path_posix_basename"]
     fn __rts_sym_2009();
-    #[link_name = "__rtsm_node_path_posix_parse"]
+    #[link_name = "__rtsm_node_path_posix_dirname"]
     fn __rts_sym_2010();
-    #[link_name = "__rtsm_node_path_posix_relative"]
+    #[link_name = "__rtsm_node_path_posix_extname"]
     fn __rts_sym_2011();
-    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_posix_format"]
     fn __rts_sym_2012();
-    #[link_name = "__rtsm_node_path_win32_basename"]
+    #[link_name = "__rtsm_node_path_posix_isAbsolute"]
     fn __rts_sym_2013();
-    #[link_name = "__rtsm_node_path_win32_dirname"]
+    #[link_name = "__rtsm_node_path_posix_matchesGlob"]
     fn __rts_sym_2014();
-    #[link_name = "__rtsm_node_path_win32_extname"]
+    #[link_name = "__rtsm_node_path_posix_normalize"]
     fn __rts_sym_2015();
-    #[link_name = "__rtsm_node_path_win32_format"]
+    #[link_name = "__rtsm_node_path_posix_parse"]
     fn __rts_sym_2016();
-    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
+    #[link_name = "__rtsm_node_path_posix_relative"]
     fn __rts_sym_2017();
-    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
+    #[link_name = "__rtsm_node_path_posix_toNamespacedPath"]
     fn __rts_sym_2018();
-    #[link_name = "__rtsm_node_path_win32_normalize"]
+    #[link_name = "__rtsm_node_path_win32_basename"]
     fn __rts_sym_2019();
-    #[link_name = "__rtsm_node_path_win32_parse"]
+    #[link_name = "__rtsm_node_path_win32_dirname"]
     fn __rts_sym_2020();
-    #[link_name = "__rtsm_node_path_win32_relative"]
+    #[link_name = "__rtsm_node_path_win32_extname"]
     fn __rts_sym_2021();
-    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
+    #[link_name = "__rtsm_node_path_win32_format"]
     fn __rts_sym_2022();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
+    #[link_name = "__rtsm_node_path_win32_isAbsolute"]
     fn __rts_sym_2023();
-    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
+    #[link_name = "__rtsm_node_path_win32_matchesGlob"]
     fn __rts_sym_2024();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
+    #[link_name = "__rtsm_node_path_win32_normalize"]
     fn __rts_sym_2025();
-    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
+    #[link_name = "__rtsm_node_path_win32_parse"]
     fn __rts_sym_2026();
-    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
+    #[link_name = "__rtsm_node_path_win32_relative"]
     fn __rts_sym_2027();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
+    #[link_name = "__rtsm_node_path_win32_toNamespacedPath"]
     fn __rts_sym_2028();
-    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks"]
     fn __rts_sym_2029();
-    #[link_name = "__rtsm_node_perf_hooks_mark"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMarks_name"]
     fn __rts_sym_2030();
-    #[link_name = "__rtsm_node_perf_hooks_measure"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures"]
     fn __rts_sym_2031();
-    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
+    #[link_name = "__rtsm_node_perf_hooks_clearMeasures_name"]
     fn __rts_sym_2032();
-    #[link_name = "__rtsm_node_perf_hooks_now"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntries"]
     fn __rts_sym_2033();
-    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByName"]
     fn __rts_sym_2034();
-    #[link_name = "__rtsm_node_process_abort"]
+    #[link_name = "__rtsm_node_perf_hooks_getEntriesByType"]
     fn __rts_sym_2035();
-    #[link_name = "__rtsm_node_process_arch"]
+    #[link_name = "__rtsm_node_perf_hooks_mark"]
     fn __rts_sym_2036();
-    #[link_name = "__rtsm_node_process_argv"]
+    #[link_name = "__rtsm_node_perf_hooks_measure"]
     fn __rts_sym_2037();
-    #[link_name = "__rtsm_node_process_argv0"]
+    #[link_name = "__rtsm_node_perf_hooks_measure_marks"]
     fn __rts_sym_2038();
-    #[link_name = "__rtsm_node_process_availableMemory"]
+    #[link_name = "__rtsm_node_perf_hooks_now"]
     fn __rts_sym_2039();
-    #[link_name = "__rtsm_node_process_chdir"]
+    #[link_name = "__rtsm_node_perf_hooks_timeOrigin"]
     fn __rts_sym_2040();
-    #[link_name = "__rtsm_node_process_constrainedMemory"]
+    #[link_name = "__rtsm_node_process_abort"]
     fn __rts_sym_2041();
-    #[link_name = "__rtsm_node_process_cpuUsage"]
+    #[link_name = "__rtsm_node_process_arch"]
     fn __rts_sym_2042();
-    #[link_name = "__rtsm_node_process_cwd"]
+    #[link_name = "__rtsm_node_process_argv"]
     fn __rts_sym_2043();
-    #[link_name = "__rtsm_node_process_env"]
+    #[link_name = "__rtsm_node_process_argv0"]
     fn __rts_sym_2044();
-    #[link_name = "__rtsm_node_process_execPath"]
+    #[link_name = "__rtsm_node_process_availableMemory"]
     fn __rts_sym_2045();
-    #[link_name = "__rtsm_node_process_exit"]
+    #[link_name = "__rtsm_node_process_chdir"]
     fn __rts_sym_2046();
-    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
+    #[link_name = "__rtsm_node_process_constrainedMemory"]
     fn __rts_sym_2047();
-    #[link_name = "__rtsm_node_process_hrtime"]
+    #[link_name = "__rtsm_node_process_cpuUsage"]
     fn __rts_sym_2048();
-    #[link_name = "__rtsm_node_process_hrtime_prev"]
+    #[link_name = "__rtsm_node_process_cwd"]
     fn __rts_sym_2049();
-    #[link_name = "__rtsm_node_process_kill"]
+    #[link_name = "__rtsm_node_process_env"]
     fn __rts_sym_2050();
-    #[link_name = "__rtsm_node_process_memoryUsage"]
+    #[link_name = "__rtsm_node_process_execPath"]
     fn __rts_sym_2051();
-    #[link_name = "__rtsm_node_process_pid"]
+    #[link_name = "__rtsm_node_process_exit"]
     fn __rts_sym_2052();
-    #[link_name = "__rtsm_node_process_platform"]
+    #[link_name = "__rtsm_node_process_getActiveResourcesInfo"]
     fn __rts_sym_2053();
-    #[link_name = "__rtsm_node_process_resourceUsage"]
+    #[link_name = "__rtsm_node_process_hrtime"]
     fn __rts_sym_2054();
-    #[link_name = "__rtsm_node_process_title"]
+    #[link_name = "__rtsm_node_process_hrtime_prev"]
     fn __rts_sym_2055();
-    #[link_name = "__rtsm_node_process_uptime"]
+    #[link_name = "__rtsm_node_process_kill"]
     fn __rts_sym_2056();
-    #[link_name = "__rtsm_node_process_version"]
+    #[link_name = "__rtsm_node_process_memoryUsage"]
     fn __rts_sym_2057();
-    #[link_name = "__rtsm_node_process_versions"]
+    #[link_name = "__rtsm_node_process_pid"]
     fn __rts_sym_2058();
-    #[link_name = "__rtsm_node_punycode_decode"]
+    #[link_name = "__rtsm_node_process_platform"]
     fn __rts_sym_2059();
-    #[link_name = "__rtsm_node_punycode_encode"]
+    #[link_name = "__rtsm_node_process_resourceUsage"]
     fn __rts_sym_2060();
-    #[link_name = "__rtsm_node_punycode_toASCII"]
+    #[link_name = "__rtsm_node_process_title"]
     fn __rts_sym_2061();
-    #[link_name = "__rtsm_node_punycode_toUnicode"]
+    #[link_name = "__rtsm_node_process_uptime"]
     fn __rts_sym_2062();
-    #[link_name = "__rtsm_node_querystring_decode"]
+    #[link_name = "__rtsm_node_process_version"]
     fn __rts_sym_2063();
-    #[link_name = "__rtsm_node_querystring_encode"]
+    #[link_name = "__rtsm_node_process_versions"]
     fn __rts_sym_2064();
-    #[link_name = "__rtsm_node_querystring_escape"]
+    #[link_name = "__rtsm_node_punycode_decode"]
     fn __rts_sym_2065();
-    #[link_name = "__rtsm_node_querystring_parse"]
+    #[link_name = "__rtsm_node_punycode_encode"]
     fn __rts_sym_2066();
-    #[link_name = "__rtsm_node_querystring_stringify"]
+    #[link_name = "__rtsm_node_punycode_toASCII"]
     fn __rts_sym_2067();
-    #[link_name = "__rtsm_node_querystring_unescape"]
+    #[link_name = "__rtsm_node_punycode_toUnicode"]
     fn __rts_sym_2068();
-    #[link_name = "__rtsm_node_tls_getCiphers"]
+    #[link_name = "__rtsm_node_querystring_decode"]
     fn __rts_sym_2069();
-    #[link_name = "__rtsm_node_tls_getCurves"]
+    #[link_name = "__rtsm_node_querystring_encode"]
     fn __rts_sym_2070();
-    #[link_name = "__rtsm_node_tty_getColorDepth"]
+    #[link_name = "__rtsm_node_querystring_escape"]
     fn __rts_sym_2071();
-    #[link_name = "__rtsm_node_tty_hasColors"]
+    #[link_name = "__rtsm_node_querystring_parse"]
     fn __rts_sym_2072();
-    #[link_name = "__rtsm_node_tty_isatty"]
+    #[link_name = "__rtsm_node_querystring_stringify"]
     fn __rts_sym_2073();
-    #[link_name = "__rtsm_node_url_domainToASCII"]
+    #[link_name = "__rtsm_node_querystring_unescape"]
     fn __rts_sym_2074();
-    #[link_name = "__rtsm_node_url_domainToUnicode"]
+    #[link_name = "__rtsm_node_tls_getCiphers"]
     fn __rts_sym_2075();
-    #[link_name = "__rtsm_node_url_fileURLToPath"]
+    #[link_name = "__rtsm_node_tls_getCurves"]
     fn __rts_sym_2076();
-    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
+    #[link_name = "__rtsm_node_tty_getColorDepth"]
     fn __rts_sym_2077();
-    #[link_name = "__rtsm_node_url_format"]
+    #[link_name = "__rtsm_node_tty_hasColors"]
     fn __rts_sym_2078();
-    #[link_name = "__rtsm_node_url_parse"]
+    #[link_name = "__rtsm_node_tty_isatty"]
     fn __rts_sym_2079();
-    #[link_name = "__rtsm_node_url_pathToFileURL"]
+    #[link_name = "__rtsm_node_url_domainToASCII"]
     fn __rts_sym_2080();
-    #[link_name = "__rtsm_node_url_resolve"]
+    #[link_name = "__rtsm_node_url_domainToUnicode"]
     fn __rts_sym_2081();
-    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
+    #[link_name = "__rtsm_node_url_fileURLToPath"]
     fn __rts_sym_2082();
-    #[link_name = "__rtsm_node_util_format"]
+    #[link_name = "__rtsm_node_url_fileURLToPathBuffer"]
     fn __rts_sym_2083();
-    #[link_name = "__rtsm_node_util_formatWithOptions"]
+    #[link_name = "__rtsm_node_url_format"]
     fn __rts_sym_2084();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
+    #[link_name = "__rtsm_node_url_parse"]
     fn __rts_sym_2085();
-    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
+    #[link_name = "__rtsm_node_url_pathToFileURL"]
     fn __rts_sym_2086();
-    #[link_name = "__rtsm_node_util_format_a1"]
+    #[link_name = "__rtsm_node_url_resolve"]
     fn __rts_sym_2087();
-    #[link_name = "__rtsm_node_util_format_a2"]
+    #[link_name = "__rtsm_node_url_urlToHttpOptions"]
     fn __rts_sym_2088();
-    #[link_name = "__rtsm_node_util_format_a3"]
+    #[link_name = "__rtsm_node_util_format"]
     fn __rts_sym_2089();
-    #[link_name = "__rtsm_node_util_format_a4"]
+    #[link_name = "__rtsm_node_util_formatWithOptions"]
     fn __rts_sym_2090();
-    #[link_name = "__rtsm_node_util_getSystemErrorName"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a1"]
     fn __rts_sym_2091();
-    #[link_name = "__rtsm_node_util_inspect"]
+    #[link_name = "__rtsm_node_util_formatWithOptions_a2"]
     fn __rts_sym_2092();
-    #[link_name = "__rtsm_node_util_inspect_opts"]
+    #[link_name = "__rtsm_node_util_format_a1"]
     fn __rts_sym_2093();
-    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
+    #[link_name = "__rtsm_node_util_format_a2"]
     fn __rts_sym_2094();
-    #[link_name = "__rtsm_node_util_parseArgs"]
+    #[link_name = "__rtsm_node_util_format_a3"]
     fn __rts_sym_2095();
-    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
+    #[link_name = "__rtsm_node_util_format_a4"]
     fn __rts_sym_2096();
-    #[link_name = "__rtsm_node_util_styleText"]
+    #[link_name = "__rtsm_node_util_getSystemErrorName"]
     fn __rts_sym_2097();
-    #[link_name = "__rtsm_node_util_toUSVString"]
+    #[link_name = "__rtsm_node_util_inspect"]
     fn __rts_sym_2098();
-    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
+    #[link_name = "__rtsm_node_util_inspect_opts"]
     fn __rts_sym_2099();
-    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
+    #[link_name = "__rtsm_node_util_isDeepStrictEqual"]
     fn __rts_sym_2100();
-    #[link_name = "__rtsm_node_zlib_crc32"]
+    #[link_name = "__rtsm_node_util_parseArgs"]
     fn __rts_sym_2101();
-    #[link_name = "__rtsm_node_zlib_crc32_prev"]
+    #[link_name = "__rtsm_node_util_stripVTControlCharacters"]
     fn __rts_sym_2102();
-    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
+    #[link_name = "__rtsm_node_util_styleText"]
     fn __rts_sym_2103();
-    #[link_name = "__rtsm_node_zlib_deflateSync"]
+    #[link_name = "__rtsm_node_util_toUSVString"]
     fn __rts_sym_2104();
-    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
+    #[link_name = "__rtsm_node_zlib_brotliCompressSync"]
     fn __rts_sym_2105();
-    #[link_name = "__rtsm_node_zlib_gunzipSync"]
+    #[link_name = "__rtsm_node_zlib_brotliDecompressSync"]
     fn __rts_sym_2106();
-    #[link_name = "__rtsm_node_zlib_gzipSync"]
+    #[link_name = "__rtsm_node_zlib_crc32"]
     fn __rts_sym_2107();
-    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
+    #[link_name = "__rtsm_node_zlib_crc32_prev"]
     fn __rts_sym_2108();
-    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
+    #[link_name = "__rtsm_node_zlib_deflateRawSync"]
     fn __rts_sym_2109();
-    #[link_name = "__rtsm_node_zlib_inflateSync"]
+    #[link_name = "__rtsm_node_zlib_deflateSync"]
     fn __rts_sym_2110();
-    #[link_name = "__rtsm_node_zlib_unzipSync"]
+    #[link_name = "__rtsm_node_zlib_deflateSync_level"]
     fn __rts_sym_2111();
-    #[link_name = "__rtsm_serde_deserialize"]
+    #[link_name = "__rtsm_node_zlib_gunzipSync"]
     fn __rts_sym_2112();
-    #[link_name = "__rtsm_serde_serialize"]
+    #[link_name = "__rtsm_node_zlib_gzipSync"]
     fn __rts_sym_2113();
-    #[link_name = "__rtsn_agen_new"]
+    #[link_name = "__rtsm_node_zlib_gzipSync_level"]
     fn __rts_sym_2114();
-    #[link_name = "__rtsn_agen_next"]
+    #[link_name = "__rtsm_node_zlib_inflateRawSync"]
     fn __rts_sym_2115();
-    #[link_name = "__rtsn_async_sm_awaited"]
+    #[link_name = "__rtsm_node_zlib_inflateSync"]
     fn __rts_sym_2116();
-    #[link_name = "__rtsn_async_sm_new"]
+    #[link_name = "__rtsm_node_zlib_unzipSync"]
     fn __rts_sym_2117();
-    #[link_name = "__rtsn_async_sm_resolve"]
+    #[link_name = "__rtsm_serde_deserialize"]
     fn __rts_sym_2118();
-    #[link_name = "__rtsn_async_sm_resume"]
+    #[link_name = "__rtsm_serde_serialize"]
     fn __rts_sym_2119();
-    #[link_name = "__rtsn_async_sm_start"]
+    #[link_name = "__rtsn_agen_new"]
     fn __rts_sym_2120();
-    #[link_name = "__rtsn_async_sm_suspend"]
+    #[link_name = "__rtsn_agen_next"]
     fn __rts_sym_2121();
-    #[link_name = "__rtsn_collect"]
+    #[link_name = "__rtsn_async_sm_awaited"]
     fn __rts_sym_2122();
-    #[link_name = "__rtsn_collect_debt"]
+    #[link_name = "__rtsn_async_sm_new"]
     fn __rts_sym_2123();
-    #[link_name = "__rtsn_error_clear"]
+    #[link_name = "__rtsn_async_sm_resolve"]
     fn __rts_sym_2124();
-    #[link_name = "__rtsn_error_get"]
+    #[link_name = "__rtsn_async_sm_resume"]
     fn __rts_sym_2125();
-    #[link_name = "__rtsn_error_get_stack"]
+    #[link_name = "__rtsn_async_sm_start"]
     fn __rts_sym_2126();
-    #[link_name = "__rtsn_error_set"]
+    #[link_name = "__rtsn_async_sm_suspend"]
     fn __rts_sym_2127();
-    #[link_name = "__rtsn_gcell_get"]
+    #[link_name = "__rtsn_collect"]
     fn __rts_sym_2128();
-    #[link_name = "__rtsn_gcell_set"]
+    #[link_name = "__rtsn_collect_debt"]
     fn __rts_sym_2129();
-    #[link_name = "__rtsn_gen_delegate_done"]
+    #[link_name = "__rtsn_error_clear"]
     fn __rts_sym_2130();
-    #[link_name = "__rtsn_gen_delegate_next"]
+    #[link_name = "__rtsn_error_get"]
     fn __rts_sym_2131();
-    #[link_name = "__rtsn_gen_delegate_start"]
+    #[link_name = "__rtsn_error_get_stack"]
     fn __rts_sym_2132();
-    #[link_name = "__rtsn_gen_sm_caught"]
+    #[link_name = "__rtsn_error_set"]
     fn __rts_sym_2133();
-    #[link_name = "__rtsn_gen_sm_done"]
+    #[link_name = "__rtsn_gcell_get"]
     fn __rts_sym_2134();
-    #[link_name = "__rtsn_gen_sm_drain"]
+    #[link_name = "__rtsn_gcell_set"]
     fn __rts_sym_2135();
-    #[link_name = "__rtsn_gen_sm_end_finally"]
+    #[link_name = "__rtsn_gen_delegate_done"]
     fn __rts_sym_2136();
-    #[link_name = "__rtsn_gen_sm_enter_try"]
+    #[link_name = "__rtsn_gen_delegate_next"]
     fn __rts_sym_2137();
-    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
+    #[link_name = "__rtsn_gen_delegate_start"]
     fn __rts_sym_2138();
-    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
+    #[link_name = "__rtsn_gen_sm_caught"]
     fn __rts_sym_2139();
-    #[link_name = "__rtsn_gen_sm_fget"]
+    #[link_name = "__rtsn_gen_sm_done"]
     fn __rts_sym_2140();
-    #[link_name = "__rtsn_gen_sm_fset"]
+    #[link_name = "__rtsn_gen_sm_drain"]
     fn __rts_sym_2141();
-    #[link_name = "__rtsn_gen_sm_is"]
+    #[link_name = "__rtsn_gen_sm_end_finally"]
     fn __rts_sym_2142();
-    #[link_name = "__rtsn_gen_sm_new"]
+    #[link_name = "__rtsn_gen_sm_enter_try"]
     fn __rts_sym_2143();
-    #[link_name = "__rtsn_gen_sm_next"]
+    #[link_name = "__rtsn_gen_sm_enter_try_catch"]
     fn __rts_sym_2144();
-    #[link_name = "__rtsn_gen_sm_return"]
+    #[link_name = "__rtsn_gen_sm_exit_try_catch"]
     fn __rts_sym_2145();
-    #[link_name = "__rtsn_gen_sm_sent"]
+    #[link_name = "__rtsn_gen_sm_fget"]
     fn __rts_sym_2146();
-    #[link_name = "__rtsn_gen_sm_setstate"]
+    #[link_name = "__rtsn_gen_sm_fset"]
     fn __rts_sym_2147();
-    #[link_name = "__rtsn_gen_sm_state"]
+    #[link_name = "__rtsn_gen_sm_is"]
     fn __rts_sym_2148();
-    #[link_name = "__rtsn_gen_sm_throw"]
+    #[link_name = "__rtsn_gen_sm_new"]
     fn __rts_sym_2149();
-    #[link_name = "__rtsn_gen_sm_yield"]
+    #[link_name = "__rtsn_gen_sm_next"]
     fn __rts_sym_2150();
-    #[link_name = "__rtsn_generator_get_ret"]
+    #[link_name = "__rtsn_gen_sm_return"]
     fn __rts_sym_2151();
-    #[link_name = "__rtsn_generator_next"]
+    #[link_name = "__rtsn_gen_sm_sent"]
     fn __rts_sym_2152();
-    #[link_name = "__rtsn_generator_next_sent"]
+    #[link_name = "__rtsn_gen_sm_setstate"]
     fn __rts_sym_2153();
-    #[link_name = "__rtsn_generator_return"]
+    #[link_name = "__rtsn_gen_sm_state"]
     fn __rts_sym_2154();
-    #[link_name = "__rtsn_generator_set_ret"]
+    #[link_name = "__rtsn_gen_sm_throw"]
     fn __rts_sym_2155();
-    #[link_name = "__rtsn_generator_throw"]
+    #[link_name = "__rtsn_gen_sm_yield"]
     fn __rts_sym_2156();
-    #[link_name = "__rtsn_inspect"]
+    #[link_name = "__rtsn_generator_get_ret"]
     fn __rts_sym_2157();
-    #[link_name = "__rtsn_iter_done"]
+    #[link_name = "__rtsn_generator_next"]
     fn __rts_sym_2158();
-    #[link_name = "__rtsn_iter_value"]
+    #[link_name = "__rtsn_generator_next_sent"]
     fn __rts_sym_2159();
-    #[link_name = "__rtsn_live_count"]
+    #[link_name = "__rtsn_generator_return"]
     fn __rts_sym_2160();
-    #[link_name = "__rtsn_object_to_string"]
+    #[link_name = "__rtsn_generator_set_ret"]
     fn __rts_sym_2161();
-    #[link_name = "__rtsn_poly_from_handle"]
+    #[link_name = "__rtsn_generator_throw"]
     fn __rts_sym_2162();
-    #[link_name = "__rtsn_poly_to_handle"]
+    #[link_name = "__rtsn_inspect"]
     fn __rts_sym_2163();
-    #[link_name = "__rtsn_report_uncaught"]
+    #[link_name = "__rtsn_iter_done"]
     fn __rts_sym_2164();
-    #[link_name = "__rtsn_spread_into_vec"]
+    #[link_name = "__rtsn_iter_value"]
     fn __rts_sym_2165();
-    #[link_name = "__rtsn_stack_depth"]
+    #[link_name = "__rtsn_live_count"]
     fn __rts_sym_2166();
-    #[link_name = "__rtsn_stack_pop"]
+    #[link_name = "__rtsn_object_to_string"]
     fn __rts_sym_2167();
-    #[link_name = "__rtsn_stack_push"]
+    #[link_name = "__rtsn_poly_from_handle"]
     fn __rts_sym_2168();
-    #[link_name = "__rtsn_string_from_f64"]
+    #[link_name = "__rtsn_poly_to_handle"]
     fn __rts_sym_2169();
-    #[link_name = "__rtsn_symbol_iterator_of"]
+    #[link_name = "__rtsn_report_uncaught"]
     fn __rts_sym_2170();
-    #[link_name = "__rtsn_vec_get_by_payload"]
+    #[link_name = "__rtsn_spread_into_vec"]
     fn __rts_sym_2171();
-    #[link_name = "__rtsn_vec_len_by_payload"]
+    #[link_name = "__rtsn_stack_depth"]
     fn __rts_sym_2172();
-    #[link_name = "__rtsn_vec_new_object"]
+    #[link_name = "__rtsn_stack_pop"]
     fn __rts_sym_2173();
-    #[link_name = "__rtsn_vec_push_by_payload"]
+    #[link_name = "__rtsn_stack_push"]
     fn __rts_sym_2174();
-    #[link_name = "__rtsn_vec_set_by_payload"]
+    #[link_name = "__rtsn_string_from_f64"]
     fn __rts_sym_2175();
+    #[link_name = "__rtsn_symbol_iterator_of"]
+    fn __rts_sym_2176();
+    #[link_name = "__rtsn_vec_get_by_payload"]
+    fn __rts_sym_2177();
+    #[link_name = "__rtsn_vec_len_by_payload"]
+    fn __rts_sym_2178();
+    #[link_name = "__rtsn_vec_new_object"]
+    fn __rts_sym_2179();
+    #[link_name = "__rtsn_vec_push_by_payload"]
+    fn __rts_sym_2180();
+    #[link_name = "__rtsn_vec_set_by_payload"]
+    fn __rts_sym_2181();
 }
 
 /// Every RTS symbol with its address, for `JITBuilder::symbol`.
@@ -4382,7 +4394,7 @@ unsafe extern "C" {
 /// Sorted ascending by name; `#[cfg]`-gated rows drop out on platforms where
 /// they do not exist, which preserves the order of the rows that remain.
 pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
-    let mut out = ::std::vec::Vec::with_capacity(2176);
+    let mut out = ::std::vec::Vec::with_capacity(2182);
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT", ptr: __rts_sym_0 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY", ptr: __rts_sym_1 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT", ptr: __rts_sym_2 as *const u8 });
@@ -5930,642 +5942,648 @@ pub fn symbols() -> ::std::vec::Vec<::rts_abi::table::SymbolEntry> {
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domexception_name", ptr: __rts_sym_1544 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domexception_new", ptr: __rts_sym_1545 as *const u8 });
     out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domexception_to_string", ptr: __rts_sym_1546 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_encode_uri", ptr: __rts_sym_1547 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_encode_uri_component", ptr: __rts_sym_1548 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_bubbles__get", ptr: __rts_sym_1549 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_cancelable__get", ptr: __rts_sym_1550 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_current_target_get", ptr: __rts_sym_1551 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_default_prevented__get", ptr: __rts_sym_1552 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_js_type", ptr: __rts_sym_1553 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_new", ptr: __rts_sym_1554 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_prevent_default", ptr: __rts_sym_1555 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_stop_immediate_propagation", ptr: __rts_sym_1556 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_stop_propagation", ptr: __rts_sym_1557 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_target", ptr: __rts_sym_1558 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_add_listener", ptr: __rts_sym_1559 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit0", ptr: __rts_sym_1560 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit1", ptr: __rts_sym_1561 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit2", ptr: __rts_sym_1562 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit3", ptr: __rts_sym_1563 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit_handle", ptr: __rts_sym_1564 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_event_names", ptr: __rts_sym_1565 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_free", ptr: __rts_sym_1566 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_get_max_listeners", ptr: __rts_sym_1567 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_listener_count", ptr: __rts_sym_1568 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_listeners", ptr: __rts_sym_1569 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_new", ptr: __rts_sym_1570 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_new_async", ptr: __rts_sym_1571 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_off", ptr: __rts_sym_1572 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_on", ptr: __rts_sym_1573 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_once", ptr: __rts_sym_1574 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_prepend_listener", ptr: __rts_sym_1575 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_prepend_once_listener", ptr: __rts_sym_1576 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_raw_listeners", ptr: __rts_sym_1577 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_remove_all_listeners", ptr: __rts_sym_1578 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_remove_listener", ptr: __rts_sym_1579 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_set_max_listeners", ptr: __rts_sym_1580 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_add_event_listener", ptr: __rts_sym_1581 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_new", ptr: __rts_sym_1582 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_remove_event_listener", ptr: __rts_sym_1583 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_kind", ptr: __rts_sym_1584 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_last_modified__get", ptr: __rts_sym_1585 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_name", ptr: __rts_sym_1586 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_new", ptr: __rts_sym_1587 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_size", ptr: __rts_sym_1588 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_text", ptr: __rts_sym_1589 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_new", ptr: __rts_sym_1590 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_register", ptr: __rts_sym_1591 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_unregister", ptr: __rts_sym_1592 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_append", ptr: __rts_sym_1593 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_delete", ptr: __rts_sym_1594 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_get", ptr: __rts_sym_1595 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_get_all", ptr: __rts_sym_1596 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_has", ptr: __rts_sym_1597 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_keys", ptr: __rts_sym_1598 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_new", ptr: __rts_sym_1599 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_set", ptr: __rts_sym_1600 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_values", ptr: __rts_sym_1601 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_copy", ptr: __rts_sym_1602 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_digest", ptr: __rts_sym_1603 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_digest_enc", ptr: __rts_sym_1604 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_update", ptr: __rts_sym_1605 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_update_enc", ptr: __rts_sym_1606 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_append", ptr: __rts_sym_1607 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_delete", ptr: __rts_sym_1608 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_get", ptr: __rts_sym_1609 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_get_set_cookie", ptr: __rts_sym_1610 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_has", ptr: __rts_sym_1611 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_keys", ptr: __rts_sym_1612 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_new", ptr: __rts_sym_1613 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_new_from", ptr: __rts_sym_1614 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_set", ptr: __rts_sym_1615 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_values", ptr: __rts_sym_1616 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_from", ptr: __rts_sym_1617 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_to_array", ptr: __rts_sym_1618 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ATTRIBUTE_NODE", ptr: __rts_sym_1619 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_CDATA_SECTION_NODE", ptr: __rts_sym_1620 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_COMMENT_NODE", ptr: __rts_sym_1621 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE", ptr: __rts_sym_1622 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_NODE", ptr: __rts_sym_1623 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_TYPE_NODE", ptr: __rts_sym_1624 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ELEMENT_NODE", ptr: __rts_sym_1625 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE", ptr: __rts_sym_1626 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_TEXT_NODE", ptr: __rts_sym_1627 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_EPSILON", ptr: __rts_sym_1628 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_SAFE_INTEGER", ptr: __rts_sym_1629 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_VALUE", ptr: __rts_sym_1630 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_SAFE_INTEGER", ptr: __rts_sym_1631 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_VALUE", ptr: __rts_sym_1632 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NEGATIVE_INFINITY", ptr: __rts_sym_1633 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NaN", ptr: __rts_sym_1634 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_POSITIVE_INFINITY", ptr: __rts_sym_1635 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_finite", ptr: __rts_sym_1636 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_integer", ptr: __rts_sym_1637 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_nan", ptr: __rts_sym_1638 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_safe_integer", ptr: __rts_sym_1639 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_new", ptr: __rts_sym_1640 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_float", ptr: __rts_sym_1641 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_int", ptr: __rts_sym_1642 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_exponential", ptr: __rts_sym_1643 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_fixed", ptr: __rts_sym_1644 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_locale_string", ptr: __rts_sym_1645 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_precision", ptr: __rts_sym_1646 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_string", ptr: __rts_sym_1647 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_value_of", ptr: __rts_sym_1648 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_proxy_new", ptr: __rts_sym_1649 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_get_reader", ptr: __rts_sym_1650 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__get", ptr: __rts_sym_1651 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__set", ptr: __rts_sym_1652 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_new", ptr: __rts_sym_1653 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_pipe_through", ptr: __rts_sym_1654 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_close", ptr: __rts_sym_1655 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_desired_size", ptr: __rts_sym_1656 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_enqueue", ptr: __rts_sym_1657 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_error", ptr: __rts_sym_1658 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_new", ptr: __rts_sym_1659 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_cancel", ptr: __rts_sym_1660 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_read", ptr: __rts_sym_1661 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_release_lock", ptr: __rts_sym_1662 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_new", ptr: __rts_sym_1663 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_sum3", ptr: __rts_sym_1664 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at0", ptr: __rts_sym_1665 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at1", ptr: __rts_sym_1666 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_bump", ptr: __rts_sym_1667 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_info", ptr: __rts_sym_1668 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label", ptr: __rts_sym_1669 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label_async", ptr: __rts_sym_1670 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_new", ptr: __rts_sym_1671 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_pairs", ptr: __rts_sym_1672 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_parts", ptr: __rts_sym_1673 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled", ptr: __rts_sym_1674 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled_or1", ptr: __rts_sym_1675 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_self_ref", ptr: __rts_sym_1676 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_set_tag", ptr: __rts_sym_1677 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_sum", ptr: __rts_sym_1678 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tag", ptr: __rts_sym_1679 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tagged", ptr: __rts_sym_1680 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_unit", ptr: __rts_sym_1681 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_with_x", ptr: __rts_sym_1682 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__get", ptr: __rts_sym_1683 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__set", ptr: __rts_sym_1684 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_y__get", ptr: __rts_sym_1685 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_address", ptr: __rts_sym_1686 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_family", ptr: __rts_sym_1687 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_flowlabel", ptr: __rts_sym_1688 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_new", ptr: __rts_sym_1689 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_parse", ptr: __rts_sym_1690 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_port", ptr: __rts_sym_1691 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_with_options", ptr: __rts_sym_1692 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_atime_ms", ptr: __rts_sym_1693 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_birthtime_ms", ptr: __rts_sym_1694 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blksize", ptr: __rts_sym_1695 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blocks", ptr: __rts_sym_1696 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ctime_ms", ptr: __rts_sym_1697 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_dev", ptr: __rts_sym_1698 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_gid", ptr: __rts_sym_1699 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ino", ptr: __rts_sym_1700 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_block", ptr: __rts_sym_1701 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_char", ptr: __rts_sym_1702 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_directory", ptr: __rts_sym_1703 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_fifo", ptr: __rts_sym_1704 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_file", ptr: __rts_sym_1705 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_socket", ptr: __rts_sym_1706 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_symlink", ptr: __rts_sym_1707 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mode", ptr: __rts_sym_1708 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mtime_ms", ptr: __rts_sym_1709 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_nlink", ptr: __rts_sym_1710 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_rdev", ptr: __rts_sym_1711 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_size", ptr: __rts_sym_1712 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_uid", ptr: __rts_sym_1713 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_clear", ptr: __rts_sym_1714 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_getItem", ptr: __rts_sym_1715 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_key", ptr: __rts_sym_1716 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_length", ptr: __rts_sym_1717 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_new", ptr: __rts_sym_1718 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_persistTo", ptr: __rts_sym_1719 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_removeItem", ptr: __rts_sym_1720 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_setItem", ptr: __rts_sym_1721 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1722 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1723 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1724 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1725 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1726 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1727 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1728 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1729 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1730 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1731 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1732 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1733 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1734 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1735 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1736 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1737 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1738 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1739 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1740 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1741 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1742 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1743 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1744 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1745 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1746 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1747 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1748 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1749 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1750 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1751 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1752 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1753 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1754 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1755 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1756 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1757 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1758 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1759 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1760 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1761 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1762 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1763 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1764 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1765 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1766 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1767 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1768 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1769 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1770 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1771 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1772 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1773 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1774 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1775 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1776 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1777 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1778 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1779 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1780 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1781 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1782 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1783 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1784 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1785 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1786 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1787 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1788 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1789 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1790 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1791 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1792 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1793 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1794 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1795 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1796 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1797 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1798 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1799 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1800 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1801 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1802 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1803 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1804 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1805 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1806 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1807 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1808 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1809 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1810 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1811 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1812 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1813 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1814 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1815 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1816 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1817 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1818 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1819 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1820 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1821 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1822 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1823 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1824 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1825 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1826 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1827 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1828 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1829 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1830 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1831 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1832 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1833 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1834 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1835 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1836 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1837 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1838 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1839 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1840 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1841 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1842 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1843 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1844 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1845 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1846 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1847 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1848 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1849 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1850 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1851 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1852 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1853 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1854 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1855 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1856 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1857 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1858 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1859 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1860 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1861 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1862 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1863 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1864 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1865 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1866 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1867 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1868 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1869 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1870 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1871 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1872 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1873 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1874 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1875 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1876 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1877 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1878 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1879 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1880 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1881 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1882 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1883 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1884 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1885 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1886 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1887 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1888 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1889 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1890 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1891 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1892 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1893 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1894 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1895 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1896 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1897 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1898 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1899 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1900 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1901 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1902 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1903 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1904 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1905 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1906 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1907 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1908 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1909 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1910 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1911 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1912 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1913 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1914 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1915 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1916 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1917 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1918 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1919 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1920 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1921 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1922 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1923 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1924 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1925 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1926 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1927 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1928 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1929 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1930 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1931 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1932 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1933 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1934 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1935 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1936 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1937 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1938 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1939 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1940 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1941 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1942 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1943 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1944 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1945 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1946 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1947 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1948 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1949 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1950 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1951 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1952 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1953 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1954 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1955 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1956 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1957 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1958 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1959 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1960 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1961 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1962 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1963 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1964 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1965 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1966 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1967 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1968 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1969 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1970 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1971 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1972 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1973 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1974 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1975 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1976 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1977 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1978 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1979 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1980 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1981 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1982 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1983 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1984 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1985 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1986 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1987 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1988 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1989 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1990 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1991 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1992 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1993 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_1994 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_1995 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_1996 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_1997 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_1998 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_1999 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_2000 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_2001 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_2002 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_2003 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_2004 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_2005 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_2006 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_2007 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_2008 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_2009 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_2010 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_2011 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_2012 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_2013 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_2014 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_2015 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_2016 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2017 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2018 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2019 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2020 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2021 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2022 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2023 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2024 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2025 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2026 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2027 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2028 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2029 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2030 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2031 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2032 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2033 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2034 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2035 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2036 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2037 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2038 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2039 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2040 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2041 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2042 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2043 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2044 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2045 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2046 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2047 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2048 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2049 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2050 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2051 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2052 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2053 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2054 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2055 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2056 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2057 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2058 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2059 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2060 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2061 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2062 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2063 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2064 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2065 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2066 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2067 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2068 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2069 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2070 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2071 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2072 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2073 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2074 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2075 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2076 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2077 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2078 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2079 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2080 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2081 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2082 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2083 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2084 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2085 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2086 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2087 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2088 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2089 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2090 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2091 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2092 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2093 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2094 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2095 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2096 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2097 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2098 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2099 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2100 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2101 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2102 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2103 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2104 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2105 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2106 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2107 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2108 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2109 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2110 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2111 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2112 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2113 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2114 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2115 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2116 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2117 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2118 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2119 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2120 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2121 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2122 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2123 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2124 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2125 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2126 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2127 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2128 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2129 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2130 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2131 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2132 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2133 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2134 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2135 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2136 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2137 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2138 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2139 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2140 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2141 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2142 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2143 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2144 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2145 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2146 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2147 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2148 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2149 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2150 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2151 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2152 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2153 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2154 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2155 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2156 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2157 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2158 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2159 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2160 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2161 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2162 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2163 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2164 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2165 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2166 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2167 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2168 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2169 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2170 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2171 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2172 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2173 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2174 as *const u8 });
-    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2175 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_count", ptr: __rts_sym_1547 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_drop", ptr: __rts_sym_1548 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_get", ptr: __rts_sym_1549 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_has", ptr: __rts_sym_1550 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_nameAt", ptr: __rts_sym_1551 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_domscope_set", ptr: __rts_sym_1552 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_encode_uri", ptr: __rts_sym_1553 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_encode_uri_component", ptr: __rts_sym_1554 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_bubbles__get", ptr: __rts_sym_1555 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_cancelable__get", ptr: __rts_sym_1556 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_current_target_get", ptr: __rts_sym_1557 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_default_prevented__get", ptr: __rts_sym_1558 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_js_type", ptr: __rts_sym_1559 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_new", ptr: __rts_sym_1560 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_prevent_default", ptr: __rts_sym_1561 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_stop_immediate_propagation", ptr: __rts_sym_1562 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_stop_propagation", ptr: __rts_sym_1563 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_event_target", ptr: __rts_sym_1564 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_add_listener", ptr: __rts_sym_1565 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit0", ptr: __rts_sym_1566 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit1", ptr: __rts_sym_1567 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit2", ptr: __rts_sym_1568 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit3", ptr: __rts_sym_1569 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_emit_handle", ptr: __rts_sym_1570 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_event_names", ptr: __rts_sym_1571 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_free", ptr: __rts_sym_1572 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_get_max_listeners", ptr: __rts_sym_1573 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_listener_count", ptr: __rts_sym_1574 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_listeners", ptr: __rts_sym_1575 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_new", ptr: __rts_sym_1576 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_new_async", ptr: __rts_sym_1577 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_off", ptr: __rts_sym_1578 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_on", ptr: __rts_sym_1579 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_once", ptr: __rts_sym_1580 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_prepend_listener", ptr: __rts_sym_1581 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_prepend_once_listener", ptr: __rts_sym_1582 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_raw_listeners", ptr: __rts_sym_1583 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_remove_all_listeners", ptr: __rts_sym_1584 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_remove_listener", ptr: __rts_sym_1585 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventemitter_set_max_listeners", ptr: __rts_sym_1586 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_add_event_listener", ptr: __rts_sym_1587 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_new", ptr: __rts_sym_1588 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_eventtarget_remove_event_listener", ptr: __rts_sym_1589 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_kind", ptr: __rts_sym_1590 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_last_modified__get", ptr: __rts_sym_1591 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_name", ptr: __rts_sym_1592 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_new", ptr: __rts_sym_1593 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_size", ptr: __rts_sym_1594 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_file_text", ptr: __rts_sym_1595 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_new", ptr: __rts_sym_1596 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_register", ptr: __rts_sym_1597 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_finalizationregistry_unregister", ptr: __rts_sym_1598 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_append", ptr: __rts_sym_1599 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_delete", ptr: __rts_sym_1600 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_get", ptr: __rts_sym_1601 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_get_all", ptr: __rts_sym_1602 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_has", ptr: __rts_sym_1603 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_keys", ptr: __rts_sym_1604 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_new", ptr: __rts_sym_1605 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_set", ptr: __rts_sym_1606 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_formdata_values", ptr: __rts_sym_1607 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_copy", ptr: __rts_sym_1608 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_digest", ptr: __rts_sym_1609 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_digest_enc", ptr: __rts_sym_1610 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_update", ptr: __rts_sym_1611 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_hash_update_enc", ptr: __rts_sym_1612 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_append", ptr: __rts_sym_1613 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_delete", ptr: __rts_sym_1614 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_get", ptr: __rts_sym_1615 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_get_set_cookie", ptr: __rts_sym_1616 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_has", ptr: __rts_sym_1617 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_keys", ptr: __rts_sym_1618 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_new", ptr: __rts_sym_1619 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_new_from", ptr: __rts_sym_1620 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_set", ptr: __rts_sym_1621 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_headers_values", ptr: __rts_sym_1622 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_from", ptr: __rts_sym_1623 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_iterator_to_array", ptr: __rts_sym_1624 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ATTRIBUTE_NODE", ptr: __rts_sym_1625 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_CDATA_SECTION_NODE", ptr: __rts_sym_1626 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_COMMENT_NODE", ptr: __rts_sym_1627 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_FRAGMENT_NODE", ptr: __rts_sym_1628 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_NODE", ptr: __rts_sym_1629 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_DOCUMENT_TYPE_NODE", ptr: __rts_sym_1630 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_ELEMENT_NODE", ptr: __rts_sym_1631 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_PROCESSING_INSTRUCTION_NODE", ptr: __rts_sym_1632 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_node_TEXT_NODE", ptr: __rts_sym_1633 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_EPSILON", ptr: __rts_sym_1634 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_SAFE_INTEGER", ptr: __rts_sym_1635 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MAX_VALUE", ptr: __rts_sym_1636 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_SAFE_INTEGER", ptr: __rts_sym_1637 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_MIN_VALUE", ptr: __rts_sym_1638 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NEGATIVE_INFINITY", ptr: __rts_sym_1639 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_NaN", ptr: __rts_sym_1640 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_POSITIVE_INFINITY", ptr: __rts_sym_1641 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_finite", ptr: __rts_sym_1642 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_integer", ptr: __rts_sym_1643 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_nan", ptr: __rts_sym_1644 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_is_safe_integer", ptr: __rts_sym_1645 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_new", ptr: __rts_sym_1646 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_float", ptr: __rts_sym_1647 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_parse_int", ptr: __rts_sym_1648 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_exponential", ptr: __rts_sym_1649 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_fixed", ptr: __rts_sym_1650 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_locale_string", ptr: __rts_sym_1651 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_precision", ptr: __rts_sym_1652 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_to_string", ptr: __rts_sym_1653 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_number_value_of", ptr: __rts_sym_1654 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_proxy_new", ptr: __rts_sym_1655 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_get_reader", ptr: __rts_sym_1656 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__get", ptr: __rts_sym_1657 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_locked__set", ptr: __rts_sym_1658 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_new", ptr: __rts_sym_1659 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestream_pipe_through", ptr: __rts_sym_1660 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_close", ptr: __rts_sym_1661 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_desired_size", ptr: __rts_sym_1662 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_enqueue", ptr: __rts_sym_1663 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_error", ptr: __rts_sym_1664 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultcontroller_new", ptr: __rts_sym_1665 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_cancel", ptr: __rts_sym_1666 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_read", ptr: __rts_sym_1667 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_readablestreamdefaultreader_release_lock", ptr: __rts_sym_1668 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_new", ptr: __rts_sym_1669 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint3_sum3", ptr: __rts_sym_1670 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at0", ptr: __rts_sym_1671 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_at1", ptr: __rts_sym_1672 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_bump", ptr: __rts_sym_1673 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_info", ptr: __rts_sym_1674 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label", ptr: __rts_sym_1675 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_label_async", ptr: __rts_sym_1676 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_new", ptr: __rts_sym_1677 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_pairs", ptr: __rts_sym_1678 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_parts", ptr: __rts_sym_1679 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled", ptr: __rts_sym_1680 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_scaled_or1", ptr: __rts_sym_1681 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_self_ref", ptr: __rts_sym_1682 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_set_tag", ptr: __rts_sym_1683 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_sum", ptr: __rts_sym_1684 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tag", ptr: __rts_sym_1685 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_tagged", ptr: __rts_sym_1686 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_unit", ptr: __rts_sym_1687 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_with_x", ptr: __rts_sym_1688 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__get", ptr: __rts_sym_1689 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_x__set", ptr: __rts_sym_1690 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_rtsepoint_y__get", ptr: __rts_sym_1691 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_address", ptr: __rts_sym_1692 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_family", ptr: __rts_sym_1693 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_flowlabel", ptr: __rts_sym_1694 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_new", ptr: __rts_sym_1695 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_parse", ptr: __rts_sym_1696 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_port", ptr: __rts_sym_1697 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_socketaddress_with_options", ptr: __rts_sym_1698 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_atime_ms", ptr: __rts_sym_1699 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_birthtime_ms", ptr: __rts_sym_1700 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blksize", ptr: __rts_sym_1701 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_blocks", ptr: __rts_sym_1702 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ctime_ms", ptr: __rts_sym_1703 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_dev", ptr: __rts_sym_1704 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_gid", ptr: __rts_sym_1705 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_ino", ptr: __rts_sym_1706 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_block", ptr: __rts_sym_1707 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_char", ptr: __rts_sym_1708 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_directory", ptr: __rts_sym_1709 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_fifo", ptr: __rts_sym_1710 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_file", ptr: __rts_sym_1711 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_socket", ptr: __rts_sym_1712 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_is_symlink", ptr: __rts_sym_1713 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mode", ptr: __rts_sym_1714 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_mtime_ms", ptr: __rts_sym_1715 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_nlink", ptr: __rts_sym_1716 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_rdev", ptr: __rts_sym_1717 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_size", ptr: __rts_sym_1718 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stats_uid", ptr: __rts_sym_1719 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_clear", ptr: __rts_sym_1720 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_getItem", ptr: __rts_sym_1721 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_key", ptr: __rts_sym_1722 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_length", ptr: __rts_sym_1723 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_new", ptr: __rts_sym_1724 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_persistTo", ptr: __rts_sym_1725 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_removeItem", ptr: __rts_sym_1726 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_storage_setItem", ptr: __rts_sym_1727 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_at", ptr: __rts_sym_1728 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_at", ptr: __rts_sym_1729 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_char_code_at", ptr: __rts_sym_1730 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_code_point_at", ptr: __rts_sym_1731 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_concat", ptr: __rts_sym_1732 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_ends_with", ptr: __rts_sym_1733 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_includes", ptr: __rts_sym_1734 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_index_of", ptr: __rts_sym_1735 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_is_well_formed", ptr: __rts_sym_1736 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_last_index_of", ptr: __rts_sym_1737 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_length", ptr: __rts_sym_1738 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_locale_compare", ptr: __rts_sym_1739 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_new", ptr: __rts_sym_1740 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_normalize", ptr: __rts_sym_1741 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_end", ptr: __rts_sym_1742 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_pad_start", ptr: __rts_sym_1743 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_repeat", ptr: __rts_sym_1744 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace", ptr: __rts_sym_1745 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_replace_all", ptr: __rts_sym_1746 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_slice", ptr: __rts_sym_1747 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_starts_with", ptr: __rts_sym_1748 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substr", ptr: __rts_sym_1749 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_substring", ptr: __rts_sym_1750 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_lower_case", ptr: __rts_sym_1751 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_locale_upper_case", ptr: __rts_sym_1752 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_lower_case", ptr: __rts_sym_1753 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_string", ptr: __rts_sym_1754 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_upper_case", ptr: __rts_sym_1755 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_to_well_formed", ptr: __rts_sym_1756 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim", ptr: __rts_sym_1757 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_end", ptr: __rts_sym_1758 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_left", ptr: __rts_sym_1759 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_right", ptr: __rts_sym_1760 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_trim_start", ptr: __rts_sym_1761 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_string_value_of", ptr: __rts_sym_1762 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_encoding", ptr: __rts_sym_1763 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end", ptr: __rts_sym_1764 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_end_buf", ptr: __rts_sym_1765 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_new", ptr: __rts_sym_1766 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_text", ptr: __rts_sym_1767 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_with_encoding", ptr: __rts_sym_1768 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_stringdecoder_write", ptr: __rts_sym_1769 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_description", ptr: __rts_sym_1770 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_for_key", ptr: __rts_sym_1771 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_js_to_string", ptr: __rts_sym_1772 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_key_for", ptr: __rts_sym_1773 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_symbol_new", ptr: __rts_sym_1774 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_decode", ptr: __rts_sym_1775 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoder_new", ptr: __rts_sym_1776 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_encoding", ptr: __rts_sym_1777 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_new", ptr: __rts_sym_1778 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_readable", ptr: __rts_sym_1779 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textdecoderstream_writable", ptr: __rts_sym_1780 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode", ptr: __rts_sym_1781 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_encode_into", ptr: __rts_sym_1782 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoder_new", ptr: __rts_sym_1783 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_encoding", ptr: __rts_sym_1784 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_new", ptr: __rts_sym_1785 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_readable", ptr: __rts_sym_1786 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_textencoderstream_writable", ptr: __rts_sym_1787 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_new", ptr: __rts_sym_1788 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_readable", ptr: __rts_sym_1789 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_transformstream_writable", ptr: __rts_sym_1790 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse", ptr: __rts_sym_1791 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_can_parse_base", ptr: __rts_sym_1792 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hash", ptr: __rts_sym_1793 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_host", ptr: __rts_sym_1794 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_hostname", ptr: __rts_sym_1795 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_href", ptr: __rts_sym_1796 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new", ptr: __rts_sym_1797 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_new_with_base", ptr: __rts_sym_1798 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_origin", ptr: __rts_sym_1799 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_password", ptr: __rts_sym_1800 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_pathname", ptr: __rts_sym_1801 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_port", ptr: __rts_sym_1802 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_protocol", ptr: __rts_sym_1803 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search", ptr: __rts_sym_1804 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_search_params", ptr: __rts_sym_1805 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hash", ptr: __rts_sym_1806 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_host", ptr: __rts_sym_1807 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_hostname", ptr: __rts_sym_1808 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_href", ptr: __rts_sym_1809 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_password", ptr: __rts_sym_1810 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_pathname", ptr: __rts_sym_1811 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_port", ptr: __rts_sym_1812 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_protocol", ptr: __rts_sym_1813 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_search", ptr: __rts_sym_1814 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_set_username", ptr: __rts_sym_1815 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_json", ptr: __rts_sym_1816 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_to_string", ptr: __rts_sym_1817 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_url_username", ptr: __rts_sym_1818 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_append", ptr: __rts_sym_1819 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_delete", ptr: __rts_sym_1820 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_get", ptr: __rts_sym_1821 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_has", ptr: __rts_sym_1822 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_new", ptr: __rts_sym_1823 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_set", ptr: __rts_sym_1824 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_size", ptr: __rts_sym_1825 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_sort", ptr: __rts_sym_1826 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_urlsearchparams_to_string", ptr: __rts_sym_1827 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_deref", ptr: __rts_sym_1828 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_weakref_new", ptr: __rts_sym_1829 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__get", ptr: __rts_sym_1830 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_locked__set", ptr: __rts_sym_1831 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestream_new", ptr: __rts_sym_1832 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_abort", ptr: __rts_sym_1833 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_close", ptr: __rts_sym_1834 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_release_lock", ptr: __rts_sym_1835 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_global_writablestreamdefaultwriter_write", ptr: __rts_sym_1836 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepEqual", ptr: __rts_sym_1837 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_deepStrictEqual", ptr: __rts_sym_1838 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch", ptr: __rts_sym_1839 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotMatch_msg", ptr: __rts_sym_1840 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_doesNotThrow", ptr: __rts_sym_1841 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_equal", ptr: __rts_sym_1842 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail", ptr: __rts_sym_1843 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_fail_msg", ptr: __rts_sym_1844 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ifError", ptr: __rts_sym_1845 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match", ptr: __rts_sym_1846 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_match_msg", ptr: __rts_sym_1847 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepEqual", ptr: __rts_sym_1848 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notDeepStrictEqual", ptr: __rts_sym_1849 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notEqual", ptr: __rts_sym_1850 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_notStrictEqual", ptr: __rts_sym_1851 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok", ptr: __rts_sym_1852 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_ok_msg", ptr: __rts_sym_1853 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_strictEqual", ptr: __rts_sym_1854 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_assert_throws", ptr: __rts_sym_1855 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_atob", ptr: __rts_sym_1856 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_buffer_btoa", ptr: __rts_sym_1857 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createCipheriv", ptr: __rts_sym_1858 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createDecipheriv", ptr: __rts_sym_1859 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHash", ptr: __rts_sym_1860 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_createHmac", ptr: __rts_sym_1861 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_generateX25519KeyPair", ptr: __rts_sym_1862 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_getHashes", ptr: __rts_sym_1863 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash", ptr: __rts_sym_1864 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hash_enc", ptr: __rts_sym_1865 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_hkdfSync", ptr: __rts_sym_1866 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_pbkdf2Sync", ptr: __rts_sym_1867 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomBytes", ptr: __rts_sym_1868 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomFillSync", ptr: __rts_sym_1869 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt", ptr: __rts_sym_1870 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomInt_minmax", ptr: __rts_sym_1871 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_randomUUID", ptr: __rts_sym_1872 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync", ptr: __rts_sym_1873 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_scryptSync_params", ptr: __rts_sym_1874 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_timingSafeEqual", ptr: __rts_sym_1875 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519DiffieHellman", ptr: __rts_sym_1876 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_crypto_x25519PublicKey", ptr: __rts_sym_1877 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket", ptr: __rts_sym_1878 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dgram_createSocket_cb", ptr: __rts_sym_1879 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_lookup", ptr: __rts_sym_1880 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve4", ptr: __rts_sym_1881 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_dns_resolve6", ptr: __rts_sym_1882 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_access", ptr: __rts_sym_1883 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_accessSync", ptr: __rts_sym_1884 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFile", ptr: __rts_sym_1885 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync", ptr: __rts_sym_1886 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_appendFileSync_enc", ptr: __rts_sym_1887 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmod", ptr: __rts_sym_1888 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chmodSync", ptr: __rts_sym_1889 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_chownSync", ptr: __rts_sym_1890 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_closeSync", ptr: __rts_sym_1891 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFile", ptr: __rts_sym_1892 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_copyFileSync", ptr: __rts_sym_1893 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync", ptr: __rts_sym_1894 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_cpSync_opts", ptr: __rts_sym_1895 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_exists", ptr: __rts_sym_1896 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_existsSync", ptr: __rts_sym_1897 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchmodSync", ptr: __rts_sym_1898 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fchownSync", ptr: __rts_sym_1899 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fdatasyncSync", ptr: __rts_sym_1900 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fstatSync", ptr: __rts_sym_1901 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_fsyncSync", ptr: __rts_sym_1902 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_ftruncateSync", ptr: __rts_sym_1903 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_futimesSync", ptr: __rts_sym_1904 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_globSync", ptr: __rts_sym_1905 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchmodSync", ptr: __rts_sym_1906 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lchownSync", ptr: __rts_sym_1907 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_linkSync", ptr: __rts_sym_1908 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstat", ptr: __rts_sym_1909 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_lstatSync", ptr: __rts_sym_1910 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdir", ptr: __rts_sym_1911 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync", ptr: __rts_sym_1912 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdirSync_opts", ptr: __rts_sym_1913 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_mkdtempSync", ptr: __rts_sym_1914 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_openSync", ptr: __rts_sym_1915 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_opendirSync", ptr: __rts_sym_1916 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_access", ptr: __rts_sym_1917 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_appendFile", ptr: __rts_sym_1918 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_copyFile", ptr: __rts_sym_1919 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_lstat", ptr: __rts_sym_1920 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_mkdir", ptr: __rts_sym_1921 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_open", ptr: __rts_sym_1922 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile", ptr: __rts_sym_1923 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readFile_enc", ptr: __rts_sym_1924 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readdir", ptr: __rts_sym_1925 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_readlink", ptr: __rts_sym_1926 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_realpath", ptr: __rts_sym_1927 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rename", ptr: __rts_sym_1928 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rm", ptr: __rts_sym_1929 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_rmdir", ptr: __rts_sym_1930 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_stat", ptr: __rts_sym_1931 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_truncate", ptr: __rts_sym_1932 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_unlink", ptr: __rts_sym_1933 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_promises_writeFile", ptr: __rts_sym_1934 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile", ptr: __rts_sym_1935 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync", ptr: __rts_sym_1936 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFileSync_enc", ptr: __rts_sym_1937 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readFile_enc", ptr: __rts_sym_1938 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readSync", ptr: __rts_sym_1939 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdir", ptr: __rts_sym_1940 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync", ptr: __rts_sym_1941 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readdirSync_opts", ptr: __rts_sym_1942 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readlinkSync", ptr: __rts_sym_1943 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync", ptr: __rts_sym_1944 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_readvSync_nopos", ptr: __rts_sym_1945 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpath", ptr: __rts_sym_1946 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_realpathSync", ptr: __rts_sym_1947 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rename", ptr: __rts_sym_1948 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_renameSync", ptr: __rts_sym_1949 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rm", ptr: __rts_sym_1950 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync", ptr: __rts_sym_1951 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmSync_opts", ptr: __rts_sym_1952 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdir", ptr: __rts_sym_1953 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_rmdirSync", ptr: __rts_sym_1954 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_stat", ptr: __rts_sym_1955 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statSync", ptr: __rts_sym_1956 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_statfsSync", ptr: __rts_sym_1957 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_symlinkSync", ptr: __rts_sym_1958 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_truncateSync", ptr: __rts_sym_1959 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlink", ptr: __rts_sym_1960 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unlinkSync", ptr: __rts_sym_1961 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_unwatchFile", ptr: __rts_sym_1962 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_utimesSync", ptr: __rts_sym_1963 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watch", ptr: __rts_sym_1964 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile", ptr: __rts_sym_1965 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_watchFile_interval", ptr: __rts_sym_1966 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFile", ptr: __rts_sym_1967 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync", ptr: __rts_sym_1968 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeFileSync_enc", ptr: __rts_sym_1969 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writeSync", ptr: __rts_sym_1970 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync", ptr: __rts_sym_1971 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_fs_writevSync_nopos", ptr: __rts_sym_1972 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_METHODS", ptr: __rts_sym_1973 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_http_STATUS_CODES", ptr: __rts_sym_1974 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_builtinModules", ptr: __rts_sym_1975 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_isBuiltin", ptr: __rts_sym_1976 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_syncBuiltinESMExports", ptr: __rts_sym_1977 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_module_wrap", ptr: __rts_sym_1978 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamily", ptr: __rts_sym_1979 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_getDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1980 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIP", ptr: __rts_sym_1981 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv4", ptr: __rts_sym_1982 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_isIPv6", ptr: __rts_sym_1983 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamily", ptr: __rts_sym_1984 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_net_setDefaultAutoSelectFamilyAttemptTimeout", ptr: __rts_sym_1985 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_EOL", ptr: __rts_sym_1986 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_arch", ptr: __rts_sym_1987 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_availableParallelism", ptr: __rts_sym_1988 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_cpus", ptr: __rts_sym_1989 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_endianness", ptr: __rts_sym_1990 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_freemem", ptr: __rts_sym_1991 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority", ptr: __rts_sym_1992 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_getPriority_pid", ptr: __rts_sym_1993 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_homedir", ptr: __rts_sym_1994 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_hostname", ptr: __rts_sym_1995 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_loadavg", ptr: __rts_sym_1996 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_machine", ptr: __rts_sym_1997 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_networkInterfaces", ptr: __rts_sym_1998 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_platform", ptr: __rts_sym_1999 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_release", ptr: __rts_sym_2000 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority", ptr: __rts_sym_2001 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_setPriority_pid", ptr: __rts_sym_2002 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_tmpdir", ptr: __rts_sym_2003 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_totalmem", ptr: __rts_sym_2004 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_type", ptr: __rts_sym_2005 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_uptime", ptr: __rts_sym_2006 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_userInfo", ptr: __rts_sym_2007 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_os_version", ptr: __rts_sym_2008 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_basename", ptr: __rts_sym_2009 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_dirname", ptr: __rts_sym_2010 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_extname", ptr: __rts_sym_2011 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_format", ptr: __rts_sym_2012 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_isAbsolute", ptr: __rts_sym_2013 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_matchesGlob", ptr: __rts_sym_2014 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_normalize", ptr: __rts_sym_2015 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_parse", ptr: __rts_sym_2016 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_relative", ptr: __rts_sym_2017 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_posix_toNamespacedPath", ptr: __rts_sym_2018 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_basename", ptr: __rts_sym_2019 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_dirname", ptr: __rts_sym_2020 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_extname", ptr: __rts_sym_2021 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_format", ptr: __rts_sym_2022 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_isAbsolute", ptr: __rts_sym_2023 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_matchesGlob", ptr: __rts_sym_2024 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_normalize", ptr: __rts_sym_2025 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_parse", ptr: __rts_sym_2026 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_relative", ptr: __rts_sym_2027 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_path_win32_toNamespacedPath", ptr: __rts_sym_2028 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks", ptr: __rts_sym_2029 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMarks_name", ptr: __rts_sym_2030 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures", ptr: __rts_sym_2031 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_clearMeasures_name", ptr: __rts_sym_2032 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntries", ptr: __rts_sym_2033 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByName", ptr: __rts_sym_2034 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_getEntriesByType", ptr: __rts_sym_2035 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_mark", ptr: __rts_sym_2036 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure", ptr: __rts_sym_2037 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_measure_marks", ptr: __rts_sym_2038 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_now", ptr: __rts_sym_2039 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_perf_hooks_timeOrigin", ptr: __rts_sym_2040 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_abort", ptr: __rts_sym_2041 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_arch", ptr: __rts_sym_2042 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv", ptr: __rts_sym_2043 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_argv0", ptr: __rts_sym_2044 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_availableMemory", ptr: __rts_sym_2045 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_chdir", ptr: __rts_sym_2046 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_constrainedMemory", ptr: __rts_sym_2047 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cpuUsage", ptr: __rts_sym_2048 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_cwd", ptr: __rts_sym_2049 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_env", ptr: __rts_sym_2050 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_execPath", ptr: __rts_sym_2051 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_exit", ptr: __rts_sym_2052 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_getActiveResourcesInfo", ptr: __rts_sym_2053 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime", ptr: __rts_sym_2054 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_hrtime_prev", ptr: __rts_sym_2055 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_kill", ptr: __rts_sym_2056 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_memoryUsage", ptr: __rts_sym_2057 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_pid", ptr: __rts_sym_2058 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_platform", ptr: __rts_sym_2059 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_resourceUsage", ptr: __rts_sym_2060 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_title", ptr: __rts_sym_2061 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_uptime", ptr: __rts_sym_2062 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_version", ptr: __rts_sym_2063 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_process_versions", ptr: __rts_sym_2064 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_decode", ptr: __rts_sym_2065 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_encode", ptr: __rts_sym_2066 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toASCII", ptr: __rts_sym_2067 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_punycode_toUnicode", ptr: __rts_sym_2068 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_decode", ptr: __rts_sym_2069 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_encode", ptr: __rts_sym_2070 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_escape", ptr: __rts_sym_2071 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_parse", ptr: __rts_sym_2072 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_stringify", ptr: __rts_sym_2073 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_querystring_unescape", ptr: __rts_sym_2074 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCiphers", ptr: __rts_sym_2075 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tls_getCurves", ptr: __rts_sym_2076 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_getColorDepth", ptr: __rts_sym_2077 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_hasColors", ptr: __rts_sym_2078 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_tty_isatty", ptr: __rts_sym_2079 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToASCII", ptr: __rts_sym_2080 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_domainToUnicode", ptr: __rts_sym_2081 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPath", ptr: __rts_sym_2082 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_fileURLToPathBuffer", ptr: __rts_sym_2083 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_format", ptr: __rts_sym_2084 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_parse", ptr: __rts_sym_2085 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_pathToFileURL", ptr: __rts_sym_2086 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_resolve", ptr: __rts_sym_2087 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_url_urlToHttpOptions", ptr: __rts_sym_2088 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format", ptr: __rts_sym_2089 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions", ptr: __rts_sym_2090 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a1", ptr: __rts_sym_2091 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_formatWithOptions_a2", ptr: __rts_sym_2092 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a1", ptr: __rts_sym_2093 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a2", ptr: __rts_sym_2094 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a3", ptr: __rts_sym_2095 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_format_a4", ptr: __rts_sym_2096 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_getSystemErrorName", ptr: __rts_sym_2097 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect", ptr: __rts_sym_2098 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_inspect_opts", ptr: __rts_sym_2099 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_isDeepStrictEqual", ptr: __rts_sym_2100 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_parseArgs", ptr: __rts_sym_2101 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_stripVTControlCharacters", ptr: __rts_sym_2102 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_styleText", ptr: __rts_sym_2103 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_util_toUSVString", ptr: __rts_sym_2104 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliCompressSync", ptr: __rts_sym_2105 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_brotliDecompressSync", ptr: __rts_sym_2106 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32", ptr: __rts_sym_2107 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_crc32_prev", ptr: __rts_sym_2108 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateRawSync", ptr: __rts_sym_2109 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync", ptr: __rts_sym_2110 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_deflateSync_level", ptr: __rts_sym_2111 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gunzipSync", ptr: __rts_sym_2112 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync", ptr: __rts_sym_2113 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_gzipSync_level", ptr: __rts_sym_2114 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateRawSync", ptr: __rts_sym_2115 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_inflateSync", ptr: __rts_sym_2116 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_node_zlib_unzipSync", ptr: __rts_sym_2117 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_deserialize", ptr: __rts_sym_2118 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsm_serde_serialize", ptr: __rts_sym_2119 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_new", ptr: __rts_sym_2120 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_agen_next", ptr: __rts_sym_2121 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_awaited", ptr: __rts_sym_2122 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_new", ptr: __rts_sym_2123 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resolve", ptr: __rts_sym_2124 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_resume", ptr: __rts_sym_2125 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_start", ptr: __rts_sym_2126 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_async_sm_suspend", ptr: __rts_sym_2127 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect", ptr: __rts_sym_2128 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_collect_debt", ptr: __rts_sym_2129 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_clear", ptr: __rts_sym_2130 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get", ptr: __rts_sym_2131 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_get_stack", ptr: __rts_sym_2132 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_error_set", ptr: __rts_sym_2133 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_get", ptr: __rts_sym_2134 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gcell_set", ptr: __rts_sym_2135 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_done", ptr: __rts_sym_2136 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_next", ptr: __rts_sym_2137 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_delegate_start", ptr: __rts_sym_2138 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_caught", ptr: __rts_sym_2139 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_done", ptr: __rts_sym_2140 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_drain", ptr: __rts_sym_2141 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_end_finally", ptr: __rts_sym_2142 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try", ptr: __rts_sym_2143 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_enter_try_catch", ptr: __rts_sym_2144 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_exit_try_catch", ptr: __rts_sym_2145 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fget", ptr: __rts_sym_2146 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_fset", ptr: __rts_sym_2147 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_is", ptr: __rts_sym_2148 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_new", ptr: __rts_sym_2149 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_next", ptr: __rts_sym_2150 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_return", ptr: __rts_sym_2151 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_sent", ptr: __rts_sym_2152 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_setstate", ptr: __rts_sym_2153 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_state", ptr: __rts_sym_2154 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_throw", ptr: __rts_sym_2155 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_gen_sm_yield", ptr: __rts_sym_2156 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_get_ret", ptr: __rts_sym_2157 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next", ptr: __rts_sym_2158 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_next_sent", ptr: __rts_sym_2159 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_return", ptr: __rts_sym_2160 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_set_ret", ptr: __rts_sym_2161 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_generator_throw", ptr: __rts_sym_2162 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_inspect", ptr: __rts_sym_2163 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_done", ptr: __rts_sym_2164 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_iter_value", ptr: __rts_sym_2165 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_live_count", ptr: __rts_sym_2166 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_object_to_string", ptr: __rts_sym_2167 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_from_handle", ptr: __rts_sym_2168 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_poly_to_handle", ptr: __rts_sym_2169 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_report_uncaught", ptr: __rts_sym_2170 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_spread_into_vec", ptr: __rts_sym_2171 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_depth", ptr: __rts_sym_2172 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_pop", ptr: __rts_sym_2173 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_stack_push", ptr: __rts_sym_2174 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_string_from_f64", ptr: __rts_sym_2175 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_symbol_iterator_of", ptr: __rts_sym_2176 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_get_by_payload", ptr: __rts_sym_2177 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_len_by_payload", ptr: __rts_sym_2178 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_new_object", ptr: __rts_sym_2179 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_push_by_payload", ptr: __rts_sym_2180 as *const u8 });
+    out.push(::rts_abi::table::SymbolEntry { name: "__rtsn_vec_set_by_payload", ptr: __rts_sym_2181 as *const u8 });
     out
 }
 
 /// The same symbols as names only, for the AOT object module's declaration
 /// list. Same order, same `#[cfg]` gating — the two paths cannot diverge.
 pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
-    let mut out = ::std::vec::Vec::with_capacity(2176);
+    let mut out = ::std::vec::Vec::with_capacity(2182);
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ABORT");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_ANY");
     out.push("__RTS_FN_GL_ABORTSIGNAL_STATIC_TIMEOUT");
@@ -8113,6 +8131,12 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
     out.push("__rtsm_global_domexception_name");
     out.push("__rtsm_global_domexception_new");
     out.push("__rtsm_global_domexception_to_string");
+    out.push("__rtsm_global_domscope_count");
+    out.push("__rtsm_global_domscope_drop");
+    out.push("__rtsm_global_domscope_get");
+    out.push("__rtsm_global_domscope_has");
+    out.push("__rtsm_global_domscope_nameAt");
+    out.push("__rtsm_global_domscope_set");
     out.push("__rtsm_global_encode_uri");
     out.push("__rtsm_global_encode_uri_component");
     out.push("__rtsm_global_event_bubbles__get");
@@ -8748,7 +8772,7 @@ pub fn aot_symbols() -> ::std::vec::Vec<&'static str> {
 /// ABI signatures derived from the Rust signatures of `#[rtse::abi]` fns.
 ///
 /// Sorted ascending by name, like the symbol table, so a lookup is a binary
-/// search. 607 of 2176 symbols carry one; the rest are not yet declared with
+/// search. 607 of 2182 symbols carry one; the rest are not yet declared with
 /// `#[rtse::abi]`.
 pub fn signatures() -> ::std::vec::Vec<(&'static str, &'static [::rts_abi::AbiType], ::rts_abi::AbiType)> {
     // The element type is spelled out: without it the `&[]` of a zero-arg

--- a/tests/claude-dom-script-globals.test.ts
+++ b/tests/claude-dom-script-globals.test.ts
@@ -143,3 +143,69 @@ describe("escopo global compartilhado entre <script> da página", () => {
     expect(textoB).toBe("B nao viu A");
   });
 });
+
+// ── APIs de plataforma que o boot de uma página real consulta ────────────────
+//
+// Estas três não são "linguagem": são superfície de browser que faltava e que
+// derrubava o script INTEIRO no primeiro uso (o resto do bootstrap ia junto).
+
+// `Node.ELEMENT_NODE` — guarda padrão antes de tocar num nó.
+const htmlNode =
+  "<div id='n'>x</div>" +
+  "<script>" +
+  "  const el = document.getElementById('n');" +
+  "  if (el !== null && el.nodeType === Node.ELEMENT_NODE) { el.setInnerHTML('e' + Node.TEXT_NODE); }" +
+  "</script>";
+const docNode = parseDocument(htmlNode);
+const ranNode = runScripts(docNode);
+const outNode = docNode.getElementById("n");
+const textoNode = outNode === null ? "" : outNode.textContent;
+
+// `new MutationObserver(cb)` + `observe` — stub honesto (registra, não entrega).
+// O que este teste trava é que o script SOBREVIVE ao `new`.
+const htmlMO =
+  "<div id='m'>antes</div>" +
+  "<script>" +
+  "  const o = new MutationObserver(function(recs, obs){ return 0; });" +
+  "  o.observe(document.getElementById('m'), {childList:true, subtree:true});" +
+  "  const el = document.getElementById('m');" +
+  "  if (el !== null) { el.setInnerHTML('sobreviveu:' + o.takeRecords().length); }" +
+  "</script>";
+const docMO = parseDocument(htmlMO);
+const ranMO = runScripts(docMO);
+const outMO = docMO.getElementById("m");
+const textoMO = outMO === null ? "" : outMO.textContent;
+
+// `x instanceof window.C` — a forma com objeto global é a MESMA checagem que
+// `x instanceof C`. Uma classe que o motor não tem responde `false`, que é a
+// resposta certa de um feature-detect (o script segue vivo).
+const htmlInst =
+  "<div id='i'>x</div>" +
+  "<script>" +
+  "  const obj = {};" +
+  "  const ehObj = obj instanceof window.Object;" +
+  "  const ehDSM = obj instanceof window.DOMStringMap;" +
+  "  const el = document.getElementById('i');" +
+  "  if (el !== null) { el.setInnerHTML((ehObj ? '1' : '0') + (ehDSM ? '1' : '0')); }" +
+  "</script>";
+const docInst = parseDocument(htmlInst);
+const ranInst = runScripts(docInst);
+const outInst = docInst.getElementById("i");
+const textoInst = outInst === null ? "" : outInst.textContent;
+
+describe("superfície de browser consultada no boot", () => {
+  test("Node.ELEMENT_NODE / TEXT_NODE existem com os valores da spec", () => {
+    expect(ranNode).toBe(1);
+    expect(textoNode).toBe("e3");
+  });
+
+  test("MutationObserver não derruba o script (stub registra e segue)", () => {
+    expect(ranMO).toBe(1);
+    expect(textoMO).toBe("sobreviveu:0");
+  });
+
+  test("instanceof window.C resolve como instanceof C", () => {
+    expect(ranInst).toBe(1);
+    expect(textoInst).toBe("10");
+  });
+});

--- a/tests/claude-dom-script-globals.test.ts
+++ b/tests/claude-dom-script-globals.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "rts:test";
+
+// ESCOPO GLOBAL COMPARTILHADO ENTRE OS <script> DA MESMA PÁGINA.
+//
+// Num browser todos os <script> de um documento falam com UM objeto global: o
+// script A define `foo = ...` e o script B, compilado depois, enxerga. Antes
+// desta fatia cada <script> era uma ilha (um `window` novo por script), e um
+// loader definido no script 2 morria com ele — o que reprovava o boot de páginas
+// reais (WhatsApp/Meta: 1 de 33 scripts rodava; os outros 28 morriam em
+// "unknown function requireLazy").
+//
+// Três mecanismos entram aqui, todos na borda do DOM (o motor não foi afrouxado):
+//   1. `window` PERSISTENTE por documento + saco de globais `__G` compartilhado;
+//   2. GLOBAL IMPLÍCITO (`x = 1` sem var/let/const) reescrito para `__G.x` — o
+//      compilador do RTS recusa criar binding implícito, e com razão; a página é
+//      que tem semântica sloppy, então a tradução mora aqui;
+//   3. duas normalizações sintáticas de JS minificado: `arguments` → rest param
+//      e sequência `a=1,b=function(){}` → statements separados.
+//
+// Pré-computado no top-level (regra do projeto: método dentro de test() pode
+// perder handle pro GC).
+
+// ── 1. um script define, o SEGUINTE consome ──────────────────────────────────
+const htmlCompart =
+  "<div id='out'>vazio</div>" +
+  "<script>publicado = 'definido no script 1';</script>" +
+  "<script>" +
+  "  const el = document.getElementById('out');" +
+  "  if (el !== null) { el.setInnerHTML(publicado); }" +
+  "</script>";
+const docCompart = parseDocument(htmlCompart);
+const ranCompart = runScripts(docCompart);
+const outCompart = docCompart.getElementById("out");
+const textoCompart = outCompart === null ? "" : outCompart.textContent;
+
+// ── 2. FUNÇÃO global publicada e CHAMADA por outro script ────────────────────
+// É a forma exata do loader da Meta: `requireLazy=function(){stub.push(arguments)}`
+// (sequência com vírgula + `arguments`), publicado num script e chamado noutro.
+const htmlLoader =
+  "<div id='r'>0</div>" +
+  "<script>__stub=[],carrega=function(){__stub.push(arguments)};</script>" +
+  "<script>carrega(['Modulo'], function(m){ return 0; }, null, 256);</script>" +
+  "<script>" +
+  "  const el = document.getElementById('r');" +
+  "  if (el !== null) { el.setInnerHTML('' + __stub.length); }" +
+  "</script>";
+const docLoader = parseDocument(htmlLoader);
+const ranLoader = runScripts(docLoader);
+const outLoader = docLoader.getElementById("r");
+const textoLoader = outLoader === null ? "" : outLoader.textContent;
+
+// ── 3. `window.x` de um script é visto pelo próximo (window persistente) ─────
+const htmlWin =
+  "<div id='w'>vazio</div>" +
+  "<script>window.marcado = 'via window';</script>" +
+  "<script>" +
+  "  const el = document.getElementById('w');" +
+  "  if (el !== null) { el.setInnerHTML(window.marcado); }" +
+  "</script>";
+const docWin = parseDocument(htmlWin);
+const ranWin = runScripts(docWin);
+const outWin = docWin.getElementById("w");
+const textoWin = outWin === null ? "" : outWin.textContent;
+
+// ── 4. NÃO-REGRESSÃO: local reatribuído não é global implícito ───────────────
+// `let i = 0; … i = i + 1` — o `i` do segundo statement parece atribuição a nome
+// livre; se o scanner o tratasse como global, o loop quebraria. Cobre o bug que
+// esta fatia introduziu e corrigiu (filtro de nomes declarados).
+const htmlLocal =
+  "<div id='l'>x</div><ul id='lista'></ul>" +
+  "<script>" +
+  "  let i = 0;" +
+  "  while (i < 3) {" +
+  "    const li = document.createElement('li');" +
+  "    li.setInnerHTML('item ' + i);" +
+  "    const lst = document.getElementById('lista');" +
+  "    if (lst !== null) { lst.appendChild(li); }" +
+  "    i = i + 1;" +
+  "  }" +
+  "</script>";
+const docLocal = parseDocument(htmlLocal);
+const ranLocal = runScripts(docLocal);
+const lisLocal = docLocal.querySelectorAll("#lista li");
+const nLisLocal = lisLocal.length;
+const ultimoLocal = nLisLocal === 3 ? lisLocal[2].textContent : "";
+
+// ── 5. SHADOWING: declaração local vence o global de mesmo nome ──────────────
+const htmlShadow =
+  "<div id='s'>vazio</div>" +
+  "<script>nome = 'global';</script>" +
+  "<script>" +
+  "  const nome = 'local';" +
+  "  const el = document.getElementById('s');" +
+  "  if (el !== null) { el.setInnerHTML(nome); }" +
+  "</script>";
+const docShadow = parseDocument(htmlShadow);
+const ranShadow = runScripts(docShadow);
+const outShadow = docShadow.getElementById("s");
+const textoShadow = outShadow === null ? "" : outShadow.textContent;
+
+// ── 6. ISOLAMENTO ENTRE DOCUMENTOS: o global de um doc não vaza pro outro ────
+const docA = parseDocument("<div id='a'>x</div><script>soDoDocA = 'A';</script>");
+runScripts(docA);
+const docB = parseDocument(
+  "<div id='b'>intacto</div>" +
+  "<script>" +
+  "  const el = document.getElementById('b');" +
+  "  if (el !== null) { el.setInnerHTML('B nao viu A'); }" +
+  "</script>");
+const ranB = runScripts(docB);
+const outB = docB.getElementById("b");
+const textoB = outB === null ? "" : outB.textContent;
+
+describe("escopo global compartilhado entre <script> da página", () => {
+  test("script publica global; o seguinte lê", () => {
+    expect(ranCompart).toBe(2);
+    expect(textoCompart).toBe("definido no script 1");
+  });
+
+  test("função global (sequência + arguments) é chamada por outro script", () => {
+    expect(ranLoader).toBe(3);
+    expect(textoLoader).toBe("1");
+  });
+
+  test("window é o MESMO objeto entre scripts do documento", () => {
+    expect(ranWin).toBe(2);
+    expect(textoWin).toBe("via window");
+  });
+
+  test("local reatribuído não vira global implícito", () => {
+    expect(ranLocal).toBe(1);
+    expect(nLisLocal).toBe(3);
+    expect(ultimoLocal).toBe("item 2");
+  });
+
+  test("declaração local faz shadow do global", () => {
+    expect(ranShadow).toBe(2);
+    expect(textoShadow).toBe("local");
+  });
+
+  test("documentos diferentes têm escopos globais isolados", () => {
+    expect(ranB).toBe(1);
+    expect(textoB).toBe("B nao viu A");
+  });
+});

--- a/tests/claude-storage-pickle.test.ts
+++ b/tests/claude-storage-pickle.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from "rts:test";
+import { fs } from "rts";
+
+// `Storage` (Web Storage API) em RUST, persistindo como PICKLE.
+//
+// Duas coisas se provam aqui.
+//
+// 1. A API da spec: getItem/setItem/removeItem/clear/key/length, string-only,
+//    `null` para chave ausente.
+//
+// 2. A PERSISTÊNCIA entre execuções, gravada como pickle (`rts_engine::heap::
+//    pickle`) em vez de texto. Pickle porque guarda estrutura e tipo — um valor
+//    com `\n` ou com o separador dentro quebraria um "k=v por linha", e isso é
+//    conteúdo comum —, porque é o mesmo mecanismo do resto do projeto, e porque
+//    produz um bloco opaco de bytes, que é o que se cifra quando a criptografia
+//    entrar.
+//
+// Contexto de POR QUE em Rust: a primeira versão era um prelude `.ts`, e as
+// ~68 linhas que ela acrescentava faziam `tests/node_util_parseargs.test.ts` —
+// sem relação nenhuma — TRAVAR. Bisseção binária isolou o gatilho em dois
+// arrays globais VAZIOS no prelude (estado global de módulo vira gcell). Em
+// Rust o estado mora na struct/HandleTable e a classe de bug não existe.
+//
+// Pré-computado no top-level (regra do projeto: método dentro de test() pode
+// perder handle pro GC).
+
+const BASE = "target/tmp-claude-storage";
+if (!fs.is_dir(BASE)) { fs.create_dir_all(BASE); }
+
+// ── 1. API em memória (sem persistTo) ───────────────────────────────────────
+const mem = new Storage();
+const memVazio = mem.length;
+mem.setItem("a", "1");
+mem.setItem("b", "2");
+const memLen = mem.length;
+const memA = mem.getItem("a");
+const memAusente = mem.getItem("naoexiste");
+const memKey0 = mem.key(0);
+const memKeyFora = mem.key(9);
+// sobrescrever NÃO duplica a chave
+mem.setItem("a", "9");
+const memSobrescrito = mem.getItem("a");
+const memLenAposSobrescrever = mem.length;
+
+// ── 2. remove e clear ───────────────────────────────────────────────────────
+const mut = new Storage();
+mut.setItem("x", "1");
+mut.setItem("y", "2");
+mut.removeItem("x");
+const aposRemove = mut.length;
+const xRemovido = mut.getItem("x");
+mut.removeItem("naoexiste"); // no-op, não pode explodir
+const aposRemoveAusente = mut.length;
+mut.clear();
+const aposClear = mut.length;
+
+// ── 3. PERSISTE entre "execuções" (dois Storage, mesmo arquivo) ────────────
+const P1 = BASE + "/basico.pickle";
+if (fs.exists(P1)) { fs.remove_file(P1); }
+const escreve = new Storage();
+escreve.persistTo(P1);
+escreve.setItem("user", "ana");
+escreve.setItem("visitas", "3");
+const arquivoCriado = fs.exists(P1);
+// outra instância, mesmo arquivo: é o que uma segunda execução veria
+const le = new Storage();
+le.persistTo(P1);
+const leUser = le.getItem("user");
+const leVisitas = le.getItem("visitas");
+const leLen = le.length;
+const leOrdem = le.key(0);
+
+// ── 4. valor HOSTIL — o que um formato de texto quebraria ──────────────────
+const P2 = BASE + "/hostil.pickle";
+if (fs.exists(P2)) { fs.remove_file(P2); }
+const hostil = "linha1\nlinha2=x\ty|z\r\nfim";
+const gravaHostil = new Storage();
+gravaHostil.persistTo(P2);
+gravaHostil.setItem("bruto", hostil);
+const leHostil = new Storage();
+leHostil.persistTo(P2);
+const voltouHostil = leHostil.getItem("bruto");
+
+// ── 5. remove/clear TAMBÉM persistem ───────────────────────────────────────
+const P3 = BASE + "/mutacao.pickle";
+if (fs.exists(P3)) { fs.remove_file(P3); }
+const m1 = new Storage();
+m1.persistTo(P3);
+m1.setItem("a", "1");
+m1.setItem("b", "2");
+m1.removeItem("a");
+const m2 = new Storage();
+m2.persistTo(P3);
+const persistidoAposRemove = m2.length;
+const aChaveSumiu = m2.getItem("a");
+m2.clear();
+const m3 = new Storage();
+m3.persistTo(P3);
+const persistidoAposClear = m3.length;
+
+// ── 6. arquivo CORROMPIDO não derruba — storage segue utilizável ───────────
+const P4 = BASE + "/corrompido.pickle";
+fs.write(P4, "isto nao e um pickle valido {{{");
+const corrompido = new Storage();
+corrompido.persistTo(P4);
+const corrompidoLen = corrompido.length;
+corrompido.setItem("novo", "ok"); // ainda funciona depois do arquivo ruim
+const corrompidoUsavel = corrompido.getItem("novo");
+
+// ── 7. arquivo INEXISTENTE é só um storage vazio ───────────────────────────
+const P5 = BASE + "/nao-existe-ainda.pickle";
+if (fs.exists(P5)) { fs.remove_file(P5); }
+const novo = new Storage();
+novo.persistTo(P5);
+const novoLen = novo.length;
+
+describe("Storage (Web Storage API) em Rust", () => {
+  test("API em memória segue a spec", () => {
+    expect(memVazio).toBe(0);
+    expect(memLen).toBe(2);
+    expect(memA).toBe("1");
+    expect(memAusente).toBe(null);
+    expect(memKey0).toBe("a");
+    expect(memKeyFora).toBe(null);
+  });
+
+  test("setItem sobrescreve sem duplicar a chave", () => {
+    expect(memSobrescrito).toBe("9");
+    expect(memLenAposSobrescrever).toBe(2);
+  });
+
+  test("removeItem e clear", () => {
+    expect(aposRemove).toBe(1);
+    expect(xRemovido).toBe(null);
+    expect(aposRemoveAusente).toBe(1);
+    expect(aposClear).toBe(0);
+  });
+});
+
+describe("Storage — persistência via pickle", () => {
+  test("sobrevive entre execuções", () => {
+    expect(arquivoCriado).toBe(1);
+    expect(leUser).toBe("ana");
+    expect(leVisitas).toBe("3");
+    expect(leLen).toBe(2);
+    expect(leOrdem).toBe("user");
+  });
+
+  test("valor com \\n, \\t e separadores volta byte a byte", () => {
+    expect(voltouHostil).toBe(hostil);
+  });
+
+  test("removeItem e clear persistem", () => {
+    expect(persistidoAposRemove).toBe(1);
+    expect(aChaveSumiu).toBe(null);
+    expect(persistidoAposClear).toBe(0);
+  });
+
+  test("arquivo corrompido não derruba e o storage segue utilizável", () => {
+    expect(corrompidoLen).toBe(0);
+    expect(corrompidoUsavel).toBe("ok");
+  });
+
+  test("arquivo inexistente é um storage vazio", () => {
+    expect(novoLen).toBe(0);
+  });
+});


### PR DESCRIPTION
Sete commits que, juntos, fazem o JS de uma página real **rodar com escopo global compartilhado** — e movem o estado que estava em prelude `.ts` para Rust, no padrão vigente (`rts-macro` declara, `rts-symbol-baker` bakeia).

## O que muda

**1. Escopo global compartilhado entre `<script>`** (`df68be19`)
Num browser todos os `<script>` de um documento falam com UM objeto global. Aqui cada um era uma ilha — um loader definido no script 2 morria com ele. Boot do WhatsApp Web medido: **1 → 32 de 33 scripts**, com o bootstrap da Meta instalado de fato (8 globais publicados: `requireLazy`, `__d`, `_btldr`, `_qplInl`…).

Três mecanismos, todos na borda do DOM — o motor não foi afrouxado:
- `window` persistente por documento + saco de globais compartilhado;
- global implícito (`x = 1` sem declaração) reescrito para `__G.x` — o compilador recusa binding implícito, e com razão; quem tem semântica sloppy é a página;
- duas normalizações de JS minificado (`arguments` → rest, sequência-com-função → statements), ambas verificadas contra o que o motor aceita.

**2. `Node`, `MutationObserver`, `instanceof window.C`** (`ff8afb1e`)
Superfície de browser que derrubava o script inteiro no primeiro uso, levando junto todo o bootstrap. O `instanceof` com objeto global tem uma metade no motor (`binop.rs`) e outra no pré-passo.

**3. `Storage` (Web Storage API) em Rust, persistindo como pickle** (`1cfa29a8`)
`localStorage` sobrevive entre execuções. Formato pickle (não texto) porque guarda estrutura e tipo — um valor com `\n` ou com o separador dentro quebraria um "k=v por linha" — e porque produz um bloco opaco, que é o que se cifra quando a criptografia entrar (o gancho já está isolado em `encode`/`decode`).

**4. `rts-dom` no `SCANNED_CRATES`** (`4e6b62e4`) — **fix de bug que existe na main**
O crate não era escaneado pelo baker, então **306 símbolos** do namespace `rts:dom` nunca entravam na tabela que é a vtable do JIT e o symbol set do AOT. A doutrina é "um símbolo está na tabela porque existe no código"; um crate ausente da lista quebrava isso silenciosamente.

**5. Constantes de `nodeType` para Rust** (`b68c51d3`)
`#[rtse::constant(global = "Node")]`, preservando o acesso como propriedade (a página escreve `Node.ELEMENT_NODE`, não uma chamada).

**6. Saco de globais para Rust** (`93c5de06`)
`rts-dom/src/scriptscope.rs` + Proxy. Duas condições precisavam valer juntas: o valor viaja como `Poly` (com `f64` o round-trip devolve `undefined`; com `Poly` uma função volta chamável), e o handle é capturado léxicamente — repassá-lo como parâmetro corrompe (#1870).

**7. Teto de memória opcional** (`ec29860e`)
`RTS_MAX_RAM_MB=300` faz o processo abortar com mensagem clara em vez de exaurir a máquina. **Desligado por padrão** — sem a variável é só um contador atômico relaxed, nenhuma checagem.

## Verificação

**Suite: 736 arquivos passam / 9 falham**, contra **10 falhas na main** medidas no mesmo binário — sem regressão. Gate verde, baker sem drift (`--check` limpo).

Canário `node_util_parseargs` 5/5, escopo global 9/9, runscripts 5/5, Storage 8/8.

## Ponto que precisa de olhar — não é regressão, mas é dívida

`__bindGlobals` consome **~24 MB de RAM por KB de JS minificado**. Bisseção isolou: corpo cru → 0 MB, `__normalizeScript` → 0 MB, `__bindGlobals` → 79 MB. O pré-passo já existia antes destes commits, então não é regressão — mas qualquer bundle grande derruba o processo. Issue separada com o repro completo.

Foi por isso que o teto de RAM entrou: sem ele, investigar isso trava a máquina.

## Revisão

Vale um olhar em dois pontos sensíveis: `crates/rts-codegen-new/src/front/run/binop.rs` (aceita `<global>.C` no RHS do `instanceof`, e só quando a base não é um local em escopo — base sombreada cai no bail honesto) e o `#[global_allocator]` novo em `src/main.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vzg1hWtBjopctJwqqi4ayX