### PR TITLE
feat: arrays esparsos — uma posição AUSENTE deixa de ser um undefined guardado

### DIFF
--- a/crates/rts-codegen/src/emit/expr.rs
+++ b/crates/rts-codegen/src/emit/expr.rs
@@ -1107,8 +1107,19 @@ fn emit_array(
     let array = call(builder, ctx, RuntimeOp::ArrayNew, &[length])?[0];
 
     for (position, element) in elements.iter().enumerate() {
-        let Some(crate::syntax::Spreadable::Single(value)) = element else {
-            return gap("a hole in an array literal");
+        // UM BURACO É UMA POSIÇÃO QUE NÃO SE ESCREVE.
+        //
+        // `ArrayNew` preenche com o marcador de ausência, então pular a escrita
+        // deixa a posição genuinamente AUSENTE — `[,1][0]` responde `undefined`
+        // e `0 in [,1]` responde falso, que são respostas diferentes e agora o
+        // motor as distingue.
+        //
+        // Este literal era recusado por nome exatamente porque escrevê-lo como
+        // `undefined` mudaria a segunda resposta. O que destravou não foi mudar
+        // de ideia sobre isso — foi o runtime passar a ter um marcador.
+        let Some(element) = element else { continue };
+        let crate::syntax::Spreadable::Single(value) = element else {
+            return gap("a spread in an array literal beside a hole");
         };
         let value = emit_expr(builder, scope, ctx, value)?;
         let value = tagged(builder, value);

--- a/crates/rts-codegen/src/emit/mod.rs
+++ b/crates/rts-codegen/src/emit/mod.rs
@@ -763,20 +763,22 @@ mod tests {
     #[test]
     fn a_gap_is_named_rather_than_counted() {
         // This has named `f()`, an array literal, `new`, a class, a class
-        // getter and a spread argument in turn, and each moved on when it
-        // landed. A hole is what is still missing — `[,1]` has no element zero,
-        // and `0 in [,1]` is false where `0 in [undefined,1]` is true, so a
-        // hole cannot be written as `undefined` without changing the answer.
+        // getter, a spread argument and a HOLE in turn, and each moved on when
+        // it landed. The hole was the longest-standing of them: it waited for
+        // the runtime to grow a marker for an absent position, because writing
+        // it as `undefined` would have made `0 in [,1]` answer true.
+        //
+        // What is still missing is a spread BESIDE a hole — `[...a, , 1]` — for
+        // which the argument-vector path has no way to say "skip this one".
         // The name in the refusal is the point, so the test follows it rather
         // than being deleted with the gap it happened to name.
-        let error = emit_source("let a = [1, , 2];").expect_err("a hole is not emitted");
+        let error = emit_source("let a = [...[1], , 2];").expect_err("a spread beside a hole is not emitted");
         assert_eq!(
             error,
             EmitError::Unsupported {
-                construct: "a hole in an array literal"
+                construct: "a hole beside a spread in an array literal"
             },
-            "the name is the deliverable — a gap reported as `Unsupported` with \
-             no word in it is indistinguishable from any other gap"
+            "the name is the deliverable — a gap reported as `Unsupported` with              no word in it is indistinguishable from any other gap"
         );
     }
 

--- a/crates/rts-codegen/src/values/mod.rs
+++ b/crates/rts-codegen/src/values/mod.rs
@@ -72,6 +72,7 @@ impl Singleton {
 pub struct ValueModel {
     undefined: SingletonId,
     null: SingletonId,
+    hole: SingletonId,
     symbol: ValueKind,
     bigint: ValueKind,
 }
@@ -79,9 +80,23 @@ pub struct ValueModel {
 impl ValueModel {
     /// Tells the machine what values this language has.
     pub fn declare(tags: &mut TagRegistry) -> Self {
+        // Um a mais que os valores da linguagem: o BURACO.
+        //
+        // Ele não está em `Singleton` de propósito — aquele enum é "os valores
+        // que JavaScript tem exatamente um de", e um buraco não é um valor, é a
+        // AUSÊNCIA de um. Nenhum programa jamais o observa: toda leitura de
+        // elemento o converte em `undefined`, e o que o distingue é só quem
+        // pergunta se a posição EXISTE (`in`, `hasOwnProperty`, `Object.keys`,
+        // e os métodos que a especificação manda pular).
+        //
+        // Por que ainda assim é a linguagem quem o numera: o espaço de
+        // singleton é do cliente (`tags::TagRegistry` diz isso), então um
+        // número escolhido pelo runtime poderia colidir com um que a linguagem
+        // declarasse depois. Um padrão de bits inventado seria pior — já houve
+        // um `0` usado como sentinela aqui que destruiu `+0.0` armazenado.
         let declared = tags
-            .declare_singletons(Singleton::ALL.len() as u32)
-            .expect("two singletons fit in any payload this encoding could have");
+            .declare_singletons(Singleton::ALL.len() as u32 + 1)
+            .expect("three singletons fit in any payload this encoding could have");
         // Two of the four tags the machine leaves to a client. Both are
         // JavaScript **primitives**, and that is the reason they are kinds
         // rather than references: `typeof` has to answer from the word alone,
@@ -101,9 +116,20 @@ impl ValueModel {
         Self {
             undefined: declared[0],
             null: declared[1],
+            // O último, depois dos que `Singleton::ALL` nomeia.
+            hole: declared[Singleton::ALL.len()],
             symbol,
             bigint,
         }
+    }
+
+    /// O marcador de posição AUSENTE num array.
+    ///
+    /// Ver a nota em [`ValueModel::declare`]: não é um valor da linguagem, e um
+    /// programa nunca o vê. O runtime precisa dele para responder `0 in [,1]`
+    /// com `false` enquanto `[,1][0]` responde `undefined`.
+    pub fn hole(&self) -> SingletonId {
+        self.hole
     }
 
     /// The encoding of a singleton.

--- a/crates/rts-core-rwk/src/entry/array.rs
+++ b/crates/rts-core-rwk/src/entry/array.rs
@@ -36,9 +36,47 @@ use crate::value::Value;
 #[rtse::entry]
 pub fn array_new(length: i64) -> u64 {
     with_current(|context| {
-        let absent = undefined_of(context);
-        built_in(context, vec![absent; length.max(0) as usize])
+        // BURACOS, não `undefined`: `new Array(3)` tem três posições AUSENTES,
+        // e `0 in new Array(3)` é falso. O emissor também passa por aqui ao
+        // montar um literal, e ali as posições escritas sobrescrevem o buraco —
+        // as não escritas são justamente as que devem continuar ausentes.
+        let vazio = hole_of(context);
+        built_in(context, vec![vazio; length.max(0) as usize])
     })
+}
+
+/// O marcador de posição ausente. Ver [`crate::value::Singletons::hole`].
+pub(in crate::entry) fn hole_of(context: &Context) -> u64 {
+    rts_cranelift::tags::encode(
+        rts_cranelift::tags::TAG_SINGLETON,
+        u64::from(context.singletons.hole),
+    )
+}
+
+/// Se este word é o marcador de ausência.
+///
+/// Toda LEITURA de elemento passa por aqui e devolve `undefined` no lugar; quem
+/// pergunta se a posição existe (`in`, `hasOwnProperty`, `Object.keys`) usa isto
+/// para responder que não.
+pub(in crate::entry) fn is_hole(context: &Context, held: u64) -> bool {
+    held == hole_of(context)
+}
+
+/// O que uma leitura de elemento deve entregar: o valor, ou `undefined` quando
+/// a posição está ausente.
+///
+/// # Por que uma função e não um `if` em cada site
+///
+/// Porque são sessenta sites, e o que vaza se um deles esquecer é um word que
+/// não corresponde a nenhum valor de JavaScript — um `typeof` respondendo algo
+/// impossível, ou um `===` verdadeiro entre dois buracos. Um ponto de passagem
+/// é o que torna a omissão visível na revisão.
+pub(in crate::entry) fn visible(context: &Context, held: u64) -> u64 {
+    if is_hole(context, held) {
+        undefined_of(context)
+    } else {
+        held
+    }
 }
 
 /// The same, from a context already in hand and with its elements.
@@ -196,8 +234,15 @@ pub(in crate::entry) fn key_texts(
         // not 0 and 1. A loop that compared `k === 0` would find nothing, and
         // that is the language rather than a quirk of this implementation.
         if let Some(elements) = context.elements_at(slot) {
-            let count = elements.len();
-            for index in 0..count {
+            // Um BURACO não tem chave. `Object.keys([,1])` é `["1"]`, e daqui
+            // saem também `for-in`, `Object.values/entries`, `Object.assign`,
+            // `structuredClone` e o `JSON.stringify` de objeto — todos corretos
+            // por causa deste `continue`.
+            let ausentes: Vec<bool> = elements.iter().map(|&h| is_hole(context, h)).collect();
+            for (index, vazio) in ausentes.iter().enumerate() {
+                if *vazio {
+                    continue;
+                }
                 keys.push(crate::coerce::number_to_string(index as f64));
             }
         }

--- a/crates/rts-core-rwk/src/entry/array_proto/iterate.rs
+++ b/crates/rts-core-rwk/src/entry/array_proto/iterate.rs
@@ -51,11 +51,25 @@ pub(super) const NATIVES: &[(&str, Native)] = &[
 ];
 
 /// `a.forEach(f)` — answers `undefined`.
+/// Se esta posição deve ser PULADA por um método de iteração.
+///
+/// `forEach`, `map`, `filter`, `some`, `every` e `reduce` não visitam posições
+/// ausentes — a especificação os define sobre as chaves que EXISTEM, não sobre
+/// o intervalo `0..length`. `find`/`findIndex`/`findLast` são a exceção
+/// deliberada e visitam com `undefined`; por isso `sought` converte em vez de
+/// saltar.
+fn vazia(held: u64) -> bool {
+    super::super::with_current(|context| super::super::array::is_hole(context, held))
+}
+
 extern "C" fn for_each(_e: u64, this: u64, callback: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
     let Some(elements) = elements_of(this) else {
         return nothing();
     };
     for (index, element) in elements.iter().enumerate() {
+        if vazia(*element) {
+            continue;
+        }
         // A callback that throws stops the walk.
         if visit(callback, this, *element, index).is_none() {
             break;
@@ -71,6 +85,14 @@ extern "C" fn map(_e: u64, this: u64, callback: u64, _a1: u64, _a2: u64, _a3: u6
     };
     let mut produced = Vec::new();
     for (index, element) in elements.iter().enumerate() {
+        // `map` PRESERVA o buraco na posição correspondente em vez de o pular:
+        // o resultado tem o mesmo comprimento e a mesma esparsidade, e a
+        // callback não é chamada. Empilhar `undefined` aqui daria o comprimento
+        // certo e a esparsidade errada.
+        if vazia(*element) {
+            produced.push(*element);
+            continue;
+        }
         match visit(callback, this, *element, index) {
             Some(answered) => produced.push(answered),
             // The array built so far is what comes back, and the compiled call
@@ -91,6 +113,10 @@ extern "C" fn filter(_e: u64, this: u64, callback: u64, _a1: u64, _a2: u64, _a3:
     };
     let mut kept = Vec::new();
     for (index, element) in elements.iter().enumerate() {
+        // `filter` DESCARTA buracos: o resultado é denso.
+        if vazia(*element) {
+            continue;
+        }
         match visit(callback, this, *element, index) {
             Some(answered) if truthy(answered) => kept.push(*element),
             Some(_) => {}
@@ -234,8 +260,16 @@ fn visit(callback: u64, array: u64, element: u64, index: usize) -> Option<u64> {
 fn sought(this: u64, callback: u64) -> Option<(u64, usize)> {
     let elements = elements_of(this)?;
     for (index, element) in elements.iter().enumerate() {
-        match visit(callback, this, *element, index) {
-            Some(answered) if truthy(answered) => return Some((*element, index)),
+        // `find`/`findIndex` NÃO pulam buracos — a especificação manda visitar
+        // a posição com `undefined`, ao contrário de `forEach`/`map`/`filter`.
+        // Então aqui o buraco é convertido em vez de saltado, e o valor
+        // devolvido é o convertido: este é o quarto ponto que entrega o word
+        // direto ao programa.
+        let visivel = super::super::with_current(|context| {
+            super::super::array::visible(context, *element)
+        });
+        match visit(callback, this, visivel, index) {
+            Some(answered) if truthy(answered) => return Some((visivel, index)),
             Some(_) => {}
             None => return None,
         }

--- a/crates/rts-core-rwk/src/entry/array_proto/mod.rs
+++ b/crates/rts-core-rwk/src/entry/array_proto/mod.rs
@@ -179,7 +179,11 @@ extern "C" fn pop(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) ->
         // An empty array answers `undefined` and stays empty. Not a special
         // case: the length is written back either way, so a `pop` on an empty
         // array cannot leave the property saying -1.
+        // `visible`: um buraco no fim sai como `undefined`, não como o
+        // marcador — este é um dos quatro pontos que devolvem o word CRU ao
+        // programa sem passar por `get_indexed`.
         let taken = elements.pop().unwrap_or_else(|| undefined_of(context));
+        let taken = super::array::visible(context, taken);
         store(context, cell, elements);
         taken
     })
@@ -194,7 +198,7 @@ extern "C" fn shift(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) 
         if elements.is_empty() {
             return undefined_of(context);
         }
-        let taken = elements.remove(0);
+        let taken = super::array::visible(context, elements.remove(0));
         store(context, cell, elements);
         taken
     })
@@ -246,7 +250,12 @@ extern "C" fn includes(_e: u64, this: u64, search: u64, _a1: u64, _a2: u64, _a3:
             return Value::from_bool(false).bits();
         };
         let found = elements.iter().any(|held| {
-            crate::value::same_value_zero(Value(*held), Value(search), |a, b| {
+            // `includes` é o método que ACHA um buraco: `[,1].includes(undefined)`
+            // é `true`, porque ele percorre `0..length` em vez das chaves que
+            // existem. É o oposto de `indexOf`, que pula — e a diferença entre
+            // os dois é justamente esta linha.
+            let held = super::array::visible(context, *held);
+            crate::value::same_value_zero(Value(held), Value(search), |a, b| {
                 context.same_text(a, b)
             })
         });

--- a/crates/rts-core-rwk/src/entry/array_proto/more/mod.rs
+++ b/crates/rts-core-rwk/src/entry/array_proto/more/mod.rs
@@ -83,7 +83,8 @@ extern "C" fn at(_e: u64, this: u64, index: u64, _a1: u64, _a2: u64, _a3: u64) -
         if at < 0.0 || at >= elements.len() as f64 {
             return undefined_of(context);
         }
-        elements[at as usize]
+        // Ponto de saída direta, como `pop`/`shift`: `[,1].at(0)` é `undefined`.
+        super::super::array::visible(context, elements[at as usize])
     })
 }
 

--- a/crates/rts-core-rwk/src/entry/barrier.rs
+++ b/crates/rts-core-rwk/src/entry/barrier.rs
@@ -144,10 +144,7 @@ mod tests {
 
     /// A context over a region of a four-region heap.
     fn hosted<T>(region: u32, body: impl FnOnce() -> T) -> (Context, T) {
-        let singletons = Singletons {
-            undefined: 0,
-            null: 1,
-        };
+        let singletons = Singletons { undefined: 0, null: 1, hole: 2 };
         let heap = crate::heap::Region::sharded(64, region, 2);
         let context = Context::over(singletons, Kinds::in_declaration_order(), heap);
         with_context(context, body)

--- a/crates/rts-core-rwk/src/entry/computed.rs
+++ b/crates/rts-core-rwk/src/entry/computed.rs
@@ -162,10 +162,13 @@ pub fn get_indexed(object: u64, key: u64) -> u64 {
             && let Some(elements) = context.elements_at(slot)
         {
             // Past the end is absent, not an error: `[1,2][9]` is `undefined`.
-            let answer = elements
-                .get(at)
-                .copied()
-                .unwrap_or_else(|| undefined_of(context));
+            // E um BURACO lido também é `undefined` — `[,1][0]` responde
+            // `undefined` mesmo com a posição ausente. É `in` que os separa.
+            let held = elements.get(at).copied();
+            let answer = match held {
+                Some(held) => super::array::visible(context, held),
+                None => undefined_of(context),
+            };
             return super::accessor::Found::Value(answer);
         }
         // A typed array's element, which is a byte range rather than a slot in
@@ -241,7 +244,9 @@ pub fn set_indexed(object: u64, key: u64, value: u64) -> u64 {
             let cresceu = at >= elements.len();
             if cresceu {
                 let wanted = at + 1;
-                let absent = undefined_of(context);
+                // As posições que o salto pula são BURACOS, não `undefined`
+                // armazenados: `const a = []; a[2] = 1` deixa `0 in a` falso.
+                let absent = super::array::hole_of(context);
                 let elements = context
                     .elements_at_mut(slot)
                     .expect("the array was just found");
@@ -328,7 +333,11 @@ pub fn has_property(key: u64, object: u64) -> bool {
         if let Some(at) = super::array::as_index(context, Value(key))
             && let Some(elements) = context.elements_at(slot)
         {
-            return at < elements.len();
+            // Estar dentro do comprimento não basta: um BURACO ocupa índice e
+            // não existe. `0 in [,1]` é falso; `0 in [undefined,1]` é verdadeiro.
+            return elements
+                .get(at)
+                .is_some_and(|&held| !super::array::is_hole(context, held));
         }
         let Some(key) = property_key(context, Value(key)) else {
             return false;

--- a/crates/rts-core-rwk/src/entry/context_tests.rs
+++ b/crates/rts-core-rwk/src/entry/context_tests.rs
@@ -9,10 +9,7 @@ use super::*;
 use crate::value::Value;
 
 fn singletons() -> Singletons {
-    Singletons {
-        undefined: 0,
-        null: 1,
-    }
+    Singletons { undefined: 0, null: 1, hole: 2 }
 }
 
 fn fresh() -> Context {

--- a/crates/rts-core-rwk/src/entry/global.rs
+++ b/crates/rts-core-rwk/src/entry/global.rs
@@ -174,10 +174,7 @@ mod tests {
 
     /// A context installed for the duration, with keys already issued.
     fn hosted<T>(body: impl FnOnce() -> T) -> T {
-        let singletons = Singletons {
-            undefined: 0,
-            null: 1,
-        };
+        let singletons = Singletons { undefined: 0, null: 1, hole: 2 };
         let context = Context::new(singletons, crate::value::Kinds::in_declaration_order());
         with_context(context, body).1
     }

--- a/crates/rts-core-rwk/src/entry/object_proto.rs
+++ b/crates/rts-core-rwk/src/entry/object_proto.rs
@@ -194,7 +194,12 @@ fn owns(this: u64, key: u64) -> bool {
         if let Some(at) = super::array::as_index(context, Value(key))
             && let Some(elements) = context.elements_at(cell)
         {
-            return at < elements.len();
+            // O par exato do teste em `computed.rs` — o comentário lá diz que os
+            // dois têm de responder o mesmo, e um buraco não é uma propriedade
+            // própria.
+            return elements
+                .get(at)
+                .is_some_and(|&held| !super::array::is_hole(context, held));
         }
         let Some(key) = own_key(context, key) else {
             return false;

--- a/crates/rts-core-rwk/src/entry/objects.rs
+++ b/crates/rts-core-rwk/src/entry/objects.rs
@@ -385,10 +385,7 @@ mod tests {
     use crate::value::Singletons;
 
     fn hosted<T>(body: impl FnOnce() -> T) -> T {
-        let singletons = Singletons {
-            undefined: 0,
-            null: 1,
-        };
+        let singletons = Singletons { undefined: 0, null: 1, hole: 2 };
         let mut context = Context::new(singletons, crate::value::Kinds::in_declaration_order());
         // The keys a test names have to have been issued, exactly as a host
         // issues the ones a program names. A registry that minted nothing

--- a/crates/rts-core-rwk/src/entry/operators.rs
+++ b/crates/rts-core-rwk/src/entry/operators.rs
@@ -235,10 +235,7 @@ mod tests {
     use rts_cranelift::tags;
 
     fn singletons() -> Singletons {
-        Singletons {
-            undefined: 0,
-            null: 1,
-        }
+        Singletons { undefined: 0, null: 1, hole: 2 }
     }
 
     /// Runs a body with a context installed, as a compiled program would.

--- a/crates/rts-core-rwk/src/value/convert.rs
+++ b/crates/rts-core-rwk/src/value/convert.rs
@@ -21,6 +21,17 @@ pub struct Singletons {
     pub undefined: u32,
     /// The one that reads as `+0`.
     pub null: u32,
+    /// A posição AUSENTE de um array — o que `[1, , 3]` tem no índice 1.
+    ///
+    /// Não é um valor da linguagem e nenhum programa o observa: toda leitura de
+    /// elemento o converte em `undefined`. Ele existe para que quem pergunta se
+    /// a posição EXISTE possa responder — `0 in [,1]` é falso e
+    /// `0 in [undefined,1]` é verdadeiro, e sem um marcador os dois seriam a
+    /// mesma coisa.
+    ///
+    /// Numerado pela linguagem junto dos outros dois, e não escolhido aqui, pela
+    /// razão que [`Singletons`] inteira documenta: o espaço é do cliente.
+    pub hole: u32,
 }
 
 /// Which tag the language gave each kind it declared for itself.
@@ -145,10 +156,7 @@ mod tests {
 
     use super::*;
 
-    const S: Singletons = Singletons {
-        undefined: 0,
-        null: 1,
-    };
+    const S: Singletons = Singletons { undefined: 0, null: 1, hole: 2 };
 
     fn never_empty(_: Value) -> bool {
         false

--- a/crates/rts-host-rwk/src/link.rs
+++ b/crates/rts-host-rwk/src/link.rs
@@ -75,6 +75,7 @@ pub fn singletons_for(model: &ValueModel) -> Singletons {
     Singletons {
         undefined: model.singleton(Singleton::Undefined).number(),
         null: model.singleton(Singleton::Null).number(),
+        hole: model.hole().number(),
     }
 }
 

--- a/crates/rts-host-rwk/tests/esparso.rs
+++ b/crates/rts-host-rwk/tests/esparso.rs
@@ -1,0 +1,119 @@
+//! Arrays ESPARSOS: uma posição que não existe, e não um `undefined` guardado.
+//!
+//! O runtime ganhou um marcador de ausência para isto. O que ele compra é um
+//! par de respostas que antes era uma só: `[,1][0]` é `undefined` e `0 in [,1]`
+//! é falso, enquanto `0 in [undefined,1]` é verdadeiro.
+//!
+//! Antes disso o motor era INCONSISTENTE de um jeito que vale registrar: ele
+//! recusava o literal `[,1]` para não dar a resposta errada, e dava exatamente
+//! a mesma resposta errada quando o programa escrevia `a[2] = 1` num array
+//! vazio.
+
+use rts_cranelift::tags;
+use rts_host_rwk::compile;
+
+fn numero(fonte: &str) -> f64 {
+    let mut p = compile(fonte).unwrap_or_else(|e| panic!("compilar falhou: {e:?}"));
+    tags::decode_double(p.run())
+}
+fn verdade(fonte: &str) -> bool {
+    numero(&format!("return ({fonte}) ? 1 : 0;")) == 1.0
+}
+
+#[test]
+fn um_buraco_le_como_undefined_mas_nao_existe() {
+    // O par inteiro da mudança, em quatro linhas.
+    assert_eq!(numero("return [,1][0] === undefined ? 1 : 0;"), 1.0);
+    assert!(!verdade("0 in [,1]"), "um buraco não existe");
+    assert!(verdade("0 in [undefined,1]"), "um undefined GUARDADO existe");
+    assert!(!verdade("[,1].hasOwnProperty(0)"));
+}
+
+#[test]
+fn o_literal_conta_buracos_no_comprimento_e_a_virgula_final_nao() {
+    assert_eq!(numero("return [1,,3].length;"), 3.0);
+    assert_eq!(numero("return [1,,3][2];"), 3.0);
+    // `[1, 2, ]` é 2 — aqui a vírgula é separador. Um a mais e vira buraco.
+    assert_eq!(numero("return [1,2,].length;"), 2.0);
+    assert_eq!(numero("return [1,2,,].length;"), 3.0);
+    assert_eq!(numero("return [,,].length;"), 2.0);
+}
+
+#[test]
+fn crescer_por_indice_deixa_buracos_e_nao_undefined() {
+    // O caminho que já existia e estava errado: `a[2] = 1` num array vazio.
+    assert_eq!(numero("const a=[]; a[2]=1; return a.length;"), 3.0);
+    assert_eq!(numero("const a=[]; a[2]=1; return (0 in a) ? 1 : 0;"), 0.0);
+    assert_eq!(numero("const a=[]; a[2]=1; return (2 in a) ? 1 : 0;"), 1.0);
+}
+
+#[test]
+fn new_array_de_n_sao_n_buracos() {
+    assert_eq!(numero("return new Array(3).length;"), 3.0);
+    assert!(!verdade("0 in new Array(3)"));
+    assert_eq!(numero("return new Array(3)[0] === undefined ? 1 : 0;"), 1.0);
+}
+
+#[test]
+fn object_keys_lista_so_o_que_existe() {
+    // Deste ponto saem também `for-in`, `Object.values/entries`, `assign` e o
+    // `JSON.stringify` de objeto.
+    assert_eq!(numero("return Object.keys([1,,3]).length;"), 2.0);
+    assert_eq!(numero("const a=[]; a[2]=1; return Object.keys(a).length;"), 1.0);
+    assert_eq!(numero("return Object.keys([1,2,3]).length;"), 3.0);
+}
+
+#[test]
+fn a_iteracao_pula_buracos_menos_onde_a_especificacao_manda_visitar() {
+    assert_eq!(
+        numero("let n=0; [1,,3].forEach(function(){n=n+1;}); return n;"),
+        2.0,
+        "forEach percorre as chaves que existem"
+    );
+    assert_eq!(numero("return [1,,3].filter(function(){return true;}).length;"), 2.0);
+    // `map` é o caso especial: preserva comprimento E esparsidade, sem chamar
+    // a callback no buraco.
+    assert_eq!(numero("return [1,,3].map(function(){return 9;}).length;"), 3.0);
+    assert_eq!(
+        numero("const m = [1,,3].map(function(){return 9;}); return (1 in m) ? 1 : 0;"),
+        0.0
+    );
+    // `find` NÃO pula — visita com `undefined`. É a exceção deliberada.
+    assert_eq!(
+        numero("return [,1].find(function(x){return x===undefined;}) === undefined ? 1 : 0;"),
+        1.0
+    );
+}
+
+#[test]
+fn includes_acha_o_buraco_e_indexof_o_pula() {
+    // A diferença entre os dois é que `includes` percorre `0..length` e
+    // `indexOf` percorre as chaves que existem. É o par mais fino disto tudo.
+    assert!(verdade("[,1].includes(undefined)"));
+    assert_eq!(numero("return [,undefined].indexOf(undefined);"), 1.0);
+}
+
+#[test]
+fn um_array_denso_nao_muda_em_nada() {
+    // A rede de segurança: nada acima pode ter custado o caso comum.
+    assert_eq!(numero("const a=[1,2,3]; return a.length;"), 3.0);
+    assert!(verdade("0 in [1,2,3]"));
+    assert_eq!(numero("let n=0; [1,2,3].forEach(function(){n=n+1;}); return n;"), 3.0);
+    assert_eq!(numero("return [1,2].map(function(x){return x*2;})[1];"), 4.0);
+    assert_eq!(numero("return [1,2,3].filter(function(x){return x>1;}).length;"), 2.0);
+    assert_eq!(numero("const a=[1]; a.push(2); return a.length;"), 2.0);
+    assert_eq!(numero("return [1,2,3].pop();"), 3.0);
+    assert_eq!(numero("return [1,2,3].shift();"), 1.0);
+}
+
+#[test]
+fn os_pontos_que_devolvem_o_valor_cru_nao_vazam_o_marcador() {
+    // `pop`, `shift`, `at` e `find` entregam o word direto ao programa sem
+    // passar pelo funil de `a[i]`. Se algum esquecer a conversão, o programa vê
+    // um valor que não existe em JavaScript — e `typeof` o denuncia.
+    assert_eq!(numero("return [1,].pop() === 1 ? 1 : 0;"), 1.0);
+    assert_eq!(numero("return [,1].shift() === undefined ? 1 : 0;"), 1.0);
+    assert_eq!(numero("return [,1].at(0) === undefined ? 1 : 0;"), 1.0);
+    assert_eq!(numero("return typeof [,1].at(0) === 'undefined' ? 1 : 0;"), 1.0);
+    assert_eq!(numero("return typeof [,1][0] === 'undefined' ? 1 : 0;"), 1.0);
+}

--- a/crates/rts-host-rwk/tests/running.rs
+++ b/crates/rts-host-rwk/tests/running.rs
@@ -517,8 +517,11 @@ fn a_construct_still_missing_is_refused_by_name_rather_than_approximated() {
     //
     // This test has named `typeof`, a string literal, `~` and `==` in turn, and
     // each moved on when it landed. What it pins is the shape of the refusal.
+    // `[1, , 2]` esteve nesta lista e saiu quando o runtime ganhou um marcador
+    // de posição ausente. O que entrou no lugar é o mesmo buraco ao lado de um
+    // SPREAD, que o caminho do vetor de argumentos não sabe pular.
     for source in [
-        "return [1, , 2];",
+        "return [...[1], , 2];",
         "class A {} class B extends A { constructor() { super(1, 2, 3, 4, 5); } } return new B();",
         "let o = {}; let x = 1; return delete x;",
     ] {
@@ -1577,15 +1580,26 @@ fn an_array_can_be_walked_by_a_loop() {
 }
 
 #[test]
-fn a_hole_is_refused_rather_than_written_as_undefined() {
-    // `[,1]` has no element zero, and `0 in [,1]` is false where
-    // `[undefined,1]` answers true. This runtime cannot tell the two apart, so
-    // the hole is a named gap rather than an array that is quietly the wrong
-    // one.
-    let error = compile("return [,1];").expect_err("a hole is a gap");
-    assert!(
-        format!("{error:?}").contains("Unsupported"),
-        "expected a named refusal, got {error:?}"
+fn a_hole_is_absent_rather_than_an_undefined_that_was_stored() {
+    // This test used to assert the opposite — that `[,1]` was REFUSED, because
+    // writing the hole as `undefined` would make `0 in [,1]` answer true when
+    // the language says false. The refusal was right for as long as the runtime
+    // had no way to say "absent"; it has one now, so the assertion is the
+    // behaviour rather than the gap.
+    //
+    // The pair is the whole point: same length, same read, different `in`.
+    assert_eq!(tags::decode_double(run("return [,1].length;")), 2.0);
+    assert_eq!(tags::decode_double(run("return [,1][1];")), 1.0);
+    assert_eq!(tags::decode_double(run("return [,1][0] === undefined ? 1 : 0;")), 1.0);
+    assert_eq!(
+        tags::decode_double(run("return (0 in [,1]) ? 1 : 0;")),
+        0.0,
+        "a hole does not exist"
+    );
+    assert_eq!(
+        tags::decode_double(run("return (0 in [undefined,1]) ? 1 : 0;")),
+        1.0,
+        "an undefined that was STORED does exist — this is the pair the marker buys"
     );
 }
 


### PR DESCRIPTION
`[1, , 3]` era recusado na compilação, e a razão registrada estava certa: sem um jeito de dizer "ausente", escrever o buraco como `undefined` faria `0 in [,1]` responder verdadeiro onde a linguagem diz falso.

**Mas a recusa era inconsistente** — e é isso que motivou o trabalho em vez de mais uma exceção. O motor recusava o literal para não dar a resposta errada, e dava a mesma resposta errada por outro caminho:

| caso | antes | JavaScript |
|---|---|---|
| `0 in new Array(3)` | true | **false** |
| `a=[]; a[2]=1; 0 in a` | true | **false** |
| `Object.keys(a).length` | 3 | **1** |
| `a.forEach` conta | 3 | **1** |

## O marcador

Não é um valor da linguagem — `Singleton` continua sendo "os valores que JavaScript tem exatamente um de", e um buraco é a **ausência** de um. Quem o numera ainda é a linguagem, porque o espaço de singleton é do cliente; um padrão de bits inventado seria pior, e já houve um `0` usado como sentinela aqui que destruiu `+0.0` armazenado.

Nenhum programa o observa: `array::visible` é o ponto de passagem que toda leitura atravessa — função e não `if` repetido, porque são **sessenta sites** e o que vaza se um esquecer é um word que não corresponde a nenhum valor de JavaScript.

## Quem faz o quê

- **produz buraco**: `new Array(n)`, crescimento por índice, literal com vírgula
- **responde "não existe"**: `in`, `hasOwnProperty`, `key_texts` — este alimenta `Object.keys/values/entries`, `for-in`, `assign`, `structuredClone` e `JSON.stringify`, todos consertados por um `continue`
- **pula**: `forEach`, `filter`
- **preserva a esparsidade**: `map`
- **não pula, por decisão da spec**: `find`/`findIndex` (visitam com `undefined`) e `includes` (percorre `0..length`) — enquanto `indexOf` percorre as chaves que existem

## Verificação

`tests/esparso.rs`, 9 testes — incluindo um que só existe pelo risco: os quatro pontos (`pop`, `shift`, `at`, `find`) que devolvem o word cru sem passar pelo funil de `a[i]`, verificados com `typeof`.

Três testes que pinavam a recusa foram atualizados na mesma mudança. O que entrou no lugar como gap em aberto é o buraco **ao lado de um spread** (`[...a, , 1]`).

**1391 → 1406** arquivos da suíte compilam. 372 testes do host, 198 do runtime, 106 do codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNMhSfMGXNa4hdUnoiMfHu