### PR TITLE
fix(engine): generator lazy encaminhado por outra função (duplo boxing)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call_spread.rs
+++ b/crates/rts-codegen-new/src/front/run/call_spread.rs
@@ -146,7 +146,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // via `Entry::GenState` — so the identity survives all of them at once.
             // The static paths that want the bare handle re-derive it by coercion
             // (`generator_receiver_handle`). Issue #2042.
-            Some(_) if sig.ret_lazy_gen => {
+            // Só o CTOR devolve o handle CRU (`Repr::Int64`, carimbado em
+            // `sig.rs`) e portanto precisa ser boxado aqui. Uma função que apenas
+            // REPASSA (`function w(){ return g(); }`) já devolve a word BOXADA —
+            // boxá-la de novo destruía o handle, e o generator alcançado através
+            // de outra função perdia tudo (`it.next()` → undefined).
+            Some(Repr::Int64) if sig.ret_lazy_gen => {
                 let v = self.builder.inst_results(call)[0];
                 let word = crate::value::emit_marshal::emit_box_object_handle(
                     module,

--- a/crates/rts-codegen-new/src/front/run/module_jit.rs
+++ b/crates/rts-codegen-new/src/front/run/module_jit.rs
@@ -312,10 +312,13 @@ pub(crate) fn populate_module(
             if let Some(s) = sigs.get_mut(&f.name) {
                 s.ret_lazy_gen = lazy;
                 s.ret_eager_gen = eager;
-                // O repasse tem de manter a REPR do alvo: um generator lazy é um
-                // handle cru (`Int64`); coagi-lo perde o handle.
+                // Um REPASSE devolve o que o alvo já devolveu — e desde #2042 o
+                // call site do ctor lazy BOXA o handle como word `TAG_OBJECT`.
+                // Então o repassador carrega uma word `Tagged`, não o handle cru:
+                // marcá-lo `Int64` fazia o call site boxar de novo e destruir o
+                // handle (generator via outra função lia `undefined`).
                 if lazy {
-                    s.ret = Some(crate::repr::Repr::Int64);
+                    s.ret = Some(crate::repr::Repr::Tagged);
                 } else if eager {
                     s.ret = Some(crate::repr::Repr::Tagged);
                 }

--- a/tests/claude-generator-encaminhado.test.ts
+++ b/tests/claude-generator-encaminhado.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "rts:test";
+
+// Um generator LAZY alcançado através de outra função perdia TUDO:
+// `it.next()` lia `undefined` em vez do primeiro valor.
+//
+//   function* inner(o) { const a = yield o.v; yield a * 2; }
+//   function wrapper() { const o = {v:5}; return inner(o); }
+//   wrapper().next().value       // undefined  ·  Node: 5
+//
+// Era DUPLO BOXING. Desde #2042 o call site do ctor lazy boxa o handle como word
+// `TAG_OBJECT`; mas o fixpoint que propaga a marca de generator para quem apenas
+// REPASSA continuava marcando o repassador como `Repr::Int64` (o comentário
+// descrevia o estado ANTERIOR àquele fix). O repassador então carregava uma word
+// já boxada, e o call site a boxava de novo — destruindo o handle.
+//
+// Correção nos dois lados: o repassador passa a ser `Tagged` (é o que ele de fato
+// carrega), e o call site só boxa quando o retorno é o handle CRU (`Int64`), que
+// é o caso exclusivo do ctor.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* inner(o) { const a = yield o.v; yield a * 2; }
+function wrapper() { const o = { v: 5 }; return inner(o); }
+const it = wrapper();
+const viaFnPrimeiro = it.next().value;
+const viaFnEnviado = it.next(10).value;
+
+function* semParam() { const a = yield 1; yield a + 1; }
+function fwd() { return semParam(); }
+const i2 = fwd();
+const semParamPrimeiro = i2.next().value;
+const semParamEnviado = i2.next(9).value;
+
+function* contador(n) { let i = 0; while (i < n) { yield i; i = i + 1; } }
+function fwd3() { return contador(3); }
+const spreadEncaminhado = [...fwd3()].join(",");
+let somaForOf = 0;
+for (const x of fwd3()) { somaForOf = somaForOf + x; }
+
+// dois níveis de repasse
+function fwdA() { return contador(2); }
+function fwdB() { return fwdA(); }
+const doisNiveis = [...fwdB()].join(",");
+
+// ── não-regressões ─────────────────────────────────────────────────────────
+const d = semParam();
+const diretoPrimeiro = d.next().value;
+const diretoEnviado = d.next(4).value;
+const spreadDireto = [...contador(2)].join(",");
+
+describe("generator lazy encaminhado por outra função", () => {
+  test("primeiro next() através da função", () => expect(viaFnPrimeiro).toBe(5));
+  test("valor ENVIADO chega ao yield", () => expect(viaFnEnviado).toBe(20));
+  test("sem parâmetro: primeiro next()", () => expect(semParamPrimeiro).toBe(1));
+  test("sem parâmetro: valor enviado", () => expect(semParamEnviado).toBe(10));
+  test("spread do resultado encaminhado", () => expect(spreadEncaminhado).toBe("0,1,2"));
+  test("for-of do resultado encaminhado", () => expect(somaForOf).toBe(3));
+  test("dois níveis de repasse", () => expect(doisNiveis).toBe("0,1"));
+});
+
+describe("não-regressões", () => {
+  test("chamada direta: primeiro next()", () => expect(diretoPrimeiro).toBe(1));
+  test("chamada direta: valor enviado", () => expect(diretoEnviado).toBe(5));
+  test("spread direto", () => expect(spreadDireto).toBe("0,1"));
+});

--- a/tests/cross-runtime/generators/claude-generator-forwarded.ts
+++ b/tests/cross-runtime/generators/claude-generator-forwarded.ts
@@ -1,0 +1,48 @@
+// Cross-runtime: a LAZY generator reached THROUGH another function keeps its
+// whole protocol — first value, sent value, spread, for-of.
+//
+// Regression guard: it was double-boxed. Since #2042 the lazy ctor's call site
+// boxes the handle as a TAG_OBJECT word, but the fixpoint that propagates the
+// generator mark to a FORWARDER still typed the forwarder as the raw `Int64`
+// handle — so the already-boxed word was boxed again and the handle died
+// (`wrapper().next().value` read `undefined`).
+
+function* inner(o) { const a = yield o.v; yield a * 2; }
+function wrapper() { const o = { v: 5 }; return inner(o); }
+const it = wrapper();
+console.log("first=" + it.next().value);
+console.log("sent=" + it.next(10).value);
+
+function* noParam() { const a = yield 1; yield a + 1; }
+function fwd() { return noParam(); }
+const i2 = fwd();
+console.log("noParamFirst=" + i2.next().value);
+console.log("noParamSent=" + i2.next(9).value);
+
+function* counter(n) { let i = 0; while (i < n) { yield i; i = i + 1; } }
+function fwd3() { return counter(3); }
+console.log("spread=" + [...fwd3()].join(","));
+
+let sum = 0;
+for (const x of fwd3()) { sum = sum + x; }
+console.log("forOf=" + sum);
+
+// two levels of forwarding
+function fwdA() { return counter(2); }
+function fwdB() { return fwdA(); }
+console.log("twoLevels=" + [...fwdB()].join(","));
+
+// each call gets its OWN iterator, not shared state
+const a1 = fwd3();
+const a2 = fwd3();
+a1.next();
+console.log("independent=" + a2.next().value);
+
+// the full result object survives the forward
+console.log("resultObject=" + JSON.stringify(fwd().next()));
+
+// ── non-regressions: the direct call ────────────────────────────────────────
+const d = noParam();
+console.log("directFirst=" + d.next().value);
+console.log("directSent=" + d.next(4).value);
+console.log("directSpread=" + [...counter(2)].join(","));


### PR DESCRIPTION
## O bug

```js
function* inner(o) { const a = yield o.v; yield a * 2; }
function wrapper() { const o = {v:5}; return inner(o); }
wrapper().next().value      // undefined   ·   Node: 5
```

Um generator lazy alcançado **através de outra função** perdia tudo.

## A causa: duplo boxing — e foi o #2042 que a introduziu

Desde aquele PR o call site do ctor lazy boxa o handle como word `TAG_OBJECT` (`call_spread.rs`). Mas o fixpoint que propaga a marca de generator para quem apenas **repassa** (`module_jit.rs`) continuou marcando o repassador como `Repr::Int64` — o comentário dele descrevia o estado *anterior* àquele fix.

Resultado: o repassador carregava uma word **já boxada**, e o call site a boxava **de novo**, destruindo o handle.

## A correção

Nos dois lados, e é a mesma ideia — cada ponto declara o que de fato carrega:

- `module_jit.rs`: repassador lazy passa a ser `Tagged` (a word boxada que ele devolve), não `Int64`.
- `call_spread.rs`: só boxa quando o retorno é o handle **cru** (`Some(Repr::Int64)` + `ret_lazy_gen`) — caso exclusivo do ctor.

## Como apareceu

Investigando o bloqueio da carga do WhatsApp Web (#2038). Tentei levantar generator-que-captura passando as capturas como parâmetros; o primeiro `next()` acertava mas o valor enviado não chegava. Ao reduzir, o repro **não tinha nada de captura** — era encaminhamento puro.

## Validação

- `claude-generator-encaminhado.test.ts` — **10/10**: primeiro valor, valor **enviado** (`next(v)`), spread, for-of, dois níveis de repasse, e não-regressões da chamada direta.
- Fixture cross-runtime `claude-generator-forwarded.ts` — **byte-idêntica a Node e Bun**, incluindo iteradores independentes por chamada e o objeto `{value,done}` inteiro.
- **Suite: 2810/2811.** A única falha — *"window é o MESMO objeto entre scripts do documento"* — é **pré-existente**, verificada na main.
- `read_before_commit.sh`: sem violação.

Refs #2042, #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)