### PR TITLE
feat(dom): microtask da página é drenada, com o erro do handler isolado

### DIFF
--- a/crates/rts-codegen-new/src/front/run/engineobj.rs
+++ b/crates/rts-codegen-new/src/front/run/engineobj.rs
@@ -176,6 +176,50 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if method == "obj_has" {
             return self.lower_engine_obj_has(module, args);
         }
+        // `run_event_loop()` — drena microtasks/timers pendentes. O host chama
+        // isto depois do `__rts_startup`, mas um `<script>` de PÁGINA roda DENTRO
+        // daquele task: o `.then` que ele registra ficava na fila e NUNCA era
+        // drenado — o callback simplesmente não acontecia, sem erro. O prelude do
+        // DOM chama isto ao fim de `runScripts`, como o browser fecha o task.
+        if method == "run_event_loop" {
+            if !args.is_empty() {
+                return unsupported!("engine.run_event_loop expects 0 args, got {}", args.len());
+            }
+            self.call_runtime(module, "__rtsn_run_event_loop", &[])?;
+            let undef = self
+                .builder
+                .ins()
+                .iconst(types::I64, crate::value::PolyValue::undefined().raw() as i64);
+            return Ok(Val::tagged_kind(undef, JsKind::Undefined));
+        }
+        // `take_error()` — consome o erro PENDENTE do motor e devolve a word (ou
+        // `undefined` se não houver). Existe para ISOLAR o drain da página: um
+        // callback de terceiro que lança não pode derrubar a página inteira, e um
+        // `try/catch` de `.ts` não contém esse erro (ele vive no slot do motor, um
+        // canal lateral que o `catch` não observa).
+        if method == "take_error" {
+            if !args.is_empty() {
+                return unsupported!("engine.take_error expects 0 args, got {}", args.len());
+            }
+            let pend = self
+                .call_runtime(module, "__rtsadp_err_pending", &[])?
+                .expect("err_pending returns a flag");
+            let taken = self
+                .call_runtime(module, "__rtsadp_err_take", &[])?
+                .expect("err_take returns a word");
+            let undef = self
+                .builder
+                .ins()
+                .iconst(types::I64, crate::value::PolyValue::undefined().raw() as i64);
+            let zero = self.builder.ins().iconst(types::I64, 0);
+            let tem = self.builder.ins().icmp(
+                cranelift_codegen::ir::condcodes::IntCC::NotEqual,
+                pend,
+                zero,
+            );
+            let w = self.builder.ins().select(tem, taken, undef);
+            return Ok(Val::new(w, crate::repr::Repr::Tagged));
+        }
         // Property descriptors + extensibility bridges (real state — Object/Reflect
         // defineProperty/getOwnPropertyDescriptor/isExtensible/preventExtensions).
         // The `.ts` unpacks the descriptor object (value + flags) and packs the

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1045,6 +1045,18 @@ function runScriptsAt(doc: Document, url: string): number {
     ran = ran + __runScriptAt(doc, j, url);
     j = j + 1;
   }
+  // Fecha o TASK da página: drena microtasks/timers que os scripts enfileiraram.
+  // Sem isto, um `.then`/`queueMicrotask` registrado por um `<script>` ficava na
+  // fila para sempre — o callback nunca acontecia, sem erro nenhum.
+  engine.run_event_loop();
+  // ISOLA como o console do browser: um callback de terceiro que LANÇA não pode
+  // derrubar a página inteira. O erro vive no slot do MOTOR — um canal lateral
+  // que um `try/catch` de `.ts` não observa —, então é preciso consumi-lo
+  // explicitamente. Reporta e segue, que é o que o browser faz.
+  const __erroMicro = engine.take_error();
+  if (__erroMicro !== undefined) {
+    console.error("[page] erro em microtask: " + __erroMicro);
+  }
   return ran;
 }
 

