### PR TITLE
fix(stdlib): JSON.stringify desembrulha wrapper Number/String/Boolean

### DIFF
--- a/crates/rts-shared/src/stdlib/json.ts
+++ b/crates/rts-shared/src/stdlib/json.ts
@@ -95,9 +95,17 @@ function __json_render(v: any, pad: string, depth: number, keyFilter: any, fnRep
   if (t === "undefined" || t === "function") return undefined;
   // A Boolean/Number/String WRAPPER object serializes as its wrapped PRIMITIVE
   // (SerializeJSONProperty reads [[BooleanData]]/ToNumber/ToString of the box) —
-  // expando properties are ignored. `__prim` is the engine-owned wrapper slot.
+  // expando properties are ignored.
+  //
+  // The engine has TWO wrapper forms and both must unwrap: `Object(5)` builds the
+  // shape object `{ __prim: 5 }`, while `new Number(5)` builds a class instance
+  // whose primitive is reached through `valueOf()`. Checking only `__prim` made
+  // `JSON.stringify(new Number(5))` render `{}` instead of `5` (issue #2017).
   if (t === "object" && typeof v.__prim !== "undefined") {
     return __json_render(v.__prim, pad, depth, keyFilter, fnReplacer, seen);
+  }
+  if (t === "object" && (v instanceof Number || v instanceof String || v instanceof Boolean)) {
+    return __json_render(v.valueOf(), pad, depth, keyFilter, fnReplacer, seen);
   }
   // Cycle detection (ECMAScript SerializeJSON*): re-entering a value already on
   // the render stack throws.

--- a/tests/claude-stringify-wrapper-objects.test.ts
+++ b/tests/claude-stringify-wrapper-objects.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from "rts:test";
+
+// `JSON.stringify(new Number(5))` rendia `{}` em vez de `5`.
+//
+// Pela spec (SerializeJSONProperty), um wrapper Boolean/Number/String serializa
+// como o PRIMITIVO embrulhado, ignorando propriedades expando. O prelude já fazia
+// isso — mas só reconhecia UMA das duas formas de wrapper do motor:
+//
+//   Object(5)      → objeto de shape `{ __prim: 5 }`  (rts-primitives/object.ts)
+//   new Number(5)  → instância de classe cujo primitivo sai por `valueOf()`
+//
+// O `.ts` checava apenas `__prim`, então a segunda forma caía no caminho de
+// objeto comum e virava `{}`. A correção acrescenta o teste por `instanceof` +
+// `valueOf()` — ambos já funcionavam —, mantendo a checagem de `__prim` para a
+// primeira forma. Corrigido no prelude, não no motor: é semântica de JSON.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+const numWrapper = JSON.stringify(new Number(5));
+const numNaN = JSON.stringify(new Number(NaN));
+const numInfinity = JSON.stringify(new Number(Infinity));
+const strWrapper = JSON.stringify(new String("hi"));
+const strComAspas = JSON.stringify(new String('a"b'));
+const boolTrue = JSON.stringify(new Boolean(true));
+const boolFalse = JSON.stringify(new Boolean(false));
+
+const aninhado = JSON.stringify({ a: new Number(7) });
+const emArray = JSON.stringify([new Number(1), new String("x"), new Boolean(false)]);
+const profundo = JSON.stringify({ a: { b: [new Number(3)] } });
+
+// a outra forma de wrapper não pode regredir
+const viaObject = JSON.stringify(Object(5));
+const viaObjectStr = JSON.stringify(Object("h"));
+
+// objeto comum continua objeto
+const objComum = JSON.stringify({ a: 1 });
+const objComValueOf = JSON.stringify({ valueOf: () => 9, a: 1 });
+const arrayComum = JSON.stringify([1, 2]);
+
+// primitivos não regridem
+const primNum = JSON.stringify(5);
+const primStr = JSON.stringify("hi");
+const primBool = JSON.stringify(true);
+const primNull = JSON.stringify(null);
+
+describe("JSON.stringify desembrulha wrapper objects", () => {
+  test("new Number(5)", () => {
+    expect(numWrapper).toBe("5");
+  });
+
+  test("new Number(NaN) vira null", () => {
+    expect(numNaN).toBe("null");
+  });
+
+  test("new Number(Infinity) vira null", () => {
+    expect(numInfinity).toBe("null");
+  });
+
+  test("new String('hi')", () => {
+    expect(strWrapper).toBe('"hi"');
+  });
+
+  test("new String com aspas é escapado", () => {
+    expect(strComAspas).toBe('"a\\"b"');
+  });
+
+  test("new Boolean(true)", () => {
+    expect(boolTrue).toBe("true");
+  });
+
+  test("new Boolean(false)", () => {
+    expect(boolFalse).toBe("false");
+  });
+
+  test("wrapper aninhado em objeto", () => {
+    expect(aninhado).toBe('{"a":7}');
+  });
+
+  test("wrappers em array", () => {
+    expect(emArray).toBe('[1,"x",false]');
+  });
+
+  test("wrapper em profundidade", () => {
+    expect(profundo).toBe('{"a":{"b":[3]}}');
+  });
+});
+
+describe("não-regressões do stringify", () => {
+  test("Object(5) — a outra forma de wrapper", () => {
+    expect(viaObject).toBe("5");
+  });
+
+  test("Object('h') — a outra forma de wrapper", () => {
+    expect(viaObjectStr).toBe('"h"');
+  });
+
+  test("objeto comum continua objeto", () => {
+    expect(objComum).toBe('{"a":1}');
+  });
+
+  test("objeto com valueOf próprio NÃO é desembrulhado", () => {
+    expect(objComValueOf).toBe('{"a":1}');
+  });
+
+  test("array comum", () => {
+    expect(arrayComum).toBe("[1,2]");
+  });
+
+  test("primitivo number", () => {
+    expect(primNum).toBe("5");
+  });
+
+  test("primitivo string", () => {
+    expect(primStr).toBe('"hi"');
+  });
+
+  test("primitivo boolean", () => {
+    expect(primBool).toBe("true");
+  });
+
+  test("null", () => {
+    expect(primNull).toBe("null");
+  });
+});

--- a/tests/cross-runtime/json/claude-stringify-wrapper-objects.ts
+++ b/tests/cross-runtime/json/claude-stringify-wrapper-objects.ts
@@ -1,0 +1,40 @@
+// Cross-runtime: `JSON.stringify` unwraps Boolean/Number/String WRAPPER objects
+// to their primitive (SerializeJSONProperty), ignoring expando properties.
+//
+// Regression guard for issue #2017: `JSON.stringify(new Number(5))` rendered
+// `{}` instead of `5`. The engine has TWO wrapper forms — `Object(5)` builds the
+// shape object `{ __prim: 5 }`, while `new Number(5)` builds a class instance
+// whose primitive is reached through `valueOf()` — and the serializer only knew
+// the first, so the second fell through to the plain-object path.
+
+console.log("number=" + JSON.stringify(new Number(5)));
+console.log("numberNaN=" + JSON.stringify(new Number(NaN)));
+console.log("numberInfinity=" + JSON.stringify(new Number(Infinity)));
+console.log("numberNegZero=" + JSON.stringify(new Number(-0)));
+console.log("string=" + JSON.stringify(new String("hi")));
+console.log("stringQuoted=" + JSON.stringify(new String('a"b')));
+console.log("stringEmpty=" + JSON.stringify(new String("")));
+console.log("boolTrue=" + JSON.stringify(new Boolean(true)));
+console.log("boolFalse=" + JSON.stringify(new Boolean(false)));
+
+console.log("nested=" + JSON.stringify({ a: new Number(7) }));
+console.log("inArray=" + JSON.stringify([new Number(1), new String("x"), new Boolean(false)]));
+console.log("deep=" + JSON.stringify({ a: { b: [new Number(3)] } }));
+
+// An expando property on a wrapper is IGNORED — the primitive wins.
+const withExpando: any = new Number(5);
+withExpando.extra = "ignored";
+console.log("expandoIgnored=" + JSON.stringify(withExpando));
+
+// ── non-regressions ─────────────────────────────────────────────────────────
+console.log("objectWrapperNum=" + JSON.stringify(Object(5)));
+console.log("objectWrapperStr=" + JSON.stringify(Object("h")));
+console.log("plainObject=" + JSON.stringify({ a: 1 }));
+// A plain object that merely HAS a `valueOf` is not a wrapper — it serializes
+// as an object (only its own enumerable data properties).
+console.log("objectWithValueOf=" + JSON.stringify({ valueOf: () => 9, a: 1 }));
+console.log("plainArray=" + JSON.stringify([1, 2]));
+console.log("primNumber=" + JSON.stringify(5));
+console.log("primString=" + JSON.stringify("hi"));
+console.log("primBool=" + JSON.stringify(true));
+console.log("primNull=" + JSON.stringify(null));


### PR DESCRIPTION
## O problema

```js
JSON.stringify(new Number(5))     // RTS: {}          Node: 5
JSON.stringify(new String("hi"))  // RTS: {}          Node: "hi"
JSON.stringify(new Boolean(true)) // RTS: {}          Node: true
JSON.stringify({a: new Number(7)})// RTS: {"a":{}}    Node: {"a":7}
```

Divergência **silenciosa** — valor errado, sem erro.

## A causa

Pela spec (SerializeJSONProperty), um wrapper serializa como o **primitivo** embrulhado, ignorando propriedades expando. O prelude já fazia isso — mas só reconhecia **uma** das duas formas de wrapper que o motor tem:

| Forma | Representação | Primitivo por |
|---|---|---|
| `Object(5)` | objeto de shape `{ __prim: 5 }` | slot `__prim` |
| `new Number(5)` | instância de classe (`Entry::Rtse`) | `valueOf()` |

O `.ts` checava apenas `__prim`, então a segunda forma caía no caminho de objeto comum e virava `{}`.

## A correção

No **prelude**, não no motor — é semântica de JSON, e tanto `instanceof` quanto `valueOf()` já funcionavam nos três wrappers. A checagem de `__prim` permanece para a primeira forma.

Cheguei a começar pelo motor (expor `__prim` no `obj_get`) e reverti ao descobrir que `new Number` não usa `Entry::NumberBox` — esse Entry é legado, só vivo em pickle/napi.

### A distinção que importa

Um objeto comum que apenas **tem** um `valueOf` (`{valueOf: () => 9, a: 1}`) **não** é wrapper e continua serializando como objeto. O teste é por `instanceof`, não pela presença do método — e isso está coberto.

## Validação

- `claude-stringify-wrapper-objects.test.ts` — **19/19**: os três wrappers, `NaN`/`Infinity` → `null`, escape de aspas, aninhamento em objeto/array/profundidade, mais as não-regressões (`Object(5)`, objeto comum, objeto com `valueOf` próprio, array, primitivos, `null`).
- Fixture cross-runtime homônima — **byte-idêntica a Node e Bun**, incluindo expando ignorado.
- **Suite: 2758/2759.** A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.
- `read_before_commit.sh`: sem violação.

Closes #2017

🤖 Generated with [Claude Code](https://claude.com/claude-code)