### PR TITLE
fix(engine): retorno de fn nativa declara handle; `this` pelo canal certo

### DIFF
--- a/crates/rts-engine/src/heap/handles.rs
+++ b/crates/rts-engine/src/heap/handles.rs
@@ -674,7 +674,16 @@ pub struct FunctionData {
     /// Vazio = assume todos i64. Usado por invoke_n para coerção correta
     /// quando método tem `number` (f64) ou outros tipos não-i64.
     pub param_kinds: Vec<u8>,
-    /// Tipo ABI do retorno: 0=i64, 1=f64, 2=bool, 3=i32, 4=void. 0 default.
+    /// Tipo ABI do retorno: 0=i64, 1=f64, 2=bool, 3=i32, 4=void, 5=handle.
+    /// 0 default.
+    ///
+    /// `5` existe porque `0` (i64) é AMBÍGUO: um `i64` de retorno pode ser um
+    /// número OU um handle de runtime, e o invoker legado resolvia a ambiguidade
+    /// assumindo número (`from_i32`/`from_f64`) — o que transformava todo handle
+    /// devolvido por uma fn nativa num número comum. Declarar `5` diz que o valor
+    /// É um handle, e o invoker o boxa pela autoridade única de retorno-de-handle
+    /// (`__rtsadp_box_handle_auto`, que inspeciona o `Entry` e escolhe a tag
+    /// certa) em vez de adivinhar (issue #2042).
     pub return_kind: u8,
     /// (#1281 packed) Endereco de um shim `extern "C" fn(*const i64, len) -> i64`
     /// que desempacota os args do buffer e chama a fn original (coercoes f64/i32

--- a/crates/rts-runtime/src/adapters/value/dyndispatch.rs
+++ b/crates/rts-runtime/src/adapters/value/dyndispatch.rs
@@ -918,6 +918,26 @@ pub fn rtsadp_idx_call(recv: u64, key: u64, a0: u64, a1: u64, argc: u64) -> u64 
             PolyValue::from_i32(argc as i32).raw(),
         );
     }