--- a/tests/claude-pagina-drena-microtask.test.ts
+++ b/tests/claude-pagina-drena-microtask.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "rts:test";
+import dom from "rts:dom";
+
+// A fila de MICROTASKS nunca era drenada no escopo de página. Um `<script>` que
+// fazia `Promise.resolve(7).then(cb)` registrava o callback e ele ficava na fila
+// PARA SEMPRE — sem erro, sem sintoma, sem jeito de o autor da página descobrir.
+//
+// O host drena depois do `__rts_startup`, mas o script da página roda DENTRO
+// daquele task. O browser fecha o task ao fim do script, e é o que `runScripts`
+// passa a fazer (`engine.run_event_loop()`, ponte sobre o `__rtsn_run_event_loop`
+// que já existia e o AOT já usava).
+//
+// Ligar o drain sozinho, porém, TROCA um problema por outro pior: os callbacks
+// passam a rodar de verdade, e um único handler de terceiro que lança derruba a
+// página inteira. Foi o que aconteceu numa tentativa anterior, revertida.
+//
+// Isolar exigiu achar ONDE o erro vive: um `try/catch` de `.ts` NÃO o contém,
+// porque o erro do motor viaja num SLOT lateral que o `catch` não observa — e há
+// DOIS slots (o do motor novo, `adapters/errslot`, e o legado
+// `collector::error`). A ponte `engine.take_error()` consome o do motor novo;
+// `runScripts` reporta e segue, como o console do browser.
+//
+// Valores conferidos contra o Node.
+
+function rodaNaPagina(script: string): string {
+  const html = "<html><body><div id=o></div><script>" + script + "</scr" + "ipt></body></html>";
+  const d: i64 = dom.parseHtml(html);
+  runScriptsAt(new Document(d), "https://exemplo/");
+  return dom.getText(d, dom.querySelector(d, "#o"));
+}
+
+const simples = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.resolve(7).then(function(v){ el.textContent = 'v=' + v; });",
+);
+
+const encadeado = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.resolve(5).then(function(v){ return v * 2; })" +
+  ".then(function(v){ el.textContent = 'v=' + v; });",
+);
+
+const comCatch = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.reject(new Error('x')).catch(function(e){ el.textContent = 'capturado'; });",
+);
+
+// um handler que LANÇA não pode impedir o resto da página de rodar
+const isolado = rodaNaPagina(
+  "var el=document.getElementById('o');" +
+  "Promise.resolve(1).then(function(){ throw new Error('boom'); });" +
+  "Promise.resolve(2).then(function(v){ el.textContent = 'seguiu=' + v; });",
+);
+
+describe("microtask da página é drenada", () => {
+  test("Promise.resolve().then chama o callback", () => {
+    expect(simples).toBe("v=7");
+  });
+
+  test("cadeia de dois then resolve", () => {
+    expect(encadeado).toBe("v=10");
+  });
+
+  test("catch de rejeição roda", () => {
+    expect(comCatch).toBe("capturado");
+  });
+});
+
+describe("um handler que lança não derruba a página", () => {
+  test("o resto das microtasks continua rodando", () => {
+    expect(isolado).toBe("seguiu=2");
+  });
+});


### PR DESCRIPTION
## O bug — falha silenciosa

```js
// dentro de um <script> da página
Promise.resolve(7).then(cb)   // cb NUNCA era chamado. Sem erro, sem sintoma.
```

O host drena depois do `__rts_startup`, mas o script da página roda **dentro** daquele task. O browser fecha o task ao fim do script — é o que `runScripts` passa a fazer, via `engine.run_event_loop()` (ponte sobre o `__rtsn_run_event_loop` que já existia e o AOT já usava).

## O drain sozinho piorava

Ligar só o drain troca um problema por outro pior: os callbacks passam a rodar de verdade, e **um único handler de terceiro que lança derruba a página inteira**. Foi o que aconteceu no #2059, revertido em `2b141d93` — a carga do WhatsApp ia de `exit=0` para `exit=1` sem nenhuma saída.

## Onde o erro vivia

Um `try/catch` de `.ts` em volta do drain **não contém** o erro: ele viaja num **slot lateral** do motor, que o `catch` não observa. E há **dois** slots — o do motor novo (`adapters/value/errslot`) e o legado (`collector::error`). Uma tentativa de isolar checando o slot legado dentro do próprio drain falhou por ler o slot errado.

A ponte `engine.take_error()` consome o do motor novo; `runScripts` reporta e segue, como o console do browser.

Medido na página real do WhatsApp Web: **`exit=0`, `scripts=33`** — carga intacta, agora com as microtasks rodando.

## O que NÃO entra aqui

Expor `fetch` na página (passo seguinte, já implementado e medido — `fetch(u).then(r => r.text())` traz 559 bytes) foi **retirado**. Com `fetch` definido, a página toma um caminho que lança **sincronamente dentro do script**, fora da microtask que este isolamento cobre. Precisa do mesmo tratamento no nível do script antes de ser seguro.

## Validação

- `claude-pagina-drena-microtask.test.ts` — **4/4**: `.then` chama de volta, cadeia de dois `then` resolve, `catch` de rejeição roda, e um handler que **lança** não impede o resto de rodar.
- **Suite: 2862/2863.** A única falha é **pré-existente** (DOM `window`), verificada na main.

Refs #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)