### PR TITLE
fix(parser): `++`/`--` sobre capturada de generator agora é traduzido, não recusado

### DIFF
--- a/crates/rts-parser/src/gencapref.rs
+++ b/crates/rts-parser/src/gencapref.rs
@@ -141,8 +141,12 @@ pub fn rewrite_by_ref(f: &mut Function, names: &HashSet<String>) -> bool {
         names,
         shadowed: Vec::new(),
         ok: true,
+        motivo: String::new(),
     };
     f.visit_mut_with(&mut v);
+    if !v.ok && std::env::var("RTS_DIAG_GEN").is_ok() {
+        eprintln!("[diag] reescrita por referência recusou: {}", v.motivo);
+    }
     v.ok
 }
 
@@ -152,6 +156,8 @@ struct Rewriter<'a> {
     /// outra variável e não pode ser reescrito.
     shadowed: Vec<HashSet<String>>,
     ok: bool,
+    /// Por que recusou — só para `RTS_DIAG_GEN`.
+    pub motivo: String,
 }
 
 impl Rewriter<'_> {
@@ -217,6 +223,7 @@ impl VisitMut for Rewriter<'_> {
                         // sempre. Recusa.
                         None => {
                             self.ok = false;
+                            self.motivo = format!("atribuição lógica `{name} {op:?}=`");
                             return;
                         }
                     },
@@ -225,11 +232,59 @@ impl VisitMut for Rewriter<'_> {
                 return;
             }
         }
-        // `s++` / `s--`: precisaria de um temporário para o valor antigo.
+        // `s++` / `--s` sobre uma capturada. O valor da EXPRESSÃO difere entre
+        // as duas formas, e é isso que decide a tradução:
+        //
+        //   ++s   →  __ss_s(__gs_s() + 1)          (vale o NOVO)
+        //   s++   →  (__ss_s(__gs_s() + 1), __gs_s() - 1)
+        //
+        // A forma pós-fixa devolve o valor ANTIGO. Em vez de sintetizar um
+        // temporário (o que exigiria um statement, e aqui só há expressão), ela
+        // é reconstruída a partir do novo: `novo - 1` para `++`, `novo + 1` para
+        // `--`. É exato para número, que é o que `++` exige — o operando passa
+        // por ToNumber, então qualquer outro tipo já virou número aqui.
         if let Expr::Update(u) = e {
             if let Expr::Ident(i) = &*u.arg {
-                if self.targets(&i.sym.to_string()) {
-                    self.ok = false;
+                let name = i.sym.to_string();
+                if self.targets(&name) {
+                    let mais = u.op == swc_ecma_ast::UpdateOp::PlusPlus;
+                    let delta = |v: f64| {
+                        Expr::Lit(swc_ecma_ast::Lit::Num(swc_ecma_ast::Number {
+                            span: Default::default(),
+                            value: v,
+                            raw: None,
+                        }))
+                    };
+                    let bin = |op, l: Expr, r: Expr| {
+                        Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: Default::default(),
+                            op,
+                            left: Box::new(l),
+                            right: Box::new(r),
+                        })
+                    };
+                    use swc_ecma_ast::BinaryOp;
+                    let op_novo = if mais { BinaryOp::Add } else { BinaryOp::Sub };
+                    let novo = call(
+                        &setter_name(&name),
+                        vec![bin(op_novo, call(&getter_name(&name), vec![]), delta(1.0))],
+                    );
+                    *e = if u.prefix {
+                        novo
+                    } else {
+                        // `(set(...), get() ∓ 1)` — a vírgula garante a ORDEM:
+                        // escreve primeiro, depois lê o valor já atualizado e o
+                        // desfaz para reconstruir o antigo.
+                        let antigo = bin(
+                            if mais { BinaryOp::Sub } else { BinaryOp::Add },
+                            call(&getter_name(&name), vec![]),
+                            delta(1.0),
+                        );
+                        Expr::Seq(swc_ecma_ast::SeqExpr {
+                            span: Default::default(),
+                            exprs: vec![Box::new(novo), Box::new(antigo)],
+                        })
+                    };
                     return;
                 }
             }
@@ -252,8 +307,9 @@ impl VisitMut for Rewriter<'_> {
         if let AssignTarget::Pat(p) = t {
             let mut names = HashSet::new();
             collect_pat_names(p, &mut names);
-            if names.iter().any(|n| self.targets(n)) {
+            if let Some(n) = names.iter().find(|n| self.targets(n)) {
                 self.ok = false;
+                self.motivo = format!("alvo desestruturante com `{n}`");
                 return;
             }
         }

--- a/tests/cross-runtime/generators/434_generator_incdec_capture.ts
+++ b/tests/cross-runtime/generators/434_generator_incdec_capture.ts
@@ -1,0 +1,68 @@
+// Cross-runtime: `++`/`--` sobre uma variável CAPTURADA por um
+// generator-expressão.
+//
+// O #2091 passou a levar as capturas ESCRITAS por referência (par
+// getter/setter), mas deixava `x++` recusado — e era exatamente ele que os três
+// generators restantes da carga do WhatsApp Web usavam (o diagnóstico
+// `RTS_DIAG_GEN=1` nomeou a forma: "recusou: `l++`").
+//
+// O valor da EXPRESSÃO difere entre as duas formas, e é isso que decide a
+// tradução: `++s` vale o NOVO, `s++` vale o ANTIGO. O pós-fixo é reconstruído a
+// partir do novo (`novo - 1`), o que é exato porque `++` já força ToNumber.
+
+function drive(it: any, envia: string): string {
+  let r = it.next();
+  let o = "";
+  while (!r.done) {
+    o = o + "[y " + r.value + "]";
+    r = it.next(envia);
+  }
+  return o + "[ret " + r.value + "]";
+}
+
+function fabrica() {
+  let n = 0;
+  let m = 10;
+  const g = function* () {
+    const a = yield "pos:" + n++;
+    const b = yield "pre:" + ++n;
+    const c = yield "dec_pos:" + m--;
+    const d = yield "dec_pre:" + --m;
+    return a + "/" + b + "/" + c + "/" + d;
+  };
+  return {
+    g: g,
+    n: function (): number { return n; },
+    m: function (): number { return m; },
+  };
+}
+
+const o = fabrica();
+console.log("passos=" + drive(o.g(), "S"));
+console.log("n_escapou=" + o.n());
+console.log("m_escapou=" + o.m());
+
+// duas instâncias do MESMO generator compartilham a variável capturada
+const p = fabrica();
+drive(p.g(), "A");
+drive(p.g(), "B");
+console.log("acumulou=" + p.n());
+
+// `++` sobre capturada dentro de try (a forma do bundle real)
+function comTry() {
+  let tentativas = 0;
+  const g = function* (x: string) {
+    try {
+      tentativas++;
+      const r = yield "t:" + x;
+      return r;
+    } catch (e) {
+      return "erro";
+    }
+  };
+  return { g: g, tentativas: function (): number { return tentativas; } };
+}
+const t = comTry();
+drive(t.g("a"), "X");
+drive(t.g("b"), "Y");
+console.log("tentativas=" + t.tentativas());


### PR DESCRIPTION
O #2091 passou a levar as capturas ESCRITAS de um generator-expressão por
REFERÊNCIA (par getter/setter), mas deixava `x++` fora — e era exatamente essa
a forma que os três generators restantes da carga do WhatsApp Web usavam.

COMO SE SOUBE: a mensagem que chega é "Yield cru", que não nomeia nada. O
`RTS_DIAG_GEN=1` (do #2094) foi estendido para dizer QUAL forma a reescrita
recusou, e respondeu "recusou: `l++`" nos três — sem isso, a única alternativa
era adivinhar entre quatro formas recusadas.

O valor da EXPRESSÃO difere entre as duas formas, e é isso que decide a
tradução:

    ++s   →  __ss_s(__gs_s() + 1)                    (vale o NOVO)
    s++   →  (__ss_s(__gs_s() + 1), __gs_s() - 1)    (vale o ANTIGO)

O pós-fixo é reconstruído a partir do novo em vez de sintetizar um temporário
(aqui só existe posição de expressão, não de statement). É exato porque `++` já
força ToNumber no operando — qualquer outro tipo já virou número nesse ponto. A
vírgula garante a ordem: escreve, depois lê o valor atualizado e o desfaz.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

ESTADO HONESTO DO ALVO: os 3 generators AVANÇARAM (mudaram de sítio) mas ainda
falham, agora por outra razão — o diagnóstico de recusa ficou MUDO, então não é
mais a reescrita por referência; a próxima camada é a elegibilidade da
state-machine, que é peça separada. Não estou creditando esta mudança por
fechá-los.

Teste: fixture cross-runtime
tests/cross-runtime/generators/434_generator_incdec_capture.ts — pós e pré-fixo
de `++` e `--`, o valor de cada forma, a escrita escapando para o escopo de
origem, duas instâncias do mesmo generator acumulando na MESMA variável, e
`++` dentro de `try` (a forma do bundle real). Idêntica em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
