### PR TITLE
fix(engine): um LOCAL sombreia o import de namespace (escopo de JS)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -81,7 +81,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // through the Registry — the SAME path a direct `rts:<ns>` member-import call
         // uses. An unknown member / unregistered namespace bails honestly.
         if let HirExprKind::Ident(obj) = &object.kind {
-            if let Some((_ns, member)) = self.builtins.get(obj).cloned() {
+            // Um LOCAL de mesmo nome SOMBREIA o import — é o escopo de JS. Sem
+            // esta guarda, `import f from "rts:fetch"` no programa do usuário
+            // fazia o `const f = this.__fwd; f.write(chunk)` do PRELUDE
+            // (streams.ts) resolver `write` contra o namespace `rts:fetch`, e o
+            // programa inteiro morria em "no matching namespace function".
+            // Ou seja: o NOME que o usuário escolhe no import podia quebrar o
+            // prelude — e código minificado usa nomes de uma letra o tempo todo.
+            let sombreado = self.local(obj).is_some() || self.classes.get(obj).is_some();
+            if let Some((_ns, member)) = self.builtins.get(obj).cloned().filter(|_| !sombreado) {
                 if member.is_empty() {
                     return self
                         .lower_builtin_call(module, &_ns, method, args)

--- a/tests/claude-import-nao-sombreia-prelude.test.ts
+++ b/tests/claude-import-nao-sombreia-prelude.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "rts:test";
+import f from "rts:fmt";
+import e from "rts:env";
+
+// O NOME escolhido num `import ... from "rts:<ns>"` podia QUEBRAR o prelude.
+//
+// `import f from "rts:fetch"` fazia o programa inteiro morrer com
+// "builtin import `write` from `rts:fetch`: no matching namespace function" —
+// um erro apontando para código que o usuário nunca escreveu. A causa: o
+// prelude `streams.ts` tem
+//
+//     const f = this.__fwd;
+//     if (f !== null) { f.write(chunk); return; }
+//
+// e a resolução de método consultava a tabela de imports ANTES de checar se o
+// nome era um LOCAL. O `f` local do prelude era sombreado pelo import do
+// usuário, e `f.write(...)` virava uma busca de membro no namespace.
+//
+// Isso é o INVERSO do escopo de JS: um `const` local sombreia o import, nunca o
+// contrário. E importa muito: nome de uma letra é o que código minificado usa.
+//
+// Este teste importa com nomes de UMA LETRA que colidem com locais do prelude —
+// antes bastava para derrubar o arquivo inteiro.
+
+const hex = f.fmt_hex(255);
+const temPath = e.get_var("PATH").length > 0;
+
+// um local com o MESMO nome do import sombreia dentro da função
+function localSombreia(): string {
+  const f = { marca: "local" };
+  return f.marca;
+}
+const doLocal = localSombreia();
+
+describe("import não sombreia local do prelude", () => {
+  test("import de uma letra (f) não quebra o prelude", () => {
+    expect(hex).toBe("0xff");
+  });
+
+  test("segundo import de uma letra (e) coexiste", () => {
+    expect(temPath).toBe(true);
+  });
+
+  test("local de mesmo nome vence o import (escopo de JS)", () => {
+    expect(doLocal).toBe("local");
+  });
+});


### PR DESCRIPTION
## O bug

```ts
import f from "rts:fetch";
// → "builtin import `write` from `rts:fetch`: no matching namespace function"
```

Um erro apontando para código que o usuário **nunca escreveu**. O **nome** escolhido no import quebrava o prelude.

## A causa

`streams.ts` (prelude) tem:

```ts
const f = this.__fwd;
if (f !== null) { f.write(chunk); return; }
```

E `try_namespace_method` consultava a tabela de imports **antes** de checar se o nome era um local. O `f` local do prelude era sombreado pelo import do usuário, e `f.write(chunk)` virava busca de membro no namespace `rts:fetch`.

É o **inverso** do escopo de JS: um `const` local sombreia o import, nunca o contrário. O caminho *ambiente* logo abaixo já fazia a checagem certa; o dos imports não fazia.

## Por que importa

Nome de **uma letra** é o que código minificado usa — e o modo de falha aponta para o prelude, algo que o autor do programa não tem como diagnosticar.

Medido: com a correção, `f`/`e`/`s`/`d`/`o`/`r`/`v`/`t` funcionam como alias. Antes, `f` derrubava o arquivo inteiro.

Descoberto tentando alcançar o `fetch` do Registry a partir do escopo de página (#2038).

## Validação

- `claude-import-nao-sombreia-prelude.test.ts` — **3/3**: importa com nomes de uma letra que colidem com locais do prelude, e checa que um local de mesmo nome vence o import dentro da função.
- **Suite: 2853/2854.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)