### PR TITLE
fix: seis defeitos onde uma conversao acontecia no sitio errado ou nao acontecia

### DIFF
--- a/crates/rts-core/src/entry/class_support.rs
+++ b/crates/rts-core/src/entry/class_support.rs
@@ -149,6 +149,21 @@ pub(in crate::entry) fn constants(context: &mut Context, cell: u32, constants: &
 /// out, in four suite files, the moment this learned to convert.
 pub(in crate::entry) fn to_number(value: u64) -> f64 {
     let value = super::primitive::to_primitive(value, crate::coerce::Hint::Number);
+    // A SYMBOL has no numeric form and the language says so with a `TypeError`,
+    // not with `NaN`. The difference is the whole point of the rule: `NaN`
+    // propagates silently through arithmetic, so `Number(sym)` answering it made
+    // a symbol that reached a numeric path produce a plausible-looking result
+    // pages later instead of failing where it was written.
+    //
+    // Asked AFTER `ToPrimitive`, which is where the specification asks it: an
+    // object whose `Symbol.toPrimitive` answers a symbol reaches the same
+    // refusal as a bare symbol, and asking first would let it through.
+    //
+    // Raised outside the borrow below, for the reason every raising native has.
+    if with_current(|context| super::symbol::is_symbol(context, value)) {
+        super::throw::type_error("Cannot convert a Symbol value to a number");
+        return f64::NAN;
+    }
     with_current(|context| super::operators::as_number(context, Value(value)).unwrap_or(f64::NAN))
 }
 

--- a/crates/rts-core/src/entry/error.rs
+++ b/crates/rts-core/src/entry/error.rs
@@ -218,6 +218,13 @@ impl AggregateError {
             };
             let key = context.well_known("errors");
             super::objects::put(context, cell, key, listed[0]);
+            // NON-ENUMERABLE, which the specification spells out and which is
+            // observable in the most ordinary way there is: `JSON.stringify(agg)`
+            // and `{...agg}` included the whole error list, and
+            // `Object.keys(agg)` reported `["errors"]` where every other engine
+            // reports nothing. `message` and `stack` are non-enumerable for the
+            // same reason and this was the one that was not.
+            super::native::hidden(context, cell, key);
             made
         })
     }

--- a/crates/rts-core/src/entry/number/parse.rs
+++ b/crates/rts-core/src/entry/number/parse.rs
@@ -70,6 +70,16 @@ pub(in crate::entry) fn leading(value: u64, parse: impl FnOnce(&str) -> f64) -> 
     if super::super::throw::in_flight() {
         return f64::NAN;
     }
+    // A SYMBOL has no text form: `ToString(sym)` is a `TypeError`, which is what
+    // both parsers inherit. It answered `NaN` — and `NaN` is what these two
+    // answer for ordinary unparseable text, so a symbol reaching `parseInt` was
+    // indistinguishable from the string `"abc"` reaching it. `Number(sym)`
+    // already refused; these did not, which made the three disagree about one
+    // value.
+    if with_current(|context| super::super::symbol::is_symbol(context, value)) {
+        super::super::throw::type_error("Cannot convert a Symbol value to a string");
+        return f64::NAN;
+    }
     let text = with_current(|context| {
         super::super::text::to_text(context, Value(value)).and_then(|text| text.to_rust())
     });

