### PR TITLE
fix(engine): generator lazy com parâmetro sem anotação de tipo rende valores

### DIFF
--- a/crates/rts-codegen-new/src/front/run/sig.rs
+++ b/crates/rts-codegen-new/src/front/run/sig.rs
@@ -235,6 +235,18 @@ impl FnSig {
         if is_eager_generator {
             ret = Repr::Tagged;
         }
+        // A LAZY generator ctor hands back the opaque `Entry::GenState` HANDLE, so its
+        // return must stay `Int64` even when a rule above already widened it. The
+        // Tagged-param rule (an UNANNOTATED param is `Tagged`) would otherwise force
+        // `Tagged` here, and the return coercion converts the handle with
+        // `fcvt_from_sint` — the GenState identity is destroyed and the iterator
+        // silently yields nothing (`[...g(1)]` → `[]`, issue #2044). Unlike a genuine
+        // value this handle is NOT a PolyValue: it is consumed as a raw i64 by
+        // `GENERATOR_NEXT`/`GEN_SM_DRAIN`, and the boxing for dynamic consumers
+        // happens at the CALL SITE (`call_spread.rs`, issue #2042) — not here.
+        if is_lazy_gen {
+            ret = Repr::Int64;
+        }
         FnSig {
             name: func.name.clone(),
             params,

--- a/tests/claude-generator-param-sem-anotacao.test.ts
+++ b/tests/claude-generator-param-sem-anotacao.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from "rts:test";
+
+// Um generator LAZY (state-machine — corpo com loop contendo `yield`) cujo
+// parâmetro NÃO tem anotação de tipo produzia um iterador VAZIO, silenciosamente:
+// `.next()` lia `undefined`, spread devolvia `[]`, `for-of` não iterava.
+//
+// A causa (issue #2044) é a mesma classe do #2042, noutro ponto. `sig.rs` tem uma
+// regra que força o RETORNO a `Tagged` quando qualquer parâmetro é `Tagged` — e um
+// parâmetro sem anotação é exatamente isso. Mas o ctor de um generator lazy não
+// devolve um valor: devolve o HANDLE opaco da `Entry::GenState`, que precisa
+// continuar `Int64`. Forçado a `Tagged`, o retorno era coagido com
+// `fcvt_from_sint` e o handle virava um double comum — identidade destruída.
+//
+// No IR o `return` do ctor mostrava a diferença exata:
+//   sem anotação:  v6 = fcvt_from_sint.f64 v3   →  return v10   (handle → double)
+//   com anotação:  return v3                    (o handle cru)
+//
+// `is_lazy_gen` já era calculado ali, mas só o caminho EAGER ajustava o `ret`; o
+// lazy não. A correção fixa `ret = Int64` para o ctor lazy, depois das demais
+// regras. O boxing para consumidores dinâmicos continua no CALL SITE (#2042).
+//
+// Importa porque JS de bundle é minificado e NÃO tem anotação de tipo — a forma
+// que aparece em código real é justamente a que falhava.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* semTipo(start, count) { for (let i = 0; i < count; i++) yield start + i; }
+function* comTipo(start: number, count: number) { for (let i = 0; i < count; i++) yield start + i; }
+function* semParam() { let n = 1; while (n <= 3) { yield n; n = n + 1; } }
+function* comDefault(start = 1) { let n = start; while (n < start + 3) { yield n; n = n + 1; } }
+function* doisParams(a, b) { let i = 0; while (i < 2) { yield a + b + i; i = i + 1; } }
+function* strParam(p) { let i = 0; while (i < 2) { yield p + i; i = i + 1; } }
+function* eagerParam(s) { yield s; yield s + 1; }
+
+const viaSpread = [...semTipo(10, 3)].join(",");
+const viaNext = semTipo(10, 3).next().value;
+
+let somaForOf = 0;
+for (const x of semTipo(1, 3)) { somaForOf = somaForOf + x; }
+
+// consumido através de uma borda dinâmica (combina com o fix da #2042)
+const viaBorda = [semTipo(10, 3)][0].next().value;
+
+// o cursor tem de avançar: mesmo iterador, não uma cópia
+const compartilhado = semTipo(100, 3);
+const sequencia =
+  compartilhado.next().value + compartilhado.next().value + compartilhado.next().value;
+
+const comAnotacao = [...comTipo(10, 3)].join(",");
+const semParametro = [...semParam()].join(",");
+const defaultOmitido = [...comDefault()].join(",");
+const defaultPassado = [...comDefault(5)].join(",");
+const doisSemTipo = [...doisParams(1, 2)].join(",");
+const stringParam = [...strParam("x")].join(",");
+const eagerComParam = [...eagerParam(7)].join(",");
+
+// generator infinito só é possível no caminho lazy (o eager materializaria tudo)
+function* infinito(start = 1) { let n = start; while (true) { yield n; n = n + 1; } }
+const doInfinito = infinito();
+const infinitoTresValores =
+  doInfinito.next().value + doInfinito.next().value + doInfinito.next().value;
+
+describe("generator lazy com parâmetro sem anotação de tipo", () => {
+  test("spread produz os valores", () => {
+    expect(viaSpread).toBe("10,11,12");
+  });
+
+  test("next() produz o primeiro valor", () => {
+    expect(viaNext).toBe(10);
+  });
+
+  test("for-of itera", () => {
+    expect(somaForOf).toBe(6);
+  });
+
+  test("atravessa borda dinâmica (com o fix da #2042)", () => {
+    expect(viaBorda).toBe(10);
+  });
+
+  test("cursor avança entre chamadas", () => {
+    expect(sequencia).toBe(303);
+  });
+
+  test("dois parâmetros sem anotação", () => {
+    expect(doisSemTipo).toBe("3,4");
+  });
+
+  test("parâmetro string sem anotação", () => {
+    expect(stringParam).toBe("x0,x1");
+  });
+
+  test("parâmetro com default, omitido", () => {
+    expect(defaultOmitido).toBe("1,2,3");
+  });
+
+  test("parâmetro com default, passado", () => {
+    expect(defaultPassado).toBe("5,6,7");
+  });
+
+  test("generator infinito rende sob demanda", () => {
+    expect(infinitoTresValores).toBe(6);
+  });
+});
+
+describe("não-regressões dos demais caminhos de generator", () => {
+  test("parâmetro ANOTADO não regrediu", () => {
+    expect(comAnotacao).toBe("10,11,12");
+  });
+
+  test("generator SEM parâmetro não regrediu", () => {
+    expect(semParametro).toBe("1,2,3");
+  });
+
+  test("generator EAGER com parâmetro não regrediu", () => {
+    expect(eagerComParam).toBe("7,8");
+  });
+});

--- a/tests/cross-runtime/generators/claude-generator-untyped-param.ts
+++ b/tests/cross-runtime/generators/claude-generator-untyped-param.ts
@@ -1,0 +1,99 @@
+// Cross-runtime: a LAZY generator (state-machine — a loop containing `yield`)
+// whose parameter carries NO type annotation must still yield its values.
+//
+// Regression guard for issue #2044. `sig.rs` widens a function's RETURN to
+// `Tagged` when any parameter is `Tagged` — and an unannotated parameter is
+// exactly that. But a lazy generator's ctor does not return a value: it returns
+// the opaque `Entry::GenState` HANDLE, which must stay `Int64`. Widened, the
+// return was coerced with `fcvt_from_sint`, the handle became an ordinary double
+// and the iterator silently yielded nothing (`[...g(1)]` → `[]`).
+//
+// This is the form that shows up in real code: bundled JS is minified and has no
+// type annotations, so the annotated variant was the only one being exercised.
+
+function* untyped(start, count) {
+  for (let i = 0; i < count; i++) yield start + i;
+}
+function* annotated(start: number, count: number) {
+  for (let i = 0; i < count; i++) yield start + i;
+}
+function* noParams() {
+  let n = 1;
+  while (n <= 3) {
+    yield n;
+    n = n + 1;
+  }
+}
+function* withDefault(start = 1) {
+  let n = start;
+  while (n < start + 3) {
+    yield n;
+    n = n + 1;
+  }
+}
+function* stringParam(p) {
+  let i = 0;
+  while (i < 2) {
+    yield p + i;
+    i = i + 1;
+  }
+}
+// A linear body stays on the EAGER path — it must keep working too.
+function* eagerParam(s) {
+  yield s;
+  yield s + 1;
+}
+
+console.log("spread=" + [...untyped(10, 3)].join(","));
+console.log("next=" + untyped(10, 3).next().value);
+
+let sum = 0;
+for (const x of untyped(1, 3)) {
+  sum = sum + x;
+}
+console.log("forOf=" + sum);
+
+// crossing a dynamic boundary as well (issue #2042)
+console.log("acrossBoundary=" + [untyped(10, 3)][0].next().value);
+
+// the cursor must advance — the same iterator, not a fresh copy each call
+const shared = untyped(100, 3);
+console.log(
+  "cursorAdvances=" +
+    (shared.next().value + shared.next().value + shared.next().value),
+);
+
+// the full result object, and exhaustion
+console.log("resultObject=" + JSON.stringify(untyped(10, 1).next()));
+const drained = untyped(10, 1);
+drained.next();
+console.log("afterExhaustion=" + JSON.stringify(drained.next()));
+
+// an INFINITE generator is only expressible on the lazy path (the eager buffer
+// would materialize forever) — it must yield lazily, on demand.
+function* naturals(start = 1) {
+  let n = start;
+  while (true) {
+    yield n;
+    n = n + 1;
+  }
+}
+function take(iter, n) {
+  const out: any[] = [];
+  for (let i = 0; i < n; i++) {
+    const r = iter.next();
+    if (r.done) break;
+    out.push(r.value);
+  }
+  return out;
+}
+console.log("takeInfinite=" + take(naturals(), 5).join(","));
+console.log("takeInfiniteFrom=" + take(naturals(10), 4).join(","));
+
+// ── non-regressions: the other generator paths ──────────────────────────────
+console.log("annotated=" + [...annotated(10, 3)].join(","));
+console.log("noParams=" + [...noParams()].join(","));
+console.log("defaultOmitted=" + [...withDefault()].join(","));
+console.log("defaultPassed=" + [...withDefault(5)].join(","));
+console.log("stringParam=" + [...stringParam("x")].join(","));
+console.log("eagerParam=" + [...eagerParam(7)].join(","));


### PR DESCRIPTION
## O bug

Um generator **lazy** (state-machine — corpo com loop contendo `yield`) cujo parâmetro **não tem anotação de tipo** produzia um iterador vazio, silenciosamente:

```js
function* untyped(start, count)                  { for (let i=0;i<count;i++) yield start+i; }
function* annotated(start: number, count: number){ for (let i=0;i<count;i++) yield start+i; }

[...untyped(10,3)]     // []            ← vazio!   (Node: [10,11,12])
[...annotated(10,3)]   // [10,11,12]    ✅
```

A anotação `: number` era a única diferença. `.next()` lia `undefined`, spread devolvia `[]`, `for-of` não iterava.

## A causa

Mesma classe do #2042 — um handle tratado como número —, noutro ponto.

`sig.rs` força o **retorno** a `Tagged` quando qualquer parâmetro é `Tagged`, e um parâmetro sem anotação é exatamente isso. Só que o ctor de um generator lazy não devolve um valor: devolve o **handle opaco** da `Entry::GenState`, que precisa continuar `Int64`. Forçado a `Tagged`, o retorno era coagido com `fcvt_from_sint` e o handle virava um double comum.

O IR mostra a diferença no `return` do ctor:

```
sem anotação:  v6 = fcvt_from_sint.f64 v3  →  return v10   (handle → double)
com anotação:  return v3                                    (o handle cru)
```

`is_lazy_gen` já era calculado ali, mas **só o caminho eager ajustava o `ret`**. A correção fixa `ret = Int64` para o ctor lazy, depois das demais regras. O boxing para consumidores dinâmicos continua no call site (`call_spread.rs`, #2042) — não aqui.

## Por que importa

**JS de bundle é minificado e não tem anotações de tipo** — a forma que aparece em código real era justamente a que falhava; a anotada era a única sendo exercitada.

Destrava também o `take(naturals(), 5)` de `368_iterator_protocol` (#2024): um generator **infinito** só é expressável no caminho lazy.

## Validação

- `tests/claude-generator-param-sem-anotacao.test.ts` — **13/13**: spread, next, for-of, borda dinâmica, avanço de cursor, dois params, string, default (omitido e passado), infinito sob demanda + não-regressões (param anotado, sem param, eager com param).
- Fixture cross-runtime `claude-generator-untyped-param.ts` — 15 linhas **byte-idênticas a Node e Bun**.
- **Suite: 2735/2736** (761/762 arquivos). A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.
- 52 testes de generator/iterador verdes.
- `read_before_commit.sh`: sem violação.

## O que ainda não passa

`368_iterator_protocol` (#2024) não passa inteira: sua função `zip` usa `a[Symbol.iterator]()`, que devolve **array materializado** em vez de iterador — o eixo independente já registrado na #2042, e que faz o `while(true)` da `zip` nunca terminar.

Closes #2044

🤖 Generated with [Claude Code](https://claude.com/claude-code)