### PR TITLE
fix(engine): generator por ALIAS mantém o protocolo em spread e for-of

### DIFF
--- a/crates/rts-codegen-new/src/front/run/globals.rs
+++ b/crates/rts-codegen-new/src/front/run/globals.rs
@@ -675,7 +675,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // A CALL of a user function whose declared return type is an array
             // (`function ks(): string[] {…}` → `for (const k of ks())`).
             HirExprKind::Call { callee, .. } => match &callee.kind {
-                HirExprKind::Ident(f) => self.sigs.get(f).is_some_and(|s| s.ret_array),
+                HirExprKind::Ident(f) => {
+                    self.sig_following_alias(f).is_some_and(|s| s.ret_array)
+                }
                 _ => false,
             },
             // A METHOD CALL whose receiver class is known and whose method's declared

--- a/crates/rts-codegen-new/src/front/run/loops.rs
+++ b/crates/rts-codegen-new/src/front/run/loops.rs
@@ -351,7 +351,9 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
     ) -> FrontResult<Option<Value>> {
         let is_lazy = match &iterable.kind {
             HirExprKind::Call { callee, .. } => match &callee.kind {
-                HirExprKind::Ident(f) => self.sigs.get(f).is_some_and(|s| s.ret_lazy_gen),
+                HirExprKind::Ident(f) => {
+                    self.sig_following_alias(f).is_some_and(|s| s.ret_lazy_gen)
+                }
                 _ => false,
             },
             // A LAZY generator LOCAL (`const gen = counter(..); for (const v

--- a/crates/rts-codegen-new/src/front/run/stmt.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt.rs
@@ -451,6 +451,29 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         }
     }
 
+    /// The signature of a callee IDENT, following a generator ALIAS first
+    /// (`const g = gg; g()` — and every hoisted generator EXPRESSION, which the
+    /// parser rewrites to `__genexpr_N` + `const g = __genexpr_N`).
+    ///
+    /// `sigs` is keyed by the DECLARED name, so a bare `sigs.get(name)` misses the
+    /// alias and the call looks like an ordinary function: `for-of`/spread then
+    /// stopped recognizing the generator and silently produced NOTHING
+    /// (`[...g()]` → `""` where `[...gg()]` → `"1,2"`). `gen_call_kind` already
+    /// followed the alias; the iteration paths did not (issue #2042).
+    /// Follows a CHAIN (`const a = gg; const b = a`). The hop budget is the map's
+    /// own size: a chain longer than that must revisit a name, i.e. it is a cycle,
+    /// so this terminates without needing an arbitrary cap.
+    pub(super) fn sig_following_alias(&self, name: &str) -> Option<&super::sig::FnSig> {
+        let mut real = name;
+        for _ in 0..self.generator_aliases.len() {
+            match self.generator_aliases.get(real) {
+                Some(next) if next.as_str() != real => real = next.as_str(),
+                _ => break,
+            }
+        }
+        self.sigs.get(real)
+    }
+
     /// The runtime GenState/Vec handle of a GENERATOR-valued receiver (a generator
     /// local, or a direct `g()` call), for `GENERATOR_NEXT`/`RETURN`/`THROW`. EAGER
     /// (`__gen_buf` array word) → its real Vec handle (`POLY_TO_HANDLE`); LAZY (raw

--- a/crates/rts-codegen-new/src/front/run/stmt_let.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_let.rs
@@ -173,10 +173,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // que `g()` seja reconhecido como chamada de generator (ver
         // `gen_call_kind`). Só o caso Ident→Ident, que é o que um bundle
         // minificado gera; qualquer coisa mais complexa segue o caminho normal.