+    // A SYMBOL key is not a member NAME. `ToString` on it yields "[object
+    // Object]", which then misses every row and surfaced as the nonsense
+    // TypeError "[object Object] is not a function". Resolve the property the way
+    // `__rtsadp_dyn_idx_get` already does (it has this branch) and INVOKE the
+    // result, so `arr[Symbol.iterator]()` calls the native values-iterator
+    // instead of dying on a stringified symbol (issue #2042).
+    if kv.is_object() {
+        use rts_runtime::namespaces::gc::handles as rt_handles;
+        let kh = rt_handles::__rtsn_poly_to_handle(kv.as_handle());
+        let is_symbol =
+            rt_handles::with_entry(kh, |e| matches!(e, Some(rt_handles::Entry::Symbol { .. })));
+        if is_symbol {
+            let m = __rtsadp_idx_get(recv, key);
+            if PolyValue::from_raw(m).is_function() {
+                return super::funcops::__rtsadp_fn_invoke_method(m, recv, a0, a1, undef(), 0);
+            }
+            super::errslot::throw_js_error("TypeError", "symbol property is not a function");
+            return undef();
+        }
+    }
     let name = if kv.is_string() {
         abi_adapter::resolve_poly(kv)
     } else {

--- a/crates/rts-runtime/src/adapters/value/funcops.rs
+++ b/crates/rts-runtime/src/adapters/value/funcops.rs
@@ -817,7 +817,7 @@ pub fn rtsadp_fn_invoke(
     // the runtime's own typed invoker (`FUNCTION_CALL`, which also applies bound
     // args), then box the raw i64 result back as a number word.
     if !uniform {
-        return invoke_legacy_fn(real, arity, bound.len(), [a0, a1, a2, a3]);
+        return invoke_legacy_fn(real, arity, bound.len(), 0, [a0, a1, a2, a3]);
     }
     // BOUND partial-application args on a UNIFORM callee (`f.bind(null, x)`):
     // prepend the stored WORDS — the call-site args shift right, and an
@@ -868,20 +868,44 @@ pub fn rtsadp_fn_invoke(
 /// Invoke a LEGACY-convention function handle (a `new Function` compile: raw
 /// all-i64 `extern "C"`, `uniform_thunk: false`) with up to 4 PolyValue-word
 /// args: unbox each to its raw i64, route through the runtime's own
-/// `FUNCTION_CALL` (which applies bound args / kinds), box the i64 result back
-/// as the tightest number word.
-fn invoke_legacy_fn(real_handle: u64, arity: u8, bound_len: usize, slots: [u64; 4]) -> u64 {
+/// `FUNCTION_CALL` (which applies bound args / kinds), then box the i64 result
+/// back per the callee's DECLARED `return_kind`.
+///
+/// The result direction used to assume "an i64 return is a NUMBER" and box it as
+/// `from_i32`/`from_f64`. That is only true for `return_kind` 0/1/3 — a native fn
+/// that returns a runtime HANDLE (`Array.prototype[Symbol.iterator]`, which hands
+/// back an iterator) had its handle silently turned into an ordinary number, so
+/// the caller saw `typeof === "number"` and every method on it failed. The
+/// argument direction never had this bug: `word_to_raw_i64` already recognizes a
+/// heap word and crosses it as its real handle. `return_kind: 5` is the missing
+/// counterpart, boxed through the ONE heterogeneous-handle authority
+/// (`__rtsadp_box_handle_auto` tag-dispatches on the `Entry`) rather than guessed
+/// here (issue #2042).
+fn invoke_legacy_fn(
+    real_handle: u64,
+    arity: u8,
+    bound_len: usize,
+    this_raw: i64,
+    slots: [u64; 4],
+) -> u64 {
     use rts_engine::heap::handles::{Entry as E, alloc_entry};
     // `FUNCTION_CALL` prepends the stored bound args itself — pass only the
     // REMAINING positional count so the total matches the callee's arity.
     let n = (arity as usize).saturating_sub(bound_len).min(4);
     let raw: Vec<i64> = slots[..n].iter().map(|&w| word_to_raw_i64(w)).collect();
     let args_h = alloc_entry(E::Vec(Box::new(raw)));
+    let ret_kind = with_entry(real_handle, |e| match e {
+        Some(Entry::Function(d)) => d.return_kind,
+        _ => 0,
+    });
     let r = rts_runtime::namespaces::globals::function::ops::__RTS_FN_GL_FUNCTION_CALL(
         real_handle,
-        0,
+        this_raw,
         args_h,
     );
+    if ret_kind == 5 {
+        return super::genops::__rtsadp_box_handle_auto(r as u64);
+    }
     if let Ok(i) = i32::try_from(r) {
         PolyValue::from_i32(i).raw()
     } else {
@@ -1032,7 +1056,7 @@ extern "C" fn raw_callee_bridge_thunk(
         Some(Entry::Function(d)) => (d.arity, d.bound_args.len()),
         _ => (0u8, 0usize),
     });
-    invoke_legacy_fn(env, arity, bound_len, [a0, a1, a2, a3])
+    invoke_legacy_fn(env, arity, bound_len, 0, [a0, a1, a2, a3])
 }
 
 /// Build the uniform wrapper FUNCTION entry over the raw callee `inner`
@@ -1226,9 +1250,19 @@ pub fn rtsadp_fn_invoke_method(
     // reified without the uniform thunk); a plain one keeps the no-this route.
     if !uniform {
         if has_this {
-            return invoke_legacy_fn(real, arity, bound.len(), [this_word, a0, a1, a2]);
+            // `this` rides FUNCTION_CALL's own receiver channel — it PREPENDS
+            // `effective_this` for a `has_this_param` callee, so also placing it
+            // in the positional slots passed `0` as the receiver and shifted every
+            // real argument one position right (issue #2042).
+            return invoke_legacy_fn(
+                real,
+                arity,
+                bound.len(),
+                word_to_raw_i64(this_word),
+                [a0, a1, a2, PolyValue::undefined().raw()],
+            );
         }
-        return invoke_legacy_fn(real, arity, bound.len(), [a0, a1, a2, PolyValue::undefined().raw()]);
+        return invoke_legacy_fn(real, arity, bound.len(), 0, [a0, a1, a2, PolyValue::undefined().raw()]);
     }
     let env_word = if env == 0 {
         PolyValue::undefined().raw()

--- a/crates/rts-std/src/collector/generator.rs
+++ b/crates/rts-std/src/collector/generator.rs
@@ -987,7 +987,10 @@ pub fn iterator_fn() -> u64 {
         is_arrow: false,
         has_this_param: true,
         param_kinds: Vec::new(),
-        return_kind: 0,
+        // The iterator is a HANDLE, not a number: `return_kind: 0` (i64) let the
+        // legacy invoker box it as a plain number, so `arr[Symbol.iterator]()`
+        // read `typeof === "number"` and had no `.next` (issue #2042).
+        return_kind: 5,
         packed_shim: 0,
         source: None,
         keep_alive: None,

--- a/tests/claude-iterador-nativo-next.test.ts
+++ b/tests/claude-iterador-nativo-next.test.ts
@@ -47,6 +47,13 @@ const itB = base.values();
 itA.next();
 const independentes = itB.next().value;
 
+// `arr[Symbol.iterator]()` — a CHAMADA (a leitura já devolvia uma função).
+const simIt = [1, 2, 3][Symbol.iterator]();
+const simTypeof = typeof simIt;
+const simPrimeiro = simIt.next().value;
+const simSegundo = simIt.next().value;
+const simSpread = [...[4, 5][Symbol.iterator]()].join(",");
+
 // `take` sobre iterador — a forma que os bundles usam
 function take(iter, n) {
   const out: any[] = [];
@@ -119,6 +126,22 @@ describe("protocolo .next() em iteradores nativos", () => {
 
   test("take() sobre iterador — a forma dos bundles", () => {
     expect(viaTake).toBe("1,2,3");
+  });
+
+  test("arr[Symbol.iterator]() devolve um objeto, não um número", () => {
+    expect(simTypeof).toBe("object");
+  });
+
+  test("arr[Symbol.iterator]().next() rende o primeiro valor", () => {
+    expect(simPrimeiro).toBe(1);
+  });
+
+  test("arr[Symbol.iterator]() avança o cursor", () => {
+    expect(simSegundo).toBe(2);
+  });
+
+  test("spread de arr[Symbol.iterator]()", () => {
+    expect(simSpread).toBe("4,5");
   });
 });
 

--- a/tests/cross-runtime/generators/claude-native-iterator-next.ts
+++ b/tests/cross-runtime/generators/claude-native-iterator-next.ts
@@ -47,6 +47,16 @@ function take(iter, n) {
 console.log("take=" + take([1, 2, 3, 4].values(), 3).join(","));
 console.log("takeBeyondEnd=" + take([1, 2].values(), 5).join(","));
 
+// `arr[Symbol.iterator]()` — the CALL. Reading the property already yielded a
+// function; calling it went through `__rtsadp_idx_call`, which ToString'd the
+// symbol key to "[object Object]", and the native fn's handle return was then
+// re-read as a number by the legacy invoker.
+const symIt = [1, 2, 3][Symbol.iterator]();
+console.log("symIterTypeof=" + typeof symIt);
+console.log("symIterFirst=" + symIt.next().value);
+console.log("symIterSecond=" + symIt.next().value);
+console.log("symIterSpread=" + [...[4, 5][Symbol.iterator]()].join(","));
+
 // ── non-regressions ─────────────────────────────────────────────────────────
 console.log("plainArrayNext=" + ([1, 2] as any).next);
 console.log("spreadValues=" + [...[1, 2].values()].join(","));


### PR DESCRIPTION
## A raiz, atacada de frente

A mesma causa apareceu **quatro vezes** nesta campanha: *"um i64 é um número"*. Os três fixes anteriores a trataram na borda (#2043, #2045, #2046). Aqui ela é corrigida onde nasce — na camada de invocação de função —, e é o que ainda travava `arr[Symbol.iterator]()`.

## Três defeitos na mesma cadeia

### 1. O retorno de fn nativa era sempre número

`invoke_legacy_fn` boxava **todo** retorno i64 como número:

```rust
if let Ok(i) = i32::try_from(r) { PolyValue::from_i32(i).raw() }
else { PolyValue::from_f64(r as f64).raw() }
```

Uma fn nativa que devolve um **handle** — `Array.prototype[Symbol.iterator]`, que devolve um iterador — tinha o handle convertido em número: o caller lia `typeof === "number"` e nenhum método funcionava.

A direção de **entrada** nunca teve esse bug — `word_to_raw_i64` já reconhece uma word de heap e a cruza como handle real. Faltava a contraparte de saída.

`FunctionData.return_kind` ganha `5` = HANDLE, boxado pela autoridade única de retorno-de-handle (`__rtsadp_box_handle_auto`, que inspeciona o `Entry` e escolhe a tag) em vez de adivinhado. `0` (i64) continua ambíguo **por definição** — por isso a declaração é necessária, e não mais um caso especial.

### 2. `this` era passado duas vezes

`FUNCTION_CALL` já prepende `effective_this` para um callee `has_this_param` (`all_args.insert(0, ..)`), mas o invoker passava `0` como receiver **e** colocava o `this` nos slots posicionais. O callee recebia `this = 0` e cada argumento real deslocado uma posição — `values_iter` recebia 0 e devolvia um iterador **vazio**.

### 3. Symbol key virava `"[object Object]"`

`__rtsadp_idx_call` fazia `ToString` da chave symbol, errava toda linha de row, e produzia a TypeError sem sentido `"[object Object] is not a function"`. Ganha a branch de symbol que `__rtsadp_dyn_idx_get` já tinha.

## Resultado

**`368_iterator_protocol` (#2024) passa byte-idêntica ao Node.** Antes ela **travava**: a `zip` fazia `a[Symbol.iterator]()`, o resultado não avançava, e o `while(true)` nunca terminava.

## Validação

- `claude-iterador-nativo-next.test.ts` — **19 → 23**: novos casos de `arr[Symbol.iterator]()` (typeof, `.next()`, avanço de cursor, spread).
- Fixture cross-runtime ampliada — **byte-idêntica a Node e Bun**.
- **Suite: 2754/2755.** A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.

O fix do `this` é **amplo** (toca todo callee legado com `has_this_param`), por isso a suite completa é a validação que importa: nada regrediu.

## O que permanece

Consumir parcialmente com `.next()` e depois espalhar/iterar reinicia do zero — o front prova "é array" e emite index-walk a partir de 0, sem consultar o cursor. É o mesmo eixo estático de sempre; registrado na #2042.

Closes #2024
Refs #2042, #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)