### PR TITLE
fix(codegen,browser): closure capturando gcell/classe + página no cache (medição determinística)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -1376,6 +1376,30 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                 emit_marshal::emit_vec_push(module, self.builder, arr, word);
                 continue;
             }
+            // Um MODULE-GLOBAL promovido a CÉLULA (#195) não é um local desta
+            // função — o valor vive na cell. Ler a cell aqui dá o valor CORRENTE,
+            // que é o mesmo que qualquer outra leitura do nome produz.
+            //
+            // Sem isto, uma closure que capturasse um global mutável derrubava o
+            // arquivo inteiro ("not a simple local in scope"), embora o lifter
+            // tivesse aceitado a captura — o nome existe, só não mora aqui.
+            if self.local(cap).is_none() {
+                if let Some(id) = self.gcell_id(cap) {
+                    let v = self.emit_gcell_get(module, id)?;
+                    let word = self.box_value(v);
+                    emit_marshal::emit_vec_push(module, self.builder, arr, word);
+                    continue;
+                }
+                // Uma CLASSE capturada por nome (`const f = () => new C()` onde a
+                // arrow foi levantada): reifica o valor-de-classe, como a leitura
+                // do nome em posição de valor já faz.
+                if self.classes.get(cap).is_some() {
+                    let v = self.reify_class(module, cap)?;
+                    let word = self.box_value(v);
+                    emit_marshal::emit_vec_push(module, self.builder, arr, word);
+                    continue;
+                }
+            }
             let local = self.local(cap).ok_or_else(|| {
                 Unsupported::new(format!(
                     "closure captures `{cap}` which is not a simple local in scope"

--- a/examples/claude-browser.ts
+++ b/examples/claude-browser.ts
@@ -410,9 +410,21 @@ while (egui.isOpen(win) !== 0) {
     const st = fetchNs.fetchPoll(pendingTicket);
     if (frame % 30 === 0) io.print("[poll] ticket=" + pendingTicket + " st=" + st);
     if (st === 1) {
-      const raw = fetchNs.fetchTake(pendingTicket);
+      const baixado = fetchNs.fetchTake(pendingTicket);
       pendingTicket = 0;
-      io.print("[nav] baixou " + raw.length + "B de " + pendingUrl);
+      // A PÁGINA também entra no cache, e o ACERTO TEM PRECEDÊNCIA — igual aos
+      // demais recursos. Sem isto a medição não fecha: a Meta serve HTML
+      // diferente a cada requisição, e duas execuções seguidas davam contagens
+      // de erro diferentes (7 e 5) sem nada ter mudado no motor.
+      // `RTS_NO_CACHE=1` busca sempre da rede.
+      const emCache = cacheGet(normalize(pendingUrl));
+      let raw = emCache;
+      if (raw.length < 1) {
+        raw = baixado;
+        cachePut(normalize(pendingUrl), raw);
+      }
+      io.print("[nav] " + raw.length + "B de " + pendingUrl
+        + (emCache.length > 0 ? " (cache)" : ""));
       const html = raw.length === 0
         ? page(pendingUrl, "<h1 style='color:#f97316'>Falhou</h1><p style='color:#a4afc4'>Nao consegui baixar.</p>")
         : page(pendingUrl, extractSite(raw, normalize(pendingUrl)));


### PR DESCRIPTION
1. CODEGEN — `build_closure_env` só sabia materializar uma captura que fosse
   LOCAL desta função ou função de topo. Faltavam duas moradas legítimas:

   - um MODULE-GLOBAL promovido a CÉLULA (#195): o valor vive na cell, e lê-la
     ali dá o valor corrente — o mesmo que qualquer outra leitura do nome;
   - uma CLASSE capturada por nome (`const f = () => new C()` com a arrow
     levantada): reifica o valor-de-classe, como a leitura em posição de valor
     já faz.

   O lifter tinha ACEITADO a captura nos dois casos; só a materialização
   faltava. O nome existe, apenas não mora onde se olhava — e o arquivo inteiro
   caía com "closure captures `X` which is not a simple local in scope".

2. BROWSER — a PÁGINA passa a entrar no cache, com o acerto tendo precedência,
   igual aos demais recursos.

   MOTIVO, e ele corrige um erro meu de medição: a Meta serve HTML diferente a
   cada requisição, então duas execuções seguidas davam 7 e 5 erros sem nada ter
   mudado no motor. Eu havia reportado o cluster de generators caindo de 3 para
   1 com base nisso — a comparação NÃO era válida, porque as duas medições eram
   de páginas diferentes. Com a página fixada, o baseline estável é 7, e os 3
   generators seguem lá. Uma métrica que muda sozinha é pior que métrica
   nenhuma, porque dá crédito por trabalho que não aconteceu.

   `RTS_NO_CACHE=1` continua buscando tudo da rede.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Medido no alvo real: os 2 `closure captures` saem da lista.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
