### PR TITLE
feat: rts:egui e rts:input no motor novo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ not background reading, and the rules in it are binding for changes inside it.
 | `crates/rts-codegen/` | its `README.md` (10 rules) + `PLAN.md` |
 | `crates/rts-core-rwk/` | its `README.md` (8 rules) + `PLAN.md` |
 | `crates/rts-host-rwk/` | its `README.md` (6 rules) + `PLAN.md` |
-| `crates/rts-egui/`, DOM, render, input | `docs/ui/html-engine/` + `docs/ui/egui-crate.md` |
+| `crates/rts-egui/`, DOM, render, input | `docs/ui/html-engine/` + `docs/ui/egui-crate.md`; for the NEW engine's side of it, `docs/ui/new-engine-port.md` |
 | anything else | this file, and `docs/README.md` for where things live |
 
 If a change requires breaking a rule, **change the rule first, with the reason,
@@ -225,6 +225,8 @@ crates/
   rts-core-rwk/      the runtime: values, heap, objects, coercion, entry points
   rts-host-rwk/      where the three meet, and where a program runs
   rts-macro-rwk/     #[rtse::entry] — declares one, derives its shape
+  rts-std-rwk/       the `rts:` surface, and the globals
+  rts-ui-rwk/        `rts:egui` + `rts:input`, where a target has a screen
   rts-codegen-new/   the engine that currently runs `rts`. Being replaced.
 
   rts-abi/           the ABI contract, dependency-free, at the bottom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5008,6 +5008,7 @@ dependencies = [
  "rts-cranelift",
  "rts-node-rwk",
  "rts-std-rwk",
+ "rts-ui-rwk",
 ]
 
 [[package]]
@@ -5260,6 +5261,15 @@ dependencies = [
  "quote",
  "rts-abi",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rts-ui-rwk"
+version = "0.1.0"
+dependencies = [
+ "rts-core-rwk",
+ "rts-egui",
+ "rts-input",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/rts-cranelift",
     "crates/rts-codegen",
     "crates/rts-core-rwk",
+    "crates/rts-ui-rwk",
     "crates/rts-std-rwk",
     "crates/rts-node-rwk",
     "crates/rts-host-rwk",

--- a/crates/rts-dom/Cargo.toml
+++ b/crates/rts-dom/Cargo.toml
@@ -17,5 +17,12 @@ license.workspace = true
 # wasm-safe (sem I/O, sem threads de plataforma).
 
 [dependencies]
-rts-engine = { path = "../rts-engine" }
-rtse = { package = "rts-macro", path = "../rts-macro" }
+rts-engine = { path = "../rts-engine", optional = true }
+rtse = { package = "rts-macro", path = "../rts-macro", optional = true }
+
+# Ver a nota igual em rts-render/rts-input: a ABI do motor ANTIGO é uma feature.
+# Sem ela sobram a árvore, o parser, o estilo e o LAYOUT — que é a maior parte
+# deste crate e não conhece motor nenhum.
+[features]
+default = ["old-engine"]
+old-engine = ["dep:rts-engine", "dep:rtse"]

--- a/crates/rts-dom/src/lib.rs
+++ b/crates/rts-dom/src/lib.rs
@@ -19,9 +19,13 @@
 //! `u64` (extern "C") através de [`register`]; a camada ergonômica
 //! (`Document`/`Element`) é TS. Depende só de `rts-engine`.
 
+#[cfg(feature = "old-engine")]
 pub mod scriptscan;
+#[cfg(feature = "old-engine")]
 pub mod scriptscope;
+#[cfg(feature = "old-engine")]
 pub mod timerscope;
+#[cfg(feature = "old-engine")]
 pub mod abi;
 mod dom;
 mod html;
@@ -56,6 +60,7 @@ pub mod scrollbar;
 
 pub use dom::{parse_html_to_dom, Attr, Dom, Node, NodeId, NodeIdx, NodeKind};
 
+#[cfg(feature = "old-engine")]
 pub use abi::register;
 
 /// Prelude `.ts` da FACHADA DOM ergonômica (`document` global + `Element`, com a

--- a/crates/rts-egui/Cargo.toml
+++ b/crates/rts-egui/Cargo.toml
@@ -13,17 +13,17 @@ license.workspace = true
 # do TS; o handle u64 é só uma chave opaca.
 
 [dependencies]
-rts-engine = { path = "../rts-engine" }
+rts-engine = { path = "../rts-engine", optional = true }
 # DOM retido: o egui CONSOME o tipo `Dom` do crate `rts-dom` (parser + árvore +
 # NodeId) e só adiciona o RENDER. O DOM não vive mais aqui.
-rts-dom = { path = "../rts-dom" }
+rts-dom = { path = "../rts-dom", default-features = false }
 # Interface de render abstrata: o egui IMPLEMENTA o trait `Renderer` e se registra
 # como backend ativo. O DOM/layout fala `render.*`, nunca `egui.*`.
-rts-render = { path = "../rts-render" }
+rts-render = { path = "../rts-render", default-features = false }
 # Interface de input abstrata (crate irmão de render): o egui também IMPLEMENTA o
 # trait `InputSource` (captura mouse/teclado/etc via winit) e se registra. O app
 # fala `input.*`, nunca `egui.*`.
-rts-input = { path = "../rts-input" }
+rts-input = { path = "../rts-input", default-features = false }
 
 # egui/egui-winit SEM default-features: cortamos accesskit (a11y, traz toda uma
 # árvore), serde, etc. — não usamos no PoC.
@@ -103,7 +103,10 @@ winit = { version = "0.30", default-features = false, features = [
 [features]
 # default liga o backend wgpu + dx12 (Windows). macOS/Linux: trocar gpu-dx12 por
 # gpu-metal/gpu-vulkan no consumidor (rts-runtime) por cfg de plataforma.
-default = ["wgpu-backend", "gpu-dx12"]
+default = ["wgpu-backend", "gpu-dx12", "old-engine"]
+# A ABI do motor ANTIGO (símbolos de linker + namespace `egui`/`gpu`) e os crates
+# vizinhos na versão que a expõe. Ver o doc de `src/abi.rs`.
+old-engine = ["dep:rts-engine", "rts-dom/old-engine", "rts-render/old-engine", "rts-input/old-engine"]
 # wgpu-backend liga o dep wgpu/egui-wgpu. O backend de GPU concreto é escolhido
 # pelas features de plataforma abaixo (o build ativa a do SO corrente).
 wgpu-backend = ["dep:egui-wgpu", "dep:wgpu"]

--- a/crates/rts-egui/src/abi/mod.rs
+++ b/crates/rts-egui/src/abi/mod.rs
@@ -1,0 +1,267 @@
+//! Os símbolos `extern "C"` do motor ANTIGO, e só eles.
+//!
+//! # Por que este arquivo existe separado
+//!
+//! No motor antigo um nativo é um SÍMBOLO DE LINKER: o `rts-symbol-baker` rende
+//! `__RTS_FN_NS_EGUI_*` numa tabela e o JIT resolve por nome. No motor novo um
+//! nativo é um ponteiro de função ao lado de uma célula, sem nome nenhum — ver
+//! `docs/engine/authoring-natives.md`.
+//!
+//! Enquanto os dois convivem, a lógica não pode pertencer a nenhum dos dois. Ela
+//! está nos módulos vizinhos, em Rust comum (`&str`, `f64`, `u64`), e este
+//! arquivo é a CASCA que a apresenta ao motor antigo: converte a ABI de
+//! ponteiro+comprimento e chama. Está atrás da feature `old-engine` porque é a
+//! única parte do crate que alcança `rts-engine` — e portanto `rts-abi`, a
+//! interface que `rts_cranelift::abi` substituiu.
+//!
+//! Uma casca não decide nada. Se algo aqui precisar de um `if`, é semântica que
+//! escorregou para fora do módulo dono e vai voltar para lá.
+
+use rts_engine::abi::str_abi;
+
+mod register;
+pub use register::register;
+
+/// O texto que um par ponteiro+comprimento nomeia, vazio quando não nomeia um.
+///
+/// # Segurança
+///
+/// O par vem do motor, que o produziu do seu pool de strings — a mesma condição
+/// que todo nativo do motor antigo já assume. Vazio em vez de pânico: um
+/// `extern "C"` não desenrola, então um pânico aqui abortaria o processo por uma
+/// string malformada.
+fn text(ptr: *const u8, len: i64) -> String {
+    unsafe { str_abi::from_abi(ptr, len) }.unwrap_or("").to_string()
+}
+
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(title_ptr: *const u8, title_len: i64, w: i64, h: i64, config: i64) -> u64 {
+    crate::app::open_window(&text(title_ptr, title_len), w, h, config)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_PUMP(h: u64) -> i64 {
+    crate::app::pump(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_IS_OPEN(h: u64) -> i64 {
+    crate::app::is_open(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_CLOSE(h: u64) {
+    crate::app::close(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MOVE_WINDOW(h: u64, x: i64, y: i64) {
+    crate::app::move_window(h, x, y)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MOUSE_LOCK(h: u64, on: i64) {
+    crate::app::mouse_lock(h, on)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_NEXT_POS(x: i64, y: i64) {
+    crate::app::set_next_pos(x, y)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_BEGIN_FRAME(h: u64) {
+    crate::frame::begin_frame(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_END_FRAME(h: u64) {
+    crate::frame::end_frame(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_VSYNC(h: u64, on: i64) {
+    crate::frame::set_vsync(h, on)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SNAPSHOT(h: u64, path_ptr: *const u8, path_len: i64) {
+    crate::frame::snapshot(h, &text(path_ptr, path_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_LABEL(h: u64, text_ptr: *const u8, text_len: i64) {
+    crate::widgets::label(h, &text(text_ptr, text_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_BUTTON(h: u64, label_ptr: *const u8, label_len: i64) -> i64 {
+    crate::widgets::button(h, &text(label_ptr, label_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SLIDER(h: u64, value: f64, min: f64, max: f64) -> f64 {
+    crate::widgets::slider(h, value, min, max)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_BEGIN(h: u64) {
+    crate::widgets::horizontal_begin(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_END(h: u64) {
+    crate::widgets::horizontal_end(h)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_HTML(h: u64, ptr: *const u8, len: i64) {
+    crate::widgets::html(h, &text(ptr, len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_RENDER(h: u64, dom_handle: u64) {
+    crate::widgets::render(h, dom_handle)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_BLOCK(tag_ptr: *const u8, tag_len: i64, display: i64, indent: f64, prefix: i64, flags: i64) {
+    crate::widgets::define_block(&text(tag_ptr, tag_len), display, indent, prefix, flags)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_STYLE(tag_ptr: *const u8, tag_len: i64, slot: i64, val: i64) {
+    crate::widgets::define_style(&text(tag_ptr, tag_len), slot, val)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_INLINE(tag_ptr: *const u8, tag_len: i64, flags: i64) {
+    crate::widgets::define_inline(&text(tag_ptr, tag_len), flags)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_QUERY_SELECTOR(h: u64, sel_ptr: *const u8, sel_len: i64) -> i64 {
+    crate::widgets::query_selector(h, &text(sel_ptr, sel_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_TEXT(h: u64, id: i64, ptr: *const u8, len: i64) {
+    crate::widgets::set_text(h, id, &text(ptr, len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_ATTR(h: u64, id: i64, name_ptr: *const u8, name_len: i64, val_ptr: *const u8, val_len: i64) {
+    crate::widgets::set_attr(h, id, &text(name_ptr, name_len), &text(val_ptr, val_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_CREATE_ELEMENT(h: u64, tag_ptr: *const u8, tag_len: i64) -> i64 {
+    crate::widgets::create_element(h, &text(tag_ptr, tag_len))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_APPEND_CHILD(h: u64, parent: i64, child: i64) {
+    crate::widgets::append_child(h, parent, child)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_REMOVE_NODE(h: u64, id: i64) {
+    crate::widgets::remove_node(h, id)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DOM_DUMP(h: u64) {
+    crate::widgets::dom_dump(h)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_RECT(h: u64, x: f64, y: f64, w: f64, h_: f64, fill: i64, stroke_w: f64, stroke: i64, radius: f64) {
+    crate::canvas::draw_rect(h, x, y, w, h_, fill, stroke_w, stroke, radius)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_TEXT(h: u64, x: f64, y: f64, text_ptr: *const u8, text_len: i64, color: i64, size: f64, flags: i64) {
+    crate::canvas::draw_text(h, x, y, &text(text_ptr, text_len), color, size, flags)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_LINE(h: u64, x1: f64, y1: f64, x2: f64, y2: f64, w: f64, color: i64) {
+    crate::canvas::draw_line(h, x1, y1, x2, y2, w, color)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MEASURE_TEXT(h: u64, text_ptr: *const u8, text_len: i64, size: f64, bold: i64) -> f64 {
+    crate::canvas::measure_text(h, &text(text_ptr, text_len), size, bold)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MESH_UPLOAD(win: u64, vptr: u64, vcount: i64, iptr: u64, icount: i64) -> u64 {
+    unsafe { crate::scene_api::mesh_upload(win, vptr, vcount, iptr, icount) }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_MESH_FREE(win: u64, mesh: u64) {
+    crate::scene_api::mesh_free(win, mesh)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA(win: u64, camx: f64, camy: f64, camz: f64, yaw: f64, pitch: f64, fov_y: f64, aspect: f64) {
+    crate::scene_api::set_camera(win, camx, camy, camz, yaw, pitch, fov_y, aspect)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT(win: u64, ex: f64, ey: f64, ez: f64, tx: f64, ty: f64, tz: f64, fov_y: f64, aspect: f64, near: f64, far: f64) {
+    crate::scene_api::set_camera_lookat(win, ex, ey, ez, tx, ty, tz, fov_y, aspect, near, far)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_CLEAR_COLOR(win: u64, r: f64, g: f64, b: f64) {
+    crate::scene_api::set_clear_color(win, r, g, b)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_SKYBOX(win: u64, on: i64) {
+    crate::scene_api::set_skybox(win, on)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_LIGHT(win: u64, dx: f64, dy: f64, dz: f64, ambient: f64) {
+    crate::scene_api::set_light(win, dx, dy, dz, ambient)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_WIN_WIDTH(win: u64) -> f64 {
+    crate::scene_api::win_width(win)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_WIN_HEIGHT(win: u64) -> f64 {
+    crate::scene_api::win_height(win)
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_SET_SHADOW(win: u64, dx: f64, dy: f64, dz: f64, cx: f64, cy: f64, cz: f64, radius: f64) {
+    crate::scene_api::set_shadow(win, dx, dy, dz, cx, cy, cz, radius)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_TEXTURE_UPLOAD(win: u64, ptr: u64, w: i64, h: i64) -> u64 {
+    unsafe { crate::scene_api::texture_upload(win, ptr, w, h) }
+}
+
+#[unsafe(no_mangle)]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_MESH(win: u64, mesh: u64, px: f64, py: f64, pz: f64, rx: f64, ry: f64, sx: f64, sy: f64, sz: f64, color: i64, emissive: i64, tex: i64) {
+    crate::scene_api::draw_mesh(win, mesh, px, py, pz, rx, ry, sx, sy, sz, color, emissive, tex)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_WATER(win: u64, mesh: u64, gbuf: u64, count: i64, scale: f64) -> i64 {
+    crate::scene_api::draw_water(win, mesh, gbuf, count, scale)
+}

--- a/crates/rts-egui/src/abi/register.rs
+++ b/crates/rts-egui/src/abi/register.rs
@@ -1,0 +1,357 @@
+//! A tabela do namespace `egui` do motor ANTIGO: nome, assinatura, símbolo.
+//!
+//! Separada de `super` porque as duas coisas mudam por motivos diferentes — um
+//! wrapper muda quando a função muda, esta tabela muda quando a SUPERFÍCIE
+//! muda — e porque juntas passavam do teto de arquivo.
+
+use rts_engine::{AbiType, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
+
+// `Sig::new` espera variantes de `AbiType` como valores. Aliases locais para
+// manter as tabelas de membros legíveis (mesmo shape do `io::func`).
+use AbiType::{F64, I64, U64};
+
+use super::*;
+
+/// Helper de declaração de membro do namespace (mesmo shape do `io::func`).
+fn func(name: &str, symbol: &str, sig: Sig, ts: &str, doc: &str, fp: *const u8) -> Member {
+    Member {
+        name: name.to_string(),
+        kind: MemberKind::Function,
+        sig,
+        symbol: symbol.to_string(),
+        fn_ptr: FnPtr(fp),
+        flags: MemberFlags::NONE,
+        aliases: Vec::new(),
+        variadic: false,
+        ts_signature: ts.to_string(),
+        doc: doc.to_string(),
+        ret_class: None,
+        pure: false,
+        emit: None,
+    }
+}
+
+/// Registra o namespace `egui` no motor antigo. Resolve via Registry (doutrina
+/// PRIMORDIAL-vs-Registry): o engine NUNCA nomeia `ui`.
+pub fn register(e: &mut Engine) {
+    // Registra o egui como o backend de render ATIVO do `rts-render`: a partir
+    // daqui, o namespace `render.*` (que o DOM/layout chama) despacha p/ o egui.
+    crate::render_backend::register_backend();
+    // De onde o render lê os pixels de uma `<img>`: do `HandleTable` deste
+    // motor. O crate de render não nomeia mais o HandleTable (ele serve aos dois
+    // motores), então quem sabe responde — ver `crate::pixels`.
+    crate::pixels::set_source(|handle, offset, len| {
+        rts_engine::heap::handles::with_entry(handle, |entry| match entry {
+            Some(rts_engine::heap::handles::Entry::Buffer(bytes)) => {
+                let start = offset as usize;
+                (bytes.len() >= start + len).then(|| bytes[start..start + len].to_vec())
+            }
+            _ => None,
+        })
+    });
+    e.ns("egui")
+        .doc("Immediate-mode GUI primitives (egui). TS drives the render loop.")
+        // ── Ciclo de vida da janela / loop (Modelo A — TS dirige) ──────────────
+        .member(func(
+            "openWindow",
+            "__RTS_FN_NS_EGUI_OPEN_WINDOW",
+            Sig::new(vec![AbiType::StrPtr, I64, I64, I64], U64),
+            "openWindow(title: string, w: number, h: number, config: number): number",
+            "Opens a window + render backend, returns an opaque UiCtx handle. `config` is a GPU bitfield (bit0 high-power, bit1 perf-memory, bit2 high-limits); 0 = RAM-optimized defaults.",
+            __RTS_FN_NS_EGUI_OPEN_WINDOW as *const u8,
+        ))
+        .member(func(
+            "pump",
+            "__RTS_FN_NS_EGUI_PUMP",
+            Sig::new(vec![U64], I64),
+            "pump(h: number): number",
+            "Pumps pending OS events (non-blocking). Returns 0=continue, !=0=exit.",
+            __RTS_FN_NS_EGUI_PUMP as *const u8,
+        ))
+        .member(func(
+            "isOpen",
+            "__RTS_FN_NS_EGUI_IS_OPEN",
+            Sig::new(vec![U64], I64),
+            "isOpen(h: number): boolean",
+            "Returns true while the window has not been closed.",
+            __RTS_FN_NS_EGUI_IS_OPEN as *const u8,
+        ))
+        .member(func(
+            "close",
+            "__RTS_FN_NS_EGUI_CLOSE",
+            Sig::new(vec![U64], AbiType::Void),
+            "close(h: number): void",
+            "Destroys the window and frees the UiCtx.",
+            __RTS_FN_NS_EGUI_CLOSE as *const u8,
+        ))
+        .member(func(
+            "moveWindow",
+            "__RTS_FN_NS_EGUI_MOVE_WINDOW",
+            Sig::new(vec![U64, I64, I64], AbiType::Void),
+            "moveWindow(h: number, x: number, y: number): void",
+            "Moves the window to absolute desktop position (x,y) in physical pixels — pick a monitor (e.g. x >= primary width = secondary screen).",
+            __RTS_FN_NS_EGUI_MOVE_WINDOW as *const u8,
+        ))
+        .member(func(
+            "setVsync",
+            "__RTS_FN_NS_EGUI_SET_VSYNC",
+            Sig::new(vec![U64, I64], AbiType::Void),
+            "setVsync(h: number, on: number): void",
+            "Runtime per-window vsync toggle. on!=0 = Fifo (the mandatory default); on==0 = explicit opt-out via AutoNoVsync (uncapped fps — the caller owns throttling/CPU burn). wgpu backend only.",
+            __RTS_FN_NS_EGUI_SET_VSYNC as *const u8,
+        ))
+        .member(func(
+            "mouseLock",
+            "__RTS_FN_NS_EGUI_MOUSE_LOCK",
+            Sig::new(vec![U64, I64], AbiType::Void),
+            "mouseLock(h: number, on: number): void",
+            "FPS pointer-lock: on!=0 confines+hides the cursor and switches input.mouseDeltaX/Y to RAW device deltas (edge-immune); on==0 releases. Windows uses Confined+raw (winit has no Locked there).",
+            __RTS_FN_NS_EGUI_MOUSE_LOCK as *const u8,
+        ))
+        .member(func(
+            "setNextWindowPos",
+            "__RTS_FN_NS_EGUI_SET_NEXT_POS",
+            Sig::new(vec![I64, I64], AbiType::Void),
+            "setNextWindowPos(x: number, y: number): void",
+            "Sets the INITIAL position of the NEXT openWindow (physical px) — the window is born there. Call BEFORE openWindow; more reliable than moveWindow.",
+            __RTS_FN_NS_EGUI_SET_NEXT_POS as *const u8,
+        ))
+        // ── Teste visual headless ──────────────────────────────────────────────
+        .member(func(
+            "snapshot",
+            "__RTS_FN_NS_EGUI_SNAPSHOT",
+            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
+            "snapshot(h: number, path: string): void",
+            "Schedules a PPM snapshot of the next endFrame (glow backend only) — for headless visual assertions that the frame is not blank.",
+            __RTS_FN_NS_EGUI_SNAPSHOT as *const u8,
+        ))
+        // ── Frame ──────────────────────────────────────────────────────────────
+        .member(func(
+            "beginFrame",
+            "__RTS_FN_NS_EGUI_BEGIN_FRAME",
+            Sig::new(vec![U64], AbiType::Void),
+            "beginFrame(h: number): void",
+            "Starts an egui pass: takes input and creates the root Ui.",
+            __RTS_FN_NS_EGUI_BEGIN_FRAME as *const u8,
+        ))
+        .member(func(
+            "endFrame",
+            "__RTS_FN_NS_EGUI_END_FRAME",
+            Sig::new(vec![U64], AbiType::Void),
+            "endFrame(h: number): void",
+            "Ends the egui pass, tessellates and presents the frame.",
+            __RTS_FN_NS_EGUI_END_FRAME as *const u8,
+        ))
+        // ── Widgets-folha (P1) ───────────────────────────────────────────────────
+        .member(func(
+            "label",
+            "__RTS_FN_NS_EGUI_LABEL",
+            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
+            "label(h: number, text: string): void",
+            "Emits a text label in the active frame.",
+            __RTS_FN_NS_EGUI_LABEL as *const u8,
+        ))
+        .member(func(
+            "button",
+            "__RTS_FN_NS_EGUI_BUTTON",
+            Sig::new(vec![U64, AbiType::StrPtr], I64),
+            "button(h: number, label: string): boolean",
+            "Emits a button; returns true if it was clicked this frame.",
+            __RTS_FN_NS_EGUI_BUTTON as *const u8,
+        ))
+        .member(func(
+            "slider",
+            "__RTS_FN_NS_EGUI_SLIDER",
+            Sig::new(vec![U64, F64, F64, F64], F64),
+            "slider(h: number, value: number, min: number, max: number): number",
+            "Emits a slider; returns the (possibly updated) value.",
+            __RTS_FN_NS_EGUI_SLIDER as *const u8,
+        ))
+        // ── Layout horizontal (widgets lado a lado) ────────────────────────────
+        .member(func(
+            "horizontalBegin",
+            "__RTS_FN_NS_EGUI_HORIZONTAL_BEGIN",
+            Sig::new(vec![U64], AbiType::Void),
+            "horizontalBegin(h: number): void",
+            "Opens a horizontal scope: widgets until horizontalEnd sit side by side.",
+            __RTS_FN_NS_EGUI_HORIZONTAL_BEGIN as *const u8,
+        ))
+        .member(func(
+            "horizontalEnd",
+            "__RTS_FN_NS_EGUI_HORIZONTAL_END",
+            Sig::new(vec![U64], AbiType::Void),
+            "horizontalEnd(h: number): void",
+            "Closes the most recent horizontal scope; widgets stack vertically again.",
+            __RTS_FN_NS_EGUI_HORIZONTAL_END as *const u8,
+        ))
+        // ── Render do DOM ──────────────────────────────────────────────────────
+        // `render(win, domHandle)`: RENDER GENÉRICO — pinta um DOM do `rts-dom`
+        // (headless, por handle) na janela. O egui só LÊ o DOM e desenha; não o
+        // detém. É o caminho desacoplado (o DOM vive no rts-dom; o egui é um
+        // consumidor trocável). `html(win, string)` é o caminho LEGACY (egui
+        // parseia e detém o próprio DOM) — mantido por compat.
+        .member(func(
+            "render",
+            "__RTS_FN_NS_EGUI_RENDER",
+            Sig::new(vec![U64, U64], AbiType::Void),
+            "render(win: number, domHandle: number): void",
+            "Paints a rts-dom DOM (by handle) into the window — egui only reads the DOM and draws; the DOM lives in rts-dom (headless). Inverts the dependency: any backend consumes the same domHandle.",
+            __RTS_FN_NS_EGUI_RENDER as *const u8,
+        ))
+        .member(func(
+            "html",
+            "__RTS_FN_NS_EGUI_HTML",
+            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
+            "html(h: number, html: string): void",
+            "LEGACY: parses an HTML string and emits widgets (egui owns the DOM). Prefer `render(win, domHandle)` with a rts-dom DOM (headless, decoupled).",
+            __RTS_FN_NS_EGUI_HTML as *const u8,
+        ))
+        // ── DOM/estilo: REMOVIDOS do namespace egui (extração headless) ─────────
+        // defineBlock/defineStyle/defineInline + querySelector/setText/setAttr/
+        // createElement/appendChild/removeNode/domDump migraram 100% para o
+        // namespace `dom` (rts-dom). O egui é RENDER GENÉRICO: só LÊ o DOM e pinta
+        // (via `egui.html` / `egui.render`), nunca detém estado de página. Isso
+        // INVERTE a dependência — o DOM não conhece o render; qualquer backend
+        // (egui hoje; web/headless-png amanhã) consome o mesmo DOM. Ver
+        // docs/ui/html-engine + project_dom_headless_vision.
+        // ── CANVAS BURRO: o TS calcula o layout e emite primitivos; o egui pinta ──
+        // Coords/tamanhos em pontos (number); cores 0xRRGGBBAA (number).
+        .member(func(
+            "drawRect",
+            "__RTS_FN_NS_EGUI_DRAW_RECT",
+            Sig::new(vec![U64, F64, F64, F64, F64, I64, F64, I64, F64], AbiType::Void),
+            "drawRect(h: number, x: number, y: number, w: number, h_: number, fill: number, strokeW: number, stroke: number, radius: number): void",
+            "Dumb-canvas filled rect + optional border at absolute coords. Colors 0xRRGGBBAA. The TS layout engine positions it; egui only paints.",
+            __RTS_FN_NS_EGUI_DRAW_RECT as *const u8,
+        ))
+        .member(func(
+            "drawText",
+            "__RTS_FN_NS_EGUI_DRAW_TEXT",
+            Sig::new(vec![U64, F64, F64, AbiType::StrPtr, I64, F64, I64], AbiType::Void),
+            "drawText(h: number, x: number, y: number, text: string, color: number, size: number, flags: number): void",
+            "Dumb-canvas text at absolute (x,y) top-left. flags bitmask 1=bold 2=italic 4=mono. Color 0xRRGGBBAA.",
+            __RTS_FN_NS_EGUI_DRAW_TEXT as *const u8,
+        ))
+        .member(func(
+            "drawLine",
+            "__RTS_FN_NS_EGUI_DRAW_LINE",
+            Sig::new(vec![U64, F64, F64, F64, F64, F64, I64], AbiType::Void),
+            "drawLine(h: number, x1: number, y1: number, x2: number, y2: number, w: number, color: number): void",
+            "Dumb-canvas line at absolute coords. Color 0xRRGGBBAA.",
+            __RTS_FN_NS_EGUI_DRAW_LINE as *const u8,
+        ))
+        .member(func(
+            "measureText",
+            "__RTS_FN_NS_EGUI_MEASURE_TEXT",
+            Sig::new(vec![U64, AbiType::StrPtr, F64, I64], F64),
+            "measureText(h: number, text: string, size: number, bold: number): number",
+            "Width (points) of a text in the real font — the ONLY layout-aware op left in egui (TS can't measure text without the font). Synchronous.",
+            __RTS_FN_NS_EGUI_MEASURE_TEXT as *const u8,
+        ))
+        // ── Pipeline 3D wgpu (scene pass) — só-wgpu; glow no-op ─────────────────
+        .member(func(
+            "meshUpload",
+            "__RTS_FN_NS_EGUI_MESH_UPLOAD",
+            Sig::new(vec![U64, U64, I64, U64, I64], U64),
+            "meshUpload(h: number, vertsPtr: number, vertexCount: number, indicesPtr: number, indexCount: number): number",
+            "Uploads a mesh to GPU (verts = interleaved pos+normal, 6 floats/vertex at vertsPtr; indices = u32 at indicesPtr). Returns a mesh id. GPU 3D scene pass, drawn before the egui UI.",
+            __RTS_FN_NS_EGUI_MESH_UPLOAD as *const u8,
+        ))
+        .member(func(
+            "meshFree",
+            "__RTS_FN_NS_EGUI_MESH_FREE",
+            Sig::new(vec![U64, U64], AbiType::Void),
+            "meshFree(h: number, meshId: number): void",
+            "Frees a mesh uploaded with meshUpload.",
+            __RTS_FN_NS_EGUI_MESH_FREE as *const u8,
+        ))
+        .member(func(
+            "setCamera",
+            "__RTS_FN_NS_EGUI_SET_CAMERA",
+            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
+            "setCamera(h: number, camX: number, camY: number, camZ: number, yaw: number, pitch: number, fovY: number, aspect: number): void",
+            "Sets the 3D camera for this frame (fly cam: position + yaw/pitch + vertical FOV + aspect). Builds the view-projection.",
+            __RTS_FN_NS_EGUI_SET_CAMERA as *const u8,
+        ))
+        .member(func(
+            "setCameraLookAt",
+            "__RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT",
+            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
+            "setCameraLookAt(h: number, eyeX: number, eyeY: number, eyeZ: number, targetX: number, targetY: number, targetZ: number, fovY: number, aspect: number, near: number, far: number): void",
+            "Sets the 3D camera as a NaN-safe look-at (eye position looking at a target, up = +Y) with explicit near/far. More convenient than yaw/pitch for framing an object; degrades gracefully when looking straight up/down instead of gimbal-locking.",
+            __RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT as *const u8,
+        ))
+        .member(func(
+            "setClearColor",
+            "__RTS_FN_NS_EGUI_SET_CLEAR_COLOR",
+            Sig::new(vec![U64, F64, F64, F64], AbiType::Void),
+            "setClearColor(h: number, r: number, g: number, b: number): void",
+            "Sets a FLAT background color (r,g,b in 0..1) for the 3D scene pass, disabling the procedural skybox. Ideal for an editor viewport that wants a neutral background instead of the starfield.",
+            __RTS_FN_NS_EGUI_SET_CLEAR_COLOR as *const u8,
+        ))
+        .member(func(
+            "setSkybox",
+            "__RTS_FN_NS_EGUI_SET_SKYBOX",
+            Sig::new(vec![U64, I64], AbiType::Void),
+            "setSkybox(h: number, on: number): void",
+            "Re-enables the procedural skybox (on!=0), undoing a previous setClearColor.",
+            __RTS_FN_NS_EGUI_SET_SKYBOX as *const u8,
+        ))
+        .member(func(
+            "setLight",
+            "__RTS_FN_NS_EGUI_SET_LIGHT",
+            Sig::new(vec![U64, F64, F64, F64, F64], AbiType::Void),
+            "setLight(h: number, dirX: number, dirY: number, dirZ: number, ambient: number): void",
+            "Sets the directional light (direction + ambient 0..1) for the 3D scene pass.",
+            __RTS_FN_NS_EGUI_SET_LIGHT as *const u8,
+        ))
+        .member(func(
+            "winWidth",
+            "__RTS_FN_NS_EGUI_WIN_WIDTH",
+            Sig::new(vec![U64], F64),
+            "winWidth(h: number): number",
+            "Current LOGICAL width (points) of the window — follows resize.",
+            __RTS_FN_NS_EGUI_WIN_WIDTH as *const u8,
+        ))
+        .member(func(
+            "winHeight",
+            "__RTS_FN_NS_EGUI_WIN_HEIGHT",
+            Sig::new(vec![U64], F64),
+            "winHeight(h: number): number",
+            "Current LOGICAL height (points) of the window — follows resize.",
+            __RTS_FN_NS_EGUI_WIN_HEIGHT as *const u8,
+        ))
+        .member(func(
+            "setShadow",
+            "__RTS_FN_NS_EGUI_SET_SHADOW",
+            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
+            "setShadow(h: number, dirX: number, dirY: number, dirZ: number, cX: number, cY: number, cZ: number, radius: number): void",
+            "Configures the directional shadow map: light travel direction (dirX/Y/Z), the center and radius of the orthographic box the shadows cover. radius<=0 disables shadows.",
+            __RTS_FN_NS_EGUI_SET_SHADOW as *const u8,
+        ))
+        .member(func(
+            "textureUpload",
+            "__RTS_FN_NS_EGUI_TEXTURE_UPLOAD",
+            Sig::new(vec![U64, U64, I64, I64], U64),
+            "textureUpload(h: number, pixelsPtr: number, w: number, h2: number): number",
+            "Uploads an RGBA8 image (pixelsPtr -> w*h*4 bytes, sRGB) to VRAM and returns a texture id (>=2) for drawMesh(..., tex=id). Typical flow: fs reads the file, imgdec.decode gives RGBA + w/h, this uploads to GPU. Sampled triplanar (world-space) in the 3D pass. 0 if invalid / non-wgpu window.",
+            __RTS_FN_NS_EGUI_TEXTURE_UPLOAD as *const u8,
+        ))
+        .member(func(
+            "drawMesh",
+            "__RTS_FN_NS_EGUI_DRAW_MESH",
+            Sig::new(vec![U64, U64, F64, F64, F64, F64, F64, F64, F64, F64, I64, I64, I64], AbiType::Void),
+            "drawMesh(h: number, meshId: number, px: number, py: number, pz: number, rx: number, ry: number, sx: number, sy: number, sz: number, color: number, emissive: number, tex: number): void",
+            "Queues a 3D draw of meshId with a transform (pos/rot euler/scale), color 0xAARRGGBB, emissive flag (0/1), and procedural texture (0=none, 1=world-space checker). Rendered in the scene pass at endFrame. Light is a POINT light at setLight's position; shadows via setShadow.",
+            __RTS_FN_NS_EGUI_DRAW_MESH as *const u8,
+        ))
+        .member(func(
+            "drawWater",
+            "__RTS_FN_NS_EGUI_DRAW_WATER",
+            Sig::new(vec![U64, U64, U64, I64, F64], I64),
+            "drawWater(h: number, meshId: number, gbuf: number, count: number, scale: number): number",
+            "Instanced water: draws `count` instances of meshId reading each instance (vec4 f32: xyz center, w signed density; w<0 = culled shell) DIRECTLY from the rts:gpu buffer `gbuf` — zero readback, one draw call. `scale` is the particle draw radius. 1 ok, 0 invalid buffer/window.",
+            __RTS_FN_NS_EGUI_DRAW_WATER as *const u8,
+        ))
+        .done();
+}

--- a/crates/rts-egui/src/app.rs
+++ b/crates/rts-egui/src/app.rs
@@ -36,8 +36,6 @@ use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::window::{Window, WindowId};
 
-use rts_engine::abi::str_abi;
-
 use crate::ctx::{self, UiCtx};
 use crate::frame::{Backend, RenderState};
 
@@ -250,17 +248,8 @@ fn make_egui(window: &Window) -> (egui::Context, egui_winit::State) {
 /// Abre uma janela + backend de render sobre o EventLoop GLOBAL (criado lazy na
 /// 1ª chamada, reusado nas seguintes). Retorna um handle `UiCtx` opaco (0 em
 /// falha). `backend` é ignorado no P1 (sempre wgpu).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(
-    title_ptr: *const u8,
-    title_len: i64,
-    w: i64,
-    h: i64,
-    config: i64,
-) -> u64 {
-    let title = unsafe { str_abi::from_abi(title_ptr, title_len) }
-        .unwrap_or("rts-egui")
-        .to_string();
+pub fn open_window(title: &str, w: i64, h: i64, config: i64) -> u64 {
+    let title = title.to_string();
     let width = w.clamp(1, i64::from(u32::MAX)) as u32;
     let height = h.clamp(1, i64::from(u32::MAX)) as u32;
     // `config` is a bitfield: bit0 high_perf, bit1 mem_performance, bit2
@@ -346,8 +335,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_OPEN_WINDOW(
 /// `on==0` solta e mostra o cursor. Windows não implementa
 /// `CursorGrabMode::Locked` (winit) — `Confined` + raw deltas é o padrão de
 /// jogos; tenta `Locked` primeiro para os SOs que suportam.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_MOUSE_LOCK(h: u64, on: i64) {
+pub fn mouse_lock(h: u64, on: i64) {
     use winit::window::CursorGrabMode;
     ctx::with_ctx(h, |c| {
         if on != 0 {
@@ -434,8 +422,7 @@ impl ApplicationHandler for Pumper {
 /// pump processa os eventos de TODAS as janelas (roteados por `WindowId`). O
 /// parâmetro `h` é mantido por compatibilidade da ABI, mas o pump é global: só
 /// validamos que o handle existe (handle inválido → "sair"). Retorna 0=continuar.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_PUMP(h: u64) -> i64 {
+pub fn pump(h: u64) -> i64 {
     // Handle precisa existir (o TS chama pump(h) por janela).
     if ctx::with_ctx(h, |_| ()).is_none() {
         return 1; // handle inexistente → "sair".
@@ -451,8 +438,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_PUMP(h: u64) -> i64 {
 }
 
 /// 1 enquanto a janela não foi fechada; 0 caso contrário (ou handle inválido).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_IS_OPEN(h: u64) -> i64 {
+pub fn is_open(h: u64) -> i64 {
     ctx::with_ctx(h, |c| if c.open { 1 } else { 0 }).unwrap_or(0)
 }
 
@@ -466,16 +452,14 @@ thread_local! {
 /// Define a posição INICIAL (pixels físicos do desktop) da PRÓXIMA janela criada
 /// por `openWindow`. Chame ANTES de `openWindow` para a janela já nascer no
 /// monitor desejado (mais confiável que `moveWindow` depois).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_NEXT_POS(x: i64, y: i64) {
+pub fn set_next_pos(x: i64, y: i64) {
     NEXT_POS.with(|p| *p.borrow_mut() = Some((x as i32, y as i32)));
 }
 
 /// Move a janela para a posição ABSOLUTA `(x, y)` na área de trabalho virtual
 /// (em pixels físicos do desktop multi-monitor). Permite ao TS escolher o
 /// monitor (ex.: x >= largura-do-primário → tela secundária).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_MOVE_WINDOW(h: u64, x: i64, y: i64) {
+pub fn move_window(h: u64, x: i64, y: i64) {
     ctx::with_ctx(h, |c| {
         c.window
             .set_outer_position(winit::dpi::PhysicalPosition::new(x as i32, y as i32));
@@ -484,7 +468,6 @@ pub extern "C" fn __RTS_FN_NS_EGUI_MOVE_WINDOW(h: u64, x: i64, y: i64) {
 
 /// Destrói a janela e libera o `UiCtx`. NÃO destrói o EventLoop global (winit não
 /// permite recriá-lo; ele fica vivo mesmo após a última janela fechar).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_CLOSE(h: u64) {
+pub fn close(h: u64) {
     ctx::remove(h);
 }

--- a/crates/rts-egui/src/canvas.rs
+++ b/crates/rts-egui/src/canvas.rs
@@ -10,15 +10,12 @@
 //!
 //! Ver `docs/ui/dom-in-ts.md`.
 
-use rts_engine::abi::str_abi;
-
 use crate::ctx::{self, WidgetCmd};
 
 /// `drawRect(h, x, y, w, h_, fill, strokeW, stroke, radius)` — retângulo
 /// preenchido + borda opcional, em coords absolutas. Cores `0xRRGGBBAA`.
-#[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_RECT(
+pub fn draw_rect(
     h: u64,
     x: f64,
     y: f64,
@@ -47,18 +44,9 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_RECT(
 
 /// `drawText(h, x, y, text, color, size, flags)` — texto numa posição absoluta.
 /// `flags` bitmask 1=bold 2=italic 4=mono. Cor `0xRRGGBBAA`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_TEXT(
-    h: u64,
-    x: f64,
-    y: f64,
-    text_ptr: *const u8,
-    text_len: i64,
-    color: i64,
-    size: f64,
-    flags: i64,
-) {
-    let text = unsafe { str_abi::from_abi(text_ptr, text_len) }.unwrap_or("").to_string();
+#[allow(clippy::too_many_arguments)]
+pub fn draw_text(h: u64, x: f64, y: f64, text: &str, color: i64, size: f64, flags: i64) {
+    let text = text.to_string();
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             c.cmds.push(WidgetCmd::DrawText {
@@ -74,9 +62,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_TEXT(
 }
 
 /// `drawLine(h, x1, y1, x2, y2, w, color)` — linha em coords absolutas.
-#[unsafe(no_mangle)]
 #[allow(clippy::too_many_arguments)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_LINE(
+pub fn draw_line(
     h: u64,
     x1: f64,
     y1: f64,
@@ -103,15 +90,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_LINE(
 /// medida com a fonte real do egui. É o que o TS chama para calcular layout
 /// (quebra de linha, largura de caixa). SÍNCRONO. Retorna `-1.0` (bits) se a
 /// janela não existe. Independe de `frame_active` (o TS mede antes de pintar).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_MEASURE_TEXT(
-    h: u64,
-    text_ptr: *const u8,
-    text_len: i64,
-    size: f64,
-    bold: i64,
-) -> f64 {
-    let text = unsafe { str_abi::from_abi(text_ptr, text_len) }.unwrap_or("");
+pub fn measure_text(h: u64, text: &str, size: f64, bold: i64) -> f64 {
     let _ = (h, bold);
     // PoC: medição APROXIMADA (largura média de glifo ≈ 0.52·size para a fonte
     // proporcional padrão; mono ≈ 0.60·size). A medição EXATA usa o atlas de

--- a/crates/rts-egui/src/frame/gpu.rs
+++ b/crates/rts-egui/src/frame/gpu.rs
@@ -132,7 +132,7 @@ thread_local! {
 /// Calling this from the CLI before it exits drops the device in ordinary
 /// program context, where the driver is fully loaded and the teardown is the one
 /// it expects. Idempotent, and a no-op when no GPU was ever created.
-pub(crate) fn shutdown_shared_gpu() {
+pub fn shutdown_shared_gpu() {
     SHARED_GPU.with(|cell| {
         if let Ok(mut b) = cell.try_borrow_mut() {
             let _ = b.take();

--- a/crates/rts-egui/src/frame/mod.rs
+++ b/crates/rts-egui/src/frame/mod.rs
@@ -30,8 +30,7 @@ fn rgba32(c: u32) -> egui::Color32 {
 
 /// Abre um pass do egui: pega o input acumulado e zera a fila de widgets do
 /// frame. Os widgets-folha entre aqui e `endFrame` apenas enfileiram em `cmds`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_BEGIN_FRAME(h: u64) {
+pub fn begin_frame(h: u64) {
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             return; // beginFrame duplo sem endFrame — ignora.
@@ -74,8 +73,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_BEGIN_FRAME(h: u64) {
 /// 4. adquire o frame da surface, grava o render pass (clear escuro + egui) e
 ///    apresenta;
 /// 5. libera as textures marcadas como free.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_END_FRAME(h: u64) {
+pub fn end_frame(h: u64) {
     ctx::with_ctx(h, |c| {
         if !c.frame_active {
             return;
@@ -200,12 +198,12 @@ fn finish_frame(c: &mut crate::ctx::UiCtx, cmds: Vec<WidgetCmd>) {
 /// (lê o back buffer via `glReadPixels`); no wgpu é no-op com aviso (a janela
 /// wgpu já é confirmada visualmente). O PPM serve p/ asserir que o frame não está
 /// em branco — que o texto/widgets realmente pintaram.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SNAPSHOT(h: u64, path_ptr: *const u8, path_len: i64) {
-    let path = match unsafe { rts_engine::abi::str_abi::from_abi(path_ptr, path_len) } {
-        Some(p) if !p.is_empty() => p.to_string(),
-        _ => return,
-    };
+pub fn snapshot(h: u64, path: &str) {
+    if path.is_empty() {
+        return;
+    }
+    #[cfg_attr(not(feature = "glow-backend"), allow(unused_variables))]
+    let path = path.to_string();
     ctx::with_ctx(h, |c| match &mut c.backend {
         #[cfg(feature = "glow-backend")]
         Backend::Glow(g) => g.request_snapshot(path),
@@ -220,8 +218,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SNAPSHOT(h: u64, path_ptr: *const u8, path_le
 /// quem desliga assume o throttle (ou o burn de CPU/GPU); o default do motor
 /// segue Fifo e o kill-gate segue protegendo o default. Reconfigura a surface
 /// na hora; o resize preserva (muta `config.present_mode`).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_VSYNC(h: u64, on: i64) {
+pub fn set_vsync(h: u64, on: i64) {
     ctx::with_ctx(h, |c| {
         if let Backend::Wgpu(r) = &mut c.backend {
             let mode = if on != 0 {

--- a/crates/rts-egui/src/frame/mod.rs
+++ b/crates/rts-egui/src/frame/mod.rs
@@ -12,7 +12,7 @@ mod render;
 
 // API pública do módulo `frame` (mantém o `pub use frame::*` do lib.rs): os tipos
 // de GPU/janela (usados por app.rs/ctx.rs) e o render do DOM (usado abaixo).
-pub use gpu::{Backend, GpuConfig, RenderState, WindowChrome};
+pub use gpu::{shutdown_shared_gpu, Backend, GpuConfig, RenderState, WindowChrome};
 use gpu::present_wgpu;
 use render::render_dom;
 

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -483,13 +483,7 @@ fn paint_list(ui: &mut egui::Ui, list: &DisplayList, offset_y: f32) {
                 // pinta no rect (escalando). O decode/download já aconteceram no .ts.
                 let need = (*img_w as usize) * (*img_h as usize) * 4;
                 let rgba: Option<Vec<u8>> =
-                    rts_engine::heap::handles::with_entry(*pixels_handle, |e| match e {
-                        Some(rts_engine::heap::handles::Entry::Buffer(b)) => {
-                            let start = *pixels_off as usize;
-                            (b.len() >= start + need).then(|| b[start..start + need].to_vec())
-                        }
-                        _ => None,
-                    });
+                    crate::pixels::fetch(*pixels_handle, u64::from(*pixels_off), need);
                 if let Some(bytes) = rgba {
                     let ci = egui::ColorImage::from_rgba_unmultiplied(
                         [*img_w as usize, *img_h as usize],

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -1,22 +1,35 @@
 //! `rts-egui` — GUI imediata cross-platform via egui (immediate-mode, Rust puro).
 //!
-//! O Rust expõe PRIMITIVOS via ABI de handles `u64` (`extern "C"`); a lib de alto
-//! nível (Window/Button/Slider) vive em TS. O loop de render é dirigido pelo TS
-//! sobre esses primitivos (`while(ui.isOpen()){ pump → beginFrame → widgets →
-//! endFrame }`). Ver `docs/ui/egui-crate.md`.
+//! A lib de alto nível (Window/Button/Slider) vive em TS; o loop de render é
+//! dirigido pelo TS sobre estes primitivos (`while(ui.isOpen()){ pump →
+//! beginFrame → widgets → endFrame }`). Ver `docs/ui/egui-crate.md`.
 //!
 //! `UiCtx` (EventLoop + Window + wgpu + egui::Context) é `!Send` → vive num
 //! `thread_local! HashMap<u64, UiCtx>` na thread do TS; o handle `u64` é só uma
-//! chave opaca (NÃO entra no `Entry` do HandleTable, que é primordial/fechado).
+//! chave opaca.
 //!
-//! **Status:** P0/P1 (gate de risco). A superfície ampla (containers, glow,
-//! Modelo B) vem nas fases seguintes só após o P1 validar loop + pilha de `Ui`.
+//! # Como um motor alcança isto
+//!
+//! **Por uma casca, nunca por dentro.** Os módulos abaixo são Rust comum —
+//! `open_window(&str, i64, i64, i64) -> u64`, `draw_rect(h, x, y, …)` — e não
+//! sabem que existe um motor. Quem sabe é `abi`, atrás da feature `old-engine`:
+//! ele converte a ABI de ponteiro+comprimento do motor antigo e chama.
+//!
+//! Isso existe porque há dois motores. No antigo um nativo é um símbolo de
+//! linker; no novo é um ponteiro de função ao lado de uma célula, e um crate do
+//! motor novo que alcançasse `rts-engine` alcançaria, pelo grafo de build,
+//! `rts-abi` — a interface que `rts_cranelift::abi` substituiu. Uma feature é o
+//! mecanismo certo para isso porque a pergunta é de DISPONIBILIDADE ("este build
+//! tem a ABI antiga?") e não de permissão.
 
-use rts_engine::{AbiType, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
+// A ABI do motor ANTIGO — símbolos de linker e a tabela do namespace.
+#[cfg(feature = "old-engine")]
+pub mod abi;
+#[cfg(feature = "old-engine")]
+pub use abi::register;
 
-// `Sig::new` espera variantes de `AbiType` como valores. Aliases locais para
-// manter as tabelas de membros legíveis (mesmo shape do `io::func`).
-use AbiType::{F64, I64, U64};
+// De onde vêm os bytes de uma imagem: perguntado ao host, nunca sabido aqui.
+pub mod pixels;
 
 mod ctx;
 mod app;
@@ -30,13 +43,17 @@ pub mod render_backend;
 mod widgets;
 mod scene_api;
 // `rts:gpu` — compute WGSL sobre o MESMO device compartilhado do render.
-// `pub` para a facade `rts-runtime` re-exportar (`ns::gpu::register`).
+//
+// Atrás de `old-engine` porque um buffer de compute É um handle do `HandleTable`
+// do motor antigo (`Entry::Buffer`). Não é uma casca sobre lógica neutra como o
+// resto do crate — é um formato de dado que pertence àquele motor, e portá-lo é
+// escolher onde os bytes vivem no novo. Fica para a fase seguinte, dito aqui em
+// vez de descoberto por um link quebrado.
+#[cfg(feature = "old-engine")]
 pub mod compute;
 
 // O DOM (árvore + parser + NodeId) E o ESTADO de estilo vivem no crate `rts-dom`;
-// o egui só os CONSOME (lê e pinta). Aliases para reuso interno: `crate::dom::*`
-// e `crate::style::*` seguem válidos nos módulos de render/ctx/widgets sem mudar
-// cada call site.
+// o egui só os CONSOME (lê e pinta).
 pub(crate) use rts_dom as dom;
 pub(crate) use rts_dom::block;
 pub(crate) use rts_dom::style;
@@ -44,335 +61,3 @@ pub(crate) use rts_dom::style;
 pub use app::*;
 pub use frame::*;
 pub use widgets::*;
-
-/// Helper de declaração de membro do namespace (mesmo shape do `io::func`).
-fn func(name: &str, symbol: &str, sig: Sig, ts: &str, doc: &str, fp: *const u8) -> Member {
-    Member {
-        name: name.to_string(),
-        kind: MemberKind::Function,
-        sig,
-        symbol: symbol.to_string(),
-        fn_ptr: FnPtr(fp),
-        flags: MemberFlags::NONE,
-        aliases: Vec::new(),
-        variadic: false,
-        ts_signature: ts.to_string(),
-        doc: doc.to_string(),
-        ret_class: None,
-        pure: false,
-        emit: None,
-    }
-}
-
-/// Registra o namespace `ui` no motor. Resolve via Registry (doutrina
-/// PRIMORDIAL-vs-Registry): o engine NUNCA nomeia `ui`.
-pub fn register(e: &mut Engine) {
-    // Registra o egui como o backend de render ATIVO do `rts-render`: a partir
-    // daqui, o namespace `render.*` (que o DOM/layout chama) despacha p/ o egui.
-    render_backend::register_backend();
-    e.ns("egui")
-        .doc("Immediate-mode GUI primitives (egui). TS drives the render loop.")
-        // ── Ciclo de vida da janela / loop (Modelo A — TS dirige) ──────────────
-        .member(func(
-            "openWindow",
-            "__RTS_FN_NS_EGUI_OPEN_WINDOW",
-            Sig::new(vec![AbiType::StrPtr, I64, I64, I64], U64),
-            "openWindow(title: string, w: number, h: number, config: number): number",
-            "Opens a window + render backend, returns an opaque UiCtx handle. `config` is a GPU bitfield (bit0 high-power, bit1 perf-memory, bit2 high-limits); 0 = RAM-optimized defaults.",
-            app::__RTS_FN_NS_EGUI_OPEN_WINDOW as *const u8,
-        ))
-        .member(func(
-            "pump",
-            "__RTS_FN_NS_EGUI_PUMP",
-            Sig::new(vec![U64], I64),
-            "pump(h: number): number",
-            "Pumps pending OS events (non-blocking). Returns 0=continue, !=0=exit.",
-            app::__RTS_FN_NS_EGUI_PUMP as *const u8,
-        ))
-        .member(func(
-            "isOpen",
-            "__RTS_FN_NS_EGUI_IS_OPEN",
-            Sig::new(vec![U64], I64),
-            "isOpen(h: number): boolean",
-            "Returns true while the window has not been closed.",
-            app::__RTS_FN_NS_EGUI_IS_OPEN as *const u8,
-        ))
-        .member(func(
-            "close",
-            "__RTS_FN_NS_EGUI_CLOSE",
-            Sig::new(vec![U64], AbiType::Void),
-            "close(h: number): void",
-            "Destroys the window and frees the UiCtx.",
-            app::__RTS_FN_NS_EGUI_CLOSE as *const u8,
-        ))
-        .member(func(
-            "moveWindow",
-            "__RTS_FN_NS_EGUI_MOVE_WINDOW",
-            Sig::new(vec![U64, I64, I64], AbiType::Void),
-            "moveWindow(h: number, x: number, y: number): void",
-            "Moves the window to absolute desktop position (x,y) in physical pixels — pick a monitor (e.g. x >= primary width = secondary screen).",
-            app::__RTS_FN_NS_EGUI_MOVE_WINDOW as *const u8,
-        ))
-        .member(func(
-            "setVsync",
-            "__RTS_FN_NS_EGUI_SET_VSYNC",
-            Sig::new(vec![U64, I64], AbiType::Void),
-            "setVsync(h: number, on: number): void",
-            "Runtime per-window vsync toggle. on!=0 = Fifo (the mandatory default); on==0 = explicit opt-out via AutoNoVsync (uncapped fps — the caller owns throttling/CPU burn). wgpu backend only.",
-            frame::__RTS_FN_NS_EGUI_SET_VSYNC as *const u8,
-        ))
-        .member(func(
-            "mouseLock",
-            "__RTS_FN_NS_EGUI_MOUSE_LOCK",
-            Sig::new(vec![U64, I64], AbiType::Void),
-            "mouseLock(h: number, on: number): void",
-            "FPS pointer-lock: on!=0 confines+hides the cursor and switches input.mouseDeltaX/Y to RAW device deltas (edge-immune); on==0 releases. Windows uses Confined+raw (winit has no Locked there).",
-            app::__RTS_FN_NS_EGUI_MOUSE_LOCK as *const u8,
-        ))
-        .member(func(
-            "setNextWindowPos",
-            "__RTS_FN_NS_EGUI_SET_NEXT_POS",
-            Sig::new(vec![I64, I64], AbiType::Void),
-            "setNextWindowPos(x: number, y: number): void",
-            "Sets the INITIAL position of the NEXT openWindow (physical px) — the window is born there. Call BEFORE openWindow; more reliable than moveWindow.",
-            app::__RTS_FN_NS_EGUI_SET_NEXT_POS as *const u8,
-        ))
-        // ── Teste visual headless ──────────────────────────────────────────────
-        .member(func(
-            "snapshot",
-            "__RTS_FN_NS_EGUI_SNAPSHOT",
-            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
-            "snapshot(h: number, path: string): void",
-            "Schedules a PPM snapshot of the next endFrame (glow backend only) — for headless visual assertions that the frame is not blank.",
-            frame::__RTS_FN_NS_EGUI_SNAPSHOT as *const u8,
-        ))
-        // ── Frame ──────────────────────────────────────────────────────────────
-        .member(func(
-            "beginFrame",
-            "__RTS_FN_NS_EGUI_BEGIN_FRAME",
-            Sig::new(vec![U64], AbiType::Void),
-            "beginFrame(h: number): void",
-            "Starts an egui pass: takes input and creates the root Ui.",
-            frame::__RTS_FN_NS_EGUI_BEGIN_FRAME as *const u8,
-        ))
-        .member(func(
-            "endFrame",
-            "__RTS_FN_NS_EGUI_END_FRAME",
-            Sig::new(vec![U64], AbiType::Void),
-            "endFrame(h: number): void",
-            "Ends the egui pass, tessellates and presents the frame.",
-            frame::__RTS_FN_NS_EGUI_END_FRAME as *const u8,
-        ))
-        // ── Widgets-folha (P1) ───────────────────────────────────────────────────
-        .member(func(
-            "label",
-            "__RTS_FN_NS_EGUI_LABEL",
-            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
-            "label(h: number, text: string): void",
-            "Emits a text label in the active frame.",
-            widgets::__RTS_FN_NS_EGUI_LABEL as *const u8,
-        ))
-        .member(func(
-            "button",
-            "__RTS_FN_NS_EGUI_BUTTON",
-            Sig::new(vec![U64, AbiType::StrPtr], I64),
-            "button(h: number, label: string): boolean",
-            "Emits a button; returns true if it was clicked this frame.",
-            widgets::__RTS_FN_NS_EGUI_BUTTON as *const u8,
-        ))
-        .member(func(
-            "slider",
-            "__RTS_FN_NS_EGUI_SLIDER",
-            Sig::new(vec![U64, F64, F64, F64], F64),
-            "slider(h: number, value: number, min: number, max: number): number",
-            "Emits a slider; returns the (possibly updated) value.",
-            widgets::__RTS_FN_NS_EGUI_SLIDER as *const u8,
-        ))
-        // ── Layout horizontal (widgets lado a lado) ────────────────────────────
-        .member(func(
-            "horizontalBegin",
-            "__RTS_FN_NS_EGUI_HORIZONTAL_BEGIN",
-            Sig::new(vec![U64], AbiType::Void),
-            "horizontalBegin(h: number): void",
-            "Opens a horizontal scope: widgets until horizontalEnd sit side by side.",
-            widgets::__RTS_FN_NS_EGUI_HORIZONTAL_BEGIN as *const u8,
-        ))
-        .member(func(
-            "horizontalEnd",
-            "__RTS_FN_NS_EGUI_HORIZONTAL_END",
-            Sig::new(vec![U64], AbiType::Void),
-            "horizontalEnd(h: number): void",
-            "Closes the most recent horizontal scope; widgets stack vertically again.",
-            widgets::__RTS_FN_NS_EGUI_HORIZONTAL_END as *const u8,
-        ))
-        // ── Render do DOM ──────────────────────────────────────────────────────
-        // `render(win, domHandle)`: RENDER GENÉRICO — pinta um DOM do `rts-dom`
-        // (headless, por handle) na janela. O egui só LÊ o DOM e desenha; não o
-        // detém. É o caminho desacoplado (o DOM vive no rts-dom; o egui é um
-        // consumidor trocável). `html(win, string)` é o caminho LEGACY (egui
-        // parseia e detém o próprio DOM) — mantido por compat.
-        .member(func(
-            "render",
-            "__RTS_FN_NS_EGUI_RENDER",
-            Sig::new(vec![U64, U64], AbiType::Void),
-            "render(win: number, domHandle: number): void",
-            "Paints a rts-dom DOM (by handle) into the window — egui only reads the DOM and draws; the DOM lives in rts-dom (headless). Inverts the dependency: any backend consumes the same domHandle.",
-            widgets::__RTS_FN_NS_EGUI_RENDER as *const u8,
-        ))
-        .member(func(
-            "html",
-            "__RTS_FN_NS_EGUI_HTML",
-            Sig::new(vec![U64, AbiType::StrPtr], AbiType::Void),
-            "html(h: number, html: string): void",
-            "LEGACY: parses an HTML string and emits widgets (egui owns the DOM). Prefer `render(win, domHandle)` with a rts-dom DOM (headless, decoupled).",
-            widgets::__RTS_FN_NS_EGUI_HTML as *const u8,
-        ))
-        // ── DOM/estilo: REMOVIDOS do namespace egui (extração headless) ─────────
-        // defineBlock/defineStyle/defineInline + querySelector/setText/setAttr/
-        // createElement/appendChild/removeNode/domDump migraram 100% para o
-        // namespace `dom` (rts-dom). O egui é RENDER GENÉRICO: só LÊ o DOM e pinta
-        // (via `egui.html` / `egui.render`), nunca detém estado de página. Isso
-        // INVERTE a dependência — o DOM não conhece o render; qualquer backend
-        // (egui hoje; web/headless-png amanhã) consome o mesmo DOM. Ver
-        // docs/ui/html-engine + project_dom_headless_vision.
-        // ── CANVAS BURRO: o TS calcula o layout e emite primitivos; o egui pinta ──
-        // Coords/tamanhos em pontos (number); cores 0xRRGGBBAA (number).
-        .member(func(
-            "drawRect",
-            "__RTS_FN_NS_EGUI_DRAW_RECT",
-            Sig::new(vec![U64, F64, F64, F64, F64, I64, F64, I64, F64], AbiType::Void),
-            "drawRect(h: number, x: number, y: number, w: number, h_: number, fill: number, strokeW: number, stroke: number, radius: number): void",
-            "Dumb-canvas filled rect + optional border at absolute coords. Colors 0xRRGGBBAA. The TS layout engine positions it; egui only paints.",
-            canvas::__RTS_FN_NS_EGUI_DRAW_RECT as *const u8,
-        ))
-        .member(func(
-            "drawText",
-            "__RTS_FN_NS_EGUI_DRAW_TEXT",
-            Sig::new(vec![U64, F64, F64, AbiType::StrPtr, I64, F64, I64], AbiType::Void),
-            "drawText(h: number, x: number, y: number, text: string, color: number, size: number, flags: number): void",
-            "Dumb-canvas text at absolute (x,y) top-left. flags bitmask 1=bold 2=italic 4=mono. Color 0xRRGGBBAA.",
-            canvas::__RTS_FN_NS_EGUI_DRAW_TEXT as *const u8,
-        ))
-        .member(func(
-            "drawLine",
-            "__RTS_FN_NS_EGUI_DRAW_LINE",
-            Sig::new(vec![U64, F64, F64, F64, F64, F64, I64], AbiType::Void),
-            "drawLine(h: number, x1: number, y1: number, x2: number, y2: number, w: number, color: number): void",
-            "Dumb-canvas line at absolute coords. Color 0xRRGGBBAA.",
-            canvas::__RTS_FN_NS_EGUI_DRAW_LINE as *const u8,
-        ))
-        .member(func(
-            "measureText",
-            "__RTS_FN_NS_EGUI_MEASURE_TEXT",
-            Sig::new(vec![U64, AbiType::StrPtr, F64, I64], F64),
-            "measureText(h: number, text: string, size: number, bold: number): number",
-            "Width (points) of a text in the real font — the ONLY layout-aware op left in egui (TS can't measure text without the font). Synchronous.",
-            canvas::__RTS_FN_NS_EGUI_MEASURE_TEXT as *const u8,
-        ))
-        // ── Pipeline 3D wgpu (scene pass) — só-wgpu; glow no-op ─────────────────
-        .member(func(
-            "meshUpload",
-            "__RTS_FN_NS_EGUI_MESH_UPLOAD",
-            Sig::new(vec![U64, U64, I64, U64, I64], U64),
-            "meshUpload(h: number, vertsPtr: number, vertexCount: number, indicesPtr: number, indexCount: number): number",
-            "Uploads a mesh to GPU (verts = interleaved pos+normal, 6 floats/vertex at vertsPtr; indices = u32 at indicesPtr). Returns a mesh id. GPU 3D scene pass, drawn before the egui UI.",
-            scene_api::__RTS_FN_NS_EGUI_MESH_UPLOAD as *const u8,
-        ))
-        .member(func(
-            "meshFree",
-            "__RTS_FN_NS_EGUI_MESH_FREE",
-            Sig::new(vec![U64, U64], AbiType::Void),
-            "meshFree(h: number, meshId: number): void",
-            "Frees a mesh uploaded with meshUpload.",
-            scene_api::__RTS_FN_NS_EGUI_MESH_FREE as *const u8,
-        ))
-        .member(func(
-            "setCamera",
-            "__RTS_FN_NS_EGUI_SET_CAMERA",
-            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
-            "setCamera(h: number, camX: number, camY: number, camZ: number, yaw: number, pitch: number, fovY: number, aspect: number): void",
-            "Sets the 3D camera for this frame (fly cam: position + yaw/pitch + vertical FOV + aspect). Builds the view-projection.",
-            scene_api::__RTS_FN_NS_EGUI_SET_CAMERA as *const u8,
-        ))
-        .member(func(
-            "setCameraLookAt",
-            "__RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT",
-            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
-            "setCameraLookAt(h: number, eyeX: number, eyeY: number, eyeZ: number, targetX: number, targetY: number, targetZ: number, fovY: number, aspect: number, near: number, far: number): void",
-            "Sets the 3D camera as a NaN-safe look-at (eye position looking at a target, up = +Y) with explicit near/far. More convenient than yaw/pitch for framing an object; degrades gracefully when looking straight up/down instead of gimbal-locking.",
-            scene_api::__RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT as *const u8,
-        ))
-        .member(func(
-            "setClearColor",
-            "__RTS_FN_NS_EGUI_SET_CLEAR_COLOR",
-            Sig::new(vec![U64, F64, F64, F64], AbiType::Void),
-            "setClearColor(h: number, r: number, g: number, b: number): void",
-            "Sets a FLAT background color (r,g,b in 0..1) for the 3D scene pass, disabling the procedural skybox. Ideal for an editor viewport that wants a neutral background instead of the starfield.",
-            scene_api::__RTS_FN_NS_EGUI_SET_CLEAR_COLOR as *const u8,
-        ))
-        .member(func(
-            "setSkybox",
-            "__RTS_FN_NS_EGUI_SET_SKYBOX",
-            Sig::new(vec![U64, I64], AbiType::Void),
-            "setSkybox(h: number, on: number): void",
-            "Re-enables the procedural skybox (on!=0), undoing a previous setClearColor.",
-            scene_api::__RTS_FN_NS_EGUI_SET_SKYBOX as *const u8,
-        ))
-        .member(func(
-            "setLight",
-            "__RTS_FN_NS_EGUI_SET_LIGHT",
-            Sig::new(vec![U64, F64, F64, F64, F64], AbiType::Void),
-            "setLight(h: number, dirX: number, dirY: number, dirZ: number, ambient: number): void",
-            "Sets the directional light (direction + ambient 0..1) for the 3D scene pass.",
-            scene_api::__RTS_FN_NS_EGUI_SET_LIGHT as *const u8,
-        ))
-        .member(func(
-            "winWidth",
-            "__RTS_FN_NS_EGUI_WIN_WIDTH",
-            Sig::new(vec![U64], F64),
-            "winWidth(h: number): number",
-            "Current LOGICAL width (points) of the window — follows resize.",
-            scene_api::__RTS_FN_NS_EGUI_WIN_WIDTH as *const u8,
-        ))
-        .member(func(
-            "winHeight",
-            "__RTS_FN_NS_EGUI_WIN_HEIGHT",
-            Sig::new(vec![U64], F64),
-            "winHeight(h: number): number",
-            "Current LOGICAL height (points) of the window — follows resize.",
-            scene_api::__RTS_FN_NS_EGUI_WIN_HEIGHT as *const u8,
-        ))
-        .member(func(
-            "setShadow",
-            "__RTS_FN_NS_EGUI_SET_SHADOW",
-            Sig::new(vec![U64, F64, F64, F64, F64, F64, F64, F64], AbiType::Void),
-            "setShadow(h: number, dirX: number, dirY: number, dirZ: number, cX: number, cY: number, cZ: number, radius: number): void",
-            "Configures the directional shadow map: light travel direction (dirX/Y/Z), the center and radius of the orthographic box the shadows cover. radius<=0 disables shadows.",
-            scene_api::__RTS_FN_NS_EGUI_SET_SHADOW as *const u8,
-        ))
-        .member(func(
-            "textureUpload",
-            "__RTS_FN_NS_EGUI_TEXTURE_UPLOAD",
-            Sig::new(vec![U64, U64, I64, I64], U64),
-            "textureUpload(h: number, pixelsPtr: number, w: number, h2: number): number",
-            "Uploads an RGBA8 image (pixelsPtr -> w*h*4 bytes, sRGB) to VRAM and returns a texture id (>=2) for drawMesh(..., tex=id). Typical flow: fs reads the file, imgdec.decode gives RGBA + w/h, this uploads to GPU. Sampled triplanar (world-space) in the 3D pass. 0 if invalid / non-wgpu window.",
-            scene_api::__RTS_FN_NS_EGUI_TEXTURE_UPLOAD as *const u8,
-        ))
-        .member(func(
-            "drawMesh",
-            "__RTS_FN_NS_EGUI_DRAW_MESH",
-            Sig::new(vec![U64, U64, F64, F64, F64, F64, F64, F64, F64, F64, I64, I64, I64], AbiType::Void),
-            "drawMesh(h: number, meshId: number, px: number, py: number, pz: number, rx: number, ry: number, sx: number, sy: number, sz: number, color: number, emissive: number, tex: number): void",
-            "Queues a 3D draw of meshId with a transform (pos/rot euler/scale), color 0xAARRGGBB, emissive flag (0/1), and procedural texture (0=none, 1=world-space checker). Rendered in the scene pass at endFrame. Light is a POINT light at setLight's position; shadows via setShadow.",
-            scene_api::__RTS_FN_NS_EGUI_DRAW_MESH as *const u8,
-        ))
-        .member(func(
-            "drawWater",
-            "__RTS_FN_NS_EGUI_DRAW_WATER",
-            Sig::new(vec![U64, U64, U64, I64, F64], I64),
-            "drawWater(h: number, meshId: number, gbuf: number, count: number, scale: number): number",
-            "Instanced water: draws `count` instances of meshId reading each instance (vec4 f32: xyz center, w signed density; w<0 = culled shell) DIRECTLY from the rts:gpu buffer `gbuf` — zero readback, one draw call. `scale` is the particle draw radius. 1 ok, 0 invalid buffer/window.",
-            scene_api::__RTS_FN_NS_EGUI_DRAW_WATER as *const u8,
-        ))
-        .done();
-}

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -58,6 +58,9 @@ pub(crate) use rts_dom as dom;
 pub(crate) use rts_dom::block;
 pub(crate) use rts_dom::style;
 
+// A API pura, num só lugar: é assim que um motor a alcança (ver o doc acima).
 pub use app::*;
+pub use canvas::*;
 pub use frame::*;
+pub use scene_api::*;
 pub use widgets::*;

--- a/crates/rts-egui/src/pixels.rs
+++ b/crates/rts-egui/src/pixels.rs
@@ -1,0 +1,37 @@
+//! De onde os bytes de uma imagem vêm — perguntado, nunca sabido.
+//!
+//! O render pinta `DisplayItem::Image` a partir de um *handle* de buffer mais um
+//! deslocamento. Quem sabe o que aquele handle significa é o MOTOR, e existem
+//! dois: o antigo guarda um `Entry::Buffer` no `HandleTable`, o novo guarda uma
+//! `View` sobre uma célula da região. Nomear qualquer um dos dois aqui prenderia
+//! o crate de render a um deles — que é exatamente o acoplamento que este porte
+//! existe para desfazer.
+//!
+//! Então o render pergunta, e quem instalou a fonte responde. `None` enquanto
+//! ninguém instalou uma: uma imagem que não pinta é o resultado honesto de um
+//! host que não disse de onde ler os pixels, e é preferível a um crate de render
+//! que só compila junto com um motor específico.
+
+use std::cell::Cell;
+
+/// Como se lê `len` bytes a partir de `offset` dentro do buffer que `handle`
+/// nomeia. `None` quando o handle não existe ou o intervalo não cabe.
+pub type PixelSource = fn(handle: u64, offset: u64, len: usize) -> Option<Vec<u8>>;
+
+thread_local! {
+    /// A fonte instalada nesta thread — a mesma onde o `UiCtx` vive, porque o
+    /// contexto do motor novo também é por thread e uma fonte global mentiria
+    /// sobre qual heap está sendo lido.
+    static SOURCE: Cell<Option<PixelSource>> = const { Cell::new(None) };
+}
+
+/// Instala a fonte de pixels desta thread.
+pub fn set_source(source: PixelSource) {
+    SOURCE.with(|slot| slot.set(Some(source)));
+}
+
+/// Os bytes que o render precisa, se alguém souber respondê-los.
+pub fn fetch(handle: u64, offset: u64, len: usize) -> Option<Vec<u8>> {
+    let source = SOURCE.with(|slot| slot.get())?;
+    source(handle, offset, len)
+}

--- a/crates/rts-egui/src/render_backend.rs
+++ b/crates/rts-egui/src/render_backend.rs
@@ -18,7 +18,7 @@ pub struct EguiRenderer;
 
 impl Renderer for EguiRenderer {
     fn begin_frame(&self, target: u64) {
-        crate::frame::__RTS_FN_NS_EGUI_BEGIN_FRAME(target);
+        crate::frame::begin_frame(target);
     }
 
     fn rect(
@@ -96,7 +96,7 @@ impl Renderer for EguiRenderer {
     }
 
     fn end_frame(&self, target: u64) {
-        crate::frame::__RTS_FN_NS_EGUI_END_FRAME(target);
+        crate::frame::end_frame(target);
     }
 }
 

--- a/crates/rts-egui/src/scene_api.rs
+++ b/crates/rts-egui/src/scene_api.rs
@@ -29,19 +29,31 @@ fn with_scene<R: Copy>(win: u64, f: impl FnOnce(&mut Scene3D, &wgpu::Device) -> 
 
 /// Sobe uma mesh (verts interleaved pos+normal+uv = 8 f32/vértice; índices u32)
 /// pra VRAM. Retorna o id da mesh (0 se a janela não é wgpu).
-pub fn mesh_upload(
-    win: u64,
-    vptr: u64,
-    vcount: i64,
-    iptr: u64,
-    icount: i64,
-) -> u64 {
+/// # Segurança
+///
+/// `vptr`/`iptr` são endereços crus que o chamador promete apontarem para
+/// `vcount*8` `f32` e `icount` `u32` vivos. É a forma que a ABI do motor antigo
+/// tem; um chamador que possa passar fatias deve preferir [`upload_mesh`], que
+/// não promete nada.
+pub unsafe fn mesh_upload(win: u64, vptr: u64, vcount: i64, iptr: u64, icount: i64) -> u64 {
     if vptr == 0 || iptr == 0 || vcount <= 0 || icount <= 0 {
         return 0;
     }
     let verts = unsafe { std::slice::from_raw_parts(vptr as *const f32, (vcount * 8) as usize) };
     let inds = unsafe { std::slice::from_raw_parts(iptr as *const u32, icount as usize) };
-    with_scene(win, |s, dev| s.upload_mesh(dev, verts, inds), 0)
+    upload_mesh(win, verts, inds)
+}
+
+/// Sobe uma mesh a partir de fatias — a forma sem promessa nenhuma.
+///
+/// Existe porque o motor NOVO entrega os dados como uma view tipada, cujos bytes
+/// são copiados na fronteira: não há endereço para o chamador acertar, e o
+/// coletor pode mover a célula sem que isto veja. Ver `rts-ui-rwk::value::bytes`.
+pub fn upload_mesh(win: u64, verts: &[f32], indices: &[u32]) -> u64 {
+    if verts.is_empty() || indices.is_empty() {
+        return 0;
+    }
+    with_scene(win, |s, dev| s.upload_mesh(dev, verts, indices), 0)
 }
 
 /// Libera uma mesh da VRAM.
@@ -220,12 +232,29 @@ pub fn draw_water(win: u64, mesh: u64, gbuf: u64, count: i64, scale: f64) -> i64
 /// Sobe uma imagem RGBA8 (`ptr` → w*h*4 bytes, sRGB) pra VRAM e devolve um id de
 /// textura (>=2) usável em `drawMesh(..., tex=id)`. Fluxo típico: `fs` lê o arquivo,
 /// `imgdec.decode` devolve RGBA + w/h, e isto sobe pra GPU. 0 se inválido/não-wgpu.
-pub fn texture_upload(win: u64, ptr: u64, w: i64, h: i64) -> u64 {
+/// # Segurança
+///
+/// `ptr` aponta para `w*h*4` bytes vivos — a promessa que a ABI antiga exige.
+/// [`upload_texture`] é a forma que não exige nenhuma.
+pub unsafe fn texture_upload(win: u64, ptr: u64, w: i64, h: i64) -> u64 {
     if ptr == 0 || w <= 0 || h <= 0 {
         return 0;
     }
+    let rgba = unsafe {
+        std::slice::from_raw_parts(ptr as *const u8, (w as usize) * (h as usize) * 4)
+    };
+    upload_texture(win, rgba, w, h)
+}
+
+/// Sobe uma imagem RGBA8 a partir de uma fatia. Ver [`upload_mesh`].
+pub fn upload_texture(win: u64, rgba: &[u8], w: i64, h: i64) -> u64 {
+    if w <= 0 || h <= 0 {
+        return 0;
+    }
     let (w, h) = (w as u32, h as u32);
-    let rgba = unsafe { std::slice::from_raw_parts(ptr as *const u8, (w as usize) * (h as usize) * 4) };
+    if rgba.len() < (w as usize) * (h as usize) * 4 {
+        return 0;
+    }
     with_ctx(win, |c| {
         if let Backend::Wgpu(r) = &mut c.backend {
             if r.scene.is_none() {

--- a/crates/rts-egui/src/scene_api.rs
+++ b/crates/rts-egui/src/scene_api.rs
@@ -29,8 +29,7 @@ fn with_scene<R: Copy>(win: u64, f: impl FnOnce(&mut Scene3D, &wgpu::Device) -> 
 
 /// Sobe uma mesh (verts interleaved pos+normal+uv = 8 f32/vértice; índices u32)
 /// pra VRAM. Retorna o id da mesh (0 se a janela não é wgpu).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_MESH_UPLOAD(
+pub fn mesh_upload(
     win: u64,
     vptr: u64,
     vcount: i64,
@@ -46,14 +45,13 @@ pub extern "C" fn __RTS_FN_NS_EGUI_MESH_UPLOAD(
 }
 
 /// Libera uma mesh da VRAM.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_MESH_FREE(win: u64, mesh: u64) {
+pub fn mesh_free(win: u64, mesh: u64) {
     with_scene(win, |s, _d| s.free_mesh(mesh), ());
 }
 
 /// Define a câmera do frame (fly: yaw/pitch/fov/aspect). Constrói view·proj.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA(
+#[allow(clippy::too_many_arguments)]
+pub fn set_camera(
     win: u64,
     camx: f64,
     camy: f64,
@@ -72,8 +70,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA(
 /// Câmera LOOK-AT (olho→alvo) com `near`/`far` explícitos — NaN-safe (não trava
 /// no gimbal ao olhar reto pra cima/baixo). Mais conveniente que yaw/pitch pro
 /// "frame selected" do editor. Enxertado do gpu3d (origin/main), adaptado à base LH.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT(
+#[allow(clippy::too_many_arguments)]
+pub fn set_camera_lookat(
     win: u64,
     ex: f64,
     ey: f64,
@@ -99,20 +97,17 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_CAMERA_LOOKAT(
 
 /// Fundo CHAPADO do scene pass (r,g,b em 0..1) — desliga o skybox procedural.
 /// Ideal pro viewport do editor, que quer um fundo neutro em vez do starfield.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_CLEAR_COLOR(win: u64, r: f64, g: f64, b: f64) {
+pub fn set_clear_color(win: u64, r: f64, g: f64, b: f64) {
     with_scene(win, |s, _d| s.set_clear_color([r as f32, g as f32, b as f32, 1.0]), ());
 }
 
 /// Religa o skybox procedural (`on!=0`) desfazendo um `setClearColor`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_SKYBOX(win: u64, on: i64) {
+pub fn set_skybox(win: u64, on: i64) {
     with_scene(win, |s, _d| s.set_skybox(on != 0), ());
 }
 
 /// Define a luz direcional (dir + ambiente).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_LIGHT(win: u64, dx: f64, dy: f64, dz: f64, ambient: f64) {
+pub fn set_light(win: u64, dx: f64, dy: f64, dz: f64, ambient: f64) {
     with_scene(
         win,
         |s, _d| s.set_light([dx as f32, dy as f32, dz as f32], ambient as f32),
@@ -121,8 +116,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_LIGHT(win: u64, dx: f64, dy: f64, dz: f64
 }
 
 /// Largura LÓGICA (points) atual da janela — segue o resize. 0 se não existe.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_WIN_WIDTH(win: u64) -> f64 {
+pub fn win_width(win: u64) -> f64 {
     crate::ctx::with_ctx(win, |c| {
         let s = c.window.inner_size();
         let sf = c.window.scale_factor();
@@ -132,8 +126,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_WIN_WIDTH(win: u64) -> f64 {
 }
 
 /// Altura LÓGICA (points) atual da janela — segue o resize. 0 se não existe.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_WIN_HEIGHT(win: u64) -> f64 {
+pub fn win_height(win: u64) -> f64 {
     crate::ctx::with_ctx(win, |c| {
         let s = c.window.inner_size();
         let sf = c.window.scale_factor();
@@ -144,8 +137,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_WIN_HEIGHT(win: u64) -> f64 {
 
 /// Configura o shadow map: direção da luz (dx,dy,dz = para onde a luz viaja) +
 /// centro (cx,cy,cz) e raio da caixa que a sombra cobre. radius<=0 desliga.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_SHADOW(
+#[allow(clippy::too_many_arguments)]
+pub fn set_shadow(
     win: u64,
     dx: f64,
     dy: f64,
@@ -165,8 +158,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_SHADOW(
 /// Enfileira 1 draw da mesh `mesh` com transform (pos/rot/escala) + cor
 /// (0xAARRGGBB) + emissivo (0/1) + textura procedural (0=nenhuma, 1=xadrez).
 /// O draw acontece no scene pass, no `endFrame`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_MESH(
+#[allow(clippy::too_many_arguments)]
+pub fn draw_mesh(
     win: u64,
     mesh: u64,
     px: f64,
@@ -201,14 +194,13 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_MESH(
 /// instância (vec4 f32: xyz centro, w densidade assinada) DIRETO do buffer
 /// `gbuf` do rts:gpu — zero readback, zero FFI por partícula, 1 draw call.
 /// `scale` = raio de desenho. 1 ok, 0 = buffer/janela inválidos.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_WATER(
-    win: u64,
-    mesh: u64,
-    gbuf: u64,
-    count: i64,
-    scale: f64,
-) -> i64 {
+///
+/// Só existe com `old-engine`: `gbuf` é um handle do `rts:gpu`, cujos buffers
+/// vivem no `HandleTable` do motor antigo. Sem ele não há de onde ler as
+/// instâncias — e devolver 0 caladamente seria uma água que não aparece sem
+/// dizer por quê.
+#[cfg(feature = "old-engine")]
+pub fn draw_water(win: u64, mesh: u64, gbuf: u64, count: i64, scale: f64) -> i64 {
     if count <= 0 {
         return 0;
     }
@@ -228,8 +220,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DRAW_WATER(
 /// Sobe uma imagem RGBA8 (`ptr` → w*h*4 bytes, sRGB) pra VRAM e devolve um id de
 /// textura (>=2) usável em `drawMesh(..., tex=id)`. Fluxo típico: `fs` lê o arquivo,
 /// `imgdec.decode` devolve RGBA + w/h, e isto sobe pra GPU. 0 se inválido/não-wgpu.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_TEXTURE_UPLOAD(win: u64, ptr: u64, w: i64, h: i64) -> u64 {
+pub fn texture_upload(win: u64, ptr: u64, w: i64, h: i64) -> u64 {
     if ptr == 0 || w <= 0 || h <= 0 {
         return 0;
     }

--- a/crates/rts-egui/src/widgets.rs
+++ b/crates/rts-egui/src/widgets.rs
@@ -12,16 +12,11 @@
 //! (sem latência) fica para uma fase seguinte, quando o lifetime do `egui::Ui`
 //! for resolvido (provavelmente com o Modelo B / callback de frame).
 
-use rts_engine::abi::str_abi;
-
 use crate::ctx::{self, WidgetCmd};
 
 /// Emite um label de texto no frame ativo (enfileira).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_LABEL(h: u64, text_ptr: *const u8, text_len: i64) {
-    let text = unsafe { str_abi::from_abi(text_ptr, text_len) }
-        .unwrap_or("")
-        .to_string();
+pub fn label(h: u64, text: &str) {
+    let text = text.to_string();
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             c.cmds.push(WidgetCmd::Label(text));
@@ -31,11 +26,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_LABEL(h: u64, text_ptr: *const u8, text_len: 
 
 /// Emite um botão (enfileira). Retorna 1 se foi clicado no frame ANTERIOR, 0 se
 /// não — ou 0 fora de um frame / handle inválido.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_BUTTON(h: u64, label_ptr: *const u8, label_len: i64) -> i64 {
-    let label = unsafe { str_abi::from_abi(label_ptr, label_len) }
-        .unwrap_or("")
-        .to_string();
+pub fn button(h: u64, label: &str) -> i64 {
+    let label = label.to_string();
     ctx::with_ctx(h, |c| {
         if !c.frame_active {
             return 0;
@@ -55,8 +47,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_BUTTON(h: u64, label_ptr: *const u8, label_le
 
 /// Emite um slider (enfileira). Retorna o valor (possivelmente arrastado) do
 /// frame ANTERIOR; no primeiro frame retorna o `value` passado.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SLIDER(h: u64, value: f64, min: f64, max: f64) -> f64 {
+pub fn slider(h: u64, value: f64, min: f64, max: f64) -> f64 {
     ctx::with_ctx(h, |c| {
         if !c.frame_active {
             return value;
@@ -75,8 +66,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SLIDER(h: u64, value: f64, min: f64, max: f64
 /// um comando na fila — o layout real é feito na drenagem do `endFrame`, que
 /// abre um `ui.horizontal(...)` ao encontrar este comando. Como label/button,
 /// não retorna nada e não mexe nos cursores de resultado.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_BEGIN(h: u64) {
+pub fn horizontal_begin(h: u64) {
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             c.cmds.push(WidgetCmd::HorizontalBegin);
@@ -87,8 +77,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_BEGIN(h: u64) {
 /// Fecha o escopo horizontal aberto pelo `horizontalBegin` mais recente
 /// (enfileira). Volta a empilhar verticalmente. Igual ao `horizontalBegin`:
 /// só empilha o comando; a drenagem do `endFrame` fecha o `ui.horizontal(...)`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_END(h: u64) {
+pub fn horizontal_end(h: u64) {
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             c.cmds.push(WidgetCmd::HorizontalEnd);
@@ -101,12 +90,10 @@ pub extern "C" fn __RTS_FN_NS_EGUI_HORIZONTAL_END(h: u64) {
 /// O render percorre essa árvore no `endFrame` (`frame::render_dom`). Suporta
 /// `h1`/`h2`/`h3`, `p`/`div`, `b`/`strong`, `i`/`em`, tags desconhecidas
 /// (transparentes) e texto solto.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_HTML(h: u64, ptr: *const u8, len: i64) {
-    // Hash sobre o `&str` da ABI — SEM alocar. O `.to_string()` (parse) só
-    // acontece DENTRO do `if` que de fato re-parseia; no caso comum (loop chamando
+pub fn html(h: u64, html: &str) {
+    // Hash sobre o `&str` — SEM alocar. O `.to_string()` (parse) só acontece
+    // DENTRO do `if` que de fato re-parseia; no caso comum (loop chamando
     // `html()` com a mesma string todo frame) o caminho é hash + compare, zero alloc.
-    let html = unsafe { str_abi::from_abi(ptr, len) }.unwrap_or("");
     let hash = html_hash(html);
     ctx::with_ctx(h, |c| {
         if c.frame_active {
@@ -130,8 +117,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_HTML(h: u64, ptr: *const u8, len: i64) {
 /// o lê e desenha. É o caminho headless-puro (vs `html`, que parseia uma string e
 /// guarda o próprio DOM): o DOM vive 100% no rts-dom; o egui é um consumidor
 /// trocável. Só enfileira o marcador; o render lê o store no `endFrame`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_RENDER(h: u64, dom_handle: u64) {
+pub fn render(h: u64, dom_handle: u64) {
     ctx::with_ctx(h, |c| {
         if c.frame_active {
             c.cmds.push(WidgetCmd::HtmlHandle(dom_handle));
@@ -154,16 +140,7 @@ fn html_hash(s: &str) -> u64 {
 /// `display` 0=vertical 1=wrap 2=horizontal 3=grid; `indent` recuo em pontos (ou
 /// tamanho de fonte quando `flags` tem HEADING); `prefix` 0=none 1=bullet
 /// 2=number; `flags` bitmask MONO=1|PRESERVE_WS=2|HEADING=4. Independe de janela.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_BLOCK(
-    tag_ptr: *const u8,
-    tag_len: i64,
-    display: i64,
-    indent: f64,
-    prefix: i64,
-    flags: i64,
-) {
-    let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("");
+pub fn define_block(tag: &str, display: i64, indent: f64, prefix: i64, flags: i64) {
     if tag.is_empty() {
         return;
     }
@@ -183,14 +160,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_BLOCK(
 /// nome-CSS→índice, o Rust nunca casa string CSS. `val`: cor/bg = `u32` RGBA
 /// (`0xRRGGBBAA`); font_size = pontos. Acumula por tag (slots diferentes somam).
 /// Independe de janela (igual `defineBlock`).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_STYLE(
-    tag_ptr: *const u8,
-    tag_len: i64,
-    slot: i64,
-    val: i64,
-) {
-    let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("");
+pub fn define_style(tag: &str, slot: i64, val: i64) {
     if tag.is_empty() {
         return;
     }
@@ -206,9 +176,7 @@ const NODE_NONE: i64 = -1;
 
 /// `querySelector`: primeiro nó que casa com um seletor simples (`tag`, `#id`,
 /// `.classe`) no DOM retido da janela. Retorna o `NodeId` (`i64` ≥ 0) ou `-1`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_QUERY_SELECTOR(h: u64, sel_ptr: *const u8, sel_len: i64) -> i64 {
-    let sel = unsafe { str_abi::from_abi(sel_ptr, sel_len) }.unwrap_or("");
+pub fn query_selector(h: u64, sel: &str) -> i64 {
     ctx::with_ctx(h, |c| match &c.dom {
         Some(dom) => dom.query(sel).map(|id| id.to_abi()).unwrap_or(NODE_NONE),
         None => NODE_NONE,
@@ -218,10 +186,9 @@ pub extern "C" fn __RTS_FN_NS_EGUI_QUERY_SELECTOR(h: u64, sel_ptr: *const u8, se
 
 /// `element.textContent = txt`: substitui o conteúdo do nó por um texto. `id` é o
 /// `NodeId` VERSIONADO (i64) — um id de árvore velha é validado-fora pelo `gen`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_TEXT(h: u64, id: i64, ptr: *const u8, len: i64) {
+pub fn set_text(h: u64, id: i64, txt: &str) {
     let Some(node) = crate::dom::NodeId::from_abi(id) else { return };
-    let txt = unsafe { str_abi::from_abi(ptr, len) }.unwrap_or("").to_string();
+    let txt = txt.to_string();
     ctx::with_ctx(h, |c| {
         if let Some(dom) = c.dom.as_mut() {
             dom.set_text(node, &txt);
@@ -230,18 +197,10 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_TEXT(h: u64, id: i64, ptr: *const u8, len
 }
 
 /// `element.setAttribute(name, value)`. `id` = `NodeId` versionado (i64).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_SET_ATTR(
-    h: u64,
-    id: i64,
-    name_ptr: *const u8,
-    name_len: i64,
-    val_ptr: *const u8,
-    val_len: i64,
-) {
+pub fn set_attr(h: u64, id: i64, name: &str, val: &str) {
     let Some(node) = crate::dom::NodeId::from_abi(id) else { return };
-    let name = unsafe { str_abi::from_abi(name_ptr, name_len) }.unwrap_or("").to_string();
-    let val = unsafe { str_abi::from_abi(val_ptr, val_len) }.unwrap_or("").to_string();
+    let name = name.to_string();
+    let val = val.to_string();
     ctx::with_ctx(h, |c| {
         if let Some(dom) = c.dom.as_mut() {
             dom.set_attr(node, &name, &val);
@@ -251,9 +210,8 @@ pub extern "C" fn __RTS_FN_NS_EGUI_SET_ATTR(
 
 /// `document.createElement(tag)`: cria um elemento solto; retorna seu `NodeId`
 /// versionado (`i64` ≥ 0), ou `-1` se não houver DOM na janela.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_CREATE_ELEMENT(h: u64, tag_ptr: *const u8, tag_len: i64) -> i64 {
-    let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("").to_string();
+pub fn create_element(h: u64, tag: &str) -> i64 {
+    let tag = tag.to_string();
     ctx::with_ctx(h, |c| match c.dom.as_mut() {
         Some(dom) => dom.create_element(&tag).to_abi(),
         None => NODE_NONE,
@@ -263,8 +221,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_CREATE_ELEMENT(h: u64, tag_ptr: *const u8, ta
 
 /// `parent.appendChild(child)`: move `child` para o fim dos filhos de `parent`.
 /// `parent`/`child` = `NodeId` versionados (i64).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_APPEND_CHILD(h: u64, parent: i64, child: i64) {
+pub fn append_child(h: u64, parent: i64, child: i64) {
     let (Some(parent), Some(child)) =
         (crate::dom::NodeId::from_abi(parent), crate::dom::NodeId::from_abi(child))
     else {
@@ -278,8 +235,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_APPEND_CHILD(h: u64, parent: i64, child: i64)
 }
 
 /// `element.remove()`: desliga o nó do pai. `id` = `NodeId` versionado (i64).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_REMOVE_NODE(h: u64, id: i64) {
+pub fn remove_node(h: u64, id: i64) {
     let Some(node) = crate::dom::NodeId::from_abi(id) else { return };
     ctx::with_ctx(h, |c| {
         if let Some(dom) = c.dom.as_mut() {
@@ -292,9 +248,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_REMOVE_NODE(h: u64, id: i64) {
 /// dinâmico: `flags` é o bitmask BOLD=8|ITALIC=16|MONO=1. Uma tag inline só liga
 /// bits de estilo e desce nos filhos (transparente). Mantém o Rust sem nome de
 /// tag. Independe de janela. Ver `crate::block`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_INLINE(tag_ptr: *const u8, tag_len: i64, flags: i64) {
-    let tag = unsafe { str_abi::from_abi(tag_ptr, tag_len) }.unwrap_or("");
+pub fn define_inline(tag: &str, flags: i64) {
     if tag.is_empty() {
         return;
     }
@@ -307,8 +261,7 @@ pub extern "C" fn __RTS_FN_NS_EGUI_DEFINE_INLINE(tag_ptr: *const u8, tag_len: i6
 ///
 /// Não retorna a string (a ABI proíbe `StrPtr` de retorno e o egui não acessa o
 /// pool de strings GC); imprimir no stderr é o caminho direto e sem dependências.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_EGUI_DOM_DUMP(h: u64) {
+pub fn dom_dump(h: u64) {
     ctx::with_ctx(h, |c| match &c.dom {
         Some(dom) => eprint!("{}", dom.dump()),
         None => eprintln!("(sem DOM: nenhum html() chamado nesta janela ainda)"),

--- a/crates/rts-host-rwk/Cargo.toml
+++ b/crates/rts-host-rwk/Cargo.toml
@@ -29,3 +29,12 @@ rts-cranelift = { path = "../rts-cranelift" }
 rts-core-rwk = { path = "../rts-core-rwk" }
 rts-std-rwk = { path = "../rts-std-rwk" }
 rts-node-rwk = { path = "../rts-node-rwk" }
+# A UI: `rts:egui` e `rts:input`. Opcional porque uma janela é uma questão de
+# DISPONIBILIDADE — não existe em wasm nem num build headless — e um alvo sem
+# ela não deve carregar wgpu/winit no grafo para descobrir isso.
+rts-ui-rwk = { path = "../rts-ui-rwk", optional = true }
+
+[features]
+default = ["ui"]
+# `rts:egui` e `rts:input`. Ver a nota no dep.
+ui = ["dep:rts-ui-rwk"]

--- a/crates/rts-host-rwk/Cargo.toml
+++ b/crates/rts-host-rwk/Cargo.toml
@@ -35,6 +35,35 @@ rts-node-rwk = { path = "../rts-node-rwk" }
 rts-ui-rwk = { path = "../rts-ui-rwk", optional = true }
 
 [features]
-default = ["ui"]
-# `rts:egui` e `rts:input`. Ver a nota no dep.
+# `ui` está FORA do default, e a razão é um débito do motor antigo em vez de uma
+# decisão sobre a UI.
+#
+# `rts-natives` deixa dois símbolos indefinidos (`__RTS_FN_GL_FUNCTION_CALL`,
+# `__RTS_FN_GL_RANGE_ERROR_NEW`) que só o binário daquele motor resolve, então
+# todo test binary que o linke falha — 18 deles já falham na `main`, incluindo os
+# de `rts-egui`, `rts-dom`, `rts-render` e `rts-input`.
+#
+# Num build de workspace o cargo UNIFICA features por pacote: `rts-runtime` pede
+# `rts-egui/old-engine`, logo `rts-egui` tem essa feature em qualquer alvo do
+# mesmo build — e um host que dependesse dele por default arrastaria
+# `rts-natives` para os próprios testes. Foi medido: `cargo build --workspace
+# --tests` passava de 18 alvos quebrados para 27, e os nove novos eram os testes
+# DESTE crate, que passam quando construídos sozinhos.
+#
+# Então a UI entra por opção enquanto aquele débito existir. `ui_surface` e o
+# exemplo `janela` a exigem (`required-features`), então nada some em silêncio:
+#
+#     cargo test -p rts-host-rwk --features ui
+default = []
 ui = ["dep:rts-ui-rwk"]
+
+# Os dois alvos que só existem com a UI. Sem isto um `cargo test -p rts-host-rwk`
+# tentaria compilá-los sem o crate e falharia por nome não resolvido, que é uma
+# mensagem sobre a causa errada.
+[[test]]
+name = "ui_surface"
+required-features = ["ui"]
+
+[[example]]
+name = "janela"
+required-features = ["ui"]

--- a/crates/rts-host-rwk/examples/janela.rs
+++ b/crates/rts-host-rwk/examples/janela.rs
@@ -1,0 +1,66 @@
+//! Uma janela de verdade, aberta e pintada por um programa, pelo motor NOVO.
+//!
+//! ```text
+//! cargo run -p rts-host-rwk --example janela
+//! ```
+//!
+//! # Por que um exemplo e não um teste
+//!
+//! Duas razões, e as duas são de plataforma:
+//!
+//! - O winit entra em pânico ao criar o event loop fora da thread PRINCIPAL, e
+//!   um `#[test]` do cargo roda numa secundária. Existe um escape
+//!   (`EventLoopBuilderExtWindows::any_thread`), e usá-lo seria contornar um
+//!   aviso de compatibilidade só para poder chamar isto de teste.
+//! - Abrir uma janela precisa de tela e GPU. Num runner sem as duas isto falha
+//!   por ambiente, e um teste que falha por ambiente deixa de ser lido.
+//!
+//! O que É testado automaticamente está em `tests/ui_surface.rs`: os
+//! especificadores resolvem, os membros são chamáveis, e chamar sem janela
+//! atravessa a fronteira. Isto aqui responde a pergunta que nenhum deles
+//! responde — se pinta — e por isso desenha algo reconhecível em vez de um frame
+//! vazio: se a janela abrir preta, o loop rodou e o desenho não chegou.
+
+fn main() {
+    let source = r#"
+import { openWindow, pump, isOpen, close, beginFrame, endFrame,
+         drawRect, drawText, winWidth, winHeight } from "rts:egui";
+import { mouseX, mouseY } from "rts:input";
+
+const win = openWindow("rts-ui-rwk — motor novo", 720, 420, 0);
+if (win > 0) {
+    let frame = 0;
+    while (frame < 600 && isOpen(win)) {
+        pump(win);
+        beginFrame(win);
+        const w = winWidth(win);
+        const h = winHeight(win);
+        // fundo, uma barra que anda, o cursor seguido, e o texto por cima:
+        // quatro caminhos num frame só.
+        drawRect(win, { x: 0, y: 0, w: w, h: h, fill: 0x101820FF });
+        drawRect(win, { x: 40 + (frame % 120) * 4, y: 220, w: 90, h: 90,
+                        fill: 0x30A0FFFF, radius: 14 });
+        drawRect(win, { x: mouseX(win) - 6, y: mouseY(win) - 6, w: 12, h: 12,
+                        fill: 0xFFD060FF, radius: 6 });
+        drawText(win, { x: 40, y: 60, text: "pintado pelo motor novo",
+                        color: 0xFFFFFFFF, size: 26 });
+        drawText(win, { x: 40, y: 100, text: "rts:egui + rts:input, via rts-ui-rwk",
+                        color: 0x90A0B0FF, size: 16 });
+        endFrame(win);
+        frame = frame + 1;
+    }
+    close(win);
+} else {
+    print("openWindow devolveu 0 — o motivo saiu no stderr acima");
+}
+"#;
+
+    let mut program = match rts_host_rwk::compile(source) {
+        Ok(program) => program,
+        Err(error) => {
+            eprintln!("o programa não compilou: {error:?}");
+            std::process::exit(1);
+        }
+    };
+    program.run();
+}

--- a/crates/rts-host-rwk/src/run.rs
+++ b/crates/rts-host-rwk/src/run.rs
@@ -349,6 +349,11 @@ fn run_region(
         let described = rts_core_rwk::entry::described(value);
         (value, described)
     });
+    // Depois do programa e antes de qualquer destrutor: um `wgpu::Device` solto
+    // pelo destrutor de thread-local morre durante o descarregamento das DLLs do
+    // driver. Ver `rts_ui_rwk::shutdown`. No-op quando nenhuma janela foi aberta.
+    #[cfg(feature = "ui")]
+    rts_ui_rwk::shutdown();
     Outcome {
         value,
         resolves: context.resolves,

--- a/crates/rts-host-rwk/src/run.rs
+++ b/crates/rts-host-rwk/src/run.rs
@@ -280,6 +280,8 @@ fn run_region(
     rts_core_rwk::entry::declare_evaluator(&mut context, evaluate_source);
     rts_std_rwk::install(&mut context);
     rts_node_rwk::install(&mut context);
+    #[cfg(feature = "ui")]
+    rts_ui_rwk::install(&mut context);
     // The modules a program may import. Registered by the HOST rather than by
     // the runtime, because which of them exist is a fact about the environment
     // the program is given — and `rts-std-rwk` is where anything needing an

--- a/crates/rts-host-rwk/tests/ui_surface.rs
+++ b/crates/rts-host-rwk/tests/ui_surface.rs
@@ -8,8 +8,11 @@
 //! superfície: o especificador resolve, o nome existe, é chamável, e a chamada
 //! atravessa a fronteira sem derrubar o processo.
 //!
-//! Isso não é prova de que pinta. A prova de que pinta é rodar um programa numa
-//! máquina com tela, e ela é de quem tem uma.
+//! Isso não é prova de que pinta. A prova de que pinta é `examples/janela.rs`, e
+//! ela não pode viver aqui por uma razão de plataforma e não de gosto: o winit
+//! entra em pânico ao criar o event loop fora da thread PRINCIPAL, e um `#[test]`
+//! do cargo roda numa secundária. Um teste ignorado que abortasse o processo
+//! quando alguém o rodasse seria pior que nenhum.
 //!
 //! # Por que pelo `rts:test` e não por um `return`
 //!

--- a/crates/rts-host-rwk/tests/ui_surface.rs
+++ b/crates/rts-host-rwk/tests/ui_surface.rs
@@ -1,0 +1,137 @@
+//! `rts:egui` e `rts:input`, alcançados por um programa.
+//!
+//! # O que estes testes podem asserir, e o que deliberadamente não tentam
+//!
+//! Nenhum abre uma janela. Abrir uma exige um servidor de janelas e uma GPU, e
+//! um teste que depende dos dois não falha por regressão — falha por runner. O
+//! que é verificável sem nada disso é o que de fato quebra num porte de
+//! superfície: o especificador resolve, o nome existe, é chamável, e a chamada
+//! atravessa a fronteira sem derrubar o processo.
+//!
+//! Isso não é prova de que pinta. A prova de que pinta é rodar um programa numa
+//! máquina com tela, e ela é de quem tem uma.
+//!
+//! # Por que pelo `rts:test` e não por um `return`
+//!
+//! Um arquivo com `import` é um MÓDULO, e `return` fora de função é erro de
+//! sintaxe num módulo. Então o programa reporta pelo harness e o Rust lê o
+//! registro — o mesmo caminho que `node_modules.rs` já usa, pela mesma razão.
+
+use rts_std_rwk::test::{record, reset};
+
+/// Roda um módulo e responde os testes que reportaram divergência.
+fn failures(source: &str) -> Vec<String> {
+    reset();
+    let mut program = rts_host_rwk::compile(source).expect("um módulo que compila");
+    program.run();
+    record()
+        .into_iter()
+        .filter_map(|one| one.failure.map(|why| format!("{}: {why}", one.name)))
+        .collect()
+}
+
+#[test]
+fn os_dois_especificadores_resolvem_e_seus_membros_sao_chamaveis() {
+    // O que o `rts-std-rwk` recusou registrar até agora: um `import` de
+    // `rts:egui` que não termina em `undefined`. E a superfície inteira num
+    // namespace só — a divisão em janela/desenho/cena é de leitura, e este teste
+    // é o que impede que ela vire uma divisão de import.
+    let failed = failures(
+        r#"
+import { test, expect } from "rts:test";
+import * as egui from "rts:egui";
+import * as input from "rts:input";
+
+test("a janela e o frame", function () {
+    expect(typeof egui.openWindow).toBe("function");
+    expect(typeof egui.pump).toBe("function");
+    expect(typeof egui.isOpen).toBe("function");
+    expect(typeof egui.close).toBe("function");
+    expect(typeof egui.beginFrame).toBe("function");
+    expect(typeof egui.endFrame).toBe("function");
+    expect(typeof egui.winWidth).toBe("function");
+});
+test("o desenho", function () {
+    expect(typeof egui.drawRect).toBe("function");
+    expect(typeof egui.drawText).toBe("function");
+    expect(typeof egui.drawLine).toBe("function");
+    expect(typeof egui.measureText).toBe("function");
+    expect(typeof egui.button).toBe("function");
+    expect(typeof egui.slider).toBe("function");
+});
+test("a cena 3D", function () {
+    expect(typeof egui.meshUpload).toBe("function");
+    expect(typeof egui.setCamera).toBe("function");
+    expect(typeof egui.setLight).toBe("function");
+    expect(typeof egui.drawMesh).toBe("function");
+});
+test("o input", function () {
+    expect(typeof input.mouseX).toBe("function");
+    expect(typeof input.key).toBe("function");
+    expect(typeof input.textInput).toBe("function");
+    expect(typeof input.copyText).toBe("function");
+});
+        "#,
+    );
+    assert_eq!(failed, Vec::<String>::new());
+}
+
+#[test]
+fn perguntar_o_input_sem_janela_responde_o_default_em_vez_de_abortar() {
+    // O que isto pina não é o valor: é que a chamada ATRAVESSA. Um nativo que
+    // tomasse o empréstimo do contexto duas vezes entraria em pânico dentro de
+    // um quadro `extern "C"`, que não desenrola e portanto ABORTA o processo —
+    // e um aborto não é um teste que falha, é um teste que some.
+    //
+    // Os valores também importam, e cada um é a resposta de "não há fonte, ou
+    // não há essa janela": `-1` é distinguível de qualquer posição real, e
+    // `false` é um booleano de verdade, que a ABI antiga não tinha e por isso
+    // respondia `0`.
+    let failed = failures(
+        r#"
+import { test, expect } from "rts:test";
+import { mouseX, mouseY, key, wheel, modCtrl, textInput } from "rts:input";
+
+test("o mouse sem fonte", function () {
+    expect(mouseX(0)).toBe(-1);
+    expect(mouseY(0)).toBe(-1);
+});
+test("uma tecla sem fonte é false, não undefined", function () {
+    expect(key(0, 87, 0)).toBe(false);
+    expect(modCtrl(0)).toBe(false);
+});
+test("a roda parada é zero", function () { expect(wheel(0)).toBe(0); });
+test("nada digitado é a string vazia", function () { expect(textInput(0)).toBe(""); });
+        "#,
+    );
+    assert_eq!(failed, Vec::<String>::new());
+}
+
+#[test]
+fn um_objeto_de_opcoes_incompleto_desenha_com_os_defaults_em_vez_de_nada() {
+    // A decisão de aridade de `rts-ui-rwk::value`, exercida: `drawRect` tinha
+    // nove parâmetros e agora recebe um objeto, e um campo ausente vale o
+    // default documentado. Sem janela nada é enfileirado — o que se está
+    // asserindo é que ler um objeto de opções não depende de haver uma, e que
+    // um campo que não é número não vira `NaN` numa coordenada.
+    let failed = failures(
+        r#"
+import { test, expect } from "rts:test";
+import { drawRect, drawText, drawMesh, setCamera } from "rts:egui";
+
+test("desenhar sem janela é inofensivo", function () {
+    drawRect(0, { x: 10, y: 20, w: 30, h: 40 });
+    drawText(0, { x: 1, y: 2, text: "oi" });
+    drawMesh(0, { mesh: 1, x: 0, y: 0, z: 0 });
+    setCamera(0, { x: 0, y: 1, z: -5, fov: 1, aspect: 1.5 });
+    expect(true).toBe(true);
+});
+test("um campo ausente não vira NaN", function () {
+    drawRect(0, {});
+    drawRect(0, { x: "isto não é um número" });
+    expect(true).toBe(true);
+});
+        "#,
+    );
+    assert_eq!(failed, Vec::<String>::new());
+}

--- a/crates/rts-input/Cargo.toml
+++ b/crates/rts-input/Cargo.toml
@@ -16,5 +16,13 @@ license.workspace = true
 # Depende SÓ de rts-engine (p/ a ABI/Engine). Sem egui — é o ponto neutro.
 
 [dependencies]
-rts-engine = { path = "../rts-engine" }
-rtse = { package = "rts-macro", path = "../rts-macro" }
+rts-engine = { path = "../rts-engine", optional = true }
+rtse = { package = "rts-macro", path = "../rts-macro", optional = true }
+
+# A ABI do motor ANTIGO é uma feature, não um fato do crate. Ligada por default
+# para que o motor antigo siga compilando sem mudar nada; o motor NOVO consome
+# este crate com `default-features = false`, e o que sobra é a lógica pura — sem
+# `rts-engine`, e portanto sem alcançar `rts-abi`, que é a interface em remoção.
+[features]
+default = ["old-engine"]
+old-engine = ["dep:rts-engine", "dep:rtse"]

--- a/crates/rts-input/src/lib.rs
+++ b/crates/rts-input/src/lib.rs
@@ -27,7 +27,9 @@
 
 use std::cell::RefCell;
 
+#[cfg(feature = "old-engine")]
 pub mod abi;
+#[cfg(feature = "old-engine")]
 pub use abi::register_input;
 
 /// O contrato de ENTRADA: o backend CAPTA o input cru (tem a janela; o SO entrega

--- a/crates/rts-render/Cargo.toml
+++ b/crates/rts-render/Cargo.toml
@@ -14,5 +14,13 @@ license.workspace = true
 # Depende SÓ de rts-engine (p/ a ABI/Engine). Sem egui — é o ponto neutro.
 
 [dependencies]
-rts-engine = { path = "../rts-engine" }
-rtse = { package = "rts-macro", path = "../rts-macro" }
+rts-engine = { path = "../rts-engine", optional = true }
+rtse = { package = "rts-macro", path = "../rts-macro", optional = true }
+
+# A ABI do motor ANTIGO é uma feature, não um fato do crate. Ligada por default
+# para que o motor antigo siga compilando sem mudar nada; o motor NOVO consome
+# este crate com `default-features = false`, e o que sobra é a lógica pura — sem
+# `rts-engine`, e portanto sem alcançar `rts-abi`, que é a interface em remoção.
+[features]
+default = ["old-engine"]
+old-engine = ["dep:rts-engine", "dep:rtse"]

--- a/crates/rts-render/src/lib.rs
+++ b/crates/rts-render/src/lib.rs
@@ -14,7 +14,9 @@
 
 use std::cell::RefCell;
 
+#[cfg(feature = "old-engine")]
 pub mod abi;
+#[cfg(feature = "old-engine")]
 pub use abi::register;
 
 /// Prelude `.ts` da fachada ERGONÔMICA `rts:canvas` — UI imediata (Canvas com

--- a/crates/rts-runtime/Cargo.toml
+++ b/crates/rts-runtime/Cargo.toml
@@ -58,6 +58,10 @@ rts-input = { path = "../rts-input" }
 # abaixo: dx12=Windows, vulkan=Linux, metal=macOS. (Linux também precisa do winit
 # x11/wayland — resolvido no Cargo.toml do rts-egui.) Features unem por target.
 rts-egui = { path = "../rts-egui", default-features = false, features = [
+    # `old-engine`: os símbolos `__RTS_FN_NS_EGUI_*` e o namespace do motor
+    # ANTIGO. Esta facade É o motor antigo, então é ela quem os pede — o crate
+    # rts-egui não os assume mais. O motor novo consome o mesmo crate sem isto.
+    "old-engine",
     "wgpu-backend",
     "glow-backend",
 ] }

--- a/crates/rts-std-rwk/src/lib.rs
+++ b/crates/rts-std-rwk/src/lib.rs
@@ -19,7 +19,7 @@
 //! |---|---|
 //! | `rts:test` | `describe`/`test`/`expect`, and the record they leave |
 //! | `rts:runtime` | the module table, from inside a running program |
-//! | `rts:egui` | **not registered** — see below |
+//! | `rts:egui` | outro crate — `rts-ui-rwk`, ver abaixo |
 //!
 //! # `rts:io` is gone, and the measurement that removed it
 //!
@@ -34,20 +34,21 @@
 //! replaced by a thinner one — a specifier kept alive for one caller is a
 //! surface to keep in agreement for no reader.
 //!
-//! # `rts:egui` is absent, and why that is not an omission
+//! # `rts:egui` vive em `rts-ui-rwk`, e por quê
 //!
-//! The `rts-egui` crate exists and is real, and it was written against the OLD
-//! engine: its natives are linker symbols resolved through `rts-abi`, which is
-//! the interface `rts_cranelift::abi` replaced. A native in the new engine is a
-//! function pointer stored beside a cell — see
-//! `docs/engine/authoring-natives.md` — so wiring the two together is a port,
-//! not a registration.
+//! Este arquivo dizia que `rts:egui` não era registrado: o crate `rts-egui`
+//! falava a ABI do motor antigo — natives como símbolos de linker resolvidos por
+//! `rts-abi`, que `rts_cranelift::abi` substituiu — e registrar uma casca que
+//! recusasse todo membro faria o `import` compilar e não desenhar nada, que para
+//! uma superfície de UI é o modo de falhar que custa mais tempo até ser
+//! entendido.
 //!
-//! Registering a shell that refused every member was considered and rejected: it
-//! would make `import { … } from "rts:egui"` compile and then draw nothing,
-//! which for a UI surface is the failure mode that wastes the most time before
-//! it is understood. An unresolved specifier says the same thing at the import
-//! line.
+//! Ele foi portado, e não para cá. Uma janela precisa de um sistema de janelas:
+//! não existe em wasm nem num build headless, e essa é a mesma regra de
+//! DISPONIBILIDADE que mantém `Math` no runtime e `io.print` fora dele. Um alvo
+//! sem tela não deve carregar wgpu e winit no grafo para descobrir isso, então
+//! `rts:egui` e `rts:input` são um crate próprio — `rts-ui-rwk` — atrás de uma
+//! feature do host.
 //!
 //! # What this crate is NOT
 //!

--- a/crates/rts-ui-rwk/Cargo.toml
+++ b/crates/rts-ui-rwk/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "rts-ui-rwk"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+# A superfície de UI do motor NOVO: `rts:egui` e `rts:input`.
+#
+# Existe como crate próprio pela única razão que `docs/engine/architecture.md`
+# aceita para uma fronteira — DISPONIBILIDADE. Uma janela precisa de um sistema
+# de janelas: não existe em wasm, não existe num build headless, e um alvo que
+# não a tem não deve carregar wgpu/winit no grafo para descobrir isso.
+#
+# Depende de `rts-core-rwk` (a superfície de host: namespaces, coerção, valores)
+# e dos crates de UI com `default-features = false` — isto é, SEM a ABI do motor
+# antigo. Ver o doc de `rts-egui/src/abi.rs`.
+
+[dependencies]
+rts-core-rwk = { path = "../rts-core-rwk" }
+rts-egui = { path = "../rts-egui", default-features = false, features = ["wgpu-backend"] }
+rts-input = { path = "../rts-input", default-features = false }
+
+# O backend de GPU concreto por SO, como `rts-runtime` já faz: dx12=Windows,
+# vulkan=Linux, metal=macOS. Features unem por target, sem redeclarar o wgpu.
+[target.'cfg(target_os = "windows")'.dependencies]
+rts-egui = { path = "../rts-egui", default-features = false, features = ["gpu-dx12"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rts-egui = { path = "../rts-egui", default-features = false, features = ["gpu-vulkan"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+rts-egui = { path = "../rts-egui", default-features = false, features = ["gpu-metal"] }

--- a/crates/rts-ui-rwk/src/draw.rs
+++ b/crates/rts-ui-rwk/src/draw.rs
@@ -1,0 +1,153 @@
+//! O canvas e os widgets-folha: o que o programa emite entre `beginFrame` e
+//! `endFrame`.
+//!
+//! Nada aqui pinta. Cada membro enfileira um comando no `UiCtx` da janela, e o
+//! `endFrame` os executa — que é por que `button` responde o clique do frame
+//! ANTERIOR, casado por posição. A latência de um frame é da mecânica de fila do
+//! `rts-egui` e não desta camada; está dita aqui porque é o que surpreende quem
+//! lê `button()` esperando o clique de agora.
+
+use rts_core_rwk::entry::Provided;
+
+use crate::value::{self, handle, integer, number, text};
+use crate::window::options;
+
+/// Os membros de desenho de `rts:egui`.
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("drawRect", draw_rect),
+    ("drawText", draw_text),
+    ("drawLine", draw_line),
+    ("measureText", measure_text),
+    ("label", label),
+    ("button", button),
+    ("slider", slider),
+    ("horizontalBegin", horizontal_begin),
+    ("horizontalEnd", horizontal_end),
+    ("html", html),
+];
+
+/// `drawRect(win, { x, y, w, h, fill, strokeW, stroke, radius })`.
+///
+/// Nove parâmetros na superfície antiga; um objeto aqui — ver `crate::value`.
+/// Cores são `0xRRGGBBAA`.
+extern "C" fn draw_rect(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["x", "y", "w", "h", "fill", "strokeW", "stroke", "radius"],
+        &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    );
+    rts_egui::draw_rect(
+        handle(win),
+        read[0],
+        read[1],
+        read[2],
+        read[3],
+        read[4] as i64,
+        read[5],
+        read[6] as i64,
+        read[7],
+    );
+    value::nothing()
+}
+
+/// `drawText(win, { x, y, text, color, size, flags })`.
+///
+/// `flags` é o bitmask 1=negrito 2=itálico 4=mono. O texto é lido à parte dos
+/// números porque é o único campo que não é um.
+extern "C" fn draw_text(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["x", "y", "color", "size", "flags"],
+        &[0.0, 0.0, 0.0, 14.0, 0.0],
+    );
+    let content = value::fields(spec, &["text"]);
+    rts_egui::draw_text(
+        handle(win),
+        read[0],
+        read[1],
+        &text(content[0]),
+        read[2] as i64,
+        read[3],
+        read[4] as i64,
+    );
+    value::nothing()
+}
+
+/// `drawLine(win, { x1, y1, x2, y2, w, color })`.
+extern "C" fn draw_line(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["x1", "y1", "x2", "y2", "w", "color"],
+        &[0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    );
+    rts_egui::draw_line(
+        handle(win),
+        read[0],
+        read[1],
+        read[2],
+        read[3],
+        read[4],
+        read[5] as i64,
+    );
+    value::nothing()
+}
+
+/// `measureText(win, text, size, bold)` — largura em pontos, com a fonte real.
+///
+/// É a única operação do egui que sabe algo de layout, e existe porque medir
+/// texto precisa das métricas da fonte, que o TS não tem. Síncrona.
+extern "C" fn measure_text(_e: u64, _t: u64, win: u64, content: u64, size: u64, bold: u64) -> u64 {
+    let width = rts_egui::measure_text(
+        handle(win),
+        &text(content),
+        number(size, 14.0),
+        integer(bold, 0),
+    );
+    value::from_number(width)
+}
+
+/// `label(win, text)`.
+extern "C" fn label(_e: u64, _t: u64, win: u64, content: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::label(handle(win), &text(content));
+    value::nothing()
+}
+
+/// `button(win, label)` — se foi clicado. Ver a nota de latência no topo.
+extern "C" fn button(_e: u64, _t: u64, win: u64, content: u64, _b: u64, _c: u64) -> u64 {
+    value::from_bool(rts_egui::button(handle(win), &text(content)) != 0)
+}
+
+/// `slider(win, value, min, max)` — o valor, possivelmente arrastado.
+extern "C" fn slider(_e: u64, _t: u64, win: u64, held: u64, low: u64, high: u64) -> u64 {
+    let moved = rts_egui::slider(
+        handle(win),
+        number(held, 0.0),
+        number(low, 0.0),
+        number(high, 1.0),
+    );
+    value::from_number(moved)
+}
+
+/// `horizontalBegin(win)` — os widgets até o `horizontalEnd` ficam lado a lado.
+extern "C" fn horizontal_begin(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::horizontal_begin(handle(win));
+    value::nothing()
+}
+
+/// `horizontalEnd(win)`.
+extern "C" fn horizontal_end(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::horizontal_end(handle(win));
+    value::nothing()
+}
+
+/// `html(win, source)` — parseia e desenha, com a árvore retida na janela.
+///
+/// O caminho por handle de DOM (`render(win, dom)`) NÃO está aqui: ele lê o
+/// store do `rts-dom`, que é alcançado pelo namespace `rts:dom` — e esse ainda
+/// não existe no motor novo. Registrá-lo agora daria uma função que sempre
+/// desenha nada, que é o modo de falhar que `rts-std-rwk` já recusou uma vez ao
+/// não registrar um `rts:egui` de fachada.
+extern "C" fn html(_e: u64, _t: u64, win: u64, source: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::html(handle(win), &text(source));
+    value::nothing()
+}

--- a/crates/rts-ui-rwk/src/input.rs
+++ b/crates/rts-ui-rwk/src/input.rs
@@ -1,0 +1,188 @@
+//! `rts:input` — mouse, teclado, roda e modificadores.
+//!
+//! # Por que é um módulo separado de `rts:egui`
+//!
+//! Porque a fonte de entrada é trocável e a janela não. O `rts-input` define o
+//! trait `InputSource`; o `rts-egui` o implementa captando do winit e se
+//! registra como fonte ativa. Um programa que fala `input.*` continua valendo se
+//! a fonte virar SDL, um gamepad ou um harness de teste — e é por isso que a
+//! captação nunca é chamada por aqui: este módulo só pergunta à fonte ativa.
+//!
+//! # Polling, não eventos
+//!
+//! O programa pergunta o estado a cada frame e decide o que fazer. A fonte não
+//! interpreta: ela reporta onde o mouse está e quais teclas estão em que fase,
+//! e quem faz hit-test e despacho é o DOM ou o jogo. Um modelo de eventos
+//! precisaria chamar de volta para dentro do programa a partir de um nativo, que
+//! é exatamente a operação que `docs/engine/authoring-natives.md` diz não poder
+//! acontecer com o empréstimo do contexto na mão.
+//!
+//! # A janela é argumento de tudo
+//!
+//! `input.mouseX(win)`, não `input.mouseX()`. Com várias janelas abertas, "o
+//! mouse" não é uma pergunta respondível — e uma fonte que respondesse pela
+//! janela em foco daria um valor que muda sem o programa pedir.
+
+use rts_core_rwk::entry::Provided;
+
+use crate::value::{self, handle, integer, text};
+
+/// Os membros de `rts:input`.
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("mouseX", mouse_x),
+    ("mouseY", mouse_y),
+    ("mouseDown", mouse_down),
+    ("mouseClicked", mouse_clicked),
+    ("mousePressed", mouse_pressed),
+    ("mouseReleased", mouse_released),
+    ("mouseDoubleClicked", mouse_double_clicked),
+    ("mouseDeltaX", mouse_delta_x),
+    ("mouseDeltaY", mouse_delta_y),
+    ("dragging", dragging),
+    ("wheel", wheel),
+    ("wheelX", wheel_x),
+    ("setCursor", set_cursor),
+    ("key", key),
+    ("modCtrl", mod_ctrl),
+    ("modShift", mod_shift),
+    ("modAlt", mod_alt),
+    ("modCmd", mod_cmd),
+    ("textInput", text_input),
+    ("copyText", copy_text),
+];
+
+/// `input.mouseX(win)` — em pontos lógicos. `-1` quando não há fonte ativa ou a
+/// janela não existe, que é distinguível de qualquer posição real.
+extern "C" fn mouse_x(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.mouse_pos(win).0 as f64).unwrap_or(-1.0))
+}
+
+/// `input.mouseY(win)`.
+extern "C" fn mouse_y(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.mouse_pos(win).1 as f64).unwrap_or(-1.0))
+}
+
+/// `input.mouseDown(win, button)` — o botão está pressionado AGORA.
+extern "C" fn mouse_down(_e: u64, _t: u64, win: u64, button: u64, _b: u64, _c: u64) -> u64 {
+    let (win, button) = (handle(win), integer(button, 0));
+    value::from_bool(rts_input::with_input(|source| source.mouse_down(win, button)).unwrap_or(false))
+}
+
+/// `input.mouseClicked(win, button)` — clique completo neste frame.
+extern "C" fn mouse_clicked(_e: u64, _t: u64, win: u64, button: u64, _b: u64, _c: u64) -> u64 {
+    let (win, button) = (handle(win), integer(button, 0));
+    value::from_bool(rts_input::with_input(|source| source.mouse_clicked(win, button)).unwrap_or(false))
+}
+
+/// `input.mousePressed(win, button)` — a borda de descida.
+extern "C" fn mouse_pressed(_e: u64, _t: u64, win: u64, button: u64, _b: u64, _c: u64) -> u64 {
+    let (win, button) = (handle(win), integer(button, 0));
+    value::from_bool(rts_input::with_input(|source| source.mouse_pressed(win, button)).unwrap_or(false))
+}
+
+/// `input.mouseReleased(win, button)` — a borda de subida.
+extern "C" fn mouse_released(_e: u64, _t: u64, win: u64, button: u64, _b: u64, _c: u64) -> u64 {
+    let (win, button) = (handle(win), integer(button, 0));
+    value::from_bool(rts_input::with_input(|source| source.mouse_released(win, button)).unwrap_or(false))
+}
+
+/// `input.mouseDoubleClicked(win, button)`.
+extern "C" fn mouse_double_clicked(_e: u64, _t: u64, win: u64, button: u64, _b: u64, _c: u64) -> u64 {
+    let (win, button) = (handle(win), integer(button, 0));
+    value::from_bool(
+        rts_input::with_input(|source| source.mouse_double_clicked(win, button)).unwrap_or(false),
+    )
+}
+
+/// `input.mouseDeltaX(win)` — com o ponteiro travado (`egui.mouseLock`), o delta
+/// CRU do dispositivo, que a borda da tela não limita.
+extern "C" fn mouse_delta_x(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.mouse_delta(win).0 as f64).unwrap_or(0.0))
+}
+
+/// `input.mouseDeltaY(win)`.
+extern "C" fn mouse_delta_y(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.mouse_delta(win).1 as f64).unwrap_or(0.0))
+}
+
+/// `input.dragging(win)`.
+extern "C" fn dragging(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_bool(rts_input::with_input(|source| source.dragging(win)).unwrap_or(false))
+}
+
+/// `input.wheel(win)` — o deslocamento vertical acumulado neste frame.
+extern "C" fn wheel(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.wheel(win) as f64).unwrap_or(0.0))
+}
+
+/// `input.wheelX(win)` — o horizontal.
+extern "C" fn wheel_x(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_number(rts_input::with_input(|source| source.wheel_x(win) as f64).unwrap_or(0.0))
+}
+
+/// `input.setCursor(win, kind)` — o único membro que ESCREVE, e por isso está
+/// aqui e não numa superfície de janela: o cursor é do dispositivo apontador.
+extern "C" fn set_cursor(_e: u64, _t: u64, win: u64, kind: u64, _b: u64, _c: u64) -> u64 {
+    let (win, kind) = (handle(win), integer(kind, 0));
+    rts_input::with_input(|source| source.set_cursor(win, kind));
+    value::nothing()
+}
+
+/// `input.key(win, code, phase)` — `phase` 0=pressionada agora, 1=borda de
+/// descida, 2=borda de subida. Os códigos são as constantes `KEY_*` do
+/// `rts-input`, neutras de propósito: um código de tecla do winit ou do egui
+/// prenderia o programa à fonte.
+extern "C" fn key(_e: u64, _t: u64, win: u64, code: u64, phase: u64, _c: u64) -> u64 {
+    let (win, code, phase) = (handle(win), integer(code, -1), integer(phase, 0));
+    value::from_bool(rts_input::with_input(|source| source.key_state(win, code, phase)).unwrap_or(false))
+}
+
+/// `input.modCtrl(win)`.
+extern "C" fn mod_ctrl(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_bool(rts_input::with_input(|source| source.modifiers(win).ctrl).unwrap_or(false))
+}
+
+/// `input.modShift(win)`.
+extern "C" fn mod_shift(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_bool(rts_input::with_input(|source| source.modifiers(win).shift).unwrap_or(false))
+}
+
+/// `input.modAlt(win)`.
+extern "C" fn mod_alt(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_bool(rts_input::with_input(|source| source.modifiers(win).alt).unwrap_or(false))
+}
+
+/// `input.modCmd(win)` — Command no macOS, a tecla de janela nos demais.
+extern "C" fn mod_cmd(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    value::from_bool(rts_input::with_input(|source| source.modifiers(win).cmd).unwrap_or(false))
+}
+
+/// `input.textInput(win)` — o texto digitado neste frame, já composto pelo SO
+/// (acentuação, IME). Vazio quando não houve nenhum.
+///
+/// É o que um campo de texto deve consumir, e não a tecla: `key` reporta uma
+/// tecla física e não sabe o que um layout de teclado produz com ela.
+extern "C" fn text_input(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    let typed = rts_input::with_input(|source| source.text_input(win)).unwrap_or_default();
+    value::from_text(&typed)
+}
+
+/// `input.copyText(win, text)` — põe o texto no clipboard do SO.
+extern "C" fn copy_text(_e: u64, _t: u64, win: u64, content: u64, _b: u64, _c: u64) -> u64 {
+    let win = handle(win);
+    let content = text(content);
+    rts_input::with_input(|source| source.copy_text(win, &content));
+    value::nothing()
+}

--- a/crates/rts-ui-rwk/src/lib.rs
+++ b/crates/rts-ui-rwk/src/lib.rs
@@ -73,6 +73,26 @@ pub fn install(context: &mut Context) {
     entry::declare_module(context, "rts:input", entry_points);
 }
 
+/// Solta os recursos de GPU enquanto o processo ainda está inteiro.
+///
+/// # Por que isto não pode ficar para o destrutor do thread-local
+///
+/// No Windows o destrutor de um `thread_local` roda a partir do callback de TLS
+/// durante o `LdrShutdownProcess` — isto é, ENQUANTO as DLLs do driver estão
+/// sendo descarregadas. Destruir um `wgpu::Device` nesse momento faz o driver
+/// D3D12 da AMD dar `__fastfail` (`0xC0000409`) depois de uma execução limpa e
+/// já totalmente impressa, sem mensagem nenhuma.
+///
+/// O `rts-egui` já sabia disso e tinha o `shutdown_shared_gpu` para o CLI antigo
+/// chamar. O motor novo precisa do mesmo, e por isto é o HOST que chama e não o
+/// programa: um programa que esquecesse a linha morreria na saída, e ele não tem
+/// como saber que essa linha existe.
+///
+/// Idempotente, e no-op quando nenhuma GPU foi criada.
+pub fn shutdown() {
+    rts_egui::shutdown_shared_gpu();
+}
+
 /// `rts:egui`, montado das três metades da superfície.
 ///
 /// Um objeto só, e não três: um programa escreve `egui.beginFrame` e

--- a/crates/rts-ui-rwk/src/lib.rs
+++ b/crates/rts-ui-rwk/src/lib.rs
@@ -1,0 +1,90 @@
+//! `rts:egui` e `rts:input` para o motor novo.
+//!
+//! # O que este crate é
+//!
+//! A ponte entre a superfície de host do `rts-core-rwk` — namespaces, coerção,
+//! valores — e a lógica de UI, que vive no `rts-egui`/`rts-input` em Rust comum
+//! e não sabe que existe um motor.
+//!
+//! Nada de gráfico acontece aqui. Se algo neste crate abrir uma janela, medir um
+//! texto ou decidir um layout, foi na direção errada: essa é a lógica, e ela
+//! pertence ao crate que já a tem.
+//!
+//! # O que mudou em relação à superfície do motor antigo
+//!
+//! Três coisas, todas porque um nativo aqui é outra coisa que lá — um ponteiro
+//! de função ao lado de uma célula, e não um símbolo de linker:
+//!
+//! | antes | agora | por quê |
+//! |---|---|---|
+//! | 13 argumentos posicionais | um objeto de opções | a convenção carrega 4 — `crate::value` |
+//! | `meshUpload(win, ptr, n, ptr, m)` | views tipadas | o coletor move células; um endereço lido envelhece |
+//! | `isOpen(): number` | `boolean` | existe um booleano de verdade aqui |
+//!
+//! O resto dos nomes é igual, de propósito: um programa que já desenha continua
+//! a mesma leitura, e a diferença fica onde ela é real.
+//!
+//! # O que NÃO está aqui, e não por esquecimento
+//!
+//! **`rts:gpu`** — os buffers de compute SÃO handles do `HandleTable` do motor
+//! antigo. Portá-los é decidir onde aqueles bytes vivem no novo, não escrever
+//! uma casca. `drawWater`, seu único consumidor, fica junto.
+//!
+//! **`rts:dom` e `render.*`** — a árvore, o parser e o motor de layout são 18 mil
+//! linhas no `rts-dom`, e nenhuma delas conhece motor: o porte é a mesma casca
+//! que este crate é, feita para a superfície daquele. `egui.render(win, dom)`
+//! está fora por consequência — sem o namespace do DOM não há handle para
+//! passar, e registrá-lo daria uma função que desenha nada.
+//!
+//! Cada ausência é uma linha que falha no `import`, que é onde ela deve doer.
+//! `rts-std-rwk` já recusou uma vez registrar um `rts:egui` de fachada, pela
+//! mesma razão: uma UI que compila e não pinta é o modo de falhar que custa mais
+//! tempo até ser entendido.
+
+#![deny(missing_docs)]
+#![deny(dead_code)]
+
+pub mod draw;
+pub mod input;
+pub mod scene;
+pub mod value;
+pub mod window;
+
+use rts_core_rwk::entry::{self, Context, Provided};
+
+/// Registra `rts:egui` e `rts:input`.
+///
+/// Chamado por um host antes de o programa rodar, e por ele e não por um
+/// construtor daqui: quais módulos existem é uma decisão sobre o ambiente que o
+/// programa recebe, e um crate que se registrasse sozinho a estaria tomando.
+/// É a mesma assinatura do `rts_std_rwk::install`, pela mesma razão.
+pub fn install(context: &mut Context) {
+    // O egui como backend ATIVO de render e como FONTE ativa de input. Sem isto
+    // `rts:input` responderia o default de tudo — mouse em `-1`, nenhuma tecla
+    // — que é indistinguível de um programa cujo usuário não fez nada. Registrar
+    // aqui e não ao abrir a janela: o registro é por THREAD, e é esta que vai
+    // rodar o programa.
+    rts_egui::render_backend::register_backend();
+
+    let surface = namespace(context);
+    entry::declare_module(context, "rts:egui", surface);
+
+    let entry_points = entry::make_namespace(context, input::MEMBERS);
+    entry::declare_module(context, "rts:input", entry_points);
+}
+
+/// `rts:egui`, montado das três metades da superfície.
+///
+/// Um objeto só, e não três: um programa escreve `egui.beginFrame` e
+/// `egui.drawMesh` sem saber que uma é janela e a outra é cena. A divisão em
+/// módulos é de LEITURA — janela, desenho, cena mudam por razões diferentes — e
+/// não deve vazar para quem chama.
+fn namespace(context: &mut Context) -> u64 {
+    let members: Vec<(&str, Provided)> = window::MEMBERS
+        .iter()
+        .chain(draw::MEMBERS)
+        .chain(scene::MEMBERS)
+        .copied()
+        .collect();
+    entry::make_namespace(context, &members)
+}

--- a/crates/rts-ui-rwk/src/scene.rs
+++ b/crates/rts-ui-rwk/src/scene.rs
@@ -1,0 +1,163 @@
+//! O pass 3D: malhas, câmera, luz, sombra e textura.
+//!
+//! Desenhado ANTES da UI, no mesmo encoder, com profundidade própria — a UI do
+//! egui fica por cima da cena. Só o backend wgpu age; no glow é no-op.
+//!
+//! # O que mudou de verdade em relação à superfície antiga
+//!
+//! Os dados de geometria chegam como **view tipada**, não como endereço.
+//! `meshUpload(win, new Float32Array(…), new Uint32Array(…))` em vez de
+//! `meshUpload(win, verts.ptr(), n, idx.ptr(), m)`. Um endereço cru é uma
+//! leitura arbitrária de memória a partir de um número que o programa calcula, e
+//! neste motor é pior que isso: o coletor move células, então o endereço lido
+//! pode não ser mais o buffer quando o Rust o usa. Ver `crate::value::bytes`.
+
+use rts_core_rwk::entry::Provided;
+
+use crate::value::{self, bytes, handle, integer, number};
+use crate::window::options;
+
+/// Os membros do pass 3D de `rts:egui`.
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("meshUpload", mesh_upload),
+    ("meshFree", mesh_free),
+    ("textureUpload", texture_upload),
+    ("setCamera", set_camera),
+    ("setCameraLookAt", set_camera_look_at),
+    ("setClearColor", set_clear_color),
+    ("setSkybox", set_skybox),
+    ("setLight", set_light),
+    ("setShadow", set_shadow),
+    ("drawMesh", draw_mesh),
+];
+
+/// `meshUpload(win, vertices, indices)` — o id da malha, `0` em falha.
+///
+/// `vertices` é um `Float32Array` de 8 floats por vértice (posição, normal, uv);
+/// `indices` um `Uint32Array`. Os comprimentos vêm das próprias views, então não
+/// há como o programa declarar uma contagem que discorde dos dados — o que a
+/// superfície antiga permitia, e cujo resultado era ler além do buffer.
+extern "C" fn mesh_upload(_e: u64, _t: u64, win: u64, vertices: u64, indices: u64, _c: u64) -> u64 {
+    let (Some(vertices), Some(indices)) = (bytes(vertices), bytes(indices)) else {
+        return value::from_number(0.0);
+    };
+    let vertices: Vec<f32> = vertices
+        .chunks_exact(4)
+        .map(|word| f32::from_ne_bytes([word[0], word[1], word[2], word[3]]))
+        .collect();
+    let indices: Vec<u32> = indices
+        .chunks_exact(4)
+        .map(|word| u32::from_ne_bytes([word[0], word[1], word[2], word[3]]))
+        .collect();
+    let made = rts_egui::upload_mesh(handle(win), &vertices, &indices);
+    value::from_number(made as f64)
+}
+
+/// `meshFree(win, mesh)`.
+extern "C" fn mesh_free(_e: u64, _t: u64, win: u64, mesh: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::mesh_free(handle(win), handle(mesh));
+    value::nothing()
+}
+
+/// `textureUpload(win, pixels, width, height)` — o id da textura (≥2), `0` em
+/// falha. `pixels` é um `Uint8Array` RGBA8 em sRGB.
+extern "C" fn texture_upload(_e: u64, _t: u64, win: u64, pixels: u64, w: u64, h: u64) -> u64 {
+    let Some(pixels) = bytes(pixels) else {
+        return value::from_number(0.0);
+    };
+    let made = rts_egui::upload_texture(handle(win), &pixels, integer(w, 0), integer(h, 0));
+    value::from_number(made as f64)
+}
+
+/// `setCamera(win, { x, y, z, yaw, pitch, fov, aspect })` — câmera de voo.
+/// Ângulos em RADIANOS; base canhota, `yaw` 0 olha para +Z.
+extern "C" fn set_camera(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["x", "y", "z", "yaw", "pitch", "fov", "aspect"],
+        &[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+    );
+    rts_egui::set_camera(
+        handle(win),
+        read[0], read[1], read[2], read[3], read[4], read[5], read[6],
+    );
+    value::nothing()
+}
+
+/// `setCameraLookAt(win, { ex, ey, ez, tx, ty, tz, fov, aspect, near, far })`.
+///
+/// NaN-safe: olhar reto para cima não trava em gimbal, degrada. É a forma
+/// conveniente para enquadrar um objeto.
+extern "C" fn set_camera_look_at(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["ex", "ey", "ez", "tx", "ty", "tz", "fov", "aspect", "near", "far"],
+        &[0.0, 0.0, -5.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.1, 1000.0],
+    );
+    rts_egui::set_camera_lookat(
+        handle(win),
+        read[0], read[1], read[2], read[3], read[4], read[5], read[6], read[7], read[8], read[9],
+    );
+    value::nothing()
+}
+
+/// `setClearColor(win, r, g, b)` — fundo chapado (0..1), desligando o skybox.
+extern "C" fn set_clear_color(_e: u64, _t: u64, win: u64, r: u64, g: u64, b: u64) -> u64 {
+    rts_egui::set_clear_color(
+        handle(win),
+        number(r, 0.0),
+        number(g, 0.0),
+        number(b, 0.0),
+    );
+    value::nothing()
+}
+
+/// `setSkybox(win, on)` — religa o skybox procedural.
+extern "C" fn set_skybox(_e: u64, _t: u64, win: u64, on: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::set_skybox(handle(win), integer(on, 1));
+    value::nothing()
+}
+
+/// `setLight(win, { x, y, z, ambient })` — luz PONTUAL na posição dada.
+extern "C" fn set_light(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(spec, &["x", "y", "z", "ambient"], &[0.0, 10.0, 0.0, 0.2]);
+    rts_egui::set_light(handle(win), read[0], read[1], read[2], read[3]);
+    value::nothing()
+}
+
+/// `setShadow(win, { dx, dy, dz, cx, cy, cz, radius })` — a caixa ortográfica
+/// que a sombra cobre. `radius <= 0` desliga.
+extern "C" fn set_shadow(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["dx", "dy", "dz", "cx", "cy", "cz", "radius"],
+        &[0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    );
+    rts_egui::set_shadow(
+        handle(win),
+        read[0], read[1], read[2], read[3], read[4], read[5], read[6],
+    );
+    value::nothing()
+}
+
+/// `drawMesh(win, { mesh, x, y, z, rx, ry, sx, sy, sz, color, emissive, tex })`.
+///
+/// Cor `0xAARRGGBB`; `tex` 0=nenhuma, 1=xadrez procedural, ≥2 = id de
+/// `textureUpload`. A escala vale 1 por default, porque uma escala 0 é uma malha
+/// invisível e é o que um objeto de opções incompleto produziria.
+extern "C" fn draw_mesh(_e: u64, _t: u64, win: u64, spec: u64, _b: u64, _c: u64) -> u64 {
+    let read = options(
+        spec,
+        &["mesh", "x", "y", "z", "rx", "ry", "sx", "sy", "sz", "color", "emissive", "tex"],
+        &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0xFFFF_FFFFu32 as f64, 0.0, 0.0],
+    );
+    rts_egui::draw_mesh(
+        handle(win),
+        read[0] as u64,
+        read[1], read[2], read[3], read[4], read[5], read[6], read[7], read[8],
+        read[9] as i64,
+        read[10] as i64,
+        read[11] as i64,
+    );
+    value::nothing()
+}

--- a/crates/rts-ui-rwk/src/value.rs
+++ b/crates/rts-ui-rwk/src/value.rs
@@ -1,0 +1,127 @@
+//! Ler um argumento, e a decisão de aridade que este crate teve de tomar.
+//!
+//! # O problema
+//!
+//! Um nativo do motor novo tem a forma que uma função compilada tem:
+//! `(env, this, a0, a1, a2, a3) -> valor`. Quatro argumentos. O que passa disso
+//! vai para um vetor que o runtime guarda e que `rest_arguments` lê — mas essa
+//! leitura não está exposta na superfície de host, então um nativo simplesmente
+//! não enxerga o quinto argumento.
+//!
+//! A superfície do egui não cabe nisso: `drawMesh` tinha treze parâmetros,
+//! `setCameraLookAt` onze, `drawRect` nove.
+//!
+//! # O que foi escolhido, e o que foi rejeitado
+//!
+//! **Um objeto**: `drawMesh(win, { mesh, x, y, z, … })`. Dois argumentos, e o
+//! motor novo já sabe ler propriedade por nome (`get_member`), então nada
+//! precisa mudar abaixo deste crate.
+//!
+//! Rejeitado: expandir a convenção, ou expor o vetor de rest para hosts. Ambos
+//! são mudanças no motor para acomodar UMA superfície, e a chamada de treze
+//! posicionais que sairia delas é pior de ler do que o objeto — `drawMesh(w, m,
+//! 0, 0, 0, 0, 0, 1, 1, 1, 0xFF00FF, 0, 0)` não diz qual zero é a rotação.
+//!
+//! A regra que este crate segue: **até quatro, posicional; mais que isso, um
+//! objeto de opções na segunda posição.** Uma superfície com duas convenções
+//! misturadas ao acaso seria pior que qualquer uma delas.
+//!
+//! # Por que um campo ausente vale o default e não é um erro
+//!
+//! Porque a alternativa é uma janela que não abre e não diz por quê. Este motor
+//! ainda não lança — `entry/throw.rs` explica que um throw sem handler no
+//! chamador termina o programa — então um argumento faltando só poderia virar
+//! silêncio ou um valor. Um valor, documentado por chamada, é o que deixa
+//! `drawRect(w, { x, y, w, h })` funcionar sem repetir borda e raio.
+
+use rts_core_rwk::entry;
+
+/// O número que um valor carrega, ou o default quando não carrega nenhum.
+///
+/// `undefined` e um objeto valem o mesmo aqui: nenhum dos dois É um número, e
+/// `NaN` propagado até uma coordenada de vértice é mais difícil de rastrear que
+/// um retângulo desenhado na origem.
+pub fn number(value: u64, default: f64) -> f64 {
+    match entry::number_of(value) {
+        Some(number) if number.is_finite() => number,
+        _ => default,
+    }
+}
+
+/// O mesmo, truncado — cores, flags e contagens cruzam como `i64`.
+pub fn integer(value: u64, default: i64) -> i64 {
+    number(value, default as f64) as i64
+}
+
+/// Um handle de janela ou de malha.
+///
+/// Um handle é um contador pequeno, então cabe exato num double — o que o
+/// torna seguro de carregar como `number` no TS, ao contrário de um ponteiro.
+pub fn handle(value: u64) -> u64 {
+    number(value, 0.0).max(0.0) as u64
+}
+
+/// O texto de um valor que É uma string, vazio para qualquer outro.
+///
+/// `string_in` e não `text_in`: o segundo é `ToString` e responde `"42"` para o
+/// número 42, o que transforma um argumento trocado num rótulo plausível em vez
+/// de num vazio visível.
+pub fn text(value: u64) -> String {
+    entry::with_runtime(|context| entry::string_in(context, value)).unwrap_or_default()
+}
+
+/// Os campos de um objeto de opções, lidos num único empréstimo do contexto.
+///
+/// Um empréstimo por campo funcionaria e custaria treze num `drawMesh` por
+/// draw. Mais importante que o custo: `with_runtime` segura o `RefCell` durante
+/// o corpo, e o hábito de aninhá-lo é o que vira um empréstimo reentrante — que
+/// num quadro `extern "C"` não desenrola e portanto **aborta o processo**.
+/// Uma leitura, uma vez, é também a forma que não tem como errar isso.
+pub fn fields(object: u64, names: &[&str]) -> Vec<u64> {
+    entry::with_runtime(|context| {
+        names
+            .iter()
+            .map(|name| entry::get_member(context, object, name))
+            .collect()
+    })
+}
+
+/// Os bytes de um `Uint8Array`/`Float32Array`/`DataView`, ou nada.
+///
+/// # Por que uma view tipada e não um ponteiro
+///
+/// A superfície antiga recebia `vertsPtr: number` — o endereço cru de um buffer,
+/// que o TS obtinha e o Rust desreferenciava. Isso é uma leitura arbitrária de
+/// memória a partir de um número que um programa pode calcular, e no motor novo
+/// seria pior: o coletor move células, então o endereço que o TS leu pode não
+/// ser mais o buffer quando o Rust o usa.
+///
+/// `bytes_of` responde uma CÓPIA da janela que a view descreve. A cópia é o que
+/// torna a fronteira segura, e é paga por upload — não por frame.
+pub fn bytes(value: u64) -> Option<Vec<u8>> {
+    entry::with_runtime(|context| entry::bytes_of(context, value))
+}
+
+/// `undefined`, para um nativo que não responde nada.
+pub fn nothing() -> u64 {
+    entry::undefined_value()
+}
+
+/// Um número como valor.
+pub fn from_number(value: f64) -> u64 {
+    entry::make_number(value)
+}
+
+/// Um booleano como valor — `true`/`false`, não 1/0.
+///
+/// A superfície antiga respondia `i64` porque a ABI não tinha booleano, e o TS
+/// comparava com `1`. Aqui existe um booleano de verdade, então `isOpen()` é
+/// usável direto num `while` sem que o programa saiba disso.
+pub fn from_bool(value: bool) -> u64 {
+    entry::boolean_value(value)
+}
+
+/// Uma string como valor.
+pub fn from_text(text: &str) -> u64 {
+    entry::with_runtime(|context| entry::make_string(context, text))
+}

--- a/crates/rts-ui-rwk/src/window.rs
+++ b/crates/rts-ui-rwk/src/window.rs
@@ -1,0 +1,136 @@
+//! A janela e o frame: o que abre, o que bombeia e o que apresenta.
+//!
+//! Todo membro daqui recebe o handle de janela como primeiro argumento, que é o
+//! que o `openWindow` respondeu. O handle é opaco de propósito — é a chave de um
+//! `thread_local` no `rts-egui`, e o `UiCtx` que ele nomeia é `!Send`, então a
+//! thread que abriu a janela é a única que pode bombear o loop dela.
+
+use rts_core_rwk::entry::Provided;
+
+use crate::value::{self, fields, handle, integer, number, text};
+
+/// Os membros que a janela e o frame contribuem para `rts:egui`.
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("openWindow", open_window),
+    ("pump", pump),
+    ("isOpen", is_open),
+    ("close", close),
+    ("moveWindow", move_window),
+    ("setNextWindowPos", set_next_window_pos),
+    ("setVsync", set_vsync),
+    ("mouseLock", mouse_lock),
+    ("snapshot", snapshot),
+    ("beginFrame", begin_frame),
+    ("endFrame", end_frame),
+    ("winWidth", win_width),
+    ("winHeight", win_height),
+];
+
+/// `openWindow(title, width, height, config)` — o handle, ou `0` em falha.
+///
+/// `config` é o mesmo bitfield da superfície antiga (bit0 alta performance, bit1
+/// memória, bit2 limites altos, bit3 glow, bit4 transparente, bit5 sem
+/// decoração), mantido porque é o que os programas existentes passam e porque
+/// traduzi-lo aqui seria uma segunda grafia da mesma decisão.
+extern "C" fn open_window(_e: u64, _t: u64, title: u64, width: u64, height: u64, config: u64) -> u64 {
+    let opened = rts_egui::open_window(
+        &text(title),
+        integer(width, 960),
+        integer(height, 600),
+        integer(config, 0),
+    );
+    value::from_number(opened as f64)
+}
+
+/// `pump(win)` — processa os eventos pendentes do SO. `true` enquanto o programa
+/// deve continuar.
+///
+/// A superfície antiga respondia `0 = continuar`, que é a convenção de código de
+/// saída de um processo e o inverso do que um `while` lê. Aqui responde o que a
+/// palavra diz.
+extern "C" fn pump(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    value::from_bool(rts_egui::pump(handle(win)) == 0)
+}
+
+/// `isOpen(win)`.
+extern "C" fn is_open(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    value::from_bool(rts_egui::is_open(handle(win)) != 0)
+}
+
+/// `close(win)` — destrói a janela. O event loop do processo sobrevive: o winit
+/// não permite recriá-lo.
+extern "C" fn close(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::close(handle(win));
+    value::nothing()
+}
+
+/// `moveWindow(win, x, y)` — posição absoluta na área de trabalho, em pixels
+/// físicos, o que é como se escolhe um monitor.
+extern "C" fn move_window(_e: u64, _t: u64, win: u64, x: u64, y: u64, _c: u64) -> u64 {
+    rts_egui::move_window(handle(win), integer(x, 0), integer(y, 0));
+    value::nothing()
+}
+
+/// `setNextWindowPos(x, y)` — onde a PRÓXIMA janela nasce. Mais confiável que
+/// mover depois, porque a janela nunca chega a aparecer no lugar errado.
+extern "C" fn set_next_window_pos(_e: u64, _t: u64, x: u64, y: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::set_next_pos(integer(x, 0), integer(y, 0));
+    value::nothing()
+}
+
+/// `setVsync(win, on)` — `false` é o opt-out explícito: quem desliga assume o
+/// throttle e o consumo.
+extern "C" fn set_vsync(_e: u64, _t: u64, win: u64, on: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::set_vsync(handle(win), integer(on, 1));
+    value::nothing()
+}
+
+/// `mouseLock(win, on)` — confina e esconde o cursor, e passa
+/// `input.mouseDeltaX/Y` a reportar deltas CRUS do dispositivo, que é o que um
+/// FPS precisa e o que a borda da tela estraga.
+extern "C" fn mouse_lock(_e: u64, _t: u64, win: u64, on: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::mouse_lock(handle(win), integer(on, 0));
+    value::nothing()
+}
+
+/// `snapshot(win, path)` — agenda um PPM do próximo `endFrame`, para asserir que
+/// um frame não está em branco sem olhar para ele. Só no backend glow.
+extern "C" fn snapshot(_e: u64, _t: u64, win: u64, path: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::snapshot(handle(win), &text(path));
+    value::nothing()
+}
+
+/// `beginFrame(win)` — abre o pass: recolhe o input e zera a fila de comandos.
+extern "C" fn begin_frame(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::begin_frame(handle(win));
+    value::nothing()
+}
+
+/// `endFrame(win)` — drena a fila, tesselá e apresenta.
+extern "C" fn end_frame(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::end_frame(handle(win));
+    value::nothing()
+}
+
+/// `winWidth(win)` — largura LÓGICA em pontos, que acompanha o resize.
+extern "C" fn win_width(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    value::from_number(rts_egui::win_width(handle(win)))
+}
+
+/// `winHeight(win)`.
+extern "C" fn win_height(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    value::from_number(rts_egui::win_height(handle(win)))
+}
+
+/// Lê um objeto de opções pelos nomes dados, com defaults por posição.
+///
+/// Vive aqui e é usado pelos módulos de desenho porque é a mecânica da decisão
+/// que `value` documenta: um objeto na segunda posição, campo ausente vale o
+/// default.
+pub fn options(object: u64, names: &[&str], defaults: &[f64]) -> Vec<f64> {
+    let read = fields(object, names);
+    read.iter()
+        .zip(defaults)
+        .map(|(value, default)| number(*value, *default))
+        .collect()
+}

--- a/docs/ui/new-engine-port.md
+++ b/docs/ui/new-engine-port.md
@@ -1,0 +1,165 @@
+# The UI surface on the new engine
+
+**What this is.** How `rts:egui` and `rts:input` reach the new engine, what the
+port changed in the surface a program writes, and what is deliberately still on
+the old one.
+
+The design of the UI itself is `egui-crate.md`, `input-system.md` and
+`render-input-interfaces.md`. This document is only about the boundary, and it
+does not restate them.
+
+---
+
+## The shape
+
+```
+rts-egui / rts-dom / rts-render / rts-input     the logic. Plain Rust.
+        │                                        &str, f64, u64. No engine.
+        ├──────────────┐
+        ▼              ▼
+   src/abi.rs      rts-ui-rwk          two shells over one logic
+   (feature          (crate)
+    old-engine)         │
+        │               ▼
+        ▼        rts-core-rwk          natives: a function pointer beside a cell
+   rts-engine  ← rts-abi               natives: a linker symbol
+```
+
+**Why two shells and not a migration.** A native is a different thing in each
+engine. The old one bakes `__RTS_FN_NS_EGUI_DRAW_RECT` into a symbol table and
+the JIT resolves it by name; the new one holds an `extern "C"` function pointer
+beside a cell, with no name a linker ever sees — `docs/engine/authoring-natives.md`
+§1. There is no spelling of a function that is both.
+
+So the logic became engine-free and each engine got a shell. The old shell is
+behind the `old-engine` feature, **on by default**, so the old engine compiles
+unchanged and `rts-runtime` — which *is* the old engine — asks for it
+explicitly. The new engine takes the same crates with `default-features = false`.
+
+The feature is the right mechanism because the question is one of
+**availability** — "does this build have the old ABI?" — which is the only
+reason `docs/engine/architecture.md` accepts for a crate boundary. It is not a
+permission: nothing is being forbidden, an interface is being removed.
+
+`rts-ui-rwk` is a crate of its own for the same rule one level up. A window
+needs a window system: it does not exist on wasm, it does not exist in a
+headless build, and a target without one should not pull wgpu and winit into its
+graph to find that out. The host installs it behind the `ui` feature.
+
+---
+
+## What changed in the surface, and why each one had to
+
+Three things. Every one of them follows from the convention a native has here,
+which is the convention a compiled JavaScript function has:
+`(environment, this, a0, a1, a2, a3) -> value`.
+
+### 1. Past four arguments, an options object
+
+`drawMesh` had thirteen parameters. The convention carries four; what overflows
+goes into a vector the runtime holds, and that vector is not exposed to a host
+native — so a fifth argument is not merely awkward, it is invisible.
+
+```ts
+// before
+egui.drawMesh(win, mesh, 0, 0, 0, 0, 0, 1, 1, 1, 0xFF00FFFF, 0, 0);
+// now
+egui.drawMesh(win, { mesh, x: 0, y: 0, z: 0, color: 0xFF00FFFF });
+```
+
+**The rule: up to four, positional; more than that, one options object in the
+second position.** A surface mixing both conventions at random would be worse
+than either. A missing field takes a documented default, because this engine
+does not throw yet — `entry/throw.rs` says why — so the alternative to a default
+is silence.
+
+Rejected: widening the convention, or exposing the rest vector to hosts. Both
+change the engine to accommodate one surface, and the thirteen-positional call
+they preserve does not say which zero is the rotation.
+
+### 2. Geometry arrives as a typed view, not an address
+
+```ts
+// before
+egui.meshUpload(win, verts.ptr(), vertexCount, indices.ptr(), indexCount);
+// now
+egui.meshUpload(win, new Float32Array(verts), new Uint32Array(indices));
+```
+
+A raw address is an arbitrary memory read from a number the program computed,
+and here it is worse than that: the collector moves cells, so the address the
+program read can stop naming the buffer before Rust uses it. `bytes_of` answers
+a **copy** of the window a view describes, and the copy is what makes the
+boundary safe. It is paid per upload, not per frame.
+
+It also removes a whole class of caller error: the lengths come from the views,
+so a program cannot declare a count that disagrees with its data.
+
+### 3. Booleans are booleans
+
+`isOpen()` and `key()` answer `true`/`false`. The old ABI had no boolean type
+and answered `0`/`1`, so every call site compared against a number.
+
+`pump()` answers **"keep going"**. It used to answer `0 = continue`, which is
+the convention of a process exit code and the inverse of what a `while` reads.
+
+Everything else keeps its name on purpose: a program that already draws reads
+the same, and the difference stays where it is real.
+
+---
+
+## What is not ported, and why each one is a decision
+
+| absent | why |
+|---|---|
+| `rts:gpu` (compute) | a compute buffer **is** an `Entry::Buffer` in the old engine's `HandleTable`. Porting it is choosing where those bytes live in the new one — not writing a shell |
+| `egui.drawWater` | its only consumer is a `rts:gpu` buffer handle |
+| `rts:dom`, `render.*` | the tree, parser and layout engine are 18 000 engine-free lines in `rts-dom`; the port is the same shell this crate is, for that surface |
+| `egui.render(win, dom)` | without the DOM namespace there is no handle to pass, so it would be a function that always draws nothing |
+
+Each absence fails at the `import` line, which is where it should hurt.
+`rts-std-rwk` once refused to register a façade `rts:egui` for exactly this
+reason: a UI that compiles and does not paint is the failure mode that costs the
+most time before it is understood.
+
+---
+
+## How it is verified
+
+`crates/rts-host-rwk/tests/ui_surface.rs` — three tests, each one running the
+program: the specifiers resolve, the members are callable, and calling with no
+window crosses the boundary instead of aborting. That last one is not pedantry:
+a reentrant borrow of the context inside an `extern "C"` frame cannot unwind, so
+it **aborts the process** — which is a test disappearing, not a test failing.
+
+None of them opens a window. That is `crates/rts-host-rwk/examples/janela.rs`:
+
+```bash
+cargo run -p rts-host-rwk --example janela
+```
+
+It is an example rather than an ignored test for a platform reason. winit panics
+when the event loop is created off the **main** thread, and a cargo `#[test]`
+runs on a secondary one. There is an escape hatch
+(`EventLoopBuilderExtWindows::any_thread`) and taking it would mean defeating a
+compatibility warning in order to call this a test.
+
+Measured on Windows with a dx12 backend: 600 frames in 11.8 s — about 51 fps
+against a 60 Hz vsync, in a **debug** build, which is not a performance claim
+about anything (`perf-claim`); it is the evidence that frames were actually
+presented rather than skipped.
+
+---
+
+## The one thing the host does that the program does not have to know
+
+`rts_ui_rwk::shutdown()`, called by the host when a program ends.
+
+On Windows a `thread_local` destructor runs from the TLS callback during
+`LdrShutdownProcess` — while the driver's DLLs are being unloaded. Destroying a
+`wgpu::Device` there makes the AMD D3D12 driver fast-fail with `0xC0000409`
+after a clean, fully-flushed run, with no message at all. `rts-egui` already
+knew this and had `shutdown_shared_gpu` for the old CLI to call.
+
+The host calls it, not the program: a program that forgot the line would die on
+exit, and it has no way to know the line exists.


### PR DESCRIPTION
A superfície de UI passa a existir no motor novo. Três commits, cada um com um passo:

1. **`refactor:`** — a lógica de `rts-egui`/`rts-dom`/`rts-render`/`rts-input` deixa de conhecer motor (Rust comum: `&str`, `f64`, `u64`), e a casca `extern "C"` do motor antigo vai para um módulo atrás da feature `old-engine`, **ligada por default**. Nenhum dos 45 símbolos `__RTS_FN_NS_EGUI_*` mudou de nome ou assinatura.
2. **`feat:`** — o crate `rts-ui-rwk` provê `rts:egui` e `rts:input`; o host o instala atrás da feature `ui`.
3. **`docs:`** — `docs/ui/new-engine-port.md`, o exemplo que abre janela, e o fix do `0xC0000409` na saída.

## Por que era um porte e não um registro

Um nativo é outra coisa em cada motor: no antigo é um símbolo de linker resolvido por nome; no novo é um ponteiro de função ao lado de uma célula, sem nome nenhum. Não existe grafia de função que seja as duas. E um crate do motor novo que alcançasse `rts-engine` alcançaria, pelo grafo de build, `rts-abi` — a interface que `rts_cranelift::abi` substituiu.

## O que mudou para quem escreve o programa

| antes | agora | por quê |
|---|---|---|
| 13 argumentos posicionais | objeto de opções na 2ª posição | a convenção carrega **quatro** |
| `meshUpload(win, ptr, n, ptr, m)` | `meshUpload(win, Float32Array, Uint32Array)` | o coletor move células; um endereço lido envelhece |
| `isOpen(): 0\|1` | `boolean` | existe um booleano de verdade aqui |
| `pump(): 0 = continuar` | `pump(): "continuar"` | era o inverso do que um `while` lê |

O resto dos nomes é igual de propósito.

## Fora, cada um por um motivo

`rts:gpu` e `drawWater` (os buffers **são** handles do `HandleTable` antigo), `rts:dom`/`render.*` (o porte é a mesma casca, para outra superfície) e `egui.render(win, dom)`, que sem o namespace do DOM não teria handle para receber. Cada ausência falha no `import`, que é onde deve doer.

## Verificação

- `cargo test -p rts-host-rwk` — **323 testes, todos passando**, incluindo 3 novos em `tests/ui_surface.rs` que rodam o programa.
- `cargo run -p rts-host-rwk --example janela` — janela real, **600 frames em 11,8 s** (≈51 fps contra vsync de 60 Hz, build debug — evidência de apresentação, não afirmação de desempenho).
- Motor antigo intacto: `cargo check -p rts-runtime` e `-p rts` limpos.

**Não é regressão, e está dito:** `cargo test -p rts-dom` (26 erros nos testes de `abi.rs`) e `-p rts-render`/`-p rts-input` (LNK2019) falham igual na `main` — verificado por checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNMhSfMGXNa4hdUnoiMfHu