### PR TITLE
fix(parser): `if` com yield na state-machine (corrige VALOR ERRADO silencioso)

### DIFF
--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -679,21 +679,26 @@ impl SmBuilder {
             Stmt::Block(b) => self.lower_seq(&b.stmts, cur),
             // `if` sem yield no corpo: mantemos verbatim (efeito colateral puro).
             Stmt::If(i) => {
-                if stmt_has_yield(&i.cons) || i.alt.as_deref().map(stmt_has_yield).unwrap_or(false)
-                    || expr_has_yield(&i.test)
-                {
-                    return None; // if com yield => inelegivel nesta fatia
+                // `yield` no TESTE exigiria suspender NO MEIO da avaliacao da
+                // condicao — a SM nao modela isso. Segue inelegivel.
+                if expr_has_yield(&i.test) {
+                    return None;
                 }
+                // `yield` nos RAMOS agora vai por estados ramificados, o mesmo
+                // caminho que o `return` ja usava. Antes isto bailava e caia no
+                // eager-buffer, onde um `yield` de VALOR (`const a = yield x`)
+                // era reescrito para `push(...)` — o `if` com yield-de-valor
+                // devolvia valor ERRADO em silencio (`1,undefined` onde o Node
+                // da `1,5`).
+                let has_yield = stmt_has_yield(&i.cons)
+                    || i.alt.as_deref().map(stmt_has_yield).unwrap_or(false);
                 // Um `return` dentro do if (mesmo sem yield) NAO pode ir verbatim:
                 // o `return;`/`return X;` cru nao casa com a assinatura i64 da fn
                 // de estado (verifier error). Lower em estados ramificados:
                 // Cond(test, then, else) e o `return` no then vira DONE.
                 let has_return = stmt_has_return(&i.cons)
                     || i.alt.as_deref().map(stmt_has_return).unwrap_or(false);
-                if has_return {
-                    if expr_has_yield(&i.test) {
-                        return None;
-                    }
+                if has_return || has_yield {
                     let then_entry = self.new_state();
                     let after = self.new_state();
                     let else_entry = if i.alt.is_some() {

--- a/tests/claude-generator-if-yield.test.ts
+++ b/tests/claude-generator-if-yield.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "rts:test";
+
+// `if` contendo `yield` era INELEGÍVEL para a state-machine, então caía no
+// eager-buffer — onde `yield` de VALOR (`const a = yield x`) é reescrito para
+// `push(...)`. O resultado era VALOR ERRADO em silêncio:
+//
+//   function* a(){ if(true){ const v = yield 1; yield v; } }
+//   a().next(); a().next(5)        // RTS: 1,undefined  ·  Node: 1,5
+//
+// A state-machine já tinha o caminho ramificado por estados — usava-o só quando
+// havia `return` dentro do `if`. Passa a usá-lo também quando há `yield`:
+// `set_cond(test, then, else)` + lower recursivo de cada ramo + `goto after`.
+//
+// LIMITE mantido: `yield` no TESTE (`if (yield x)`) continua inelegível —
+// exigiria suspender NO MEIO da avaliação da condição, que a SM não modela.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* comBloco() { if (true) { const v = yield 1; yield v; } }
+const ia = comBloco();
+const blocoPrimeiro = ia.next().value;
+const blocoEnviado = ia.next(5).value;
+
+function* ramoThen() { const v = yield 1; if (v > 0) yield v * 2; else yield 0; }
+const ib = ramoThen();
+const thenPrimeiro = ib.next().value;
+const thenEnviado = ib.next(5).value;
+
+function* ramoElse() { const v = yield 1; if (v > 0) yield v * 2; else yield -1; }
+const ic = ramoElse();
+ic.next();
+const peloElse = ic.next(-3).value;
+
+function* ifAninhado() {
+  const x = yield 1;
+  if (x > 10) { const y = yield x; yield y + 1; } else { yield 0; }
+}
+const ig = ifAninhado();
+const an1 = ig.next().value;
+const an2 = ig.next(20).value;
+const an3 = ig.next(7).value;
+
+function* ifEmLoop() { let i = 0; while (i < 3) { if (i % 2 === 0) yield i; i = i + 1; } }
+const noLoop = [...ifEmLoop()].join(",");
+
+// ── não-regressões ─────────────────────────────────────────────────────────
+function* ifFalso() { if (false) { yield 9; } yield 1; }
+const ramoNaoTomado = [...ifFalso()].join(",");
+
+function* ifSemBloco() { if (true) yield 1; else yield 2; yield 3; }
+const semChaves = [...ifSemBloco()].join(",");
+
+function* ifComReturn() { if (true) { return; } yield 1; }
+const comReturn = [...ifComReturn()].join(",");
+
+function* semIf() { const a = yield 1; yield a * 3; }
+const sd = semIf();
+const semIfPrimeiro = sd.next().value;
+const semIfEnviado = sd.next(4).value;
+
+describe("if contendo yield na state-machine", () => {
+  test("if com bloco: primeiro valor", () => expect(blocoPrimeiro).toBe(1));
+  test("if com bloco: valor ENVIADO chega", () => expect(blocoEnviado).toBe(5));
+  test("ramo then tomado", () => expect(thenEnviado).toBe(10));
+  test("ramo else tomado", () => expect(peloElse).toBe(-1));
+  test("if aninhado com dois yields de valor", () =>
+    expect(an1 + "," + an2 + "," + an3).toBe("1,20,8"));
+  test("if dentro de while", () => expect(noLoop).toBe("0,2"));
+});
+
+describe("não-regressões", () => {
+  test("ramo não tomado não rende", () => expect(ramoNaoTomado).toBe("1"));
+  test("if sem chaves", () => expect(semChaves).toBe("1,3"));
+  test("if com return encerra", () => expect(comReturn).toBe(""));
+  test("generator sem if: primeiro", () => expect(semIfPrimeiro).toBe(1));
+  test("generator sem if: enviado", () => expect(semIfEnviado).toBe(12));
+});

--- a/tests/cross-runtime/generators/claude-generator-if-yield.ts
+++ b/tests/cross-runtime/generators/claude-generator-if-yield.ts
@@ -1,0 +1,62 @@
+// Cross-runtime: an `if` whose branches contain `yield`, including `yield` in
+// VALUE position (`const v = yield x`).
+//
+// This produced a WRONG VALUE, silently. An `if` containing yield was ineligible
+// for the state machine, so it fell back to the eager buffer — which rewrites
+// every `yield X` into a push, including in value position. `const v = yield 1`
+// then read back `undefined` instead of the sent value.
+//
+// The state machine already had the branch-into-states path; it was only used
+// when the `if` contained a `return`. It now covers `yield` too.
+//
+// Still ineligible on purpose: `yield` in the TEST (`if (yield x)`) would need
+// to suspend in the MIDDLE of evaluating the condition.
+
+function* withBlock() { if (true) { const v = yield 1; yield v; } }
+const ia = withBlock();
+console.log("blockFirst=" + ia.next().value);
+console.log("blockSent=" + ia.next(5).value);
+
+function* thenBranch() { const v = yield 1; if (v > 0) yield v * 2; else yield 0; }
+const ib = thenBranch();
+ib.next();
+console.log("thenTaken=" + ib.next(5).value);
+
+function* elseBranch() { const v = yield 1; if (v > 0) yield v * 2; else yield -1; }
+const ic = elseBranch();
+ic.next();
+console.log("elseTaken=" + ic.next(-3).value);
+
+function* nested() {
+  const x = yield 1;
+  if (x > 10) { const y = yield x; yield y + 1; } else { yield 0; }
+}
+const ig = nested();
+console.log("nested=" + ig.next().value + "," + ig.next(20).value + "," + ig.next(7).value);
+
+function* insideLoop() { let i = 0; while (i < 3) { if (i % 2 === 0) yield i; i = i + 1; } }
+console.log("insideLoop=" + [...insideLoop()].join(","));
+
+function* elseIfChain() {
+  const v = yield 1;
+  if (v === 1) yield "um";
+  else if (v === 2) yield "dois";
+  else yield "outro";
+}
+const ie = elseIfChain();
+ie.next();
+console.log("elseIfChain=" + ie.next(2).value);
+
+// ── non-regressions ─────────────────────────────────────────────────────────
+function* falseBranch() { if (false) { yield 9; } yield 1; }
+console.log("branchNotTaken=" + [...falseBranch()].join(","));
+
+function* noBraces() { if (true) yield 1; else yield 2; yield 3; }
+console.log("noBraces=" + [...noBraces()].join(","));
+
+function* withReturn() { if (true) { return; } yield 1; }
+console.log("withReturn=" + [...withReturn()].join(",") + "|");
+
+function* noIf() { const a = yield 1; yield a * 3; }
+const sd = noIf();
+console.log("noIf=" + sd.next().value + "," + sd.next(4).value);


### PR DESCRIPTION
## O bug: valor errado, em silêncio

```js
function* a(){ if(true){ const v = yield 1; yield v; } }
// RTS: 1,undefined   ·   Node: 1,5

function* b(){ const v = yield 1; if(v>0) yield v*2; else yield 0; }
// RTS: 1,0           ·   Node: 1,10
```

`if` cujos ramos contêm `yield` era **inelegível** para a state-machine e caía no eager-buffer — que reescreve todo `yield X` para `push(X)`, **inclusive em posição de valor**. O `const v = yield 1` então lia `undefined` em vez do valor enviado.

## A correção é a condição de entrada, não um mecanismo novo

A state-machine **já tinha** o caminho ramificado por estados — `set_cond(test, then, else)` + lower recursivo de cada ramo + `goto after` — e o usava quando havia `return` dentro do `if`. Agora usa também quando há `yield`.

## Limite mantido explícito

`yield` no **teste** (`if (yield x)`) continua inelegível: exigiria suspender no meio da avaliação da condição, que a SM não modela.

## Como apareceu

Atacando o bloqueio da carga do WhatsApp Web (#2038). Bundle minificado é feito de `if` com generator — e o modo de falha silencioso é o pior possível para diagnosticar.

## Validação

- `claude-generator-if-yield.test.ts` — **11/11**: bloco, ramo then, ramo else, `if` aninhado com dois yields de valor, `if` dentro de while; mais não-regressões (ramo não tomado, sem chaves, com `return`, generator sem `if`).
- Fixture cross-runtime — **byte-idêntica a Node e Bun**, incluindo cadeia `else if`.
- **Suite: 2827/2828.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038, #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)