### PR TITLE
fix(parser,codegen): generator SM aceita fn-decl aninhada e bloco rotulado; new Function compila em thread de pilha grande

### DIFF
--- a/crates/rts-codegen-new/src/front/run/dynfn.rs
+++ b/crates/rts-codegen-new/src/front/run/dynfn.rs
@@ -63,6 +63,26 @@ pub(super) fn register_hook() {
 /// `JITModule`, and hand back the finalized code pointer + the module as the
 /// keep-alive anchor.
 fn compile_dynamic_fn(params: &[&str], body: &str) -> anyhow::Result<CompiledFn> {
+    // A multi-megabyte minified page bundle recurses DEEP through the swc
+    // parse + normalize + lowering pipeline — deeper than the caller thread's
+    // default stack (the browser host's main thread overflowed the moment the
+    // WhatsApp bundles started compiling past their first error). Compile on a
+    // dedicated big-stack thread, synchronously. Safe off-thread: the codegen
+    // state that must be shared (shapes / ctor tables / gcells) is process-
+    // global by design (see `crate::state`), and the per-thread items are pure
+    // caches; `parcompile` already compiles on worker threads the same way.
+    std::thread::scope(|s| {
+        std::thread::Builder::new()
+            .name("rts-dynfn-compile".into())
+            .stack_size(256 * 1024 * 1024)
+            .spawn_scoped(s, || compile_dynamic_fn_inner(params, body))
+            .map_err(|e| anyhow::anyhow!("new Function: compile thread spawn failed: {e}"))?
+            .join()
+            .unwrap_or_else(|_| anyhow::bail!("new Function: compile thread panicked"))
+    })
+}
+
+fn compile_dynamic_fn_inner(params: &[&str], body: &str) -> anyhow::Result<CompiledFn> {
     // Params UNTYPED (Tagged/`any`): real-JS semantics — a page script's
     // `function f(el) { el.textContent = x }` dispatches dynamically. A caller
     // MAY still pass an explicit annotation in the param string ("h: i64").

--- a/crates/rts-parser/src/generator_sm.rs
+++ b/crates/rts-parser/src/generator_sm.rs
@@ -342,6 +342,14 @@ pub(crate) struct SmBuilder {
     /// um `catch` NÃO conta — um throw ali propaga para o chamador, que é
     /// exatamente o que o verbatim faz.
     pub(crate) throw_protected_depth: usize,
+    /// `function n(){…}` DECLARADAS no corpo do generator, içadas para o
+    /// prólogo da state-fn (depois dos FGET). JS iça fn-decls ao topo da função,
+    /// então uma helper chamada num estado ANTERIOR à sua posição léxica — a
+    /// forma padrão das fábricas do Babel (`var t=n(); … function n(){…}`) —
+    /// resolve. A cada retomada a fn é recriada capturando os locais recém-
+    /// restaurados do frame; como toda suspensão persiste todos os slots, os
+    /// valores batem entre retomadas.
+    hoisted_fn_decls: Vec<Stmt>,
     /// Nomes que o generator DECLARA (params + todo `var`/`let`/`const`, binding
     /// de `for…of`/`in`, param de `catch`). Só estes podem virar slot de frame.
     ///
@@ -366,6 +374,7 @@ impl SmBuilder {
             pending_label: None,
             try_depth: 0,
             throw_protected_depth: 0,
+            hoisted_fn_decls: Vec::new(),
             declared: std::collections::HashSet::new(),
         }
     }
@@ -858,10 +867,39 @@ impl SmBuilder {
             // no `LoopTarget`. Um rótulo sobre algo que não é laço fica sem
             // consumidor, e um `break L` correspondente não resolve (bail).
             Stmt::Labeled(l) => {
+                // BLOCO rotulado (`e: { … break e; … }`) — early-exit padrão do
+                // Babel (todo `if/else` achatado do asyncToGenerator vira isso).
+                // Não é laço: modela como região só-de-break (mesmo TargetKind
+                // do switch — `continue` até ele nunca resolve), com o `after`
+                // como alvo do `break e`.
+                if let Stmt::Block(b) = &*l.body {
+                    let after = self.new_state();
+                    self.loop_stack
+                        .push(crate::generator_sm_loops::LoopTarget {
+                            kind: crate::generator_sm_loops::TargetKind::Switch,
+                            label: Some(l.label.sym.to_string()),
+                            brk: after,
+                            cont: usize::MAX,
+                            try_depth: self.try_depth,
+                        });
+                    let exit = self.lower_seq(&b.stmts, cur);
+                    self.loop_stack.pop();
+                    let exit = exit?;
+                    self.set_goto(exit, after);
+                    return Some(after);
+                }
                 self.pending_label = Some(l.label.sym.to_string());
                 let out = self.lower_stmt(&l.body, cur);
                 self.pending_label = None;
                 out
+            }
+            // `function n(){…}` no corpo do generator: iça para o prólogo da
+            // state-fn (ver o campo `hoisted_fn_decls`). O corpo da fn aninhada
+            // não contém o yield DESTE generator (fronteira de função), então é
+            // inerte para a máquina; o estado atual segue inalterado.
+            Stmt::Decl(Decl::Fn(_)) => {
+                self.hoisted_fn_decls.push(stmt.clone());
+                Some(cur)
             }
             // `for (x of src)` / `for (k in obj)` / `do … while` — estados
             // pelo protocolo lazy de iteracao; ver `generator_sm_iter`.
@@ -1372,8 +1410,13 @@ fn stmt_needs_lazy(s: &Stmt) -> bool {
         }
         Stmt::Block(b) => body_needs_lazy(&b.stmts),
         // `L: for (…) { yield }` — sem este arm o rotulo escondia o laço do
-        // gate e o corpo inteiro caia no eager-buffer.
-        Stmt::Labeled(l) => stmt_needs_lazy(&l.body),
+        // gate e o corpo inteiro caia no eager-buffer. BLOCO rotulado com
+        // yield idem: o eager não desce em Labeled (o yield sobreviveria cru),
+        // e a SM modela `break L` de bloco — então qualquer yield ali exige SM.
+        Stmt::Labeled(l) => match &*l.body {
+            b @ Stmt::Block(_) => stmt_has_yield(b) || stmt_needs_lazy(b),
+            other => stmt_needs_lazy(other),
+        },
         // QUALQUER `yield` num `switch` exige a SM: o eager-buffer nao modela
         // switch de forma alguma (o yield sobrevive ao desugar e chega cru ao
         // lowering), entao nao ha' caminho alternativo a preservar aqui.
@@ -1578,6 +1621,9 @@ fn build_state_fn(state_fn_name: &str, builder: &SmBuilder) -> Option<FnDecl> {
             call("__RTS_GEN_SM_FGET", vec![ident_expr(G), num_expr(i as f64)]),
         ));
     }
+    // fn-decls do corpo do generator, içadas (JS hoisting) — DEPOIS dos FGET,
+    // para capturarem os locais já restaurados do frame.
+    body.extend(builder.hoisted_fn_decls.iter().cloned());
 
     // while (true) { const __st = STATE(__g); if(__st==0){...} else if ... }
     let mut chain: Option<Stmt> = None;

--- a/tests/claude-bundle-real-gaps-2.test.ts
+++ b/tests/claude-bundle-real-gaps-2.test.ts
@@ -122,6 +122,33 @@ function lab(): any {
   return acc;
 }
 
+// ── fn DECL aninhada no corpo do generator (hoisted, usada antes) ───────────
+const gA = function* (e: any) {
+  var t = n();
+  return yield ("save:" + t), e.length;
+  function n(): any { return e.join("-"); }
+};
+const rA = drive(gA, [["a", "b"]], ["ok"]);
+
+// ── bloco ROTULADO com yield + break rótulo (early-exit do Babel) ───────────
+const gB = function* (t: any) {
+  e: {
+    if (t === "u") { yield "upd"; break e; }
+    if (t === "r") { yield "rw1"; yield "rw2"; break e; }
+    yield "other";
+  }
+  return "end";
+};
+const rB = drive(gB, ["r"], [0, 0, 0]);
+
+// ── yield no TESTE de if (dentro de &&) ─────────────────────────────────────
+function hy(): any { return true; }
+const gC = function* () {
+  if (hy() && (yield "ask") === true) return "yes";
+  return "no";
+};
+const rC = drive(gC, [], [true]);
+
 // ── static não declarado, atribuído depois, e CHAMADO ───────────────────────
 class WaSet {}
 (WaSet as any).add = function (v: any) { return "got:" + v; };
@@ -154,5 +181,14 @@ describe("gaps de bundle real — rodada 2 (throw em generator + lifter + cell)"
   });
   test("static dinâmico chamado", () => {
     expect(dynstatic).toBe("got:5");
+  });
+  test("fn decl aninhada no generator (hoisted, usada antes)", () => {
+    expect(rA).toBe("[y save:a-b][ret 2]");
+  });
+  test("bloco rotulado com yield + break rótulo", () => {
+    expect(rB).toBe("[y rw1][y rw2][ret end]");
+  });
+  test("yield no teste de if via &&", () => {
+    expect(rC).toBe("[y ask][ret yes]");
   });
 });


### PR DESCRIPTION
Camada seguinte dos gaps do bundle real (WhatsApp Web), extraída com
RTS_DYNFN_DUMP e reduzida a repro mínima conferida contra o Node:

1. `function n(){…}` DECLARADA no corpo do generator (generator_sm.rs): caía
   no `_ => None` e derrubava o generator para o eager. Agora é içada para o
   prólogo da state-fn (depois dos FGET, JS hoisting): uma helper chamada num
   estado ANTERIOR à sua posição léxica — a forma padrão das fábricas do Babel
   (`var t=n(); … function n(){…}`) — resolve. A cada retomada a fn é recriada
   capturando os locais recém-restaurados do frame; como toda suspensão
   persiste todos os slots, os valores batem entre retomadas.
2. BLOCO rotulado com yield (`e: { … yield …; break e; … }` — o early-exit que
   o Babel emite para if/else achatado): modelado como região só-de-break
   (mesmo TargetKind do switch) com o `after` como alvo do `break e`. E o gate
   de lazy passou a exigir SM para bloco-rotulado-com-yield — o eager não
   desce em Labeled e o yield sobreviveria cru.
3. `new Function` compila numa thread dedicada de 256 MiB (dynfn.rs): com os
   generators destravados, os bundles de 6 MB compilam mais fundo e a recursão
   do pipeline swc estourava a pilha default da thread do host — o browser
   morria com STATUS_STACK_OVERFLOW no meio da página. Off-thread é seguro: o
   estado compartilhado do codegen é process-global por design e o parcompile
   já compila em workers.

Medido no alvo real: os 5 scripts do padrão Yield saem do erro de compilação e
avançam para a próxima camada (lifter de nomes livres, `__genexpr_266` em span
1,49 MB adiante); 33/33 scripts, sem crash. Suíte 3212/3213 — única falha é a
pré-existente (`window é o MESMO objeto`), verificada na main limpa hoje.

Testes: +3 casos em claude-bundle-real-gaps-2.test.ts (fn-decl aninhada,
bloco rotulado, yield em teste de if), valores do Node.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
