### PR TITLE
fix(parser): generator-expressão que ESCREVE captura passa a ser içável (por referência)

### DIFF
--- a/crates/rts-parser/src/gencapref.rs
+++ b/crates/rts-parser/src/gencapref.rs
@@ -1,0 +1,283 @@
+//! Capturas ESCRITAS de um generator-expressão, passadas por REFERÊNCIA.
+//!
+//! O `GenExprHoister` (em [`crate::lowering_items`]) leva um `function*` que é
+//! EXPRESSÃO para o topo, porque a state-machine de generators só existe para
+//! declarações de topo. As capturas viajam como ARGUMENTOS do wrapper, isto é,
+//! POR VALOR — e por isso ele recusava içar quando alguma capturada era
+//! ESCRITA: a escrita ficaria no parâmetro e nunca chegaria ao escopo de
+//! origem, trocando uma recusa honesta por um efeito que some em silêncio.
+//!
+//! Essa recusa custava caro: é exatamente a forma que todo `async` transpilado
+//! produz, porque o `asyncToGenerator` do Babel embrulha um `function*` que
+//! memoiza requires preguiçosos (`s || (s = n("Promise"))`).
+//!
+//! ## O mecanismo
+//!
+//! Em vez de um esquema novo, este módulo reusa o que o motor JÁ tem: o lifter
+//! de closures transforma um local capturado-E-escrito numa CÉLULA
+//! compartilhada. O wrapper é uma fn-expressão comum no escopo declarante, logo
+//! passa por esse lifter. Então basta o wrapper entregar ao generator um PAR de
+//! funções por capturada escrita:
+//!
+//! ```text
+//!   var s;
+//!   const g = function* () { return (s || (s = f())).x; };
+//! vira
+//!   function* __genexpr_N(__gs_s, __ss_s) { return (__gs_s() || __ss_s(f())).x; }
+//!   const g = function () { return __genexpr_N(() => s, (v) => (s = v)); };
+//! ```
+//!
+//! As duas arrows do wrapper capturam e escrevem `s`, então o lifter faz de `s`
+//! uma célula e ambas enxergam a MESMA caixa — que é o comportamento correto.
+//! O setter devolve o valor atribuído, porque `s = v` é uma expressão cujo valor
+//! é `v` (`x = (s = 1)` tem de dar `1`).
+//!
+//! ## O que ele RECUSA
+//!
+//! `s++` / `s--` e a atribuição desestruturante (`[s] = xs`) não são reescritos:
+//! exigiriam sintetizar um temporário para preservar o valor antigo, e uma
+//! reescrita parcial devolveria um valor errado calado. Nesses casos o hoist
+//! não acontece e o generator continua recusado, como antes.
+
+use std::collections::HashSet;
+
+use swc_ecma_ast::{
+    ArrowExpr, AssignExpr, AssignOp, AssignTarget, BindingIdent, BlockStmtOrExpr, CallExpr, Callee,
+    Expr, ExprOrSpread, Function, Ident, Param, Pat, SimpleAssignTarget,
+};
+use swc_ecma_visit::{VisitMut, VisitMutWith};
+
+/// O nome do parâmetro-getter de `name`.
+pub fn getter_name(name: &str) -> String {
+    format!("__gs_{name}")
+}
+
+/// O nome do parâmetro-setter de `name`.
+pub fn setter_name(name: &str) -> String {
+    format!("__ss_{name}")
+}
+
+fn ident(n: &str) -> Ident {
+    Ident {
+        span: Default::default(),
+        ctxt: Default::default(),
+        sym: n.into(),
+        optional: false,
+    }
+}
+
+fn ident_expr(n: &str) -> Expr {
+    Expr::Ident(ident(n))
+}
+
+fn call(callee: &str, args: Vec<Expr>) -> Expr {
+    Expr::Call(CallExpr {
+        span: Default::default(),
+        ctxt: Default::default(),
+        callee: Callee::Expr(Box::new(ident_expr(callee))),
+        args: args
+            .into_iter()
+            .map(|e| ExprOrSpread {
+                spread: None,
+                expr: Box::new(e),
+            })
+            .collect(),
+        type_args: None,
+    })
+}
+
+/// `(nome) => corpo` — a forma que o lifter de closures reconhece.
+fn arrow(params: Vec<&str>, body: Expr) -> Expr {
+    Expr::Arrow(ArrowExpr {
+        span: Default::default(),
+        ctxt: Default::default(),
+        params: params
+            .into_iter()
+            .map(|p| Pat::Ident(BindingIdent::from(ident(p))))
+            .collect(),
+        body: Box::new(BlockStmtOrExpr::Expr(Box::new(body))),
+        is_async: false,
+        is_generator: false,
+        type_params: None,
+        return_type: None,
+    })
+}
+
+/// Os argumentos que o WRAPPER passa por `name`: `() => name` e
+/// `(v) => (name = v)`.
+pub fn wrapper_args(name: &str) -> [Expr; 2] {
+    let get = arrow(vec![], ident_expr(name));
+    let set = arrow(
+        vec!["__v"],
+        Expr::Assign(AssignExpr {
+            span: Default::default(),
+            op: AssignOp::Assign,
+            left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent::from(ident(name)))),
+            right: Box::new(ident_expr("__v")),
+        }),
+    );
+    [get, set]
+}
+
+/// Os PARÂMETROS que o generator içado recebe por `name`, em ordem.
+pub fn hoisted_params(name: &str) -> [Param; 2] {
+    let p = |n: String| Param {
+        span: Default::default(),
+        decorators: Vec::new(),
+        pat: Pat::Ident(BindingIdent::from(ident(&n))),
+    };
+    [p(getter_name(name)), p(setter_name(name))]
+}
+
+/// Reescreve, no corpo de `f`, toda LEITURA e ESCRITA dos nomes em `names` para
+/// o par getter/setter. Devolve `false` (sem tocar em `f`) quando encontra uma
+/// forma que não sabe reescrever — o chamador então não iça, mantendo a recusa
+/// honesta em vez de uma reescrita pela metade.
+pub fn rewrite_by_ref(f: &mut Function, names: &HashSet<String>) -> bool {
+    if names.is_empty() {
+        return true;
+    }
+    let mut v = Rewriter {
+        names,
+        shadowed: Vec::new(),
+        ok: true,
+    };
+    f.visit_mut_with(&mut v);
+    v.ok
+}
+
+struct Rewriter<'a> {
+    names: &'a HashSet<String>,
+    /// Escopos aninhados que REDECLARAM um dos nomes — dentro deles o nome é
+    /// outra variável e não pode ser reescrito.
+    shadowed: Vec<HashSet<String>>,
+    ok: bool,
+}
+
+impl Rewriter<'_> {
+    fn targets(&self, n: &str) -> bool {
+        self.names.contains(n) && !self.shadowed.iter().any(|s| s.contains(n))
+    }
+
+    /// Nomes que `params` liga — um deles sombreia a capturada de mesmo nome.
+    fn bound_by(params: &[Pat]) -> HashSet<String> {
+        let mut out = HashSet::new();
+        for p in params {
+            if let Pat::Ident(i) = p {
+                out.insert(i.id.sym.to_string());
+            }
+        }
+        out
+    }
+}
+
+impl VisitMut for Rewriter<'_> {
+    fn visit_mut_function(&mut self, f: &mut Function) {
+        let pats: Vec<Pat> = f.params.iter().map(|p| p.pat.clone()).collect();
+        self.shadowed.push(Self::bound_by(&pats));
+        f.visit_mut_children_with(self);
+        self.shadowed.pop();
+    }
+
+    fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
+        self.shadowed.push(Self::bound_by(&a.params));
+        a.visit_mut_children_with(self);
+        self.shadowed.pop();
+    }
+
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        // ATRIBUIÇÃO primeiro: o alvo é um `Ident` que NÃO pode virar leitura.
+        if let Expr::Assign(a) = e {
+            let target = match &a.left {
+                AssignTarget::Simple(SimpleAssignTarget::Ident(i))
+                    if self.targets(&i.id.sym.to_string()) =>
+                {
+                    Some(i.id.sym.to_string())
+                }
+                _ => None,
+            };
+            if let Some(name) = target {
+                // O RHS é reescrito normalmente (pode ler a mesma capturada).
+                a.right.visit_mut_with(self);
+                let rhs = (*a.right).clone();
+                let value = match a.op {
+                    AssignOp::Assign => rhs,
+                    // `s <op>= v` → `__ss_s(__gs_s() <op> v)`. O valor da
+                    // expressão continua sendo o novo valor, que é o que o
+                    // setter devolve.
+                    op => match op.to_update() {
+                        Some(bin) => Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: Default::default(),
+                            op: bin,
+                            left: Box::new(call(&getter_name(&name), vec![])),
+                            right: Box::new(rhs),
+                        }),
+                        // Lógicos (`&&=`/`||=`/`??=`) precisariam curto-circuitar
+                        // a ESCRITA; reescrever sem isso dispararia o setter
+                        // sempre. Recusa.
+                        None => {
+                            self.ok = false;
+                            return;
+                        }
+                    },
+                };
+                *e = call(&setter_name(&name), vec![value]);
+                return;
+            }
+        }
+        // `s++` / `s--`: precisaria de um temporário para o valor antigo.
+        if let Expr::Update(u) = e {
+            if let Expr::Ident(i) = &*u.arg {
+                if self.targets(&i.sym.to_string()) {
+                    self.ok = false;
+                    return;
+                }
+            }
+        }
+        e.visit_mut_children_with(self);
+        // LEITURA — depois dos filhos, para não reescrever um `Ident` que já
+        // virou parte de uma chamada acima.
+        if let Expr::Ident(i) = e {
+            let n = i.sym.to_string();
+            if self.targets(&n) {
+                *e = call(&getter_name(&n), vec![]);
+            }
+        }
+    }
+
+    /// Um alvo de atribuição DESESTRUTURANTE (`[s] = xs`, `({s} = o)`) escreve
+    /// sem passar pelo arm de `Expr::Assign` acima. Recusa em vez de deixar a
+    /// escrita cair no parâmetro.
+    fn visit_mut_assign_target(&mut self, t: &mut AssignTarget) {
+        if let AssignTarget::Pat(p) = t {
+            let mut names = HashSet::new();
+            collect_pat_names(p, &mut names);
+            if names.iter().any(|n| self.targets(n)) {
+                self.ok = false;
+                return;
+            }
+        }
+        t.visit_mut_children_with(self);
+    }
+}
+
+fn collect_pat_names(p: &swc_ecma_ast::AssignTargetPat, out: &mut HashSet<String>) {
+    use swc_ecma_ast::AssignTargetPat;
+    match p {
+        AssignTargetPat::Array(a) => {
+            for el in a.elems.iter().flatten() {
+                if let Pat::Ident(i) = el {
+                    out.insert(i.id.sym.to_string());
+                }
+            }
+        }
+        AssignTargetPat::Object(o) => {
+            for pr in &o.props {
+                if let swc_ecma_ast::ObjectPatProp::Assign(a) = pr {
+                    out.insert(a.key.sym.to_string());
+                }
+            }
+        }
+        AssignTargetPat::Invalid(_) => {}
+    }
+}

