### PR TITLE
fix: cinco defeitos, quatro deles so resoluveis desde que existe a contagem de argumentos

### DIFF
--- a/crates/rts-codegen/src/emit/foreach.rs
+++ b/crates/rts-codegen/src/emit/foreach.rs
@@ -744,26 +744,37 @@ pub(super) fn close_iterator_stmt(
 
     let return_name = ctx.names.intern("return");
     let return_member = member_expr(ident(iterator, at), return_name, at);
-    let is_callable = Expr {
-        kind: ExprKind::Binary {
-            op: BinaryOp::StrictEqual,
-            left: Box::new(Expr {
-                kind: ExprKind::Unary {
-                    op: UnaryOp::TypeOf,
-                    operand: Box::new(return_member.clone()),
-                },
-                at,
-            }),
-            right: Box::new(text_expr("function", at)),
-        },
-        at,
-    };
+    // `it.return?.()` — an OPTIONAL call, which is `GetMethod` exactly.
+    //
+    // It was `typeof it.return === "function"` followed by `it.return()`, and
+    // the member expression was CLONED between the two — so the property was
+    // read twice. For an ordinary method that is invisible; for a `return`
+    // defined as a getter it is not, and an iterator whose `return` counts its
+    // own reads saw two where the language performs one.
+    //
+    // The optional form also gets the refusal right without a second test: it
+    // skips `null` and `undefined`, and throws a `TypeError` for anything else
+    // that is not callable — which is what `GetMethod` says and what the
+    // `typeof` guard silently swallowed. A plain iterator-like object with a
+    // bare `next()` and no `return` still closes without calling anything,
+    // which is the case the guard existed for.
     let called = Expr {
         kind: ExprKind::Call {
             callee: Box::new(return_member),
             arguments: Vec::new(),
-            optional: false,
+            optional: true,
         },
+        at,
+    };
+    // Wrapped in the chain BOUNDARY, which is what makes the `optional` flag do
+    // anything at all. Without it the flag says "this link may skip" with
+    // nowhere to skip TO, and the call happened regardless — six fixtures went
+    // from passing to `TypeError: it.return is not a function` before this line
+    // existed, because every iterator without a `return` was suddenly called.
+    // `ExprKind::Chain`'s own documentation says the flag on a link is only half
+    // of it; this is the other half.
+    let called = Expr {
+        kind: ExprKind::Chain(Box::new(called)),
         at,
     };
     let called = match awaited {
@@ -774,14 +785,7 @@ pub(super) fn close_iterator_stmt(
         },
     };
     let inner = Stmt {
-        kind: StmtKind::If {
-            condition: is_callable,
-            then_branch: Box::new(Stmt {
-                kind: StmtKind::Expr(called),
-                at,
-            }),
-            else_branch: None,
-        },
+        kind: StmtKind::Expr(called),
         at,
     };
     Stmt {

--- a/crates/rts-core/src/entry/array_proto/iterate.rs
+++ b/crates/rts-core/src/entry/array_proto/iterate.rs
@@ -266,7 +266,21 @@ extern "C" fn reduce(_e: u64, this: u64, callback: u64, initial: u64, _a2: u64, 
     let Some(count) = len_of(this) else {
         return nothing();
     };
-    let seeded = !with_current(|context| initial == undefined_of(context));
+    // Whether a seed was PASSED, not whether it is `undefined`.
+    //
+    // `[1].reduce(f, undefined)` has a seed and it is `undefined`; `[1].reduce(f)`
+    // has none and the first element becomes the accumulator. The two are
+    // different programs and comparing against `undefined` answered the same for
+    // both — so an explicit `undefined` seed was silently dropped and the fold
+    // started one element later than the program wrote.
+    //
+    // `arguments_at` is what knows: the call site records how many arguments it
+    // wrote, so the padding the convention adds is distinguishable from a value
+    // the program passed. Its own documentation names this as the thing the
+    // count made possible.
+    let seeded = with_current(|context| {
+        super::arguments_at(context, 0, [callback, initial, initial, initial]).len() >= 2
+    });
     let (mut carried, from) = if seeded {
         (initial, 0)
     } else {

--- a/crates/rts-core/src/entry/array_proto/joining.rs
+++ b/crates/rts-core/src/entry/array_proto/joining.rs
@@ -49,7 +49,17 @@ pub(super) extern "C" fn join(
     // what it expects.
     let separator = super::super::primitive::to_primitive(separator, crate::coerce::Hint::String);
     let staged = with_current(|context| {
-        let (_, elements) = staged(context, this)?;
+        // Generic over an array-LIKE, the same fallback `at` and `slice` take.
+        // The specification defines `join` over `LengthOfArrayLike(ToObject(this))`
+        // and never asks whether the receiver is an Array, so
+        // `Array.prototype.join.call({length: 2, 0: "a", 1: "b"}, "-")` is
+        // `"a-b"` — and it answered `undefined` here for every receiver that was
+        // not a real array. That is the spelling `Array.prototype.toString`
+        // reaches for a non-array receiver, so the two were wrong together.
+        let elements = match staged(context, this) {
+            Some((_, elements)) => elements,
+            None => super::array_like(context, this)?,
+        };
         // O buraco vira `undefined` AQUI, dentro do mesmo empréstimo que leu os
         // elementos. Sem isto ele escapava ao conjunto `empty` de baixo — que
         // tem `undefined` e `null` e não tinha como listar um terceiro word —

--- a/crates/rts-core/src/entry/array_proto/more/mod.rs
+++ b/crates/rts-core/src/entry/array_proto/more/mod.rs
@@ -372,8 +372,15 @@ extern "C" fn flat_map(
 
 
 /// `a.toReversed()` — a new array, where `reverse` mutates.
+///
+/// Reads with [`seen`] and not [`snapshot`], which is the whole difference
+/// between this and `reverse`: the ES2023 copying methods are defined with
+/// `Get`, not `HasProperty`, so a HOLE in the source becomes an own `undefined`
+/// in the result. `[0, , 2].toReversed()` has three own indices where
+/// `[0, , 2].reverse()` still has two — and this answered the second shape,
+/// carrying the hole across into an array the language says has none.
 extern "C" fn to_reversed(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
-    match snapshot(this) {
+    match seen(this) {
         Some(mut elements) => {
             elements.reverse();
             built(elements)

--- a/crates/rts-core/src/entry/array_proto/more/splice.rs
+++ b/crates/rts-core/src/entry/array_proto/more/splice.rs
@@ -10,7 +10,7 @@ use super::super::super::objects::undefined_of;
 use super::super::super::string::{absent, relative};
 use super::super::super::with_current;
 use super::super::{built, staged, store};
-use super::{nothing, snapshot};
+use super::nothing;
 use crate::value::Value;
 
 /// `a.splice(start, count, x, y)` — removes, inserts, answers what it removed.
@@ -26,9 +26,19 @@ use crate::value::Value;
 pub(super) extern "C" fn splice(_e: u64, this: u64, start: u64, count: u64, x: u64, y: u64) -> u64 {
     let removed = with_current(|context| {
         let (cell, mut elements) = staged(context, this)?;
+        // How many arguments the SITE wrote, which is what decides the deletion
+        // and cannot be read off the values: `a.splice()` deletes NOTHING and
+        // `a.splice(0)` deletes everything from zero, yet both arrive here with
+        // `start` and `count` padded to `undefined`. Comparing against
+        // `undefined` answered "delete to the end" for both, so `a.splice()`
+        // emptied the array — the most destructive possible reading of a call
+        // that asks for nothing.
+        let written = super::super::arguments_at(context, 0, [start, count, x, y]).len();
         let from = relative(Value(start).numeric().unwrap_or(0.0), elements.len());
         let left = (elements.len() - from) as f64;
-        let taken = if absent(context, count) {
+        let taken = if written == 0 {
+            0
+        } else if absent(context, count) {
             left as usize
         } else {
             Value(count).numeric().unwrap_or(0.0).clamp(0.0, left) as usize
@@ -67,7 +77,14 @@ pub(super) extern "C" fn splice(_e: u64, this: u64, start: u64, count: u64, x: u
 /// passes the same array twice.
 pub(super) extern "C" fn to_spliced(_e: u64, this: u64, start: u64, count: u64, x: u64, a3: u64) -> u64 {
     let spliced = with_current(|context| {
-        let (_, mut elements) = staged(context, this)?;
+        // Every hole materialised, the same rule `with` and `toReversed` follow:
+        // a copying method reads its source with `Get`, so the result has an own
+        // `undefined` where the source had nothing.
+        let (_, elements) = staged(context, this)?;
+        let mut elements: Vec<u64> = elements
+            .iter()
+            .map(|held| super::super::super::array::visible(context, *held))
+            .collect();
         let from = relative(Value(start).numeric().unwrap_or(0.0), elements.len());
         let left = (elements.len() - from) as f64;
         // An absent count removes to the end, for the reason `splice` records:
@@ -95,7 +112,10 @@ pub(super) extern "C" fn to_spliced(_e: u64, this: u64, start: u64, count: u64, 
 /// Answering the unchanged copy was rejected: that is a wrong program that
 /// keeps running, where this one fails at the next use of the result.
 pub(super) extern "C" fn with(_e: u64, this: u64, index: u64, value: u64, _a2: u64, _a3: u64) -> u64 {
-    let Some(mut elements) = snapshot(this) else {
+    // `seen` and not `snapshot`: the ES2023 copying methods read the source with
+    // `Get`, so a HOLE becomes an own `undefined` in the copy. `[1, , 3].with(0, 9)`
+    // has three own indices, and carrying the hole across made it have two.
+    let Some(mut elements) = super::seen(this) else {
         return nothing();
     };
     let asked = Value(index).numeric().unwrap_or(f64::NAN);


### PR DESCRIPTION
| | pass / alcancavel |
|---|---|
| antes | 1170 / 1510 (77.5%) |
| depois | 1173 / 1511 (**77.6%**) |

**GANHOS 2, PERDAS 0**, contra um binario do `main` guardado antes da primeira
edicao, comparado por ficheiro.

## Primeiro: o que ja estava resolvido

Duas correccoes que eu tinha pendentes — a validacao do token de
`FinalizationRegistry` e a pergunta "este simbolo esta registado" — foram
**descartadas**: o `da9ddd21` ja as trazia, e melhor, com um
`weak::holdable_in` e um `symbol::is_registered` partilhados pelas quatro
coleccoes fracas. Escrever as minhas por cima teria sido a segunda resposta a
uma pergunta que passou a ter uma.

## 1. O fecho do iterador lia `return` duas vezes

Era `typeof it.return === "function"` seguido de `it.return()`, com a expressao
de membro **clonada** entre os dois. Para um metodo vulgar e invisivel; para um
`return` que e um getter nao e.

Passa a `it.return?.()`, que e o `GetMethod` exacto: le uma vez, salta `null` e
`undefined`, e lanca `TypeError` para o resto nao-chamavel — que a guarda
`typeof` engolia.

**A fronteira e obrigatoria, e custou seis ficheiros a descobrir.** Um
`Call { optional: true }` sozinho nao salta nada: a flag diz "esta ligacao pode
saltar" e sem `ExprKind::Chain` a envolver nao ha para onde. Sem ela, todo o
iterador sem `return` passou a ser **chamado**, e cinco ficheiros de generators
ofuscados mais um de destructuring sairam de `pass` para
`TypeError: it.return is not a function`.

## 2. `Array.prototype.join` nao era generico

`Array.prototype.join.call({length: 2, 0: "a", 1: "b"}, "-")` respondia
`undefined`. E a soletracao que `Array.prototype.toString` alcanca para um
receptor nao-array, portanto os dois estavam errados juntos.

## 3. `toReversed`, `with` e `toSpliced` carregavam os buracos

Os metodos copiadores de ES2023 leem com `Get`, portanto um buraco vira um
`undefined` **proprio** na copia. `[0, , 2].toReversed()` tem tres indices
proprios; este respondia dois.

## 4 e 5. Os dois que so agora sao resoluveis

`reduce(f, undefined)` deitava a semente fora, e `a.splice()` **esvaziava o
array** — a leitura mais destrutiva possivel de uma chamada que nao pede nada.

Ha uma semana escrevi que distinguir `splice()` de `splice(undefined)` precisa da
**contagem** de argumentos e que a ABI nao a carregava. Carrega: o
`call_counted` que entrou entretanto grava quantos argumentos o sitio escreveu, e
`arguments_at` sabe cortar as quatro ranhuras no sitio certo em vez de no ultimo
nao-`undefined`. A documentacao dele nomeia isto como o que a contagem tornou
possivel — foi so preciso ir la buscar.

490 testes unitarios verdes.

## O que fica, verificado neste binario

Um acessor de corpo de classe continua enumeravel; `+sym` e `sym | 0` respondem
`NaN` e `0`; a species de subclasse nao chega ao `flat`; um construtor derivado
que devolve um primitivo nao lanca; a leitura de um campo privado nao verifica a
marca do receptor. O fecho do iterador num `throw` tambem fica: precisa de um
`try` sintetico a envolver o laco, e a documentacao do `foreach` nomeia o custo —
a analise de captura decide que nomes vao para o heap **antes** de essas
instrucoes existirem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wXZQ9XaiUkRkvvESR3UEn