### PR TITLE
fix(engine): iterador de generator sobrevive a qualquer borda dinâmica

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call_spread.rs
+++ b/crates/rts-codegen-new/src/front/run/call_spread.rs
@@ -136,6 +136,25 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let call = self.builder.ins().call(func_ref, lowered);
 
         let result = match sig.ret {
+            // A LAZY generator ctor returns the `Entry::GenState` HANDLE in a raw
+            // `Repr::Int64`. `Val::new` would stamp it `JsKind::Number` (repr says
+            // "int"), and boxing a number converts it with `fcvt_from_sint` — the
+            // handle becomes an ordinary double and every dynamic consumer loses the
+            // generator identity, so `it.next()` reads `undefined` once the value
+            // crosses ANY boundary (array/object/arg/field/Map). Box it HERE as a
+            // TAG_OBJECT word — the shape `try_generator_dyn`/`to_iter_array` detect
+            // via `Entry::GenState` — so the identity survives all of them at once.
+            // The static paths that want the bare handle re-derive it by coercion
+            // (`generator_receiver_handle`). Issue #2042.
+            Some(_) if sig.ret_lazy_gen => {
+                let v = self.builder.inst_results(call)[0];
+                let word = crate::value::emit_marshal::emit_box_object_handle(
+                    module,
+                    self.builder,
+                    v,
+                );
+                Val::new_with_kind(word, Repr::Tagged, JsKind::GenHandle)
+            }
             Some(ret) => {
                 let v = self.builder.inst_results(call)[0];
                 Val::new(v, ret)

--- a/crates/rts-codegen-new/src/front/run/loops.rs
+++ b/crates/rts-codegen-new/src/front/run/loops.rs
@@ -327,7 +327,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // DRAIN returns the RAW Vec handle; rebox it as a TAG_OBJECT array
             // word (the spread-append consumer reads a word — a raw id there
             // appended nothing).
-            let handle = self.coerce(res, Repr::Int64)?;
+            let handle = self.gen_state_handle(module, res)?;
             let arr = self
                 .call_runtime(module, "__rtsn_gen_sm_drain", &[handle])?
                 .expect("GEN_SM_DRAIN returns a Vec handle");
@@ -367,7 +367,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // The GenState handle rides a raw `Int64`; pass it verbatim to DRAIN.
         // DRAIN returns the RAW Vec handle → rebox as a TAG_OBJECT array word
         // (spread-append / element reads consume a word).
-        let handle = self.coerce(h, Repr::Int64)?;
+        let handle = self.gen_state_handle(module, h)?;
         let arr = self
             .call_runtime(module, "__rtsn_gen_sm_drain", &[handle])?
             .expect("GEN_SM_DRAIN returns a Vec handle");

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -75,6 +75,15 @@ pub(crate) enum JsKind {
     Object,
     /// Not statically provable (a Tagged value from a variable/call/etc.).
     Unknown,
+    /// An OPAQUE runtime handle carried in `Repr::Int64` — the `Entry::GenState` of
+    /// a LAZY generator (`sig.ret_lazy_gen`). It is NOT a number: boxing it with the
+    /// `Repr::Int64` default (`fcvt_from_sint` → double) turns the handle into an
+    /// ordinary f64 and every dynamic consumer loses the generator identity, so
+    /// `it.next()` silently reads `undefined` after the value crosses ANY dynamic
+    /// boundary (array/object/arg/field/Map). Boxed as a `TAG_OBJECT` word instead —
+    /// the shape `try_generator_dyn` / `to_iter_array` detect via `Entry::GenState`
+    /// (issue #2042).
+    GenHandle,
 }
 
 /// An SSA value tagged with the representation it carries + a static kind hint.

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -429,6 +429,28 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
     }
 
+    /// The bare `Entry::GenState` handle behind a LAZY-generator value. Since #2042
+    /// such a value rides as a `TAG_OBJECT` PolyValue word (so its identity survives
+    /// array/object/arg/field/Map), so the handle is recovered from the word exactly
+    /// as an array word's is. A value still carried in a raw `Int64` (a path that
+    /// produces the handle directly) rides verbatim.
+    pub(super) fn gen_state_handle(
+        &mut self,
+        module: &mut dyn Module,
+        v: crate::front::run::lower::Val,
+    ) -> FrontResult<cranelift_codegen::ir::Value> {
+        if v.repr == Repr::Tagged {
+            let word = self.box_value(v);
+            Ok(crate::value::emit_marshal::emit_table_load(
+                module,
+                self.builder,
+                word,
+            ))
+        } else {
+            self.coerce(v, Repr::Int64)
+        }
+    }
+
     /// The runtime GenState/Vec handle of a GENERATOR-valued receiver (a generator
     /// local, or a direct `g()` call), for `GENERATOR_NEXT`/`RETURN`/`THROW`. EAGER
     /// (`__gen_buf` array word) → its real Vec handle (`POLY_TO_HANDLE`); LAZY (raw
@@ -451,7 +473,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         };
         let v = self.lower_expr(module, recv)?;
         let handle = if is_lazy {
-            self.coerce(v, Repr::Int64)?
+            self.gen_state_handle(module, v)?
         } else {
             let word = self.box_value(v);
             crate::value::emit_marshal::emit_table_load(module, self.builder, word)

--- a/crates/rts-codegen-new/src/front/run/stmt_let.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_let.rs
@@ -156,16 +156,11 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if let Some(is_lazy) = self.gen_call_kind(init) {
             let val = self.lower_expr(module, init)?;
             if is_lazy {
-                let h = self.coerce(val, Repr::Int64)?;
-                let var = self.builder.declare_var(cl_type(Repr::Int64));
-                self.builder.def_var(var, h);
-                self.locals.insert(
-                    name.to_string(),
-                    Local {
-                        var,
-                        repr: Repr::Int64,
-                    },
-                );
+                // Since #2042 a lazy generator rides as a TAG_OBJECT PolyValue word
+                // (so its identity survives array/object/arg/field/Map). Bind the
+                // local as Tagged — truncating it back to a raw `Int64` here would
+                // re-strip the tag the moment the local crossed any boundary.
+                self.bind_tagged_local(name, val);
             } else {
                 self.bind_tagged_local(name, val);
                 self.local_shapes.insert(name.to_string(), HeapShape::Array);

--- a/crates/rts-runtime/src/adapters/value/dyndispatch.rs
+++ b/crates/rts-runtime/src/adapters/value/dyndispatch.rs
@@ -1232,7 +1232,12 @@ fn try_generator_dyn(recv: u64, metodo: &str, a0: u64) -> Option<u64> {
         .into_iter()
         .find(|&c| c != 0 && with_entry(c, |e| matches!(e, Some(Entry::GenState(_)))))?;
     let undef = PolyValue::undefined().raw();
-    Some(match metodo {
+    // The `__rtsn_gen*` entry points hand back the RAW handle of the `{value, done}`
+    // result — the front's STATIC path converts it via `build_iter_result`. Here the
+    // word returns DIRECTLY to the caller, so it must be boxed as an OBJECT: a raw
+    // handle is not in the boxed quadrant and would be read as a denormal double
+    // (`1.39e-309` — literally the handle's bits). Issue #2042.
+    let bruto = match metodo {
         "next" if a0 != undef => {
             rts_std::collector::generator::__rtsn_generator_next_sent(h, a0 as i64)
         }
@@ -1240,5 +1245,11 @@ fn try_generator_dyn(recv: u64, metodo: &str, a0: u64) -> Option<u64> {
         "return" => rts_std::collector::generator::__rtsn_gen_sm_return(h, a0 as i64),
         "throw" => rts_std::collector::generator::__rtsn_gen_sm_throw(h, a0 as i64),
         _ => return None,
-    })
+    };
+    Some(
+        PolyValue::from_object_handle(
+            rts_runtime::namespaces::gc::handles::__rtsn_poly_from_handle(bruto),
+        )
+        .raw(),
+    )
 }

--- a/tests/claude-generator-bordas.test.ts
+++ b/tests/claude-generator-bordas.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "rts:test";
+
+// O iterador de um generator LAZY tem de manter o protocolo (`next`/`return`/
+// `throw`) ao atravessar QUALQUER borda dinâmica — array, objeto, argumento,
+// campo de instância, `Map`, destructuring.
+//
+// A causa raiz (issue #2042) era de REPRESENTAÇÃO, não de despacho: o ctor de um
+// generator lazy devolve o handle da `Entry::GenState` num `Repr::Int64` cru, e
+// `Val::new` carimba todo `Int64` como `JsKind::Number` — então boxar o valor
+// para cruzar uma borda o convertia com `fcvt_from_sint` e o handle virava um
+// double comum. O `.next()` seguinte não achava a GenState e lia `undefined`,
+// SILENCIOSAMENTE. O valor observado era o próprio handle: `1.39e-309` são os
+// bits de `0x0001_0000_0000_0A54` (generation 1, slot 0xA54).
+//
+// A correção boxa o handle como word `TAG_OBJECT` já no retorno do ctor
+// (`call_spread.rs`) — a forma que `try_generator_dyn`/`to_iter_array` detectam
+// via `Entry::GenState` —, então a identidade sobrevive a todas as bordas de uma
+// vez, em vez de exigir um remendo por borda.
+//
+// As não-regressões importam tanto quanto o fix: um i64 legítimo NÃO pode virar
+// object word, e um array comum NÃO pode passar a responder a `.next()`.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* gl() { let i = 1; while (i <= 3) { yield i; i = i + 1; } }
+
+// ── as bordas ──────────────────────────────────────────────────────────────
+const viaArray = [gl()][0].next().value;
+
+const obj = { it: gl() };
+const viaObjeto = obj.it.next().value;
+
+function consome(x) { return x.next(); }
+const viaArgumento = consome(gl()).value;
+
+const empurrado: any[] = [];
+empurrado.push(gl());
+const viaPush = empurrado[0].next().value;
+
+class Portador { it: any; constructor() { this.it = gl(); } }
+const viaCampo = new Portador().it.next().value;
+
+const mapa = new Map();
+mapa.set("k", gl());
+const viaMap = mapa.get("k").next().value;
+
+const [desestruturado] = [gl()];
+const viaDestructuring = desestruturado.next().value;
+
+// atravessa a borda E consome em sequência (o cursor tem de ser o MESMO)
+const guardado = { it: gl() };
+const sequencia =
+  guardado.it.next().value + guardado.it.next().value + guardado.it.next().value;
+
+// ── não-regressões ─────────────────────────────────────────────────────────
+const direto = gl().next().value;
+const inteiroEmArray = [42][0];
+const grandeEmArray = [9007199254740991][0];
+const arrayComumNext = ([1, 2] as any).next;
+const porSpread = [...gl()].join(",");
+let somaForOf = 0;
+for (const x of gl()) { somaForOf = somaForOf + x; }
+
+describe("iterador de generator atravessa bordas dinâmicas", () => {
+  test("elemento de array literal", () => {
+    expect(viaArray).toBe(1);
+  });
+
+  test("campo de objeto literal", () => {
+    expect(viaObjeto).toBe(1);
+  });
+
+  test("argumento de função", () => {
+    expect(viaArgumento).toBe(1);
+  });
+
+  test("push em array", () => {
+    expect(viaPush).toBe(1);
+  });
+
+  test("campo de instância de classe", () => {
+    expect(viaCampo).toBe(1);
+  });
+
+  test("valor guardado em Map", () => {
+    expect(viaMap).toBe(1);
+  });
+
+  test("destructuring de array", () => {
+    expect(viaDestructuring).toBe(1);
+  });
+
+  test("cursor avança na travessia (mesmo iterador, não uma cópia)", () => {
+    expect(sequencia).toBe(6);
+  });
+});
+
+describe("não-regressões do value model", () => {
+  test("chamada direta não regrediu", () => {
+    expect(direto).toBe(1);
+  });
+
+  test("i64 legítimo em array continua número", () => {
+    expect(inteiroEmArray).toBe(42);
+  });
+
+  test("i64 grande em array preserva o valor exato", () => {
+    expect(grandeEmArray).toBe(9007199254740991);
+  });
+
+  test("array comum não responde a .next", () => {
+    expect(arrayComumNext).toBe(undefined);
+  });
+
+  test("spread de generator não regrediu", () => {
+    expect(porSpread).toBe("1,2,3");
+  });
+
+  test("for-of de generator não regrediu", () => {
+    expect(somaForOf).toBe(6);
+  });
+});

--- a/tests/claude-generator-travessia.test.ts
+++ b/tests/claude-generator-travessia.test.ts
@@ -17,9 +17,11 @@ import { describe, test, expect } from "rts:test";
 //   2. o despacho dinâmico reconhece a `Entry::GenState` pelo HANDLE
 //      (dyndispatch), então o protocolo não depende só do rastreio estático.
 //
-// LIMITE CONHECIDO, honesto: atravessar um ARRAY (`const a = [g()]; a[0].next()`)
-// ainda perde o protocolo — o handle é re-boxado ao entrar no array e vira outro.
-// Fica na issue #2042; este teste cobre o que passou a funcionar.
+// A travessia por ARRAY (e por objeto/argumento/campo/Map/destructuring) era o
+// limite que sobrava aqui. A causa não era re-boxing: o handle da GenState nunca
+// era boxado — `Val::new` carimba todo `Repr::Int64` como `JsKind::Number`, então
+// cruzar uma borda o convertia em double. Corrigido boxando-o como word
+// `TAG_OBJECT` no retorno do ctor; cobertura em `claude-generator-bordas.test.ts`.
 //
 // Valores conferidos contra o Node. Pré-computado no top-level.
 

--- a/tests/cross-runtime/generators/claude-generator-crosses-dynamic-boundaries.ts
+++ b/tests/cross-runtime/generators/claude-generator-crosses-dynamic-boundaries.ts
@@ -1,0 +1,82 @@
+// Cross-runtime: a generator's iterator must keep the `next`/`return`/`throw`
+// protocol after crossing a DYNAMIC boundary — array, object field, argument,
+// class field, Map value, destructuring.
+//
+// Regression guard for issue #2042: the lazy-generator ctor hands back the
+// `Entry::GenState` handle in a raw `Repr::Int64`, and the engine stamped every
+// `Int64` as a NUMBER — so boxing the value to cross a boundary converted the
+// handle to a double and the identity was lost. `.next()` then read `undefined`
+// silently instead of throwing.
+function* gen() {
+  let i = 1;
+  while (i <= 3) {
+    yield i;
+    i = i + 1;
+  }
+}
+
+// ── the boundaries ──────────────────────────────────────────────────────────
+console.log("array=" + [gen()][0].next().value);
+
+const obj = { it: gen() };
+console.log("objectField=" + obj.it.next().value);
+
+function consume(x) {
+  return x.next();
+}
+console.log("argument=" + consume(gen()).value);
+
+const pushed: any[] = [];
+pushed.push(gen());
+console.log("push=" + pushed[0].next().value);
+
+class Holder {
+  it: any;
+  constructor() {
+    this.it = gen();
+  }
+}
+console.log("classField=" + new Holder().it.next().value);
+
+const map = new Map();
+map.set("k", gen());
+console.log("mapValue=" + map.get("k").next().value);
+
+const [destructured] = [gen()];
+console.log("destructuring=" + destructured.next().value);
+
+// The stored iterator must be the SAME one, so the cursor advances across calls
+// (a copy would restart at 1 every time and print 3).
+const kept = { it: gen() };
+console.log(
+  "cursorAdvances=" +
+    (kept.it.next().value + kept.it.next().value + kept.it.next().value),
+);
+
+// The full result object survives the boundary, not just `.value`.
+console.log("resultObject=" + JSON.stringify([gen()][0].next()));
+
+// Exhaustion still reports `done` correctly after the boundary.
+const drained = { it: gen() };
+drained.it.next();
+drained.it.next();
+drained.it.next();
+console.log("afterExhaustion=" + JSON.stringify(drained.it.next()));
+
+// `return()` through the boundary closes the iterator.
+const closed = { it: gen() };
+console.log("returnMethod=" + JSON.stringify(closed.it.return(99)));
+console.log("afterReturn=" + JSON.stringify(closed.it.next()));
+
+// ── non-regressions: the value model must not over-apply the fix ────────────
+console.log("direct=" + gen().next().value);
+console.log("intInArray=" + [42][0]);
+console.log("bigIntInArray=" + [9007199254740991][0]);
+console.log("plainArrayNext=" + ([1, 2] as any).next);
+console.log("spread=" + [...gen()].join(","));
+
+let sum = 0;
+for (const x of gen()) {
+  sum = sum + x;
+}
+console.log("forOf=" + sum);


### PR DESCRIPTION
## O bug

`.next()` de um generator lazy lia `undefined` — **silenciosamente** — assim que o iterador atravessava qualquer borda dinâmica:

```js
function* gl(){ let i=1; while(i<=3){ yield i; i=i+1; } }

const a=[gl()];                          a[0].next()   // undefined
const o={it:gl()};                       o.it.next()   // undefined
function f(x){return x.next();} f(gl())                // undefined
arr.push(gl());                          arr[0].next() // undefined
class C{constructor(){this.it=gl();}}    new C().it.next() // undefined
m.set('k',gl());                         m.get('k').next() // undefined
```

## A causa: representação, não despacho

O ctor de um generator lazy devolve o handle da `Entry::GenState` num `Repr::Int64` cru. E `Val::new` (`lower.rs:91`) carimba **todo** `Int64` como `JsKind::Number`:

```rust
Repr::Float64 | Repr::Int32 | Repr::Int64 => JsKind::Number,
```

Então boxar o valor para cruzar uma borda o convertia com `fcvt_from_sint` — o handle virava um double comum e a identidade do iterador se perdia **antes** de chegar ao despacho.

O valor observado era o próprio handle:

```
1.390671161580064e-309  →  0x0001_0000_0000_0A54   (generation 1, slot 0xA54)
```

`genops.rs:717` já descrevia exatamente esse padrão: *"a raw handle … reads as a **DENORMAL** ≥ 2^48"*.

Isso explica por que as tentativas anteriores não pegaram: todas ajustaram o **consumidor** (despacho dinâmico, side-table no `__gen_buf`), mas o valor já chegava corrompido. O rastro dessa perseguição é `try_generator_dyn`, que hoje testa cinco codificações do mesmo handle.

## A correção

Boxar na **origem**: o retorno do ctor lazy vira word `TAG_OBJECT` (`call_spread.rs`) — a forma que `try_generator_dyn`/`to_iter_array` detectam via `Entry::GenState`. A identidade sobrevive a todas as bordas de uma vez, em vez de um remendo por borda. Consumidores do handle cru o recuperam por `gen_state_handle` (`stmt.rs`).

Corrigido também o vazamento na **outra ponta**: `try_generator_dyn` devolvia o `{value,done}` como handle cru, pelo mesmo motivo.

O precedente já existia na árvore — `thunk.rs:282` faz exatamente isso na fronteira uniform-ABI, com o mesmo comentário.

## Validação

- `tests/claude-generator-bordas.test.ts` — **14/14**: as 6 bordas + avanço de cursor (prova que é o mesmo iterador, não cópia) + não-regressões do value model (`[42][0]`→42, `[9007199254740991][0]` exato, `[1,2].next`→undefined, spread, for-of).
- Fixture cross-runtime `claude-generator-crosses-dynamic-boundaries.ts` — saída **byte-idêntica a Node e Bun** (18 linhas). Sem o fix, ela imprime o denormal.
- **Suite: 2722/2723** (760/761 arquivos). A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main sem estas mudanças.
- 38/38 nos testes de generator/iterador (idêntico ao baseline).
- `read_before_commit.sh`: sem violação; nenhuma linha adicionada às listas de REVIEW.

Efeito colateral positivo: a fixture `379_yield_star` (issue #2021) passa a bater com Node.

## O que permanece na #2042

Por isso a issue **não** é fechada aqui:

1. `function* g(){ yield 1 }` (corpo linear, sem loop) é inelegível ao state-machine por `body_needs_lazy` (`generator_sm.rs:79`) e vira eager-buffer, indistinguível de um array comum em runtime.
2. `.values()`/`.entries()`/`[Symbol.iterator]()` devolvem array materializado em vez de iterador, então `.next()` sobre eles falha **mesmo sem travessia** — eixo independente deste bug, e a outra metade do padrão dos bundles do WhatsApp.

Refs #2042

🤖 Generated with [Claude Code](https://claude.com/claude-code)