--- a/crates/rts-parser/src/lib.rs
+++ b/crates/rts-parser/src/lib.rs
@@ -5,6 +5,7 @@
 //! `FrontendMode` and the lexer module.
 
 pub mod free_scope;
+pub mod gencapref;
 pub mod generator_desugar;
 pub mod generator_sm;
 pub mod generator_sm_iter;

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -131,10 +131,23 @@ impl swc_ecma_visit::VisitMut for GenExprHoister {
                     // explícita.
                     let caps = Self::capturas(&fe.function, &self.irmas_do_bloco);
                     let escritas = crate::free_scope::free_assigned_names(&fe.function);
-                    if caps.iter().any(|c| escritas.contains(c)) {
-                        return;
-                    }
+                    // Capturadas que o generator ESCREVE viajam por REFERÊNCIA
+                    // (par getter/setter — ver `crate::gencapref`), não por
+                    // valor: o wrapper é uma fn-expressão comum, então o lifter
+                    // de closures faz da variável uma CÉLULA e as duas arrows
+                    // enxergam a mesma caixa. Sem isto a escrita ficava no
+                    // parâmetro e sumia — por isso o hoist era recusado, e a
+                    // recusa custava TODO `async` transpilado (o
+                    // `asyncToGenerator` do Babel memoiza requires preguiçosos).
+                    let por_ref: std::collections::HashSet<String> =
+                        caps.iter().filter(|c| escritas.contains(*c)).cloned().collect();
                     if !caps.is_empty() {
+                        // A reescrita pode RECUSAR (`s++`, desestruturante): aí
+                        // não se iça, e a falha continua explícita como antes.
+                        let mut corpo_ref = fe.function.clone();
+                        if !crate::gencapref::rewrite_by_ref(&mut corpo_ref, &por_ref) {
+                            return;
+                        }
                         let name = format!("__genexpr_{}", self.counter);
                         self.counter += 1;
                         let ident_de = |n: &str| swc_ecma_ast::Ident {
@@ -144,15 +157,19 @@ impl swc_ecma_visit::VisitMut for GenExprHoister {
                             optional: false,
                         };
                         let id_gen = ident_de(&name);
-                        let mut levantada = fe.function.clone();
-                        let mut ps: Vec<swc_ecma_ast::Param> = caps
-                            .iter()
-                            .map(|c| swc_ecma_ast::Param {
-                                span: Default::default(),
-                                decorators: Vec::new(),
-                                pat: swc_ecma_ast::Pat::Ident(ident_de(c).into()),
-                            })
-                            .collect();
+                        let mut levantada = corpo_ref;
+                        let mut ps: Vec<swc_ecma_ast::Param> = Vec::new();
+                        for c in &caps {
+                            if por_ref.contains(c) {
+                                ps.extend(crate::gencapref::hoisted_params(c));
+                            } else {
+                                ps.push(swc_ecma_ast::Param {
+                                    span: Default::default(),
+                                    decorators: Vec::new(),
+                                    pat: swc_ecma_ast::Pat::Ident(ident_de(c).into()),
+                                });
+                            }
+                        }
                         ps.extend(fe.function.params.clone());
                         levantada.params = ps;
                         self.hoisted.push(swc_ecma_ast::FnDecl {
@@ -160,13 +177,22 @@ impl swc_ecma_visit::VisitMut for GenExprHoister {
                             declare: false,
                             function: levantada,
                         });
-                        let mut args: Vec<swc_ecma_ast::ExprOrSpread> = caps
-                            .iter()
-                            .map(|c| swc_ecma_ast::ExprOrSpread {
-                                spread: None,
-                                expr: Box::new(Expr::Ident(ident_de(c))),
-                            })
-                            .collect();
+                        let mut args: Vec<swc_ecma_ast::ExprOrSpread> = Vec::new();
+                        for c in &caps {
+                            if por_ref.contains(c) {
+                                for a in crate::gencapref::wrapper_args(c) {
+                                    args.push(swc_ecma_ast::ExprOrSpread {
+                                        spread: None,
+                                        expr: Box::new(a),
+                                    });
+                                }
+                            } else {
+                                args.push(swc_ecma_ast::ExprOrSpread {
+                                    spread: None,
+                                    expr: Box::new(Expr::Ident(ident_de(c))),
+                                });
+                            }
+                        }
                         for pp in &fe.function.params {
                             if let swc_ecma_ast::Pat::Ident(bi) = &pp.pat {
                                 args.push(swc_ecma_ast::ExprOrSpread {

--- a/tests/cross-runtime/generators/431_generator_expr_writes_capture.ts
+++ b/tests/cross-runtime/generators/431_generator_expr_writes_capture.ts
@@ -1,0 +1,76 @@
+// Cross-runtime: um GENERATOR-EXPRESSÃO que ESCREVE uma variável capturada.
+//
+// É a forma que todo `async` transpilado produz: o `asyncToGenerator` do Babel
+// embrulha um `function*` que memoiza requires preguiçosos (`s || (s = f())`).
+//
+// O RTS leva um generator-expressão para o topo (a state-machine só existe para
+// declarações de topo) e passava as capturas como ARGUMENTOS — por valor. Uma
+// escrita ficaria no parâmetro e nunca chegaria ao escopo de origem, então o
+// motor RECUSAVA o arquivo inteiro. Agora as capturadas ESCRITAS viajam por
+// referência (par getter/setter), e o lifter de closures faz da variável uma
+// célula compartilhada.
+//
+// A fixture conta as inicializações: o modo de falha aqui é a memoização não
+// "colar", o que produz o valor certo com a inicialização rodando toda vez.
+
+function drive(it: any, send: string): string {
+  let r = it.next();
+  let out = "";
+  while (!r.done) {
+    out = out + "[y " + r.value + "]";
+    r = it.next(send);
+  }
+  return out + "[ret " + r.value + "]";
+}
+
+function fabrica() {
+  let cache: any;
+  let inits = 0;
+  const g = function* (x: number) {
+    const m =
+      cache ||
+      (cache = (function () {
+        inits = inits + 1;
+        return { nome: "M" };
+      })());
+    return yield m.nome + "/" + x;
+  };
+  return {
+    g: g,
+    inits: function (): number {
+      return inits;
+    },
+    cache: function (): any {
+      return cache;
+    },
+  };
+}
+
+const o = fabrica();
+console.log("primeira=" + drive(o.g(1), "A"));
+console.log("segunda=" + drive(o.g(2), "B"));
+console.log("inits=" + o.inits());
+console.log("escapou=" + (o.cache() !== undefined));
+
+// a escrita é visível para OUTRO consumidor do mesmo escopo.
+// Usa yield em posição de VALOR (`const _ = yield x`) porque é essa forma que
+// exige a state-machine — e é ela que o hoist por referência serve.
+function contador() {
+  let n = 0;
+  const g = function* () {
+    n = n + 1;
+    const a = yield n;
+    n = n + 10;
+    const b = yield n;
+    return a + "/" + b;
+  };
+  return {
+    g: g,
+    ler: function (): number {
+      return n;
+    },
+  };
+}
+const c = contador();
+console.log("passos=" + drive(c.g(), "s"));
+console.log("visto_de_fora=" + c.ler());


### PR DESCRIPTION
Era o MAIOR cluster restante da carga do WhatsApp Web — 4 dos 9 erros — e é a
forma que TODO `async` transpilado produz: o `asyncToGenerator` do Babel
embrulha um `function*` que memoiza requires preguiçosos (`s || (s = f())`).

O `GenExprHoister` leva um generator-expressão para o topo, porque a
state-machine só existe para declarações de topo, e as capturas viajavam como
ARGUMENTOS do wrapper — POR VALOR. Uma escrita ficaria no parâmetro e nunca
chegaria ao escopo de origem, então o hoist era RECUSADO. A recusa estava
certa (o contrário trocaria uma falha honesta por um efeito que some em
silêncio); o que faltava era um caminho para a escrita.

Sem esquema novo: as capturadas ESCRITAS passam a viajar como um PAR
getter/setter, e o resto é maquinaria que já existia.

    var s;
    const g = function* () { return (s || (s = f())).x; };
  vira
    function* __genexpr_N(__gs_s, __ss_s) { return (__gs_s() || __ss_s(f())).x; }
    const g = function () { return __genexpr_N(() => s, (v) => (s = v)); };

O wrapper é uma fn-expressão comum no escopo declarante, então ele passa pelo
lifter de closures — e as duas arrows capturam-e-escrevem `s`, o que já faz
dela uma CÉLULA compartilhada. As duas enxergam a mesma caixa; a escrita
escapa. O setter devolve o valor atribuído, porque `s = v` é uma expressão cujo
valor é `v`.

RECUSAS MANTIDAS (reescrita parcial daria valor errado calado): `s++`/`s--`
precisariam de um temporário para o valor antigo; `&&=`/`||=`/`??=`
precisariam curto-circuitar a ESCRITA, não só o valor; e a atribuição
desestruturante (`[s] = xs`) escreve por um caminho que o reescritor não cobre.
Nesses casos o hoist não acontece e a falha continua explícita, como antes. O
reescritor também não desce em escopo aninhado que REDECLARE o nome.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/generators/431_generator_expr_writes_capture.ts. Ela CONTA
as inicializações de propósito — o modo de falha é a memoização não "colar", o
que dá o valor certo com a inicialização rodando toda vez. Cobre memoização
entre duas instâncias do generator, a escrita vista de fora, e a capturada só
LIDA (que segue no caminho por valor). Idêntica em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
