### PR TITLE
fix(engine): Promise.resolve(num).then entregava os BITS de f64, não o número

### DIFF
--- a/crates/rts-runtime/src/adapters/value/dyndispatch.rs
+++ b/crates/rts-runtime/src/adapters/value/dyndispatch.rs
@@ -755,15 +755,24 @@ pub fn rtsadp_promise_resolve_w(word: u64) -> u64 {
             return out;
         }
     }
-    // Plain value / existing promise: the legacy resolve path (word passes as
-    // handle-or-value exactly like the static marshal did).
-    let raw = if v.is_object() || v.is_function() || v.is_string() {
-        rt_handles::__rtsn_poly_to_handle(v.as_handle())
-    } else {
-        word
-    };
-    let r = rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_GL_PROMISE_RESOLVE(raw);
-    r as u64
+    // Valor com HANDLE por trás (objeto/função/string): caminho legado, que já
+    // trata passthrough de Promise existente e thenable.
+    if v.is_object() || v.is_function() || v.is_string() {
+        let h = rt_handles::__rtsn_poly_to_handle(v.as_handle());
+        return rts_runtime::namespaces::globals::fetch::instance::__RTS_FN_GL_PROMISE_RESOLVE(h)
+            as u64;
+    }
+    // Valor SEM handle (número, bool, null, undefined): a WORD é o valor. Passá-la
+    // ao caminho legado guardava a word num slot marcado como NÃO-word, e o
+    // `.then` entregava os bits crus ao callback — `Promise.resolve(7).then(v =>
+    // …)` via `4619567317775286272`, que são exatamente os bits de f64 de `7.0`.
+    // (O `await` escapava por converter por heurística em `normalize_settled_i64`,
+    // o que explica `await` certo e `.then` errado no MESMO valor.)
+    //
+    // Marcar o slot com `resolve_word` é o que faz a entrega reboxar direito.
+    let slot = promise_slot::new_pending();
+    promise_slot::resolve_word(&slot, word as i64);
+    rt_handles::alloc_entry(rt_handles::Entry::PromiseAsync(slot))
 }
 
 /// `recv.method(a0..a2)` — GENERIC dynamic method dispatch on a Tagged

--- a/tests/claude-promise-resolve-then-numero.test.ts
+++ b/tests/claude-promise-resolve-then-numero.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "rts:test";
+import { promise } from "rts";
+
+// `Promise.resolve(7).then(v => …)` entregava LIXO ao callback:
+// `4619567317775286272` — que são exatamente os bits de f64 de `7.0`.
+//
+// Só NÚMERO corrompia; string, bool, objeto e array passavam certo. E o MESMO
+// valor lido por `await` vinha correto:
+//
+//   await Promise.resolve(7)            // 7      ✅
+//   Promise.resolve(7).then(v => v)     // lixo   ❌
+//
+// A assimetria denuncia a causa. Um valor SEM handle (número/bool/null) tem a
+// própria WORD como valor, mas era gravado num slot marcado como NÃO-word, e a
+// entrega do `.then` repassava os bits crus. O `await` escapava porque
+// `normalize_settled_i64` reconverte por heurística (bits de f64 → inteiro).
+//
+// Correção: valor sem handle é gravado com `resolve_word`, que marca o slot — aí
+// a entrega reboxa direito. Valor COM handle segue pelo caminho legado, que já
+// trata passthrough de Promise existente e adoção de thenable.
+//
+// `promise.wait` força o drain da microtask (mesmo padrão de
+// `promise_microtask_order.test.ts`), tornando o teste determinístico.
+
+const inteiro = promise.wait(Promise.resolve(7).then(function (v) { return v; }));
+const negativo = promise.wait(Promise.resolve(-42).then(function (v) { return v; }));
+const zero = promise.wait(Promise.resolve(0).then(function (v) { return v; }));
+// o valor tem de ser USÁVEL, não só transportado
+const dobrado = promise.wait(Promise.resolve(5).then(function (v) { return v * 2; }));
+const encadeado = promise.wait(
+  Promise.resolve(3)
+    .then(function (v) { return v + 1; })
+    .then(function (v) { return v * 10; }),
+);
+// não-regressão: o caminho do `await` sobre o mesmo valor
+async function viaAwait() { return await Promise.resolve(11); }
+const doAwait = promise.wait(viaAwait().then(function (v) { return v; }));
+
+describe("Promise.resolve(num).then entrega o número, não os bits", () => {
+  test("inteiro", () => expect(inteiro).toBe(7));
+  test("negativo", () => expect(negativo).toBe(-42));
+  test("zero", () => expect(zero).toBe(0));
+  test("o valor é USÁVEL em aritmética", () => expect(dobrado).toBe(10));
+  test("encadeamento de dois then", () => expect(encadeado).toBe(40));
+});
+
+describe("não-regressões", () => {
+  test("await sobre Promise.resolve continua correto", () => expect(doAwait).toBe(11));
+});

--- a/tests/cross-runtime/events-async/claude-promise-resolve-then-number.ts
+++ b/tests/cross-runtime/events-async/claude-promise-resolve-then-number.ts
@@ -1,0 +1,30 @@
+// Cross-runtime: `Promise.resolve(n).then(cb)` must hand the NUMBER to the
+// callback, not the raw f64 bits.
+//
+// It delivered `4619567317775286272` for `7` — exactly the f64 bit pattern of
+// 7.0. Only numbers were affected; string/bool/object/array were fine. And the
+// SAME value read through `await` was correct, which is what pinned the cause: a
+// value with no handle (number/bool/null) IS its PolyValue word, but the slot was
+// marked as NOT-a-word, so `.then` forwarded the raw bits. `await` escaped it by
+// heuristically converting f64 bits back to an integer.
+
+Promise.resolve(7).then(function (v) { console.log("num=" + v); });
+Promise.resolve(-42).then(function (v) { console.log("neg=" + v); });
+Promise.resolve(3.5).then(function (v) { console.log("frac=" + v); });
+Promise.resolve(0).then(function (v) { console.log("zero=" + v); });
+
+// the value must be USABLE, not merely printable
+Promise.resolve(5).then(function (v) { return v * 2; }).then(function (v) {
+  console.log("chain=" + v);
+});
+
+// ── non-regressions: the types that already worked ──────────────────────────
+Promise.resolve(true).then(function (v) { console.log("bool=" + v); });
+Promise.resolve(null).then(function (v) { console.log("null=" + v); });
+Promise.resolve("oi").then(function (v) { console.log("str=" + v); });
+Promise.resolve({ a: 1 }).then(function (v) { console.log("obj=" + JSON.stringify(v)); });
+Promise.resolve([1, 2]).then(function (v) { console.log("arr=" + v.join(",")); });
+
+// `await` over the same value stays correct
+async function viaAwait() { return await Promise.resolve(11); }
+viaAwait().then(function (v) { console.log("await=" + v); });


### PR DESCRIPTION
## O bug

```js
Promise.resolve(7).then(v => console.log(v))
// → 4619567317775286272   (os bits de f64 de 7.0)   ·   Node: 7
```

Só **número** corrompia — string, bool, objeto e array passavam certo.

## A assimetria que denuncia a causa

```js
await Promise.resolve(7)          // 7      ✅
Promise.resolve(7).then(v => v)   // lixo   ❌
```

Um valor **sem handle** (número/bool/null) *é* a sua PolyValue word. Mas `rtsadp_promise_resolve_w` a repassava ao caminho legado, que grava com `new_fulfilled` — marcando o slot como **não-word**. A entrega do `.then` então repassava os bits crus.

O `await` escapava porque `normalize_settled_i64` reconverte por heurística (bits de f64 → inteiro) — o que **mascarava o defeito justamente no caminho mais coberto por teste**.

## A correção

Valor sem handle é gravado com `resolve_word`, que marca o slot; a entrega reboxa direito. Valor **com** handle continua pelo caminho legado (passthrough de Promise existente, adoção de thenable) — nada muda para ele.

## Como apareceu

Tentando expor `fetch` no escopo de página (#2038): o `fetch` novo devolvia uma Promise cujo `.then` *parecia* não chamar o callback. Não era o `.then` — era o valor chegando irreconhecível.

## Validação

- `claude-promise-resolve-then-numero.test.ts` — **6/6**: usa `promise.wait` para forçar o drain da microtask (padrão de `promise_microtask_order`); cobre inteiro/negativo/zero, o valor **usado em aritmética**, encadeamento de dois `then`, e a não-regressão do `await`.
- Fixture cross-runtime — **byte-idêntica a Node e Bun**, incluindo a ordem das microtasks e os cinco tipos que já funcionavam.
- **Suite: 2856/2857.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)