### PR TITLE
fix(engine): `new RegExp(re)` copia source/flags + ctor de string coage o argumento

### DIFF
--- a/crates/rts-codegen-new/src/front/run/globalclass.rs
+++ b/crates/rts-codegen-new/src/front/run/globalclass.rs
@@ -151,28 +151,34 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok((Val::tagged_kind(word, JsKind::Object), class.to_string()))
     }
 
-    /// `new RegExp(pattern[, flags])` — both args must be proven strings (a regex
-    /// from a non-string pattern is a later increment). Interns nothing extra: the
-    /// pattern/flags string PolyValue words go straight to `__rtsadp_re_compile`.
-    /// Returns the boxed `TAG_OBJECT` RegExp instance word.
+    /// `new RegExp(pattern[, flags])`. Um argumento que NÃO é string provada é
+    /// coagido em runtime (`__rtsadp_to_string`) — que é exatamente o que a spec
+    /// manda: `new RegExp(x)` faz `ToString(x)`, e para uma RegExp isso devolve
+    /// o `source` dela, então a cópia `new RegExp(/a/)` cai naturalmente no
+    /// mesmo caminho. Antes isso era um bail ("a later increment") e derrubava
+    /// scripts reais de página: bundles minificados constroem regex a partir de
+    /// variável o tempo todo.
+    ///
+    /// Retorna a word `TAG_OBJECT` da instância RegExp.
     fn emit_regex_ctor(&mut self, module: &mut dyn Module, args: &[HirExpr]) -> FrontResult<Value> {
         if args.is_empty() || args.len() > 2 {
             return unsupported!("`new RegExp(..)` expects 1 or 2 args, got {}", args.len());
         }
+        // O pattern vai CRU para o runtime: se for outra RegExp, `re_compile`
+        // copia o `source`/`flags` dela (a spec manda isso, e `ToString(re)`
+        // devolveria `/ab+c/` COM as barras — a cópia deixaria de casar o que a
+        // original casa). Qualquer outro não-string é coagido lá também.
         let pat = self.lower_expr(module, &args[0])?;
-        if !matches!(pat.kind, JsKind::Str) {
-            return unsupported!(
-                "`new RegExp(pattern)` with a non-string pattern (a regex-from-regex \
-                 copy / coercion is a later increment)"
-            );
-        }
         let pat_word = self.box_value(pat);
         let flags_word = if args.len() == 2 {
             let f = self.lower_expr(module, &args[1])?;
-            if !matches!(f.kind, JsKind::Str) {
-                return unsupported!("`new RegExp(pattern, flags)` with a non-string flags arg");
+            let f_boxed = self.box_value(f);
+            if matches!(f.kind, JsKind::Str) {
+                f_boxed
+            } else {
+                self.call_runtime(module, "__rtsadp_to_string", &[f_boxed])?
+                    .expect("to_string returns a value")
             }
-            self.box_value(f)
         } else {
             self.emit_str_const_word(module, "")?
         };

--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -112,11 +112,19 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             };
             call
         };
-        // A `StrPtr` param fed a non-proven-string BAILS (the marshal would
-        // ToString-coerce — a behavior change we refuse; same rule as the statics).
-        for (i, v) in vals.iter().enumerate() {
-            if matches!(call.arg_abis[i], AbiType::StrPtr) && !matches!(v.kind, JsKind::Str) {
-                return unsupported!("`new {class}(..)` — argument {i} is not a proven string");
+        // Um param `StrPtr` alimentado com não-string é COAGIDO explicitamente
+        // (`__rtsadp_to_string`), que é o que a spec desses construtores manda:
+        // `new URL(x)` faz `ToString(x)`. Antes isto bailava por medo de que o
+        // marshal coagisse por baixo dos panos — mas coagir DE PROPÓSITO, no
+        // lugar visível, não é mudança de comportamento: é a semântica. O bail
+        // custava scripts reais de página, onde a URL quase nunca é literal.
+        for i in 0..vals.len() {
+            if matches!(call.arg_abis[i], AbiType::StrPtr) && !matches!(vals[i].kind, JsKind::Str) {
+                let boxed = self.box_value(vals[i]);
+                let coagido = self
+                    .call_runtime(module, "__rtsadp_to_string", &[boxed])?
+                    .expect("to_string returns a value");
+                vals[i] = Val::tagged_kind(coagido, JsKind::Str);
             }
         }
         // Pad the omitted tail with the chosen ctor's spec defaults.

--- a/crates/rts-runtime/src/adapters/value/regexops.rs
+++ b/crates/rts-runtime/src/adapters/value/regexops.rs
@@ -89,6 +89,42 @@ fn handle_str(h: u64) -> String {
 /// `.test` on it simply never matches (the runtime's `with_engine` default).
 #[rtse::abi]
 pub fn rtsadp_re_compile(pat_word: u64, flags_word: u64) -> u64 {
+    // `new RegExp(re)` — cópia a partir de outra RegExp. A spec manda usar o
+    // `source`/`flags` DELA, não `ToString(re)`: este devolve `/ab+c/` COM as
+    // barras, e compilar isso produz uma regex que casa o texto literal "/ab+c/"
+    // (a cópia deixava de casar o que a original casava, sem erro nenhum).
+    // Flags explícitas no 2º argumento vencem as da original, como na spec.
+    if PolyValue::from_raw(pat_word).is_object() {
+        let orig = unbox_re(pat_word);
+        let src_h = rt_regexp::__RTS_FN_GL_REGEXP_SOURCE(orig);
+        if src_h != 0 {
+            let src = handle_str(src_h);
+            let explicit = handle_str(str_handle(flags_word));
+            let flags = if explicit.is_empty() {
+                let fh = rt_regexp::__RTS_FN_GL_REGEXP_FLAGS(orig);
+                if fh == 0 {
+                    String::new()
+                } else {
+                    handle_str(fh).to_string()
+                }
+            } else {
+                explicit.to_string()
+            };
+            let h = rt_re::__RTS_FN_NS_REGEX_COMPILE(
+                src.as_ptr(),
+                src.len() as i64,
+                flags.as_ptr(),
+                flags.len() as i64,
+            );
+            return box_re(h);
+        }
+    }
+    // Não-string que não é RegExp (número, bool…): coage aqui, como a spec.
+    let pat_word = if PolyValue::from_raw(pat_word).is_string() {
+        pat_word
+    } else {
+        genops::__rtsadp_to_string(pat_word)
+    };
     let pat = handle_str(str_handle(pat_word));
     let flags = handle_str(str_handle(flags_word));
     let h = rt_re::__RTS_FN_NS_REGEX_COMPILE(

--- a/tests/claude-ctor-coercao-string.test.ts
+++ b/tests/claude-ctor-coercao-string.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "rts:test";
+
+// Construtor de classe do Registry cujo parâmetro é string (`new URL(x)`,
+// `new TextDecoder(x)`, …) alimentado com algo que NÃO é string literal.
+//
+// Antes bailava — "argument 0 is not a proven string" — por receio de que o
+// marshal coagisse por baixo dos panos. Mas a spec desses construtores MANDA
+// `ToString(x)`, então coagir DE PROPÓSITO, no lugar visível, é a semântica, não
+// uma mudança de comportamento. O bail custava scripts reais de página, onde a
+// URL quase nunca é literal (vem de concatenação, de variável, de campo).
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+// ── concatenação ───────────────────────────────────────────────────────────
+const base = "https://exemplo.com";
+const porConcat = new URL(base + "/caminho");
+const concatPath = porConcat.pathname;
+const concatHost = porConcat.hostname;
+
+// ── variável simples ───────────────────────────────────────────────────────
+const texto = "https://outro.org/a/b?q=1";
+const porVar = new URL(texto);
+const varPath = porVar.pathname;
+const varQuery = porVar.search;
+
+// ── campo de objeto ────────────────────────────────────────────────────────
+const cfg: any = { endpoint: "https://api.dev/v1" };
+const porCampo = new URL(cfg.endpoint);
+const campoPath = porCampo.pathname;
+
+// ── retorno de função ──────────────────────────────────────────────────────
+function monta(): string { return "https://fn.io/z"; }
+const porFn = new URL(monta());
+const fnPath = porFn.pathname;
+
+// ── literal continua funcionando (não pode regredir) ───────────────────────
+const literal = new URL("https://lit.com/x");
+const litPath = literal.pathname;
+
+describe("construtor com parâmetro string coage o argumento", () => {
+  test("concatenação", () => {
+    expect(concatPath).toBe("/caminho");
+    expect(concatHost).toBe("exemplo.com");
+  });
+
+  test("variável", () => {
+    expect(varPath).toBe("/a/b");
+    expect(varQuery).toBe("?q=1");
+  });
+
+  test("campo de objeto", () => {
+    expect(campoPath).toBe("/v1");
+  });
+
+  test("retorno de função", () => {
+    expect(fnPath).toBe("/z");
+  });
+
+  test("literal não regrediu", () => {
+    expect(litPath).toBe("/x");
+  });
+});

--- a/tests/claude-regexp-copia.test.ts
+++ b/tests/claude-regexp-copia.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "rts:test";
+
+// `new RegExp(x)` com `x` que NÃO é string literal.
+//
+// Antes era um bail explícito ("a regex-from-regex copy / coercion is a later
+// increment") e derrubava scripts reais de página: bundle minificado constrói
+// regex a partir de variável o tempo todo.
+//
+// A armadilha, e o motivo deste teste existir: coagir com `ToString(re)` PARECE
+// certo e está errado — devolve `/ab+c/` COM as barras, e compilar isso produz
+// uma regex que casa o texto literal "/ab+c/". A cópia deixaria de casar o que a
+// original casa, SEM erro nenhum. A spec manda usar o `source`/`flags` da
+// original, que é o que `re_compile` faz agora.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level (regra do
+// projeto: método dentro de test() pode perder handle pro GC).
+
+// ── cópia de uma RegExp: tem de casar o que a original casa ────────────────
+const orig = /ab+c/;
+const copia = new RegExp(orig);
+const copiaCasa = copia.test("abbc");
+const copiaNaoCasa = copia.test("axc");
+const copiaSource = copia.source;
+
+// ── flags são HERDADAS da original quando não há 2º argumento ──────────────
+const comFlags = /x/gi;
+const copiaFlags = new RegExp(comFlags);
+const herdouSource = copiaFlags.source;
+const herdouFlags = copiaFlags.flags;
+
+// ── flags EXPLÍCITAS vencem as da original (spec) ──────────────────────────
+const sobrescreve = new RegExp(/a/i, "g");
+const sobrescreveSource = sobrescreve.source;
+const sobrescreveFlags = sobrescreve.flags;
+
+// ── pattern vindo de VARIÁVEL string (o caso comum em bundle) ──────────────
+const pat = "a.c";
+const deVar = new RegExp(pat);
+const deVarCasa = deVar.test("axc");
+
+// ── string literal continua funcionando (não pode regredir) ────────────────
+const literal = new RegExp("a", "g");
+const literalSource = literal.source;
+const literalFlags = literal.flags;
+
+// ── flags vindas de variável ───────────────────────────────────────────────
+const fl = "gi";
+const flagsDeVar = new RegExp("x", fl);
+const flagsDeVarFlags = flagsDeVar.flags;
+
+describe("new RegExp com pattern não-literal", () => {
+  test("cópia de RegExp casa o que a original casa", () => {
+    expect(copiaCasa).toBe(true);
+    expect(copiaNaoCasa).toBe(false);
+    expect(copiaSource).toBe("ab+c");
+  });
+
+  test("flags são herdadas da original", () => {
+    expect(herdouSource).toBe("x");
+    expect(herdouFlags).toBe("gi");
+  });
+
+  test("flags explícitas vencem as da original", () => {
+    expect(sobrescreveSource).toBe("a");
+    expect(sobrescreveFlags).toBe("g");
+  });
+
+  test("pattern vindo de variável string", () => {
+    expect(deVarCasa).toBe(true);
+  });
+
+  test("string literal não regrediu", () => {
+    expect(literalSource).toBe("a");
+    expect(literalFlags).toBe("g");
+  });
+
+  test("flags vindas de variável", () => {
+    expect(flagsDeVarFlags).toBe("gi");
+  });
+});


### PR DESCRIPTION
Dois bails que derrubavam scripts reais de página, ambos onde a spec já diz o que fazer — o motor é que recusava por precaução.

## 1. `new RegExp(x)` com pattern não-literal

Bailava com *"a regex-from-regex copy / coercion is a later increment"*. Bundle minificado constrói regex a partir de variável o tempo todo.

**A armadilha:** coagir com `ToString(re)` *parece* certo e está **errado** — devolve `/ab+c/` **com as barras**, e compilar isso produz uma regex que casa o texto literal `"/ab+c/"`. A cópia deixaria de casar o que a original casa, **sem erro nenhum**. A spec manda usar o `source`/`flags` da original; flags explícitas no 2º argumento vencem as dela.

```js
new RegExp(/ab+c/).test("abbc")   // antes: bail  ·  ToString ingênuo: false  ·  agora: true
new RegExp(/x/gi).flags           // "gi" (herda)
new RegExp(/a/i, "g").flags       // "g"  (explícita vence)
```

## 2. Construtor do Registry com parâmetro string

`new URL(x)` bailava com *"argument 0 is not a proven string"*, por receio de que o marshal coagisse por baixo dos panos. Mas `new URL(x)` **faz `ToString(x)` por spec** — coagir de propósito, no sítio visível, é a semântica, não uma mudança de comportamento. A URL de uma página quase nunca é literal (vem de concatenação, variável, campo).

## Efeito

`new RegExp`, `new URL` e `Object.assign` somem da lista de erros da carga do WhatsApp Web. O que resta são **8 gaps pontuais e nomeados** (generators `function*`, `Object.assign` lido como *valor* e não chamado, receiver de shape dinâmico) — não mais um bloqueio sistemático do pré-passo.

## Validação

- Testes novos: `claude-regexp-copia.test.ts` (6) e `claude-ctor-coercao-string.test.ts` (5), com os casos-armadilha explícitos
- Suite: **756/757 arquivos, 2693/2694 testes**. A única falha (`wrapper_class_toprimitive`) passa isolada 22/22 — pré-existente
- Gate sem violação hard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017k43FcCXn8a1zqWfDmJAWr