### PR TITLE
fix(codegen): compound-assign e `++`/`--` sobre alvo com PARTE EFETIVA

### DIFF
--- a/crates/rts-codegen-new/src/front/run/assign.rs
+++ b/crates/rts-codegen-new/src/front/run/assign.rs
@@ -46,11 +46,7 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         // does NOT short-circuit the RHS (the binary form always evaluates it before
         // the store) — exact for a side-effect-free RHS on a plain data property,
         // which is the covered surface.
-        if matches!(
-            &target.kind,
-            HirExprKind::Member { object, .. } | HirExprKind::Index { object, .. }
-                if Self::is_replayable_base(object)
-        ) {
+        if Self::target_is_replayable(target) {
             // Logical assign on a MEMBER short-circuits the whole STORE (spec
             // AssignmentExpression : LeftHandSideExpression &&= ...): the target
             // is read once, and the RHS + the setter run ONLY on the taken
@@ -73,6 +69,49 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 );
                 return self.lower_assign(module, target, &new_value);
             }
+        }
+        // A member/index target whose base is NOT replayable (`f().p += x`,
+        // `a[g()].n |= m`): evaluate each effectful part ONCE into a hidden
+        // local and retry against those. The desugar then replays only bare
+        // identifiers, so nothing runs twice — which is the whole reason the
+        // replay restriction existed. Same technique the destructuring path uses.
+        match &target.kind {
+            HirExprKind::Member { object, prop } if !Self::is_replayable_base(object) => {
+                let base = self.hidden_local_for(module, object, "obj")?;
+                let t = HirExpr::new(
+                    HirExprKind::Member {
+                        object: Box::new(base),
+                        prop: prop.clone(),
+                    },
+                    HirType::Unknown,
+                );
+                return self.lower_assign_op(module, op, &t, value);
+            }
+            HirExprKind::Index { object, index } => {
+                let base_ok = Self::is_replayable_base(object);
+                let idx_ok = matches!(index.kind, HirExprKind::Ident(_) | HirExprKind::Lit(_));
+                if !base_ok || !idx_ok {
+                    let base = if base_ok {
+                        (**object).clone()
+                    } else {
+                        self.hidden_local_for(module, object, "obj")?
+                    };
+                    let idx = if idx_ok {
+                        (**index).clone()
+                    } else {
+                        self.hidden_local_for(module, index, "idx")?
+                    };
+                    let t = HirExpr::new(
+                        HirExprKind::Index {
+                            object: Box::new(base),
+                            index: Box::new(idx),
+                        },
+                        HirType::Unknown,
+                    );
+                    return self.lower_assign_op(module, op, &t, value);
+                }
+            }
+            _ => {}
         }
         let name = ident_target(target)?;
         // Logical-assign ops short-circuit: `a &&= b` only evaluates/assigns `b`
@@ -141,6 +180,45 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
         let coerced = self.coerce(result, local.repr)?;
         self.builder.def_var(local.var, coerced);
         Ok(Val::new(coerced, local.repr))
+    }
+
+    /// Whether the WHOLE member/index target can be replayed: the base, and —
+    /// for an index — the KEY too. Checking only the base was a real hole:
+    /// `arr[f()] *= 3` passed the base test, took the desugar path, and ran
+    /// `f()` TWICE (medido: 2 chamadas onde o Node faz 1).
+    pub(super) fn target_is_replayable(target: &HirExpr) -> bool {
+        match &target.kind {
+            HirExprKind::Member { object, .. } => Self::is_replayable_base(object),
+            HirExprKind::Index { object, index } => {
+                Self::is_replayable_base(object)
+                    && matches!(index.kind, HirExprKind::Ident(_) | HirExprKind::Lit(_))
+            }
+            _ => false,
+        }
+    }
+
+    /// Evaluate `e` ONCE, bind the word to a fresh hidden local, and return an
+    /// `Ident` expression naming it. Lets a target with an effectful part be
+    /// rewritten into one whose parts are all bare identifiers — replayable by
+    /// construction, so the load/store desugar cannot re-run the effect.
+    pub(super) fn hidden_local_for(
+        &mut self,
+        module: &mut dyn Module,
+        e: &HirExpr,
+        what: &str,
+    ) -> FrontResult<HirExpr> {
+        let v = self.lower_expr(module, e)?;
+        let word = self.box_value(v);
+        // Nome único por SÍTIO: o contador de blocos do builder já é único e
+        // monotônico dentro da função, e o `what` separa base de índice no
+        // mesmo alvo. Um nome reusado sobrescreveria o temporário de um
+        // compound-assign aninhado.
+        let name = format!(
+            "__rtsn_ca_{what}_{}",
+            self.builder.create_block().as_u32()
+        );
+        self.bind_tagged_local(&name, Val::new(word, Repr::Tagged));
+        Ok(HirExpr::new(HirExprKind::Ident(name), HirType::Unknown))
     }
 
     /// Whether the OBJECT of a compound-assign target can be evaluated TWICE

--- a/crates/rts-codegen-new/src/front/run/stmt_assign.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_assign.rs
@@ -209,10 +209,42 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 return self.lower_member_index_incdec(module, target, inc, prefix);
             }
         }
