### PR TITLE
fix(parser): `try` que suspende com catch SEM yield na state-machine

### DIFF
--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -586,7 +586,14 @@ impl SmBuilder {
                 // fora desta fatia (bail).
                 if let Some(h) = &t.handler {
                     let catch_has_yield = h.body.stmts.iter().any(stmt_has_yield);
-                    if catch_has_yield && t.finalizer.is_none() {
+                    // Basta o TRY suspender para precisar deste caminho — o catch
+                    // não precisa ter yield. `try { ...yield... } catch(e) { trata }`
+                    // é a forma comum, e antes ela caía no `return None` abaixo e
+                    // ia para o eager-buffer, onde um `yield` de VALOR vira
+                    // `push(...)`. O catch sem yield é lowerado como statements
+                    // ordinários dentro do estado do catch — nada mais é preciso.
+                    let body_has_yield = t.block.stmts.iter().any(stmt_has_yield);
+                    if (catch_has_yield || body_has_yield) && t.finalizer.is_none() {
                         // param do catch: ident simples (ou ausente).
                         let catch_param = match h.param.as_ref() {
                             Some(swc_ecma_ast::Pat::Ident(id)) => {

--- a/tests/claude-generator-try-yield.test.ts
+++ b/tests/claude-generator-try-yield.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "rts:test";
+
+// `try { ...yield... } catch (e) { ...sem yield... }` — a forma COMUM — era
+// inelegível para a state-machine e caía no eager-buffer, onde `yield` de VALOR
+// vira `push(...)`. O caso simplesmente não compilava
+// ("expression raw/unrecognized: Yield").
+//
+// O caminho já existia e estava certo (ENTER_TRY_CATCH → body → CAUGHT → catch),
+// mas a condição de entrada exigia yield NO CATCH. Basta o TRY suspender: o
+// catch sem yield é lowerado como statements ordinários dentro do estado do
+// catch — nada mais é preciso.
+//
+// LIMITE mantido: `try/catch` combinado com `finally` segue fora desta fatia.
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* catchVazio() { try { const v = yield 1; yield v; } catch (e) { } }
+const ia = catchVazio();
+const vazioPrimeiro = ia.next().value;
+const vazioEnviado = ia.next(5).value;
+
+function* catchComYield() { try { const v = yield 1; yield v; } catch (e) { yield 9; } }
+const ib = catchComYield();
+const comYieldPrimeiro = ib.next().value;
+const comYieldEnviado = ib.next(5).value;
+
+function* continuaDepois() { try { const v = yield 1; yield v * 2; } catch (e) { } yield 99; }
+const id = continuaDepois();
+const d1 = id.next().value;
+const d2 = id.next(3).value;
+const d3 = id.next().value;
+
+function* catchComCorpo() {
+  let marca = 0;
+  try { const v = yield 1; yield v; } catch (e) { marca = 1; }
+  yield marca;
+}
+const ie = catchComCorpo();
+ie.next();
+ie.next(7);
+const marcaFinal = ie.next().value;
+
+// ── não-regressões ─────────────────────────────────────────────────────────
+function* tryFinally() { try { yield 1; } finally { } yield 2; }
+const comFinally = [...tryFinally()].join(",");
+
+function* semTry() { const a = yield 1; yield a * 3; }
+const st = semTry();
+const semTryPrimeiro = st.next().value;
+const semTryEnviado = st.next(4).value;
+
+describe("try com yield no BODY e catch sem yield", () => {
+  test("catch vazio: primeiro valor", () => expect(vazioPrimeiro).toBe(1));
+  test("catch vazio: valor ENVIADO chega", () => expect(vazioEnviado).toBe(5));
+  test("catch COM yield continua funcionando", () => expect(comYieldEnviado).toBe(5));
+  test("execução continua depois do try", () =>
+    expect(d1 + "," + d2 + "," + d3).toBe("1,6,99"));
+  test("catch com corpo (sem yield) não é executado sem erro", () =>
+    expect(marcaFinal).toBe(0));
+});
+
+describe("não-regressões", () => {
+  test("try/finally não regrediu", () => expect(comFinally).toBe("1,2"));
+  test("generator sem try: primeiro", () => expect(semTryPrimeiro).toBe(1));
+  test("generator sem try: enviado", () => expect(semTryEnviado).toBe(12));
+});

--- a/tests/cross-runtime/generators/claude-generator-try-yield.ts
+++ b/tests/cross-runtime/generators/claude-generator-try-yield.ts
@@ -1,0 +1,46 @@
+// Cross-runtime: `try { ...yield... } catch (e) { ...no yield... }` — the common
+// shape — inside a generator.
+//
+// It did not compile ("expression raw/unrecognized: Yield"): the state machine's
+// try/catch path required the yield to be IN THE CATCH, so a try that suspends
+// with an ordinary catch fell back to the eager buffer, which cannot express a
+// value-position yield.
+//
+// The machinery was already right (ENTER_TRY_CATCH → body → CAUGHT → catch); only
+// the entry condition was too narrow. A catch without yield lowers as ordinary
+// statements inside the catch state.
+
+function* emptyCatch() { try { const v = yield 1; yield v; } catch (e) { } }
+const ia = emptyCatch();
+console.log("emptyFirst=" + ia.next().value);
+console.log("emptySent=" + ia.next(5).value);
+
+function* catchWithYield() { try { const v = yield 1; yield v; } catch (e) { yield 9; } }
+const ib = catchWithYield();
+ib.next();
+console.log("catchYieldSent=" + ib.next(5).value);
+
+function* continuesAfter() { try { const v = yield 1; yield v * 2; } catch (e) { } yield 99; }
+const id = continuesAfter();
+console.log("after=" + id.next().value + "," + id.next(3).value + "," + id.next().value);
+
+function* catchBodyNotRun() {
+  let mark = 0;
+  try { const v = yield 1; yield v; } catch (e) { mark = 1; }
+  yield mark;
+}
+const ie = catchBodyNotRun();
+ie.next();
+ie.next(7);
+console.log("catchNotRun=" + ie.next().value);
+
+// the full result object survives
+console.log("resultObject=" + JSON.stringify(emptyCatch().next()));
+
+// ── non-regressions ─────────────────────────────────────────────────────────
+function* tryFinally() { try { yield 1; } finally { } yield 2; }
+console.log("tryFinally=" + [...tryFinally()].join(","));
+
+function* noTry() { const a = yield 1; yield a * 3; }
+const st = noTry();
+console.log("noTry=" + st.next().value + "," + st.next(4).value);


### PR DESCRIPTION
## O bug

```js
function* g(){ try { const v = yield 1; yield v; } catch (e) { } }
// não compilava: "expression raw/unrecognized: Yield"
```

É **a forma comum** — `try` que suspende, catch ordinário.

## A causa

O caminho de try/catch da state-machine já existia e estava certo (`ENTER_TRY_CATCH` → body → `CAUGHT` → catch), mas a condição de entrada exigia o yield estar **no catch**. Um `try` que suspende com catch ordinário caía no `return None` e ia para o eager-buffer, que não expressa `yield` de valor.

Basta o **try** suspender. Um catch sem yield é lowerado como statements ordinários dentro do estado do catch — a mudança é a condição, não o mecanismo.

## Limites mantidos

`try/catch` combinado com `finally` segue fora desta fatia, e `throw` dentro do try continua inelegível.

## Validação

- `claude-generator-try-yield.test.ts` — **8/8**: catch vazio (primeiro valor e valor **enviado**), catch com yield (não-regressão), continuação depois do try, catch com corpo que **não** roda sem erro; mais try/finally e generator sem try.
- Fixture cross-runtime — **byte-idêntica a Node e Bun**.
- **Suite: 2838/2839.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038, #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)