### PR TITLE
fix(codegen): AOT volta a linkar — thunks completos no caminho compilado (CI vermelho)

### DIFF
--- a/crates/rts-codegen-new/src/front/run/thunk.rs
+++ b/crates/rts-codegen-new/src/front/run/thunk.rs
@@ -141,7 +141,23 @@ pub fn is_used(id: FuncId) -> bool {
     USED.with(|u| u.borrow().contains(&id))
 }
 
+/// Whether EVERY function gets a thunk, skipping the address-taken analysis.
+///
+/// Forced ON for AOT. The analysis marks a thunk used when the LOWERING reifies
+/// the function, but an AOT object also carries relocations emitted OUTSIDE that
+/// path — the prelude's class new-thunks and statics among them — and a missed
+/// mark there is not a slower start, it is `undefined symbol` at link time
+/// (measured: `rts compile` of any program touching the Error/Map/Reflect
+/// prelude failed on the Windows CI runner).
+///
+/// The perf this analysis buys is JIT STARTUP: half of what gets
+/// machine-compiled was a bridge. That does not apply to AOT, which compiles
+/// once and lets the linker drop what it does not need. So the trade is only
+/// worth making where it pays.
 fn all_thunks() -> bool {
+    if super::aot_str::aot_mode() {
+        return true;
+    }
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| {
         std::env::var("RTS_ALL_THUNKS")


### PR DESCRIPTION
O job `Build Artifacts` (windows-latest) falhava no smoke test de `rts compile`
desde 2026-08-02T00:02, com `undefined symbol` em ~12 thunks do prelude
(`__rtsn_ctor_Error__rtsn_thunk`, `__rtsn_static_Map_groupBy__rtsn_thunk`,
`__rtsn_static_Reflect_get__rtsn_thunk`, …). Reproduz local com qualquer
programa que toque o prelude: `rts compile -p x.ts out`.

CAUSA: a análise de "endereço tomado" (que passou a emitir thunk só para quem é
reificado) vale para os dois caminhos, mas ela marca a partir do LOWERING — e um
objeto AOT carrega relocações emitidas FORA desse caminho, entre elas os
new-thunks de classe e os estáticos do prelude. Uma marca perdida ali não é
início mais lento: é falha de LINK.

O ganho da análise é o STARTUP do JIT (metade do que era compilado a máquina era
ponte). Isso não se aplica ao AOT, que compila uma vez e deixa o linker
descartar o que não usa — então o corte passa a valer só onde ele paga.
`RTS_ALL_THUNKS=1` segue funcionando como antes para o JIT.

Verificado: `rts compile` de `class E2 extends Error {}` produz `.exe` que RODA,
com a mesma saída do `rts run` do mesmo fonte.

Suíte completa: 3255/3256. A única falha (`window é o MESMO objeto entre
scripts`) é PRÉ-EXISTENTE, verificada na main limpa nesta sessão.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BFbMpS5wmVDxAB6SL8VzF2
