### PR TITLE
fix: bigint <<, >>, ** e ~ + Number(1n); e o psm fora da árvore

### DIFF
--- a/CLAUDE-REVIEW-bigint-psm.md
+++ b/CLAUDE-REVIEW-bigint-psm.md
@@ -1,0 +1,257 @@
+# Revisão: BigInt (`<<`, `>>`, `**`, `~`, `Number(1n)`) e a saída do `psm`
+
+Handoff de uma sessão de 2026-08-10. Escrito para quem vai revisar o diff sem ter
+acompanhado o caminho até ele.
+
+**Este arquivo não é o `CLAUDE.md`.** O da raiz é o contrato do repositório e
+continua sendo a única entrada; isto é o relatório de uma mudança e sai daqui
+quando a branch entrar.
+
+---
+
+## O que foi pedido
+
+Dois problemas, relatados juntos:
+
+1. um erro que aparecia como "de linker" depois que o sistema passou a usar o
+   codegen novo, batendo em `rts-host-rwk` e `rts-cli` e poupando
+   `rts-core-rwk`, `rts-std-rwk`, `rts-node-rwk` e `rts-runtime-rwk`;
+2. BigInt quebrado — `<<` dando `0`, `>>` dando `0`, `**` dando `NaN` e
+   `Number(5n)` dando `NaN`.
+
+Depois, no meio do trabalho: fazer o caso do número grande demais responder o
+que o Node responde.
+
+---
+
+## Parte 1 — o "erro de linker" não era de linker
+
+### O que está provado
+
+`cargo check` de `rts-host-rwk` e de `rts-cli` termina **limpo no host Windows**.
+Não há símbolo faltando, nem duplicado, nem staticlib estagnada — o build de duas
+etapas do `rts-runtime` não tem relação com isto. O erro só existe ao **cruzar**
+para Linux, e vem de `build.rs` de terceiros que compilam C/assembly **para o
+target**, o que exige uma toolchain C cruzada que a máquina não tem.
+
+### Por que só aqueles dois crates
+
+Rota única: `swc_ecma_parser` → `stacker` → `psm`, e `stacker` é feature
+**default** do swc. Os crates que passavam limpo estão ABAIXO do `rts-codegen` no
+grafo; `rts-host-rwk` está acima dele (`crates/rts-codegen/Cargo.toml` declara
+`swc_ecma_parser` direto). Para o `rts-cli` o `psm` já estava na árvore antes do
+cutover, via `rts-parser` — **ali não é regressão do motor novo.**
+
+### O que esta branch faz
+
+Desliga a feature nos dois manifestos. Precisa ser nos **dois**, senão o cargo
+reunifica a feature e o `psm` volta:
+
+```toml
+swc_ecma_parser = { version = "39.0.0", default-features = false, features = ["typescript"] }
+```
+
+O swc tem fallback limpo sem ela — sob `not(feature = "stacker")` o `maybe_grow`
+vira `callback()` direto. Verificado: `cargo tree -p rts-cli -i psm` responde que
+o pacote não existe mais no workspace, e o check segue verde.
+
+**O que se perde:** o crescimento automático de pilha do parser em expressão
+profunda. O repo já cobre isso pelo outro lado — `rts-cli/src/cli/new_engine.rs`
+e `rts-host-rwk/examples/suite_run.rs` rodam o compile numa thread de 64 MB. Se um
+fixture profundo estourar, a correção é subir o `STACK`, **não** trazer o `psm` de
+volta. A suíte inteira rodou depois da mudança e nada estourou.
+
+### O que NÃO está resolvido, e é o mais importante desta metade
+
+**Tirar o `psm` não te dá o build Linux.** Com o target instalado
+(`rustup target add x86_64-unknown-linux-gnu`), o check cruzado ainda falha — em
+**`ring`**:
+
+```
+error: failed to run custom build command for `ring v0.17.14`
+  error occurred in cc-rs: failed to find tool "x86_64-linux-gnu-gcc"
+```
+
+`ring` vem de `rustls` ← `rts-natives` ← `rts-engine` ← (`rts-cli`,
+`rts-codegen-new`, `rts-dom`, …). É C e assembly de verdade: é o TLS que `fetch`,
+WebSocket e HTTPS usam, e não é uma feature que dê para desligar.
+
+**Conclusão honesta: cruzar Windows→Linux exige uma toolchain C de qualquer
+jeito.** A saída do `psm` continua certa — uma dependência C a menos, e uma da
+qual não dependemos de fato — mas quem quiser o binário Linux vai por
+`cargo-zigbuild` (o `zig cc` faz esse cross sem instalar toolchain) ou por
+container/CI Linux. Isso é decisão de projeto e **não foi tomada aqui**.
+
+---
+
+## Parte 2 — BigInt
+
+### O diagnóstico, que é mais curto do que parece
+
+Cinco divergências, **três causas**.
+
+`bigint_class::binary` é quem decide bigint-vs-Number, e **não existe tabela de
+despacho**: cada entry point faz a pergunta por conta própria, com um
+`if let Some(…) = binary(…) { return … }` copiado. No HEAD:
+
+| entry point | perguntava? |
+|---|---|
+| `bit_and`, `bit_or`, `bit_xor` | sim |
+| `bit_not`, `shift_left`, `shift_right`, `exponent` | **não** |
+| `shift_right_unsigned` | não — e está certo, `>>>` sobre bigint é `TypeError` na spec |
+
+Sem a pergunta, o operando vai para `operators::as_number`, que devolve `None`
+para um bigint, e `operands` substitui por `NaN`. Daí `to_int32(NaN)` é `0` — por
+isso `<<` e `>>` davam `0` — e `powf(NaN, NaN)` é `NaN` — por isso `**` dava
+`NaN`. **Mesma causa, sintomas diferentes só no último passo.**
+
+`Number(5n)` é outra causa: `number/mod.rs` chamava a conversão compartilhada, e a
+recusa dela está **certa** — é `ToNumber`, e `ToNumber(bigint)` é `TypeError` na
+spec; é essa recusa que faz `1n + 1` não virar número em silêncio. O que faltava
+era a carve-out: `Number(x)` usa `ToNumeric`, e `Number(1n)` é `1`.
+
+`~1n` era a quinta divergência, não estava no relato original, e é o mesmo defeito
+na forma unária.
+
+**O front está inocente.** `emit/expr.rs` mapeia `Shl`/`Shr`/`Exponent` para o
+`RuntimeOp` certo e `emit/proven.rs` recusa provar bitwise, então não há fast path
+inline: todo shift chega ao entry point. O bug era inteiramente do runtime.
+
+**A aritmética já existia e já era testada** — `BigInt::shl`/`shr` em
+`bigint/bits.rs`, `pow` (square-and-multiply) em `arith.rs`. Nada de matemática
+nova foi escrito; ela só não era alcançada. É por isso que o fix é pequeno.
+
+### Representação (para quem for mexer)
+
+Não é tag dedicada: é **client kind**, NaN-boxed carregando um `Slot(u32)` que é um
+ÍNDICE num `Slab<BigInt>` no `Context`. `BigInt` é sign-magnitude
+`{ negative: bool, digits: Vec<u32> }`, base 2^32, normalizado, **precisão
+arbitrária sem teto**. Igualdade por VALOR e não por slot, senão `1n === 1n` seria
+falso. Nunca coletado.
+
+`9007199254740993n` e `18446744073709551617n` cabem folgado e **já respondiam
+certo antes** — nenhuma das cinco divergências era de representação.
+
+### Dois DoS que o fix teve de tratar antes de ser um fix
+
+Isto é o que separa "passa no repro" de "pode entrar":
+
+1. **O operando direito de `<<` e `**` é uma CONTAGEM.** `1n << 2n**40n` é uma
+   linha de código e um terabyte de dígitos. Sem teto, o fix mata o processo na
+   primeira contagem grande. Teto em 1 gigabit (`MAX_BITS`), que é onde o V8 para.
+2. **`BigInt::shr` varria `(0..amount)`** — um passo por unidade da contagem, não
+   por bit do operando. `-1n >> 2n**40n` não falharia: **nunca retornaria**. Estava
+   invisível porque nada chamava `shr`; corrigir o item anterior o EXPÕE. A
+   varredura agora para na largura, já que todo bit acima dela é zero.
+
+### O caso do número grande demais: `RangeError`
+
+Pedido depois, e implementado. `1n << 2n**40n` e `2n ** 2n**40n` lançam
+`RangeError: Maximum BigInt size exceeded` (a mensagem do V8, para quem procurar o
+texto achar a mesma página); `2n ** -1n` lança `Exponent must be non-negative`.
+Capturável, `instanceof RangeError` verdadeiro, programa continua.
+
+`-1n >> 2n**40n` **não** lança: shift à direita só perde bits, então contagem além
+da largura satura em `-1n` — que é o que o Node responde.
+
+#### A armadilha, e é a parte deste diff que merece revisão de verdade
+
+A primeira tentativa **abortava o processo**. `throw::range_error` constrói o
+objeto de erro através do mesmo `RefCell` do `Context`, e chamá-lo de dentro do
+`with_current` dá `RefCell already borrowed` dentro de `_rts_shift_left` — num
+frame que **não pode desenrolar**. Não é panic que falha um teste; é abort.
+
+A forma final: `binary` devolve `Option<Result<u64, Refused>>` e carrega a recusa
+para FORA do empréstimo; só `settled` lança. `settled` de propósito **não recebe
+`Context`**, para que a regra seja difícil de quebrar sem querer.
+
+**O ponto que o revisor precisa olhar:** `operators.rs` e `primitives.rs` chamam
+`settled` DENTRO do empréstimo. Isso é são hoje e só hoje, porque `+ - * / %` e as
+comparações não recusam. **Divisão por zero é o que quebra isso**: ela responde
+`undefined` hoje onde a linguagem lança, e no dia em que passar a lançar — que é o
+certo — esses cinco call sites têm de sair do empréstimo **na mesma mudança**.
+Está escrito em `settled` e no site do `Op::Sub`.
+
+### Doc do módulo corrigido
+
+O doc de `bigint_class.rs` dizia que operação mista responde `NaN` "porque não dá
+para lançar", já que `entry/throw.rs` encerraria o programa. **Este fix torna isso
+falso** — o `RangeError` lança e o programa segue. Reescrito: agora é uma escolha,
+não um limite. E a escolha é que o `TypeError` do misto tem de entrar em todos os
+operadores de uma vez; pôr só nos três tocados deixaria uma regra da linguagem com
+duas respostas dependendo do operador.
+
+(O `CLAUDE.md` da raiz proíbe deixar regra que o código contradiz — por isso o doc
+mudou junto e não depois.)
+
+---
+
+## Medição
+
+Régua: `rts-host-rwk/examples/suite_run`, **um processo por arquivo**, release.
+Baseline em `git worktree` no `HEAD` com `CARGO_TARGET_DIR` próprio — **sem
+`git stash`**, que aplicaria um stash alheio se o tree estivesse limpo.
+
+| | passa |
+|---|---|
+| baseline (HEAD) | 740 / 796 |
+| esta branch | **741 / 797** |
+
+**Perdidos: nenhum. Ganho: a fixture nova.** A lista de perdidos vazia é o que
+autoriza dizer "sem regressão"; o número líquido nunca autorizou.
+
+Rodada duas vezes: uma depois do fix de aritmética, outra depois do `RangeError` —
+porque a segunda mudança alterou o call site de **todo** operador aritmético, não
+só dos três que ganharam o throw.
+
+Também: `cargo test -p rts-core-rwk` 229/229; `scripts/read_before_commit.sh
+--no-build` sem violação dura (as listas amarelas são de `rts-codegen-new` e não
+cresceram — o trabalho todo foi em `rts-core-rwk`).
+
+Que o baseline era genuíno foi conferido rodando o repro no binário dele:
+`shl=0 shr=0 pow=NaN Number(5n)=NaN`.
+
+### Cobertura: o achado que vale mais que o número
+
+**Ganho zero de arquivos existentes.** O fix não fez nenhum teste da suíte passar,
+porque **a suíte não cobria isso**: só existem `bigint_asintn` e
+`bigint_literal_as_i64`, e nenhum toca shift, `**` ou `Number(1n)`. A suíte não
+protegia o fix e não pegaria a regressão dele.
+
+Daí `tests/claude-bigint-shift-pow.test.ts`, que **passa com o fix e falha sem** —
+verificado nos dois binários. Cobre também o que o repro original não pegava:
+`1n << 64n` (onde `1 << 64` daria `1`), contagem negativa invertendo a direção,
+`-5n >> 1n` arredondando para -infinito, `~1n`, e os três `RangeError`.
+
+---
+
+## Arquivos
+
+| arquivo | o quê |
+|---|---|
+| `crates/rts-codegen/Cargo.toml` | desliga `stacker` |
+| `crates/rts-parser/Cargo.toml` | idem — precisa ser nos dois |
+| `crates/rts-core-rwk/src/entry/bitwise.rs` | a pergunta bigint em `<<`, `>>`, `**`, `~`; cada uma no seu próprio empréstimo |
+| `crates/rts-core-rwk/src/entry/bigint_class.rs` | `Op::{Shl,Shr,Pow}`, teto, `settled`, doc corrigido |
+| `crates/rts-core-rwk/src/entry/number/mod.rs` | carve-out do `Number(1n)` |
+| `crates/rts-core-rwk/src/entry/operators.rs` | `Result` propagado + o comentário sobre divisão por zero |
+| `crates/rts-core-rwk/src/entry/primitives.rs` | `Result` propagado no `+` |
+| `crates/rts-core-rwk/src/bigint/bits.rs` | varredura do `shr` limitada à largura + teste que a pina |
+| `crates/rts-core-rwk/src/bigint/mod.rs` | `bit_len()`, para recusar ANTES de alocar |
+| `tests/claude-bigint-shift-pow.test.ts` | novo |
+
+---
+
+## Aberto — nada disto foi decidido aqui
+
+1. **`TypeError` do misto.** `1n + 1` responde `NaN` e devia lançar. Vale para
+   todos os operadores de uma vez, e exige mover os call sites de `operators.rs`
+   para fora do empréstimo.
+2. **Divisão por zero de bigint** responde `undefined` onde o Node lança
+   `RangeError`. Mesma dependência do item 1.
+3. **Cross para Linux**: `cargo-zigbuild` ou container, por causa do `ring`.
+4. **`e.constructor.name` é `undefined`** em erros — pré-existente e não desta
+   mudança (acontece igual com `new RangeError("x")` escrito à mão). `e.name` e
+   `String(e)` estão corretos.
+5. **`Object(1n)`** (wrapper) continua ausente, por decisão já registrada no doc
+   do módulo.

--- a/crates/rts-codegen/Cargo.toml
+++ b/crates/rts-codegen/Cargo.toml
@@ -20,7 +20,7 @@ rts-cranelift = { path = "../rts-cranelift" }
 # and so is not something a language layer may skip.
 swc_common = "21.0.1"
 swc_ecma_ast = "23.0.0"
-swc_ecma_parser = "39.0.0"
+swc_ecma_parser = { version = "39.0.0", default-features = false, features = ["typescript"] }
 
 [dev-dependencies]
 # The integration tests build trees that carry machine positions, so they name

--- a/crates/rts-core-rwk/src/bigint/bits.rs
+++ b/crates/rts-core-rwk/src/bigint/bits.rs
@@ -44,7 +44,12 @@ impl BigInt {
         if !self.negative {
             return Self::from_parts(false, shifted);
         }
-        let lost = (0..amount as usize).any(|index| mag_bit(&self.digits, index));
+        // Scanning to `amount` would be right and would also be a four-billion
+        // step loop for a count the caller is allowed to pass: `-1n >> 2n**40n`
+        // is `-1n`, and every bit at or above the width is already zero, so the
+        // scan stops at the width rather than at the count.
+        let scan = (amount as usize).min(mag_bit_len(&self.digits));
+        let lost = (0..scan).any(|index| mag_bit(&self.digits, index));
         if lost {
             Self::from_parts(true, shifted).sub(&BigInt::from_i64(1))
         } else {
@@ -198,6 +203,17 @@ mod tests {
         assert_eq!(big("-8").shr(1), big("-4"), "and exact division does not round");
         assert_eq!(big("-8").shr(2), big("-2"));
         assert_eq!(big("-9").shr(2), big("-3"));
+    }
+
+    #[test]
+    fn shifting_right_by_an_enormous_count_finishes() {
+        // The count is a bigint, so a program may pass one that no loop can
+        // walk. Answering `-1n` here takes a step per bit of the OPERAND, not
+        // per unit of the count — without that, this test does not fail, it
+        // never returns.
+        assert_eq!(big("-1").shr(u32::MAX), big("-1"));
+        assert_eq!(big("-12345678901234567890").shr(u32::MAX), big("-1"));
+        assert_eq!(big("12345678901234567890").shr(u32::MAX), BigInt::zero());
     }
 
     #[test]

--- a/crates/rts-core-rwk/src/bigint/mod.rs
+++ b/crates/rts-core-rwk/src/bigint/mod.rs
@@ -222,6 +222,16 @@ impl BigInt {
         self.negative
     }
 
+    /// How many bits the magnitude occupies; zero for zero.
+    ///
+    /// Exposed for the callers that have to REFUSE an operation before running
+    /// it: `1n << 2n**40n` and `2n ** 2n**40n` are each one line of arithmetic
+    /// and a terabyte of digits, and a size that has to be checked after the
+    /// allocation is a size nothing checks.
+    pub fn bit_len(&self) -> usize {
+        arith::mag_bit_len(&self.digits)
+    }
+
     /// Numeric order.
     ///
     /// Delegates to [`Ord`] rather than the other way round, so the two can

--- a/crates/rts-core-rwk/src/entry/bigint_class.rs
+++ b/crates/rts-core-rwk/src/entry/bigint_class.rs
@@ -12,11 +12,21 @@
 //! recognised before conversion, which is what the operator entry points now do:
 //! ask this module first, and fall through only when neither side is one.
 //!
-//! # What a mixed operation answers, since it cannot throw
+//! # What a mixed operation answers, and why it is still not a throw
 //!
-//! `NaN`, and that is a stated divergence rather than a choice: `entry/throw.rs`
-//! ends the program, so a `TypeError` here would kill a program over one
-//! expression. `NaN` is what the operation would have produced if the bigint had
+//! `NaN`, and the reason recorded here used to be that raising was impossible —
+//! that `entry/throw.rs` ended the program. **That is no longer true**: a native
+//! raises a catchable error, and the shift refusals below do it, so a program
+//! catches `1n << 2n**40n` and carries on.
+//!
+//! So this is now a CHOICE and not a limit, and it is the smaller of two: the
+//! `TypeError` belongs on every mixed operation at once — `+`, `-`, `*`, `/`,
+//! `%` and the comparisons — because raising it on the three that happen to have
+//! been touched would leave one language rule with two answers depending on the
+//! operator. That change also has to move those call sites out of their
+//! borrows first, for the reason [`settled`] states.
+//!
+//! Until then `NaN` is what the operation would have produced if the bigint had
 //! converted and failed, so it is the least surprising wrong answer available.
 //!
 //! **`===` is the exception and it is exact.** `1n === 1` is false and `1n === 1n`
@@ -184,7 +194,20 @@ pub fn bigint_new(digits: u64) -> u64 {
 /// `None` means neither side is one, and the caller carries on with the numeric
 /// path — which is what keeps every operation that has nothing to do with
 /// bigints paying one comparison rather than a conversion.
-pub(super) fn binary(context: &mut Context, op: Op, left: u64, right: u64) -> Option<u64> {
+///
+/// The inner `Err` is a refusal that has to become a `RangeError`, and it is
+/// carried OUT rather than raised here: this runs holding the context's
+/// `RefCell`, and `throw::range_error` builds the error object through that same
+/// cell. Raising in place is not a worse style, it is an abort — the first
+/// attempt panicked `RefCell already borrowed` inside `_rts_shift_left`, which
+/// cannot unwind. [`settled`] is where the caller turns it into a throw, after
+/// the borrow has ended.
+pub(super) fn binary(
+    context: &mut Context,
+    op: Op,
+    left: u64,
+    right: u64,
+) -> Option<Result<u64, Refused>> {
     let held = |value: u64| super::bigints::digits_of(context, value).cloned();
     let (a, b) = (held(left), held(right));
     if a.is_none() && b.is_none() {
@@ -207,12 +230,12 @@ pub(super) fn binary(context: &mut Context, op: Op, left: u64, right: u64) -> Op
                 // A fraction, a `NaN` or an infinity: no bigint says the same
                 // thing, and every relational operator answers false for an
                 // unordered pair — which is what `NaN` already produces.
-                _ => return Some(Value::from_bool(false).bits()),
+                _ => return Some(Ok(Value::from_bool(false).bits())),
             }
         }
         // Arithmetic with one side only. The language refuses to coerce, and
         // this cannot throw.
-        _ => return Some(Value::from_f64(f64::NAN).bits()),
+        _ => return Some(Ok(Value::from_f64(f64::NAN).bits())),
     };
 
     let produced = match op {
@@ -222,22 +245,142 @@ pub(super) fn binary(context: &mut Context, op: Op, left: u64, right: u64) -> Op
         // Division by zero is a `RangeError`; `undefined` is the stated answer.
         Op::Div => match a.div(&b) {
             Some(held) => held,
-            None => return Some(undefined_of(context)),
+            None => return Some(Ok(undefined_of(context))),
         },
         Op::Rem => match a.rem(&b) {
             Some(held) => held,
-            None => return Some(undefined_of(context)),
+            None => return Some(Ok(undefined_of(context))),
         },
         Op::BitAnd => a.bit_and(&b),
         Op::BitOr => a.bit_or(&b),
         Op::BitXor => a.bit_xor(&b),
+        // A shift and an exponent take their right operand as a COUNT rather
+        // than as a second operand, which is why they cannot go through the
+        // pairwise helpers above. A refused count RAISES, unlike the divisions
+        // above: the count is the whole reason a result can be too large to
+        // build, and answering `undefined` there hands the program a value for
+        // a request the machine could not honour. `throw::range_error` is what
+        // `buffer::alloc` already does with a negative size, for that reason.
+        Op::Shl => match shifted(&a, &b, true) {
+            Ok(held) => held,
+            Err(why) => return Some(Err(why)),
+        },
+        Op::Shr => match shifted(&a, &b, false) {
+            Ok(held) => held,
+            Err(why) => return Some(Err(why)),
+        },
+        Op::Pow => match raised(&a, &b) {
+            Ok(held) => held,
+            Err(why) => return Some(Err(why)),
+        },
         // A comparison answers a boolean rather than a bigint, so it leaves
         // before the value is stored.
         Op::Compare(want) => {
-            return Some(Value::from_bool(want.holds(a.cmp(&b))).bits());
+            return Some(Ok(Value::from_bool(want.holds(a.cmp(&b))).bits()));
         }
     };
-    Some(context.bigint_value(produced))
+    Some(Ok(context.bigint_value(produced)))
+}
+
+/// How large a result these operations will build before refusing.
+///
+/// A gigabit, which is what V8 answers `RangeError: Maximum BigInt size
+/// exceeded` past — matched rather than invented so that a program that works
+/// in Node does not meet a different wall here. There has to be one: the
+/// operand of `<<` and of `**` is a COUNT, so `1n << 2n**40n` asks for a
+/// terabyte of digits from an expression that fits on one line.
+const MAX_BITS: u64 = 1 << 30;
+
+/// Why a count was refused — the text the `RangeError` carries.
+///
+/// The two reasons are told apart rather than merged into one message because a
+/// program meets them for opposite mistakes: `2n ** -1n` is a sign error and
+/// `1n << 2n**40n` is a size the machine cannot hold, and "out of range" for
+/// both would tell the reader neither.
+type Refused = &'static str;
+
+/// V8's wording for each, so a message a user searches for finds the same page.
+const TOO_LARGE: Refused = "Maximum BigInt size exceeded";
+const NEGATIVE_EXPONENT: Refused = "Exponent must be non-negative";
+
+/// Turns what [`binary`] carried out into a value, raising if it refused.
+///
+/// **Call this outside `with_current`.** Building the error object borrows the
+/// context, and doing that while `binary`'s borrow is still live aborts the
+/// process rather than failing — the panic cannot unwind through the entry
+/// point. The signature keeps no `Context`, which is what makes the rule hard to
+/// break by accident.
+///
+/// The value answered on a refusal is never read: the compiled call site
+/// re-raises what `throw::range_error` recorded. It exists because the entry
+/// point returns `u64`.
+///
+/// `operators.rs` and `primitives.rs` do call this inside a borrow, and that is
+/// sound only because `+`, `-`, `*`, `/`, `%` and the comparisons cannot refuse
+/// — division by zero answers `undefined` rather than raising. Making that one
+/// throw means moving those calls out of their borrows in the same change.
+pub(super) fn settled(outcome: Result<u64, Refused>) -> u64 {
+    match outcome {
+        Ok(value) => value,
+        Err(why) => {
+            super::throw::range_error(why);
+            super::modules::undefined_value()
+        }
+    }
+}
+
+/// `a << b` and `a >> b`, which differ in a direction and share everything else.
+///
+/// A negative count reverses the direction — that is the language's definition
+/// rather than a convenience — so both spellings reach both shifts and the
+/// decision is made once.
+fn shifted(value: &BigInt, amount: &BigInt, left: bool) -> Result<BigInt, Refused> {
+    let toward_left = left != amount.is_negative();
+    let magnitude = amount.as_i64().map(i64::unsigned_abs);
+    if !toward_left {
+        // A right shift only ever loses bits, so a count past the width and a
+        // count of the width answer the same thing — which is what lets a count
+        // too large to name saturate instead of being refused.
+        let by = magnitude.and_then(|m| u32::try_from(m).ok()).unwrap_or(u32::MAX);
+        return Ok(value.shr(by));
+    }
+    // A left count too large to even NAME is already too large to build, so the
+    // two ways of being too big answer the same refusal.
+    let bits = magnitude
+        .and_then(|m| u32::try_from(m).ok())
+        .ok_or(TOO_LARGE)?;
+    match value.bit_len() as u64 + u64::from(bits) <= MAX_BITS {
+        true => Ok(value.shl(bits)),
+        false => Err(TOO_LARGE),
+    }
+}
+
+/// `a ** b`.
+///
+/// A negative exponent is a `RangeError` in the language, which is the same
+/// shape [`BigInt::pow`]'s unsigned parameter already states.
+fn raised(value: &BigInt, exponent: &BigInt) -> Result<BigInt, Refused> {
+    let count = exponent.as_i64().ok_or(TOO_LARGE)?;
+    if count < 0 {
+        return Err(NEGATIVE_EXPONENT);
+    }
+    let power = u32::try_from(count).map_err(|_| TOO_LARGE)?;
+    // Checked before the multiplying starts: the size is known from the operand
+    // and the count, and a check after the fact is a check that never runs.
+    match (value.bit_len() as u64).saturating_mul(u64::from(power)) <= MAX_BITS {
+        true => Ok(value.pow(power)),
+        false => Err(TOO_LARGE),
+    }
+}
+
+/// The double a bigint stands for, when the caller is allowed to ask.
+///
+/// `Number(1n)` is `1` and `1n + 1` is a `TypeError`, so this is deliberately
+/// NOT part of [`super::operators::as_number`]: putting it there would make
+/// every arithmetic operator coerce a bigint silently, which is the one thing
+/// the type exists to prevent.
+pub(super) fn as_f64(context: &Context, value: u64) -> Option<f64> {
+    super::bigints::digits_of(context, value).map(BigInt::to_f64)
 }
 
 /// `-x` where `x` is a bigint.
@@ -282,6 +425,12 @@ pub(super) enum Op {
     BitOr,
     /// `^`
     BitXor,
+    /// `<<`
+    Shl,
+    /// `>>`
+    Shr,
+    /// `**`
+    Pow,
     /// One of the four relational operators.
     Compare(Relation),
 }

--- a/crates/rts-core-rwk/src/entry/bitwise.rs
+++ b/crates/rts-core-rwk/src/entry/bitwise.rs
@@ -67,16 +67,19 @@ fn shift_by(value: f64) -> u32 {
 /// `a & b`.
 #[rtse::entry]
 pub fn bit_and(left: u64, right: u64) -> u64 {
-    with_current(|context| {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
         // A bigint has no thirty-two-bit truncation: `&` on two of them is
         // over the whole two's-complement value, which is what makes
         // `-1n & 3n` answer `3n` where `-1 & 3` also does and `(2n**40n) & 1n`
         // would not survive `ToInt32`.
-        if let Some(answer) =
-            super::bigint_class::binary(context, super::bigint_class::Op::BitAnd, left, right)
-        {
-            return answer;
-        }
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::BitAnd, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
+    with_current(|context| {
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(f64::from(to_int32(a) & to_int32(b))).bits()
     })
@@ -85,12 +88,15 @@ pub fn bit_and(left: u64, right: u64) -> u64 {
 /// `a | b`.
 #[rtse::entry]
 pub fn bit_or(left: u64, right: u64) -> u64 {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::BitOr, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
     with_current(|context| {
-        if let Some(answer) =
-            super::bigint_class::binary(context, super::bigint_class::Op::BitOr, left, right)
-        {
-            return answer;
-        }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(f64::from(to_int32(a) | to_int32(b))).bits()
     })
@@ -99,12 +105,15 @@ pub fn bit_or(left: u64, right: u64) -> u64 {
 /// `a ^ b`.
 #[rtse::entry]
 pub fn bit_xor(left: u64, right: u64) -> u64 {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::BitXor, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
     with_current(|context| {
-        if let Some(answer) =
-            super::bigint_class::binary(context, super::bigint_class::Op::BitXor, left, right)
-        {
-            return answer;
-        }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(f64::from(to_int32(a) ^ to_int32(b))).bits()
     })
@@ -118,6 +127,13 @@ pub fn bit_xor(left: u64, right: u64) -> u64 {
 #[rtse::entry]
 pub fn bit_not(value: u64) -> u64 {
     with_current(|context| {
+        // `~1n` is `-2n` over the whole value, not over thirty-two bits. Unary,
+        // so it cannot go through `binary` — the pattern is the same and the
+        // one-operand shape is not.
+        if let Some(held) = super::bigints::digits_of(context, value).map(crate::bigint::BigInt::bit_not)
+        {
+            return context.bigint_value(held);
+        }
         let (a, _) = operands(context, Value(value), Value(value));
         Value::from_f64(f64::from(!to_int32(a))).bits()
     })
@@ -126,6 +142,18 @@ pub fn bit_not(value: u64) -> u64 {
 /// `a << b`.
 #[rtse::entry]
 pub fn shift_left(left: u64, right: u64) -> u64 {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
+        // A bigint shift has no width and no thirty-two-bit mask: `1n << 64n` is
+        // the number, where `1 << 64` is `1`. Asked before the conversion for
+        // the reason `&` states — reaching `ToInt32` at all is already the wrong
+        // operation.
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::Shl, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
     with_current(|context| {
         let (a, b) = operands(context, Value(left), Value(right));
         // `wrapping_shl` because the count is already masked to 0..=31, so
@@ -139,6 +167,14 @@ pub fn shift_left(left: u64, right: u64) -> u64 {
 /// `a >> b` — the sign-propagating shift.
 #[rtse::entry]
 pub fn shift_right(left: u64, right: u64) -> u64 {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::Shr, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
     with_current(|context| {
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(f64::from(to_int32(a).wrapping_shr(shift_by(b)))).bits()
@@ -173,6 +209,14 @@ pub fn shift_right_unsigned(left: u64, right: u64) -> u64 {
 /// finds later — the answer is a plausible number rather than a crash.
 #[rtse::entry]
 pub fn exponent(left: u64, right: u64) -> u64 {
+    // Asked in a borrow of its own: a refused count becomes a `RangeError`,
+    // and building that error borrows the context again, so `settled` has to
+    // run after this borrow has ended.
+    if let Some(outcome) = with_current(|context| {
+        super::bigint_class::binary(context, super::bigint_class::Op::Pow, left, right)
+    }) {
+        return super::bigint_class::settled(outcome);
+    }
     with_current(|context| {
         let (base, power) = operands(context, Value(left), Value(right));
         let answer = if power.is_infinite() && base.abs() == 1.0 {

--- a/crates/rts-core-rwk/src/entry/number/mod.rs
+++ b/crates/rts-core-rwk/src/entry/number/mod.rs
@@ -86,8 +86,15 @@ impl Number {
             // the same as `undefined` being passed, and this is the one place
             // the difference is visible.
             true => 0.0,
-            // Outside any borrow, because it may run a `valueOf`.
-            false => super::class_support::to_number(value),
+            // A bigint is the one argument `ToNumber` refuses and `Number(x)`
+            // accepts: `1n + 1` is a `TypeError` and `Number(1n)` is `1`. So it
+            // is answered here rather than in the shared conversion, which every
+            // arithmetic operator also reaches.
+            false => match with_current(|context| super::bigint_class::as_f64(context, value)) {
+                Some(number) => number,
+                // Outside any borrow, because it may run a `valueOf`.
+                None => super::class_support::to_number(value),
+            },
         };
         let bits = Value::from_f64(number).bits();
         with_current(|context| super::primitive_proto::wrap(context, this, bits));

--- a/crates/rts-core-rwk/src/entry/operators.rs
+++ b/crates/rts-core-rwk/src/entry/operators.rs
@@ -80,8 +80,14 @@ pub fn subtract(left: u64, right: u64) -> u64 {
         crate::coerce::Hint::Number,
     );
     with_current(|context| {
-        if let Some(answer) = super::bigint_class::binary(context, Op::Sub, left, right) {
-            return answer;
+        // `settled` inside the borrow is safe for THIS op and not in general:
+        // only `<<`, `>>` and `**` refuse, and they ask in a borrow of their own
+        // for that reason (see `bitwise.rs`). The one that would break this is
+        // division by zero — it answers `undefined` today where the language
+        // throws, and making it raise means moving these five calls out of the
+        // borrow first. Raising in place aborts; it does not fail.
+        if let Some(outcome) = super::bigint_class::binary(context, Op::Sub, left, right) {
+            return super::bigint_class::settled(outcome);
         }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(a - b).bits()
@@ -98,8 +104,8 @@ pub fn multiply(left: u64, right: u64) -> u64 {
         crate::coerce::Hint::Number,
     );
     with_current(|context| {
-        if let Some(answer) = super::bigint_class::binary(context, Op::Mul, left, right) {
-            return answer;
+        if let Some(outcome) = super::bigint_class::binary(context, Op::Mul, left, right) {
+            return super::bigint_class::settled(outcome);
         }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(a * b).bits()
@@ -120,8 +126,8 @@ pub fn divide(left: u64, right: u64) -> u64 {
         crate::coerce::Hint::Number,
     );
     with_current(|context| {
-        if let Some(answer) = super::bigint_class::binary(context, Op::Div, left, right) {
-            return answer;
+        if let Some(outcome) = super::bigint_class::binary(context, Op::Div, left, right) {
+            return super::bigint_class::settled(outcome);
         }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(a / b).bits()
@@ -144,8 +150,8 @@ pub fn remainder(left: u64, right: u64) -> u64 {
         crate::coerce::Hint::Number,
     );
     with_current(|context| {
-        if let Some(answer) = super::bigint_class::binary(context, Op::Rem, left, right) {
-            return answer;
+        if let Some(outcome) = super::bigint_class::binary(context, Op::Rem, left, right) {
+            return super::bigint_class::settled(outcome);
         }
         let (a, b) = operands(context, Value(left), Value(right));
         Value::from_f64(a % b).bits()
@@ -181,8 +187,10 @@ fn compare(op: Relational, left: u64, right: u64) -> bool {
             Relational::Greater => Relation::Greater,
             Relational::GreaterEqual => Relation::GreaterEqual,
         };
-        if let Some(answer) = super::bigint_class::binary(context, Op::Compare(want), left, right) {
-            return Value(answer).as_bool().unwrap_or(false);
+        if let Some(outcome) = super::bigint_class::binary(context, Op::Compare(want), left, right) {
+            return Value(super::bigint_class::settled(outcome))
+                .as_bool()
+                .unwrap_or(false);
         }
 
         let text_of = |value: Value| {

--- a/crates/rts-core-rwk/src/entry/primitives.rs
+++ b/crates/rts-core-rwk/src/entry/primitives.rs
@@ -63,10 +63,10 @@ pub fn add(left: u64, right: u64) -> u64 {
         };
         if !is_text(left)
             && !is_text(right)
-            && let Some(answer) =
+            && let Some(outcome) =
                 super::bigint_class::binary(context, super::bigint_class::Op::Add, left, right)
         {
-            return answer;
+            return super::bigint_class::settled(outcome);
         }
         let text_of = |value: Value| {
             value

--- a/crates/rts-parser/Cargo.toml
+++ b/crates/rts-parser/Cargo.toml
@@ -10,5 +10,5 @@ rts-diagnostics = { path = "../rts-diagnostics" }
 anyhow = "1.0"
 swc_common = "21.0.1"
 swc_ecma_ast = "23.0.0"
-swc_ecma_parser = "39.0.0"
+swc_ecma_parser = { version = "39.0.0", default-features = false, features = ["typescript"] }
 swc_ecma_visit = "=23.0.0"

--- a/tests/claude-bigint-shift-pow.test.ts
+++ b/tests/claude-bigint-shift-pow.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "rts:test";
+
+// Um shift de bigint não tem largura e não passa por ToInt32: `1n << 64n` é o
+// número, onde `1 << 64` é `1`. Antes de 2026-08-10 o entry point de `<<`, `>>`,
+// `**` e `~` não perguntava se o operando era bigint, caía na conversão de
+// Number e respondia 0 (to_int32 zera NaN) ou NaN (powf propaga). O que pinamos
+// aqui é a pergunta existir, não a aritmética — `BigInt::shl/shr/pow` já eram
+// testados em bigint/.
+
+let out: string = "";
+function print(v: string): void { out += v + "\n"; }
+
+print("shl=" + (1n << 10n));
+print("shl64=" + (1n << 64n));       // passa de 64 bits: 1 << 64 daria 1
+print("shr=" + (1024n >> 5n));
+print("shr_neg_arg=" + (1024n >> -2n));  // contagem negativa inverte a direção
+print("shr_neg_val=" + (-5n >> 1n));     // arredonda para -infinito, não para zero
+print("pow=" + (2n ** 10n));
+print("pow_grande=" + (3n ** 50n));
+print("not=" + (~1n));               // sobre o valor inteiro, não sobre 32 bits
+print("num=" + Number(5n));          // Number(x) é ToNumeric; ToNumber recusaria
+
+// Uma contagem que o resultado não caberia RECUSA, e recusa lançando: o operando
+// direito de `<<` e de `**` é uma contagem, então `1n << 2n**40n` é uma linha e um
+// terabyte de dígitos. Responder `undefined` daria ao programa um valor por um
+// pedido que a máquina não honrou.
+function porque(f: () => any): string {
+  try {
+    f();
+    return "nao lancou";
+  } catch (e: any) {
+    return (e instanceof RangeError ? "RangeError" : "outro") + ": " + e.message;
+  }
+}
+
+print("shl_demais=" + porque(() => 1n << (2n ** 40n)));
+print("pow_demais=" + porque(() => 2n ** (2n ** 40n)));
+print("pow_negativo=" + porque(() => 2n ** -1n));
+// Um shift à DIREITA grande demais satura em vez de recusar: ele só perde bits,
+// então a contagem além da largura responde o mesmo que a contagem da largura.
+print("shr_demais=" + (-1n >> (2n ** 40n)));
+
+describe("shift, expoente e ~ alcançam o caminho de bigint", () => {
+  test("matches expected stdout", () =>
+    expect(out).toBe(
+      "shl=1024\n" +
+      "shl64=18446744073709551616\n" +
+      "shr=32\n" +
+      "shr_neg_arg=4096\n" +
+      "shr_neg_val=-3\n" +
+      "pow=1024\n" +
+      "pow_grande=717897987691852588770249\n" +
+      "not=-2\n" +
+      "num=5\n" +
+      "shl_demais=RangeError: Maximum BigInt size exceeded\n" +
+      "pow_demais=RangeError: Maximum BigInt size exceeded\n" +
+      "pow_negativo=RangeError: Exponent must be non-negative\n" +
+      "shr_demais=-1\n"
+    )
+  );
+});


### PR DESCRIPTION
Dois problemas relatados juntos. O handoff completo para revisão está em
`CLAUDE-REVIEW-bigint-psm.md`, na raiz da branch.

## BigInt

`<<` dava `0`, `>>` dava `0`, `**` dava `NaN`, `Number(5n)` dava `NaN` — e `~1n`
dava `-1`, que não estava no relato. **Cinco divergências, três causas.**

A principal: não existe tabela de despacho bigint. Cada entry point faz a
pergunta por conta própria, e quatro nunca a faziam — o operando caía no caminho
de Number, virava `NaN`, e `to_int32` o zerava. A aritmética já existia e já era
testada; ela só não era alcançada.

Junto vieram dois DoS que tinham de fechar antes: uma contagem grande demais
alocando um terabyte, e uma varredura no `shr` que era por unidade da contagem e
não por bit do operando (`-1n >> 2n**40n` nunca retornava).

Uma contagem recusada agora lança `RangeError`, com as mensagens do V8.

## `psm`

**Não era erro de linker** — `cargo check` de `rts-host-rwk` e `rts-cli` é limpo
no host. Era cross-compile: `swc_ecma_parser` puxa `stacker` → `psm`, cujo
`build.rs` compila assembly para o target.

Desligar a feature nos dois manifestos tira o `psm` do workspace. **Mas isso não
entrega o build Linux**: o cross ainda falha em `ring`, que nenhuma feature
remove. Cruzar do Windows exige toolchain C de qualquer jeito — `cargo-zigbuild`
ou container. Decisão deixada em aberto.

## Medição

`suite_run`, um processo por arquivo, release, baseline em worktree (sem `git
stash`): **740/796 → 741/797, nenhum arquivo perdido**, o ganho sendo a fixture
nova. Rodada duas vezes, porque o `RangeError` alterou o call site de todo
operador aritmético.

A suíte não cobria nada disto — daí `tests/claude-bigint-shift-pow.test.ts`, que
foi verificada FALHANDO no binário do baseline.

`cargo test -p rts-core-rwk` 229/229. Gate estático sem violação dura.

## Aberto (nada decidido aqui)

- `TypeError` do misto (`1n + 1` responde `NaN`) — vale para todos os operadores
  de uma vez, e exige mover os call sites de `operators.rs` para fora do
  empréstimo do `RefCell`. O porquê está no doc e no código.
- Divisão por zero de bigint responde `undefined` onde o Node lança.
- Cross para Linux (`ring`).
- `e.constructor.name` é `undefined` em erros — pré-existente, não desta mudança.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhPTjthooZj4uNvKjGcw7a
