### PR TITLE
fix(codegen): função de topo REATRIBUÍDA é binding gravável (memoização do Babel)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -278,8 +278,16 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // `__rtsadp_fn_reify_this`, so `m.call(obj, …)`/`m.bind(obj)` bind the
         // receiver correctly.
         let ident_fn_word = match &object.kind {
+            // `gcell_id` is `None` for an ordinary function; it is `Some` only
+            // when the program REASSIGNS the name, and then the cell holds the
+            // CURRENT value while the fn table holds only the original. Reifying
+            // from the table there made `function v(){ v = memoized; return
+            // v.apply(this, args) }` — the Babel async wrapper — call ITSELF
+            // forever (measured: stack overflow). Fall through to the value path,
+            // which reads the cell.
             HirExprKind::Ident(n)
                 if self.local(n).is_none()
+                    && self.gcell_id(n).is_none()
                     && self.sigs.get(n.as_str()).is_some_and(|s| !s.is_async) =>
             {
                 let name = n.clone();
@@ -629,7 +637,14 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return self.lower_value_call_word(module, f.v, args);
         }
         // A statically-known user function → the native fast path (NOT regressed).
-        if let Some(sig) = self.sigs.get(&name).cloned() {
+        // UNLESS the name was promoted to a cell because the program REASSIGNS it
+        // (`function v(){ v = memoized; … }` — the Babel async pattern): the cell
+        // then holds the CURRENT value and the fn table holds only the original,
+        // so taking the fast path here would call the pre-assignment body forever.
+        // The gcell branch below handles it; `gcell_id` is `None` for every
+        // ordinary function, so nothing else changes.
+        if let Some(sig) = self.sigs.get(&name).cloned().filter(|_| self.gcell_id(&name).is_none())
+        {
             // An ASYNC function call SPAWNS its body on the shared runtime and
             // returns the pending Promise handle immediately (the
             // promise-centric model, #437) — `Promise.all([f(..), g(..)])`

--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -86,7 +86,19 @@ pub fn module_globals(
             top.push(name.clone());
         }
     }
-    if top.is_empty() {
+    // A top-level FUNCTION whose NAME is REASSIGNED is a mutable binding too, so
+    // it belongs on this list next to the `let`s. In JS a function declaration
+    // creates an ordinary writable binding, and reassigning it is the
+    // memoization every Babel-transpiled async function is built on:
+    //
+    //     function v(a) { v = _asyncToGenerator(…); return v.apply(this, args) }
+    //
+    // Without this the write had no home — the name resolved to the immutable
+    // top-level fn table — and the whole file bailed "assignment to unbound".
+    // Gated on being WRITTEN (never on merely being read): an ordinary function
+    // keeps resolving through the fn table and its direct-call fast path.
+    let fn_names: Vec<String> = funcs.iter().map(|f| f.name.clone()).collect();
+    if top.is_empty() && fn_names.is_empty() {
         return HashMap::new();
     }
     // Names written OR read (free) inside SOME function: minus that fn's own params
@@ -134,6 +146,22 @@ pub fn module_globals(
             || force.contains(&name)
             || read_free.contains(&name);
         if promote {
+            map.insert(name, id);
+            id += 1;
+        }
+    }
+    // Reassigned top-level functions (see `fn_names` above). WRITTEN-only — a
+    // read-only function must NOT become a cell, or every ordinary call would
+    // lose its direct fast path. A name already promoted as a `let` keeps its id.
+    // A write from the TOP LEVEL counts for a function name too (`function v(){}
+    // … v = other;`), unlike for a `let` — a top-level `let` written at top level
+    // is just main's own local, but a FUNCTION is visible to every other
+    // function, so the new value has to reach them through the cell.
+    let top_writes = mutated_names(&main.body);
+    for name in fn_names {
+        if (written_free.contains(&name) || top_writes.contains(&name))
+            && !map.contains_key(&name)
+        {
             map.insert(name, id);
             id += 1;
         }

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -685,6 +685,34 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
         }
 
+        // FUNCTION-HOISTING prologue (main only): seed the cell of every top-level
+        // function whose NAME IS REASSIGNED with the function itself.
+        //
+        // Such a name is a mutable binding (`funcval::module_globals` promotes it
+        // to a gcell, the same as a written `let`), so reads no longer go through
+        // the immutable fn table — they read the cell, and the cell has to already
+        // hold the function. Seeding it HERE, before the first statement, is
+        // exactly JS function hoisting: the binding is callable above its own
+        // declaration line.
+        //
+        // Which gcells are fn-backed is DERIVED (`gcells` ∩ `sigs`), not a new
+        // field threaded through the pipeline.
+        if ctx.is_main {
+            let mut seed: Vec<(String, u32)> = gcells
+                .iter()
+                .filter(|(name, _)| sigs.contains_key(*name))
+                .map(|(n, i)| (n.clone(), *i))
+                .collect();
+            // Deterministic order — emitted IR must not depend on HashMap
+            // iteration order (that non-determinism produced broken AOT objects).
+            seed.sort();
+            for (name, id) in seed {
+                let f = ctx.reify_function(module, &name)?;
+                let word = ctx.box_value(f);
+                ctx.emit_gcell_set(module, id, word)?;
+            }
+        }
+
         // METHOD-TABLE prologue (main only): register every class method's
         // (instance shape-id, name) → thunk addr in the runtime table, so the
         // dynamic property read reifies a class method as a VALUE (obj_get miss

--- a/crates/rts-codegen-new/src/front/run/obj.rs
+++ b/crates/rts-codegen-new/src/front/run/obj.rs
@@ -1310,7 +1310,13 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             return Ok(None);
         };
         // A local of this name shadows the function — not a function-value receiver.
-        if self.local(name).is_some() || !self.sigs.contains_key(name) {
+        // A gcell means the program REASSIGNS the name, so the fn table holds a
+        // stale value: fall through to the ordinary ident read, which loads the
+        // cell. (`gcell_id` is `None` for every function that is never written.)
+        if self.local(name).is_some()
+            || self.gcell_id(name).is_some()
+            || !self.sigs.contains_key(name)
+        {
             return Ok(None);
         }
         let name = name.clone();

--- a/crates/rts-codegen-new/src/front/run/trycatch.rs
+++ b/crates/rts-codegen-new/src/front/run/trycatch.rs
@@ -46,48 +46,6 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         Ok(())
     }
 
-    /// Throw a real Error-family instance (`kind`/`message` are compile-time
-    /// constants) from EXPRESSION position and keep lowering: the throw routes
-    /// like any other (innermost `catch`, else sentinel-return), and the builder
-    /// resumes on a fresh UNREACHABLE block so the surrounding expression can
-    /// finish emitting into a live block. The returned `Val` is the `undefined`
-    /// word — never observed, since control cannot reach it.
-    ///
-    /// This is what lets a construct that is a COMPILE-time error in the numeric
-    /// subset but a RUNTIME error in JS (reading an unbound identifier) keep the
-    /// program compiling: a UMD/minified bundle names `exports`/`module`/`define`
-    /// in branches it never takes, and bailing the whole compile on a dead branch
-    /// rejects the file outright.
-    pub(super) fn emit_throw_error_expr(
-        &mut self,
-        module: &mut dyn Module,
-        kind: &str,
-        message: &str,
-    ) -> FrontResult<Val> {
-        let mut slots = Vec::with_capacity(4);
-        for s in [kind, message] {
-            let word = self.emit_str_const_word(module, s)?;
-            let handle = crate::value::emit_marshal::emit_table_load(module, self.builder, word);
-            let (ptr, len) =
-                crate::value::emit_marshal::emit_string_ptr_len(module, self.builder, handle);
-            slots.push(ptr);
-            slots.push(len);
-        }
-        self.call_runtime(module, "__rtsadp_throw_js_error", &slots)?;
-        self.unwind(module)?;
-        // Resume on a fresh block with NO predecessors: dead code, but a live
-        // insertion point, so the caller's remaining emission stays valid.
-        let dead = self.builder.create_block();
-        self.builder.switch_to_block(dead);
-        self.builder.seal_block(dead);
-        self.block_terminated = false;
-        let undef = self
-            .builder
-            .ins()
-            .iconst(types::I64, value::PolyValue::undefined().raw() as i64);
-        Ok(Val::tagged_kind(undef, JsKind::Undefined))
-    }
-
     /// Route an in-progress unwind: jump to the innermost active `catch`/`finally`
     /// block (if inside a `try`), else RETURN a sentinel from the current function
     /// (propagate to the caller). Terminates the current block.

--- a/tests/claude-fn-reassigned-binding.test.ts
+++ b/tests/claude-fn-reassigned-binding.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "rts:test";
+
+// Uma DECLARAÇÃO de função cria um binding GRAVÁVEL, como qualquer `let`.
+// Reatribuí-lo é a memoização que todo async transpilado por Babel emite:
+//
+//   function v(a) { v = _asyncToGenerator(…); return v.apply(this, args) }
+//
+// O motor resolvia o nome pela tabela IMUTÁVEL de funções de topo, então a
+// escrita não tinha onde pousar e o arquivo inteiro era recusado
+// ("assignment to unbound `v`") — 3 dos 9 erros por carga do WhatsApp Web.
+//
+// Correção: `module_globals` promove a gcell uma função de topo cujo nome é
+// ESCRITO (nunca por ser apenas lida — uma função comum mantém o caminho
+// rápido de chamada direta), e o prólogo de `main` semeia a cell com a própria
+// função, que é exatamente o hoisting de função do JS. Os três caminhos que
+// resolviam pelo fn-table — chamada direta, `fn_value_word` e o receiver de
+// `.call`/`.apply`/`.bind` — passaram a preferir a cell quando ela existe; sem
+// o terceiro, `v.apply(...)` reificava o valor ORIGINAL e a memoização chamava
+// a si mesma para sempre (medido: stack overflow).
+//
+// Valores conferidos contra Node e Bun (fixture cross-runtime
+// tests/cross-runtime/fn-meta/421_function_reassigned_memoization.ts).
+
+function make(): any {
+  return function (a: any) { return "real:" + a; };
+}
+
+// ── a função troca a si mesma na primeira chamada ───────────────────────────
+function v(a: any): any {
+  v = make() as any;
+  return (v as any).apply(null, [a]);
+}
+const self1 = v(1);
+const self2 = v(2);
+
+// ── outra função enxerga o valor NOVO, não uma captura do original ──────────
+function chama(a: any): any { return (v as any).apply(null, [a]); }
+const viaOutra = chama(3);
+
+// ── reatribuição a partir do TOPO alcança quem já referenciava o nome ───────
+function base(): any { return "orig"; }
+function leBase(): any { return base(); }
+const antes = leBase();
+base = function (): any { return "trocada"; } as any;
+const depois = leBase();
+
+// ── hoisting: o binding vale acima da própria linha de declaração ───────────
+const hoisted = antesDaDecl();
+function antesDaDecl(): any { return "ok"; }
+
+// ── inicialização preguiçosa: o corpo original roda UMA vez ─────────────────
+let initCount = 0;
+function lazy(n: any): any {
+  initCount = initCount + 1;
+  lazy = function (m: any): any { return m + 100; } as any;
+  return (lazy as any)(n);
+}
+const lazy1 = lazy(1);
+const lazy2 = lazy(2);
+
+// ── uma função NUNCA reatribuída não muda de comportamento ──────────────────
+function pura(x: any): any { return x * 2; }
+const puraVal = pura(21);
+const puraName = pura.name;
+
+describe("função de topo reatribuída é binding gravável", () => {
+  test("a função troca a si mesma na primeira chamada", () => {
+    expect(self1).toBe("real:1");
+    expect(self2).toBe("real:2");
+  });
+  test("outra função enxerga o valor novo", () => {
+    expect(viaOutra).toBe("real:3");
+  });
+  test("reatribuição do topo alcança quem referencia o nome", () => {
+    expect(antes).toBe("orig");
+    expect(depois).toBe("trocada");
+  });
+  test("hoisting: chamável acima da própria declaração", () => {
+    expect(hoisted).toBe("ok");
+  });
+  test("inicialização preguiçosa roda o corpo original uma vez só", () => {
+    expect(lazy1).toBe(101);
+    expect(lazy2).toBe(102);
+    expect(initCount).toBe(1);
+  });
+  test("função não reatribuída segue no caminho rápido", () => {
+    expect(puraVal).toBe(42);
+    expect(puraName).toBe("pura");
+  });
+});

--- a/tests/cross-runtime/fn-meta/421_function_reassigned_memoization.ts
+++ b/tests/cross-runtime/fn-meta/421_function_reassigned_memoization.ts
@@ -1,0 +1,66 @@
+// Cross-runtime: uma DECLARAÇÃO de função cria um binding GRAVÁVEL, e
+// reatribuí-lo é a memoização que todo async transpilado por Babel emite:
+//
+//   function v(a) { v = _asyncToGenerator(...); return v.apply(this, args) }
+//
+// O RTS resolvia o nome pela tabela imutável de funções de topo, então a
+// escrita não tinha onde pousar e o arquivo inteiro era recusado.
+
+function make() {
+  return function (a: number) {
+    return "real:" + a;
+  };
+}
+
+// 1. a função troca a si mesma na primeira chamada
+function v(a: number): string {
+  v = make() as typeof v;
+  return (v as (a: number) => string).apply(null, [a]);
+}
+console.log("self1=" + v(1));
+console.log("self2=" + v(2));
+
+// 2. outra função enxerga o valor NOVO (não a captura do original)
+function chama(a: number): string {
+  return (v as (a: number) => string).apply(null, [a]);
+}
+console.log("via_outra=" + chama(3));
+
+// 3. reatribuição a partir do TOPO alcança quem já referenciava o nome
+function base(): string {
+  return "orig";
+}
+function leBase(): string {
+  return base();
+}
+console.log("antes=" + leBase());
+base = function (): string {
+  return "trocada";
+};
+console.log("depois=" + leBase());
+
+// 4. hoisting: o binding vale acima da própria linha de declaração
+console.log("hoisted=" + antesDaDecl());
+function antesDaDecl(): string {
+  return "ok";
+}
+
+// 5. uma função NUNCA reatribuída não muda de comportamento
+function pura(x: number): number {
+  return x * 2;
+}
+console.log("pura=" + pura(21));
+console.log("pura_name=" + pura.name);
+
+// 6. reatribuição condicional (a forma que o wrapper realmente usa)
+let contadorInit = 0;
+function lazy(n: number): number {
+  contadorInit = contadorInit + 1;
+  lazy = function (m: number): number {
+    return m + 100;
+  };
+  return lazy(n);
+}
+console.log("lazy1=" + lazy(1));
+console.log("lazy2=" + lazy(2));
+console.log("init_rodou=" + contadorInit);

--- a/tests/cross-runtime/syntax/422_global_scope_chain.ts
+++ b/tests/cross-runtime/syntax/422_global_scope_chain.ts
@@ -1,0 +1,81 @@
+// Cross-runtime: o ÚLTIMO ELO da cadeia de escopo é o OBJETO GLOBAL. Um nome nu
+// que não casa com binding léxico nenhum resolve contra `globalThis`, e só um
+// miss ali é ReferenceError — lançado quando o controle chega no ponto, não em
+// tempo de compilação. É assim que um script publica algo para os outros.
+//
+// Junto: `&&`/`||`/ternário precisam CURTO-CIRCUITAR de verdade — avaliar o lado
+// não tomado transformaria o sniff de ambiente que todo bundle abre num throw.
+//
+// A MENSAGEM do ReferenceError diverge entre engines, então só o TIPO é impresso.
+
+declare var __xrtFn: (a: number, b: number) => string;
+declare var __xrtObj: { mode: string };
+
+(globalThis as Record<string, unknown>)["__xrtFn"] = function (a: number, b: number) {
+  return "w:" + a + b;
+};
+(globalThis as Record<string, unknown>)["__xrtObj"] = { mode: "live" };
+
+// 1. publicado dinamicamente, alcançado por NOME NU (chamada e leitura)
+function chamaGlobal(): string {
+  return __xrtFn(1, 2);
+}
+console.log("call=" + chamaGlobal());
+console.log("read=" + __xrtObj.mode);
+
+// 2. ausente de verdade → ReferenceError em RUNTIME, no ponto do uso
+let tipoCall = "NAO-LANCOU";
+try {
+  (globalThis as Record<string, unknown>)["naoLido"];
+  (naoExisteChamada as () => void)();
+} catch (e) {
+  tipoCall = (e as Error).constructor.name;
+}
+console.log("miss_call=" + tipoCall);
+
+let tipoRead = "NAO-LANCOU";
+try {
+  const x = (naoExisteLeitura as number) + 1;
+  tipoRead = "NAO-LANCOU:" + x;
+} catch (e) {
+  tipoRead = (e as Error).constructor.name;
+}
+console.log("miss_read=" + tipoRead);
+
+// 3. curto-circuito: o lado não tomado NÃO pode ser avaliado
+function andLiteral(): string {
+  if (false && (semNome1 as boolean)) return "y";
+  return "n";
+}
+function andMembro(): string {
+  if (false && (semNome2 as { x: number }).x) return "y";
+  return "n";
+}
+function orLiteral(): string {
+  if (true || (semNome3 as boolean)) return "y";
+  return "n";
+}
+function ternario(c: boolean): string {
+  return c ? "sim" : (semNome4 as string);
+}
+console.log("sc_and=" + andLiteral());
+console.log("sc_membro=" + andMembro());
+console.log("sc_or=" + orLiteral());
+console.log("sc_tern=" + ternario(true));
+
+// 4. sniff de ambiente: o ramo não tomado nomeia coisas que não existem
+function sniff(): string {
+  if (typeof naoDefinidoA !== "undefined" && (naoDefinidoA as { x: number }).x) return "a";
+  if (typeof naoDefinidoB === "function") return "b";
+  return "nenhum";
+}
+console.log("sniff=" + sniff());
+
+// 5. param sombreia o global de mesmo nome
+function sombra(__xrtFn: string): string {
+  return __xrtFn + "!";
+}
+console.log("sombra=" + sombra("param"));
+
+// 6. typeof de nome ausente é "undefined" e NÃO lança
+console.log("typeof=" + typeof aindaNaoDefinido);


### PR DESCRIPTION
Uma declaração de função cria um binding gravável, como qualquer `let`, e
reatribuí-lo é a memoização que todo async transpilado por Babel emite:

    function v(a) { v = _asyncToGenerator(…); return v.apply(this, args) }

O motor resolvia o nome pela tabela IMUTÁVEL de funções de topo, então a
escrita não tinha onde pousar e o ARQUIVO INTEIRO era recusado ("assignment to
unbound `v`"). Era 1 dos 9 erros por carga do WhatsApp Web e aparece em todo
bundle transpilado.

A correção tem quatro partes, três delas obrigatórias juntas:

1. `funcval::module_globals` promove a gcell uma função de topo cujo nome é
   ESCRITO — de dentro de qualquer função (inclusive dela mesma) ou do topo.
   Gated em ESCRITA, nunca em leitura: uma função comum continua resolvendo
   pela tabela e mantém o caminho rápido de chamada direta.

2. Prólogo de `main`: semeia a cell com a própria função. É exatamente o
   hoisting de função do JS — o binding vale acima da sua linha de declaração.
   Quais gcells são de função é DERIVADO (`gcells` ∩ `sigs`), sem campo novo
   atravessando o pipeline; a ordem de emissão é ordenada (IR não pode depender
   de iteração de HashMap — isso já produziu objeto AOT quebrado).

3. Os TRÊS caminhos que resolviam pelo fn-table passaram a preferir a cell
   quando ela existe: a chamada direta (`call.rs`), `fn_value_word` (`obj.rs`)
   e o receiver de `.call`/`.apply`/`.bind` (`call.rs`). O terceiro não é
   opcional — sem ele `v.apply(…)` reificava o valor ORIGINAL e a memoização
   chamava a si mesma para sempre (medido: stack overflow, não erro).

4. `emit_throw_error_expr` (trycatch.rs) ficou sem chamador no PR #2078 e foi
   DELETADO — `dead_code` é erro neste projeto.

Medido no alvo real: `assignment to unbound __rtsn_arrow_467` sai da lista.
Restam 3 `assignment to unbound <nome de usuário>`, que são a contraparte de
ESCRITA da cadeia de escopo (global implícito de modo sloppy) — NÃO tratada
aqui de propósito: escrever no objeto global quando o nome for, na verdade, um
local que o lifter perdeu produziria um valor errado em SILÊNCIO, que é pior
que a recusa atual. Precisa distinguir os dois casos antes, e isso é mudança
própria.

Suíte completa: 3228/3229. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Testes: tests/claude-fn-reassigned-binding.test.ts (6 casos) e DUAS fixtures
cross-runtime novas, ambas com saída idêntica byte a byte em Node, Bun e RTS:
  - fn-meta/421_function_reassigned_memoization.ts (memoização, hoisting,
    reatribuição do topo, init preguiçosa, e a função não-reatribuída intacta)
  - syntax/422_global_scope_chain.ts (cobre o PR #2078: global publicado
    dinamicamente, ReferenceError em runtime, curto-circuito, sniff de ambiente)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
