### PR TITLE
fix(codegen): 5 gaps de bundle real — throw em generator SM, lifter, cell bitwise, static dinâmico

### DIFF
--- a/crates/rts-codegen-new/src/front/run/assign.rs
+++ b/crates/rts-codegen-new/src/front/run/assign.rs
@@ -92,6 +92,10 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             let rhs = self.lower_expr(module, value)?;
             let result = if op.is_arithmetic() || matches!(op, HirBinOp::Exp) {
                 self.lower_arith(module, op, cur, rhs)?
+            } else if op.is_bitwise() {
+                // Same ToInt32/ToUint32 generic path a plain local uses — the cell
+                // read is already Tagged, exactly what `lower_bitwise` boxes.
+                self.lower_bitwise(module, op, cur, rhs)?
             } else {
                 return unsupported!("compound-assign operator {op:?} on a global cell");
             };
@@ -110,6 +114,8 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             let rhs = self.lower_expr(module, value)?;
             let result = if op.is_arithmetic() || matches!(op, HirBinOp::Exp) {
                 self.lower_arith(module, op, cur, rhs)?
+            } else if op.is_bitwise() {
+                self.lower_bitwise(module, op, cur, rhs)?
             } else {
                 return unsupported!("compound-assign operator {op:?} on a local cell");
             };

--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -736,6 +736,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
         };
         let result_map = result_map.expect("GENERATOR_* returns a result-Map handle");
+        // The state fn runs USER CODE — a `throw` in the generator body (or any
+        // runtime error mid-state) lands in the error slot during this call.
+        // Route the pending-error unwind HERE, like every other user-code call
+        // edge: without it the error surfaced only at the next checking call,
+        // which could be OUTSIDE the caller's `try` — `try { it.next() } catch`
+        // missed the throw and the program died uncaught.
+        self.emit_post_call_error_check(module)?;
         Ok(Some(self.build_iter_result(module, result_map)))
     }
 

