### PR TITLE
fix: uma funcao anonima num literal tem nome, e bind escreve name e length

### DIFF
--- a/crates/rts-codegen/src/emit/object.rs
+++ b/crates/rts-codegen/src/emit/object.rs
@@ -83,11 +83,40 @@ pub(super) fn emit_object(
         // written.
         let (key, value) = match property {
             Property::Value { key, value, .. } => {
+                // The KEY is lent to an anonymous function on the right, which
+                // is `NamedEvaluation`: `{ gamma: function () {} }` and
+                // `{ delta: () => {} }` are both called by their property name,
+                // exactly as `const f = function () {}` is called `f`. Only
+                // three of the four forms in a literal were inferred here and
+                // this was the missing one, so `obj.gamma.name` read `""`.
+                //
+                // Only for a WRITTEN key: a computed one is an expression whose
+                // value is not known while compiling, and a name inferred from
+                // the source text of `{ [k]: f }` would be a different string
+                // from the one the language says (`k`'s value at run time).
+                //
+                // Lent rather than assigned, so `take_lent_name` can be taken by
+                // the function that is actually the initialiser and not by one
+                // nested inside it — the same reason the declaration form lends.
+                if let PropertyKey::Named(name) = key {
+                    ctx.lend_name(*name);
+                }
                 let value = emit_expr(builder, scope, ctx, value)?;
+                // Anything the initialiser did not take is dropped: a lent name
+                // that outlived its initialiser would be picked up by the next
+                // function emitted anywhere, which is a wrong name rather than a
+                // missing one.
+                let _ = ctx.take_lent_name();
                 (key, value)
             }
             Property::Method { key, function } => {
+                // A method shorthand — `{ beta() {} }` — has no name of its own
+                // either, and the key is it.
+                if let PropertyKey::Named(name) = key {
+                    ctx.lend_name(*name);
+                }
                 let value = super::function::emit_closure(builder, scope, ctx, function)?;
+                let _ = ctx.take_lent_name();
                 (key, value)
             }
             // An accessor is defined, not written: a getter stored under the

--- a/crates/rts-core/src/entry/function_proto.rs
+++ b/crates/rts-core/src/entry/function_proto.rs
@@ -245,8 +245,9 @@ impl Context {
 /// three `undefined`s in front of the caller's arguments and no bound call would
 /// ever line up.
 fn bound(target: u64, receiver: u64, partial: Vec<u64>) -> u64 {
-    let made = with_current(|context| {
+    with_current(|context| {
         let made = super::native::callable(context, forward);
+        let taken = partial.len();
         if let Some(cell) = Value(made).as_slot() {
             context.bound.set(cell, Bound {
                 target,
@@ -254,9 +255,42 @@ fn bound(target: u64, receiver: u64, partial: Vec<u64>) -> u64 {
                 partial,
             });
         }
+        // `name` and `length`, which the specification's `BoundFunctionCreate`
+        // writes and this wrote neither of — both read `undefined`.
+        //
+        // The name is the TARGET's with `"bound "` in front, and it chains:
+        // `f.bind().bind().name` is `"bound bound f"`. That is not decoration —
+        // a stack trace and a debugger label a bound function by it, and the
+        // prefix is how a reader tells a wrapper from the thing it wraps.
+        //
+        // The length is the target's MINUS the partial arguments, floored at
+        // zero. Flooring matters: `((a) => a).bind(null, 1, 2, 3).length` is 0
+        // and not -2, and a negative arity reaching arithmetic in a currying
+        // helper is the failure this would otherwise cause somewhere else.
+        //
+        // Both are read off the TARGET's own properties rather than from a
+        // table, because a program may have redefined them — and a bound
+        // function must describe the function it actually forwards to.
+        let described = Value(target).as_slot().and_then(|cell| {
+            let name = context.well_known("name");
+            let length = context.well_known("length");
+            let named = super::objects::read_property(context, cell, name)
+                .and_then(|value| value.as_slot())
+                .and_then(|cell| context.text_at(cell))
+                .and_then(|text| text.to_rust())
+                .unwrap_or_default();
+            let arity = super::objects::read_property(context, cell, length)
+                .and_then(|value| value.numeric())
+                .unwrap_or(0.0);
+            Some((named, arity))
+        });
+        if let Some((named, arity)) = described {
+            super::native::name_of(context, made, &format!("bound {named}"));
+            let left = (arity - taken as f64).max(0.0);
+            super::native::length_of(context, made, left as u32);
+        }
         made
-    });
-    made
+    })
 }
 
 /// What every bound function runs.


### PR DESCRIPTION
| | pass / alcancavel |
|---|---|
| antes | 1081 / 1511 (71.5%) |
| depois | 1085 / 1511 (**71.8%**) |

**GANHOS 4, PERDAS 0.**

## 1. `NamedEvaluation` nao chegava a um literal de objecto

`const f = function () {}` ja se chamava `f` — o emissor **empresta** o nome da
ligacao a funcao anonima do lado direito. Um literal de objecto nao emprestava
nada, portanto tres das quatro formas ficavam sem nome:

| escrito | `.name` antes | depois |
|---|---|---|
| `{ beta() {} }` | `""` | `"beta"` |
| `{ gamma: function () {} }` | `""` | `"gamma"` |
| `{ delta: () => {} }` | `""` | `"delta"` |

So para uma chave **escrita**. Uma chave computada e uma expressao cujo valor
nao se conhece a compilar, e um nome inferido do texto de `{ [k]: f }` seria uma
string diferente da que a linguagem manda (o *valor* de `k` em execucao) — fica
por fazer, escrito no codigo em vez de adivinhado.

O nome e **emprestado** e o resto e deitado fora a seguir: um emprestimo que
sobrevivesse ao seu inicializador seria apanhado pela proxima funcao emitida em
qualquer sitio — um nome **errado**, que e pior do que um em falta.

## 2. `bind` nao escrevia `name` nem `length`

Ambos liam `undefined`.

O nome e o do alvo com `"bound "` a frente, e **encadeia**:
`f.bind().bind().name` e `"bound bound f"`. Um stack trace e um depurador
rotulam uma funcao ligada por ele.

O `length` e o do alvo **menos** os parciais, com chao em zero. O chao importa:
`((a) => a).bind(null, 1, 2, 3).length` e 0 e nao -2, e uma aridade negativa a
chegar a aritmetica num ajudante de currying e a falha que isto causaria noutro
sitio qualquer.

Os dois sao lidos das **propriedades** do alvo e nao de uma tabela, porque um
programa pode te-las redefinido — e uma funcao ligada tem de descrever a funcao
para a qual encaminha de facto.

486 testes unitarios verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn