### PR TITLE
fix: o protocolo de species existe, e um construtor diz a sua aridade

### DIFF
--- a/crates/rts-core/src/entry/array_proto/mod.rs
+++ b/crates/rts-core/src/entry/array_proto/mod.rs
@@ -162,6 +162,11 @@ pub(super) fn constructor(context: &mut Context) -> u64 {
     // `Array.name`, for the reason `string::constructor` gives: a hand-built
     // constructor has nothing deriving its name.
     super::native::name_of(context, callable, "Array");
+    // `Array.length` is 1 — the `SetFunctionLength` every constructor gets, and
+    // it answered `undefined`. A program forwarding a constructor reads it, and
+    // `undefined` there is not a smaller answer than 1: `f.length` participates
+    // in arithmetic, and `NaN` is what a currying helper got.
+    super::native::length_of(context, callable, 1);
     let prototype = match prototype_of(context) {
         Some(cell) => Value::from_slot(cell).bits(),
         None => return undefined_of(context),
@@ -184,6 +189,12 @@ pub(super) fn constructor(context: &mut Context) -> u64 {
         super::objects::put(context, cell, key, callable);
         super::native::hidden(context, cell, key);
     }
+    // `Array[Symbol.species]`, the other half of the protocol the comment above
+    // describes. Without it the read answered `undefined` and the derivation
+    // fell back to the intrinsic — which looks identical for `Array` itself and
+    // is exactly wrong for a subclass, whose whole reason to inherit the hook is
+    // to be answered instead.
+    super::native::species(context, callable);
     callable
 }
 

--- a/crates/rts-core/src/entry/bigint_class.rs
+++ b/crates/rts-core/src/entry/bigint_class.rs
@@ -45,7 +45,12 @@ use crate::bigint::BigInt;
 use crate::value::Value;
 
 /// `BigInt`.
-#[rtse::class("BigInt")]
+///
+/// `tag` because `BigInt.prototype[Symbol.toStringTag]` is `"BigInt"` in the
+/// language and answered `undefined` here — so a boxed BigInt described itself
+/// as `[object Object]`, and the descriptor for a property the specification
+/// requires was absent.
+#[rtse::class("BigInt", tag)]
 impl BigIntClass {
     /// `BigInt(x)` — from a number, a string, or a boolean.
     ///

--- a/crates/rts-core/src/entry/collections/mod.rs
+++ b/crates/rts-core/src/entry/collections/mod.rs
@@ -108,6 +108,7 @@ pub(in crate::entry) fn register_map(context: &mut Context) -> u64 {
     let made = map::register_map(context);
     alias(context, "Map", "entries", &iterator_key());
     sized(context, "Map");
+    super::native::species(context, made);
     made
 }
 
@@ -122,6 +123,7 @@ pub(in crate::entry) fn register_set(context: &mut Context) -> u64 {
     alias(context, "Set", "values", "keys");
     alias(context, "Set", "values", &iterator_key());
     sized(context, "Set");
+    super::native::species(context, made);
     made
 }
 

--- a/crates/rts-core/src/entry/global.rs
+++ b/crates/rts-core/src/entry/global.rs
@@ -114,7 +114,15 @@ pub(in crate::entry) fn supply(
             "Number" => super::number::register_number(context),
             "Boolean" => super::number::register_boolean(context),
             "BigInt" => super::bigint_class::register_big_int_class(context),
-            "Promise" => super::promise::register_promise(context),
+            // The species hook is installed here rather than by the class
+            // attribute: only seven built-ins have one, so a member every
+            // `#[rtse::class]` emitted would be six wrong answers to buy one
+            // right one.
+            "Promise" => {
+                let made = super::promise::register_promise(context);
+                super::native::species(context, made);
+                made
+            }
             // Through `eval`, which is the same registration with the one thing
             // a class declaration cannot give it: what `new Function(…)` runs.
             // See that module for why the constructor is not a `#[construct]`

--- a/crates/rts-core/src/entry/native.rs
+++ b/crates/rts-core/src/entry/native.rs
@@ -119,7 +119,7 @@ pub(in crate::entry) fn name_of(context: &mut Context, callable: u64, name: &str
 
 /// Writes `.length` on a callable — the parameter count the specification's
 /// `SetFunctionLength` puts there before a body ever runs.
-fn length_of(context: &mut Context, callable: u64, arity: u32) {
+pub(in crate::entry) fn length_of(context: &mut Context, callable: u64, arity: u32) {
     if let Some(cell) = Value(callable).as_slot() {
         let key = context.well_known("length");
         let value = Value::from_f64(f64::from(arity)).bits();
@@ -178,7 +178,17 @@ pub(in crate::entry) fn getter(context: &mut Context, cell: u32, name: &str, cod
     // `get size`, which is what `SetFunctionName` puts on an accessor's getter —
     // a program reading `descriptor.get.name` sees the prefix, and it is the
     // only place the two halves of an accessor pair are told apart by name.
-    name_of(context, function, &format!("get {name}"));
+    //
+    // A SYMBOL key is spelled `[Symbol.species]` rather than by the internal
+    // encoding: `super::symbol::PREFIX` is how this crate stores a symbol key
+    // in a string-keyed table, and it is an implementation detail that must not
+    // reach `descriptor.get.name`. The specification's own spelling for a
+    // well-known symbol's accessor is the bracketed form.
+    let label = match name.strip_prefix(super::symbol::PREFIX) {
+        Some(described) => format!("get [Symbol.{described}]"),
+        None => format!("get {name}"),
+    };
+    name_of(context, function, &label);
     let key = context.well_known(name);
     if let crate::object::Key::Name(named) = key {
         context.define_accessor_and_invalidate(cell, named.index() as u32, Some(function), None);
@@ -192,6 +202,39 @@ pub(in crate::entry) fn getter(context: &mut Context, cell: u32, name: &str, cod
             configurable: true,
         });
     }
+}
+
+/// Installs `Symbol.species` on a constructor, answering the constructor.
+///
+/// # Why every one of them is the same function
+///
+/// Because `get [Symbol.species] { return this; }` IS the specification's
+/// definition, for `Array`, `Map`, `Set`, `Promise`, `RegExp`, `ArrayBuffer` and
+/// `%TypedArray%` alike. The whole point of the hook is that a SUBCLASS inherits
+/// it and therefore answers itself, which is what makes `sub.map(f)` build a
+/// `Sub` — so a per-class function would be seven copies of `return this` that
+/// could only ever differ by being wrong.
+///
+/// It answered `undefined` before, which is not a smaller version of this: the
+/// species protocol reads the property and falls back to the intrinsic when it
+/// is `undefined`, so every derivation quietly produced a plain `Array` and a
+/// program could not tell the hook was missing from the answer alone —
+/// `Object.getOwnPropertyDescriptor(Array, Symbol.species)` was the only thing
+/// that said so, and it said `undefined` too.
+/// Takes the constructor VALUE rather than a class name: `Array` and `RegExp`
+/// are built by hand and never recorded in `class_support`, so a name lookup
+/// would silently skip exactly the two whose species protocol is most used.
+pub(in crate::entry) fn species(context: &mut Context, constructor: u64) {
+    let Some(cell) = Value(constructor).as_slot() else {
+        return;
+    };
+    let key = format!("{}species", super::symbol::PREFIX);
+    getter(context, cell, &key, receiver as Native);
+}
+
+/// A getter answering its receiver — `Symbol.species`, and nothing else yet.
+extern "C" fn receiver(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    this
 }
 
 /// An object with nothing on it, for something to be a prototype.

--- a/crates/rts-core/src/entry/regex/mod.rs
+++ b/crates/rts-core/src/entry/regex/mod.rs
@@ -224,11 +224,25 @@ fn prototype_of(context: &mut Context) -> u64 {
 /// exists and knows nothing about regular expressions.
 pub(super) fn constructor(context: &mut Context) -> u64 {
     let callable = super::native::callable(context, methods::construct);
+    // `RegExp.name`, which nothing else derives for a hand-built constructor.
+    super::native::name_of(context, callable, "RegExp");
+    // `RegExp.length` is 2 — the pattern and the flags.
+    super::native::length_of(context, callable, 2);
     let prototype = prototype_of(context);
     if let Some(cell) = Value(callable).as_slot() {
         let key = context.well_known("prototype");
         super::objects::put(context, cell, key, prototype);
     }
+    // `RegExp.prototype.constructor`, and then the species hook that reads it.
+    // Both were missing, and the pair is what makes a subclass of `RegExp`
+    // answer itself from `Symbol.split` and `Symbol.replace` rather than a
+    // plain one.
+    if let Some(cell) = Value(prototype).as_slot() {
+        let key = context.well_known("constructor");
+        super::objects::put(context, cell, key, callable);
+        super::native::hidden(context, cell, key);
+    }
+    super::native::species(context, callable);
     callable
 }
 

--- a/crates/rts-core/src/entry/symbol.rs
+++ b/crates/rts-core/src/entry/symbol.rs
@@ -294,7 +294,40 @@ pub(super) fn prototype_of(context: &mut Context) -> Option<u32> {
     // interning allocates, which can reach back here.
     context.symbols.prototype = Some(cell);
     super::native::install(context, cell, NATIVES);
+    // `description` as a prototype ACCESSOR, and `Symbol.prototype
+    // [Symbol.toStringTag]` as a data property.
+    //
+    // `description` was already answerable — [`property`] intercepts the read on
+    // a primitive receiver, the same shape `"a".length` has — but it was not a
+    // PROPERTY: `Object.getOwnPropertyDescriptor(Symbol.prototype,
+    // "description")` said `undefined` for something every symbol answers, and a
+    // program walking the prototype to describe it found nothing there. The
+    // accessor does not replace that interception: a primitive has no cell, so
+    // the read still cannot reach a getter through an ordinary property walk.
+    // What it adds is the property being VISIBLE, which is what the descriptor,
+    // `Object.getOwnPropertyNames` and a wrapper object all ask for.
+    super::native::getter(context, cell, "description", description as super::native::Native);
+    let tag = context.well_known(&format!("{PREFIX}toStringTag"));
+    let value = context.intern_value(Str::from_str("Symbol")).bits();
+    super::objects::put(context, cell, tag, value);
+    super::native::hidden(context, cell, tag);
     Some(cell)
+}
+
+/// `Symbol.prototype.description` — the getter half of the accessor above.
+///
+/// Reaches the same [`property`] the primitive path does, so the two cannot
+/// answer differently for one symbol: a wrapper object and the primitive it
+/// boxes describe themselves alike, which is the one thing a second reader here
+/// would eventually get wrong.
+extern "C" fn description(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    super::with_current(|context| {
+        let wanted = context.well_known("description");
+        match property(context, this, wanted) {
+            Some(found) => found,
+            None => undefined_of(context),
+        }
+    })
 }
 
 /// What `Symbol.prototype` holds.


### PR DESCRIPTION
Seis tarefas numa passagem. Medido por ficheiro contra o relatorio anterior.

| | pass / alcancavel | erros |
|---|---|---|
| antes | 1078 / 1511 (71.3%) | 135 |
| depois | 1078 / 1510 (71.4%) | **129** |

**GANHOS 1, PERDAS 0**, e mais **seis ficheiros passaram de erro para
divergencia** — deixaram de morrer numa leitura e chegam ao fim.

## 1. `Symbol.species` nao existia em NENHUM construtor

Respondia `undefined` em `Array`, `Map`, `Set`, `Promise` e `RegExp`. E
`undefined` nao e uma versao mais pequena do protocolo: a derivacao le a
propriedade e recorre ao intrinseco quando ela e `undefined`, portanto toda a
derivacao produzia calmamente um `Array` simples e **um programa nao podia dizer
pela resposta que o gancho faltava**. O unico sitio que o dizia era o descritor
— e dizia `undefined` tambem.

Uma funcao para os cinco: `get [Symbol.species] { return this; }` E a definicao
da especificacao para cada um. Cinco copias de `return this` so poderiam diferir
por estarem erradas.

Recebe o **valor** do construtor e nao o nome da classe: `Array` e `RegExp` sao
construidos a mao e nunca registados em `class_support`, portanto uma procura
por nome saltaria em silencio exactamente os dois cujo protocolo mais se usa.

## 2. `Symbol.prototype.description` nao era uma propriedade

Ja era respondivel — a leitura num receptor primitivo e interceptada, a mesma
forma que `"a".length` tem — mas o descritor dizia `undefined`. O accessor **nao
substitui** essa intercepcao (um primitivo nao tem celula); acrescenta a
propriedade ser VISIVEL. O getter chama a mesma funcao, para que os dois nao
possam responder diferente para um simbolo.

## 3. `BigInt.prototype[Symbol.toStringTag]` faltava

Um BigInt encaixotado descrevia-se como `[object Object]`.

## 4. `Array.length` e `RegExp.length` respondiam `undefined`

`f.length` participa em aritmetica, e um ajudante de currying recebia `NaN`. Os
construtores gerados pelo atributo continuam sem ela: derivar a aridade precisa
da assinatura do membro `#[construct]`, que o macro ve e nao propaga.

## 5. `RegExp.prototype.constructor` faltava

Nao e decoracao: o protocolo de species comeca por ler `constructor` do
receptor.

## 6. Uma chave de simbolo nao pode aparecer com a codificacao interna

`native::getter` escrevia `get @@species` em `descriptor.get.name`, expondo o
prefixo de armazenamento. Passa a escrever `get [Symbol.species]`.

## Sobre a medicao

O relatorio acusou `286_setimmediate` a sair de `pass` para `bun_node_diverge`.
**Nao e regressao e nao envolve sequer o RTS**: e o Bun e o Node a discordarem
entre si sob carga paralela. Corridos isolados, tres vezes cada, concordam.
Segunda vez esta semana que a saturacao do medidor aparece no relatorio.

484 testes unitarios verdes.

## O que fica

`RegExp.prototype.flags`, `.global`, `.source` e
`ArrayBuffer.prototype.byteLength` continuam propriedades de dados na
**instancia** onde a linguagem as poe como accessors no prototipo. A ferramenta
para os converter existe agora; falta tirar a propriedade da instancia sem
partir o `detach`, que reescreve `byteLength` para zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn