### PR TITLE
fix(codegen): método ausente na superfície Number vai ao despacho dinâmico, não ao bail

### DIFF
--- a/crates/rts-codegen-new/src/front/run/method.rs
+++ b/crates/rts-codegen-new/src/front/run/method.rs
@@ -427,9 +427,27 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             // .finally` num number genuíno, então rotear pro dispatch DINÂMICO
             // de Promise é sound (o trampolim `promise_handle(recv)` valida o
             // handle; um number genuíno vira `undefined`, nunca valor errado).
-            if matches!(class, RecvClass::Number) && matches!(method, "then" | "catch" | "finally")
-            {
+            // GENERALIZADO: qualquer método ausente na superfície Number vai ao
+            // despacho DINÂMICO, não só `then`/`catch`/`finally`.
+            //
+            // O motivo é o mesmo, e vale para todo handle: um HANDLE de runtime
+            // (Promise pendente, nó de DOM, socket…) viaja pela superfície
+            // NUMBER, então `el.getAttribute("x")` chegava aqui como
+            // `Number.getAttribute` e derrubava o ARQUIVO INTEIRO.
+            //
+            // É sound porque `resolve_method` já respondeu que Number NÃO tem
+            // esse método: não há membro sendo sombreado. Um number GENUÍNO com
+            // um método inexistente é TypeError em JS, e é isso que o despacho
+            // dinâmico produz — nunca um valor errado.
+            if matches!(class, RecvClass::Number) {
                 if let Some(val) = self.try_method_dispatch_dynamic(module, recv, method, args)? {
+                    return Ok(Some(val));
+                }
+                // O recurso final: lê o método do receiver (slot próprio ou
+                // cadeia de protótipo) e o invoca. É o mesmo caminho que um
+                // receiver `any` já usa; um miss em runtime é TypeError, que é
+                // a resposta do JS.
+                if let Some(val) = self.try_generic_dyn_method_call(module, recv, method, args)? {
                     return Ok(Some(val));
                 }
             }

--- a/tests/cross-runtime/numeric/435_number_missing_method.ts
+++ b/tests/cross-runtime/numeric/435_number_missing_method.ts
@@ -1,0 +1,36 @@
+// Cross-runtime: um método que NÃO existe na superfície de Number.
+//
+// Chamar `x.naoExiste()` num number é TypeError em RUNTIME, no ponto da
+// chamada — não erro de compilação. O RTS recusava o ARQUIVO INTEIRO
+// ("no Registry entry for `Number.<m>`").
+//
+// O caso real não é nem um number: todo HANDLE de runtime (Promise pendente,
+// nó de DOM, socket) viaja pela superfície NUMBER, então
+// `elemento.getAttribute("x")` chegava como `Number.getAttribute` e derrubava o
+// bundle. Agora um método ausente em Number cai no despacho dinâmico — que lê o
+// método do próprio receiver —, e só um miss de verdade vira TypeError.
+
+let tipo = "NAO-LANCOU";
+try {
+  (5 as any).metodoInexistente();
+} catch (e) {
+  tipo = (e as Error).constructor.name;
+}
+console.log("ausente=" + tipo);
+
+let tipoComArgs = "NAO-LANCOU";
+try {
+  (7 as any).outroInexistente(1, 2);
+} catch (e) {
+  tipoComArgs = (e as Error).constructor.name;
+}
+console.log("ausente_com_args=" + tipoComArgs);
+
+// a superfície REAL de Number não pode ter regredido
+console.log("toFixed=" + (3.14159).toFixed(2));
+console.log("toString_16=" + (255).toString(16));
+console.log("toString_2=" + (5).toString(2));
+console.log("valueOf=" + (42).valueOf());
+console.log("toPrecision=" + (123.456).toPrecision(4));
+console.log("toExponential=" + (1234).toExponential(2));
+console.log("toLocaleString_existe=" + (typeof (1).toLocaleString === "function"));


### PR DESCRIPTION
Chamar um método inexistente num number é TypeError em RUNTIME, no ponto da
chamada — nunca erro de compilação. O motor recusava o ARQUIVO INTEIRO com
"no Registry entry for `Number.<m>`".

E o caso real não é sequer um number: todo HANDLE de runtime (Promise pendente,
nó de DOM, socket) viaja pela superfície NUMBER — o próprio código já
documentava isso num caso especial para `then`/`catch`/`finally`. Então
`elemento.getAttribute("x")` chegava como `Number.getAttribute` e derrubava um
bundle inteiro da carga do WhatsApp Web.

A correção generaliza aquele caso especial em vez de acrescentar outro: QUALQUER
método ausente em Number cai no despacho dinâmico e, se ele também declinar, no
genérico por cadeia de protótipo — o mesmo caminho que um receiver `any` já
usa. Um miss de verdade vira TypeError, que é a resposta do JS.

É sound porque `resolve_method` já respondeu que Number NÃO tem esse método:
não há membro sendo sombreado, e um number genuíno com método inexistente
produz o TypeError correto (verificado contra Node e Bun) em vez de um valor.

Suíte completa: 3245/3246. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Teste: fixture cross-runtime tests/cross-runtime/numeric/435_number_missing_method.ts
— método ausente com e sem argumentos (TypeError nos dois) mais a superfície
REAL de Number inteira (toFixed/toString com raiz/valueOf/toPrecision/
toExponential/toLocaleString), para provar que nada dela foi desviado para o
caminho dinâmico. Idêntica em Node, Bun e RTS.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
