### PR TITLE
fix(codegen): compound-assign sobre CADEIA de propriedades (`this.a.b += 1`)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/assign.rs
+++ b/crates/rts-codegen-new/src/front/run/assign.rs
@@ -49,7 +49,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         if matches!(
             &target.kind,
             HirExprKind::Member { object, .. } | HirExprKind::Index { object, .. }
-                if matches!(object.kind, HirExprKind::Ident(_))
+                if Self::is_replayable_base(object)
         ) {
             // Logical assign on a MEMBER short-circuits the whole STORE (spec
             // AssignmentExpression : LeftHandSideExpression &&= ...): the target
@@ -141,6 +141,35 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let coerced = self.coerce(result, local.repr)?;
         self.builder.def_var(local.var, coerced);
         Ok(Val::new(coerced, local.repr))
+    }
+
+    /// Whether the OBJECT of a compound-assign target can be evaluated TWICE
+    /// (once for the load, once for the store) with the same result and no extra
+    /// effect — which is what lets `o.p += v` desugar to `o.p = o.p + v`.
+    ///
+    /// A bare identifier qualifies (`this` reaches here as one), and so does a CHAIN of
+    /// plain property reads over one: `this.$1.count += 1` and `a.b[k] |= m` are
+    /// routine in minified code, and requiring the base to be a single ident
+    /// rejected the whole file for them. An INDEX is only replayable when the key
+    /// itself is — a literal or an identifier; anything computed (`a[f()].n += 1`)
+    /// would run twice, so it keeps bailing.
+    ///
+    /// The assumption is the same one the single-ident case already made: a plain
+    /// property read has no observable effect. A getter with side effects breaks
+    /// it, exactly as it did before — this widens the shape, not the risk.
+    fn is_replayable_base(e: &HirExpr) -> bool {
+        match &e.kind {
+            HirExprKind::Ident(_) => true,
+            HirExprKind::Member { object, .. } => Self::is_replayable_base(object),
+            HirExprKind::Index { object, index } => {
+                Self::is_replayable_base(object)
+                    && matches!(
+                        index.kind,
+                        HirExprKind::Ident(_) | HirExprKind::Lit(_)
+                    )
+            }
+            _ => false,
+        }
     }
 
     /// Logical-assign `a &&= b` / `a ||= b` / `a ??= b` on a simple ident LHS.

--- a/tests/cross-runtime/syntax/428_compound_assign_member_chain.ts
+++ b/tests/cross-runtime/syntax/428_compound_assign_member_chain.ts
@@ -1,0 +1,52 @@
+// Cross-runtime: compound-assign (`+=`, `*=`, `|=`, …) sobre uma CADEIA de
+// propriedades, não só sobre `ident.prop`.
+//
+// `o.p += v` é desugarado para `o.p = o.p + v`, o que exige poder avaliar o
+// OBJETO duas vezes. O motor só aceitava isso quando o objeto era um
+// identificador único, então `this.$1.count += 1` e `a.b[k] |= m` — rotina em
+// código minificado — recusavam o ARQUIVO INTEIRO.
+//
+// Uma chave COMPUTADA (`a[f()].n += 1`) continua recusada de propósito: ali a
+// dupla avaliação rodaria `f()` duas vezes.
+
+const o: any = { a: { b: 1, arr: [10, 20] }, k: "b" };
+
+o.a.b += 5;
+console.log("membro_aninhado=" + o.a.b);
+
+o.a.arr[1] *= 3;
+console.log("indice_em_cadeia=" + o.a.arr[1]);
+
+o.a[o.k] |= 8;
+console.log("indice_por_ident=" + o.a.b);
+
+o.a.arr[0] -= 4;
+console.log("subtracao=" + o.a.arr[0]);
+
+o.a.b <<= 2;
+console.log("shift=" + o.a.b);
+
+// dentro de método, sobre `this`
+class Contador {
+  estado: any = { n: 1, tags: ["x"] };
+  bump(): number {
+    this.estado.n += 2;
+    return this.estado.n;
+  }
+  concat(): string {
+    this.estado.tags[0] += "y";
+    return this.estado.tags[0];
+  }
+}
+const c = new Contador();
+console.log("this_cadeia=" + c.bump());
+console.log("this_indice=" + c.concat());
+
+// concatenação de string por cadeia
+const s: any = { m: { txt: "a" } };
+s.m.txt += "b";
+console.log("string=" + s.m.txt);
+
+// o valor da expressão é o NOVO valor
+const r: any = { v: { n: 1 } };
+console.log("valor_da_expr=" + (r.v.n += 9));


### PR DESCRIPTION
`o.p += v` é desugarado para `o.p = o.p + v`, o que exige poder avaliar o
OBJETO duas vezes. O motor só aceitava isso quando o objeto era um
identificador ÚNICO, então `this.$1.count += 1` e `a.b[k] |= m` — rotina em
código minificado — recusavam o ARQUIVO INTEIRO ("assignment target must be a
simple identifier"). Era 1 dos 9 erros por carga do WhatsApp Web.

Agora a base pode ser uma CADEIA de leituras de propriedade sobre um
identificador. Um ÍNDICE só entra quando a própria chave é replayável (literal
ou identificador): `a[f()].n += 1` continua recusado de propósito, porque ali a
dupla avaliação rodaria `f()` duas vezes.

A premissa é a MESMA que o caso de identificador único já assumia — uma leitura
de propriedade simples não tem efeito observável. Um getter com efeito colateral
a quebra, exatamente como antes: isto alarga a FORMA aceita, não o risco.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/syntax/428_compound_assign_member_chain.ts — membro
aninhado, índice em cadeia, índice por identificador, shift, cadeia sobre
`this` dentro de método, concatenação de string e o valor da própria expressão
(que é o NOVO valor). Idêntica byte a byte em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
