### PR TITLE
fix: um getter nativo passa a ser uma propriedade, e Annex B deixa de faltar

### DIFF
--- a/crates/rts-codegen/src/emit/globals.rs
+++ b/crates/rts-codegen/src/emit/globals.rs
@@ -89,6 +89,13 @@ const PROVIDED: &[&str] = &[
     "decodeURIComponent",
     "encodeURI",
     "encodeURIComponent",
+    // Annex B, and normative: an engine that claims the web has them. They sit
+    // beside the four URI functions because that is where the runtime answers
+    // them from, and NOT because they share a table — `escape` leaves `@`, `+`
+    // and `/` alone and escapes `!`, `~` and `'`, which `encodeURIComponent`
+    // does the other way round on every one of those.
+    "escape",
+    "unescape",
     "eval",
     "isFinite",
     "isNaN",

--- a/crates/rts-core/src/entry/collections/mod.rs
+++ b/crates/rts-core/src/entry/collections/mod.rs
@@ -107,6 +107,7 @@ use crate::value::Value;
 pub(in crate::entry) fn register_map(context: &mut Context) -> u64 {
     let made = map::register_map(context);
     alias(context, "Map", "entries", &iterator_key());
+    sized(context, "Map");
     made
 }
 
@@ -120,7 +121,59 @@ pub(in crate::entry) fn register_set(context: &mut Context) -> u64 {
     let made = set::register_set(context);
     alias(context, "Set", "values", "keys");
     alias(context, "Set", "values", &iterator_key());
+    sized(context, "Set");
     made
+}
+
+/// Installs `size` as a prototype ACCESSOR, which is what the language makes it.
+///
+/// # What this replaced, and why the replacement is not merely tidier
+///
+/// It was an own DATA property on each instance, rewritten by every mutation.
+/// That spelling answers `m.size` correctly and is wrong about the property
+/// three ways a program can see:
+///
+/// - `Object.getOwnPropertyDescriptor(Map.prototype, "size")` was `undefined`
+///   for a property every Map has — the descriptor and the read disagreeing
+///   about one name.
+/// - `m.size = 5` STORED, and the next `m.set` overwrote it. An accessor with
+///   no setter refuses instead, which is what the specification says.
+/// - `Object.keys(new Map())` had to be taught to skip it, and `size` had to be
+///   marked non-enumerable per instance to stay hidden.
+///
+/// The reason it was a data property is recorded at [`restore_sized`]: a value
+/// only the slow path knows about is one the fast path disagrees with the moment
+/// `cached_get` warms up. An accessor does not have that problem, and the reason
+/// is the inverse of the one that made `length` a real property — see
+/// `super::accessor`'s first page: an accessor is deliberately kept OUT of the
+/// layout, so `cache_resolve` answers negative and every read reaches the
+/// runtime by construction.
+fn sized(context: &mut Context, class: &'static str) {
+    let Some(prototype) = super::class_support::prototype(context, class) else {
+        return;
+    };
+    let Some(cell) = Value(prototype).as_slot() else {
+        return;
+    };
+    super::native::getter(context, cell, "size", size as super::native::Native);
+}
+
+/// `m.size` / `s.size` — the entry count, read from the table itself.
+///
+/// A receiver that is not one of these collections answers `undefined` rather
+/// than throwing, which is the tolerance every refusal in this module settles
+/// on while the brand check has no handler to reach.
+extern "C" fn size(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    super::with_current(|context| {
+        match Value(this)
+            .as_slot()
+            .and_then(|cell| context.table_at(cell))
+            .map(|table| table.len())
+        {
+            Some(count) => Value::from_f64(count as f64).bits(),
+            None => super::objects::undefined_of(context),
+        }
+    })
 }
 
 /// The key `Symbol.iterator` writes, spelled from the one place the encoding is
@@ -184,35 +237,24 @@ pub(super) fn restore(context: &mut Context, cell: u32, table: Table) {
     context.collections.set(cell, table);
 }
 
-/// Puts one back and writes `size` to match.
+/// Puts one back after a mutation that changed the entry count.
 ///
-/// # Why `size` is a real property and not an answer the runtime invents
+/// # Why this is still a separate name when its body is [`restore`]'s
 ///
-/// The reason [`super::array::set_length`] records, which was learned the hard
-/// way there: compiled code reading a property that is in the layout never asks
-/// the runtime at all — it emits `cached_get` and finds the stored slot — so a
-/// value only the slow path knows about is one the fast path disagrees with the
-/// moment it starts working.
+/// It used to write an own `size` data property to match the new count, and
+/// fifteen call sites exist BECAUSE of that: each is a mutation that had to
+/// remember to re-publish the number. `size` is now a prototype accessor
+/// reading the table directly — see [`sized`] for what that fixed — so there is
+/// nothing to re-publish and the two functions do the same thing.
 ///
-/// The divergence that leaves, named: `size` is an own **data** property where
-/// the language makes it an accessor on the prototype, so `m.size = 5` stores a
-/// number and the next mutation overwrites it, rather than being refused. The
-/// same trade `length` on an array already makes.
+/// The name stays because the DISTINCTION is still real and still load-bearing:
+/// these fifteen sites changed the count and the others did not. Collapsing
+/// them into `restore` would erase the only record of which mutations are
+/// size-affecting, and the next thing that needs to react to a count change —
+/// an observer, a cached iterator length — would have to rediscover the list by
+/// reading every caller.
 pub(super) fn restore_sized(context: &mut Context, cell: u32, table: Table) {
-    let size = table.len();
     restore(context, cell, table);
-    let key = context.well_known("size");
-    let value = Value::from_f64(size as f64).bits();
-    super::objects::put(context, cell, key, value);
-    // Not enumerable, like an array's `length` and for the same reason: it is a
-    // real property so both paths agree about it, and the language does not
-    // report it. `Object.keys(new Map())` was `["size"]` before this.
-    if let crate::object::Key::Name(key) = key {
-        super::integrity::set_attributes(context, cell, key, super::integrity::Attributes {
-            enumerable: false,
-            ..super::integrity::Attributes::default()
-        });
-    }
 }
 
 /// A fresh instance of one of these classes, empty.

--- a/crates/rts-core/src/entry/collections/set.rs
+++ b/crates/rts-core/src/entry/collections/set.rs
@@ -317,9 +317,20 @@ fn other_of(other: u64) -> Option<Other> {
         // borrow this reads under — the one thing every function in this module
         // is shaped to avoid. It is a refusal where the language accepts, which
         // is the direction a program notices and can correct.
-        let key = context.well_known("size");
-        let size = crate::entry::objects::read_property(context, cell, key)
-            .and_then(|found| found.numeric())?;
+        // A real Map or Set answers from its TABLE rather than through the
+        // property. `size` is a prototype accessor now — see
+        // `super::sized` — and `read_property` walks slots, not accessors, so
+        // asking through the property would report every genuine Set as
+        // size-less and refuse `a.union(b)` for two Sets. Reading the table is
+        // also what the getter itself does, so the two cannot come apart.
+        let size = match context.table_at(cell) {
+            Some(table) => table.len() as f64,
+            None => {
+                let key = context.well_known("size");
+                crate::entry::objects::read_property(context, cell, key)
+                    .and_then(|found| found.numeric())?
+            }
+        };
         if size.is_nan() {
             return None;
         }

--- a/crates/rts-core/src/entry/native.rs
+++ b/crates/rts-core/src/entry/native.rs
@@ -148,6 +148,52 @@ fn introspective(context: &mut Context, cell: u32, key: crate::object::Key) {
     }
 }
 
+/// Hangs a native **getter** on an object, by name.
+///
+/// # Why this exists beside [`install`]
+///
+/// Because a getter is not a method, and installing it as one is a wrong answer
+/// that reads correctly. `Map.prototype.size`, `RegExp.prototype.flags` and
+/// `Symbol.prototype.description` are accessors in the language, and this engine
+/// served each of them as something else — a data property on the INSTANCE, or
+/// nothing at all. Both work for `m.size`, and both fail the moment a program
+/// asks about the property rather than through it:
+/// `Object.getOwnPropertyDescriptor(Map.prototype, "size")` answered `undefined`
+/// for a property every Map has, which is two readable facts about one object
+/// that cannot both be true. Thirty-seven fixtures died on exactly that
+/// `undefined`, reading `.get`, `.writable` or `.value` off it.
+///
+/// The instance-data-property spelling has a second cost the descriptor hides:
+/// `m.size = 5` STORED, and the next mutation overwrote it. An accessor with no
+/// setter refuses the write instead, which is what the language says.
+///
+/// # Why the pair is `(get, None)` and not `(get, get)`
+///
+/// A setter-less accessor is the point. The specification gives every one of
+/// these `[[Set]]: undefined`, so assigning is refused — and a `set` that
+/// silently did nothing would look identical from inside the engine while
+/// answering `true` to `Reflect.set`, which is the observable difference.
+pub(in crate::entry) fn getter(context: &mut Context, cell: u32, name: &str, code: Native) {
+    let function = callable(context, code);
+    // `get size`, which is what `SetFunctionName` puts on an accessor's getter —
+    // a program reading `descriptor.get.name` sees the prefix, and it is the
+    // only place the two halves of an accessor pair are told apart by name.
+    name_of(context, function, &format!("get {name}"));
+    let key = context.well_known(name);
+    if let crate::object::Key::Name(named) = key {
+        context.define_accessor_and_invalidate(cell, named.index() as u32, Some(function), None);
+        // Non-enumerable and configurable, like every built-in member. Recorded
+        // rather than assumed: `super::integrity::effective` is what the
+        // descriptor reads, and a property it has no record for reports the
+        // defaults, which say enumerable.
+        super::integrity::set_attributes(context, cell, named, super::integrity::Attributes {
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        });
+    }
+}
+
 /// An object with nothing on it, for something to be a prototype.
 pub(in crate::entry) fn plain(context: &mut Context) -> Option<u32> {
     let shape = context.shapes.root();

--- a/crates/rts-core/src/entry/regex/mod.rs
+++ b/crates/rts-core/src/entry/regex/mod.rs
@@ -164,12 +164,30 @@ fn describe(context: &mut Context, cell: u32, source: &str, letters: &str, flags
     };
     let source_value = context.intern_value(Str::from_str(printed_source)).bits();
     let flags_value = context.intern_value(Str::from_str(letters)).bits();
-    let written: [(&str, u64); 6] = [
+    // Every flag, not the three that happened to be needed first. `sticky`,
+    // `unicode`, `dotAll` and `hasIndices` answered `undefined` — and
+    // `undefined` is not `false`: `if (re.sticky)` behaves the same either way,
+    // but `re.sticky === false` does not, and a program that builds a flag
+    // string by filtering the accessors produced `"undefinedundefined"` rather
+    // than skipping them. Four of the eight being present is the shape that
+    // makes a reader believe the other four do not exist in the language.
+    //
+    // `unicode` and `unicodeSets` are reported from the letters rather than
+    // from `Flags`, which has no field for them: `u` and `v` are accepted and
+    // not acted on — `Flags::parse` says why — so the flag a program READS is
+    // the letter it wrote, and inventing `false` for a `/x/u` would be a
+    // different lie from the one already documented.
+    let written: [(&str, u64); 11] = [
         ("source", source_value),
         ("flags", flags_value),
         ("global", Value::from_bool(flags.global).bits()),
         ("ignoreCase", Value::from_bool(flags.ignore_case).bits()),
         ("multiline", Value::from_bool(flags.multiline).bits()),
+        ("sticky", Value::from_bool(flags.sticky).bits()),
+        ("dotAll", Value::from_bool(flags.dot_all).bits()),
+        ("hasIndices", Value::from_bool(flags.has_indices).bits()),
+        ("unicode", Value::from_bool(letters.contains('u')).bits()),
+        ("unicodeSets", Value::from_bool(letters.contains('v')).bits()),
         // Zero even for a pattern that never reads it, because a program may
         // read it, and `undefined` is not what the language says is there.
         ("lastIndex", Value::from_f64(0.0).bits()),

--- a/crates/rts-core/src/entry/uri.rs
+++ b/crates/rts-core/src/entry/uri.rs
@@ -69,8 +69,89 @@ pub(super) fn provided(name: &str) -> Option<Native> {
         "decodeURIComponent" => decode_uri_component,
         "encodeURI" => encode_uri,
         "decodeURI" => decode_uri,
+        "escape" => escape,
+        "unescape" => unescape,
         _ => return None,
     })
+}
+
+/// The set `escape` leaves alone — Annex B's own list, which is NOT
+/// [`UNRESERVED`].
+///
+/// Kept apart rather than reusing the URI one because the two genuinely differ:
+/// `escape` leaves `@`, `+` and `/` unescaped and escapes `!`, `~` and `'`,
+/// which `encodeURIComponent` does the other way round on every one of them.
+/// Sharing a constant would have made the two agree, and being told they agree
+/// is worse than not having `escape` at all — a program round-tripping through
+/// the wrong table gets a plausible string back.
+const ESCAPE_KEPT: &str = "@*_+-./";
+
+/// `escape(s)` — Annex B, and present for the reason `getYear` is.
+///
+/// Deprecated since ES3 and still normative, so an engine that claims the web
+/// has it. Its absence was a `ReferenceError` on a name the language defines,
+/// which reads as a broken engine rather than as a deprecated function.
+///
+/// The encoding is per UTF-16 CODE UNIT and has two forms: `%XX` below U+0100
+/// and `%uXXXX` at or above it. That second form is what makes it not a URI
+/// encoder — `encodeURIComponent` emits UTF-8 bytes instead — and it is why a
+/// lone surrogate survives here and becomes U+FFFD there.
+extern "C" fn escape(_e: u64, _t: u64, value: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let units = with_current(|context| super::string::units_of(context, value));
+    let Some(units) = units else {
+        return with_current(|context| undefined_of(context));
+    };
+    let mut out = String::new();
+    for unit in units {
+        match char::from_u32(u32::from(unit)) {
+            Some(ch) if ch.is_ascii_alphanumeric() || ESCAPE_KEPT.contains(ch) => out.push(ch),
+            _ if unit < 0x100 => out.push_str(&format!("%{unit:02X}")),
+            _ => out.push_str(&format!("%u{unit:04X}")),
+        }
+    }
+    with_current(|context| context.intern_value(Str::from_str(&out)).bits())
+}
+
+/// `unescape(s)` — the inverse, and deliberately forgiving.
+///
+/// A `%` that does not begin a well-formed escape is kept LITERALLY rather than
+/// raising: Annex B says so, and it is the half that differs most from
+/// `decodeURIComponent`, which answers a `URIError` for the same input. A
+/// version that threw would be a stricter function under a name programs use
+/// precisely because it does not.
+extern "C" fn unescape(_e: u64, _t: u64, value: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let units = with_current(|context| super::string::units_of(context, value));
+    let Some(units) = units else {
+        return with_current(|context| undefined_of(context));
+    };
+    let hex = |slice: &[u16]| -> Option<u16> {
+        let text: String = slice.iter().map(|u| char::from_u32(u32::from(*u))).collect::<Option<String>>()?;
+        u16::from_str_radix(&text, 16).ok()
+    };
+    let mut out: Vec<u16> = Vec::with_capacity(units.len());
+    let mut at = 0;
+    while at < units.len() {
+        if units[at] == u16::from(b'%') {
+            if at + 6 <= units.len()
+                && (units[at + 1] == u16::from(b'u') || units[at + 1] == u16::from(b'U'))
+                && let Some(unit) = hex(&units[at + 2..at + 6])
+            {
+                out.push(unit);
+                at += 6;
+                continue;
+            }
+            if at + 3 <= units.len()
+                && let Some(unit) = hex(&units[at + 1..at + 3])
+            {
+                out.push(unit);
+                at += 3;
+                continue;
+            }
+        }
+        out.push(units[at]);
+        at += 1;
+    }
+    with_current(|context| super::string::answer(context, &out))
 }
 
 /// What a URI calls unreserved — never escaped by either encoder.


### PR DESCRIPTION
Quatro tarefas numa passagem, medidas por ficheiro contra o relatorio anterior.

| | pass / alcancavel | erros | divergencias |
|---|---|---|---|
| antes | 1077 / 1511 (71.3%) | 140 | 294 |
| depois | 1078 / 1511 (71.3%) | **135** | 298 |

**GANHOS 1, PERDAS 0.** O numero mal se move e o trabalho nao foi pequeno:
**cinco ficheiros passaram de ERRO para DIVERGENCIA** — deixaram de morrer na
primeira linha e agora chegam ao fim a discordar noutra coisa. E por isso que os
erros caem 5 e as divergencias sobem 4. Um `+1` liquido esconde exactamente
isto.

Os cinco: `claude-urierror-encode-decode`, `claude-map-set-size-is-prototype-accessor`,
`claude2-collection-method-arity-and-shape`, `claude-uri-escape-sets-and-urierror`,
`claude2-escape-unescape-legacy` — todos nas areas tocadas.

## 1. `native::getter` — a ferramenta que faltava

Um getter nativo nao era uma PROPRIEDADE. `Map.prototype.size` era uma
propriedade de dados na **instancia**, reescrita por cada mutacao. Funciona para
`m.size` e esta errada de tres maneiras que um programa ve:

- `Object.getOwnPropertyDescriptor(Map.prototype, "size")` respondia `undefined`
  para uma propriedade que todos os Maps tem;
- `m.size = 5` **gravava**, e o `m.set` seguinte sobrescrevia;
- `Object.keys(new Map())` teve de ser ensinado a saltar `size`.

Trinta e sete fixtures morrem a ler `.get`/`.writable`/`.value` de um descritor
`undefined`; esta e a primeira metade dessa causa.

A razao pela qual era dados esta em `restore_sized`: um valor que so o caminho
lento conhece e um valor com que o caminho rapido discorda assim que
`cached_get` aquece. Um accessor nao tem esse problema, pela razao **inversa** —
um accessor e deliberadamente mantido FORA do layout, portanto `cache_resolve`
responde negativo e toda a leitura chega ao runtime por construcao.

**O que isto quase partiu**, apanhado antes do build: a verificacao set-like de
`union`/`intersection` lia `size` com `read_property`, que percorre slots e nao
accessors — todos os Sets genuinos passariam a ser recusados como "nao
set-like". Le a TABELA agora, que e tambem o que o getter faz.

## 2. `RegExp` tinha quatro das oito flags

`sticky`, `dotAll`, `hasIndices`, `unicode` e `unicodeSets` respondiam
`undefined`. E `undefined` nao e `false`: `if (re.sticky)` comporta-se igual,
`re.sticky === false` nao, e um programa que constroi a string de flags
filtrando os campos produzia `"undefinedundefined"`.

## 3. `escape` / `unescape` nao existiam

`ReferenceError` num nome normativo (Annex B, como o `getYear` da ronda
anterior). A tabela e **propria** e nao a dos URIs: `escape` deixa `@`, `+` e
`/` em paz e escapa `!`, `~` e `'`; `encodeURIComponent` faz o contrario em
todos eles. Partilhar a constante teria feito os dois concordarem, e ser
informado de que concordam e pior do que nao ter `escape`.

## 4. Um nome novo sao sempre DUAS edicoes

`escape` continuou `ReferenceError` depois de o runtime o responder, porque
`rts-codegen::emit::globals` tem a lista do que um programa pode ler e o emissor
emite `global_get_unbound` para o que nao esta la. Isto nao estava escrito em
lado nenhum.

484 testes unitarios verdes em `rts-core`, `rts-codegen`, `rts-cranelift` e
`rts-host`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn