### PR TITLE
fix(linker): -no-pie no link ELF — AOT smoke do ubuntu voltava a linkar

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -61,6 +61,16 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 
+      # AOT smoke linka ALSA (cpal no runtime archive → `snd_pcm_*`). O runner
+      # traz a lib de runtime (libasound.so.2), mas não o symlink de dev
+      # (libasound.so) que `-lasound` exige; o linker do rts proba o .so.2 por
+      # caminho completo, e o -dev aqui deixa o caso canônico coberto também.
+      # Retry: o apt do runner flakeia (ver cross-runtime.yml).
+      - name: Install ALSA dev (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          for i in 1 2 3; do sudo apt-get update && sudo apt-get install -y libasound2-dev && break || sleep 5; done
+
       # MSVC env must be a job step: env it exports via GITHUB_ENV does not
       # propagate out of a composite action, so the bundled link.exe stays off
       # PATH and build.rs fails to link.

--- a/crates/rts-linker/src/system_linker.rs
+++ b/crates/rts-linker/src/system_linker.rs
@@ -239,6 +239,17 @@ fn build_linker_args(
             args.push("-o".to_string());
             args.push(output_path.display().to_string());
 
+            // AOT objects are non-PIC on Linux (module_aot::make_object_module
+            // deliberately leaves `is_pic` off — same bytes as the JIT), so the
+            // emitted .text carries absolute relocations. Modern clang/gcc
+            // default to PIE, which forbids text relocations ("relocation
+            // against `SYM` in read-only section `.text`" → link failure).
+            // Force a classic non-PIE executable; raw linkers (ld.lld) already
+            // default to ET_EXEC and take no `-no-pie`.
+            if linker.is_compiler_driver() {
+                args.push("-no-pie".to_string());
+            }
+
             // Raw linkers (ld.lld, rust-lld) don't add CRT startup code automatically.
             // Probe system lib paths and prepend crt1.o + crti.o before user objects.
             let syslib_paths = if linker.is_raw_linker() {

--- a/crates/rts-linker/src/system_linker.rs
+++ b/crates/rts-linker/src/system_linker.rs
@@ -311,6 +311,24 @@ fn build_linker_args(
             args.push("-lm".to_string());
             args.push("-lpthread".to_string());
             args.push("-ldl".to_string());
+            // cpal (áudio, sempre no runtime archive) referencia ALSA
+            // (`snd_pcm_*`). `-lasound` só resolve com o pacote -dev instalado
+            // (dono do symlink `libasound.so`); a lib de RUNTIME
+            // (`libasound.so.2`) está em quase toda máquina — mesma situação do
+            // libgcc_s.so.1 abaixo. Proba as duas formas em todos os diretórios
+            // de sistema e passa o caminho versionado quando só ele existe.
+            {
+                let asound_dirs = elf_sysroot_lib_paths(&target.triple);
+                if asound_dirs.iter().any(|p| p.join("libasound.so").is_file()) {
+                    args.push("-lasound".to_string());
+                } else if let Some(so2) = asound_dirs
+                    .iter()
+                    .map(|p| p.join("libasound.so.2"))
+                    .find(|p| p.is_file())
+                {
+                    args.push(so2.display().to_string());
+                }
+            }
             if !syslib_paths.is_empty() {
                 args.push("-lc".to_string());
                 // libgcc_s provides stack unwinding; only link if present on this


### PR DESCRIPTION
## Problema

O job **build (ubuntu-latest)** do Build Artifacts falha na main (run do commit b3425210) e em todo PR, no smoke AOT:

```
/usr/bin/ld: smoke_aot.o: warning: relocation against `__RTS_FN_NS_DOM_QUERY_SELECTOR_ALL_AT' in read-only section `.text'
clang: error: linker command failed with exit code 1
```

## Causa

`module_aot::make_object_module` deixa `is_pic` desligado no Linux **de propósito** (mesmos bytes do JIT — pré-requisito do replay do manifest bakeado). O objeto sai com relocations absolutas em `.text`. Só que clang/gcc modernos linkam **PIE por padrão**, e PIE proíbe text relocations → o link morre. Windows (COFF, sem PIE) e macOS (`is_pic` ligado) não são afetados — por isso só o ubuntu quebrava.

## Fix

`-no-pie` no ramo ELF do system_linker quando o linker é compiler driver (clang/gcc). Raw linkers (ld.lld/rust-lld) já produzem ET_EXEC por padrão e não recebem a flag.

## Validação

Não há como linkar ELF no host Windows — a validação é o próprio job **build (ubuntu-latest)** deste PR, que executa exatamente o smoke que falhava (`rts compile bench/pi_machin.ts` + rodar o binário).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017k43FcCXn8a1zqWfDmJAWr