### PR TITLE
fix(parser): desugar eager de generator não descia em `try`/`switch`/rótulo

### DIFF
--- a/crates/rts-parser/src/generator_desugar.rs
+++ b/crates/rts-parser/src/generator_desugar.rs
@@ -255,8 +255,51 @@ fn transform_stmt(stmt: Stmt) -> Vec<Stmt> {
             // visivel aos statements seguintes do mesmo bloco.
             out
         }
+        // `try`/`switch`/`L:` — o eager-buffer precisa DESCER neles como desce
+        // em `if`/`while`/`for`. Sem estes arms o statement passava INTACTO e um
+        // `yield` lá dentro sobrevivia ao desugar, chegando ao lowering como
+        // `Yield` cru ("expression raw/unrecognized"). É a forma mais comum do
+        // `asyncToGenerator` do Babel — `try { yield f() } catch (e) { … }` —
+        // então o buraco custava o arquivo inteiro num bundle real.
+        Stmt::Try(t) => {
+            let mut tt = t;
+            tt.block = transform_block(tt.block);
+            if let Some(h) = tt.handler.as_mut() {
+                h.body = transform_block(h.body.clone());
+            }
+            if let Some(f) = tt.finalizer.as_mut() {
+                *f = transform_block(f.clone());
+            }
+            vec![Stmt::Try(tt)]
+        }
+        Stmt::Switch(sw) => {
+            let mut s2 = sw;
+            for c in s2.cases.iter_mut() {
+                let mut out: Vec<Stmt> = Vec::with_capacity(c.cons.len());
+                for st in c.cons.drain(..) {
+                    out.extend(transform_stmt(st));
+                }
+                c.cons = out;
+            }
+            vec![Stmt::Switch(s2)]
+        }
+        Stmt::Labeled(l) => {
+            let mut l2 = l;
+            l2.body = Box::new(transform_stmt_single(*l2.body));
+            vec![Stmt::Labeled(l2)]
+        }
         other => vec![other],
     }
+}
+
+/// Aplica [`transform_stmt`] a cada statement de um bloco, preservando o bloco.
+fn transform_block(mut b: BlockStmt) -> BlockStmt {
+    let mut out: Vec<Stmt> = Vec::with_capacity(b.stmts.len());
+    for st in b.stmts.drain(..) {
+        out.extend(transform_stmt(st));
+    }
+    b.stmts = out;
+    b
 }
 
 /// Helper: `<kind> <name> = <init>;` com nome ident.

--- a/crates/rts-parser/src/lowering_items.rs
+++ b/crates/rts-parser/src/lowering_items.rs
@@ -141,11 +141,15 @@ impl swc_ecma_visit::VisitMut for GenExprHoister {
                     // `asyncToGenerator` do Babel memoiza requires preguiçosos).
                     let por_ref: std::collections::HashSet<String> =
                         caps.iter().filter(|c| escritas.contains(*c)).cloned().collect();
+                    if caps.is_empty() {
+                        diag_gen("yield de VALOR sem capturas — nem eager nem hoist", &por_ref);
+                    }
                     if !caps.is_empty() {
                         // A reescrita pode RECUSAR (`s++`, desestruturante): aí
                         // não se iça, e a falha continua explícita como antes.
                         let mut corpo_ref = fe.function.clone();
                         if !crate::gencapref::rewrite_by_ref(&mut corpo_ref, &por_ref) {
+                            diag_gen("reescrita por referência recusou", &por_ref);
                             return;
                         }
                         let name = format!("__genexpr_{}", self.counter);
@@ -2121,4 +2125,16 @@ fn top_level_names(p: &SwcProgram) -> std::collections::HashSet<String> {
         }
     }
     out
+}
+
+/// `RTS_DIAG_GEN=1`: por que um generator-EXPRESSÃO não foi içado. O erro que
+/// chega ao usuário é `expression raw/unrecognized: Yield`, que não nomeia nem a
+/// razão nem os nomes envolvidos — e num bundle minificado não há como
+/// distinguir uma reescrita recusada de um caso sem captura nenhuma.
+fn diag_gen(motivo: &str, nomes: &std::collections::HashSet<String>) {
+    if std::env::var("RTS_DIAG_GEN").is_ok() {
+        let mut v: Vec<&String> = nomes.iter().collect();
+        v.sort();
+        eprintln!("[diag] generator não içado: {motivo} (por_ref={v:?})");
+    }
 }

--- a/tests/cross-runtime/generators/433_generator_yield_in_try_switch.ts
+++ b/tests/cross-runtime/generators/433_generator_yield_in_try_switch.ts
@@ -1,0 +1,84 @@
+// Cross-runtime: `yield` dentro de `try`, `switch` e bloco ROTULADO num
+// generator-expressão que CAPTURA (o caminho eager-buffer).
+//
+// O desugar eager descia em `if`/`while`/`for`, mas passava `try`/`switch`/`L:`
+// INTACTOS — então um `yield` lá dentro sobrevivia e chegava ao lowering como
+// `Yield` cru ("expression raw/unrecognized"), derrubando o ARQUIVO INTEIRO.
+//
+// É a forma mais comum do `asyncToGenerator` do Babel — `try { yield f() }
+// catch (e) { … }` —, então o buraco valia vários bundles de uma página real.
+//
+// Usa `for-of` (e não `.next()`) porque o buffer eager perde o protocolo de
+// iterador ao atravessar propriedade/retorno — gap SEPARADO, registrado na
+// issue #2092, que não deve mascarar o que esta fixture testa.
+
+function coleta(it: Iterable<unknown>): string {
+  let o = "";
+  for (const v of it) o = o + "[" + v + "]";
+  return o;
+}
+
+function fabrica() {
+  let falhou = false;
+  const g = function* (x: string) {
+    if (x !== "pula") {
+      try {
+        yield "t:" + x;
+      } catch (e) {
+        falhou = true;
+      }
+    }
+    yield "fim";
+  };
+  return {
+    g: g,
+    ok: function (): boolean {
+      return !falhou;
+    },
+  };
+}
+
+const m = fabrica();
+console.log("try_com=" + coleta(m.g("a")));
+console.log("try_sem=" + coleta(m.g("pula")));
+console.log("captura_intacta=" + m.ok());
+
+// switch + bloco rotulado
+function outra() {
+  let marca = "";
+  const h = function* (n: number) {
+    switch (n) {
+      case 1:
+        yield "um";
+        break;
+      default:
+        yield "outro";
+    }
+    L: {
+      marca = "visitou";
+      yield "rot";
+    }
+  };
+  return { h: h, marca: function (): string { return marca; } };
+}
+const o = outra();
+console.log("switch_1=" + coleta(o.h(1)));
+console.log("switch_d=" + coleta(o.h(9)));
+console.log("rotulo_efeito=" + o.marca());
+
+// try/finally também
+function comFinally() {
+  let passos = "";
+  const g = function* () {
+    try {
+      yield "corpo";
+    } finally {
+      passos = passos + "F";
+    }
+    yield "depois";
+  };
+  return { g: g, passos: function (): string { return passos; } };
+}
+const f = comFinally();
+console.log("finally=" + coleta(f.g()));
+console.log("finally_rodou=" + f.passos());


### PR DESCRIPTION
Um generator-expressão que CAPTURA e usa `yield` só em posição de STATEMENT vai
para o eager-buffer. Esse desugar descia em `if`/`while`/`for`, mas passava
`try`, `switch` e `L:` INTACTOS — então um `yield` lá dentro sobrevivia e
chegava ao lowering como `Yield` cru ("expression raw/unrecognized"),
derrubando o ARQUIVO INTEIRO.

É a forma mais comum do `asyncToGenerator` do Babel — `try { yield f() } catch
(e) { … }` — e por isso valia vários bundles de uma página real: era o cluster
de 3 generators restante na carga do WhatsApp Web.

COMO FOI ACHADO, porque o caminho importou: a mensagem só diz "Yield cru", sem
razão nem nomes, então adicionei `RTS_DIAG_GEN=1` (por que um
generator-expressão não foi içado). O diagnóstico ficou MUDO — e foi isso que
apontou o certo: o generator nunca chegou aos pontos de recusa do hoist, logo
tinha ido para o eager. Ler o fonte no span confirmou o `yield` dentro do
`try`. Uma hipótese anterior (a interação com a reescrita por referência do
#2091) foi testada com repro e PASSOU, então caiu.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime
tests/cross-runtime/generators/433_generator_yield_in_try_switch.ts — `yield` em
try/catch (com e sem entrar no ramo), em `switch` com `break` e `default`, em
bloco rotulado, e em `try/finally` conferindo que o finally roda. Usa `for-of` e
NÃO `.next()` de propósito: o buffer eager perde o protocolo de iterador ao
atravessar propriedade/retorno (gap separado, issue #2092), e deixá-lo no
caminho mascararia o que a fixture testa. Idêntica em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