--- a/crates/rts-codegen-new/src/front/run/class/dispatch.rs
+++ b/crates/rts-codegen-new/src/front/run/class/dispatch.rs
@@ -192,8 +192,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             _ => object,
         };
         match &object.kind {
+            // A CAPTURE or a gcell with this name means the ident denotes a
+            // VALUE in this function, not the class — minified bundles reuse
+            // one-letter names (`t` is a class in one module and a `Set` in the
+            // next), and stealing the name here routed `t.add(v)` to the static
+            // path of the wrong class. Same double-check `lower_call` does.
             HirExprKind::Ident(name)
                 if self.local(name).is_none()
+                    && !self.captures.contains_key(name)
+                    && self.gcell_id(name).is_none()
                     && self.local_classes.get(name).is_none()
                     && self.classes.get(name).is_some() =>
             {
@@ -229,7 +236,15 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return self.call_synth_fn(module, &desc.ctor, Some(this_word), &args[1..]);
         }
         let Some(fn_name) = desc.statics.get(method).cloned() else {
-            return unsupported!("`{class}.{method}()` — no such static method on class `{class}`");
+            // Not a static written in the class body. JS still allows `C.m = fn`
+            // AFTER the fact (undeclared static — what a minifier emits), and the
+            // WRITE path already supports it; mirror it here: read the property
+            // as a VALUE through the same runtime statics walk the field read
+            // uses, and invoke whatever it holds. Absent everywhere ⇒ invoking
+            // `undefined` — the runtime call error, which is the JS behaviour.
+            let val = self.try_static_field_read(module, class, method)?;
+            let fn_word = self.box_value(val);
+            return self.lower_value_call_word(module, fn_word, args);
         };
         // `defineProperty(obj, …)` (Object/Reflect) GROWS `obj`'s shape at runtime
         // (engine.define_prop). A subsequent STATIC `obj.key` read would miss the new

--- a/crates/rts-codegen-new/src/front/run/dynfn.rs
+++ b/crates/rts-codegen-new/src/front/run/dynfn.rs
@@ -35,6 +35,23 @@ use rts_runtime::namespaces::globals::function::ops::{CompiledFn, register_compi
 /// collides with user code: each snippet compiles into a FRESH `JITModule`.
 const DYN_FN_NAME: &str = "__rtsdyn_anonymous";
 
+/// Diagnostics: with `RTS_DYNFN_DUMP=<dir>` set, a `new Function` body that
+/// FAILS to compile is written to `<dir>/dynfn_fail_<N>.js` alongside its error.
+/// A dynamic body only exists in memory (its span does not index any on-disk
+/// source), so without this there is no way to extract a failing function from
+/// a multi-megabyte page bundle for a minimal repro.
+fn dump_failing_body(src: &str, err: &impl std::fmt::Display) {
+    let Ok(dir) = std::env::var("RTS_DYNFN_DUMP") else {
+        return;
+    };
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static N: AtomicU32 = AtomicU32::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    let path = std::path::Path::new(&dir).join(format!("dynfn_fail_{n}.js"));
+    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::write(&path, format!("// error: {err}\n{src}"));
+}
+
 /// Install [`compile_dynamic_fn`] as the rts-primitives `COMPILE_FN_HOOK`.
 /// Idempotent (OnceLock behind `register_compile_fn`).
 pub(super) fn register_hook() {
@@ -51,11 +68,15 @@ fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn>
     // MAY still pass an explicit annotation in the param string ("h: i64").
     let plist = params.to_vec().join(", ");
     let src = format!("function {DYN_FN_NAME}({plist}) {{\n{body}\n}}\n");
-    let prog =
-        super::build_with_includes(&src).map_err(|e| anyhow::anyhow!("new Function body: {e}"))?;
+    let prog = super::build_with_includes(&src).map_err(|e| {
+        dump_failing_body(&src, &e);
+        anyhow::anyhow!("new Function body: {e}")
+    })?;
     let mut module = super::module_jit::make_module();
-    super::module_jit::populate_module(&mut module, &prog)
-        .map_err(|e| anyhow::anyhow!("new Function body: {e}"))?;
+    super::module_jit::populate_module(&mut module, &prog).map_err(|e| {
+        dump_failing_body(&src, &e);
+        anyhow::anyhow!("new Function body: {e}")
+    })?;
     module
         .finalize_definitions()
         .map_err(|e| anyhow::anyhow!("new Function finalize: {e}"))?;

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -798,6 +798,15 @@ fn collect_declared(stmts: &[HirStmt], out: &mut HashSet<String>) {
             HirStmt::ForOf { body, .. } | HirStmt::ForIn { body, .. } => {
                 collect_declared(body, out);
             }
+            // A `case` body declares like any block — a nested `function z()`
+            // in one (minified module factories switch on a module id) lowers
+            // to a `let` here, and missing it made the cell branch refuse the
+            // whole enclosing arrow.
+            HirStmt::Switch { cases, .. } => {
+                for c in cases {
+                    collect_declared(&c.body, out);
+                }
+            }
             HirStmt::Block(body) => collect_declared(body, out),
             _ => {}
         }
@@ -999,6 +1008,11 @@ impl Ctx {
                     self.rewrite_block(&mut c.body, scope, mutated);
                 }
             }
+            // `L: <stmt>` — a label is a minifier staple (`continue L` out of a
+            // collapsed loop); an arrow under one must lift like anywhere else.
+            // The sibling walkers (rename/scan_free/scan) already descend here;
+            // this rewrite had been left behind → `expression arrow`.
+            HirStmt::Labeled { body, .. } => self.rewrite_stmt(body, scope, mutated),
             // Other statement kinds are outside the lowering subset; any arrow in
             // them will reach the lowering and bail. Leave untouched.
             _ => {}
@@ -1075,6 +1089,9 @@ impl Ctx {
                     self.rewrite_expr(it, scope, mutated);
                 }
             }
+            // `(<expr> as T)` — an arrow under a cast must lift; the sibling
+            // walkers (scan_free/scan/class::walk) already descend through Cast.
+            HirExprKind::Cast { expr, .. } => self.rewrite_expr(expr, scope, mutated),
             HirExprKind::Arrow { .. } => {
                 // Try to extract this arrow into a top-level function or closure. On
                 // success, replace the node with an Ident of the synthesized name.

--- a/crates/rts-codegen-new/src/front/run/funcval/scan.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/scan.rs
@@ -50,34 +50,35 @@ pub(crate) fn arrow_decl_names(stmts: &[HirStmt]) -> HashSet<String> {
 
 fn collect_arrow_decls(stmts: &[HirStmt], out: &mut HashSet<String>) {
     for s in stmts {
-        match s {
-            HirStmt::Let {
-                name,
-                init: Some(e),
-                ..
-            }
-            | HirStmt::Const { name, init: e, .. } => {
-                // Pre-rewrite the init is an inline `Arrow`; post-rewrite (the
-                // prologue's cell-hoisting scan runs on the REWRITTEN body) it
-                // is an `Ident` of the synthesized fn — accept both.
-                let is_fn_init = matches!(e.kind, HirExprKind::Arrow { .. })
-                    || matches!(&e.kind, HirExprKind::Ident(n)
-                        if n.starts_with("__rtsn_arrow_") || n.starts_with("__rtsl_"));
-                if is_fn_init {
-                    out.insert(name.clone());
-                }
-            }
-            HirStmt::If { then, else_, .. } => {
-                collect_arrow_decls(then, out);
-                if let Some(e) = else_ {
-                    collect_arrow_decls(e, out);
-                }
-            }
-            HirStmt::While { body, .. } => collect_arrow_decls(body, out),
-            HirStmt::Block(b) => collect_arrow_decls(b, out),
-            _ => {}
+        if let HirStmt::Let {
+            name,
+            init: Some(e),
+            ..
         }
+        | HirStmt::Const { name, init: e, .. } = s
+        {
+            // Pre-rewrite the init is an inline `Arrow`; post-rewrite (the
+            // prologue's cell-hoisting scan runs on the REWRITTEN body) it
+            // is an `Ident` of the synthesized fn — accept both.
+            let is_fn_init = matches!(e.kind, HirExprKind::Arrow { .. })
+                || matches!(&e.kind, HirExprKind::Ident(n)
+                    if n.starts_with("__rtsn_arrow_") || n.starts_with("__rtsl_"));
+            if is_fn_init {
+                out.insert(name.clone());
+            }
+        }
+        // Descend through EVERY statement kind via the one exhaustive walker. The
+        // hand-rolled descent covered only if/while/block, so a nested fn
+        // declared inside a `try`/`switch`/`for` — routine in a minified module
+        // factory — was invisible to the forward-reference set, and a sibling
+        // referencing it ahead lost the name entirely ("call to unknown
+        // function `__w`" from inside the lifted fn).
+        for_each_child_stmt(s, &mut |st| collect_arrow_decls_one(st, out));
     }
+}
+
+fn collect_arrow_decls_one(s: &HirStmt, out: &mut HashSet<String>) {
+    collect_arrow_decls(std::slice::from_ref(s), out);
 }
 
 /// The names DECLARED (`let`/`const`) anywhere in `stmts` (top-level + nested

--- a/crates/rts-hir/src/lower.rs
+++ b/crates/rts-hir/src/lower.rs
@@ -1184,9 +1184,10 @@ fn swc_bin_op_to_hir(op: swc::BinaryOp) -> HirBinOp {
         // `key in obj` — own-property membership; the engine lowers it to a real
         // has-key check (distinct from the `Unsupported` sentinel).
         swc::BinaryOp::In => HirBinOp::In,
+        // Every swc BinaryOp is now mapped — no `_` arm, so a NEW operator
+        // variant fails to compile here instead of silently decaying to
+        // `Unsupported` (which consumers bail on, but explicitly is better).
         swc::BinaryOp::InstanceOf => HirBinOp::InstanceOf,
-        // An unmapped op lands here and the consumer BAILs.
-        _ => HirBinOp::Unsupported,
     }
 }
 

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -335,6 +335,13 @@ pub(crate) struct SmBuilder {
     /// Profundidade de regiões `try` abertas. Um `break` que sairia de uma
     /// região pularia o `finally`, então é recusado (bail honesto).
     pub(crate) try_depth: usize,
+    /// Profundidade de regiões onde um `throw` verbatim seria INFIEL: o corpo
+    /// de um `try` modelado (o erro teria de redirecionar para o catch/finally
+    /// da máquina, e o runtime não faz isso para erro interno de estado) e o
+    /// corpo de um `finally` (substituiria a completion pendente). O corpo de
+    /// um `catch` NÃO conta — um throw ali propaga para o chamador, que é
+    /// exatamente o que o verbatim faz.
+    pub(crate) throw_protected_depth: usize,
     /// Nomes que o generator DECLARA (params + todo `var`/`let`/`const`, binding
     /// de `for…of`/`in`, param de `catch`). Só estes podem virar slot de frame.
     ///
@@ -358,6 +365,7 @@ impl SmBuilder {
             loop_stack: Vec::new(),
             pending_label: None,
             try_depth: 0,
+            throw_protected_depth: 0,
             declared: std::collections::HashSet::new(),
         }
     }
@@ -649,6 +657,39 @@ impl SmBuilder {
                 // codigo apos return eh inalcancavel; novo estado morto p/ seq.
                 Some(self.new_state())
             }
+            // `throw E;` — o asyncToGenerator do Babel emite um em praticamente
+            // todo catch (`catch(e){ throw log(), e }`), e sem este arm o `_ =>
+            // None` derrubava o generator INTEIRO para o eager-buffer, que não
+            // expressa yield de valor (era o cluster dominante do bundle real:
+            // 5 de 9 falhas). Fora de região protegida o throw vai VERBATIM: o
+            // erro sobe da state-fn para o chamador de `.next()` como qualquer
+            // erro de runtime — que é a semântica JS —, marcando o generator
+            // done ANTES (JS: um throw não capturado o encerra; sem o DONE o
+            // `.next()` seguinte re-executava o estado e re-lançava). Dentro do
+            // corpo de um `try` modelado ou de um `finally` o verbatim seria
+            // INFIEL (pularia o catch/finally da máquina) — recusa honesta,
+            // como antes.
+            Stmt::Throw(t) => {
+                if expr_has_yield(&t.arg) {
+                    return None; // residual pós-normalização nunca tem yield
+                }
+                if self.throw_protected_depth > 0 {
+                    return None;
+                }
+                self.push_stmt(
+                    cur,
+                    call_stmt(call(
+                        "__RTS_GEN_SM_DONE",
+                        vec![ident_expr(G), undef_expr()],
+                    )),
+                );
+                self.push_stmt(cur, Stmt::Throw(t.clone()));
+                // O `return DONE(...)` do terminal é inalcançável após o throw;
+                // ele existe só para o estado ficar bem-formado (Trans::Unset
+                // derrubaria o build inteiro).
+                self.set_done(cur, None);
+                Some(self.new_state())
+            }
             // `try { ... } finally { ... }` (#477 fatia 2)
             Stmt::Try(t) => {
                 // (#211 try/catch com yield) `try { ...yields... } catch (e) {
@@ -709,7 +750,9 @@ impl SmBuilder {
                         let body_entry = self.new_state();
                         self.set_goto(cur, body_entry);
                         self.try_depth += 1;
+                        self.throw_protected_depth += 1;
                         let body_exit = self.lower_seq(&t.block.stmts, body_entry);
+                        self.throw_protected_depth -= 1;
                         self.try_depth -= 1;
                         let body_exit = body_exit?;
                         // saida normal do body (sem excecao): limpa o catch e segue.
@@ -768,6 +811,7 @@ impl SmBuilder {
                 let body_entry = self.new_state();
                 self.set_goto(cur, body_entry);
                 self.try_depth += 1;
+                self.throw_protected_depth += 1;
                 let body_exit = self.lower_seq(&t.block.stmts, body_entry);
                 let fin_exit = body_exit
                     .and_then(|be| {
@@ -775,6 +819,7 @@ impl SmBuilder {
                         self.set_goto(be, finally_entry);
                         self.lower_seq(&finalizer.stmts, finally_entry)
                     });
+                self.throw_protected_depth -= 1;
                 self.try_depth -= 1;
                 let fin_exit = fin_exit?;
                 // ao fim do finally: END_FINALLY; se nada pendente, segue p/ after.
@@ -1317,11 +1362,13 @@ fn stmt_needs_lazy(s: &Stmt) -> bool {
         Stmt::For(f) => stmt_has_yield(&f.body),
         Stmt::ForOf(fo) => stmt_has_yield(&fo.body),
         Stmt::ForIn(fi) => stmt_has_yield(&fi.body),
-        // try/finally com yield em qualquer parte exige state-machine.
+        // try com yield OU throw em qualquer parte exige state-machine (o
+        // throw pelo mesmo motivo do arm `Stmt::Throw` abaixo).
         Stmt::Try(t) => {
             t.block.stmts.iter().any(stmt_has_yield)
                 || t.handler.as_ref().map(|h| h.body.stmts.iter().any(stmt_has_yield)).unwrap_or(false)
                 || t.finalizer.as_ref().map(|f| f.stmts.iter().any(stmt_has_yield)).unwrap_or(false)
+                || has_throw_anywhere(t)
         }
         Stmt::Block(b) => body_needs_lazy(&b.stmts),
         // `L: for (…) { yield }` — sem este arm o rotulo escondia o laço do
@@ -1335,8 +1382,48 @@ fn stmt_needs_lazy(s: &Stmt) -> bool {
             stmt_needs_lazy(&i.cons)
                 || i.alt.as_deref().map(stmt_needs_lazy).unwrap_or(false)
         }
+        // Um `throw` no corpo exige a SM: o eager-buffer executa o corpo
+        // INTEIRO na construção, então `function* g(){ yield 1; throw e }`
+        // lançava em `g()` — antes de qualquer `.next()` — e fora do try do
+        // chamador real. A SM lança na retomada certa (verbatim no estado).
+        Stmt::Throw(_) => true,
         _ => false,
     }
+}
+
+/// True se o try carrega um `throw` em qualquer bloco (body/catch/finally) em
+/// profundidade — usado só pelo gate de lazy acima (sem descer em fns
+/// aninhadas, que lançam no próprio frame).
+fn has_throw_anywhere(t: &swc_ecma_ast::TryStmt) -> bool {
+    fn walk(s: &Stmt) -> bool {
+        match s {
+            Stmt::Throw(_) => true,
+            Stmt::Block(b) => b.stmts.iter().any(walk),
+            Stmt::If(i) => walk(&i.cons) || i.alt.as_deref().map(walk).unwrap_or(false),
+            Stmt::Try(t) => {
+                t.block.stmts.iter().any(walk)
+                    || t.handler
+                        .as_ref()
+                        .map(|h| h.body.stmts.iter().any(walk))
+                        .unwrap_or(false)
+                    || t.finalizer.as_ref().map(|f| f.stmts.iter().any(walk)).unwrap_or(false)
+            }
+            Stmt::While(w) => walk(&w.body),
+            Stmt::DoWhile(d) => walk(&d.body),
+            Stmt::For(f) => walk(&f.body),
+            Stmt::ForOf(fo) => walk(&fo.body),
+            Stmt::ForIn(fi) => walk(&fi.body),
+            Stmt::Labeled(l) => walk(&l.body),
+            Stmt::Switch(sw) => sw.cases.iter().any(|c| c.cons.iter().any(walk)),
+            _ => false,
+        }
+    }
+    t.block.stmts.iter().any(walk)
+        || t.handler
+            .as_ref()
+            .map(|h| h.body.stmts.iter().any(walk))
+            .unwrap_or(false)
+        || t.finalizer.as_ref().map(|f| f.stmts.iter().any(walk)).unwrap_or(false)
 }
 
 /// True se o stmt contem um `return` em qualquer profundidade (sem descer em

--- a/tests/claude-bundle-real-gaps-2.test.ts
+++ b/tests/claude-bundle-real-gaps-2.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "rts:test";
+
+// Rodada 2 dos gaps de bundle real (WhatsApp Web) — 9 falhas de carga, 5 delas
+// o MESMO padrão: `asyncToGenerator(function*(){ try { x = yield f() } catch(e)
+// { throw g(), e } })`, o async/await transpilado do Babel. Fixes cobertos:
+//
+// 1. generator SM ganhou `Stmt::Throw` (verbatim + done fora de região
+//    protegida; recusa honesta dentro de try/finally modelado). Sem o arm, um
+//    único `throw` — presente em todo catch do Babel — derrubava o generator
+//    inteiro para o eager-buffer, que não expressa yield de valor.
+// 2. corpo com `throw` agora conta como "precisa de lazy": o eager executava o
+//    corpo INTEIRO na construção e o throw disparava em `g()`, fora do try real.
+// 3. `.next()/.return()/.throw()` de generator emitem o post-call error check —
+//    sem ele `try { it.next() } catch` perdia o throw (aflorava fora do try).
+// 4. bitwise compound (`<<=` etc.) em cell local e gcell (antes: bail).
+// 5. lifter: fn-irmã declarada dentro de try/switch/for agora é visível
+//    (collect_arrow_decls/collect_declared exaustivos); arrow sob rótulo e sob
+//    cast é levantada (arms Labeled/Cast no rewrite).
+// 6. `C.m()` onde `m` é static NÃO declarado no corpo (`C.m = fn` depois) chama
+//    o valor via o caminho dinâmico em vez de bailar; e um nome capturado/gcell
+//    não é mais roubado pelo caminho estático de classe homônima.
+//
+// Valores conferidos contra o Node (generators em módulo; item 5-sibling em
+// script sloppy, onde function-em-bloco iça à la Annex B como nas páginas).
+
+function d(x: any) { return x + 1; }
+function fmk(n: any) { return { success() { return "ok:" + n; } }; }
+function ymk(e: any) { return "Y:" + e; }
+
+function drive(g: any, args: any, sends: any): string {
+  const it = g.apply(null, args);
+  let out = "", res = it.next();
+  let k = 0;
+  while (!res.done) { out += "[y " + res.value + "]"; res = it.next(sends[k]); k = k + 1; }
+  return out + "[ret " + res.value + "]";
+}
+
+// ── padrão Babel destilado: yield-valor em try + throw no catch ─────────────
+const g1 = function* (t: any) {
+  try {
+    var l = yield t();
+    return "done:" + l, l;
+  } catch (e) {
+    throw "logged", e;
+  }
+};
+const r1 = drive(g1, [() => 7], [42]);
+
+// ── cond && (r = yield f()) + multi-declarator com yield + catch-rethrow ────
+const g2 = function* (e: any, t: any) {
+  var n = e.map(d), r;
+  t === 1 && (r = yield fmk(n.length));
+  try {
+    var a, i = yield ymk(e);
+    return (a = r) == null || a.success(), i;
+  } catch (e2) {
+    throw e2;
+  }
+};
+const r2 = drive(g2, [[1, 2], 1], [fmk(9), "II"]);
+
+// ── throw de topo (sem try nenhum) não pode derrubar a compilação ───────────
+const g3 = function* (e: any, t: any) {
+  var n = "req:" + e, r = yield n, a = "parsed:" + r;
+  if (a) return a;
+  throw new Error("fail");
+};
+const r3 = drive(g3, ["E", 0], ["RESP"]);
+
+// ── throw não capturado: propaga ao chamador de .next() e ENCERRA ───────────
+function* gt(): any { yield 1; throw new Error("boom"); }
+const it = gt();
+let tprop = "y" + it.next().value;
+try {
+  it.next();
+  tprop += "|NOTHROW";
+} catch (e: any) {
+  tprop += "|caught:" + e.message;
+}
+const after = it.next();
+tprop += "|done:" + after.done + ":" + after.value;
+
+// ── construção NÃO executa o corpo (o throw só dispara na retomada) ─────────
+function* glazy(): any { yield 1; throw new Error("early"); }
+let lazyOk = "ctor-ok";
+const itl = glazy();          // Node: nada lança aqui
+lazyOk += "|first:" + itl.next().value;
+
+// ── bitwise compound em CELL (capturada e mutada por closure) ───────────────
+function hashish(arr: any): any {
+  let x = 1;
+  arr.forEach(function (c: any) {
+    x <<= 2;
+    x |= c & 1;
+    x ^= 3;
+    x >>= 1;
+  });
+  return x;
+}
+
+// ── fn-irmã declarada dentro de try/switch, referência ADIANTE ──────────────
+function mk(): any {
+  var api = function () { return w() + z(); };
+  try {
+    function w(): any { return 1; }
+  } catch (e) {}
+  switch (1) {
+    case 1:
+      function z(): any { return 2; }
+  }
+  return api;
+}
+
+// ── arrow sob rótulo ────────────────────────────────────────────────────────
+function lab(): any {
+  let acc = 0;
+  L: for (let i = 0; i < 3; i++) {
+    const f = () => i;
+    if (i === 1) continue L;
+    acc += f();
+  }
+  return acc;
+}
+
+// ── static não declarado, atribuído depois, e CHAMADO ───────────────────────
+class WaSet {}
+(WaSet as any).add = function (v: any) { return "got:" + v; };
+const dynstatic = (WaSet as any).add(5);
+
+describe("gaps de bundle real — rodada 2 (throw em generator + lifter + cell)", () => {
+  test("padrão Babel: yield-valor em try, throw no catch", () => {
+    expect(r1).toBe("[y 7][ret 42]");
+  });
+  test("&& com atribuição-yield + multi-declarator", () => {
+    expect(r2).toBe("[y [object Object]][y Y:1,2][ret II]");
+  });
+  test("throw de topo no fim do generator", () => {
+    expect(r3).toBe("[y req:E][ret parsed:RESP]");
+  });
+  test("throw não capturado propaga e encerra o generator", () => {
+    expect(tprop).toBe("y1|caught:boom|done:true:undefined");
+  });
+  test("construir o generator não roda o corpo", () => {
+    expect(lazyOk).toBe("ctor-ok|first:1");
+  });
+  test("bitwise compound em cell local", () => {
+    expect(hashish([5, 2])).toBe(7);
+  });
+  test("fn-irmã em try/switch vista pela referência adiante", () => {
+    expect(mk()()).toBe(3);
+  });
+  test("arrow sob rótulo é levantada", () => {
+    expect(lab()).toBe(2);
+  });
+  test("static dinâmico chamado", () => {
+    expect(dynstatic).toBe("got:5");
+  });
+});


### PR DESCRIPTION
Rodada 2 dos gaps que a carga do WhatsApp Web expõe (9 falhas de new Function
por carga; 5 eram o MESMO padrão — asyncToGenerator do Babel, isto é, todo
async/await transpilado). Cada fix tem repro mínima conferida contra o Node
antes da edição; a ferramenta que destravou a extração foi a flag nova
RTS_DYNFN_DUMP (dynfn.rs): em erro de compilação de new Function (parse OU
lowering) grava o corpo num arquivo — um corpo dinâmico não existe em disco e
sem isso não há como cortar a função que falha de um bundle de 6 MB.

1. generator SM: arm `Stmt::Throw` (generator_sm.rs). O catch-all `_ => None`
   fazia UM throw derrubar o generator inteiro para o eager-buffer, que não
   expressa yield de valor — e todo catch do Babel tem throw. Verbatim + DONE
   fora de região protegida (o erro sobe ao chamador de .next(), semântica JS);
   dentro do corpo de try/finally modelado segue recusando (redirecionar erro
   interno de estado ao catch da máquina é trabalho futuro, e verbatim ali
   PULARIA o catch — infiel).
2. gate de lazy: corpo com `throw` agora exige a SM. O eager executa o corpo
   inteiro na construção — `function* g(){ yield 1; throw e }` lançava em g(),
   antes de qualquer .next() e fora do try do chamador real.
3. `.next()/.return()/.throw()` de generator emitem emit_post_call_error_check
   (call.rs::try_generator_method). A state-fn roda código de usuário; sem o
   check `try { it.next() } catch` perdia o throw — o erro só aflorava no
   próximo call que checasse, possivelmente fora do try (uncaught errado).
4. bitwise compound em CELL local e GCELL (assign.rs): `x <<= 2` numa let
   capturada-e-mutada por closure bailava; roteia pelo mesmo lower_bitwise
   genérico (ToInt32/ToUint32) do local comum. Lógicos seguem recusados (o
   def_var condicional clobberaria o handle — limitação documentada).
5. lifter de closures: (a) collect_arrow_decls agora desce por TODO statement
   via for_each_child_stmt — fn-irmã declarada dentro de try/switch/for era
   invisível ao conjunto de referência-adiante e a referência morria com
   "call to unknown function" DENTRO da fn levantada; (b) collect_declared
   ganhou o arm Switch (case declara como bloco); (c) rewrite_stmt desce em
   Labeled e rewrite_expr em Cast — arrow sob rótulo/cast ficava inline e
   bailava como "expression arrow".
6. static dinâmico (class/dispatch.rs): `C.m()` onde `m` não é static do corpo
   lê a propriedade pelo caminho de statics de runtime (o mesmo da leitura) e
   invoca o valor — `class t{}; t.add = fn; t.add(v)` é o que minificador
   emite. E class_name_receiver exige !captures && !gcell antes de roubar um
   ident para o caminho estático de classe homônima (nome curto minificado
   colide o tempo todo).

Medido no alvo real (RTS_URL=https://web.whatsapp.com): t.add()/Shl/2 Yields
saem da lista; os scripts avançam mais fundo e a próxima camada aparece
(__genexpr_30→141, spans 128k→721k adiante). Cauda longa, como mapeado.

Suíte completa: 3209/3210 (805/806 arquivos) — a única falha (`window é o
MESMO objeto entre scripts`) é PRÉ-EXISTENTE, verificada hoje na main limpa
com release rebuildado. Testes novos: claude-bundle-real-gaps-2.test.ts (9
casos, todos conferidos contra Node; o sibling-em-try conferido em script
sloppy, onde function-em-bloco iça à la Annex B como nas páginas).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
