### PR TITLE
fix(codegen): argumentos EXTRAS num `new` são ignorados, não recusados

### DIFF
--- a/crates/rts-codegen-new/src/front/run/registryclass.rs
+++ b/crates/rts-codegen-new/src/front/run/registryclass.rs
@@ -84,15 +84,47 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 (required_args(&c.default_args, total)..=total).contains(&argc)
             })
             .collect();
-        if candidates.is_empty() {
-            return unsupported!("`new {class}({argc} args)` — no matching constructor");
-        }
+        // ARGUMENTOS EXTRAS são ignorados em JS — chamar um construtor com mais
+        // argumentos do que ele declara é legal, e os que sobram simplesmente
+        // não são lidos. Sem isto o motor exigia aridade exata e recusava o
+        // ARQUIVO INTEIRO por um `new FormData(a, b)` / `new AbortSignal(x)`.
+        //
+        // Os extras ainda são AVALIADOS (abaixo, com os demais) — a avaliação é
+        // observável, só o valor é descartado.
+        //
+        // RESSALVA: para um builtin cujo argumento extra TEM significado na spec
+        // (`new FormData(form)` deveria popular a partir do elemento), isto
+        // ignora esse significado. O motor não implementa esse comportamento de
+        // nenhum jeito, então a escolha é entre ignorar o argumento e rejeitar o
+        // arquivo — nunca entre ignorar e acertar.
+        let (candidates, argc) = if candidates.is_empty() {
+            let widest = registry::class_ctors(class)
+                .into_iter()
+                .filter(|c| c.arg_abis.len() < argc)
+                .max_by_key(|c| c.arg_abis.len());
+            match widest {
+                Some(c) => {
+                    let n = c.arg_abis.len();
+                    (vec![c], n)
+                }
+                None => {
+                    return unsupported!("`new {class}({argc} args)` — no matching constructor");
+                }
+            }
+        } else {
+            (candidates, argc)
+        };
         // Lower the provided args ONCE (needed to disambiguate same-arity
         // overloads by proven kind, and reused for the marshal).
-        let mut vals: Vec<Val> = Vec::with_capacity(argc);
+        // TODOS os argumentos escritos são lowerados (a avaliação é observável),
+        // mas só os `argc` primeiros seguem para o marshal — os extras foram
+        // descartados pelo ajuste de aridade acima.
+        let mut vals: Vec<Val> = Vec::with_capacity(args.len());
         for a in args {
             vals.push(self.lower_expr(module, a)?);
         }
+        vals.truncate(argc);
+        let args = &args[..argc.min(args.len())];
         // Pick the overload: a single candidate wins outright; a tie is broken by
         // every provided arg's proven `JsKind` matching its param `AbiType`. None
         // matching (an `any`/Tagged arg) BAILS — no runtime-type guessing.

--- a/tests/cross-runtime/object-meta/432_ctor_extra_args_ignored.ts
+++ b/tests/cross-runtime/object-meta/432_ctor_extra_args_ignored.ts
@@ -1,0 +1,38 @@
+// Cross-runtime: argumentos EXTRAS num `new` são ignorados.
+//
+// Chamar um construtor com mais argumentos do que ele declara é legal em JS —
+// os que sobram simplesmente não são lidos. O RTS exigia aridade EXATA para as
+// classes registradas e recusava o ARQUIVO INTEIRO por um `new FormData(a, b)`
+// ou `new AbortSignal(x)` vindos de um bundle.
+//
+// Os extras continuam sendo AVALIADOS: a avaliação é observável, só o valor é
+// descartado — por isso a fixture conta os efeitos colaterais.
+
+let efeitos = 0;
+function ef(v: string): string {
+  efeitos = efeitos + 1;
+  return v;
+}
+
+// classe de usuário
+class Ponto {
+  v: unknown;
+  constructor(a: unknown) {
+    this.v = a;
+  }
+}
+const p = new (Ponto as any)(1, ef("x"), ef("y"));
+console.log("usuario=" + p.v);
+console.log("extras_avaliados=" + efeitos);
+
+// classes registradas
+const m = new (Map as any)([["k", 1]], ef("m"));
+console.log("map=" + m.get("k"));
+
+const s = new (Set as any)([1, 2], ef("s"));
+console.log("set=" + s.size);
+
+const u = new (URL as any)("https://exemplo.com/caminho", undefined, ef("u"));
+console.log("url=" + u.pathname);
+
+console.log("efeitos_total=" + efeitos);


### PR DESCRIPTION
Chamar um construtor com mais argumentos do que ele declara é legal em JS — os
que sobram simplesmente não são lidos. O motor exigia aridade EXATA para as
classes registradas e recusava o ARQUIVO INTEIRO: `new FormData(2 args)` e
`new AbortSignal(1 args)` eram 2 dos 8 erros por carga do WhatsApp Web.

Quando nenhum construtor registrado admite `argc`, escolhe o de maior aridade
abaixo dela e descarta o excedente. Os extras continuam sendo AVALIADOS — a
avaliação é observável, só o valor é descartado.

RESSALVA, e ela é real: para um builtin cujo argumento extra TEM significado na
spec (`new FormData(form)` deveria popular a partir do elemento), isto ignora
esse significado. O motor não implementa esse comportamento de nenhum jeito, e
o `FormData` daqui não lê elemento de formulário — então a escolha era entre
ignorar o argumento e rejeitar o arquivo, nunca entre ignorar e acertar.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/object-meta/432_ctor_extra_args_ignored.ts — classe de
usuário e classes registradas (Map/Set/URL), contando os efeitos colaterais para
provar que os extras são avaliados e só o valor cai. Idêntica em Node, Bun e
RTS. `FormData` ficou FORA da fixture de propósito: o Node valida o argumento
por WebIDL e lança, então ele não serve para comparar entre runtimes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