--- a/crates/rts-core/src/entry/regex/compile.rs
+++ b/crates/rts-core/src/entry/regex/compile.rs
@@ -207,6 +207,50 @@ impl Flags {
     /// `fancy-regex` takes options as inline groups, so the same three facts are
     /// spelled as a prefix. Written from the same structure the builder is
     /// configured from, so the two cannot disagree about what `i` means.
+    /// The flag letters in the CANONICAL order the language prints them.
+    ///
+    /// `RegExp.prototype.flags` is defined as a getter that reads each flag in a
+    /// fixed sequence — `d g i m s u v y` — and appends its letter. It is not
+    /// the text the program wrote: `new RegExp("a", "mis").flags` is `"ims"` and
+    /// `/x/yug.flags` is `"guy"`.
+    ///
+    /// This engine kept the written text and answered it verbatim, so two
+    /// regular expressions with the same meaning compared unequal through their
+    /// `flags` and `source` — which is exactly what `new RegExp(re)` copies and
+    /// what a program uses to cache a compiled pattern by key.
+    ///
+    /// `u` and `v` are carried from the written text rather than from a field,
+    /// because [`Flags`] has none for them: both are accepted and not acted on,
+    /// which [`Flags::parse`] states as the divergence it is.
+    pub(super) fn canonical(self, written: &str) -> String {
+        let mut letters = String::new();
+        if self.has_indices {
+            letters.push('d');
+        }
+        if self.global {
+            letters.push('g');
+        }
+        if self.ignore_case {
+            letters.push('i');
+        }
+        if self.multiline {
+            letters.push('m');
+        }
+        if self.dot_all {
+            letters.push('s');
+        }
+        if written.contains('u') {
+            letters.push('u');
+        }
+        if written.contains('v') {
+            letters.push('v');
+        }
+        if self.sticky {
+            letters.push('y');
+        }
+        letters
+    }
+
     fn inline(self, pattern: &str) -> String {
         let mut prefix = String::new();
         if self.ignore_case {

--- a/crates/rts-core/src/entry/regex/mod.rs
+++ b/crates/rts-core/src/entry/regex/mod.rs
@@ -173,6 +173,8 @@ let Some(parsed) = Flags::parse(letters) else {
         let own = prototype_of(context);
         let prototype = super::functions::prototype_for_new(context, own);
         context.set_prototype(cell, prototype);
+        // The CANONICAL order, not the written one — see `Flags::canonical`.
+        let letters = &parsed.canonical(letters);
         describe(context, cell, source, letters, parsed);
         context.regexes.set(cell, Regexp {
             engine,

--- a/crates/rts-core/src/entry/string/basic.rs
+++ b/crates/rts-core/src/entry/string/basic.rs
@@ -175,17 +175,29 @@ extern "C" fn slice(_e: u64, this: u64, from: u64, to: u64, _a2: u64, _a3: u64) 
 
 /// `s.substring(from, to)` — negative clamps to zero, and the two swap.
 extern "C" fn substring(_e: u64, this: u64, from: u64, to: u64, _a2: u64, _a3: u64) -> u64 {
+    // Converted BEFORE the borrow: `ToNumber` of an object runs the program's
+    // `valueOf`, and calling user code from inside `with_current` re-enters the
+    // `RefCell`. See `super::integer_outside`.
+    let missing = with_current(|context| absent(context, to));
+    let asked_from = super::integer_outside(from);
+    let asked_to = match missing {
+        true => 0.0,
+        false => super::integer_outside(to),
+    };
+    if super::super::throw::in_flight() {
+        return with_current(|context| nothing(context));
+    }
     with_current(|context| {
         let Some(units) = units_of(context, this) else {
             return nothing(context);
         };
         let length = units.len() as f64;
         let clamp = |value: f64| value.clamp(0.0, length) as usize;
-        let start = clamp(super::integer_arg(context, from).max(0.0));
-        let end = if absent(context, to) {
+        let start = clamp(asked_from.max(0.0));
+        let end = if missing {
             units.len()
         } else {
-            clamp(super::integer_arg(context, to).max(0.0))
+            clamp(asked_to.max(0.0))
         };
         let (start, end) = if start > end { (end, start) } else { (start, end) };
         answer(context, &units[start..end])

--- a/crates/rts-core/src/entry/string/mod.rs
+++ b/crates/rts-core/src/entry/string/mod.rs
@@ -327,6 +327,28 @@ pub(super) fn nothing(context: &Context) -> u64 {
 /// The infinities pass through as themselves. A caller compares against a length
 /// before it casts, so `±∞` is out of range by arithmetic rather than by a case.
 ///
+/// The same conversion, performed OUTSIDE any borrow so an object converts.
+///
+/// [`integer_arg`] answers zero for an object, and its own documentation calls
+/// that the stated gap: `ToNumber` on an object runs the program's `valueOf`,
+/// and calling user code from inside a `with_current` re-enters the `RefCell`.
+///
+/// This is the other half. A method that wants an object argument to work calls
+/// this BEFORE it borrows, and passes the number in — which is exactly the shape
+/// `array_proto::more::at` already uses and the reason its own two statements
+/// are two. `"abc".substring({valueOf: () => 1}, {valueOf: () => 3})` answered
+/// the empty string and now answers `"bc"`.
+///
+/// A symbol raises here rather than answering zero, because [`super::class_support::to_number`]
+/// is what performs the conversion and that refusal is the language's.
+pub(super) fn integer_outside(value: u64) -> f64 {
+    let number = super::class_support::to_number(value);
+    match number.is_nan() {
+        true => 0.0,
+        false => number.trunc(),
+    }
+}
+
 /// An object answers `NaN` and therefore zero, because `ToNumber` on one runs
 /// user code and this is inside a borrow. The stated gap: `s.at({valueOf: …})`
 /// reads index 0.

--- a/crates/rts-core/src/entry/string/points.rs
+++ b/crates/rts-core/src/entry/string/points.rs
@@ -185,6 +185,18 @@ extern "C" fn raw(_e: u64, _this: u64, strings: u64, a: u64, b: u64, c: u64) -> 
         let Some(value) = substitutions.get(at).copied() else {
             continue;
         };
+        // `ToString` of the substitution, which for an object means calling its
+        // `toString` — user code, therefore OUTSIDE the borrow. `arg_units`
+        // alone answers `None` for an object, so a substitution that was not
+        // already a primitive was silently DROPPED: `` String.raw`a${obj}b` ``
+        // produced `"ab"`, losing a piece rather than converting it.
+        let value = super::super::primitive::to_primitive(value, crate::coerce::Hint::String);
+        // Rule 8: a `toString` that threw did not answer, and appending
+        // `undefined` would put the word into the result of a call that never
+        // happened.
+        if super::super::throw::in_flight() {
+            return with_current(|context| super::super::objects::undefined_of(context));
+        }
         with_current(|context| {
             if let Some(units) = arg_units(context, value) {
                 out.extend(units);


### PR DESCRIPTION
| | pass / alcancavel |
|---|---|
| antes | 1100 / 1511 (72.8%) |
| depois | 1103 / 1511 (**73.0%**) |

**GANHOS 3, PERDAS 0.**

1. **`RegExp.prototype.flags` respondia as letras como foram escritas.**
   `new RegExp("a", "mis").flags` era `"mis"`; a linguagem define um getter que
   le cada flag numa sequencia fixa (`d g i m s u v y`). Duas expressoes com o
   mesmo significado comparavam desiguais pelo par `source`/`flags` — que e
   exactamente o que `new RegExp(re)` copia e o que um programa usa como chave
   de cache.

2. **Um simbolo convertido para numero respondia `NaN`.** `NaN` propaga em
   silencio, portanto um simbolo num caminho numerico dava um resultado
   plausivel paginas a frente em vez de falhar onde foi escrito.

3. **`parseInt`/`parseFloat` tambem nao recusavam**, e este e o caso pior: `NaN`
   e o que os dois respondem para texto vulgar, portanto um simbolo era
   indistinguivel de `"abc"`. O `Number` ja recusava, o que fazia os tres
   discordarem sobre um valor.

4. **`AggregateError.errors` era enumeravel** — `JSON.stringify(agg)` e
   `{...agg}` incluiam a lista inteira de erros.

5. **`String.raw` deixava cair** uma substituicao que nao fosse ja primitiva:
   `` String.raw`a${obj}b` `` dava `"ab"`.

6. **`"abc".substring({valueOf:()=>1}, {valueOf:()=>3})` era vazio.** O
   `integer_arg` corre dentro de um emprestimo e a sua propria documentacao ja
   chamava a isto a lacuna declarada. Foi escrita a outra metade,
   `integer_outside`.

## O que fica, medido

`+sym` e `sym | 0` continuam a responder `NaN` e `0` — sao caminhos do
**emissor**, nao deste crate. E um acessor declarado num corpo de classe
continua enumeravel: o mesmo ponto de entrada serve um literal de objecto, onde
ele *deve* ser enumeravel, portanto a correccao precisa que o emissor diga qual
dos dois e.

486 testes unitarios verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn