### PR TITLE
feat: rts:gpu no motor novo, e a correção de por que ele não estava lá

### DIFF
--- a/crates/rts-egui/src/abi/gpu.rs
+++ b/crates/rts-egui/src/abi/gpu.rs
@@ -1,0 +1,267 @@
+//! A casca do `rts:gpu` para o motor ANTIGO.
+//!
+//! Mesma divisão que `super`: a lógica está em `crate::compute`, em Rust comum,
+//! e aqui ficam os símbolos de linker e a tabela do namespace. A tradução que
+//! esta casca faz é de ONDE VÊM E PARA ONDE VÃO OS BYTES — `crate::compute` só
+//! sobe e baixa, e quem sabe o que um handle de `rts:buffer` significa é este
+//! motor.
+
+use rts_engine::abi::ty::{Handle, I64, U64};
+use rts_engine::heap::handles::{Entry, with_entry, with_entry_mut};
+use rts_engine::{AbiType, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
+
+use crate::compute::{self, Poll};
+
+/// Os bytes de um `rts:buffer`, do offset dado.
+fn source(src: u64, offset: i64, bytes: i64) -> Option<Vec<u8>> {
+    if bytes <= 0 || offset < 0 {
+        return None;
+    }
+    with_entry(src, |entry| match entry {
+        Some(Entry::Buffer(held)) => {
+            let start = offset as usize;
+            let end = start.saturating_add(bytes as usize).min(held.len());
+            (start < end).then(|| held[start..end].to_vec())
+        }
+        _ => None,
+    })
+}
+
+/// Escreve num `rts:buffer` e responde quantos bytes couberam.
+fn sink(dst: u64, data: &[u8]) -> i64 {
+    with_entry_mut(dst, |entry| match entry {
+        Some(Entry::Buffer(held)) => {
+            let n = data.len().min(held.len());
+            held[..n].copy_from_slice(&data[..n]);
+            n as i64
+        }
+        _ => -1,
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_AVAILABLE() -> I64 {
+    i64::from(compute::available())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_SHADER(src_ptr: *const u8, src_len: i64) -> Handle {
+    match unsafe { rts_engine::abi::str_abi::from_abi(src_ptr, src_len) } {
+        Some(source) => compute::shader(source),
+        None => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_BUFFER(bytes: I64) -> Handle {
+    compute::buffer(bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_WRITE(gbuf: U64, src: U64, bytes: I64) -> I64 {
+    match source(src, 0, bytes) {
+        Some(data) => i64::from(compute::write(gbuf, &data)),
+        None => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_WRITE_AT(
+    gbuf: U64,
+    src: U64,
+    src_off: I64,
+    dst_off: I64,
+    bytes: I64,
+) -> I64 {
+    match source(src, src_off, bytes) {
+        // Curto de propósito: a superfície antiga recusava uma origem que não
+        // cobrisse `bytes` inteiros, e `source` já responde `None` para isso.
+        Some(data) if data.len() == bytes.max(0) as usize => {
+            i64::from(compute::write_at(gbuf, dst_off, &data))
+        }
+        _ => 0,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_BIND(pipe: U64, slot: I64, gbuf: U64) -> I64 {
+    i64::from(compute::bind_buffer(pipe, slot, gbuf))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_DISPATCH(pipe: U64, gx: I64, gy: I64, gz: I64) -> I64 {
+    i64::from(compute::dispatch(pipe, gx, gy, gz))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_READ(gbuf: U64, dst: U64, bytes: I64) -> I64 {
+    match compute::read(gbuf, bytes) {
+        Some(data) => sink(dst, &data),
+        None => -1,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_READ_BEGIN(gbuf: U64, bytes: I64) -> Handle {
+    compute::read_begin(gbuf, bytes)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_READ_POLL(ticket: U64, dst: U64) -> I64 {
+    match compute::read_poll(ticket) {
+        Poll::Pending => 0,
+        Poll::Failed => -1,
+        Poll::Done(data) => sink(dst, &data),
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_BUFFER_FREE(gbuf: U64) -> I64 {
+    i64::from(compute::buffer_free(gbuf))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn __RTS_FN_NS_GPU_ADAPTER_NAME() -> Handle {
+    use rts_engine::heap::string_pool::__RTS_FN_NS_GC_STRING_NEW;
+    match compute::adapter_name() {
+        Some(name) => unsafe { __RTS_FN_NS_GC_STRING_NEW(name.as_ptr(), name.len() as i64) },
+        None => 0,
+    }
+}
+
+/// Solta tudo que o `rts:gpu` segura, na ordem, enquanto o processo está
+/// inteiro — reexportado aqui porque o binário do motor antigo chama
+/// `ns::gpu::shutdown()` na saída, e este módulo É o `ns::gpu` dele.
+///
+/// Ver `crate::compute::shutdown` para por que não pode ficar para o destrutor
+/// de thread-local.
+pub fn shutdown() {
+    compute::shutdown();
+}
+
+fn func(name: &str, symbol: &str, sig: Sig, ts: &str, doc: &str, fp: *const u8) -> Member {
+    Member {
+        name: name.to_string(),
+        kind: MemberKind::Function,
+        sig,
+        symbol: symbol.to_string(),
+        fn_ptr: FnPtr(fp),
+        flags: MemberFlags::NONE,
+        aliases: Vec::new(),
+        variadic: false,
+        ts_signature: ts.to_string(),
+        doc: doc.to_string(),
+        ret_class: None,
+        pure: false,
+        emit: None,
+    }
+}
+
+/// Registra a namespace `gpu` no motor.
+pub fn register(e: &mut Engine) {
+    e.ns("gpu")
+        .doc("Compute WGSL na GPU compartilhada do runtime (headless ou junto do render).")
+        .member(func(
+            "available",
+            "__RTS_FN_NS_GPU_AVAILABLE",
+            Sig::new(Vec::new(), AbiType::I64),
+            "available(): number",
+            "1 se há GPU utilizável (cria o device headless na primeira consulta).",
+            __RTS_FN_NS_GPU_AVAILABLE as *const u8,
+        ))
+        .member(func(
+            "shader",
+            "__RTS_FN_NS_GPU_SHADER",
+            Sig::new(vec![AbiType::StrPtr], AbiType::Handle),
+            "shader(wgsl: string): number",
+            "Compila um kernel WGSL (entry point `main`). Handle do pipeline; 0 = erro de validação (stderr).",
+            __RTS_FN_NS_GPU_SHADER as *const u8,
+        ))
+        .member(func(
+            "buffer",
+            "__RTS_FN_NS_GPU_BUFFER",
+            Sig::new(vec![AbiType::I64], AbiType::Handle),
+            "buffer(bytes: number): number",
+            "Storage buffer na GPU. Handle; 0 = erro.",
+            __RTS_FN_NS_GPU_BUFFER as *const u8,
+        ))
+        .member(func(
+            "write",
+            "__RTS_FN_NS_GPU_WRITE",
+            Sig::new(vec![AbiType::U64, AbiType::U64, AbiType::I64], AbiType::I64),
+            "write(gbuf: number, src: number, bytes: number): number",
+            "Sobe bytes de um rts:buffer para o buffer de GPU. 1 ok, 0 erro.",
+            __RTS_FN_NS_GPU_WRITE as *const u8,
+        ))
+        .member(func(
+            "write_at",
+            "__RTS_FN_NS_GPU_WRITE_AT",
+            Sig::new(
+                vec![AbiType::U64, AbiType::U64, AbiType::I64, AbiType::I64, AbiType::I64],
+                AbiType::I64,
+            ),
+            "write_at(gbuf: number, src: number, srcOff: number, dstOff: number, bytes: number): number",
+            "Partial write with offsets: copies bytes from the rts:buffer into the GPU buffer at dstOff. Enables poking ONE body without re-uploading full state. 1 ok, 0 error.",
+            __RTS_FN_NS_GPU_WRITE_AT as *const u8,
+        ))
+        .member(func(
+            "bind_buffer",
+            "__RTS_FN_NS_GPU_BIND",
+            Sig::new(vec![AbiType::U64, AbiType::I64, AbiType::U64], AbiType::I64),
+            "bind_buffer(pipe: number, slot: number, gbuf: number): number",
+            "Liga o buffer ao @binding(slot) do @group(0) do pipeline. 1 ok.",
+            __RTS_FN_NS_GPU_BIND as *const u8,
+        ))
+        .member(func(
+            "dispatch",
+            "__RTS_FN_NS_GPU_DISPATCH",
+            Sig::new(
+                vec![AbiType::U64, AbiType::I64, AbiType::I64, AbiType::I64],
+                AbiType::I64,
+            ),
+            "dispatch(pipe: number, gx: number, gy: number, gz: number): number",
+            "Submete gx*gy*gz workgroups (assíncrono — `read` sincroniza). 1 ok.",
+            __RTS_FN_NS_GPU_DISPATCH as *const u8,
+        ))
+        .member(func(
+            "read",
+            "__RTS_FN_NS_GPU_READ",
+            Sig::new(vec![AbiType::U64, AbiType::U64, AbiType::I64], AbiType::I64),
+            "read(gbuf: number, dst: number, bytes: number): number",
+            "Espera a GPU e copia bytes do buffer de GPU para um rts:buffer. Bytes lidos, -1 erro.",
+            __RTS_FN_NS_GPU_READ as *const u8,
+        ))
+        .member(func(
+            "read_begin",
+            "__RTS_FN_NS_GPU_READ_BEGIN",
+            Sig::new(vec![AbiType::U64, AbiType::I64], AbiType::Handle),
+            "read_begin(gbuf: number, bytes: number): number",
+            "Async read, step 1: schedules the GPU->staging copy WITHOUT waiting; returns a ticket (0 = error). Poll with read_poll.",
+            __RTS_FN_NS_GPU_READ_BEGIN as *const u8,
+        ))
+        .member(func(
+            "read_poll",
+            "__RTS_FN_NS_GPU_READ_POLL",
+            Sig::new(vec![AbiType::U64, AbiType::U64], AbiType::I64),
+            "read_poll(ticket: number, dst: number): number",
+            "Async read, step 2: non-blocking check. Ready -> copies into the rts:buffer dst, consumes the ticket, returns bytes. In flight -> 0. Error -> -1.",
+            __RTS_FN_NS_GPU_READ_POLL as *const u8,
+        ))
+        .member(func(
+            "buffer_free",
+            "__RTS_FN_NS_GPU_BUFFER_FREE",
+            Sig::new(vec![AbiType::U64], AbiType::I64),
+            "buffer_free(gbuf: number): number",
+            "Libera um buffer de GPU (e o desliga de todos os pipelines). 1 se existia.",
+            __RTS_FN_NS_GPU_BUFFER_FREE as *const u8,
+        ))
+        .member(func(
+            "adapter_name",
+            "__RTS_FN_NS_GPU_ADAPTER_NAME",
+            Sig::new(Vec::new(), AbiType::Handle),
+            "adapter_name(): string",
+            "Nome do adapter de GPU em uso (debug).",
+            __RTS_FN_NS_GPU_ADAPTER_NAME as *const u8,
+        ))
+        .done();
+}

--- a/crates/rts-egui/src/abi/mod.rs
+++ b/crates/rts-egui/src/abi/mod.rs
@@ -22,6 +22,10 @@ use rts_engine::abi::str_abi;
 mod register;
 pub use register::register;
 
+// `rts:gpu` é um namespace próprio no motor antigo, com registro próprio — a
+// facade o alcança como `ns::gpu::register`.
+pub mod gpu;
+
 /// O texto que um par ponteiro+comprimento nomeia, vazio quando não nomeia um.
 ///
 /// # Segurança

--- a/crates/rts-egui/src/compute.rs
+++ b/crates/rts-egui/src/compute.rs
@@ -36,9 +36,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use rts_engine::abi::ty::{Handle, I64, U64};
-use rts_engine::heap::handles::{Entry, with_entry, with_entry_mut};
-use rts_engine::{AbiType, Engine, FnPtr, Member, MemberFlags, MemberKind, Sig};
 
 use crate::frame::gpu::{GpuConfig, SharedGpu, shared_gpu};
 
@@ -129,18 +126,13 @@ fn with_gpu<R>(default: R, f: impl FnOnce(&mut Ctx) -> R) -> R {
 }
 
 /// 1 se há GPU utilizável (cria o device na primeira consulta).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_AVAILABLE() -> I64 {
-    with_gpu(0, |_| 1)
+pub fn available() -> bool {
+    with_gpu(false, |_| true)
 }
 
 /// Compila um kernel WGSL (entry point `main`). Handle do pipeline, 0 em erro
 /// de validação (mensagem no stderr).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_SHADER(src_ptr: *const u8, src_len: i64) -> Handle {
-    let Some(src) = (unsafe { rts_engine::abi::str_abi::from_abi(src_ptr, src_len) }) else {
-        return 0;
-    };
+pub fn shader(src: &str) -> u64 {
     with_gpu(0, |c| {
         let dev = &c.gpu.device;
         // Error scope: WGSL inválido vira Err aqui em vez de panic global.
@@ -175,8 +167,7 @@ pub extern "C" fn __RTS_FN_NS_GPU_SHADER(src_ptr: *const u8, src_len: i64) -> Ha
 }
 
 /// Storage buffer de `bytes` na GPU. Handle, 0 em erro.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_BUFFER(bytes: I64) -> Handle {
+pub fn buffer(bytes: i64) -> u64 {
     if bytes <= 0 {
         return 0;
     }
@@ -201,59 +192,31 @@ pub extern "C" fn __RTS_FN_NS_GPU_BUFFER(bytes: I64) -> Handle {
     })
 }
 
-/// Sobe `bytes` do `rts:buffer` `src` para o buffer de GPU. 1 ok, 0 erro.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_WRITE(gbuf: U64, src: U64, bytes: I64) -> I64 {
-    let Some(data) = with_entry(src, |e| match e {
-        Some(Entry::Buffer(b)) => Some(b[..(bytes as usize).min(b.len())].to_vec()),
-        _ => None,
-    }) else {
-        return 0;
-    };
-    with_gpu(0, |c| {
+/// Sobe `data` para o buffer de GPU, a partir de `dst_off`. `true` ok.
+///
+/// Recebe os BYTES e não um handle de buffer do programa: de onde eles vêm é
+/// pergunta do motor, e há dois. A casca de cada um lê os seus — do
+/// `HandleTable` no antigo, de uma view tipada no novo — e este módulo só sobe.
+pub fn write_at(gbuf: u64, dst_off: i64, data: &[u8]) -> bool {
+    if dst_off < 0 || data.is_empty() {
+        return false;
+    }
+    with_gpu(false, |c| {
         let Some(buf) = c.buffers.get(&gbuf) else {
-            return 0;
+            return false;
         };
-        c.gpu.queue.write_buffer(buf, 0, &data);
-        1
+        if (dst_off as u64) + data.len() as u64 > buf.size() {
+            return false;
+        }
+        c.gpu.queue.write_buffer(buf, dst_off as u64, data);
+        true
     })
 }
 
-/// Escrita PARCIAL com offset: copia `bytes` do rts:buffer `src` (a partir de
-/// `src_off`) para o buffer de GPU `gbuf` (a partir de `dst_off`). 1 ok.
-/// É o que permite "cutucar" UM corpo sem reenviar o estado inteiro (o upload
-/// completo em pleno jogo reescrevia velocidades de todos com valores velhos).
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_WRITE_AT(
-    gbuf: U64,
-    src: U64,
-    src_off: I64,
-    dst_off: I64,
-    bytes: I64,
-) -> I64 {
-    if bytes <= 0 || src_off < 0 || dst_off < 0 {
-        return 0;
-    }
-    let Some(data) = with_entry(src, |e| match e {
-        Some(Entry::Buffer(b)) => {
-            let a = src_off as usize;
-            let fim = a.saturating_add(bytes as usize);
-            if fim <= b.len() { Some(b[a..fim].to_vec()) } else { None }
-        }
-        _ => None,
-    }) else {
-        return 0;
-    };
-    with_gpu(0, |c| {
-        let Some(buf) = c.buffers.get(&gbuf) else {
-            return 0;
-        };
-        if (dst_off as u64) + data.len() as u64 > buf.size() {
-            return 0;
-        }
-        c.gpu.queue.write_buffer(buf, dst_off as u64, &data);
-        1
-    })
+/// O mesmo a partir do início — `writeAt(gbuf, 0, data)`, nomeado porque é o
+/// caso comum e porque a superfície antiga tinha as duas.
+pub fn write(gbuf: u64, data: &[u8]) -> bool {
+    write_at(gbuf, 0, data)
 }
 
 /// Liga o buffer `gbuf` ao `@binding(slot)` do `@group(0)` do pipeline. 1 ok.
@@ -262,31 +225,29 @@ pub extern "C" fn __RTS_FN_NS_GPU_WRITE_AT(
 /// `Function.prototype.bind` ANTES de resolver membro de namespace, e o script
 /// morre com "unbound identifier `gpu`". Membro de namespace não pode se chamar
 /// `bind`/`call`/`apply` enquanto isso for assim.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_BIND(pipe: U64, slot: I64, gbuf: U64) -> I64 {
-    with_gpu(0, |c| {
+pub fn bind_buffer(pipe: u64, slot: i64, gbuf: u64) -> bool {
+    with_gpu(false, |c| {
         if !c.buffers.contains_key(&gbuf) {
-            return 0;
+            return false;
         }
         let Some(p) = c.pipes.get_mut(&pipe) else {
-            return 0;
+            return false;
         };
         p.binds.retain(|(s, _)| *s != slot as u32);
         p.binds.push((slot as u32, gbuf));
-        1
+        true
     })
 }
 
 /// Submete `gx × gy × gz` workgroups do pipeline. NÃO espera a GPU terminar —
 /// `read` é quem sincroniza. 1 ok, 0 erro.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_DISPATCH(pipe: U64, gx: I64, gy: I64, gz: I64) -> I64 {
+pub fn dispatch(pipe: u64, gx: i64, gy: i64, gz: i64) -> bool {
     if gx <= 0 || gy <= 0 || gz <= 0 {
-        return 0;
+        return false;
     }
-    with_gpu(0, |c| {
+    with_gpu(false, |c| {
         let Some(p) = c.pipes.get(&pipe) else {
-            return 0;
+            return false;
         };
         let entries: Vec<wgpu::BindGroupEntry> = p
             .binds
@@ -322,20 +283,22 @@ pub extern "C" fn __RTS_FN_NS_GPU_DISPATCH(pipe: U64, gx: I64, gy: I64, gz: I64)
         c.gpu.queue.submit([enc.finish()]);
         if let Some(e) = pollster::block_on(scope.pop()) {
             eprintln!("[rts:gpu] dispatch inválido: {e}");
-            return 0;
+            return false;
         }
-        1
+        true
     })
 }
 
-/// Lê `bytes` do buffer de GPU para o `rts:buffer` `dst`. SINCRONIZA (espera
-/// todo trabalho submetido terminar). Bytes lidos, -1 erro.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_READ(gbuf: U64, dst: U64, bytes: I64) -> I64 {
+/// Lê até `bytes` do buffer de GPU. SINCRONIZA — espera todo trabalho submetido
+/// terminar. `None` em erro ou buffer inexistente.
+///
+/// Devolve os bytes em vez de escrevê-los num destino, pela razão que
+/// [`write_at`] documenta: para onde eles vão é pergunta do motor.
+pub fn read(gbuf: u64, bytes: i64) -> Option<Vec<u8>> {
     if bytes <= 0 {
-        return -1;
+        return None;
     }
-    let data: Option<Vec<u8>> = with_gpu(None, |c| {
+    with_gpu(None, |c| {
         let Some(buf) = c.buffers.get(&gbuf) else {
             return None;
         };
@@ -366,25 +329,13 @@ pub extern "C" fn __RTS_FN_NS_GPU_READ(gbuf: U64, dst: U64, bytes: I64) -> I64 {
         let out = slice.get_mapped_range().to_vec();
         staging.unmap();
         Some(out)
-    });
-    let Some(data) = data else {
-        return -1;
-    };
-    with_entry_mut(dst, |e| match e {
-        Some(Entry::Buffer(b)) => {
-            let n = data.len().min(b.len());
-            b[..n].copy_from_slice(&data[..n]);
-            n as i64
-        }
-        _ => -1,
     })
 }
 
 /// LEITURA ASSÍNCRONA, passo 1: agenda a cópia GPU→staging e o map, SEM
 /// esperar. Devolve um ticket (0 = erro). A física-como-serviço nasce aqui:
 /// o jogo agenda no fim do frame e pergunta nos seguintes com `read_poll`.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_READ_BEGIN(gbuf: U64, bytes: I64) -> Handle {
+pub fn read_begin(gbuf: u64, bytes: i64) -> u64 {
     if bytes <= 0 {
         return 0;
     }
@@ -429,14 +380,26 @@ pub extern "C" fn __RTS_FN_NS_GPU_READ_BEGIN(gbuf: U64, bytes: I64) -> Handle {
     })
 }
 
-/// LEITURA ASSÍNCRONA, passo 2: pergunta SEM bloquear. Pronto → copia para o
-/// rts:buffer `dst`, consome o ticket e devolve os bytes. Ainda em voo → 0.
-/// Erro/ticket inválido → -1.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_READ_POLL(ticket: U64, dst: U64) -> I64 {
-    let data: i64 = with_gpu(-1, |c| {
+/// O que uma consulta a um ticket encontrou.
+///
+/// Um enum e não um inteiro com três significados: a superfície antiga devolvia
+/// `0` para "em voo" e `-1` para "falhou", e um chamador que testasse
+/// `if (n)` tratava a falha como sucesso. Cada motor traduz isto para o que sua
+/// linguagem sabe dizer.
+pub enum Poll {
+    /// A cópia ainda está em voo. Pergunte de novo no próximo frame.
+    Pending,
+    /// O ticket não existe, ou o mapeamento falhou. Foi consumido.
+    Failed,
+    /// Pronto, e estes são os bytes. O ticket foi consumido.
+    Done(Vec<u8>),
+}
+
+/// LEITURA ASSÍNCRONA, passo 2: pergunta SEM bloquear.
+pub fn read_poll(ticket: u64) -> Poll {
+    with_gpu(Poll::Failed, |c| {
         if !c.pending.contains_key(&ticket) {
-            return -1;
+            return Poll::Failed;
         }
         // Espera DIRIGIDA pela submissao da copia, com timeout de 1 ms:
         // pronta -> callbacks disparam agora; nao pronta -> volta em 1 ms.
@@ -467,39 +430,29 @@ pub extern "C" fn __RTS_FN_NS_GPU_READ_POLL(ticket: U64, dst: U64) -> I64 {
             None => 2,
         };
         if done == 0 {
-            return 0;
+            return Poll::Pending;
         }
         let p = c.pending.remove(&ticket).expect("checado acima");
         if done == 2 {
             c.stagings.insert(p.src, p.staging);   // devolve p/ reuso
-            return -1;
+            return Poll::Failed;
         }
         let out = p.staging.slice(..).get_mapped_range().to_vec();
         p.staging.unmap();
         c.stagings.insert(p.src, p.staging);       // devolve p/ reuso
-        let n = with_entry_mut(dst, |e| match e {
-            Some(Entry::Buffer(b)) => {
-                let n = out.len().min(b.len());
-                b[..n].copy_from_slice(&out[..n]);
-                n as i64
-            }
-            _ => -1,
-        });
-        n
-    });
-    data
+        Poll::Done(out)
+    })
 }
 
 /// Libera um buffer de GPU. 1 se existia.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_BUFFER_FREE(gbuf: U64) -> I64 {
-    with_gpu(0, |c| {
+pub fn buffer_free(gbuf: u64) -> bool {
+    with_gpu(false, |c| {
         // Também some dos binds de todo pipeline — um dispatch posterior com o
         // slot vazio falha a validação em vez de usar buffer morto.
         for p in c.pipes.values_mut() {
             p.binds.retain(|(_, id)| *id != gbuf);
         }
-        i64::from(c.buffers.remove(&gbuf).is_some())
+        c.buffers.remove(&gbuf).is_some()
     })
 }
 
@@ -510,143 +463,6 @@ pub(crate) fn buffer_handle(id: u64) -> Option<wgpu::Buffer> {
 }
 
 /// Nome do adapter (debug/telemetria). Handle de string GC, 0 sem GPU.
-#[unsafe(no_mangle)]
-pub extern "C" fn __RTS_FN_NS_GPU_ADAPTER_NAME() -> Handle {
-    use rts_engine::heap::string_pool::__RTS_FN_NS_GC_STRING_NEW;
-    with_gpu(0, |c| {
-        let info = c.gpu.adapter.get_info();
-        let name = info.name;
-        unsafe { __RTS_FN_NS_GC_STRING_NEW(name.as_ptr(), name.len() as i64) }
-    })
-}
-
-// ---------------------------------------------------------------------------
-// Registro (builder hand-written, padrão rts:audio)
-// ---------------------------------------------------------------------------
-
-fn func(name: &str, symbol: &str, sig: Sig, ts: &str, doc: &str, fp: *const u8) -> Member {
-    Member {
-        name: name.to_string(),
-        kind: MemberKind::Function,
-        sig,
-        symbol: symbol.to_string(),
-        fn_ptr: FnPtr(fp),
-        flags: MemberFlags::NONE,
-        aliases: Vec::new(),
-        variadic: false,
-        ts_signature: ts.to_string(),
-        doc: doc.to_string(),
-        ret_class: None,
-        pure: false,
-        emit: None,
-    }
-}
-
-/// Registra a namespace `gpu` no motor.
-pub fn register(e: &mut Engine) {
-    e.ns("gpu")
-        .doc("Compute WGSL na GPU compartilhada do runtime (headless ou junto do render).")
-        .member(func(
-            "available",
-            "__RTS_FN_NS_GPU_AVAILABLE",
-            Sig::new(Vec::new(), AbiType::I64),
-            "available(): number",
-            "1 se há GPU utilizável (cria o device headless na primeira consulta).",
-            __RTS_FN_NS_GPU_AVAILABLE as *const u8,
-        ))
-        .member(func(
-            "shader",
-            "__RTS_FN_NS_GPU_SHADER",
-            Sig::new(vec![AbiType::StrPtr], AbiType::Handle),
-            "shader(wgsl: string): number",
-            "Compila um kernel WGSL (entry point `main`). Handle do pipeline; 0 = erro de validação (stderr).",
-            __RTS_FN_NS_GPU_SHADER as *const u8,
-        ))
-        .member(func(
-            "buffer",
-            "__RTS_FN_NS_GPU_BUFFER",
-            Sig::new(vec![AbiType::I64], AbiType::Handle),
-            "buffer(bytes: number): number",
-            "Storage buffer na GPU. Handle; 0 = erro.",
-            __RTS_FN_NS_GPU_BUFFER as *const u8,
-        ))
-        .member(func(
-            "write",
-            "__RTS_FN_NS_GPU_WRITE",
-            Sig::new(vec![AbiType::U64, AbiType::U64, AbiType::I64], AbiType::I64),
-            "write(gbuf: number, src: number, bytes: number): number",
-            "Sobe bytes de um rts:buffer para o buffer de GPU. 1 ok, 0 erro.",
-            __RTS_FN_NS_GPU_WRITE as *const u8,
-        ))
-        .member(func(
-            "write_at",
-            "__RTS_FN_NS_GPU_WRITE_AT",
-            Sig::new(
-                vec![AbiType::U64, AbiType::U64, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
-            ),
-            "write_at(gbuf: number, src: number, srcOff: number, dstOff: number, bytes: number): number",
-            "Partial write with offsets: copies bytes from the rts:buffer into the GPU buffer at dstOff. Enables poking ONE body without re-uploading full state. 1 ok, 0 error.",
-            __RTS_FN_NS_GPU_WRITE_AT as *const u8,
-        ))
-        .member(func(
-            "bind_buffer",
-            "__RTS_FN_NS_GPU_BIND",
-            Sig::new(vec![AbiType::U64, AbiType::I64, AbiType::U64], AbiType::I64),
-            "bind_buffer(pipe: number, slot: number, gbuf: number): number",
-            "Liga o buffer ao @binding(slot) do @group(0) do pipeline. 1 ok.",
-            __RTS_FN_NS_GPU_BIND as *const u8,
-        ))
-        .member(func(
-            "dispatch",
-            "__RTS_FN_NS_GPU_DISPATCH",
-            Sig::new(
-                vec![AbiType::U64, AbiType::I64, AbiType::I64, AbiType::I64],
-                AbiType::I64,
-            ),
-            "dispatch(pipe: number, gx: number, gy: number, gz: number): number",
-            "Submete gx*gy*gz workgroups (assíncrono — `read` sincroniza). 1 ok.",
-            __RTS_FN_NS_GPU_DISPATCH as *const u8,
-        ))
-        .member(func(
-            "read",
-            "__RTS_FN_NS_GPU_READ",
-            Sig::new(vec![AbiType::U64, AbiType::U64, AbiType::I64], AbiType::I64),
-            "read(gbuf: number, dst: number, bytes: number): number",
-            "Espera a GPU e copia bytes do buffer de GPU para um rts:buffer. Bytes lidos, -1 erro.",
-            __RTS_FN_NS_GPU_READ as *const u8,
-        ))
-        .member(func(
-            "read_begin",
-            "__RTS_FN_NS_GPU_READ_BEGIN",
-            Sig::new(vec![AbiType::U64, AbiType::I64], AbiType::Handle),
-            "read_begin(gbuf: number, bytes: number): number",
-            "Async read, step 1: schedules the GPU->staging copy WITHOUT waiting; returns a ticket (0 = error). Poll with read_poll.",
-            __RTS_FN_NS_GPU_READ_BEGIN as *const u8,
-        ))
-        .member(func(
-            "read_poll",
-            "__RTS_FN_NS_GPU_READ_POLL",
-            Sig::new(vec![AbiType::U64, AbiType::U64], AbiType::I64),
-            "read_poll(ticket: number, dst: number): number",
-            "Async read, step 2: non-blocking check. Ready -> copies into the rts:buffer dst, consumes the ticket, returns bytes. In flight -> 0. Error -> -1.",
-            __RTS_FN_NS_GPU_READ_POLL as *const u8,
-        ))
-        .member(func(
-            "buffer_free",
-            "__RTS_FN_NS_GPU_BUFFER_FREE",
-            Sig::new(vec![AbiType::U64], AbiType::I64),
-            "buffer_free(gbuf: number): number",
-            "Libera um buffer de GPU (e o desliga de todos os pipelines). 1 se existia.",
-            __RTS_FN_NS_GPU_BUFFER_FREE as *const u8,
-        ))
-        .member(func(
-            "adapter_name",
-            "__RTS_FN_NS_GPU_ADAPTER_NAME",
-            Sig::new(Vec::new(), AbiType::Handle),
-            "adapter_name(): string",
-            "Nome do adapter de GPU em uso (debug).",
-            __RTS_FN_NS_GPU_ADAPTER_NAME as *const u8,
-        ))
-        .done();
+pub fn adapter_name() -> Option<String> {
+    with_gpu(None, |c| Some(c.gpu.adapter.get_info().name))
 }

--- a/crates/rts-egui/src/lib.rs
+++ b/crates/rts-egui/src/lib.rs
@@ -43,16 +43,8 @@ pub mod render_backend;
 mod widgets;
 mod scene_api;
 // `rts:gpu` — compute WGSL sobre o MESMO device compartilhado do render.
-//
-// Atrás de `old-engine` porque a casca do motor novo ainda não foi escrita, e
-// NÃO por impedimento. Uma nota anterior aqui dizia que um buffer de compute
-// "É um handle do HandleTable" e que portá-lo era decidir onde aqueles bytes
-// vivem no motor novo. Era falsa, e saiu de raciocinar sobre o módulo em vez de
-// lê-lo: o `wgpu::Buffer` vive num `HashMap<u64, wgpu::Buffer>` do próprio
-// `compute`, e o que vem do motor antigo é só o buffer de BYTES do programa
-// (`Entry::Buffer(Vec<u8>)`) — que o `rts-core-rwk` já responde, nos três
-// sentidos, com `bytes_of`/`write_bytes`/`make_bytes` sobre uma view tipada.
-#[cfg(feature = "old-engine")]
+// Lógica pura, como o resto do crate: a casca do motor antigo é `abi::gpu`, a do
+// novo é `rts-ui-rwk`. Este módulo sobe e baixa bytes e não sabe de onde vêm.
 pub mod compute;
 
 // O DOM (árvore + parser + NodeId) E o ESTADO de estilo vivem no crate `rts-dom`;

--- a/crates/rts-egui/src/scene_api.rs
+++ b/crates/rts-egui/src/scene_api.rs
@@ -207,11 +207,6 @@ pub fn draw_mesh(
 /// `gbuf` do rts:gpu — zero readback, zero FFI por partícula, 1 draw call.
 /// `scale` = raio de desenho. 1 ok, 0 = buffer/janela inválidos.
 ///
-/// Só existe com `old-engine` porque `crate::compute` só existe com ele — e
-/// isso é a casca do `rts:gpu` ainda não escrita, não um impedimento: o
-/// `wgpu::Buffer` que `buffer_handle` devolve vive num `HashMap` daquele
-/// módulo, não no `HandleTable`.
-#[cfg(feature = "old-engine")]
 pub fn draw_water(win: u64, mesh: u64, gbuf: u64, count: i64, scale: f64) -> i64 {
     if count <= 0 {
         return 0;

--- a/crates/rts-host-rwk/Cargo.toml
+++ b/crates/rts-host-rwk/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["ui"]
 [[example]]
 name = "janela"
 required-features = ["ui"]
+
+[[example]]
+name = "gpu"
+required-features = ["ui"]

--- a/crates/rts-host-rwk/examples/gpu.rs
+++ b/crates/rts-host-rwk/examples/gpu.rs
@@ -1,0 +1,65 @@
+//! Compute WGSL pelo motor novo: soma 1024 elementos na GPU e confere o
+//! resultado no programa.
+//!
+//! ```text
+//! cargo run -p rts-host-rwk --example gpu
+//! ```
+//!
+//! Exemplo e não teste pela razão que `examples/janela.rs` documenta e que a
+//! medição confirmou aqui também: criar o device wgpu numa thread secundária —
+//! que é onde um `#[test]` do cargo roda — não retorna. O `tests/ui_surface.rs`
+//! cobre o que é verificável sem device (os nomes existem e são chamáveis).
+
+fn main() {
+    let source = r#"
+import { available, shader, buffer, write, bindBuffer, dispatch, read,
+         bufferFree, adapterName } from "rts:gpu";
+
+if (!available()) {
+    println("sem GPU utilizável — nada a fazer");
+} else {
+    println("adapter: " + adapterName());
+
+    // Um kernel que dobra cada u32 do buffer.
+    const pipe = shader(`
+        @group(0) @binding(0) var<storage, read_write> dados: array<u32>;
+        @compute @workgroup_size(64)
+        fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+            dados[id.x] = dados[id.x] * 2u;
+        }
+    `);
+    if (pipe === 0) {
+        println("o kernel não compilou");
+    } else {
+        const n = 1024;
+        const entrada = new Uint32Array(n);
+        let i = 0;
+        while (i < n) { entrada[i] = i; i = i + 1; }
+
+        const gbuf = buffer(n * 4);
+        write(gbuf, entrada);
+        bindBuffer(pipe, 0, gbuf);
+        dispatch(pipe, n / 64, 1, 1);
+
+        const saida = new Uint32Array(read(gbuf, n * 4).buffer);
+        let erros = 0;
+        let j = 0;
+        while (j < n) {
+            if (saida[j] !== j * 2) { erros = erros + 1; }
+            j = j + 1;
+        }
+        println("elementos: " + n + "  divergências: " + erros);
+        println(erros === 0 ? "a GPU computou o que o kernel diz" : "DIVERGIU");
+        bufferFree(gbuf);
+    }
+}
+"#;
+    let mut program = match rts_host_rwk::compile(source) {
+        Ok(program) => program,
+        Err(error) => {
+            eprintln!("o programa não compilou: {error:?}");
+            std::process::exit(1);
+        }
+    };
+    program.run();
+}

--- a/crates/rts-host-rwk/tests/ui_surface.rs
+++ b/crates/rts-host-rwk/tests/ui_surface.rs
@@ -138,3 +138,39 @@ test("um campo ausente não vira NaN", function () {
     );
     assert_eq!(failed, Vec::<String>::new());
 }
+
+#[test]
+fn rts_gpu_resolve_e_seus_membros_sao_chamaveis() {
+    // Só `typeof`, e a limitação é medida e não suposta: chamar QUALQUER membro
+    // cria o device wgpu, e criar o device numa thread secundária — que é onde
+    // um `#[test]` do cargo roda — não retorna. Ficou dez minutos parado antes
+    // de eu matá-lo. O mesmo muro do winit em `examples/janela.rs`, por um
+    // caminho diferente.
+    //
+    // Quem exercita o compute de verdade é `examples/gpu.rs`, na thread
+    // principal: sobe 1024 u32, roda um kernel que os dobra, lê de volta e
+    // confere. Aqui fica o que quebra num porte de superfície e não precisa de
+    // device: o especificador resolve e os nomes existem.
+    let failed = failures(
+        r#"
+import { test, expect } from "rts:test";
+import * as gpu from "rts:gpu";
+
+test("a superfície inteira é chamável", function () {
+    expect(typeof gpu.available).toBe("function");
+    expect(typeof gpu.shader).toBe("function");
+    expect(typeof gpu.buffer).toBe("function");
+    expect(typeof gpu.write).toBe("function");
+    expect(typeof gpu.writeAt).toBe("function");
+    expect(typeof gpu.bindBuffer).toBe("function");
+    expect(typeof gpu.dispatch).toBe("function");
+    expect(typeof gpu.read).toBe("function");
+    expect(typeof gpu.readBegin).toBe("function");
+    expect(typeof gpu.readPoll).toBe("function");
+    expect(typeof gpu.bufferFree).toBe("function");
+    expect(typeof gpu.adapterName).toBe("function");
+});
+        "#,
+    );
+    assert_eq!(failed, Vec::<String>::new());
+}

--- a/crates/rts-runtime/src/namespaces/mod.rs
+++ b/crates/rts-runtime/src/namespaces/mod.rs
@@ -31,7 +31,7 @@ pub use rts_egui as egui;
 /// `gpu` — compute WGSL sobre o device wgpu compartilhado do `rts-egui`
 /// (headless ou junto do render). Resolve via Registry: `ns::gpu::register`.
 /// `import gpu from "rts:gpu"`.
-pub use rts_egui::compute as gpu;
+pub use rts_egui::abi::gpu;
 pub mod globals;
 pub use rts_std::atomic;
 pub use rts_shared::trace;

--- a/crates/rts-ui-rwk/src/gpu.rs
+++ b/crates/rts-ui-rwk/src/gpu.rs
@@ -1,0 +1,165 @@
+//! `rts:gpu` — compute WGSL sobre o mesmo device do render.
+//!
+//! # O que esta casca traduz
+//!
+//! Só uma coisa: **de onde vêm e para onde vão os bytes**. O `crate::compute` do
+//! `rts-egui` compila kernel, aloca buffer de GPU, despacha e lê — e recebe e
+//! devolve `&[u8]`/`Vec<u8>`, porque quem sabe o que é um buffer do PROGRAMA é o
+//! motor, e há dois.
+//!
+//! No motor antigo os bytes moram num `Entry::Buffer` do `HandleTable` e a
+//! travessia é por handle. Aqui moram numa view tipada, e a travessia é
+//! `bytes_of` na ida e `write_bytes` na volta — as mesmas funções que o
+//! `meshUpload` já usa. Nada disso é novo: é `crate::value::bytes` e o
+//! `reuse-check` que o `lib.rs` registra.
+//!
+//! # Três coisas mudaram, e são as mesmas do resto do porte
+//!
+//! - **`writeAt` recebe um objeto.** Cinco parâmetros não cabem em quatro slots.
+//! - **`read` responde os BYTES**, não escreve num destino que o chamador
+//!   passou. Um `Uint8Array` de volta é o que uma linguagem com views tipadas
+//!   sabe dizer; a superfície antiga precisava do destino porque não tinha como
+//!   devolver um buffer.
+//! - **`readPoll` responde `null` / `false` / os bytes**, em vez de `0` / `-1` /
+//!   uma contagem. Aquele inteiro com três significados fazia um chamador que
+//!   testasse `if (n)` tratar a FALHA como sucesso — e `-1` é verdadeiro.
+
+use rts_core_rwk::entry::{self, Provided};
+use rts_egui::compute::{self, Poll};
+
+use crate::value::{self, bytes, handle, integer, text};
+use crate::window::options;
+
+/// Os membros de `rts:gpu`.
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("available", available),
+    ("shader", shader),
+    ("buffer", buffer),
+    ("write", write),
+    ("writeAt", write_at),
+    ("bindBuffer", bind_buffer),
+    ("dispatch", dispatch),
+    ("read", read),
+    ("readBegin", read_begin),
+    ("readPoll", read_poll),
+    ("bufferFree", buffer_free),
+    ("adapterName", adapter_name),
+];
+
+/// `available()` — há GPU utilizável. Cria o device na primeira consulta.
+extern "C" fn available(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    value::from_bool(compute::available())
+}
+
+/// `shader(wgsl)` — compila um kernel (entry point `main`). O id do pipeline, ou
+/// `0` com o erro de validação no stderr.
+extern "C" fn shader(_e: u64, _t: u64, source: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    value::from_number(compute::shader(&text(source)) as f64)
+}
+
+/// `buffer(bytes)` — um storage buffer na GPU. O id, ou `0`.
+extern "C" fn buffer(_e: u64, _t: u64, size: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    value::from_number(compute::buffer(integer(size, 0)) as f64)
+}
+
+/// `write(gbuf, data)` — sobe uma view tipada inteira para o buffer de GPU.
+extern "C" fn write(_e: u64, _t: u64, gbuf: u64, data: u64, _c: u64, _d: u64) -> u64 {
+    let Some(data) = bytes(data) else {
+        return value::from_bool(false);
+    };
+    value::from_bool(compute::write(handle(gbuf), &data))
+}
+
+/// `writeAt(gbuf, { data, srcOff, dstOff, bytes })` — escrita parcial.
+///
+/// É o que permite cutucar UM corpo sem reenviar o estado inteiro. `srcOff` e
+/// `bytes` recortam a view antes de subir; ausentes, sobe a view toda.
+extern "C" fn write_at(_e: u64, _t: u64, gbuf: u64, spec: u64, _c: u64, _d: u64) -> u64 {
+    let Some(source) = bytes(value::fields(spec, &["data"])[0]) else {
+        return value::from_bool(false);
+    };
+    let read = options(spec, &["srcOff", "dstOff", "bytes"], &[0.0, 0.0, -1.0]);
+    let from = (read[0].max(0.0) as usize).min(source.len());
+    let count = match read[2] {
+        n if n < 0.0 => source.len() - from,
+        n => (n as usize).min(source.len() - from),
+    };
+    value::from_bool(compute::write_at(
+        handle(gbuf),
+        read[1] as i64,
+        &source[from..from + count],
+    ))
+}
+
+/// `bindBuffer(pipe, slot, gbuf)` — liga o buffer ao `@binding(slot)` do
+/// `@group(0)`.
+///
+/// `bindBuffer` e não `bind` porque o lowering trata `.bind(` como
+/// `Function.prototype.bind` antes de resolver membro de namespace — a mesma
+/// razão que o nome tinha na superfície antiga, e ela continua valendo.
+extern "C" fn bind_buffer(_e: u64, _t: u64, pipe: u64, slot: u64, gbuf: u64, _d: u64) -> u64 {
+    value::from_bool(compute::bind_buffer(
+        handle(pipe),
+        integer(slot, 0),
+        handle(gbuf),
+    ))
+}
+
+/// `dispatch(pipe, gx, gy, gz)` — submete os workgroups. NÃO espera a GPU:
+/// `read` é quem sincroniza.
+extern "C" fn dispatch(_e: u64, _t: u64, pipe: u64, gx: u64, gy: u64, gz: u64) -> u64 {
+    value::from_bool(compute::dispatch(
+        handle(pipe),
+        integer(gx, 1),
+        integer(gy, 1),
+        integer(gz, 1),
+    ))
+}
+
+/// `read(gbuf, bytes)` — espera a GPU e responde um `Uint8Array` com o que leu,
+/// ou `undefined` em erro.
+extern "C" fn read(_e: u64, _t: u64, gbuf: u64, size: u64, _c: u64, _d: u64) -> u64 {
+    let Some(data) = compute::read(handle(gbuf), integer(size, 0)) else {
+        return value::nothing();
+    };
+    entry::with_runtime(|context| entry::make_bytes(context, &data))
+}
+
+/// `readBegin(gbuf, bytes)` — agenda a cópia GPU→staging SEM esperar, e
+/// responde um ticket (`0` em erro).
+///
+/// A física-como-serviço nasce aqui: o jogo agenda no fim do frame e pergunta
+/// nos seguintes.
+extern "C" fn read_begin(_e: u64, _t: u64, gbuf: u64, size: u64, _c: u64, _d: u64) -> u64 {
+    value::from_number(compute::read_begin(handle(gbuf), integer(size, 0)) as f64)
+}
+
+/// `readPoll(ticket)` — pergunta sem bloquear.
+///
+/// `null` = ainda em voo, pergunte de novo. `false` = falhou ou o ticket não
+/// existe, e ele foi consumido. Um `Uint8Array` = pronto, e ele foi consumido.
+///
+/// Três valores distinguíveis em vez do inteiro de três significados da
+/// superfície antiga, onde `-1` (falha) passava num `if`.
+extern "C" fn read_poll(_e: u64, _t: u64, ticket: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    match compute::read_poll(handle(ticket)) {
+        Poll::Pending => entry::null_value(),
+        Poll::Failed => value::from_bool(false),
+        Poll::Done(data) => entry::with_runtime(|context| entry::make_bytes(context, &data)),
+    }
+}
+
+/// `bufferFree(gbuf)` — libera o buffer e o desliga de todo pipeline, para que
+/// um dispatch posterior falhe a validação em vez de usar memória morta.
+extern "C" fn buffer_free(_e: u64, _t: u64, gbuf: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    value::from_bool(compute::buffer_free(handle(gbuf)))
+}
+
+/// `adapterName()` — o nome do adapter em uso, para depuração. `undefined` sem
+/// GPU.
+extern "C" fn adapter_name(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    match compute::adapter_name() {
+        Some(name) => value::from_text(&name),
+        None => value::nothing(),
+    }
+}

--- a/crates/rts-ui-rwk/src/lib.rs
+++ b/crates/rts-ui-rwk/src/lib.rs
@@ -26,9 +26,10 @@
 //!
 //! # O que NÃO está aqui, e não por esquecimento
 //!
-//! **`rts:gpu`** — os buffers de compute SÃO handles do `HandleTable` do motor
-//! antigo. Portá-los é decidir onde aqueles bytes vivem no novo, não escrever
-//! uma casca. `drawWater`, seu único consumidor, fica junto.
+//! `rts:gpu` ESTAVA nesta lista, com a justificativa de que um buffer de compute
+//! seria um handle do motor antigo. Era falso — o `wgpu::Buffer` vive num
+//! `HashMap` do próprio `compute`, e o que atravessava era só o buffer de bytes
+//! do programa, que `bytes_of`/`write_bytes` já respondem. Está portado.
 //!
 //! **`rts:dom` e `render.*`** — a árvore, o parser e o motor de layout são 18 mil
 //! linhas no `rts-dom`, e nenhuma delas conhece motor: o porte é a mesma casca
@@ -66,6 +67,7 @@
 #![deny(dead_code)]
 
 pub mod draw;
+pub mod gpu;
 pub mod input;
 pub mod scene;
 pub mod value;
@@ -92,6 +94,9 @@ pub fn install(context: &mut Context) {
 
     let entry_points = entry::make_namespace(context, input::MEMBERS);
     entry::declare_module(context, "rts:input", entry_points);
+
+    let compute = entry::make_namespace(context, gpu::MEMBERS);
+    entry::declare_module(context, "rts:gpu", compute);
 }
 
 /// Solta os recursos de GPU enquanto o processo ainda está inteiro.
@@ -109,9 +114,18 @@ pub fn install(context: &mut Context) {
 /// programa: um programa que esquecesse a linha morreria na saída, e ele não tem
 /// como saber que essa linha existe.
 ///
+/// # A ordem importa
+///
+/// `compute::shutdown` solta pipelines, buffers e stagings E a cópia que aquele
+/// contexto tem dos handles do device, e só então o device compartilhado. Chamar
+/// direto o `shutdown_shared_gpu` deixava o contexto de compute vivo com uma
+/// referência ao device, então o drop dele acontecia depois — no destrutor de
+/// thread-local, que é exatamente o momento que isto existe para evitar. Foi
+/// visto: o `examples/gpu` computava certo, imprimia tudo e morria na saída.
+///
 /// Idempotente, e no-op quando nenhuma GPU foi criada.
 pub fn shutdown() {
-    rts_egui::shutdown_shared_gpu();
+    rts_egui::compute::shutdown();
 }
 
 /// `rts:egui`, montado das três metades da superfície.

--- a/docs/ui/new-engine-port.md
+++ b/docs/ui/new-engine-port.md
@@ -112,28 +112,41 @@ the same, and the difference stays where it is real.
 
 | absent | why |
 |---|---|
-| `rts:gpu` (compute) | the shell is not written yet. **Not** a blocker — see the correction below |
-| `egui.drawWater` | its only consumer is `crate::compute`, which is behind the same feature |
 | `rts:dom`, `render.*` | the tree, parser and layout engine are 18 000 engine-free lines in `rts-dom`; the port is the same shell this crate is, for that surface |
 | `egui.render(win, dom)` | without the DOM namespace there is no handle to pass, so it would be a function that always draws nothing |
 
-### A correction, kept rather than quietly fixed
+### `rts:gpu` was on this list, wrongly, and is now ported
 
-This table first said that `rts:gpu` was blocked because "a compute buffer **is**
-an `Entry::Buffer` in the old engine's `HandleTable`", so porting it meant
-deciding where those bytes live in the new engine.
+The table said it was blocked because "a compute buffer **is** an `Entry::Buffer`
+in the old engine's `HandleTable`", so porting it meant deciding where those
+bytes live in the new engine.
 
 **That was false**, and it came from reasoning about the module instead of
 reading it. The `wgpu::Buffer` lives in a `HashMap<u64, wgpu::Buffer>` inside
-`compute` itself. What crosses from the old engine is only the program-side byte
-buffer — and `rts-core-rwk` already answers that in all three directions:
-`bytes_of`, `write_bytes` and `make_bytes` over a typed view, which is exactly
-what `meshUpload` in this very port already uses.
+`compute` itself. What crossed from the old engine was only the program-side
+byte buffer — which `bytes_of`/`write_bytes`/`make_bytes` already answer.
 
-So `rts:gpu` is the same shell as everything else here. What it actually needs:
-the five-argument calls (`writeAt`) take an options object like the rest,
-`Entry::Buffer` reads become `bytes_of`, the read-back becomes `write_bytes`,
-and `adapterName` becomes `make_string`. Work not done, not a wall.
+So it was the same shell as everything else, and it is written. `crate::compute`
+now takes and returns `&[u8]`/`Vec<u8>`, because where the bytes come FROM is the
+engine's question and there are two of them; each shell answers its own. Three
+things changed in the surface, all of them the same reasons as above:
+
+- `writeAt(gbuf, { data, srcOff, dstOff, bytes })` — five parameters do not fit
+  in four slots.
+- `read(gbuf, bytes)` answers a `Uint8Array` instead of writing into a
+  destination the caller supplied. The old signature needed the destination
+  because it had no way to hand back a buffer.
+- `readPoll(ticket)` answers `null` (in flight) / `false` (failed) / the bytes,
+  instead of `0` / `-1` / a count. That integer with three meanings made a caller
+  writing `if (n)` treat FAILURE as success, because `-1` is truthy.
+
+`egui.drawWater` came back with it — its only obstacle was `compute` being behind
+the feature.
+
+Verified by running: `cargo run -p rts-host-rwk --example gpu` uploads 1024
+`u32`, runs a kernel that doubles them, reads back and checks every element. On
+an RTX 2080 Ti: zero mismatches. And the old engine's own suite still passes —
+`rts.exe test tests/gpu_compute.test.ts`, 5/5.
 
 Each absence fails at the `import` line, which is where it should hurt.
 `rts-std-rwk` once refused to register a façade `rts:egui` for exactly this


### PR DESCRIPTION
Porta o `rts:gpu` (compute WGSL) e o `egui.drawWater` para o motor novo, com o mesmo desenho do PR #2101 — uma lógica, duas cascas.

## Por que ele tinha ficado de fora, e por que a razão era falsa

O PR anterior afirmou que um buffer de compute **era** um handle do `HandleTable` do motor antigo, e que portá-lo exigia decidir "onde aqueles bytes vivem". Isso saiu de raciocinar sobre o módulo em vez de lê-lo.

O `wgpu::Buffer` vive num `HashMap<u64, wgpu::Buffer>` dentro do próprio `compute.rs`. O que atravessava do motor antigo era só o buffer de **bytes do programa**, que o `rts-core-rwk` já responde nos três sentidos — `bytes_of`, `write_bytes`, `make_bytes` — e que o `meshUpload` daquele mesmo PR já usava.

## O que mudou na superfície

| antes | agora | por quê |
|---|---|---|
| `write_at(gbuf, src, srcOff, dstOff, bytes)` | `writeAt(gbuf, { data, srcOff, dstOff, bytes })` | cinco parâmetros não cabem em quatro slots |
| `read(gbuf, dst, bytes)` escrevendo num destino | `read(gbuf, bytes)` devolvendo `Uint8Array` | a assinatura antiga precisava do destino porque não tinha como devolver um buffer |
| `readPoll` → `0` / `-1` / contagem | `null` / `false` / bytes | `-1` é verdadeiro: quem escrevia `if (n)` tratava a FALHA como sucesso |

## Um bug de ordem que o exemplo achou

`shutdown` chamava direto o `shutdown_shared_gpu` e deixava o contexto de compute vivo com uma cópia dos handles do device — então o drop dele caía no destrutor de thread-local, que é exatamente o momento que aquela função existe para evitar. Computava certo, imprimia tudo e morria na saída. Agora chama `compute::shutdown`, que solta pipelines, buffers e stagings e só então o device.

## Verificação — rodando, nos dois motores

```
cargo run -p rts-host-rwk --example gpu      # 1024 u32, kernel que os dobra,
                                             # leitura de volta: 0 divergências
                                             # (RTX 2080 Ti)
rts.exe test tests/gpu_compute.test.ts       # 5/5 no motor ANTIGO, sem mudança
cargo test -p rts-host-rwk --features ui     # 326 testes, 0 falhas
```

O teste automatizado do `rts:gpu` cobre só `typeof`, e o limite é **medido**: chamar qualquer membro cria o device wgpu, e criar o device numa thread secundária — onde um `#[test]` do cargo roda — não retorna (ficou dez minutos parado antes de eu matá-lo). Mesmo muro do winit em `examples/janela.rs`, por outro caminho. Por isso o exercício real é um exemplo, na thread principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNMhSfMGXNa4hdUnoiMfHu