### PR TITLE
fix(parser): `break` em generator TRAVAVA para sempre; e eager não inventa mais sent-value

### DIFF
--- a/crates/rts-parser/src/generator_desugar.rs
+++ b/crates/rts-parser/src/generator_desugar.rs
@@ -222,12 +222,25 @@ fn transform_stmt(stmt: Stmt) -> Vec<Stmt> {
                             );
                             out.push(decl_from_pat(d.name.clone(), Some(get_ret), kind, span));
                         } else {
-                            // const r = yield v -> push(v); const r = undefined;
-                            out.push(push_call_stmt(y.arg.as_deref().cloned(), span));
-                            let undef = Expr::Ident(Ident::new(
-                                "undefined".into(), span, Default::default(),
+                            // `const r = yield v` — o VALOR ENVIADO por
+                            // `it.next(v)` so' existe na state-machine; o
+                            // eager-buffer nao tem como alimenta-lo de volta.
+                            //
+                            // Antes isto virava `push(v); const r = undefined;`
+                            // — um VALOR ERRADO em silencio (`0,1` onde o Node
+                            // da `0,2`). Agora o `yield` fica INTACTO: o lowering
+                            // recusa com "expression raw/unrecognized: Yield",
+                            // que e' uma falha honesta. Corpos que a SM aceita
+                            // nao passam por aqui (o value-yield ja' os torna
+                            // elegiveis a lazy); so' chegam os que ela recusa
+                            // — hoje `break`/`continue`, `switch`, `throw` no
+                            // try, e `yield` em sub-expressao.
+                            out.push(decl_from_pat(
+                                d.name.clone(),
+                                Some(Expr::Yield(y.clone())),
+                                kind,
+                                span,
                             ));
-                            out.push(decl_from_pat(d.name.clone(), Some(undef), kind, span));
                         }
                     }
                     other_init => {

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -79,6 +79,18 @@ pub fn try_build(name: &str, function: &Function) -> Option<(FnDecl, FnDecl)> {
     if !body_needs_lazy(&body.stmts) {
         return None;
     }
+    // `break`/`continue` NAO sao modelados pela state-machine: o corpo do loop
+    // vira ESTADOS, e um `break` emitido verbatim dentro do estado nao tem loop
+    // para sair — a maquina ignorava o corte e o generator rodava PARA SEMPRE
+    // (`while(true){ if(i>=2) break; yield i; i=i+1 }` travava, sem erro).
+    //
+    // Inelegivel => cai no eager-buffer, que mantem o corpo verbatim e portanto
+    // respeita o `break` corretamente. Perde-se a lazy nesses corpos; ganha-se
+    // terminar. Voltar a aceita-los exige modelar break/continue como alvo de
+    // estado (com pilha de alvos p/ rotulos), nao apenas relaxar esta guarda.
+    if body.stmts.iter().any(stmt_has_break_or_continue) {
+        return None;
+    }
 
     let mut builder = SmBuilder::new();
     // Pre-registra params como locais (slots 0..n).
@@ -1387,6 +1399,27 @@ fn stmt_has_return(s: &Stmt) -> bool {
         Stmt::Switch(sw) => sw.cases.iter().any(|c| c.cons.iter().any(stmt_has_return)),
         _ => false,
     }
+}
+
+/// True se o stmt contem `break`/`continue` em qualquer profundidade, SEM descer
+/// em funcoes aninhadas (um `break` la dentro pertence a outro corpo).
+fn stmt_has_break_or_continue(s: &Stmt) -> bool {
+    use swc_ecma_visit::{Visit, VisitWith};
+    #[derive(Default)]
+    struct Achou(bool);
+    impl Visit for Achou {
+        fn visit_break_stmt(&mut self, _: &swc_ecma_ast::BreakStmt) {
+            self.0 = true;
+        }
+        fn visit_continue_stmt(&mut self, _: &swc_ecma_ast::ContinueStmt) {
+            self.0 = true;
+        }
+        fn visit_function(&mut self, _: &Function) {}
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {}
+    }
+    let mut v = Achou::default();
+    s.visit_with(&mut v);
+    v.0
 }
 
 fn stmt_has_yield(s: &Stmt) -> bool {

--- a/tests/claude-generator-break-continue.test.ts
+++ b/tests/claude-generator-break-continue.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from "rts:test";
+
+// `break` num loop de generator TRAVAVA PARA SEMPRE — sem erro, sem saída:
+//
+//   function* a(){ let i=0; while(true){ if(i>=2) break; yield i; i=i+1; } }
+//   [...a()]        // travava (exit 124 por timeout)  ·  Node: [0,1]
+//
+// `break`/`continue` não são modelados pela state-machine: o corpo do loop vira
+// ESTADOS, e um `break` emitido verbatim dentro de um estado não tem loop de
+// onde sair. A máquina ignorava o corte e o generator rodava indefinidamente.
+//
+// Correção: corpo com `break`/`continue` é INELEGÍVEL para a SM e cai no
+// eager-buffer, que mantém o corpo verbatim e portanto respeita o corte. Perde-se
+// a lazy nesses corpos; ganha-se terminar.
+//
+// Segunda correção, junto: o eager-buffer reescrevia `const r = yield v` para
+// `push(v); const r = undefined` — o valor ENVIADO por `next(v)` não existe no
+// modelo eager. Era um VALOR ERRADO em silêncio. Agora o `yield` fica intacto e
+// o lowering recusa honestamente. Um corpo que a SM aceita não passa por aí (o
+// value-yield já o torna elegível a lazy).
+//
+// Valores conferidos contra o Node. Pré-computado no top-level.
+
+function* breakWhile() { let i = 0; while (true) { if (i >= 2) break; yield i; i = i + 1; } }
+const doWhile = [...breakWhile()].join(",");
+
+function* breakFor() { for (let i = 0; i < 5; i++) { if (i === 2) break; yield i; } }
+const doFor = [...breakFor()].join(",");
+
+function* continueForOf() { for (const x of [1, 2, 3]) { if (x === 2) continue; yield x; } }
+const doContinue = [...continueForOf()].join(",");
+
+function* breakDoWhile() { let i = 0; do { if (i >= 2) break; yield i; i = i + 1; } while (true); }
+const doDoWhile = [...breakDoWhile()].join(",");
+
+// ── não-regressões: o que DEVE continuar lazy ──────────────────────────────
+function* infinito() { let i = 0; while (true) { yield i; i = i + 1; } }
+const ii = infinito();
+const infinitoA = ii.next().value;
+const infinitoB = ii.next().value;
+
+function* comSent() { let i = 0; while (i < 3) { const v = yield i; i = i + (v || 1); } }
+const is = comSent();
+const sentPrimeiro = is.next().value;
+const sentEnviado = is.next(2).value;
+
+function* semBreak() { let i = 0; while (i < 2) { yield i; i = i + 1; } }
+const semCorte = [...semBreak()].join(",");
+
+describe("break/continue em generator", () => {
+  test("break em while(true) TERMINA", () => expect(doWhile).toBe("0,1"));
+  test("break em for", () => expect(doFor).toBe("0,1"));
+  test("continue em for-of", () => expect(doContinue).toBe("1,3"));
+  test("break em do-while", () => expect(doDoWhile).toBe("0,1"));
+});
+
+describe("não-regressões: o caminho lazy é preservado", () => {
+  test("generator INFINITO continua lazy", () =>
+    expect(infinitoA + "," + infinitoB).toBe("0,1"));
+  test("valor enviado por next(v) continua chegando", () =>
+    expect(sentPrimeiro + "," + sentEnviado).toBe("0,2"));
+  test("loop sem break não regrediu", () => expect(semCorte).toBe("0,1"));
+});

--- a/tests/cross-runtime/generators/claude-generator-break-continue.ts
+++ b/tests/cross-runtime/generators/claude-generator-break-continue.ts
@@ -1,0 +1,40 @@
+// Cross-runtime: `break` / `continue` inside a generator loop.
+//
+// `break` used to HANG FOREVER — no error, no output. The state machine turns a
+// loop body into STATES, and a `break` emitted verbatim inside a state has no
+// loop to leave, so the cut was ignored and the generator ran forever.
+//
+// Such a body is now ineligible for the state machine and falls back to the
+// eager buffer, which keeps the body verbatim and therefore honours the cut.
+// Laziness is lost for those bodies; termination is gained.
+
+function* breakWhile() { let i = 0; while (true) { if (i >= 2) break; yield i; i = i + 1; } }
+console.log("breakWhile=" + [...breakWhile()].join(","));
+
+function* breakFor() { for (let i = 0; i < 5; i++) { if (i === 2) break; yield i; } }
+console.log("breakFor=" + [...breakFor()].join(","));
+
+function* continueForOf() { for (const x of [1, 2, 3]) { if (x === 2) continue; yield x; } }
+console.log("continueForOf=" + [...continueForOf()].join(","));
+
+function* breakDoWhile() { let i = 0; do { if (i >= 2) break; yield i; i = i + 1; } while (true); }
+console.log("breakDoWhile=" + [...breakDoWhile()].join(","));
+
+function* continueWhile() { let i = 0; while (i < 4) { i = i + 1; if (i % 2 === 0) continue; yield i; } }
+console.log("continueWhile=" + [...continueWhile()].join(","));
+
+// `.next()` walks the same values one at a time
+const it = breakWhile();
+console.log("next=" + it.next().value + "," + it.next().value + "," + JSON.stringify(it.next()));
+
+// ── non-regressions: what must stay LAZY ────────────────────────────────────
+function* infinite() { let i = 0; while (true) { yield i; i = i + 1; } }
+const ii = infinite();
+console.log("infiniteStaysLazy=" + ii.next().value + "," + ii.next().value);
+
+function* withSent() { let i = 0; while (i < 3) { const v = yield i; i = i + (v || 1); } }
+const is = withSent();
+console.log("sentValue=" + is.next().value + "," + is.next(2).value);
+
+function* noBreak() { let i = 0; while (i < 2) { yield i; i = i + 1; } }
+console.log("noBreak=" + [...noBreak()].join(","));


### PR DESCRIPTION
## 1. `break` num generator travava indefinidamente

```js
function* a(){ let i=0; while(true){ if(i>=2) break; yield i; i=i+1; } }
[...a()]      // TRAVAVA (exit 124)   ·   Node: [0,1]
```

Sem erro, sem saída. Viola o piso do projeto ("nada que trava conta como pass").

`break`/`continue` **não são modelados** pela state-machine: o corpo do loop vira estados, e um `break` emitido verbatim dentro de um estado não tem loop de onde sair — a máquina ignorava o corte.

Corpo com `break`/`continue` passa a ser inelegível para a SM e cai no eager-buffer, que mantém o corpo verbatim e respeita o corte. **Perde-se a lazy nesses corpos; ganha-se terminar.** Voltar a aceitá-los exige modelar break/continue como alvo de estado (com pilha para rótulos), não apenas relaxar a guarda.

## 2. O eager inventava o valor de `next(v)`

Cair no eager expôs uma aproximação errada que já estava lá, documentada: `const r = yield v` virava `push(v); const r = undefined`. O valor **enviado** só existe na state-machine, e o eager devolvia `undefined` calado — `0,1` onde o Node dá `0,2`.

Agora o `yield` fica **intacto** e o lowering recusa honestamente. Um corpo que a SM aceita não passa por aí (o value-yield já o torna elegível a lazy); só chegam os que ela recusa. O caso `const r = yield* gen()` é diferente e **correto** (lê o ret do delegado) — preservado.

## Validação

- `claude-generator-break-continue.test.ts` — **7/7**: break em while(true)/for/do-while, continue em for-of; e as não-regressões que importam — generator **infinito continua lazy**, e `next(v)` continua entregando o valor enviado quando não há break.
- Fixture cross-runtime — **byte-idêntica a Node e Bun**.
- **Suite: 2846/2847.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038, #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)