### PR TITLE
fix: cinco respostas erradas da superficie embutida (70.9% -> 71.3%)

### DIFF
--- a/crates/rts-core/src/entry/array_proto/cursor.rs
+++ b/crates/rts-core/src/entry/array_proto/cursor.rs
@@ -353,7 +353,7 @@ fn forwarded(this: u64, name: &str, a0: u64, a1: u64) -> u64 {
     if throw::in_flight() {
         return absent();
     }
-    let iterator = list_iterator::over(listed);
+    let iterator = list_iterator::over(listed, "Array Iterator");
     let method = with_current(|context| {
         let Some(cell) = Value(iterator).as_slot() else {
             return objects::undefined_of(context);

--- a/crates/rts-core/src/entry/bitwise.rs
+++ b/crates/rts-core/src/entry/bitwise.rs
@@ -196,17 +196,41 @@ pub fn shift_right_unsigned(left: u64, right: u64) -> u64 {
     })
 }
 
+/// `Number::exponentiate`, where it disagrees with Rust's `powf`.
+///
+/// # The two rows IEEE-754 and ECMAScript answer differently
+///
+/// - **`1 ** NaN` is `NaN`.** IEEE makes a base of one absorbing, so
+///   `pow(1, NaN)` is `1`, and Rust follows it. The language propagates the
+///   `NaN` instead. This is the kind of divergence nothing finds later: the
+///   answer is a plausible number rather than a crash, and `x ** y` over
+///   unknown data quietly answers 1 where every other NaN-touching operation
+///   propagates.
+/// - **`(±1) ** ±Infinity` is `NaN`**, for the same reason.
+///
+/// Every other row `powf` already agrees with — `0 ** -1` being `Infinity`, the
+/// odd/even-integer sign rules on a negative base — so only the exceptions are
+/// written, rather than the whole table restated in a form that could drift
+/// from it.
+///
+/// # Why this is a function and not two copies
+///
+/// There are two callers: the `**` operator below and `Math.pow`. They were
+/// two copies of a partial table, and they had already drifted — the operator
+/// handled the infinite exponent and `Math.pow` handled neither. A rule written
+/// twice is a rule that will be written differently, which here means `x ** 2`
+/// and `Math.pow(x, 2)` answering differently for the same `x`.
+pub(super) fn exponentiate(base: f64, power: f64) -> f64 {
+    if power.is_nan() {
+        return f64::NAN;
+    }
+    if power.is_infinite() && base.abs() == 1.0 {
+        return f64::NAN;
+    }
+    base.powf(power)
+}
+
 /// `a ** b`.
-///
-/// # The case Rust and JavaScript disagree about
-///
-/// `(-1) ** Infinity` is `NaN` in JavaScript and `1.0` from Rust's `powf`,
-/// which follows IEEE-754's `pow` where the specification does not. The
-/// specification is explicit: if the exponent is infinite and the base's
-/// magnitude is exactly one, the answer is `NaN`.
-///
-/// Handled rather than inherited, because it is the kind of divergence nothing
-/// finds later — the answer is a plausible number rather than a crash.
 #[rtse::entry]
 pub fn exponent(left: u64, right: u64) -> u64 {
     // Asked in a borrow of its own: a refused count becomes a `RangeError`,
@@ -219,11 +243,6 @@ pub fn exponent(left: u64, right: u64) -> u64 {
     }
     with_current(|context| {
         let (base, power) = operands(context, Value(left), Value(right));
-        let answer = if power.is_infinite() && base.abs() == 1.0 {
-            f64::NAN
-        } else {
-            base.powf(power)
-        };
-        Value::from_f64(answer).bits()
+        Value::from_f64(exponentiate(base, power)).bits()
     })
 }

--- a/crates/rts-core/src/entry/buffers/typed.rs
+++ b/crates/rts-core/src/entry/buffers/typed.rs
@@ -380,6 +380,118 @@ pub(in crate::entry) fn includes(this: u64, search: u64, from: u64) -> bool {
     })
 }
 
