### PR TITLE
fix(codegen): local sombreando função de topo homônima produzia VALOR ERRADO em silêncio

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -63,6 +63,39 @@ use scan::{
 /// function print(v) { __rtsCapturedOutput += v + "\n"; }`) is the canonical case.
 /// `const` is excluded (immutable → never written). A name shadowed by a param or
 /// a local `let` inside the writing function is NOT counted (that write is local).
+/// Diagnostic for `RTS_DIAG_UNBOUND=<name>`: report WHY the lifter decided the
+/// free identifier `id` is not a capture of the closure it is synthesizing.
+///
+/// A wrong decision here does not necessarily bail — it can silently resolve the
+/// name to something else and produce a plausible WRONG VALUE (that is how the
+/// top-level-shadowing bug was found: a captured-and-written local read the
+/// same-named top-level function instead, yielding `undefined` where Node gave a
+/// real value). There is no other way to see this decision from outside, and the
+/// per-ident volume makes an unfiltered dump useless, so it is keyed by name.
+#[allow(clippy::too_many_arguments)]
+fn diag_skipped_capture(
+    id: &str,
+    fn_name: &str,
+    is_param: bool,
+    is_global: bool,
+    is_top_level: bool,
+    has_captures: bool,
+    is_module_global: bool,
+    in_scope: bool,
+) {
+    let Ok(want) = std::env::var("RTS_DIAG_UNBOUND") else {
+        return;
+    };
+    if want != id {
+        return;
+    }
+    eprintln!(
+        "[diag] `{id}` NÃO capturado em `{fn_name}`: param={is_param} global={is_global} \
+         top_level={is_top_level} tem_capturas={has_captures} \
+         module_global={is_module_global} no_escopo={in_scope}"
+    );
+}
+
 pub fn module_globals(
     funcs: &[HirFunc],
     main: &HirFunc,
@@ -1272,7 +1305,17 @@ impl Ctx {
                 // skippable: its direct name cannot be called from a scope that
                 // lacks its captured locals — fall through to the capture path,
                 // which snapshots its REIFIED fn VALUE (env embedded).
-                || (self.top_level.contains(id) && !self.captures.contains_key(id))
+                //
+                // `!scope.contains(id)` for the same reason the Registry test
+                // below has it: an in-scope OUTER LOCAL SHADOWS a same-named
+                // top-level function (JS scoping). A minified bundle reuses
+                // one-letter names across modules, so `var e, s = null` in one
+                // module factory collided with a `var e = function(){…}` hoisted
+                // to top level by another — `s` was captured and `e` silently
+                // was not, and the write to it bailed "assignment to unbound".
+                || (!scope.contains(id)
+                    && self.top_level.contains(id)
+                    && !self.captures.contains_key(id))
                 || self.module_globals.contains(id)
                 // An in-scope OUTER LOCAL/PARAM SHADOWS a same-named Registry
                 // namespace/class (JS scoping): `parse(input: string)` captures
@@ -1281,12 +1324,24 @@ impl Ctx {
                 || (!scope.contains(id)
                     && (super::registry::has_namespace(id) || super::registry::has_class(id)))
             {
+                diag_skipped_capture(
+                    id,
+                    &name,
+                    param_names.contains(id),
+                    GLOBALS.contains(&id.as_str()),
+                    self.top_level.contains(id),
+                    self.captures.contains_key(id),
+                    self.module_globals.contains(id),
+                    scope.contains(id),
+                );
                 continue;
             }
             // A top-level closure name: capture its fn VALUE (the enclosing
             // body reifies it — ITS captures are that body's leading params, so
             // the env embeds transitively). Never a mutable-capture cell.
-            if self.top_level.contains(id) {
+            // Same shadowing guard as above: an in-scope local of that name is
+            // an ordinary capture (and may need a cell), not the top-level fn.
+            if !scope.contains(id) && self.top_level.contains(id) {
                 captures.push(id.clone());
                 continue;
             }

--- a/crates/rts-codegen-new/src/front/run/stmt_assign.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_assign.rs
@@ -121,6 +121,21 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 }
             }
         }
+        // `RTS_DIAG_UNBOUND=<name>`: what the failing scope actually holds. Pairs
+        // with the lifter-side report in `funcval` — together they say whether a
+        // name is missing because the closure never captured it, and why.
+        if self.local(&name).is_none() && std::env::var("RTS_DIAG_UNBOUND").as_deref() == Ok(&*name)
+        {
+            let mut locals: Vec<&String> = self.locals.keys().collect();
+            locals.sort();
+            eprintln!(
+                "[diag] escrita a `{name}` sem binding em `{}` | capturas={:?} | cells={:?} \
+                 | locais={locals:?}",
+                self.current_fn,
+                self.captures.get(&self.current_fn),
+                self.cell_locals,
+            );
+        }
         let local = self
             .local(&name)
             .ok_or_else(|| Unsupported::new(format!("assignment to unbound `{name}`")))?;

--- a/tests/claude-local-shadows-toplevel-fn.test.ts
+++ b/tests/claude-local-shadows-toplevel-fn.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "rts:test";
+
+// Um LOCAL sombreia uma função de topo de mesmo nome — escopo léxico básico do
+// JS. O lifter de closures decidia "esse nome livre é a função de topo
+// homônima" ANTES de consultar o escopo, e descartava a captura: a função
+// aninhada passava a ler a FUNÇÃO em vez do local, e a escrita nunca chegava ao
+// local.
+//
+// O que torna isso sério: NÃO era um bail. Saía um valor errado EM SILÊNCIO
+// (`sess-undefined` onde Node/Bun dão `sess-ID:Env`) — verificado revertendo o
+// fix. Um minificador reusa `e`/`t`/`n`/`r` em todo módulo, então a colisão é a
+// regra num bundle real; na carga do WhatsApp Web ela também aparecia como
+// "assignment to unbound `e`", que era só a face visível do mesmo defeito.
+//
+// A correção dá à checagem de função-de-topo a MESMA guarda de sombreamento que
+// a checagem de namespace do Registry logo abaixo dela já tinha: só vale quando
+// o nome NÃO está no escopo.
+//
+// Valores conferidos contra Node e Bun (fixture cross-runtime
+// tests/cross-runtime/syntax/423_local_shadows_toplevel_fn.ts).
+
+// ── função de topo chamada `e` ──────────────────────────────────────────────
+var e = function (): any { return "TOPO"; };
+
+// ── fábrica com o SEU PRÓPRIO `e`, capturado E escrito por fn aninhada ──────
+function fabrica(req: any): any {
+  var e, s = null;
+  function pega(): any {
+    if (s != null) return s;
+    const v = (e || (e = req("Env"))).id;
+    s = "sess-" + v;
+    return s;
+  }
+  return pega;
+}
+const p = fabrica(function (n: any) { return { id: "ID:" + n }; });
+const primeira = p();
+const memoizada = p();
+const topoIntacto = (e as any)();
+
+// ── mesmo nome como PARÂMETRO ───────────────────────────────────────────────
+function comParam(e: any): any {
+  const inner = function (): any { return "param:" + e; };
+  return inner();
+}
+const viaParam = comParam("X");
+
+// ── duas closures irmãs escrevendo o MESMO local sombreador ─────────────────
+function duasIrmas(): any {
+  var e = 0;
+  const inc = function (): void { e = e + 1; };
+  const ler = function (): any { return e; };
+  inc();
+  inc();
+  return ler();
+}
+const irmas = duasIrmas();
+
+// ── sombreamento com o local só LIDO ────────────────────────────────────────
+function soLeitura(): any {
+  const e = "local";
+  const f = function (): any { return e; };
+  return f();
+}
+const leitura = soLeitura();
+
+describe("local sombreia função de topo homônima", () => {
+  test("captura escrita alcança o LOCAL, não a função de topo", () => {
+    expect(primeira).toBe("sess-ID:Env");
+  });
+  test("memoização devolve o valor guardado na segunda chamada", () => {
+    expect(memoizada).toBe("sess-ID:Env");
+  });
+  test("a função de topo continua intacta", () => {
+    expect(topoIntacto).toBe("TOPO");
+  });
+  test("param sombreia a função de topo", () => {
+    expect(viaParam).toBe("param:X");
+  });
+  test("closures irmãs compartilham o local sombreador", () => {
+    expect(irmas).toBe(2);
+  });
+  test("sombreamento vale também para local só lido", () => {
+    expect(leitura).toBe("local");
+  });
+});

--- a/tests/cross-runtime/syntax/423_local_shadows_toplevel_fn.ts
+++ b/tests/cross-runtime/syntax/423_local_shadows_toplevel_fn.ts
@@ -1,0 +1,68 @@
+// Cross-runtime: um LOCAL sombreia uma função de topo de mesmo nome (escopo JS).
+//
+// Minificador reusa letras (`e`, `t`, `n`, `r`) em todo módulo, então essa
+// colisão é a regra, não a exceção. No RTS o lifter de closures tratava um nome
+// livre como "é a função de topo homônima" ANTES de olhar o escopo léxico, e a
+// captura era descartada: a função aninhada lia a FUNÇÃO em vez do local, e a
+// escrita nunca chegava ao local. Resultado: valor errado EM SILÊNCIO (nenhum
+// erro), que é pior do que uma recusa.
+
+// função de topo chamada `e`
+var e = function (): string {
+  return "TOPO";
+};
+
+// fábrica com o SEU PRÓPRIO `e`, capturado E escrito por uma função aninhada
+// (memoização de require preguiçoso — a forma que todo bundle da Meta usa)
+function fabrica(req: (n: string) => { id: string }): () => string {
+  var e: { id: string } | undefined,
+    s: string | null = null;
+  function pega(): string {
+    if (s != null) return s;
+    const v = (e || (e = req("Env"))).id;
+    s = "sess-" + v;
+    return s;
+  }
+  return pega;
+}
+
+const p = fabrica(function (n: string) {
+  return { id: "ID:" + n };
+});
+console.log("primeira=" + p());
+console.log("memoizada=" + p());
+console.log("topo_intacto=" + e());
+
+// mesmo nome, agora como PARÂMETRO sombreando a função de topo
+function comParam(e: string): string {
+  const inner = function (): string {
+    return "param:" + e;
+  };
+  return inner();
+}
+console.log("param=" + comParam("X"));
+
+// local sombreando, escrito por DUAS closures irmãs (a mesma célula)
+function duasIrmas(): string {
+  var e = 0;
+  const inc = function (): void {
+    e = e + 1;
+  };
+  const ler = function (): number {
+    return e;
+  };
+  inc();
+  inc();
+  return "cont=" + ler();
+}
+console.log("irmas=" + duasIrmas());
+
+// o local sombreia mesmo quando NUNCA escrito (só lido)
+function soLeitura(): string {
+  const e = "local";
+  const f = function (): string {
+    return e;
+  };
+  return f();
+}
+console.log("so_leitura=" + soLeitura());


### PR DESCRIPTION
O lifter de closures decidia "esse nome livre é a função de topo homônima"
ANTES de consultar o escopo léxico, e descartava a captura. A função aninhada
passava a ler a FUNÇÃO em vez do local, e a escrita nunca chegava ao local.

O grave é que NÃO era um bail. Medido, revertendo o fix:

    var e = function(){ return "TOPO" };
    function fabrica(req) {
      var e, s = null;
      function pega(){ if (s != null) return s;
                       const v = (e || (e = req("Env"))).id;
                       return s = "sess-" + v, s }
      return pega;
    }
    fabrica(n => ({id:"ID:"+n}))()
    // Node/Bun: "sess-ID:Env"    RTS antes: "sess-undefined"   sem erro nenhum

Um minificador reusa `e`/`t`/`n`/`r` em todo módulo, então essa colisão é a
REGRA num bundle real, não a exceção — e a face silenciosa do defeito é a
perigosa. Na carga do WhatsApp Web ele também aparecia como "assignment to
unbound `e`" (3 dos 9 erros por carga), que era só a parte visível.

A correção dá à checagem de função-de-topo a MESMA guarda de sombreamento que a
checagem de namespace/classe do Registry, dez linhas abaixo, já tinha desde
sempre: ela só vale quando o nome NÃO está no escopo. Duas linhas, nos dois
pontos que consultam `top_level`.

DIAGNÓSTICO (o que achou isto, mantido): `RTS_DIAG_UNBOUND=<nome>` reporta, do
lado do lifter, POR QUE um ident livre não virou captura (param/global/
top_level/module_global/escopo) e, do lado da escrita, o que o escopo que
falhou realmente tem. Filtrado por nome porque o volume por-ident torna um dump
irrestrito inútil. Foi o que transformou "adivinhar a forma" em "ler a decisão":
`top_level=true` com `no_escopo=true` apontou a linha exata.

Método: bisseção binária por fronteira de módulo (`__G.__d(...)`) sobre o dump
de 472 KB do bundle real → 2 módulos, 7 KB. Nenhum dos dois falha SOZINHO — é a
colisão entre eles, que é exatamente por que a forma escrita à mão não
reproduzia. Medir achou; deduzir não teria achado.

Medido no alvo real: `assignment to unbound e` sai (3 casos); o bundle de 472 KB
avança de "unbound e" para `.setInterval()` com callback, bem mais fundo.

Suíte completa: 3234/3235. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Testes: tests/claude-local-shadows-toplevel-fn.test.ts (6 casos) e a fixture
cross-runtime tests/cross-runtime/syntax/423_local_shadows_toplevel_fn.ts,
saída idêntica byte a byte em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
