### PR TITLE
fix(runtime,codegen): `Object.fromEntries` com fonte não-array resolvida em runtime

### DIFF
--- a/crates/rts-codegen-new/src/front/run/objstatic.rs
+++ b/crates/rts-codegen-new/src/front/run/objstatic.rs
@@ -643,11 +643,12 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // A proven array source: an array-valued expr OR an `Object.entries(...)`
         // call (whose result is always a freshly-built array of pairs — the common
         // round-trip `fromEntries(entries(o))`).
-        if !self.is_array_valued(&args[0]) && !self.is_object_static_array_expr(&args[0]) {
-            return unsupported!(
-                "Object.fromEntries with a non-array source (Map/iterator is a later increment)"
-            );
-        }
+        // Any OTHER source (an opaque `any`, a param — what minified code
+        // passes) goes to the SAME trampoline: it resolves a non-array source's
+        // `entries()` by name at runtime, so a Map — or any user class with an
+        // `entries()` — works without the front proving the type. Bailing here
+        // rejected the whole file for a call whose source it merely could not
+        // see through.
         let v = self.lower_expr(module, &args[0])?;
         let entries = self.box_value(v);
         let res = self

--- a/crates/rts-runtime/src/adapters/value/objops.rs
+++ b/crates/rts-runtime/src/adapters/value/objops.rs
@@ -724,6 +724,14 @@ fn added_key_shape(obj_word: u64, key_str_handle: u64) -> Option<u32> {
 /// overwrites). The key is ToString'd to a property key (numbers/bools coerce like
 /// JS). Returns the new object word. A non-array entry (or non-array source) is
 /// skipped defensively — the lowering only routes a proven-array source here.
+/// Whether `w` is an ARRAY word (not a keyed object): the same test the dynamic
+/// dispatch uses, so `fromEntries` and method resolution cannot disagree about
+/// what an array is.
+fn is_pair_array(w: u64) -> bool {
+    let v = PolyValue::from_raw(w);
+    v.is_object() && !super::inspect::looks_like_object(v)
+}
+
 #[rtse::abi]
 pub fn rtsadp_obj_from_entries(entries_word: u64) -> u64 {
     // Empty keyed object (slot 0 = empty-shape id, like a `{}` literal).
@@ -733,6 +741,35 @@ pub fn rtsadp_obj_from_entries(entries_word: u64) -> u64 {
     rt_vec::__RTS_FN_NS_COLLECTIONS_VEC_PUSH(obj_handle, slot0);
     let obj_word =
         PolyValue::from_object_handle(rt_handles::__rtsn_poly_from_handle(obj_handle)).raw();
+
+    // A NON-ARRAY source (a Map, or anything else that publishes `entries()`):
+    // the spec iterates it, and every such value in this runtime exposes the
+    // pair sequence through `entries()`. Resolve that by NAME through the
+    // ordinary dynamic dispatch — no class is named here, so a user class with
+    // an `entries()` works exactly like the built-in one. A source WITHOUT
+    // `entries()` falls through to the array walk below, which reads a
+    // non-array as zero pairs (an empty object — the spec answer for an empty
+    // iterable, and never a crash).
+    let entries_word = if is_pair_array(entries_word) {
+        entries_word
+    } else if PolyValue::from_raw(entries_word).is_object() {
+        let key = super::abi_adapter::intern_poly("entries").raw();
+        let undef = PolyValue::undefined().raw();
+        let pairs = super::dyndispatch::__rtsadp_dyn_method_call(
+            entries_word,
+            key,
+            undef,
+            undef,
+            undef,
+        );
+        if is_pair_array(pairs) {
+            pairs
+        } else {
+            entries_word
+        }
+    } else {
+        entries_word
+    };
 
     let entries = PolyValue::from_raw(entries_word);
     if entries.is_object() {

--- a/tests/cross-runtime/object-meta/426_object_fromentries_map.ts
+++ b/tests/cross-runtime/object-meta/426_object_fromentries_map.ts
@@ -1,0 +1,28 @@
+// Cross-runtime: `Object.fromEntries` sobre uma fonte NÃO-array.
+//
+// O RTS só aceitava a fonte quando conseguia provar estaticamente que era um
+// array (ou uma classe conhecida com `entries()`); uma fonte opaca — um Map
+// numa variável `any`, ou um parâmetro, que é o que código minificado passa —
+// recusava o ARQUIVO INTEIRO. Agora o trampolim resolve `entries()` por NOME em
+// runtime, então a prova estática deixa de ser necessária.
+
+const m = new Map<string, number>([["a", 1], ["b", 2]]);
+console.log("map=" + JSON.stringify(Object.fromEntries(m)));
+console.log("array=" + JSON.stringify(Object.fromEntries([["x", 9]])));
+console.log("vazio=" + JSON.stringify(Object.fromEntries(new Map())));
+
+// fonte OPACA (o caso que bailava): o tipo não é visível no ponto da chamada
+function viaParam(src: any): any {
+  return Object.fromEntries(src);
+}
+console.log("opaco_map=" + JSON.stringify(viaParam(m)));
+console.log("opaco_array=" + JSON.stringify(viaParam([["y", 7]])));
+
+// ida e volta
+console.log("roundtrip=" + JSON.stringify(Object.fromEntries(Object.entries({ k: 3 }))));
+
+// chaves numéricas viram string, como manda a spec
+console.log("chave_num=" + JSON.stringify(Object.fromEntries([[1, "um"]])));
+
+// a última ocorrência de uma chave repetida vence
+console.log("dup=" + JSON.stringify(Object.fromEntries([["d", 1], ["d", 2]])));


### PR DESCRIPTION
O front só aceitava a chamada quando conseguia PROVAR estaticamente que a fonte
era um array (ou uma classe conhecida com `entries()`). Uma fonte opaca — um
Map numa variável `any`, ou um parâmetro, que é o que código minificado passa —
recusava o ARQUIVO INTEIRO. Era 1 dos 9 erros por carga do WhatsApp Web.

Agora `__rtsadp_obj_from_entries` resolve o `entries()` de uma fonte não-array
por NOME, pelo despacho dinâmico que já existe — nenhuma classe é nomeada, então
um Map e uma classe de usuário com `entries()` seguem o mesmo caminho. O front
deixa de exigir a prova e lowera a fonte como valor.

A checagem "é array" usa exatamente o mesmo teste do despacho dinâmico, para
`fromEntries` e resolução de método não poderem discordar sobre o que é array.
Uma fonte sem `entries()` cai na varredura de array, que lê um não-array como
zero pares — objeto vazio, a resposta da spec para um iterável vazio, nunca um
crash.

DIVERGÊNCIA CONHECIDA: `Object.fromEntries(x)` onde `x` tem `entries()` mas não
é iterável — o Node exige um iterável e lança TypeError, o RTS devolve o
resultado. Não é novo: é exatamente o que o motor já fazia para uma classe
ESTATICAMENTE conhecida com `entries()`; esta mudança só estende o mesmo
comportamento à fonte dinâmica, em vez de ter duas regras. Fora da fixture
cross-runtime de propósito.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/object-meta/426_object_fromentries_map.ts — Map, array,
Map vazio, fonte opaca por parâmetro (o caso que bailava), ida e volta com
`Object.entries`, chave numérica virando string e chave duplicada. Saída
idêntica byte a byte em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
