### PR TITLE
feat(dom): microtask da página é drenada; `fetch` existe no escopo de página

### DIFF
--- a/crates/rts-codegen-new/src/front/run/engineobj.rs
+++ b/crates/rts-codegen-new/src/front/run/engineobj.rs
@@ -176,6 +176,36 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if method == "obj_has" {
             return self.lower_engine_obj_has(module, args);
         }
+        // `run_event_loop()` — drena microtasks/timers/promises pendentes.
+        //
+        // O host já chama isto depois do `__rts_startup`, mas um `<script>` de
+        // PÁGINA roda DENTRO daquele task: o `.then` que ele registra fica na
+        // fila e nunca era drenado, então o callback simplesmente não acontecia
+        // (`Promise.resolve(7).then(cb)` numa página não chamava `cb`). O
+        // prelude do DOM chama isto ao fim de `runScripts` para fechar o task
+        // da página, como o browser faz.
+        // `fetch_text(url)` — GET síncrono devolvendo o corpo. Existe porque o
+        // `.ts` do prelude não alcança um namespace do Registry (só o motor
+        // alcança) e a PÁGINA precisa de um `fetch` global. Delega ao MESMO
+        // membro de Registry que `import f from "rts:fetch"; f.fetchText(u)`
+        // usa — nenhuma marshalling nova, nenhuma reimplementação.
+        if method == "fetch_text" {
+            return self.lower_builtin_call(module, "fetch", "fetchText", args);
+        }
+        if method == "run_event_loop" {
+            if !args.is_empty() {
+                return unsupported!(
+                    "engine.run_event_loop expects 0 args, got {}",
+                    args.len()
+                );
+            }
+            self.call_runtime(module, "__rtsn_run_event_loop", &[])?;
+            let undef = self.builder.ins().iconst(
+                types::I64,
+                crate::value::PolyValue::undefined().raw() as i64,
+            );
+            return Ok(Val::tagged_kind(undef, JsKind::Undefined));
+        }
         // Property descriptors + extensibility bridges (real state — Object/Reflect
         // defineProperty/getOwnPropertyDescriptor/isExtensible/preventExtensions).
         // The `.ts` unpacks the descriptor object (value + flags) and packs the

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1045,6 +1045,12 @@ function runScriptsAt(doc: Document, url: string): number {
     ran = ran + __runScriptAt(doc, j, url);
     j = j + 1;
   }
+  // Fecha o TASK da página: drena microtasks/timers que os scripts enfileiraram.
+  // Sem isto, um `.then`/`queueMicrotask` registrado por um `<script>` ficava na
+  // fila para sempre — o callback simplesmente nunca acontecia, sem erro. O host
+  // drena depois do `__rts_startup`, mas o script da página roda DENTRO daquele
+  // task; o browser fecha o task ao fim do script, e é o que fazemos aqui.
+  engine.run_event_loop();
   return ran;
 }
 

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -297,6 +297,43 @@ class MutationObserver {
   takeRecords(): any[] { return []; }
 }
 
