### PR TITLE
fix: quatro especies passam a dizer o que sao, e matchAll responde um iterador

### DIFF
--- a/crates/rts-core/src/entry/arguments.rs
+++ b/crates/rts-core/src/entry/arguments.rs
@@ -93,5 +93,25 @@ fn build(context: &mut Context, collected: Vec<u64>) -> u64 {
             super::native::hidden(context, cell, key);
         }
     }
+
+    // `Symbol.toStringTag`, so `Object.prototype.toString.call(arguments)`
+    // answers `[object Arguments]`.
+    //
+    // The language gives this one an internal class rather than a tag property,
+    // and this engine has no slot to record that in: an arguments object is an
+    // ordinary object carrying indices, a `length` and an iterator, which is
+    // precisely why `object_proto`'s per-kind table cannot tell it from any
+    // other object and answered `[object Object]`. A real tag is the one
+    // spelling available, and it is observable in the direction that matters —
+    // the value is right, and the extra own key it costs is non-enumerable.
+    //
+    // The cost is a property per arguments object rather than one on a shared
+    // prototype, and that is not a choice: these inherit from
+    // `Object.prototype`, so a tag installed there would label every object in
+    // the program.
+    let tag = context.well_known(&format!("{}toStringTag", super::symbol::PREFIX));
+    let value = context.intern_value(crate::text::Str::from_str("Arguments")).bits();
+    super::objects::put(context, cell, tag, value);
+    super::native::hidden(context, cell, tag);
     object
 }

--- a/crates/rts-core/src/entry/array_proto/cursor.rs
+++ b/crates/rts-core/src/entry/array_proto/cursor.rs
@@ -215,6 +215,15 @@ pub(super) fn over(receiver: u64, kind: Kind) -> u64 {
         let key = context.well_known(&format!("{}iterator", symbol::PREFIX));
         let itself = native::callable(context, itself as native::Native);
         objects::put(context, cell, key, itself);
+
+        // `Symbol.toStringTag`, so `Object.prototype.toString.call([].values())`
+        // answers `[object Array Iterator]`. On the INSTANCE for the same reason
+        // as the key above, and a plain string because all three kinds share one
+        // tag — the language distinguishes `keys`, `values` and `entries` by
+        // what they yield, not by what they call themselves.
+        let key = context.well_known(&format!("{}toStringTag", symbol::PREFIX));
+        let tag = context.intern_value(crate::text::Str::from_str("Array Iterator")).bits();
+        objects::put(context, cell, key, tag);
         Value::from_slot(cell).bits()
     })
 }

--- a/crates/rts-core/src/entry/generator/mod.rs
+++ b/crates/rts-core/src/entry/generator/mod.rs
@@ -425,6 +425,21 @@ pub(in crate::entry) fn register(context: &mut Context) -> u64 {
         let key = context.well_known(&format!("{}iterator", super::symbol::PREFIX));
         let itself = super::native::callable(context, itself as super::native::Native);
         super::objects::put(context, cell, key, itself);
+
+        // `Symbol.toStringTag`, so `Object.prototype.toString.call(g())` answers
+        // `[object Generator]`. It went to `[object Object]`, which is the
+        // fallback `object_proto`'s per-kind table gives anything it does not
+        // recognise — and a generator is exactly the case that table cannot
+        // recognise, because a generator object has no internal slot this engine
+        // records and is otherwise an ordinary object with a prototype.
+        //
+        // On the PROTOTYPE rather than each instance: every generator shares it,
+        // a tag is a fact about the kind rather than the object, and a program
+        // that makes a million of them should not pay a property for each.
+        let tag = context.well_known(&format!("{}toStringTag", super::symbol::PREFIX));
+        let value = context.intern_value(crate::text::Str::from_str("Generator")).bits();
+        super::objects::put(context, cell, tag, value);
+        super::native::hidden(context, cell, tag);
     }
     made
 }

--- a/crates/rts-core/src/entry/string/pattern.rs
+++ b/crates/rts-core/src/entry/string/pattern.rs
@@ -259,7 +259,7 @@ extern "C" fn match_all(_e: u64, this: u64, pattern: u64, _a1: u64, _a2: u64, _a
     });
 
     let Some((found, subject, positions)) = collected else {
-        return super::super::array_proto::built(Vec::new());
+        return iterator_over(Vec::new());
     };
     let matches: Vec<u64> = found
         .into_iter()
