### PR TITLE
feat(primitives): estáticos de Object legíveis como VALOR

### DIFF
--- a/crates/rts-primitives/src/object.ts
+++ b/crates/rts-primitives/src/object.ts
@@ -106,4 +106,16 @@ class Object {
   static isSealed(o: any): boolean { return Object.isSealed(o); }
   static getPrototypeOf(o: any): any { return Object.getPrototypeOf(o); }
   static getOwnPropertyNames(o: any): any { return Object.getOwnPropertyNames(o); }
+  // O resto da superfície estática que o caminho nativo JÁ lowera na forma
+  // CHAMADA. Sem estes shims a forma LIDA continuava bailando — e é a forma que
+  // bundle minificado usa o tempo todo (`var d = Object.defineProperty`).
+  static defineProperty(o: any, k: any, d: any): any { return Object.defineProperty(o, k, d); }
+  static defineProperties(o: any, d: any): any { return Object.defineProperties(o, d); }
+  static fromEntries(it: any[]): any { return Object.fromEntries(it); }
+  static create(proto: any): any { return Object.create(proto); }
+  static setPrototypeOf(o: any, proto: any): any { return Object.setPrototypeOf(o, proto); }
+  static getOwnPropertyDescriptor(o: any, k: any): any { return Object.getOwnPropertyDescriptor(o, k); }
+  static getOwnPropertySymbols(o: any): any { return Object.getOwnPropertySymbols(o); }
+  static preventExtensions(o: any): any { return Object.preventExtensions(o); }
+  static isExtensible(o: any): boolean { return Object.isExtensible(o); }
 }

--- a/tests/claude-object-statics-como-valor.test.ts
+++ b/tests/claude-object-statics-como-valor.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "rts:test";
+
+// Ler um estático de `Object` como VALOR (`const d = Object.defineProperty`)
+// bailava com "no such static field on class `Object`", embora a forma CHAMADA
+// (`Object.defineProperty(o, k, desc)`) já funcionasse.
+//
+// O leitor genérico de estático de classe procura em `desc.statics`, populado
+// pelos shims de `rts-primitives/src/object.ts`. Metade da superfície não tinha
+// shim — então só metade era legível. Cada shim delega ao MESMO caminho nativo;
+// nada é reimplementado.
+//
+// Importa porque bundle minificado guarda esses estáticos em variável o tempo
+// todo (`var d = Object.defineProperty`).
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+const tDefineProperty = typeof Object.defineProperty;
+const tDefineProperties = typeof Object.defineProperties;
+const tFromEntries = typeof Object.fromEntries;
+const tCreate = typeof Object.create;
+const tSetPrototypeOf = typeof Object.setPrototypeOf;
+const tGetOwnPropertyDescriptor = typeof Object.getOwnPropertyDescriptor;
+const tGetOwnPropertySymbols = typeof Object.getOwnPropertySymbols;
+const tPreventExtensions = typeof Object.preventExtensions;
+const tIsExtensible = typeof Object.isExtensible;
+
+// não basta ser "function": tem de ser CHAMÁVEL e fazer a coisa certa
+const dp = Object.defineProperty;
+const alvo: any = {};
+dp(alvo, "a", { value: 7 });
+const usado = alvo.a;
+
+const fe = Object.fromEntries;
+const doFromEntries = JSON.stringify(fe([["k", 1]]));
+
+const ge = Object.getOwnPropertyDescriptor;
+const desc: any = ge({ a: 5 }, "a");
+const doDescriptor = desc.value;
+
+// os que já funcionavam não podem regredir
+const tKeys = typeof Object.keys;
+const tAssign = typeof Object.assign;
+const keysUsado = (Object.keys)({ x: 1, y: 2 }).join(",");
+
+describe("estáticos de Object legíveis como valor", () => {
+  test("defineProperty", () => expect(tDefineProperty).toBe("function"));
+  test("defineProperties", () => expect(tDefineProperties).toBe("function"));
+  test("fromEntries", () => expect(tFromEntries).toBe("function"));
+  test("create", () => expect(tCreate).toBe("function"));
+  test("setPrototypeOf", () => expect(tSetPrototypeOf).toBe("function"));
+  test("getOwnPropertyDescriptor", () => expect(tGetOwnPropertyDescriptor).toBe("function"));
+  test("getOwnPropertySymbols", () => expect(tGetOwnPropertySymbols).toBe("function"));
+  test("preventExtensions", () => expect(tPreventExtensions).toBe("function"));
+  test("isExtensible", () => expect(tIsExtensible).toBe("function"));
+});
+
+describe("o valor lido é realmente chamável", () => {
+  test("defineProperty guardado define a propriedade", () => expect(usado).toBe(7));
+  test("fromEntries guardado constrói o objeto", () => expect(doFromEntries).toBe('{"k":1}'));
+  test("getOwnPropertyDescriptor guardado lê o descritor", () => expect(doDescriptor).toBe(5));
+});
+
+describe("não-regressões", () => {
+  test("keys continua legível", () => expect(tKeys).toBe("function"));
+  test("assign continua legível", () => expect(tAssign).toBe("function"));
+  test("keys guardado continua funcionando", () => expect(keysUsado).toBe("x,y"));
+});

--- a/tests/cross-runtime/object-meta/claude-object-statics-as-values.ts
+++ b/tests/cross-runtime/object-meta/claude-object-statics-as-values.ts
@@ -1,0 +1,36 @@
+// Cross-runtime: `Object`'s static surface must be readable as a VALUE
+// (`const d = Object.defineProperty`), not only callable in place.
+//
+// Regression guard for the WhatsApp-Web bundle campaign (#2038): reading one of
+// these bailed with "no such static field on class `Object`" while the CALLED
+// form already worked. Minified bundles stash these in a variable constantly
+// (`var d = Object.defineProperty`), so the read form is the common one.
+
+console.log("defineProperty=" + typeof Object.defineProperty);
+console.log("defineProperties=" + typeof Object.defineProperties);
+console.log("fromEntries=" + typeof Object.fromEntries);
+console.log("create=" + typeof Object.create);
+console.log("setPrototypeOf=" + typeof Object.setPrototypeOf);
+console.log("getOwnPropertyDescriptor=" + typeof Object.getOwnPropertyDescriptor);
+console.log("getOwnPropertySymbols=" + typeof Object.getOwnPropertySymbols);
+console.log("preventExtensions=" + typeof Object.preventExtensions);
+console.log("isExtensible=" + typeof Object.isExtensible);
+
+// Being "function" is not enough — the stored value must actually WORK.
+const dp = Object.defineProperty;
+const target: any = {};
+dp(target, "a", { value: 7 });
+console.log("definePropertyWorks=" + target.a);
+
+const fe = Object.fromEntries;
+console.log("fromEntriesWorks=" + JSON.stringify(fe([["k", 1]])));
+
+const gopd = Object.getOwnPropertyDescriptor;
+const d: any = gopd({ a: 5 }, "a");
+console.log("descriptorWorks=" + d.value);
+
+// ── non-regressions: the ones that already worked ───────────────────────────
+console.log("keys=" + typeof Object.keys);
+console.log("assign=" + typeof Object.assign);
+const k = Object.keys;
+console.log("keysWorks=" + k({ x: 1, y: 2 }).join(","));


### PR DESCRIPTION
## O problema

```js
const d = Object.defineProperty;   // "no such static field on class `Object`"
Object.defineProperty(o, k, desc); // ✅ já funcionava
```

Metade da superfície estática tinha esse buraco: `defineProperty`, `defineProperties`, `fromEntries`, `create`, `setPrototypeOf`, `getOwnPropertyDescriptor`, `getOwnPropertySymbols`, `preventExtensions`, `isExtensible`.

## A correção

O mecanismo já existia e estava certo: o leitor genérico de estático de classe (`class/dispatch.rs`) procura em `desc.statics`, populado pelos shims de `rts-primitives/src/object.ts` — o mesmo que já fazia `Object.keys` e `JSON.stringify` serem reificáveis. **Só faltavam os shims.**

Cada um delega ao **mesmo caminho nativo**: `objstatic.rs` intercepta a forma chamada antes de chegar aqui, então o caminho rápido por shape fica intacto. Nada é reimplementado.

Detalhe que custou uma iteração: `fromEntries` precisa de `it: any[]` — sem a anotação o próprio shim não compila, porque o lowering nativo exige um array **provado** e `any` não serve.

## Por que importa

Bundle minificado guarda esses estáticos em variável o tempo todo (`var d = Object.defineProperty`). Era um dos gaps nomeados da carga do WhatsApp Web (#2038) e sai da lista de erros dela.

## Validação

- `claude-object-statics-como-valor.test.ts` — **15/15**: cada estático legível, e três deles **chamados a partir da variável** (defineProperty define de fato, fromEntries constrói, getOwnPropertyDescriptor lê), mais não-regressões de `keys`/`assign`.
- Fixture cross-runtime `claude-object-statics-as-values.ts` — **byte-idêntica a Node e Bun**.
- **Suite: 2787/2788.** A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.
- `read_before_commit.sh`: sem violação.

Refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)