+/// `t.indexOf(search, from)` — the first index holding it, or `-1`.
+///
+/// Strict equality rather than [`includes`]'s SameValueZero, and the difference
+/// is the whole reason both exist: `new Float64Array([NaN]).includes(NaN)` is
+/// `true` and `.indexOf(NaN)` is `-1`. A single implementation serving both
+/// would have to pick one, and whichever it picked would be wrong for the other
+/// on exactly that input.
+///
+/// A typed array has no holes, so there is no skipping rule to mirror from
+/// `Array.prototype` — every index in range is a property.
+pub(in crate::entry) fn index_of(this: u64, search: u64, from: u64) -> f64 {
+    let from = super::optional_number(from);
+    with_current(|context| {
+        let Some(view) = super::view_of(context, this) else {
+            return -1.0;
+        };
+        let values = elements(context, &view);
+        let start = relative_start(from, values.len());
+        for (at, held) in values.iter().enumerate().skip(start) {
+            if crate::value::strict_equals(Value(*held), Value(search), |a, b| context.same_text(a, b)) {
+                return at as f64;
+            }
+        }
+        -1.0
+    })
+}
+
+/// `t.lastIndexOf(search, from)` — the last index holding it, or `-1`.
+///
+/// The backwards walk clamps its `from` differently from [`index_of`], which is
+/// the asymmetry `Array.prototype` has and the reason this is not the forward
+/// scan reversed: a negative `from` past the start makes `lastIndexOf` find
+/// nothing at all, where `indexOf` clamps to zero and searches everything.
+pub(in crate::entry) fn last_index_of(this: u64, search: u64, from: u64) -> f64 {
+    let from = super::optional_number(from);
+    with_current(|context| {
+        let Some(view) = super::view_of(context, this) else {
+            return -1.0;
+        };
+        let values = elements(context, &view);
+        let count = values.len() as f64;
+        let last = match from {
+            Some(asked) if asked.is_nan() => return -1.0,
+            Some(asked) if asked < 0.0 => {
+                let shifted = count + asked;
+                if shifted < 0.0 {
+                    return -1.0;
+                }
+                shifted as usize
+            }
+            Some(asked) => (asked as usize).min(values.len().saturating_sub(1)),
+            None => values.len().saturating_sub(1),
+        };
+        for at in (0..=last).rev() {
+            let Some(held) = values.get(at) else { continue };
+            if crate::value::strict_equals(Value(*held), Value(search), |a, b| context.same_text(a, b)) {
+                return at as f64;
+            }
+        }
+        -1.0
+    })
+}
+
+/// `t.join(separator)` — the elements as text, separated.
+///
+/// An absent separator is a comma, and — unlike `Array.prototype.join` — there
+/// is no `null`/`undefined`-becomes-empty rule to apply, because a typed array's
+/// elements are numbers and every one of them has a text form.
+pub(in crate::entry) fn join(this: u64, separator: u64) -> u64 {
+    let apart = with_current(|context| match super::super::string::absent(context, separator) {
+        true => ",".to_owned(),
+        false => super::super::string::text_of(context, separator)
+            .and_then(|text| text.to_rust())
+            .unwrap_or_else(|| ",".to_owned()),
+    });
+    with_current(|context| {
+        let Some(view) = super::view_of(context, this) else {
+            return undefined_of(context);
+        };
+        let joined = elements(context, &view)
+            .into_iter()
+            .map(|held| {
+                Value(held)
+                    .numeric()
+                    .map(|number| {
+                        crate::coerce::number_to_string(number)
+                            .to_rust()
+                            .unwrap_or_default()
+                    })
+                    .unwrap_or_default()
+            })
+            .collect::<Vec<String>>()
+            .join(&apart);
+        context
+            .intern_value(crate::text::Str::from_str(&joined))
+            .bits()
+    })
+}
+
+/// The index a forward scan starts at, given the argument as written.
+///
+/// Shared by [`index_of`] so the clamping is stated once; `last_index_of` walks
+/// the other way and clamps differently, which is why it does not call this.
+fn relative_start(from: Option<f64>, count: usize) -> usize {
+    match from {
+        Some(asked) if asked.is_nan() => 0,
+        Some(asked) if asked < 0.0 => (count as f64 + asked).max(0.0) as usize,
+        Some(asked) => asked as usize,
+        None => 0,
+    }
+}
+
 /// `t.values()` — an iterator over the elements.
 ///
 /// # Why the borrow ends before `over`
@@ -398,7 +510,7 @@ pub(in crate::entry) fn values(this: u64) -> u64 {
         return with_current(|context| undefined_of(context));
     };
     let listed = with_current(|context| crate::entry::array::built_in(context, elements));