-        if let HirExprKind::Index { object, .. } = &target.kind {
-            if Self::is_replayable_base(object) {
+        if let HirExprKind::Index { object, index } = &target.kind {
+            if Self::is_replayable_base(object)
+                && matches!(index.kind, HirExprKind::Ident(_) | HirExprKind::Lit(_))
+            {
                 return self.lower_member_index_incdec(module, target, inc, prefix);
             }
+        }
+        // Alvo com parte EFETIVA (`f().n++`, `a[g()]--`): avalia cada parte uma
+        // vez num local oculto e refaz sobre elas — o mesmo que o compound-assign
+        // faz, pelo mesmo motivo (o desugar lê e escreve o alvo, então uma
+        // chamada na base rodaria duas vezes).
+        match &target.kind {
+            HirExprKind::Member { object, prop } if !Self::is_replayable_base(object) => {
+                let base = self.hidden_local_for(module, object, "obj")?;
+                let t = HirExpr::new(
+                    HirExprKind::Member { object: Box::new(base), prop: prop.clone() },
+                    rts_hir::HirType::Unknown,
+                );
+                return self.lower_incdec(module, &t, inc, prefix);
+            }
+            HirExprKind::Index { object, index } => {
+                let base_ok = Self::is_replayable_base(object);
+                let idx_ok = matches!(index.kind, HirExprKind::Ident(_) | HirExprKind::Lit(_));
+                if !base_ok || !idx_ok {
+                    let base = if base_ok { (**object).clone() }
+                               else { self.hidden_local_for(module, object, "obj")? };
+                    let idx = if idx_ok { (**index).clone() }
+                              else { self.hidden_local_for(module, index, "idx")? };
+                    let t = HirExpr::new(
+                        HirExprKind::Index { object: Box::new(base), index: Box::new(idx) },
+                        rts_hir::HirType::Unknown,
+                    );
+                    return self.lower_incdec(module, &t, inc, prefix);
+                }
+            }
+            _ => {}
         }
         let name = ident_target(target)?;
         // MODULE-LEVEL MUTABLE GLOBAL (epic #195): `++`/`--` on a cell var. Read the

--- a/tests/cross-runtime/syntax/430_compound_assign_effectful_target.ts
+++ b/tests/cross-runtime/syntax/430_compound_assign_effectful_target.ts
@@ -1,0 +1,45 @@
+// Cross-runtime: compound-assign e `++`/`--` sobre um alvo com PARTE EFETIVA.
+//
+// `o.p += v` é desugarado para `o.p = o.p + v`, então o alvo é lido E escrito.
+// Se a base (ou a chave de índice) for uma chamada, ela rodaria DUAS vezes. O
+// motor recusava esses alvos; agora cada parte efetiva é avaliada UMA vez num
+// temporário e o desugar replica só identificadores.
+//
+// A fixture conta as chamadas justamente porque o modo de falha aqui é
+// silencioso: o valor final pode sair certo enquanto o efeito colateral roda
+// duas vezes.
+
+let chamadas = 0;
+const store: any = { a: { n: 1 }, arr: [10, 20] };
+
+function pega(): any {
+  chamadas = chamadas + 1;
+  return store.a;
+}
+function idx(): number {
+  chamadas = chamadas + 1;
+  return 1;
+}
+
+pega().n += 5;
+console.log("base_chamada=" + store.a.n + " chamadas=" + chamadas);
+
+store.arr[idx()] *= 3;
+console.log("chave_chamada=" + store.arr[1] + " chamadas=" + chamadas);
+
+pega().n++;
+console.log("incdec_base=" + store.a.n + " chamadas=" + chamadas);
+
+store.arr[idx()]--;
+console.log("incdec_chave=" + store.arr[1] + " chamadas=" + chamadas);
+
+// base E chave efetivas ao mesmo tempo
+function obj(): any {
+  chamadas = chamadas + 1;
+  return store;
+}
+obj().arr[idx()] += 100;
+console.log("ambas=" + store.arr[1] + " chamadas=" + chamadas);
+
+// o valor da expressão continua sendo o NOVO valor
+console.log("valor=" + (pega().n += 1));


### PR DESCRIPTION
`o.p += v` é desugarado para `o.p = o.p + v`, então o alvo é lido E escrito. Se
a base — ou a chave de índice — for uma chamada, ela rodaria duas vezes, e por
isso o motor recusava esses alvos ("assignment target must be a simple
identifier"). Restava como 2 dos erros por carga do WhatsApp Web depois do
#2088/#2089.

Agora cada parte EFETIVA é avaliada UMA vez num local oculto e o alvo é refeito
sobre esses nomes — o desugar então replica só identificadores, que é
exatamente a condição que a restrição existia para garantir. Mesma técnica que
o caminho de destructuring já usava.

BURACO ENCONTRADO NO CAMINHO, e ele é anterior a esta mudança: a checagem de
"replayável" olhava só a BASE. `arr[f()] *= 3` passava por ela, tomava o
desugar, e rodava `f()` DUAS VEZES — medido, 2 chamadas onde o Node faz 1.
Valor final certo, efeito colateral duplicado: falha silenciosa. A condição
virou um predicado do ALVO INTEIRO (`target_is_replayable`), que checa a base e,
num índice, também a chave — e o mesmo predicado passou a valer no caminho de
`++`/`--`, em vez de a regra estar escrita em três lugares.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/syntax/430_compound_assign_effectful_target.ts. Ela CONTA as
chamadas de propósito — o modo de falha aqui é silencioso, o valor final pode
sair certo enquanto o efeito roda duas vezes. Cobre base efetiva, chave efetiva,
`++`/`--` de ambas, base E chave juntas, e o valor da expressão. Idêntica byte a
byte em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
