### PR TITLE
fix(engine): catch(e) escopado ao bloco + self-name de fn-expr respeita sombra — WhatsApp 33/33

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -1313,9 +1313,14 @@ impl Ctx {
         }
         // Bind a NAMED fn-expression's self-name: internal references become
         // references to the synthesized top-level name (registered below), so
-        // they are neither free nor captures.
+        // they are neither free nor captures. A body-declared binding with the
+        // SAME name shadows the self-name (`function t(e){ var t; t = e; … }` —
+        // `var` re-declares it for the whole function scope, a minified-bundle
+        // staple): every internal reference is then the local, and renaming it
+        // turned `t = e` into an assignment to the synthesized name
+        // ("assignment to unbound `__rtsn_arrow_N`").
         if let Some(sn) = &self_name {
-            if !param_names.contains(sn) {
+            if !param_names.contains(sn) && !declared_locals(&body_stmts).contains(sn) {
                 rename_ident_stmts(&mut body_stmts, sn, &name);
             }
         }

--- a/crates/rts-codegen-new/src/front/run/trycatch.rs
+++ b/crates/rts-codegen-new/src/front/run/trycatch.rs
@@ -286,9 +286,39 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // shape slots by key for a `.ts` Error and reads `undefined` for a
             // non-object throw — both JS-correct. `e instanceof Error` resolves via
             // the normal user-class dynamic-instanceof (Error is a prelude class).
+            //
+            // The binding is scoped to the CATCH BLOCK (spec): save whatever the
+            // name meant before and restore it after the handler. Leaving it in
+            // `locals` shadowed a same-named outer function for the REST of the
+            // enclosing body — `function e(..){..} … try{..}catch(e){..} e(x)`
+            // died with "not a function" (real minified-bundle pattern: helpers
+            // named `e`/`t` + `catch(e)`).
+            let saved_local = self.locals.get(name.as_str()).cloned();
+            let saved_shape = self.local_shapes.get(name.as_str()).cloned();
+            let saved_class = self.local_classes.get(name.as_str()).cloned();
+            let saved_obj = self.object_locals.contains(name.as_str());
             self.bind_catch_local(name, word);
+            self.lower_block(module, &handler.body)?;
+            match saved_local {
+                Some(l) => {
+                    self.locals.insert(name.clone(), l);
+                }
+                None => {
+                    self.locals.remove(name.as_str());
+                }
+            }
+            if let Some(s) = saved_shape {
+                self.local_shapes.insert(name.clone(), s);
+            }
+            if let Some(c) = saved_class {
+                self.local_classes.insert(name.clone(), c);
+            }
+            if saved_obj {
+                self.object_locals.insert(name.clone());
+            }
+        } else {
+            self.lower_block(module, &handler.body)?;
         }
-        self.lower_block(module, &handler.body)?;
         if !self.block_terminated {
             self.builder.ins().jump(next, &[]);
         }

--- a/examples/claude-browser.ts
+++ b/examples/claude-browser.ts
@@ -71,14 +71,9 @@ function resolveUrl(base: string, href: string): string {
 function extractSite(rawHtml: string, pageUrl: string): string {
   const site = dom.parseHtml(rawHtml);
   let styles = "";
-  // 1) <style> inline.
+  // 1) <style> inline: contados só para o log — as tags ficam onde estão, dentro
+  //    do head/body preservados abaixo (mover mudaria a cascade; duplicar, pior).
   const sc = dom.querySelectorAllCount(site, "style");
-  let i = 0;
-  while (i < sc) {
-    const s = dom.querySelectorAllAt(site, "style", i);
-    styles = styles + "<style>" + dom.getText(site, s) + "</style>";
-    i = i + 1;
-  }
   // 2) <link rel=stylesheet> → baixa o CSS e injeta como <style>.
   const lc = dom.querySelectorAllCount(site, "link");
   let cssCount = 0;
@@ -103,14 +98,13 @@ function extractSite(rawHtml: string, pageUrl: string): string {
   // 3) <script>: preserva o FONTE para o runScripts executar depois do parse da
   //    página montada. Três origens:
   //      • inline — o texto do próprio nó;
-  //      • `src="data:...;base64,…"` — DECODIFICADO aqui. Não é caso de nicho:
-  //        WhatsApp/Meta embutem quase todo o bootstrap assim (numa carga real,
-  //        33 dos 42 `<script src>` são data-URI), então ignorá-los era descartar
-  //        o loader inteiro da página;
+  //      • `src="data:...;base64,…"` — a tag passa INTACTA (o motor decodifica
+  //        ao executar). Não é caso de nicho: WhatsApp/Meta embutem quase todo o
+  //        bootstrap assim (numa carga real, 33 dos 42 `<script src>` são
+  //        data-URI), então ignorá-los era descartar o loader da página;
   //      • `src="http(s)://…"` — ainda NÃO baixado. São os bundles de aplicação
   //        (no WhatsApp, 9 arquivos somando ~15 MB); já compilam sem estourar
   //        memória, mas cada um leva segundos, o que travaria o load da janela.
-  let scripts = "";
   const scc = dom.querySelectorAllCount(site, "script");
   let k = 0;
   let inlineCount = 0;
@@ -119,42 +113,28 @@ function extractSite(rawHtml: string, pageUrl: string): string {
   while (k < scc) {
     const s = dom.querySelectorAllAt(site, "script", k);
     const src = dom.getAttribute(site, s, "src");
-    const stype = dom.getAttribute(site, s, "type").toLowerCase();
-    // `type="application/json"` e afins são DADOS, não código — executá-los
-    // gerava erro de sintaxe em massa.
-    const isJs = stype.length === 0 || stype === "text/javascript"
-      || stype === "application/javascript" || stype === "module"
-      || stype === "application/x-javascript" || stype === "text/ecmascript";
-    if (src.length > 5 && src.substring(0, 5) === "data:") {
-      const comma = src.indexOf(",");
-      if (comma >= 0) {
-        const meta = src.substring(0, comma);
-        const payload = src.substring(comma + 1);
-        const code = meta.indexOf("base64") >= 0 ? atob(payload) : decodeURIComponent(payload);
-        if (code.length > 0) {
-          scripts = scripts + "<script>" + code + "</script>";
-          dataCount = dataCount + 1;
-          
-        }
-      }
-    } else if (src.length > 0) {
-      extCount = extCount + 1;
-    } else if (isJs) {
-      const code = dom.getText(site, s);
-      if (code.length > 0) {
-        scripts = scripts + "<script>" + code + "</script>";
-        inlineCount = inlineCount + 1;
-      }
-    }
+    if (src.length > 5 && src.substring(0, 5) === "data:") dataCount = dataCount + 1;
+    else if (src.length > 0) extCount = extCount + 1;
+    else if (dom.getText(site, s).length > 0) inlineCount = inlineCount + 1;
     k = k + 1;
   }
   if (extCount > 0) io.print("[js] " + extCount + " <script src=http> nao baixados (bundles de aplicacao)");
-  // 4) innerHTML do body.
+  // 4) head + body na ORDEM ORIGINAL, com os <script> onde o autor os pôs. Duas
+  //    lições de uma carga real do WhatsApp aqui:
+  //      • re-embutir código decodificado como <script> inline estilhaça a
+  //        página (JS minificado tem `<`, `&`, `</script>` em strings — o parser
+  //        HTML corta no primeiro `</script>`); as tags `src=data:` ficam
+  //        intactas e o `__runScriptAt` do motor decodifica ao executar;
+  //      • mover os scripts para o fim REORDENA: o loader (`requireLazy`) mora
+  //        no <head> e os 25 chamadores no <body> — com o head atrás, todos
+  //        falhavam com "call to unknown function `requireLazy`".
+  const headEl = dom.querySelector(site, "head");
+  const headInner = headEl >= 0 ? dom.innerHtml(site, headEl) : "";
   const body = dom.querySelector(site, "body");
   const inner = body >= 0 ? dom.innerHtml(site, body) : rawHtml;
   io.print("[site] styles_inline=" + sc + " css_baixados=" + cssCount + " scripts_inline=" + inlineCount + " scripts_data=" + dataCount + " body=" + inner.length + "B");
   dom.free(site);
-  return styles + inner + scripts;
+  return styles + headInner + inner;
 }
 
 // Percorre os <img> do doc já montado, baixa cada src (binário) + decodifica +
@@ -335,6 +315,8 @@ while (egui.isOpen(win) !== 0) {
       // companhia). Lido via `docF._dom`, NUNCA pelo `d` solto: handle passado
       // como valor entre chamadas corrompe (#1870) e o contador vem 0.
       io.print("[js] globais da pagina: " + DomScope.count(docF._dom));
+      let __gi = 0;
+      while (__gi < DomScope.count(docF._dom)) { io.print("   g: " + DomScope.nameAt(docF._dom, __gi)); __gi = __gi + 1; }
       io.print("[js] scripts executados: " + njs);
     } else if (st < 0) {
       pendingTicket = 0; // ticket inválido: aborta

--- a/tests/claude-catch-binding-scope.test.ts
+++ b/tests/claude-catch-binding-scope.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "rts:test";
+
+// O binding do `catch (e)` é escopado ao BLOCO do catch (spec) — não pode vazar
+// e sombrear um nome externo pelo resto do corpo.
+//
+// O bug: `bind_catch_local` (trycatch.rs) inseria o nome em `locals` e nunca
+// restaurava. Depois do try/catch, `e` continuava sendo o local Tagged do catch
+// — e uma FUNÇÃO externa chamada `e` virava "TypeError: not a function" na
+// primeira chamada após o bloco.
+//
+// Não é caso teórico: bundle minificado da Meta (bootstrap do WhatsApp Web)
+// nomeia helpers de `e`/`t`/`n` e usa `catch(e){return}` na mesma função — o
+// padrão exato `function e(..){..} function r(r){ try{..}catch(e){..} e(r) }`.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level (regra do
+// projeto: método dentro de test() pode perder handle pro GC).
+
+// ── função externa `e` + catch(e) na mesma função ──────────────────────────
+function e(x: any): number { return x * 2; }
+function usaDepoisDoCatch(y: number): number {
+  try { y = y + 1; } catch (e) { return 0; }
+  return e(y); // precisa resolver a FUNÇÃO e, não o binding morto do catch
+}
+const depoisDoCatch = usaDepoisDoCatch(5);
+
+// ── o catch ainda captura o erro normalmente ───────────────────────────────
+let msgPega = "";
+try { throw new Error("boom"); } catch (e) { msgPega = e.message; }
+
+// ── com throw REAL no try, o caminho pós-catch também restaura ─────────────
+function comThrow(): number {
+  let marca = 0;
+  try { throw new Error("x"); } catch (e) { marca = 1; }
+  return marca + e(10); // e() de novo a função externa
+}
+const comThrowV = comThrow();
+
+// ── variável externa sombreada pelo catch volta a ser visível ──────────────
+function varExterna(): string {
+  const s = "fora";
+  try { throw new Error("dentro"); } catch (s) { /* sombra só aqui */ }
+  return s;
+}
+const varExternaV = varExterna();
+
+// ── catches ANINHADOS: cada nível restaura o de fora ───────────────────────
+function aninhado(): string {
+  let out = "";
+  try {
+    throw new Error("a");
+  } catch (e) {
+    try { throw new Error("b"); } catch (e) { out = out + e.message; }
+    out = out + e.message; // o `e` de FORA voltou
+  }
+  return out;
+}
+const aninhadoV = aninhado();
+
+// ── catch SEM binding continua funcionando ─────────────────────────────────
+function semBinding(): number {
+  try { throw new Error("x"); } catch { return 7; }
+  return 0;
+}
+const semBindingV = semBinding();
+
+describe("catch(e) é escopado ao bloco do catch", () => {
+  test("função externa `e` volta a resolver depois do catch", () => {
+    expect(depoisDoCatch).toBe(12);
+  });
+
+  test("o catch ainda captura o erro", () => {
+    expect(msgPega).toBe("boom");
+  });
+
+  test("com throw real, o pós-catch também restaura", () => {
+    expect(comThrowV).toBe(21);
+  });
+
+  test("variável externa sombreada volta", () => {
+    expect(varExternaV).toBe("fora");
+  });
+
+  test("catches aninhados restauram nível a nível", () => {
+    expect(aninhadoV).toBe("ba");
+  });
+
+  test("catch sem binding segue ok", () => {
+    expect(semBindingV).toBe(7);
+  });
+});

--- a/tests/claude-fnexpr-selfname-shadow.test.ts
+++ b/tests/claude-fnexpr-selfname-shadow.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "rts:test";
+
+// Fn-expression NOMEADA cujo corpo re-declara o PRÓPRIO nome: o `var`/`let`
+// local sombreia o self-name para a função inteira, então toda referência
+// interna é ao local — não à função.
+//
+// O bug: o lifter (`funcval::try_extract`) renomeava o self-name para o nome
+// sintetizado (`__rtsn_arrow_N`) em TODO o corpo, sem respeitar a sombra. Um
+// `t = e` interno virava atribuição ao nome liftado → "assignment to unbound
+// `__rtsn_arrow_N`", e o script inteiro morria na compilação.
+//
+// Padrão real: bundle minificado da Meta (bootstrap do WhatsApp Web) —
+// `function t(e){var t; … ((t=n(e))==null?void 0:t.asyncCss)}` aninhada em
+// IIFE. Minificadores reciclam nomes de 1 letra o tempo todo.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+// ── aninhada: var sombreia o self-name e recebe atribuição ─────────────────
+function externa1(): number {
+  function t(e: any): any { var t; t = e; return t; }
+  return t(7);
+}
+const sombraVar = externa1();
+
+// ── a forma exata do bundle: atribuição DENTRO de expressão ────────────────
+function externa2(): any {
+  function t(e: any): any {
+    var t;
+    return (t = e) == null ? undefined : t.tag;
+  }
+  return t({ tag: "ok" });
+}
+const sombraExpr = externa2();
+
+// ── sombra com inicializador ───────────────────────────────────────────────
+function externa3(): number {
+  const g = function t(e: number): number { var t = 0; t = e * 2; return t; };
+  return g(21);
+}
+const sombraInit = externa3();
+
+// ── SEM sombra, o self-name segue amarrando recursão ───────────────────────
+const fat = function fact(n: number): number { return n < 2 ? 1 : n * fact(n - 1); };
+const recursao = fat(5);
+
+describe("self-name de fn-expr sombreado por var local", () => {
+  test("var t; t = e dentro de function t", () => {
+    expect(sombraVar).toBe(7);
+  });
+
+  test("atribuição ao shadow dentro de expressão (padrão minificado)", () => {
+    expect(sombraExpr).toBe("ok");
+  });
+
+  test("shadow com inicializador", () => {
+    expect(sombraInit).toBe(42);
+  });
+
+  test("sem sombra, recursão pelo self-name continua", () => {
+    expect(recursao).toBe(120);
+  });
+});


### PR DESCRIPTION
## O que muda

Dois bugs de motor, achados rodando o **bootstrap real do WhatsApp Web** (bundle minificado da Meta) e isolados por bisseção binária:

### 1. `catch (e)` vazava o binding (trycatch.rs)

`bind_catch_local` inseria o nome em `locals` e nunca restaurava — depois do try/catch, uma função externa chamada `e` virava `TypeError: not a function`:

```ts
function e(x) { return x * 2 }
function r(y) {
  try { y = y + 1 } catch (e) { return 0 }
  return e(y)   // Node: 12 · RTS antes: TypeError
}
```

A spec escopa o binding ao bloco do catch. Fix: salvar/restaurar `locals`/`local_shapes`/`local_classes`/`object_locals` do nome ao redor do handler.

### 2. Self-name de fn-expr renomeado sob sombra (funcval)

`function t(e){ var t; t = e; … }` aninhada — o lifter renomeava o self-name para `__rtsn_arrow_N` no corpo inteiro sem respeitar o `var t` local → `assignment to unbound __rtsn_arrow_N` e o script morria na compilação. Fix: guarda com `declared_locals`. O caso top-level passa por outro pipeline e segue quebrado — #2030 (pré-existente).

Ambos são padrão de minificador (helpers de 1 letra `e`/`t`/`n` + `catch(e)` na mesma função).

### Browser (examples/claude-browser.ts)

- `src="data:...;base64"` passa **intacto** (re-embutir código decodificado como `<script>` inline estilhaça no parser HTML — JS minificado tem `<`/`&`/`</script>` em strings);
- head+body preservam a **ordem** original (mover scripts pro fim punha o loader `requireLazy` do head atrás dos 25 chamadores do body).

## Resultado

WhatsApp Web: **33/33 scripts executados, zero erros** (antes: 32/33 + 26 erros), 8 globais publicados (`requireLazy` incluso).

## Validação

- Suite TS completa: **752/752 arquivos, 2669/2669 testes, zero regressão**
- Testes novos: `claude-catch-binding-scope.test.ts` (6) + `claude-fnexpr-selfname-shadow.test.ts` (4)
- `read_before_commit.sh` sem violação hard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017k43FcCXn8a1zqWfDmJAWr