@@ -294,7 +294,28 @@ extern "C" fn match_all(_e: u64, this: u64, pattern: u64, _a1: u64, _a2: u64, _a
             array
         })
         .collect();
-    super::super::array_proto::built(matches)
+    iterator_over(matches)
+}
+
+/// What `matchAll` answers: an ITERATOR over the matches, not the array.
+///
+/// # Why the array was wrong even though it iterated
+///
+/// `for (const m of s.matchAll(re))` and `[...s.matchAll(re)]` work over either,
+/// which is why this went unnoticed. What does not work over an array is
+/// `s.matchAll(re).next()`, and that is the whole difference between a method
+/// that answers a sequence and one that answers a collection: a program driving
+/// the matches by hand — the reason to reach for `matchAll` over `match` — found
+/// no `next` at all. `Array.isArray(s.matchAll(re))` also answered `true`, and
+/// `Object.prototype.toString.call` said `[object Array]` where the language
+/// says `[object RegExp String Iterator]`.
+///
+/// The list is still built eagerly. That is [`super::super::list_iterator`]'s
+/// stated cost rather than a new one, and wrapping does not add to it: the
+/// matches were already all collected before this is reached.
+fn iterator_over(matches: Vec<u64>) -> u64 {
+    let listed = super::super::array_proto::built(matches);
+    super::super::list_iterator::over(listed, "RegExp String Iterator")
 }
 
 /// The matcher's group names by position, when the pattern asked for `indices`.


### PR DESCRIPTION
| | pass / alcancavel | erros |
|---|---|---|
| antes | 1079 / 1511 (71.4%) | 129 |
| depois | 1079 / 1510 (71.4%) | **128** |

**GANHOS 1, PERDAS 0.**

`Object.prototype.toString.call` e o idioma com que um programa pergunta o que
uma coisa **realmente** e, por cima de qualquer `toString` que um prototipo pelo
caminho tenha substituido. Quatro especies respondiam a pergunta errada:

| | antes | depois |
|---|---|---|
| `[].values()` | `[object Object]` | `[object Array Iterator]` |
| `(function*(){})()` | `[object Object]` | `[object Generator]` |
| `arguments` | `[object Object]` | `[object Arguments]` |
| `"a".matchAll(/a/g)` | `[object Array]` | `[object RegExp String Iterator]` |

Cada uma foi instalada onde o custo e menor e a semantica esta certa, que **nao
e o mesmo sitio nas quatro**: o iterador leva a etiqueta na instancia (um so
prototipo serve as quatro especies de iterador aqui); o generator leva-a no
prototipo (todos o partilham, e um programa que faca um milhao deles nao deve
pagar uma propriedade por cada); o `arguments` leva-a na instancia e **nao ha
alternativa** — herda de `Object.prototype`, portanto uma etiqueta la rotularia
todos os objectos do programa.

## `matchAll` respondia um array

`for (const m of s.matchAll(re))` e `[...s.matchAll(re)]` funcionam sobre
qualquer dos dois, que e porque isto passou despercebido. O que nao funciona
sobre um array e **`s.matchAll(re).next()`** — e essa e a diferenca inteira
entre um metodo que responde uma SEQUENCIA e um que responde uma COLECCAO: um
programa a conduzir os resultados a mao, que e a razao para preferir `matchAll`
a `match`, nao encontrava `next` nenhum. `Array.isArray` sobre ele dizia `true`.

A lista continua construida de uma vez — custo ja declarado do `list_iterator`,
nao um novo: os resultados ja estavam todos recolhidos antes do embrulho.

## O que fica, medido

`generatorFn`, `asyncFn` e `asyncGenFn` continuam `[object Function]`, e um
async generator diz `[object Generator]`. As tres primeiras precisam que o
compilador marque a **especie** da funcao — mudanca no emissor, nao aqui; a
quarta precisa de prototipo proprio para o async generator, que hoje partilha o
do generator.

## Medicao

`286_setimmediate` voltou a sair de `pass` para `bun_node_diverge` — Bun e Node
a discordarem **entre si** sob carga, sem o RTS envolvido, segunda vez em dois
relatorios. A fixture depende de ordenacao de temporizadores e o medidor
satura-a: fica anotado como problema do **corpus**, nao do motor.

486 testes unitarios verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn