### PR TITLE
docs: o motor passou a lançar durante o porte, e a nota ficou para trás

### DIFF
--- a/crates/rts-ui-rwk/src/value.rs
+++ b/crates/rts-ui-rwk/src/value.rs
@@ -28,11 +28,24 @@
 //!
 //! # Por que um campo ausente vale o default e não é um erro
 //!
-//! Porque a alternativa é uma janela que não abre e não diz por quê. Este motor
-//! ainda não lança — `entry/throw.rs` explica que um throw sem handler no
-//! chamador termina o programa — então um argumento faltando só poderia virar
-//! silêncio ou um valor. Um valor, documentado por chamada, é o que deixa
-//! `drawRect(w, { x, y, w, h })` funcionar sem repetir borda e raio.
+//! Este parágrafo dizia "este motor ainda não lança", e **deixou de ser
+//! verdade** enquanto o porte era escrito: `af0c5a03` fez com que um nativo
+//! possa levantar um erro capturável, sob a regra 8 do
+//! `crates/rts-core-rwk/README.md` — todo nativo que chama código de usuário
+//! pergunta se ele deixou um throw pendente antes de olhar a resposta.
+//!
+//! O que continua verdade é mais estreito e é uma LACUNA, não uma propriedade:
+//! `throw::type_error` é `pub(in crate::entry)`, então a fábrica de erro não
+//! está na superfície de host. O que um host alcança é `entry::throw(tag,
+//! payload)`, que exige construir o valor do erro por fora. Enquanto for assim,
+//! um argumento faltando aqui só pode virar silêncio ou um valor.
+//!
+//! **E um valor é o que se quer nesta superfície de qualquer modo.** `drawRect(w,
+//! { x, y, w, h })` deve funcionar sem repetir borda e raio; o default é a API,
+//! não o contorno da lacuna. O que a lacuna de fato custa é o caso oposto — um
+//! `drawMesh(w, "texto")` desenha na origem em vez de dizer que o argumento está
+//! errado. Esse é o dia de expor a fábrica, e é um pedido ao `rts-core-rwk` do
+//! mesmo formato que os outros oito pares que a `modules.rs` já registra.
 
 use rts_core_rwk::entry;
 

--- a/docs/ui/new-engine-port.md
+++ b/docs/ui/new-engine-port.md
@@ -69,9 +69,15 @@ egui.drawMesh(win, { mesh, x: 0, y: 0, z: 0, color: 0xFF00FFFF });
 
 **The rule: up to four, positional; more than that, one options object in the
 second position.** A surface mixing both conventions at random would be worse
-than either. A missing field takes a documented default, because this engine
-does not throw yet — `entry/throw.rs` says why — so the alternative to a default
-is silence.
+than either. A missing field takes a documented default. The first version of this said the
+reason was that the engine cannot throw; that stopped being true while this port
+was being written (`af0c5a03` — a native can now raise a catchable error, under
+rule 8 of `rts-core-rwk/README.md`). What remains is narrower and is a **gap**
+rather than a property: `throw::type_error` is `pub(in crate::entry)`, so the
+error factory is not on the host surface. Until it is, a missing argument here
+can only become silence or a value — and a value is what this surface wants
+anyway, since `drawRect(w, { x, y, w, h })` should work without restating border
+and radius.
 
 Rejected: widening the convention, or exposing the rest vector to hosts. Both
 change the engine to accommodate one surface, and the thirteen-positional call


### PR DESCRIPTION
Correção pequena e de fato: `crates/rts-ui-rwk/src/value.rs` e `docs/ui/new-engine-port.md` justificavam os defaults com "este motor ainda não lança". Isso deixou de ser verdade **durante** o porte — af0c5a03 (`feat: a native can raise a catchable error, and every native asks`) fez um nativo poder levantar um erro capturável, sob a regra 8 do README do `rts-core-rwk`.

O que sobra é mais estreito e é uma **lacuna**, não uma propriedade: `throw::type_error` é `pub(in crate::entry)`, então a fábrica de erro não está na superfície de host — o que um host alcança é `throw(tag, payload)`, que exige construir o valor por fora.

A decisão não muda e agora está justificada pelo motivo certo: o default **é** a API. O que a lacuna custa é o caso oposto — um `drawMesh(win, "texto")` desenha na origem em vez de dizer que o argumento está errado —, e isso fica anotado como pedido ao `rts-core-rwk`, no mesmo formato dos outros oito pares que a `modules.rs` já registra.

Só documentação; 4 testes de `ui_surface` seguem verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNMhSfMGXNa4hdUnoiMfHu