+// `Response` — o resultado de `fetch()`. Superfície mínima do que a página usa:
+// `.ok`/`.status`/`.url` e os leitores `.text()`/`.json()`, ambos Promise como
+// manda a spec.
+//
+// LIMITE honesto: o corpo já vem MATERIALIZADO (o `fetch` abaixo é síncrono por
+// baixo), então `.text()` é uma Promise já resolvida — não há streaming, e um
+// erro de rede chega como corpo vazio com `ok=false`, não como rejeição.
+class Response {
+  _body: string;
+  constructor(body: string) {
+    this._body = body;
+  }
+  get ok(): boolean { return this._body.length > 0; }
+  get status(): number { return this._body.length > 0 ? 200 : 0; }
+  // `url`/`statusText` FICAM DE FORA de propósito: um getter que devolve STRING
+  // nesta classe lê vazio no escopo de página (os de boolean/number funcionam) —
+  // gap do motor, ainda não diagnosticado. Expor os dois faria `res.url` valer
+  // `undefined` calado, e valor errado é pior que membro ausente: código que
+  // testa `if (res.url)` decidiria errado. Voltam quando o getter-string voltar.
+  text(): any { return Promise.resolve(this._body); }
+  json(): any { return Promise.resolve(JSON.parse(this._body)); }
+}
+
+// `fetch(url)` — o global que a PÁGINA enxerga. Antes `typeof fetch` era
+// `undefined` dentro de um `<script>`: o `fetch` do motor é membro de namespace
+// (`rts:fetch`), e namespace não é alcançável do escopo de página nem de um
+// prelude `.ts`. A ponte PRIVADA `engine.fetch_text` resolve isso delegando ao
+// MESMO membro de Registry.
+//
+// LIMITE honesto: é um GET síncrono embrulhado numa Promise já resolvida.
+// `init` (método/headers/body) é aceito e IGNORADO — POST ainda não existe.
+// Ficam de fora streaming, abort e redirect manual.
+function fetch(url: string, init?: any): any {
+  const corpo = engine.fetch_text(url);
+  return Promise.resolve(new Response(corpo));
+}
+
 // Fábrica usada pelo `runScripts` para injetar o window num <script>. `vw/vh` são
 // o viewport (o host passa; default 1000x800 quando não sabe).
 function __makeWindow(domHandle: i64, url: string, vw: number, vh: number): WindowImpl {

--- a/tests/claude-pagina-microtask-e-fetch.test.ts
+++ b/tests/claude-pagina-microtask-e-fetch.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "rts:test";
+import dom from "rts:dom";
+
+// Duas coisas que impediam qualquer código assíncrono de funcionar numa PÁGINA.
+//
+// 1) A fila de MICROTASKS nunca era drenada no escopo de página. Um `<script>`
+//    que fazia `Promise.resolve(7).then(cb)` registrava o callback e ele ficava
+//    na fila PARA SEMPRE — sem erro, sem sintoma. O host drena depois do
+//    `__rts_startup`, mas o script da página roda DENTRO daquele task; o browser
+//    fecha o task ao fim do script, e é o que `runScripts` passa a fazer
+//    (`engine.run_event_loop()`).
+//
+// 2) `fetch` não existia na página. O `fetch` do motor é membro de namespace
+//    (`rts:fetch`), e namespace não é alcançável nem do escopo de página nem de
+//    um prelude `.ts` — só o motor alcança. A ponte PRIVADA `engine.fetch_text`
+//    resolve isso delegando ao MESMO membro de Registry.
+//
+// Sem (1), (2) seria pior que inútil: `typeof fetch === "function"` passaria no
+// feature-detect e o `.then` nunca chamaria de volta — falha silenciosa.
+
+function rodaNaPagina(script: string): string {
+  const html = "<html><body><div id=o></div><script>" + script + "</scr" + "ipt></body></html>";
+  const d: i64 = dom.parseHtml(html);
+  runScriptsAt(new Document(d), "https://exemplo/");
+  return dom.getText(d, dom.querySelector(d, "#o"));
+}
+
+const microtask = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.resolve(7).then(function(v){ el.textContent = 'v=' + v; });",
+);
+
+const encadeado = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.resolve(5).then(function(v){ return v * 2; })" +
+  ".then(function(v){ el.textContent = 'v=' + v; });",
+);
+
+const temFetch = rodaNaPagina(
+  "document.getElementById('o').textContent = " +
+  "'fetch=' + (typeof fetch) + ' Response=' + (typeof Response);",
+);
+
+describe("microtask da página é drenada", () => {
+  test("Promise.resolve().then chama o callback", () => {
+    expect(microtask).toBe("v=7");
+  });
+
+  test("cadeia de dois then resolve", () => {
+    expect(encadeado).toBe("v=10");
+  });
+});
+
+describe("fetch existe no escopo de página", () => {
+  test("fetch e Response são funções", () => {
+    expect(temFetch).toBe("fetch=function Response=function");
+  });
+});


### PR DESCRIPTION
## 1. A fila de microtasks nunca era drenada — falha silenciosa

```js
// dentro de um <script> da página
Promise.resolve(7).then(cb)   // cb NUNCA era chamado. Sem erro, sem sintoma.
```

O host drena depois do `__rts_startup`, mas o script da página roda **dentro** daquele task. O browser fecha o task ao fim do script — é o que `runScripts` passa a fazer, via `engine.run_event_loop()` (ponte sobre o `__rtsn_run_event_loop` que já existia e o AOT já usava).

## 2. `fetch` não existia na página

O `fetch` do motor é membro de namespace (`rts:fetch`), e namespace não é alcançável nem do escopo de página nem de um prelude `.ts`. A ponte privada `engine.fetch_text` delega ao **mesmo** membro de Registry; `window.ts` ganha `fetch()` + `class Response`, no arquivo onde `MutationObserver` já vive.

**A ordem importa:** sem (1), o (2) seria *pior* que inútil — `typeof fetch === "function"` passaria no feature-detect e o `.then` nunca chamaria de volta. Foi por isso que uma tentativa anterior de expor só o `fetch` foi revertida.

Medido, numa página real:

```
fetch('https://example.com').then(r => r.text()).then(t => …)
→ len=559 temHtml=true
```

## Limites declarados

- `fetch` é um **GET síncrono** embrulhado numa Promise já resolvida. `init` (método/headers/body) é aceito e **ignorado** — POST não existe. Sem streaming, abort ou redirect manual.
- `Response` expõe `ok`/`status`/`text()`/`json()`. **`url`/`statusText` ficam de fora de propósito**: um getter que devolve *string* nesta classe lê vazio no escopo de página (os de boolean/number funcionam) — gap do motor ainda não diagnosticado. Expor os dois faria `res.url` valer `undefined` calado, e valor errado é pior que membro ausente.

## Validação

- `claude-pagina-microtask-e-fetch.test.ts` — **3/3**: roda scripts numa página real e checa que o `.then` chama de volta, que a cadeia de dois `then` resolve, e que `fetch`/`Response` existem.
- **Suite: 2862/2863.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)