-    crate::entry::list_iterator::over(listed)
+    crate::entry::list_iterator::over(listed, "Array Iterator")
 }
 
 /// `t.keys()` — an iterator over the indices.
@@ -408,7 +520,7 @@ pub(in crate::entry) fn keys(this: u64) -> u64 {
     };
     let indices = (0..count).map(|at| Value::from_f64(at as f64).bits()).collect();
     let listed = with_current(|context| crate::entry::array::built_in(context, indices));
-    crate::entry::list_iterator::over(listed)
+    crate::entry::list_iterator::over(listed, "Array Iterator")
 }
 
 /// `t.entries()` — an iterator over `[index, element]` pairs.
@@ -428,7 +540,7 @@ pub(in crate::entry) fn entries(this: u64) -> u64 {
         })
         .collect();
     let listed = with_current(|context| crate::entry::array::built_in(context, pairs));
-    crate::entry::list_iterator::over(listed)
+    crate::entry::list_iterator::over(listed, "Array Iterator")
 }
 
 /// A new instance of the view's own class, over these bytes.

--- a/crates/rts-core/src/entry/buffers/typed_classes.rs
+++ b/crates/rts-core/src/entry/buffers/typed_classes.rs
@@ -133,6 +133,31 @@ macro_rules! declare {
                     typed::includes(this, search, from)
                 }
 
+                /// `t.indexOf(search, from)` — strict equality, so it and
+                /// `includes` disagree about `NaN`. See [`typed::index_of`].
+                #[js("indexOf")]
+                fn index_of(this: u64, search: u64, from: u64) -> f64 {
+                    typed::index_of(this, search, from)
+                }
+
+                /// `t.lastIndexOf(search, from)`.
+                #[js("lastIndexOf")]
+                fn last_index_of(this: u64, search: u64, from: u64) -> f64 {
+                    typed::last_index_of(this, search, from)
+                }
+
+                /// `t.join(separator)`.
+                ///
+                /// Present because its absence was not a missing feature but a
+                /// missing NAME: `t.join(",")` is a `TypeError` on a method the
+                /// language defines, and `String(t)` reaches it through
+                /// `Array.prototype.toString`, so a typed array printed as
+                /// `[object Uint8Array]` where every other engine prints its
+                /// elements.
+                fn join(this: u64, separator: u64) -> u64 {
+                    typed::join(this, separator)
+                }
+
                 /// `t.values()`. `for`-`of` and spread reach a typed array's
                 /// elements directly — `iterate::iterate` knows a view — so
                 /// no `[Symbol.iterator]` member is installed here; only this

--- a/crates/rts-core/src/entry/collections/cursor.rs
+++ b/crates/rts-core/src/entry/collections/cursor.rs
@@ -105,8 +105,8 @@ const SPENT: u32 = u32::MAX;
 /// A value that is not one of these collections answers an iterator that yields
 /// nothing, where the language throws — the same tolerance every refusal in this
 /// module settles on while a throw from here cannot find a handler.
