### PR TITLE
fix: um padrao que nao compila lanca SyntaxError em vez de corromper o objecto

### DIFF
--- a/crates/rts-core/src/entry/regex/compile.rs
+++ b/crates/rts-core/src/entry/regex/compile.rs
@@ -43,7 +43,7 @@ impl Engine {
     /// `SyntaxError` there; see [`super::regex_new`] for why this answers rather
     /// than throws.
     pub(super) fn compile(pattern: &str, flags: Flags) -> Option<Engine> {
-        let pattern = unescape_solidus(pattern);
+        let pattern = empty_classes(&unescape_solidus(pattern));
         match regex::RegexBuilder::new(&pattern)
             .case_insensitive(flags.ignore_case)
             .multi_line(flags.multiline)
@@ -262,9 +262,87 @@ fn unescape_solidus(pattern: &str) -> String {
     out
 }
 
+/// Rewrites the two character classes JavaScript has and Rust's engine refuses.
+///
+/// `[]` matches NOTHING and `[^]` matches ANY character, both legal JavaScript
+/// and both a parse error for the `regex` crate, which reads an empty class as
+/// malformed. Neither is exotic: `[^]` is the ordinary way to write "any
+/// character including a newline" in code predating the `s` flag, and it appears
+/// in minified output constantly.
+///
+/// They are translated rather than refused because the translations are EXACT
+/// and there is no ambiguity to lose: `[^\s\S]` is the empty set by
+/// construction, and `[\s\S]` is its complement. That is the difference from
+/// [`unescape_solidus`]'s neighbouring case, which refuses rather than guesses —
+/// a wrong translation there would be a pattern matching the wrong text, and
+/// here there is only one thing either class can mean.
+///
+/// Only outside a class, and only where the bracket is not itself escaped: `[[]`
+/// is a class containing `[`, and `\[]` is the two literal characters. A blind
+/// `replace` on the string got both wrong.
+fn empty_classes(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let characters: Vec<char> = pattern.chars().collect();
+    let mut at = 0;
+    let mut inside = false;
+    while at < characters.len() {
+        let character = characters[at];
+        if character == '\\' {
+            out.push(character);
+            if let Some(next) = characters.get(at + 1) {
+                out.push(*next);
+            }
+            at += 2;
+            continue;
+        }
+        if !inside && character == '[' {
+            if characters.get(at + 1) == Some(&']') {
+                out.push_str("[^\\s\\S]");
+                at += 2;
+                continue;
+            }
+            if characters.get(at + 1) == Some(&'^') && characters.get(at + 2) == Some(&']') {
+                out.push_str("[\\s\\S]");
+                at += 3;
+                continue;
+            }
+            inside = true;
+        } else if inside && character == ']' {
+            inside = false;
+        }
+        out.push(character);
+        at += 1;
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_two_empty_classes_are_translated_and_nothing_else_is() {
+        assert_eq!(empty_classes("[]"), "[^\\s\\S]");
+        assert_eq!(empty_classes("[^]"), "[\\s\\S]");
+        assert_eq!(empty_classes("a[]b[^]c"), "a[^\\s\\S]b[\\s\\S]c");
+        // A bracket INSIDE a class is an ordinary member, and one that is
+        // escaped is a literal — a blind `replace` got both of these wrong.
+        assert_eq!(empty_classes("[[]"), "[[]");
+        assert_eq!(empty_classes("\\[]"), "\\[]");
+        assert_eq!(empty_classes("[a]"), "[a]");
+        assert_eq!(empty_classes("[^a]"), "[^a]");
+        assert_eq!(empty_classes("[\\]]"), "[\\]]");
+    }
+
+    #[test]
+    fn the_empty_class_matches_nothing_and_its_complement_matches_everything() {
+        let never = Engine::compile("[]", Flags::default()).expect("`[]` is legal JavaScript");
+        assert!(!never.matches_at("a", 0));
+        assert!(!never.matches_at("\n", 0));
+        let always = Engine::compile("[^]", Flags::default()).expect("`[^]` is legal JavaScript");
+        assert!(always.matches_at("a", 0));
+        assert!(always.matches_at("\n", 0));
+    }
 
     #[test]
     fn an_unknown_flag_letter_is_refused_rather_than_ignored() {

--- a/crates/rts-core/src/entry/regex/methods.rs
+++ b/crates/rts-core/src/entry/regex/methods.rs
@@ -48,7 +48,7 @@ pub(super) extern "C" fn construct(
     _a2: u64,
     _a3: u64,
 ) -> u64 {
-    with_current(|context| {
+    let outcome = with_current(|context| {
         // `RegExp(re)` called WITHOUT `new`, with no explicit `flags`, answers
         // the SAME object — `context.new_targets` is how `wrap` above answers
         // the identical "was this a construct" question for `Number`/`Boolean`/
@@ -63,7 +63,7 @@ pub(super) extern "C" fn construct(
             && context.regexp_at(cell).is_some()
             && text_of(context, flags).is_none()
         {
-            return pattern;
+            return Made::Answered(pattern);
         }
         // `new RegExp(existingRegExp)` copies `source`/`flags` from the
         // original rather than `ToString`-ing it: `String(/ab+c/)` is the
@@ -81,18 +81,42 @@ pub(super) extern "C" fn construct(
                 Some(explicit) => explicit,
                 None => inherited,
             };
-            return super::make(context, &source, &letters);
+            let made = super::make(context, &source, &letters);
+            return Made::Built(made, source, letters);
         }
         let Some(source) = text_of(context, pattern) else {
             // A pattern that is not a string. `new RegExp(1)` runs `ToString`
             // on it, and `ToString` of an object calls user code an entry point
             // cannot call — so the conversion stops where that becomes true,
             // rather than half-doing it for the cases that would work.
-            return undefined_of(context);
+            return Made::Answered(undefined_of(context));
         };
         let letters = text_of(context, flags).unwrap_or_default();
-        super::make(context, &source, &letters)
-    })
+        let made = super::make(context, &source, &letters);
+        Made::Built(made, source, letters)
+    });
+    // Outside the borrow: `super::refusal` builds an error, which borrows the
+    // context again — the re-entrant `RefCell` this crate's rule 8 exists to
+    // keep out of an `extern "C"` frame.
+    match outcome {
+        Made::Answered(value) => value,
+        Made::Built(made, source, letters) => {
+            super::refusal(made, &source, &letters);
+            made
+        }
+    }
+}
+
+/// What the borrow above decided, so the raise can happen after it ends.
+///
+/// Two arms and not an `Option`: a value answered WITHOUT compiling anything —
+/// the `RegExp(re)` identity case, and a pattern that is not a string — owes no
+/// `SyntaxError`, and collapsing it into "no value" would raise for both.
+enum Made {
+    /// Answered without building a pattern; nothing to refuse.
+    Answered(u64),
+    /// Built (or failed to build) from this source and these flags.
+    Built(u64, String, String),
 }
 
 /// `re.test(s)` — whether there is a match.

--- a/crates/rts-core/src/entry/regex/mod.rs
+++ b/crates/rts-core/src/entry/regex/mod.rs
@@ -59,6 +59,42 @@ use super::{Context, with_current};
 use crate::text::Str;
 use crate::value::Value;
 
+/// Raises the `SyntaxError` a refused pattern owes, OUTSIDE any borrow.
+///
+/// # Why this is a second function and not two lines inside [`make`]
+///
+/// Because `make` runs inside a `with_current` closure at every call site, and
+/// building an error borrows the context again — a re-entrant `RefCell` borrow,
+/// which is an abort in an `extern "C"` frame and not a catchable fault. The
+/// first version raised in place and the panic was immediate.
+///
+/// So the shape every raising native in this crate uses applies here too:
+/// decide inside the borrow, answer, and raise after it ends. `make` answers
+/// `undefined` for a pattern it could not build, and this turns that answer into
+/// the throw the language owes — which matters because `undefined` from a
+/// CONSTRUCTOR is not a quiet failure: `new` hands back the half-built `this`
+/// instead, and the program dies later reading `.exec` off an object with no
+/// pattern in it.
+///
+/// The two messages are kept apart because they are different faults with
+/// different fixes for whoever reads one: an unknown FLAG LETTER is a typo in
+/// the second argument, and an unbuildable PATTERN is the first.
+pub(super) fn refusal(made: u64, source: &str, letters: &str) -> bool {
+    let refused = with_current(|context| made == undefined_of(context));
+    if !refused {
+        return false;
+    }
+    match Flags::parse(letters) {
+        None => super::throw::syntax_error(&format!(
+            "invalid regular expression flags: {letters:?}"
+        )),
+        Some(_) => super::throw::syntax_error(&format!(
+            "invalid regular expression: /{source}/{letters}"
+        )),
+    }
+    true
+}
+
 /// A compiled pattern and how a match is driven over it.
 ///
 /// `lastIndex` is **not** here. It is an ordinary property of the object,
@@ -91,15 +127,18 @@ pub(super) struct Regexp {
 /// program uses the result rather than at an arbitrary later point.
 #[rtse::entry]
 pub fn regex_new(pattern: u64, flags: u64) -> u64 {
-    with_current(|context| {
-        let Some(source) = text_of(context, pattern) else {
-            return undefined_of(context);
-        };
-        let Some(letters) = text_of(context, flags) else {
-            return undefined_of(context);
-        };
-        make(context, &source, &letters)
-    })
+    let read = with_current(|context| {
+        let source = text_of(context, pattern)?;
+        let letters = text_of(context, flags)?;
+        let made = make(context, &source, &letters);
+        Some((made, source, letters))
+    });
+    let Some((made, source, letters)) = read else {
+        return with_current(|context| undefined_of(context));
+    };
+    // Outside the borrow, for the reason [`refusal`] states.
+    refusal(made, &source, &letters);
+    made
 }
 
 /// The object, from text that has already been read.
@@ -110,7 +149,10 @@ pub fn regex_new(pattern: u64, flags: u64) -> u64 {
 /// where the text came from, and that difference ends here.
 pub(super) fn make(context: &mut Context, source: &str, letters: &str) -> u64 {
     {
-        let Some(parsed) = Flags::parse(letters) else {
+        // A pattern this engine cannot build answers `undefined`, and the
+        // CALLER raises the `SyntaxError` after its borrow has ended — see
+        // [`refusal`] for why the raise cannot happen here.
+let Some(parsed) = Flags::parse(letters) else {
             return undefined_of(context);
         };
         let Some(engine) = Engine::compile(source, parsed) else {

--- a/crates/rts-core/src/entry/throw.rs
+++ b/crates/rts-core/src/entry/throw.rs
@@ -329,6 +329,7 @@ pub(in crate::entry) fn range_error(message: &str) {
     named_error("RangeError", message);
 }
 
+
 /// Raises a plain `Error` a `catch` in the program can see.
 ///
 /// For a failure that is about none of the three things the errors above name —
@@ -342,9 +343,17 @@ pub(in crate::entry) fn plain_error(message: &str) {
 
 /// Raises a `SyntaxError` a `catch` in the program can see.
 ///
-/// Same construction as [`type_error`], for `JSON.parse` of text that is not
-/// JSON — the one place in this crate that is malformed *input* rather than a
-/// misused value.
+/// Same construction as [`type_error`], for malformed *input* rather than a
+/// misused value. Two places reach it, and both are text a program computed:
+/// `JSON.parse` of something that is not JSON, and a pattern `new RegExp(…)`
+/// cannot build.
+///
+/// The second was answering `undefined` instead, which is worse than it looks:
+/// `new` on a callable that answers a primitive gives back the half-built
+/// `this`, so `new RegExp("[]")` produced an object with no `source`, no
+/// `flags` and no compiled pattern. The program carried on and died several
+/// lines later reading `.exec` off it — naming neither the pattern nor the line
+/// that wrote it.
 pub(in crate::entry) fn syntax_error(message: &str) {
     named_error("SyntaxError", message);
 }


### PR DESCRIPTION
| | pass / alcancavel |
|---|---|
| antes | 1078 / 1510 (71.4%) |
| depois | 1079 / 1511 (71.4%) |

**GANHOS 1, PERDAS 0.** O numero mal se move e o defeito corrigido e dos piores
que este motor tinha.

## O que estava errado

`regex::make` respondia `undefined` para um padrao que nao conseguia construir.
E `undefined` vindo de um **construtor** nao e uma falha silenciosa — o `new`
devolve o `this` meio-construido quando o corpo responde um primitivo. Portanto
`new RegExp("[]")` produzia um OBJECTO: sem `source`, sem `flags`, sem padrao
compilado, e com o prototipo certo. O programa seguia e morria varias linhas
depois em

```
TypeError: Cannot read properties of undefined (reading 'exec')
```

sem nomear o padrao nem a linha que o escreveu. **Cinco fixtures falhavam assim,
e o erro apontava para o sitio errado em todas as cinco.**

Agora lanca `SyntaxError`, como o Bun e o Node para o mesmo programa. As duas
mensagens sao distintas de proposito: uma LETRA de flag desconhecida e uma
gralha no segundo argumento, um PADRAO que nao constroi e o primeiro.

## Onde o raise tem de estar, e custou um panic a descobrir

`make` corre dentro de um `with_current` em todos os pontos de entrada, e
construir um erro pede o contexto outra vez — emprestimo re-entrante do
`RefCell`, que num quadro `extern "C"` e um **abort** e nao uma falha apanhavel.
A primeira versao levantou ali e o panic foi imediato.

Dai `regex::refusal` ser funcao separada. O construtor precisou de um `enum
Made` com dois ramos e nao de um `Option`: um valor respondido **sem compilar
nada** — o caso identidade `RegExp(re)`, e um padrao que nao e string — nao deve
nenhum `SyntaxError`.

## `[]` e `[^]` passam a funcionar

JavaScript legal (`[]` nao casa nada, `[^]` casa qualquer caracter) e erro de
parse para o crate `regex`. Nenhum e exotico: `[^]` e a maneira comum de
escrever "qualquer caracter, quebra de linha incluida" em codigo anterior a flag
`s`, e aparece constantemente em saida minificada.

Sao **traduzidos** e nao recusados porque as traducoes sao exactas: `[^\s\S]` e
o conjunto vazio por construcao e `[\s\S]` e o seu complemento. So fora de uma
classe e so onde o parentesis nao esta escapado — `[[]` e uma classe que contem
`[`, e `\[]` sao dois literais. Um `replace` cego errava os dois; ha um teste que
fixa isso.

## O que isto NAO conserta

As cinco fixtures de regex continuam a falhar, agora com um `SyntaxError` claro
em vez de um `TypeError` enganador. Usam lookbehind de comprimento variavel,
escapes de propriedade unicode e operacoes de conjunto da flag `v` — nenhum dos
motores por baixo os tem. E trabalho de capacidade, nao de mensagem.

484 testes unitarios verdes, dois novos sobre as classes vazias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn