### PR TITLE
fix(codegen): param capturado E reatribuído vira célula (parâmetro com default transpilado)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/funcval/mod.rs
+++ b/crates/rts-codegen-new/src/front/run/funcval/mod.rs
@@ -63,6 +63,17 @@ use scan::{
 /// function print(v) { __rtsCapturedOutput += v + "\n"; }`) is the canonical case.
 /// `const` is excluded (immutable → never written). A name shadowed by a param or
 /// a local `let` inside the writing function is NOT counted (that write is local).
+/// Diagnostic for `RTS_DIAG_BAIL=1`: report WHY the lifter REFUSED to extract an
+/// arrow. A refusal leaves the arrow inline, and the lowering then bails
+/// "expression arrow" — a message that names neither the offending construct nor
+/// the reason. In a minified bundle there is no other way to tell a mutated-param
+/// capture from a free `this`.
+fn diag_bail(fn_name: &str, why: &str) {
+    if std::env::var("RTS_DIAG_BAIL").is_ok() {
+        eprintln!("[diag] lifter recusou `{fn_name}`: {why}");
+    }
+}
+
 /// Diagnostic for `RTS_DIAG_UNBOUND=<name>`: report WHY the lifter decided the
 /// free identifier `id` is not a capture of the closure it is synthesizing.
 ///
@@ -456,6 +467,7 @@ pub fn extract_arrows(
         cells: HashMap::new(),
         current_fn: String::new(),
         current_fn_lets: HashSet::new(),
+        current_fn_params: HashSet::new(),
         current_fn_arrow_decls: HashSet::new(),
         self_binding: None,
         counter: 0,
@@ -471,6 +483,7 @@ pub fn extract_arrows(
         let mutated = mutated_names(&f.body);
         ctx.current_fn = f.name.clone();
         ctx.current_fn_lets = declared_locals(&f.body);
+        ctx.current_fn_params = params.clone();
         ctx.current_fn_arrow_decls = arrow_decl_names(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
     }
@@ -478,6 +491,7 @@ pub fn extract_arrows(
     let main_mutated = mutated_names(&main.body);
     ctx.current_fn = main.name.clone();
     ctx.current_fn_lets = declared_locals(&main.body);
+    ctx.current_fn_params = main_params.clone();
     ctx.current_fn_arrow_decls = arrow_decl_names(&main.body);
     ctx.rewrite_block(&mut main.body, &main_params, &main_mutated);
 
@@ -501,6 +515,7 @@ pub fn extract_arrows(
         let mutated = mutated_names(&f.body);
         ctx.current_fn = f.name.clone();
         ctx.current_fn_lets = declared_locals(&f.body);
+        ctx.current_fn_params = params.clone();
         ctx.current_fn_arrow_decls = arrow_decl_names(&f.body);
         ctx.rewrite_block(&mut f.body, &params, &mutated);
         ctx.synthesized[i] = f;
@@ -899,6 +914,11 @@ struct Ctx {
     /// body — the only locals a captured-mutated name may be a cell of this
     /// increment (a deeper-block or param capture bails, kept sound).
     current_fn_lets: HashSet<String>,
+    /// The PARAMS of [`Self::current_fn`]. A param that a closure captures AND
+    /// something reassigns is cellable exactly like a `let`: the callee prologue
+    /// allocates the cell from the incoming argument. Kept apart from
+    /// `current_fn_lets` because only a param needs that prologue treatment.
+    current_fn_params: HashSet<String>,
     /// Names in the CURRENT function declared with a fn-valued initializer
     /// (`const factor = (..) => …`) — a capture of one is a CELL (mutual
     /// forward refs read the live value; see `arrow_decl_names`).
@@ -1216,6 +1236,7 @@ impl Ctx {
             .enumerate()
             .any(|(i, p)| p.variadic && i + 1 != params.len())
         {
+            diag_bail(&name, "param variádico fora da última posição");
             return None;
         }
         let mut param_names: HashSet<String> = params.iter().map(|p| p.name.clone()).collect();
@@ -1353,6 +1374,7 @@ impl Ctx {
             if !scope.contains(id) && !self.current_fn_arrow_decls.contains(id.as_str()) {
                 // `this` is not a value this pass can carry — leave it to bail.
                 if id == "this" {
+                    diag_bail(&name, "`this` livre não carregável");
                     return None;
                 }
                 // Any OTHER name that is no local in scope is a FREE GLOBAL
@@ -1402,7 +1424,33 @@ impl Ctx {
                     captures.push(id.clone());
                     continue;
                 }
-                return None; // mutable param / non-let-local capture — bail.
+                // A PARAM of the declaring function is cellable too: the callee
+                // prologue allocates the cell from the incoming argument (see
+                // the param-cell prologue in `run::lower`), which is the same
+                // "the declaration site allocates it" rule a `let` follows.
+                //
+                // This is what a TRANSPILED DEFAULT PARAMETER looks like —
+                // `function s(t, n, l) { l === void 0 && (l = false); … }` is how
+                // Babel/tsc emit `l = false`, so the param is reassigned, and a
+                // closure capturing it hit the bail. Refusing here rejected the
+                // whole file for a construct that is merely a default argument.
+                if self.current_fn_params.contains(id) {
+                    cell_caps.push(id.clone());
+                    captures.push(id.clone());
+                    continue;
+                }
+                // MUTATED capture that is not a `let` of the declaring function
+                // (a mutated PARAM, or a local the scan did not classify as a
+                // let) — no sound home for the cell, so the arrow stays inline
+                // and the lowering bails "expression arrow".
+                diag_bail(&name, &format!(
+                    "captura mutada `{id}` sem `let` declarante \
+                     (body_assigns={} mutated={} ja_cell={})",
+                    body_assigns.contains(id),
+                    mutated.contains(id),
+                    already_cell,
+                ));
+                return None;
             }
             captures.push(id.clone());
         }

--- a/crates/rts-codegen-new/src/front/run/lower.rs
+++ b/crates/rts-codegen-new/src/front/run/lower.rs
@@ -685,6 +685,47 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             }
         }
 
+        // PARAM-CELL prologue: a PARAM that a closure captures AND something
+        // reassigns lives in a cell, exactly like such a `let`. A `let`
+        // allocates its cell at the declaration statement; a param's
+        // "declaration" is the binding above, so the cell is allocated HERE,
+        // seeded with the incoming argument, and the name rebound to the handle.
+        //
+        // The construct this serves is the TRANSPILED DEFAULT PARAMETER —
+        // `function s(t, n, l) { l === void 0 && (l = false); … }` is how
+        // Babel/tsc emit `l = false`. The reassignment makes every closure
+        // capturing `l` unsound by value, and refusing it rejected the whole
+        // file (the lifter's "expression arrow" bail).
+        //
+        // A CAPTURE param is excluded: a synthesized closure receives its
+        // captured cells as leading params ALREADY HOLDING THE HANDLE, so
+        // allocating again would box the handle inside a second cell — the
+        // closure then returned the box instead of the value (measured: `[15]`
+        // where Node gives `15`) and writes landed in the wrong box.
+        {
+            let capture_params = captures.get(&func.name);
+            let param_cells: Vec<String> = func
+                .params
+                .iter()
+                .map(|p| p.name.clone())
+                .filter(|n| {
+                    ctx.cell_locals.contains(n)
+                        && !ctx.hoisted_cells.contains(n)
+                        && !capture_params.is_some_and(|c| c.contains(n))
+                })
+                .collect();
+            for name in param_cells {
+                let Some(local) = ctx.local(&name) else {
+                    continue;
+                };
+                let cur = ctx.builder.use_var(local.var);
+                let word = ctx.box_value(Val::new(cur, local.repr));
+                let handle = ctx.emit_cell_alloc(module, word);
+                ctx.bind_tagged_local(&name, Val::new(handle, Repr::Tagged));
+                ctx.hoisted_cells.insert(name);
+            }
+        }
+
         // FUNCTION-HOISTING prologue (main only): seed the cell of every top-level
         // function whose NAME IS REASSIGNED with the function itself.
         //

--- a/tests/claude-param-cell-capture.test.ts
+++ b/tests/claude-param-cell-capture.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "rts:test";
+
+// Um PARÂMETRO capturado por closure E reatribuído vira uma CÉLULA, igual a um
+// `let` na mesma situação. Antes o lifter só aceitava encaixotar um `let`, e um
+// param mutado o fazia RECUSAR a extração — o arquivo inteiro morria em
+// "expression arrow".
+//
+// A construção que isso serve é o PARÂMETRO COM VALOR PADRÃO transpilado:
+//   function s(a, flag = false)
+// vira
+//   function s(a, flag) { flag === void 0 && (flag = false); … }
+// ou seja, o param é reatribuído — então toda closure que o captura ficava sem
+// caminho sólido. Em bundle transpilado isso é onipresente.
+//
+// A cell é alocada no PRÓLOGO da própria função, a partir do argumento
+// recebido: é a mesma regra do `let` (quem declara, aloca). Uma exclusão é
+// obrigatória: um param de CAPTURA de closure sintetizada já chega com o
+// HANDLE, e re-alocar encaixotaria a caixa (medido: a closure devolvia `[15]`
+// onde o Node dá `15`, e escritas pousavam na caixa errada).
+//
+// Valores conferidos contra Node e Bun (fixture cross-runtime
+// tests/cross-runtime/fn-meta/424_param_captured_and_reassigned.ts).
+
+// ── o padrão do parâmetro com default transpilado ───────────────────────────
+function comDefault(a: any, flag: any): any {
+  flag === undefined && (flag = false);
+  const ler = function (): any { return "flag=" + flag; };
+  return ler();
+}
+const defOmitido = comDefault(1, undefined);
+const defDado = comDefault(1, true);
+
+// ── o param muda DEPOIS da closure existir ──────────────────────────────────
+function mudaDepois(n: any): any {
+  const ler = function (): any { return n; };
+  n = n + 10;
+  return ler();
+}
+const depois = mudaDepois(5);
+
+// ── a closure ESCREVE o param; o corpo externo enxerga ──────────────────────
+function closureEscreve(v: any): any {
+  const set = function (x: any): void { v = x; };
+  set("novo");
+  return v;
+}
+const escrito = closureEscreve("velho");
+
+// ── duas closures compartilham o MESMO param ────────────────────────────────
+function duasClosures(p: any): any {
+  const inc = function (): void { p = p + 1; };
+  const ler = function (): any { return p; };
+  inc();
+  inc();
+  return ler();
+}
+const duas = duasClosures(0);
+
+// ── cada CHAMADA tem sua própria caixa ──────────────────────────────────────
+function contador(inicio: any): any {
+  return function (): any { inicio = inicio + 1; return inicio; };
+}
+const c1 = contador(0);
+const c2 = contador(100);
+const c1a = c1();
+const c1b = c1();
+const c2a = c2();
+
+describe("param capturado e reatribuído vira célula", () => {
+  test("parâmetro com default transpilado", () => {
+    expect(defOmitido).toBe("flag=false");
+    expect(defDado).toBe("flag=true");
+  });
+  test("closure vê a mutação feita depois de criada", () => {
+    expect(depois).toBe(15);
+  });
+  test("escrita da closure alcança o corpo externo", () => {
+    expect(escrito).toBe("novo");
+  });
+  test("duas closures compartilham a mesma caixa", () => {
+    expect(duas).toBe(2);
+  });
+  test("cada chamada tem sua própria caixa", () => {
+    expect(c1a).toBe(1);
+    expect(c1b).toBe(2);
+    expect(c2a).toBe(101);
+  });
+});

--- a/tests/cross-runtime/fn-meta/424_param_captured_and_reassigned.ts
+++ b/tests/cross-runtime/fn-meta/424_param_captured_and_reassigned.ts
@@ -1,0 +1,79 @@
+// Cross-runtime: um PARÂMETRO capturado por closure E reatribuído.
+//
+// É como Babel/tsc transpilam um parâmetro com valor padrão:
+//   function s(a, flag = false)  ->  function s(a, flag) { flag === void 0 && (flag = false); … }
+// O param passa a ser reatribuído, então nenhuma closure que o captura pode
+// levar uma cópia por valor. O RTS só sabia encaixotar (cell) um `let`, e um
+// param mutado fazia o lifter RECUSAR a extração — o arquivo inteiro morria em
+// "expression arrow". Agora o prólogo da própria função aloca a cell a partir
+// do argumento recebido, que é a mesma regra do `let` (quem declara, aloca).
+
+// 1. o padrão do parâmetro com default transpilado
+function comDefault(a: number, flag?: boolean): string {
+  flag === undefined && (flag = false);
+  const ler = function (): string {
+    return "flag=" + flag;
+  };
+  return ler();
+}
+console.log("default_omitido=" + comDefault(1, undefined));
+console.log("default_dado=" + comDefault(1, true));
+
+// 2. o param muda DEPOIS da closure existir — ela vê o valor novo
+function mudaDepois(n: number): number {
+  const ler = function (): number {
+    return n;
+  };
+  n = n + 10;
+  return ler();
+}
+console.log("muda_depois=" + mudaDepois(5));
+
+// 3. a closure ESCREVE o param; o corpo externo enxerga
+function closureEscreve(v: string): string {
+  const set = function (x: string): void {
+    v = x;
+  };
+  set("novo");
+  return v;
+}
+console.log("closure_escreve=" + closureEscreve("velho"));
+
+// 4. duas closures compartilham o MESMO param
+function duasClosures(p: number): number {
+  const inc = function (): void {
+    p = p + 1;
+  };
+  const ler = function (): number {
+    return p;
+  };
+  inc();
+  inc();
+  return ler();
+}
+console.log("duas_closures=" + duasClosures(0));
+
+// 5. cada CHAMADA tem sua própria caixa (não vaza entre invocações)
+function contador(inicio: number): () => number {
+  return function (): number {
+    inicio = inicio + 1;
+    return inicio;
+  };
+}
+const c1 = contador(0);
+const c2 = contador(100);
+console.log("c1=" + c1() + "," + c1());
+console.log("c2=" + c2());
+
+// 6. param mutado E lido dentro de um laço com closure por iteração
+function noLaco(base: number): string {
+  const fs: Array<() => number> = [];
+  for (let i = 0; i < 3; i++) {
+    fs.push(function (): number {
+      return base + i;
+    });
+  }
+  base = base * 10;
+  return fs.map((f) => f()).join(",");
+}
+console.log("no_laco=" + noLaco(1));


### PR DESCRIPTION
O lifter só sabia encaixotar um `let`: uma captura MUTADA cujo nome fosse um
PARÂMETRO fazia ele RECUSAR a extração, e o arquivo inteiro morria em
"expression arrow" — sem dizer qual construção nem por quê.

A construção é o PARÂMETRO COM VALOR PADRÃO transpilado. Babel/tsc emitem

    function s(a, flag = false)   ->   function s(a, flag) {
                                         flag === void 0 && (flag = false); … }

isto é, o param passa a ser REATRIBUÍDO — então nenhuma closure que o captura
pode levar cópia por valor, e a recusa disparava. Em bundle transpilado isso é
onipresente; era 3 dos 9 erros por carga do WhatsApp Web.

A cell agora é alocada no PRÓLOGO da própria função, a partir do argumento
recebido. É a mesma regra que o `let` já seguia — quem declara, aloca — e a
"declaração" de um param é a sua ligação na entrada.

UMA EXCLUSÃO É OBRIGATÓRIA: um param de CAPTURA de closure sintetizada já chega
com o HANDLE da cell, então re-alocar encaixotaria a caixa. Medido antes de
excluir: a closure devolvia `[15]` onde o Node dá `15`, e as escritas pousavam
na caixa errada (`velho` em vez de `novo`). Detectado porque a repro cobre
leitura E escrita pelos dois lados — só leitura teria passado.

DIAGNÓSTICO (o que achou isto, mantido): `RTS_DIAG_BAIL=1` reporta POR QUE o
lifter recusou uma arrow — "captura mutada `l` sem `let` declarante" apontou a
linha na primeira execução. "expression arrow" sozinho não nomeia nem a
construção nem a razão, e num bundle minificado não há como distinguir uma
captura de param mutado de um `this` livre.

Método: bisseção por fronteira de módulo (`__G.__d(`) levou o dump de 153 KB a
UM módulo de 2,5 KB; o diagnóstico fez o resto.

Medido no alvo real: os 3 `expression arrow` SAEM. Mais relevante que a
contagem — os bloqueadores restantes mudaram de natureza: eram formas de JS que
o motor não modelava, agora são builtins não implementados
(`Object.fromEntries` sobre Map, `ArrayBuffer.isView`, `String.toString`
estático), que são bem mais tratáveis.

Suíte completa: 3239/3240. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Testes: tests/claude-param-cell-capture.test.ts (5 casos) e a fixture
cross-runtime tests/cross-runtime/fn-meta/424_param_captured_and_reassigned.ts
(8 saídas, idênticas byte a byte em Node, Bun e RTS) — inclui caixa por
CHAMADA (duas invocações não vazam entre si) e closure por iteração de laço.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
