### PR TITLE
fix(codegen): `++`/`--` e captura de closure sobre nome LIVRE

### DIFF
--- a/crates/rts-codegen-new/src/front/run/call.rs
+++ b/crates/rts-codegen-new/src/front/run/call.rs
@@ -1400,11 +1400,25 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
                     continue;
                 }
             }
-            let local = self.local(cap).ok_or_else(|| {
-                Unsupported::new(format!(
-                    "closure captures `{cap}` which is not a simple local in scope"
-                ))
-            })?;
+            // Última morada: o nome é um GLOBAL (inclusive um global implícito,
+            // criado por atribuição a nome livre). Lê pelo mesmo trampolim da
+            // cadeia de escopo — o valor corrente, e ReferenceError em runtime
+            // se não existir mesmo, que é a resposta do JS. Recusar aqui
+            // derrubava o arquivo inteiro por um nome que EXISTE, só não é
+            // local desta função.
+            let local = match self.local(cap) {
+                Some(l) => l,
+                None => {
+                    let name_w = self.emit_str_const_word(module, cap)?;
+                    let sym = rts_runtime::adapters::value::globalthis::GLOBAL_REF_ABI.name;
+                    let w = self
+                        .call_runtime(module, sym, &[name_w])?
+                        .expect("__rtsadp_global_ref returns a word");
+                    self.emit_post_call_error_check(module)?;
+                    emit_marshal::emit_vec_push(module, self.builder, arr, w);
+                    continue;
+                }
+            };
             let v = self.builder.use_var(local.var);
             let word = self.box_value(Val::new(v, local.repr));
             emit_marshal::emit_vec_push(module, self.builder, arr, word);

--- a/crates/rts-codegen-new/src/front/run/stmt_assign.rs
+++ b/crates/rts-codegen-new/src/front/run/stmt_assign.rs
@@ -300,6 +300,32 @@ impl<'a, 'b, 'c> Lowerer<'a, 'b, 'c> {
             let produced = if prefix { new_num } else { old_num };
             return Ok(Val::new(produced, Repr::Tagged));
         }
+        // Nome livre: `x++` lê e escreve o OBJETO GLOBAL, compondo os dois
+        // trampolins que a cadeia de escopo já usa (`global_ref` na leitura,
+        // `global_set` na escrita) — a mesma forma do caminho de célula logo
+        // acima. Recusar derrubava o arquivo inteiro; um nome ausente de
+        // verdade lança ReferenceError na LEITURA, que é a resposta do JS.
+        if self.local(&name).is_none() {
+            let name_w = self.emit_str_const_word(module, &name)?;
+            let get = rts_runtime::adapters::value::globalthis::GLOBAL_REF_ABI.name;
+            let set = rts_runtime::adapters::value::globalthis::GLOBAL_SET_ABI.name;
+            let cur = self
+                .call_runtime(module, get, &[name_w])?
+                .expect("__rtsadp_global_ref returns a word");
+            self.emit_post_call_error_check(module)?;
+            let old_num = self
+                .call_runtime(module, "__rtsadp_pos", &[cur])?
+                .expect("__rtsadp_pos returns a value");
+            let one_f64 = self.builder.ins().f64const(1.0);
+            let one_word = self.box_value(Val::new(one_f64, Repr::Float64));
+            let op = if inc { "__rtsadp_add" } else { "__rtsadp_sub" };
+            let new_num = self
+                .call_runtime(module, op, &[old_num, one_word])?
+                .expect("generic arithmetic returns a value");
+            self.call_runtime(module, set, &[name_w, new_num])?;
+            let produced = if prefix { new_num } else { old_num };
+            return Ok(Val::new(produced, Repr::Tagged));
+        }
         let local = self
             .local(&name)
             .ok_or_else(|| Unsupported::new(format!("`++`/`--` on unbound `{name}`")))?;

--- a/tests/claude-free-name-incdec-capture.test.ts
+++ b/tests/claude-free-name-incdec-capture.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "rts:test";
+
+// Fecha o par da CADEIA DE ESCOPO, junto com #2078 (leitura) e #2098 (escrita):
+//
+// 1. `x++` / `--x` sobre um nome LIVRE compõe os dois trampolins — lê pelo
+//    `global_ref`, escreve pelo `global_set` —, exatamente como o caminho de
+//    célula já fazia. Antes recusava o ARQUIVO INTEIRO.
+//
+// 2. Uma CLOSURE que CAPTURA um nome livre materializa a captura pelo mesmo
+//    `global_ref`. O `build_closure_env` só sabia ler local, função de topo,
+//    gcell e classe (#2095); um GLOBAL — inclusive um global implícito — não
+//    tinha morada e o arquivo caía, embora o nome EXISTA.
+//
+// NÃO É FIXTURE CROSS-RUNTIME pelo mesmo motivo do #2098: Node e Bun discordam
+// sobre o MODO de um `.ts` (script sloppy vs módulo strict), então uma fixture
+// documentaria a escolha de módulo do runtime, não o motor. Valores conferidos
+// contra o Node.
+
+declare var cnt: any;
+declare var dec: any;
+declare var visto: any;
+
+// ── `++`/`--` sobre nome livre ──────────────────────────────────────────────
+cnt = 0;
+function posfixo(): any { return cnt++; }
+const p1 = posfixo();
+const p2 = posfixo();
+const depoisPos = cnt;
+
+function prefixo(): any { return ++cnt; }
+const pre = prefixo();
+
+dec = 5;
+const decPos = dec--;
+const depoisDec = dec;
+
+// ── closure capturando nome livre ───────────────────────────────────────────
+visto = "G";
+const leCaptura = () => visto + "!";
+const cap1 = leCaptura();
+visto = "H";
+const cap2 = leCaptura();
+const viaMap = [1].map(() => visto)[0];
+
+describe("nome livre: ++/-- e captura por closure", () => {
+  test("pós-fixo devolve o antigo e escreve o global", () => {
+    expect(p1).toBe(0);
+    expect(p2).toBe(1);
+    expect(depoisPos).toBe(2);
+  });
+  test("pré-fixo devolve o novo", () => {
+    expect(pre).toBe(3);
+  });
+  test("decremento pós-fixo", () => {
+    expect(decPos).toBe(5);
+    expect(depoisDec).toBe(4);
+  });
+  test("closure lê o valor CORRENTE do global, não um instantâneo", () => {
+    expect(cap1).toBe("G!");
+    expect(cap2).toBe("H!");
+  });
+  test("captura de nome livre dentro de callback", () => {
+    expect(viaMap).toBe("H");
+  });
+});


### PR DESCRIPTION
Fecha o par da cadeia de escopo, junto com o #2078 (leitura) e o #2098
(escrita) — as duas formas que ainda recusavam o ARQUIVO INTEIRO por um nome
que EXISTE, só não é local da função.

1. `x++` / `--x` sobre nome livre compõe os dois trampolins que já existem: lê
   pelo `global_ref`, escreve pelo `global_set`. É a mesma forma do caminho de
   CÉLULA logo acima, com a cell trocada pelo objeto global — nenhum mecanismo
   novo. Um nome ausente de verdade lança ReferenceError na LEITURA, que é a
   resposta do JS.

2. `build_closure_env` sabia materializar uma captura que fosse local, função de
   topo, gcell ou classe (#2095); faltava a última morada — um GLOBAL, inclusive
   um global implícito criado por atribuição a nome livre. Lê pelo mesmo
   `global_ref`, então a closure vê o valor CORRENTE, não um instantâneo do
   momento da reificação.

Suíte completa: 3250/3251. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

NÃO HÁ FIXTURE CROSS-RUNTIME, pelo mesmo motivo do #2098: Node e Bun discordam
sobre o MODO de um arquivo `.ts` (script sloppy vs módulo strict), e ambos os
casos aqui dependem de global implícito. Uma fixture documentaria a escolha de
módulo do runtime, não o motor.

Teste: tests/claude-free-name-incdec-capture.test.ts — pós e pré-fixo (com o
valor de cada forma), decremento, e a closure lendo o valor corrente do global
depois de ele mudar, inclusive dentro de callback. Valores conferidos contra o
Node.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