+        // Resolve o alvo SEGUINDO alias (`sig_following_alias`), não por
+        // `sigs.get` direto: um alias não está em `sigs` (que é indexado pelo nome
+        // DECLARADO), então uma CADEIA `const a = gg; const b = a` parava no
+        // segundo elo — `b()` deixava de ser reconhecido como generator.
         if let HirExprKind::Ident(alvo) = &init.kind {
             if self
-                .sigs
-                .get(alvo.as_str())
+                .sig_following_alias(alvo.as_str())
                 .is_some_and(|s| s.ret_lazy_gen || s.ret_eager_gen)
             {
                 self.generator_aliases

--- a/tests/claude-generator-alias-iteracao.test.ts
+++ b/tests/claude-generator-alias-iteracao.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "rts:test";
+
+// Um generator alcançado por ALIAS (`const g = gg`) perdia o protocolo nos
+// caminhos de ITERAÇÃO — `[...g()]` e `for (const x of g())` produziam NADA,
+// silenciosamente, enquanto `[...gg()]` funcionava.
+//
+// `sigs` é indexado pelo nome DECLARADO, então `sigs.get("g")` não acha nada e a
+// chamada parece uma função comum. `gen_call_kind` (o caminho de `.next()`) já
+// seguia `generator_aliases`; os caminhos de iteração (`try_lazy_gen_source_word`
+// em loops.rs, e a prova de `ret_array` em globals.rs) não seguiam.
+//
+// Importa muito mais do que parece: o parser reescreve TODA generator EXPRESSION
+// para `__genexpr_N` + `const g = __genexpr_N`, então `const g = function*(){…}`
+// caía exatamente nisso — e é a forma que aparece em bundle minificado.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+// ── alias explícito ────────────────────────────────────────────────────────
+function* eagerDecl() { yield* [1, 2]; }
+const aliasEager = eagerDecl;
+const spreadViaAlias = [...aliasEager()].join(",");
+
+function* doisValores() { yield 1; yield 2; }
+const aliasDois = doisValores;
+let somaForOf = 0;
+for (const x of aliasDois()) { somaForOf = somaForOf + x; }
+
+// ── generator EXPRESSION (vira alias no parser) ────────────────────────────
+const exprEager = function* () { yield* [3, 4]; };
+const spreadExpr = [...exprEager()].join(",");
+
+const exprLazy = function* () { let i = 1; while (i <= 3) { yield i; i = i + 1; } };
+const spreadLazy = [...exprLazy()].join(",");
+const nextLazy = exprLazy().next().value;
+
+let somaLazyForOf = 0;
+for (const x of exprLazy()) { somaLazyForOf = somaLazyForOf + x; }
+
+// ── CADEIA de alias (`const b = a` onde `a` já é alias) ────────────────────
+// O registro do alias resolvia o alvo por `sigs.get` direto, e um alias não está
+// em `sigs` — então o segundo elo da cadeia parava de ser reconhecido.
+const aliasDeAlias = aliasEager;
+const spreadCadeia = [...aliasDeAlias()].join(",");
+
+// ── o caminho de `.next()` por alias não pode regredir ─────────────────────
+const nextViaAlias = aliasDois().next().value;
+
+// ── declaração direta não pode regredir ────────────────────────────────────
+const spreadDireto = [...eagerDecl()].join(",");
+let somaDireta = 0;
+for (const x of doisValores()) { somaDireta = somaDireta + x; }
+
+describe("generator por alias mantém o protocolo na iteração", () => {
+  test("spread via alias explícito", () => {
+    expect(spreadViaAlias).toBe("1,2");
+  });
+
+  test("for-of via alias explícito", () => {
+    expect(somaForOf).toBe(3);
+  });
+
+  test("spread de generator EXPRESSION (eager)", () => {
+    expect(spreadExpr).toBe("3,4");
+  });
+
+  test("spread de generator EXPRESSION (lazy)", () => {
+    expect(spreadLazy).toBe("1,2,3");
+  });
+
+  test("for-of de generator EXPRESSION (lazy)", () => {
+    expect(somaLazyForOf).toBe(6);
+  });
+
+  test(".next() de generator EXPRESSION (lazy)", () => {
+    expect(nextLazy).toBe(1);
+  });
+
+  test("cadeia de alias resolve até o generator real", () => {
+    expect(spreadCadeia).toBe("1,2");
+  });
+});
+
+describe("não-regressões", () => {
+  test(".next() via alias continua funcionando", () => {
+    expect(nextViaAlias).toBe(1);
+  });
+
+  test("spread da declaração direta", () => {
+    expect(spreadDireto).toBe("1,2");
+  });
+
+  test("for-of da declaração direta", () => {
+    expect(somaDireta).toBe(3);
+  });
+});

--- a/tests/cross-runtime/generators/claude-generator-alias-iteration.ts
+++ b/tests/cross-runtime/generators/claude-generator-alias-iteration.ts
@@ -1,0 +1,45 @@
+// Cross-runtime: a generator reached through an ALIAS (`const g = gg`) must keep
+// its protocol on the ITERATION paths — spread and `for-of` — not only on
+// `.next()`.
+//
+// Regression guard for issue #2042: `sigs` is keyed by the DECLARED name, so
+// `sigs.get("g")` missed the alias and the call looked like an ordinary
+// function; spread and for-of then silently produced NOTHING (`[...g()]` → ""
+// while `[...gg()]` → "1,2"). `.next()` already followed the alias.
+//
+// This matters far beyond an explicit alias: the parser rewrites EVERY generator
+// EXPRESSION to `__genexpr_N` + `const g = __genexpr_N`, so
+// `const g = function*(){…}` — the form minified bundles use — hit exactly this.
+
+function* eagerDecl() { yield* [1, 2]; }
+const aliasEager = eagerDecl;
+console.log("spreadViaAlias=" + [...aliasEager()].join(","));
+
+function* twoValues() { yield 1; yield 2; }
+const aliasTwo = twoValues;
+let sum = 0;
+for (const x of aliasTwo()) { sum = sum + x; }
+console.log("forOfViaAlias=" + sum);
+console.log("nextViaAlias=" + aliasTwo().next().value);
+
+// generator EXPRESSION — becomes an alias in the parser
+const exprEager = function* () { yield* [3, 4]; };
+console.log("spreadExprEager=" + [...exprEager()].join(","));
+
+const exprLazy = function* () { let i = 1; while (i <= 3) { yield i; i = i + 1; } };
+console.log("spreadExprLazy=" + [...exprLazy()].join(","));
+console.log("nextExprLazy=" + exprLazy().next().value);
+
+let lazySum = 0;
+for (const x of exprLazy()) { lazySum = lazySum + x; }
+console.log("forOfExprLazy=" + lazySum);
+
+// an alias chain still resolves
+const aliasOfAlias = aliasEager;
+console.log("aliasChain=" + [...aliasOfAlias()].join(","));
+
+// ── non-regressions: the direct declaration ─────────────────────────────────
+console.log("spreadDirect=" + [...eagerDecl()].join(","));
+let direct = 0;
+for (const x of twoValues()) { direct = direct + x; }
+console.log("forOfDirect=" + direct);


### PR DESCRIPTION
## O bug

Um generator alcançado por alias produzia **nada** em spread e for-of — silenciosamente:

```js
function* gg(){ yield* [1,2]; }
const g = gg;
[...g()]     // ""      ← errado
[...gg()]    // "1,2"   ← certo
```

## Por que importa muito mais do que um alias explícito

O parser reescreve **toda generator EXPRESSION** para `__genexpr_N` + `const g = __genexpr_N` (`lowering_items.rs:56`). Então isto caía no mesmo buraco:

```js
const g = function*(){ yield* [1,2]; };
[...g()]     // ""
```

— e é justamente a forma que **bundle minificado** gera.

## A causa

`sigs` é indexado pelo nome **declarado**, então `sigs.get("g")` não acha nada e a chamada parece uma função comum. `gen_call_kind` (o caminho de `.next()`) já seguia `generator_aliases`; os caminhos de **iteração** não — `try_lazy_gen_source_word` (`loops.rs`) e a prova de `ret_array` (`globals.rs`) consultavam `sigs` direto.

### Segundo defeito, na mesma linha

O **registro** do alias também resolvia o alvo por `sigs.get` direto — e um alias não está em `sigs`. Uma **cadeia** (`const a = gg; const b = a`) parava no segundo elo.

Ambos passam agora pelo mesmo helper `sig_following_alias`, que segue a cadeia com orçamento igual ao **tamanho do mapa**: uma cadeia mais longa que isso necessariamente revisita um nome (é ciclo), então termina sem teto arbitrário.

## Validação

- `claude-generator-alias-iteracao.test.ts` — **10/10**: alias explícito, generator expression eager e lazy (spread/for-of/next), cadeia de alias, e não-regressões (`.next()` por alias, declaração direta).
- Fixture cross-runtime `claude-generator-alias-iteration.ts` — **byte-idêntica a Node e Bun**.
- **Suite: 2787/2788.** A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.
- `read_before_commit.sh`: sem violação.

Refs #2042, #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)