-pub(in crate::entry) fn over(collection: u64, kind: Kind) -> u64 {
-    let iterator = list_iterator::over(collection);
+pub(in crate::entry) fn over(collection: u64, kind: Kind, tag: &str) -> u64 {
+    let iterator = list_iterator::over(collection, tag);
     with_current(|context| {
         if let Some(cell) = Value(iterator).as_slot() {
             let key = context.well_known(KIND);

--- a/crates/rts-core/src/entry/collections/map.rs
+++ b/crates/rts-core/src/entry/collections/map.rs
@@ -132,12 +132,12 @@ impl Map {
 
     /// `m.keys()` — a live iterator, for the reason [`super::cursor`] gives.
     fn keys(this: u64) -> u64 {
-        super::cursor::over(this, super::cursor::Kind::Keys)
+        super::cursor::over(this, super::cursor::Kind::Keys, "Map Iterator")
     }
 
     /// `m.values()`.
     fn values(this: u64) -> u64 {
-        super::cursor::over(this, super::cursor::Kind::Values)
+        super::cursor::over(this, super::cursor::Kind::Values, "Map Iterator")
     }
 
     /// `m.entries()` — a `[key, value]` array per entry.
@@ -145,7 +145,7 @@ impl Map {
     /// Also what `m[Symbol.iterator]` is, and the SAME function object rather
     /// than one that agrees: [`super::register_map`] installs the second name.
     fn entries(this: u64) -> u64 {
-        super::cursor::over(this, super::cursor::Kind::Entries)
+        super::cursor::over(this, super::cursor::Kind::Entries, "Map Iterator")
     }
 
     /// `Map.groupBy(items, cb)` — ES2024.

--- a/crates/rts-core/src/entry/collections/set.rs
+++ b/crates/rts-core/src/entry/collections/set.rs
@@ -136,12 +136,12 @@ impl Set {
     /// rather than three that agree — [`super::register_set`] installs the other
     /// two names, which is why neither is written here.
     fn values(this: u64) -> u64 {
-        super::cursor::over(this, super::cursor::Kind::Keys)
+        super::cursor::over(this, super::cursor::Kind::Keys, "Set Iterator")
     }
 
     /// `s.entries()` — `[v, v]` pairs, for parity with `Map`.
     fn entries(this: u64) -> u64 {
-        super::cursor::over(this, super::cursor::Kind::Entries)
+        super::cursor::over(this, super::cursor::Kind::Entries, "Set Iterator")
     }
 
     /// `s.union(other)`.

--- a/crates/rts-core/src/entry/date/class.rs
+++ b/crates/rts-core/src/entry/date/class.rs
@@ -244,6 +244,24 @@ impl Date {
         field(this, |parts| parts.year as f64)
     }
 
+    /// `date.getYear()` — the year MINUS 1900, and Annex B rather than an
+    /// oversight.
+    ///
+    /// Present because a program that predates `getFullYear` still runs, and
+    /// because its absence is the loud kind: `d.getYear()` is a `TypeError` on
+    /// a name the language does define, which reads as a broken engine rather
+    /// than as a deprecated method. It is normative in Annex B, so an engine
+    /// that claims the web has it.
+    ///
+    /// The offset is the whole method — `getYear` on a date in 2026 answers
+    /// `126`, not `26` — and getting that wrong is the bug the method is famous
+    /// for. An invalid date answers `NaN`, which falls out of `field` rather
+    /// than being special-cased: `NaN - 1900` is `NaN`.
+    #[js("getYear")]
+    fn get_year(this: u64) -> f64 {
+        field(this, |parts| parts.year as f64 - 1900.0)
+    }
+
     /// `date.getMonth()` — zero-based, as the language spells it.
     fn get_month(this: u64) -> f64 {
         field(this, |parts| parts.month as f64)

--- a/crates/rts-core/src/entry/list_iterator.rs
+++ b/crates/rts-core/src/entry/list_iterator.rs
@@ -34,6 +34,15 @@
 use super::with_current;
 use crate::value::Value;
 
+/// The `Symbol.toStringTag` every ES2025 iterator HELPER carries.
+///
+/// Named once rather than spelled at each of the five, because the five are the
+/// same thing to a program asking what it holds: `it.map(f)`, `it.filter(p)`,
+/// `it.take(n)`, `it.drop(n)` and `it.flatMap(f)` all answer an Iterator Helper
+/// and the specification gives them one tag between them. A literal repeated
+/// five times is five chances to write a sixth spelling.
+const HELPER: &str = "Iterator Helper";
+
 /// `Iterator` — the ES2025 helper base, as a namespace carrying `from`.
 ///
 /// Not a class with a `prototype` every iterator inherits: this engine's
@@ -57,7 +66,7 @@ impl Iterator {
     /// rather than adding a second notion of "iterable-ish" beside it.
     fn from(iterable: u64) -> u64 {
         let array = super::iterate::iterate(iterable);
-        over(array)
+        over(array, "Iterator")
     }
 }
 
@@ -74,7 +83,7 @@ impl ListIterator {
         for (index, element) in remaining(this).into_iter().enumerate() {
             produced.push(apply(callback, element, index));
         }
-        over(listed(produced))
+        over(listed(produced), HELPER)
     }
 
     /// `it.filter(p)` — the elements `p` answers truthy for.
@@ -85,19 +94,19 @@ impl ListIterator {
                 kept.push(element);
             }
         }
-        over(listed(kept))
+        over(listed(kept), HELPER)
     }
 
     /// `it.take(n)` — at most the first `n`.
     fn take(this: u64, count: f64) -> u64 {
         let count = at_most(count);
-        over(listed(remaining(this).into_iter().take(count).collect()))
+        over(listed(remaining(this).into_iter().take(count).collect()), HELPER)
     }
 
     /// `it.drop(n)` — everything after the first `n`.
     fn drop(this: u64, count: f64) -> u64 {
         let count = at_most(count);
-        over(listed(remaining(this).into_iter().skip(count).collect()))
+        over(listed(remaining(this).into_iter().skip(count).collect()), HELPER)
     }
 
     /// `it.flatMap(f)` — `f`'s answers, one level flattened.
@@ -121,7 +130,7 @@ impl ListIterator {
                 None => produced.push(answered),
             }
         }
-        over(listed(produced))
+        over(listed(produced), HELPER)
     }
 
     /// `it.toArray()` — the elements, as an array.
@@ -241,7 +250,7 @@ impl ListIterator {
 ///
 /// `listed` is an array value — what every caller already had — and it is held
 /// rather than copied, so nothing walks it twice.
-pub(in crate::entry) fn over(listed: u64) -> u64 {
+pub(in crate::entry) fn over(listed: u64, tag: &str) -> u64 {
     with_current(|context| {
         let prototype = match super::class_support::prototype(context, "ListIterator") {
             Some(prototype) => prototype,
@@ -266,6 +275,24 @@ pub(in crate::entry) fn over(listed: u64) -> u64 {
         let key = context.well_known(&format!("{}iterator", super::symbol::PREFIX));
         let itself = super::native::callable(context, itself as super::native::Native);
         super::objects::put(context, cell, key, itself);
+
+        // `Symbol.toStringTag`, so `Object.prototype.toString.call([].values())`
+        // answers `[object Array Iterator]` rather than `[object Object]` —
+        // the idiom a program uses to ask what something really is.
+        //
+        // The tag is a PARAMETER because one prototype serves every kind here:
+        // the language gives an array's iterator, a map's, a set's and a
+        // string's four different tags, and this engine builds all four from
+        // this function. Hard-coding one would have made three of them lie,
+        // which is worse than the `[object Object]` they answered before —
+        // a wrong specific answer is believed where a generic one is not.
+        //
+        // On the INSTANCE for the reason `Symbol.iterator` above is: the
+        // attribute helper names a member with a string and this key is a
+        // symbol.
+        let tag_key = context.well_known(&format!("{}toStringTag", super::symbol::PREFIX));
+        let tag_value = context.intern_value(crate::text::Str::from_str(tag)).bits();
+        super::objects::put(context, cell, tag_key, tag_value);
         Value::from_slot(cell).bits()
     })
 }

--- a/crates/rts-core/src/entry/math.rs
+++ b/crates/rts-core/src/entry/math.rs
@@ -373,8 +373,12 @@ impl Math {
     }
 
     /// `Math.pow(base, exponent)`.
+    ///
+    /// The same `Number::exponentiate` the `**` operator performs, and the same
+    /// function: `super::bitwise::exponentiate` says which rows Rust's `powf`
+    /// gets wrong and why the two callers must not each carry their own copy.
     fn pow(base: f64, exponent: f64) -> f64 {
-        base.powf(exponent)
+        super::bitwise::exponentiate(base, exponent)
     }
 
     /// `Math.fround(x)` — the nearest single-precision value.

--- a/crates/rts-core/src/entry/native.rs
+++ b/crates/rts-core/src/entry/native.rs
@@ -113,6 +113,7 @@ pub(in crate::entry) fn name_of(context: &mut Context, callable: u64, name: &str
         let key = context.well_known("name");
         let value = context.intern_value(Str::from_str(name)).bits();
         super::objects::put(context, cell, key, value);
+        introspective(context, cell, key);
     }
 }
 
@@ -123,6 +124,27 @@ fn length_of(context: &mut Context, callable: u64, arity: u32) {
         let key = context.well_known("length");
         let value = Value::from_f64(f64::from(arity)).bits();
         super::objects::put(context, cell, key, value);
+        introspective(context, cell, key);
+    }
+}
+
+/// Marks `name` or `length` on a callable: **non-writable**, non-enumerable,
+/// configurable.
+///
+/// Not [`hidden`], which is the attribute set for a METHOD — writable, so that a
+/// program may replace `Array.prototype.map`. `SetFunctionName` and
+/// `SetFunctionLength` both spell out `[[Writable]]: false` instead, and the
+/// difference is program-visible twice: `Object.keys(Array.prototype.map)`
+/// answered `["name"]` because nothing marked it non-enumerable, and
+/// `fn.name = "x"` stored a new name where the language refuses the write and
+/// leaves `defineProperty` as the only way through.
+fn introspective(context: &mut Context, cell: u32, key: crate::object::Key) {
+    if let crate::object::Key::Name(named) = key {
+        super::integrity::set_attributes(context, cell, named, super::integrity::Attributes {
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        });
     }
 }
 

--- a/crates/rts-core/src/entry/string/mod.rs
+++ b/crates/rts-core/src/entry/string/mod.rs
@@ -121,7 +121,7 @@ extern "C" fn iterate_units(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a
     // reached the object path and iterated nothing, where the language iterates
     // its `[[StringData]]`.
     let held = with_current(|context| receiver(context, this));
-    super::list_iterator::over(super::iterate::iterate(held))
+    super::list_iterator::over(super::iterate::iterate(held), "String Iterator")
 }
 
 /// `String` itself, as the value the name reads.


### PR DESCRIPTION
Cinco defeitos que as fixtures cross-runtime desta semana expuseram, corrigidos
numa passagem e medidos contra um binario guardado ANTES da primeira edicao.

|  | pass / alcancavel | |
|---|---|---|
| antes | 1071 / 1511 | 70.9% |
| depois | 1077 / 1511 | **71.3%** |

**GANHOS 6, PERDAS 0** — comparado por ficheiro, porque `+6` tambem seria
consistente com oito ganhos contra dois perdidos.

Ganhos: `claude2-date-getter-family-consistency`, `claude-math-pow-special-cases`,
`claude2-nan-across-search-apis`, `codex3_082_typedarray_set_overlap_both_directions`,
`codex3_084_uint8clamped_round_ties`, `codex3_090_typedarray_subarray_negative_shared`.

## O que mudou

1. **`.name` e `.length` numa funcao eram enumeraveis e escreviveis.**
   `Object.keys(Array.prototype.map)` respondia `["name"]`, e `fn.name = "x"`
   gravava onde a especificacao diz `[[Writable]]: false`. E um conjunto de
   atributos diferente do que um METODO leva — um metodo e escrevivel de
   proposito, para um programa poder substituir `Array.prototype.map` — por isso
   `introspective` existe ao lado de `hidden`.

2. **`1 ** NaN` respondia `1`.** O IEEE-754 faz da base 1 um absorvente; a
   linguagem propaga o NaN. O operador `**` ja tratava `(-1) ** Infinity` e o
   `Math.pow` nao tratava nada — duas copias parciais da mesma tabela, ja
   divergidas. Agora ha uma funcao so, `bitwise::exponentiate`.

3. **Nenhum iterador tinha `Symbol.toStringTag`.** A etiqueta e um PARAMETRO de
   `list_iterator::over`, nao uma constante: um so prototipo serve array, mapa,
   conjunto e string aqui, e fixar uma etiqueta faria as outras tres mentir —
   pior que o `[object Object]` anterior, porque uma resposta especifica errada
   e acreditada onde uma generica nao e.

4. **`Date.prototype.getYear` nao existia.** Annex B normativo; a ausencia era
   um `TypeError` num nome que a linguagem define.

5. **`%TypedArray%` nao tinha `indexOf`, `lastIndexOf` nem `join`.** O `join`
   nao era funcionalidade em falta mas NOME em falta: `String(t)` chega la por
   `Array.prototype.toString`, portanto um typed array imprimia-se como
   `[object Uint8Array]`.

## Sobre a medicao

Uma falha apareceu no primeiro par de relatorios e **nao era regressao**: era
`timeout apos 10s` com 4 jobs paralelos sobre 1512 fixtures. O ficheiro corre
8 em 8 limpo isolado, e a segunda medicao com menos paralelismo deu LOST vazio.
Fica escrito porque um numero medido sob saturacao e um numero sobre o medidor.

484 testes unitarios verdes em `rts-core`, `rts-codegen`, `rts-cranelift` e
`rts-host`.

## O que NAO foi corrigido

`splice()` sem argumentos remove tudo em vez de nada. Distinguir `splice()` de
`splice(undefined)` precisa da CONTAGEM de argumentos e a ABI deste nativo nao a
carrega. Escolher um dos casos quebraria o outro na mesma fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn