### PR TITLE
fix(codegen): `<ClasseGlobal>.toString()` devolve a renderização `[native code]`

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -75,6 +75,31 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 }
             }
         }
+        // `<GlobalClass>.toString()` — a constructor IS a function object, so
+        // this is `Function.prototype.toString` on it: the `[native code]`
+        // rendering. Resolved HERE, ahead of the per-class static dispatchers,
+        // because each of those would otherwise have to answer it separately —
+        // and the class NAME is a value read from the receiver, never a literal,
+        // so one arm serves every global class.
+        //
+        // Bundles call this to detect a tampered builtin
+        // (`x.toString() === "function String() { [native code] }"`); a bail
+        // rejected the whole file over an anti-tamper probe.
+        if (method == "toString" || method == "toLocaleString") && args.is_empty() {
+            if let HirExprKind::Ident(cls) = &object.kind {
+                // Gated on the Registry knowing the class — DATA, so the set
+                // grows with the Registry instead of a list here. A local of
+                // that name shadows the global (JS scoping).
+                if self.local(cls).is_none()
+                    && (super::registry::has_class(cls)
+                        || super::globals::is_global_static_class(cls))
+                {
+                    let s = format!("function {cls}() {{ [native code] }}");
+                    let v = self.emit_str_const_word(module, &s)?;
+                    return Ok(Val::tagged_kind(v, JsKind::Str));
+                }
+            }
+        }
         // PRIVATE `engine.*` (arch/time/trace) — prelude-only (privacy gate). A
         // user caller bails here; a prelude caller lowers the runtime call.
         if let Some(val) = self.try_engine_call(module, object, method, args)? {

--- a/crates/rts-codegen-new/src/front/run/globals.rs
+++ b/crates/rts-codegen-new/src/front/run/globals.rs
@@ -774,6 +774,6 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
 /// instance methods only). Mirrors `mathobj::is_wrapper_primordial_static` and
 /// `globalclass::is_wrapper_primordial`. Only `String` (and `Array`, which has no
 /// prelude class today) reaches `try_global_static_call`'s class-shadow gate.
-fn is_global_static_class(name: &str) -> bool {
+pub(super) fn is_global_static_class(name: &str) -> bool {
     matches!(name, "String" | "Array")
 }

--- a/tests/cross-runtime/fn-meta/427_builtin_ctor_tostring.ts
+++ b/tests/cross-runtime/fn-meta/427_builtin_ctor_tostring.ts
@@ -1,0 +1,29 @@
+// Cross-runtime: `<ClasseGlobal>.toString()` — um construtor É um objeto-função,
+// então isso é `Function.prototype.toString` sobre ele, com a renderização
+// `[native code]`. Bundles chamam exatamente isso para detectar um builtin
+// adulterado, e o RTS recusava o ARQUIVO INTEIRO por causa dessa sonda.
+//
+// A GRAFIA EXATA é definida pela implementação e DIVERGE: o V8 (Node) emite uma
+// linha só, o JSC (Bun) emite três. Então a fixture normaliza espaços em branco
+// e asserta o que a spec de fato garante — o nome da função e o marcador
+// `[native code]`. Comparar a string crua faria a fixture falhar em Bun por uma
+// diferença que não é defeito de ninguém.
+
+function norma(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+console.log("String=" + norma(String.toString()));
+console.log("Number=" + norma(Number.toString()));
+console.log("Object=" + norma(Object.toString()));
+console.log("Array=" + norma(Array.toString()));
+console.log("Boolean=" + norma(Boolean.toString()));
+console.log("Date=" + norma(Date.toString()));
+
+// o idioma como o bundle escreve (sobre o resultado normalizado)
+function ehNativo(s: string, nome: string): boolean {
+  return norma(s) === "function " + nome + "() { [native code] }";
+}
+console.log("nativo_String=" + ehNativo(String.toString(), "String"));
+console.log("nativo_Array=" + ehNativo(Array.toString(), "Array"));
+console.log("nativo_errado=" + ehNativo(Array.toString(), "String"));


### PR DESCRIPTION
Um construtor É um objeto-função, então `String.toString()` é
`Function.prototype.toString` sobre ele. O motor bailava
("String.toString(...) static method (later increment)") e derrubava o ARQUIVO
INTEIRO — e o chamador é uma sonda ANTI-ADULTERAÇÃO: bundles comparam
`x.toString() === "function String() { [native code] }"` para detectar um
builtin trocado. Era 1 dos 9 erros por carga do WhatsApp Web.

Resolvido em UM ponto, antes dos dispatchers por classe, com o nome vindo do
RECEIVER e o conjunto de classes vindo da REGISTRY — não há lista de nomes no
motor, e um local de mesmo nome sombreia o global. A primeira versão desta
correção ficava dentro de `string_static_call` com a string "String" literal:
além de hardcode, só resolvia uma classe (`Number.toString()` seguia bailando),
o que o teste expôs de imediato.

GRAFIA: a spec deixa a renderização a cargo da implementação e os runtimes
DIVERGEM — V8 (Node) emite uma linha, JSC (Bun) emite três. O RTS segue o V8. A
fixture cross-runtime normaliza espaços em branco e asserta o que a spec
garante (o nome da função e o marcador `[native code]`); comparar a string crua
faria a fixture falhar em Bun por uma diferença que não é defeito de ninguém.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime tests/cross-runtime/fn-meta/427_builtin_ctor_tostring.ts
(String/Number/Object/Array/Boolean/Date + o idioma de detecção, incluindo o
caso NEGATIVO), idêntica em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
