### PR TITLE
perf: cache disposable layout measurements by local epoch

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -25,7 +25,7 @@
 //! teste unitário determinístico (`cargo test -p rts-egui`), SEM abrir janela:
 //! compara-se o `dump()` (ou a estrutura) com o esperado. Ver `#[cfg(test)]`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::html::{tokenize, Token};
@@ -225,12 +225,16 @@ pub struct Dom {
     /// (pré-pass de medição + pintura + intrínsecas). Invalidado quando a revisão
     /// muda. `RefCell` porque `computed_style_idx` é `&self` (chamado do layout).
     computed_memo: std::cell::RefCell<HashMap<NodeIdx, crate::style::ComputedStyle>>,
-    /// A revisão de render em que o `computed_memo` foi preenchido.
+    /// O epoch de animação em que o `computed_memo` foi preenchido. Mutações locais
+    /// de conteúdo não invalidam esse cache; animações continuam invalidando o estilo
+    /// final interpolado.
     memo_revision: std::cell::Cell<u64>,
+    /// O epoch global de estilos em que o `computed_memo` foi preenchido.
+    memo_style_epoch: std::cell::Cell<u64>,
     /// Memo do ALVO-BASE (cascade SEM a camada de animação, `with_anim=false`) que o
-    /// `advance` consulta por nó a cada frame. Invalida só pela revisão ESTRUTURAL
-    /// (`revision`+viewport+style_epoch, SEM o `anim_epoch`) — então frames de
-    /// animação (que só bumpam `anim_epoch`) o REUSAM, tornando o `advance` barato.
+    /// `advance` consulta por nó a cada frame. Invalida por epoch global de estilo,
+    /// viewport ou dirty bit local — então frames de animação que só bumpam
+    /// `anim_epoch` o REUSAM, tornando o `advance` barato.
     base_memo: std::cell::RefCell<HashMap<NodeIdx, crate::style::ComputedStyle>>,
     /// A revisão estrutural em que o `base_memo` foi preenchido.
     base_memo_revision: std::cell::Cell<u64>,
@@ -298,6 +302,7 @@ impl Dom {
             anim_epoch: 0,
             computed_memo: std::cell::RefCell::new(HashMap::new()),
             memo_revision: std::cell::Cell::new(0),
+            memo_style_epoch: std::cell::Cell::new(crate::style::props::style_epoch()),
             base_memo: std::cell::RefCell::new(HashMap::new()),
             base_memo_revision: std::cell::Cell::new(u64::MAX),
             base_memo_viewport: std::cell::Cell::new((0, 0)),
@@ -403,11 +408,56 @@ impl Dom {
         self.viewport.set((w, h));
     }
 
-    /// Marca que ALGO que afeta o render mudou (bumpa a revisão). Chamado por todo
-    /// método mutador de árvore/atributo/texto/estilo/animação. Barato (u64 += 1);
-    /// um bump espúrio (mutação que falhou a validação) só invalida cache à toa.
+    /// Marca uma mudança global de estilo/estrutura: invalida os memos de todos os
+    /// nós. É o fallback seguro para mudanças de stylesheet, estrutura ou regras que
+    /// podem atravessar a árvore.
     fn touch(&mut self) {
         self.revision = self.revision.wrapping_add(1);
+        self.computed_memo.borrow_mut().clear();
+        self.base_memo.borrow_mut().clear();
+    }
+
+    /// Marca uma mudança que altera pixels/geometria, mas não o estilo computado.
+    /// O cache de cascade pode continuar válido para o próximo layout.
+    fn touch_render_only(&mut self) {
+        self.revision = self.revision.wrapping_add(1);
+    }
+
+    /// Invalida estilo apenas no nó e em seus descendentes. É seguro para `style=""`
+    /// e overrides locais porque a mudança pode afetar propriedades herdadas.
+    fn touch_subtree(&mut self, idx: NodeIdx) {
+        self.revision = self.revision.wrapping_add(1);
+        let mut stack = vec![idx];
+        let mut computed = self.computed_memo.borrow_mut();
+        let mut base = self.base_memo.borrow_mut();
+        while let Some(node) = stack.pop() {
+            computed.remove(&node);
+            base.remove(&node);
+            stack.extend(self.nodes[node].children.iter().copied());
+        }
+    }
+
+    /// Invalida várias subárvores em uma única revisão. É o equivalente local ao
+    /// batching de invalidation sets dos browsers: sobreposições são deduplicadas e
+    /// os caches só sofrem uma operação de escrita por lote.
+    fn touch_subtrees<I>(&mut self, roots: I)
+    where
+        I: IntoIterator<Item = NodeIdx>,
+    {
+        self.revision = self.revision.wrapping_add(1);
+        let mut affected = HashSet::new();
+        let mut stack: Vec<NodeIdx> = roots.into_iter().collect();
+        while let Some(node) = stack.pop() {
+            if affected.insert(node) {
+                stack.extend(self.nodes[node].children.iter().copied());
+            }
+        }
+        let mut computed = self.computed_memo.borrow_mut();
+        let mut base = self.base_memo.borrow_mut();
+        for node in affected {
+            computed.remove(&node);
+            base.remove(&node);
+        }
     }
 
     /// A revisão de RENDER desta árvore: muda sempre que árvore/estilo/animação
@@ -428,13 +478,6 @@ impl Dom {
         address.rotate_left(17) ^ self.generation as u64
     }
 
-    /// A revisão ESTRUTURAL: muda com árvore/atributo/estilo/viewport (o que altera o
-    /// ALVO-BASE da cascade), mas NÃO com a interpolação de animação (`anim_epoch`).
-    /// É a chave do `base_memo` — o que o `advance` reusa entre frames de animação.
-    fn struct_revision(&self) -> u64 {
-        self.revision.wrapping_add(crate::style::props::style_epoch())
-    }
-
     /// Bumpa SÓ o epoch de animação (invalida o layout p/ re-pintar a interpolação),
     /// sem tocar a revisão estrutural — o `advance` chama isto por frame no lugar de
     /// `touch()`, para o `base_memo` sobreviver ao frame.
@@ -447,12 +490,12 @@ impl Dom {
     /// estrutural estável) é um hit de cache — a cascade não re-roda. `None` p/
     /// não-elemento.
     fn base_style_idx(&self, idx: NodeIdx) -> Option<crate::style::ComputedStyle> {
-        let rev = self.struct_revision();
+        let style_epoch = crate::style::props::style_epoch();
         let (vw, vh) = self.viewport.get();
         let vp_key = (vw.to_bits(), vh.to_bits());
-        if self.base_memo_revision.get() != rev || self.base_memo_viewport.get() != vp_key {
+        if self.base_memo_revision.get() != style_epoch || self.base_memo_viewport.get() != vp_key {
             self.base_memo.borrow_mut().clear();
-            self.base_memo_revision.set(rev);
+            self.base_memo_revision.set(style_epoch);
             self.base_memo_viewport.set(vp_key);
         }
         if let Some(hit) = self.base_memo.borrow().get(&idx) {
@@ -685,11 +728,11 @@ impl Dom {
     /// Substitui TODO o conteúdo de um elemento por um único nó de texto (o
     /// equivalente a `element.textContent = txt`). Não faz nada num nó de texto.
     pub fn set_text(&mut self, id: NodeId, text: &str) {
-        self.touch();
         let Some(idx) = self.resolve(id) else { return };
         if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
             return;
         }
+        self.touch_render_only();
         // Descarta os filhos atuais (arena não compacta; vira lixo inacessível —
         // ok para o uso atual, a árvore é reconstruída a cada `html()`). Zera o
         // `parent` de cada um para `is_attached`/query não os acharem.
@@ -725,12 +768,17 @@ impl Dom {
         // é determinística — e o layout a consulta várias vezes por nó (medição +
         // pintura). Um clone do ComputedStyle é muito mais barato que re-rodar
         // todas as regras do stylesheet (Bootstrap: ~2700).
-        let rev = self.render_revision();
+        let anim_epoch = self.anim_epoch;
+        let style_epoch = crate::style::props::style_epoch();
         let (vw, vh) = self.viewport.get();
         let vp_key = (vw.to_bits(), vh.to_bits());
-        if self.memo_revision.get() != rev || self.memo_viewport.get() != vp_key {
+        if self.memo_revision.get() != anim_epoch
+            || self.memo_style_epoch.get() != style_epoch
+            || self.memo_viewport.get() != vp_key
+        {
             self.computed_memo.borrow_mut().clear();
-            self.memo_revision.set(rev);
+            self.memo_revision.set(anim_epoch);
+            self.memo_style_epoch.set(style_epoch);
             self.memo_viewport.set(vp_key);
         }
         if let Some(hit) = self.computed_memo.borrow().get(&idx) {
@@ -1248,10 +1296,9 @@ impl Dom {
     /// val)` é interpretado pelo `apply_slot` do `ComputedStyle` (nunca casa string
     /// CSS aqui). Ignora id que não resolve.
     pub fn set_node_style_slot(&mut self, id: NodeId, slot: i64, val: i64) {
-        self.touch();
-        if let Some(idx) = self.resolve(id) {
-            self.style_overrides.entry(idx).or_default().apply_slot(slot, val);
-        }
+        let Some(idx) = self.resolve(id) else { return };
+        self.touch_subtree(idx);
+        self.style_overrides.entry(idx).or_default().apply_slot(slot, val);
     }
 
     /// Aplica um LOTE de triplas `(nodeId, slot, val)` de uma vez (invariante 6:
@@ -1260,11 +1307,20 @@ impl Dom {
     /// slot1, val1, …]` (o jeito que o buffer GC chega da ABI). Triplas com id
     /// inválido são ignoradas (robustez).
     pub fn apply_style_batch(&mut self, triples: &[i64]) {
-        self.touch();
+        let mut updates = Vec::with_capacity(triples.len() / 3);
         for t in triples.chunks_exact(3) {
             if let Some(node) = NodeId::from_abi(t[0]) {
-                self.set_node_style_slot(node, t[1], t[2]);
+                if let Some(idx) = self.resolve(node) {
+                    updates.push((idx, t[1], t[2]));
+                }
             }
+        }
+        if updates.is_empty() {
+            return;
+        }
+        self.touch_subtrees(updates.iter().map(|(idx, _, _)| *idx));
+        for (idx, slot, val) in updates {
+            self.style_overrides.entry(idx).or_default().apply_slot(slot, val);
         }
     }
 
@@ -1711,7 +1767,14 @@ impl Dom {
         else {
             return;
         };
-        self.touch();
+        let affects_parent_selectors =
+            matches!(name_lc.as_str(), "id" | "class") || self.stylesheet.has_attribute_selectors();
+        let dirty_root = if affects_parent_selectors {
+            self.nodes[idx].parent.unwrap_or(idx)
+        } else {
+            idx
+        };
+        self.touch_subtree(dirty_root);
         self.nodes[idx].attrs.retain(|a| a.name != name_lc);
         // Limpa somente os buckets que o atributo removido ocupava.
         match name_lc.as_str() {
@@ -2002,8 +2065,15 @@ impl Dom {
         {
             return;
         }
-        self.touch();
         let affects_index = matches!(name_lc.as_str(), "id" | "class");
+        let affects_parent_selectors =
+            affects_index || self.stylesheet.has_attribute_selectors();
+        let dirty_root = if affects_parent_selectors {
+            self.nodes[idx].parent.unwrap_or(idx)
+        } else {
+            idx
+        };
+        self.touch_subtree(dirty_root);
         if affects_index {
             self.deindex_node(idx);
         }
@@ -2706,6 +2776,101 @@ mod tests {
         assert_eq!(dom2.computed_style(c).unwrap().color, Some(0x0000FFFF)); // inline
         dom2.set_node_style_slot(c, SLOT_COLOR, 0xFF0000FF);
         assert_eq!(dom2.computed_style(c).unwrap().color, Some(0xFF0000FF)); // override vence
+    }
+
+    #[test]
+    fn dirty_bits_invalidam_apenas_subarvore_local() {
+        let mut dom = parse_html_to_dom("<div><p id='a'>a</p><p id='b'>b</p></div>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        let a_idx = idx(&dom, a);
+        let b_idx = idx(&dom, b);
+
+        // Preenche os dois memos antes da mutação.
+        let _ = dom.computed_style(a);
+        let _ = dom.computed_style(b);
+        assert!(dom.computed_memo.borrow().contains_key(&a_idx));
+        assert!(dom.computed_memo.borrow().contains_key(&b_idx));
+
+        let before_noop = dom.render_revision();
+        dom.set_attr(a, "data-state", "on");
+        assert_ne!(dom.render_revision(), before_noop);
+        assert!(!dom.computed_memo.borrow().contains_key(&a_idx));
+        assert!(dom.computed_memo.borrow().contains_key(&b_idx));
+
+        // Repetir o mesmo setAttribute é um no-op e não cria nova invalidação.
+        let before_repeat = dom.render_revision();
+        dom.set_attr(a, "data-state", "on");
+        assert_eq!(dom.render_revision(), before_repeat);
+    }
+
+    #[test]
+    fn atributo_invalida_irmaos_quando_usado_em_seletor() {
+        let mut dom = parse_html_to_dom(
+            "<style>[data-state='on'] + p { color:#ff0000 }</style>\
+             <div><p id='first'>a</p><p id='second'>b</p></div>",
+        );
+        let first = dom.query("#first").unwrap();
+        let second = dom.query("#second").unwrap();
+        assert_eq!(dom.computed_style(second).unwrap().color, None);
+
+        dom.set_attr(first, "data-state", "on");
+        assert_eq!(dom.computed_style(second).unwrap().color, Some(0xFF0000FF));
+    }
+
+    #[test]
+    fn classe_no_pai_invalida_descendentes_herdados() {
+        let mut dom = parse_html_to_dom(
+            "<style>.hot { color:#ff0000 }</style><div id='parent'><p id='child'>x</p></div>",
+        );
+        let parent = dom.query("#parent").unwrap();
+        let child = dom.query("#child").unwrap();
+        assert_eq!(dom.computed_style(child).unwrap().color, None);
+
+        dom.set_attr(parent, "class", "hot");
+        assert_eq!(dom.computed_style(child).unwrap().color, Some(0xFF0000FF));
+    }
+
+    #[test]
+    fn stylesheet_invalida_todos_os_memos() {
+        let mut dom = parse_html_to_dom("<p id='a'>a</p><p id='b'>b</p>");
+        let a = dom.query("#a").unwrap();
+        let b = dom.query("#b").unwrap();
+        let _ = dom.computed_style(a);
+        let _ = dom.computed_style(b);
+        assert!(!dom.computed_memo.borrow().is_empty());
+        assert!(!dom.base_memo.borrow().is_empty());
+
+        dom.add_stylesheet("p { color:#0000ff }");
+        assert!(dom.computed_memo.borrow().is_empty());
+        assert!(dom.base_memo.borrow().is_empty());
+        assert_eq!(dom.computed_style(a).unwrap().color, Some(0x0000FFFF));
+        assert_eq!(dom.computed_style(b).unwrap().color, Some(0x0000FFFF));
+    }
+
+    #[test]
+    fn animacao_preserva_memo_base_entre_frames() {
+        let mut dom = parse_html_to_dom(
+            "<style>@keyframes pulse { from { opacity:0 } to { opacity:1 } } \
+             #a { animation:pulse 100ms infinite linear }</style><p id='a'>x</p>",
+        );
+        let node = dom.query("#a").unwrap();
+        let node_idx = idx(&dom, node);
+
+        assert!(dom.advance(0.0));
+        let base_revision = dom.base_memo_revision.get();
+        let base_before = dom.base_memo.borrow().get(&node_idx).cloned();
+        assert!(base_before.is_some());
+        let _ = dom.computed_style(node);
+        assert!(dom.computed_memo.borrow().contains_key(&node_idx));
+
+        assert!(dom.advance(50.0));
+        assert_eq!(dom.base_memo_revision.get(), base_revision);
+        assert_eq!(dom.base_memo.borrow().get(&node_idx), base_before.as_ref());
+        // O epoch de animação muda, portanto o memo interpolado é recalculado sob
+        // demanda; o alvo-base continua sendo o mesmo objeto lógico.
+        let _ = dom.computed_style(node);
+        assert!(dom.computed_memo.borrow().contains_key(&node_idx));
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -517,14 +517,37 @@ impl Dom {
 
     /// Registra um nó nos índices a partir de seus atributos `id`/`class`.
     fn deindex_node(&mut self, id: NodeIdx) {
-        self.id_index.retain(|_, v| {
-            v.retain(|&x| x != id);
-            !v.is_empty()
-        });
-        for v in self.class_index.values_mut() {
-            v.retain(|&x| x != id);
+        let old_id = self.nodes[id].attr("id").map(str::to_owned);
+        let old_classes: Vec<String> = self.nodes[id]
+            .attr("class")
+            .map(|value| value.split_whitespace().map(str::to_owned).collect())
+            .unwrap_or_default();
+        if let Some(key) = old_id {
+            if let Some(bucket) = self.id_index.get_mut(&key) {
+                bucket.retain(|&x| x != id);
+                if bucket.is_empty() {
+                    self.id_index.remove(&key);
+                }
+            }
         }
-        self.class_index.retain(|_, v| !v.is_empty());
+        for key in old_classes {
+            if let Some(bucket) = self.class_index.get_mut(&key) {
+                bucket.retain(|&x| x != id);
+                if bucket.is_empty() {
+                    self.class_index.remove(&key);
+                }
+            }
+        }
+    }
+
+    fn remove_index_key(&mut self, key: &str, id: NodeIdx, is_id: bool) {
+        let index = if is_id { &mut self.id_index } else { &mut self.class_index };
+        if let Some(bucket) = index.get_mut(key) {
+            bucket.retain(|&x| x != id);
+            if bucket.is_empty() {
+                index.remove(key);
+            }
+        }
     }
 
     fn index_node(&mut self, id: NodeIdx) {
@@ -918,7 +941,6 @@ impl Dom {
 
     /// `el.style.cssText = v` (set) — substitui o `style=""` inteiro.
     pub fn set_css_text(&mut self, id: NodeId, text: &str) {
-        self.touch();
         self.set_attr(id, "style", text);
     }
 
@@ -926,7 +948,6 @@ impl Dom {
     /// inline, preservando as demais. Re-serializa a string `style`. Valor vazio
     /// REMOVE a propriedade (como `removeProperty`).
     pub fn set_style_property(&mut self, id: NodeId, name: &str, value: &str) {
-        self.touch();
         let cur = self.css_text(id);
         let new = upsert_css_decl(&cur, name.trim(), value.trim());
         self.set_attr(id, "style", &new);
@@ -934,7 +955,6 @@ impl Dom {
 
     /// `el.style.removeProperty(name)` — remove a propriedade do `style=""`.
     pub fn remove_style_property(&mut self, id: NodeId, name: &str) {
-        self.touch();
         let cur = self.css_text(id);
         let new = upsert_css_decl(&cur, name.trim(), ""); // valor vazio = remover
         self.set_attr(id, "style", &new);
@@ -1466,8 +1486,10 @@ impl Dom {
     fn collect_by_classes(&self, idx: NodeIdx, wanted: &[&str], out: &mut Vec<NodeId>) {
         if idx != self.root {
             if let Some(class_attr) = self.nodes[idx].attr("class") {
-                let have: Vec<&str> = class_attr.split_whitespace().collect();
-                if wanted.iter().all(|w| have.contains(w)) {
+                if wanted
+                    .iter()
+                    .all(|wanted_class| class_attr.split_whitespace().any(|class| class == *wanted_class))
+                {
                     out.push(self.make_id(idx));
                 }
             }
@@ -1679,22 +1701,24 @@ impl Dom {
     /// `element.removeAttribute(name)`: remove o atributo (no-op se ausente).
     /// Limpa os índices id/class para o nó (a busca revalida, mas evita stale).
     pub fn remove_attr(&mut self, id: NodeId, name: &str) {
-        self.touch();
         let Some(idx) = self.resolve(id) else { return };
         let name_lc = name.to_ascii_lowercase();
+        let Some(old_value) = self.nodes[idx]
+            .attrs
+            .iter()
+            .find(|a| a.name == name_lc)
+            .map(|a| a.value.clone())
+        else {
+            return;
+        };
+        self.touch();
         self.nodes[idx].attrs.retain(|a| a.name != name_lc);
-        // limpa o índice correspondente (entradas stale são toleradas, mas
-        // remover ajuda a manter o índice enxuto).
+        // Limpa somente os buckets que o atributo removido ocupava.
         match name_lc.as_str() {
-            "id" => {
-                self.id_index.retain(|_, v| {
-                    v.retain(|&x| x != idx);
-                    !v.is_empty()
-                });
-            }
+            "id" => self.remove_index_key(&old_value, idx, true),
             "class" => {
-                for v in self.class_index.values_mut() {
-                    v.retain(|&x| x != idx);
+                for class in old_value.split_whitespace() {
+                    self.remove_index_key(class, idx, false);
                 }
             }
             _ => {}
@@ -1968,9 +1992,17 @@ impl Dom {
     /// Define/atualiza um atributo (`element.setAttribute`). Cria se não existir.
     /// Reindexa `id`/`class` para que mudanças de valor não deixem candidatos stale.
     pub fn set_attr(&mut self, id: NodeId, name: &str, value: &str) {
-        self.touch();
         let Some(idx) = self.resolve(id) else { return };
         let name_lc = name.to_ascii_lowercase();
+        if self.nodes[idx]
+            .attrs
+            .iter()
+            .find(|a| a.name == name_lc)
+            .is_some_and(|a| a.value == value)
+        {
+            return;
+        }
+        self.touch();
         let affects_index = matches!(name_lc.as_str(), "id" | "class");
         if affects_index {
             self.deindex_node(idx);
@@ -2892,6 +2924,19 @@ mod tests {
         let r2 = dom.render_revision();
         crate::style::define_style("tag_rev_teste", crate::style::SLOT_COLOR, 0x11223344);
         assert_ne!(dom.render_revision(), r2, "defineStyle bumpa o epoch global");
+    }
+
+    #[test]
+    fn no_op_mutations_nao_invalidam_layout() {
+        let mut dom = parse_html_to_dom("<div id='a' style='color:#fff'>x</div>");
+        let a = dom.query("#a").unwrap();
+        let r0 = dom.render_revision();
+        dom.set_attr(a, "style", "color:#fff");
+        assert_eq!(dom.render_revision(), r0, "set_attr igual deve ser no-op");
+        dom.remove_attr(a, "data-ausente");
+        assert_eq!(dom.render_revision(), r0, "remove_attr ausente deve ser no-op");
+        dom.set_css_text(a, "color:#fff");
+        assert_eq!(dom.render_revision(), r0, "set_css_text igual deve ser no-op");
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -34,6 +34,24 @@ use crate::html::{tokenize, Token};
 /// cruza a fronteira (TS/ABI) é sempre o `NodeId` VERSIONADO, nunca este índice.
 pub type NodeIdx = usize;
 
+/// Chave de uma medição de layout descartável. O cache guarda apenas `(outer_w,
+/// outer_h)`, nunca itens de pintura; por isso a posição `(x,y)` não participa.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct LayoutMeasureKey {
+    pub(crate) tree: u64,
+    pub(crate) node_epoch: u64,
+    pub(crate) style_epoch: u64,
+    pub(crate) node: NodeIdx,
+    pub(crate) avail_w: u32,
+    pub(crate) avail_h: Option<u32>,
+    pub(crate) forced_outer_w: Option<u32>,
+    pub(crate) forced_outer_h: Option<u32>,
+    pub(crate) shrink_to_fit: bool,
+    pub(crate) viewport_w: u32,
+    pub(crate) viewport_h: u32,
+    pub(crate) measurer: u64,
+}
+
 /// Contador global de gerações de árvore. Cada `Dom` novo (parse ou vazio) toma a
 /// próxima geração; assim duas árvores nunca colidem e um `NodeId` de uma árvore
 /// velha é detectável como stale na árvore atual.
@@ -239,9 +257,16 @@ pub struct Dom {
     /// A revisão estrutural em que o `base_memo` foi preenchido.
     base_memo_revision: std::cell::Cell<u64>,
     base_memo_viewport: std::cell::Cell<(u32, u32)>,
+    /// Cache derivado de medições de bloco feitas em listas descartáveis durante
+    /// flex/grid/inline-block/out-of-flow. É limpo em qualquer mutação visual para
+    /// não reutilizar tamanho sob estilo ou conteúdo stale.
+    layout_measure_cache: std::cell::RefCell<HashMap<LayoutMeasureKey, (f32, f32)>>,
+    /// Epoch local de geometria. Filhos e ancestrais são incrementados quando uma
+    /// mutação pode alterar seu tamanho; irmãos independentes mantêm o valor.
+    layout_epochs: Vec<u64>,
     /// O VIEWPORT corrente (w, h) — setado pelo layout no início da passada
     /// ([`set_viewport`](Dom::set_viewport)); a base de `vw`/`vh` na cascade
-    /// (font-size fluido) e do `@media` futuro. Default 1280×800 (headless).
+    /// (font-size fluido/calc) e do `@media` futuro. Default 1280×800 (headless).
     viewport: std::cell::Cell<(f32, f32)>,
     /// O viewport com que o `computed_memo` foi preenchido (o computed depende
     /// dele via vw/vh) — muda → memo invalida.
@@ -306,6 +331,8 @@ impl Dom {
             base_memo: std::cell::RefCell::new(HashMap::new()),
             base_memo_revision: std::cell::Cell::new(u64::MAX),
             base_memo_viewport: std::cell::Cell::new((0, 0)),
+            layout_measure_cache: std::cell::RefCell::new(HashMap::new()),
+            layout_epochs: vec![0],
             viewport: std::cell::Cell::new((1280.0, 800.0)),
             memo_viewport: std::cell::Cell::new((1280.0f32.to_bits(), 800.0f32.to_bits())),
             input_values: HashMap::new(),
@@ -415,25 +442,38 @@ impl Dom {
         self.revision = self.revision.wrapping_add(1);
         self.computed_memo.borrow_mut().clear();
         self.base_memo.borrow_mut().clear();
+        self.layout_measure_cache.borrow_mut().clear();
     }
 
     /// Marca uma mudança que altera pixels/geometria, mas não o estilo computado.
     /// O cache de cascade pode continuar válido para o próximo layout.
     fn touch_render_only(&mut self) {
         self.revision = self.revision.wrapping_add(1);
+        self.layout_measure_cache.borrow_mut().clear();
     }
 
     /// Invalida estilo apenas no nó e em seus descendentes. É seguro para `style=""`
     /// e overrides locais porque a mudança pode afetar propriedades herdadas.
     fn touch_subtree(&mut self, idx: NodeIdx) {
         self.revision = self.revision.wrapping_add(1);
+        let mut affected = HashSet::new();
         let mut stack = vec![idx];
+        while let Some(node) = stack.pop() {
+            if affected.insert(node) {
+                stack.extend(self.nodes[node].children.iter().copied());
+            }
+        }
         let mut computed = self.computed_memo.borrow_mut();
         let mut base = self.base_memo.borrow_mut();
-        while let Some(node) = stack.pop() {
+        for &node in &affected {
             computed.remove(&node);
             base.remove(&node);
-            stack.extend(self.nodes[node].children.iter().copied());
+            self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+        }
+        let mut ancestor = self.nodes[idx].parent;
+        while let Some(node) = ancestor {
+            self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+            ancestor = self.nodes[node].parent;
         }
     }
 
@@ -445,11 +485,20 @@ impl Dom {
         I: IntoIterator<Item = NodeIdx>,
     {
         self.revision = self.revision.wrapping_add(1);
+        let roots: Vec<NodeIdx> = roots.into_iter().collect();
         let mut affected = HashSet::new();
-        let mut stack: Vec<NodeIdx> = roots.into_iter().collect();
+        let mut stack = roots.clone();
         while let Some(node) = stack.pop() {
             if affected.insert(node) {
                 stack.extend(self.nodes[node].children.iter().copied());
+            }
+        }
+        let mut ancestors = HashSet::new();
+        for root in roots {
+            let mut ancestor = self.nodes[root].parent;
+            while let Some(node) = ancestor {
+                ancestors.insert(node);
+                ancestor = self.nodes[node].parent;
             }
         }
         let mut computed = self.computed_memo.borrow_mut();
@@ -457,7 +506,29 @@ impl Dom {
         for node in affected {
             computed.remove(&node);
             base.remove(&node);
+            self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
         }
+        for node in ancestors {
+            self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+        }
+    }
+
+    pub(crate) fn layout_epoch(&self, idx: NodeIdx) -> u64 {
+        self.layout_epochs[idx]
+    }
+
+    pub(crate) fn layout_measure_get(&self, key: LayoutMeasureKey) -> Option<(f32, f32)> {
+        self.layout_measure_cache.borrow().get(&key).copied()
+    }
+
+    pub(crate) fn layout_measure_put(&self, key: LayoutMeasureKey, value: (f32, f32)) {
+        let mut cache = self.layout_measure_cache.borrow_mut();
+        if cache.len() >= 4096 && !cache.contains_key(&key) {
+            if let Some(old_key) = cache.keys().next().copied() {
+                cache.remove(&old_key);
+            }
+        }
+        cache.insert(key, value);
     }
 
     /// A revisão de RENDER desta árvore: muda sempre que árvore/estilo/animação
@@ -483,6 +554,7 @@ impl Dom {
     /// `touch()`, para o `base_memo` sobreviver ao frame.
     fn touch_anim(&mut self) {
         self.anim_epoch = self.anim_epoch.wrapping_add(1);
+        self.layout_measure_cache.borrow_mut().clear();
     }
 
     /// O ALVO-BASE (cascade sem animação) de um nó, MEMOIZADO por revisão estrutural.
@@ -617,6 +689,7 @@ impl Dom {
             parent: Some(parent),
             children: Vec::new(),
         });
+        self.layout_epochs.push(0);
         self.index_node(id);
         self.nodes[parent].children.push(id);
         id
@@ -2193,6 +2266,7 @@ impl Dom {
     fn push_detached(&mut self, kind: NodeKind) -> NodeIdx {
         let id = self.nodes.len();
         self.nodes.push(Node { kind, attrs: Vec::new(), parent: None, children: Vec::new() });
+        self.layout_epochs.push(0);
         id
     }
 

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -39,7 +39,7 @@
 //!   fatia futura generaliza `layout_children_horizontal` por eixo (`column` =
 //!   main vertical, justify no Y). `flex-grow`/`shrink`/`basis` também fora.
 
-use crate::dom::{Dom, NodeIdx, NodeKind};
+use crate::dom::{Dom, LayoutMeasureKey, NodeIdx, NodeKind};
 use crate::style::{ComputedStyle, ResolveCtx};
 
 /// Um retângulo em coordenadas de conteúdo (a origem é o canto da área de render;
@@ -226,6 +226,57 @@ pub struct LayoutCtx<'a> {
     pub measurer: &'a dyn TextMeasurer,
 }
 
+/// Mede um bloco sem emitir pintura. É usado apenas pelos pré-passos de flex/grid/
+/// inline-block e pelo posicionamento out-of-flow. O resultado depende das constraints
+/// e do estilo vigente, mas não da posição absoluta; por isso o cache não guarda uma
+/// DisplayList e a chamada final continua responsável por pintar tudo no z-order certo.
+#[allow(clippy::too_many_arguments)]
+fn measure_block(
+    dom: &Dom,
+    id: NodeIdx,
+    avail_w: f32,
+    avail_h: Option<f32>,
+    forced_outer_w: Option<f32>,
+    forced_outer_h: Option<f32>,
+    shrink_to_fit: bool,
+    ctx: &LayoutCtx,
+) -> (f32, f32) {
+    let measurer = std::ptr::from_ref(ctx.measurer) as *const () as usize as u64;
+    let key = LayoutMeasureKey {
+        tree: dom.cache_identity(),
+        node_epoch: dom.layout_epoch(id),
+        style_epoch: crate::style::props::style_epoch(),
+        node: id,
+        avail_w: avail_w.to_bits(),
+        avail_h: avail_h.map(f32::to_bits),
+        forced_outer_w: forced_outer_w.map(f32::to_bits),
+        forced_outer_h: forced_outer_h.map(f32::to_bits),
+        shrink_to_fit,
+        viewport_w: ctx.viewport_w.to_bits(),
+        viewport_h: ctx.viewport_h.to_bits(),
+        measurer,
+    };
+    if let Some(size) = dom.layout_measure_get(key) {
+        return size;
+    }
+    let mut scratch = DisplayList::default();
+    let size = layout_block(
+        dom,
+        id,
+        0.0,
+        0.0,
+        avail_w,
+        avail_h,
+        forced_outer_w,
+        forced_outer_h,
+        shrink_to_fit,
+        ctx,
+        &mut scratch,
+    );
+    dom.layout_measure_put(key, size);
+    size
+}
+
 /// Calcula o layout de um `Dom` inteiro e devolve a [`DisplayList`]. Ponto de
 /// entrada do motor: percorre os filhos de `#document` como blocos empilhados na
 /// largura do viewport, resolvendo box model e emitindo os itens de pintura.
@@ -357,8 +408,7 @@ fn layout_out_of_flow(
         viewport_h: ctx.viewport_h,
     };
     // mede (w, h) numa lista descartável para resolver right/bottom.
-    let mut scratch = DisplayList::default();
-    let (w, h) = layout_block(dom, id, 0.0, 0.0, cb.w, Some(cb.h), None, None, true, ctx, &mut scratch);
+    let (w, h) = measure_block(dom, id, cb.w, Some(cb.h), None, None, true, ctx);
     let left = resolve_inset(css.inset_left, cb.w, &resolve);
     let right = resolve_inset(css.inset_right, cb.w, &resolve);
     let top = resolve_inset(css.inset_top, cb.h, &resolve);
@@ -1889,10 +1939,7 @@ fn layout_inline_block_line(
     // 1) mede a largura+altura desejada (shrink) de cada item numa lista descartável.
     let mut sizes: Vec<(NodeIdx, f32, f32)> = Vec::with_capacity(run.len());
     for &child in run {
-        let mut scratch = DisplayList::default();
-        let (w, h) = layout_block(
-            dom, child, content_x, y, content_w, avail_h, None, None, true, ctx, &mut scratch,
-        );
+        let (w, h) = measure_block(dom, child, content_w, avail_h, None, None, true, ctx);
         sizes.push((child, w, h));
     }
     // 2) agrupa em LINHAS (soma das larguras ≤ content_w). Cada linha guarda os
@@ -2152,10 +2199,8 @@ fn layout_children_horizontal(
         // só quando o main mudou (senão a medição do pré-pass vale).
         for it in line.iter_mut() {
             if !it.is_text && (it.main - it.base).abs() > 0.5 {
-                let mut scratch = DisplayList::default();
-                let (_, h) = layout_block(
-                    dom, it.node, 0.0, 0.0, content_w, container_content_h,
-                    Some(it.main), None, true, ctx, &mut scratch,
+                let (_, h) = measure_block(
+                    dom, it.node, content_w, container_content_h, Some(it.main), None, true, ctx,
                 );
                 it.h = h;
             }
@@ -2317,8 +2362,7 @@ fn layout_children_grid(
         let r = i / ncols;
         let ci = i % ncols;
         let cw = col_sizes[ci.min(col_sizes.len() - 1)];
-        let mut scratch = DisplayList::default();
-        let (_, h) = layout_block(dom, child, 0.0, 0.0, cw, container_content_h, None, None, true, ctx, &mut scratch);
+        let (_, h) = measure_block(dom, child, cw, container_content_h, None, None, true, ctx);
         content_row_h[r] = content_row_h[r].max(h);
     }
     let auto_row = css.grid_auto_rows;
@@ -2374,8 +2418,7 @@ fn layout_children_grid(
         // mede o tamanho natural do item (shrink) p/ o alinhamento não-stretch.
         let stretch_x = justify == crate::style::AlignItems::Stretch;
         let stretch_y = align == crate::style::AlignItems::Stretch;
-        let mut scratch = DisplayList::default();
-        let (nat_w, nat_h) = layout_block(dom, child, 0.0, 0.0, cell_w, Some(cell_h), None, None, true, ctx, &mut scratch);
+        let (nat_w, nat_h) = measure_block(dom, child, cell_w, Some(cell_h), None, None, true, ctx);
         let iw = if stretch_x { cell_w } else { nat_w.min(cell_w) };
         let ih = if stretch_y { cell_h } else { nat_h.min(cell_h) };
         let x = cell_x + cell_align_offset(justify, cell_w, iw);
@@ -2591,9 +2634,9 @@ fn layout_children_column(
             let child_x = if stretch {
                 content_x
             } else {
-                let mut scratch = DisplayList::default();
-                let (w, _) =
-                    layout_block(dom, it.node, content_x, y, content_w, container_content_h, None, None, true, ctx, &mut scratch);
+                let (w, _) = measure_block(
+                    dom, it.node, content_w, container_content_h, None, None, true, ctx,
+                );
                 let free_x = (content_w - w).max(0.0);
                 content_x + align_offset(align, content_w, content_w - free_x)
             };
@@ -2679,8 +2722,7 @@ fn child_outer_height(
     match &dom.node(id).kind {
         NodeKind::Element { .. } if is_block_level(dom, id) => {
             // layout de teste numa lista descartável: o (_, outer_h) é a altura real.
-            let mut scratch = DisplayList::default();
-            let (_, outer_h) = layout_block(dom, id, 0.0, 0.0, container_w, container_h, None, None, true, ctx, &mut scratch);
+            let (_, outer_h) = measure_block(dom, id, container_w, container_h, None, None, true, ctx);
             outer_h
         }
         NodeKind::Text(_) => ctx.measurer.line_height(parent_font),
@@ -3267,6 +3309,26 @@ mod tests {
         let dom = parse_html_to_dom(html);
         let ctx = LayoutCtx { viewport_w: vw, viewport_h: 600.0, measurer: &ApproxMeasurer };
         layout_document(&dom, &ctx)
+    }
+
+    #[test]
+    fn cache_de_medidas_invalida_largura_mutada() {
+        def_div();
+        let mut dom = parse_html_to_dom(
+            "<div id='host' style='display:flex'><div id='card' style='width:100px;height:10px'></div></div>",
+        );
+        let card = dom.query("#card").unwrap();
+        let card_idx = dom.resolve(card).unwrap();
+        let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+
+        let first = layout_document(&dom, &ctx);
+        let _warm = layout_document(&dom, &ctx);
+        let before = first.node_rects[&card_idx].w;
+        dom.set_style_property(card, "width", "200px");
+        let after = layout_document(&dom, &ctx).node_rects[&card_idx].w;
+
+        assert!((before - 100.0).abs() < 0.1);
+        assert!((after - 200.0).abs() < 0.1);
     }
 
     #[test]

--- a/crates/rts-dom/src/style/ruleindex.rs
+++ b/crates/rts-dom/src/style/ruleindex.rs
@@ -38,6 +38,9 @@ pub struct RuleIndex {
     /// stale e é reconstruído.
     covered: usize,
     has_custom_rules: bool,
+    /// Há seletores cuja correspondência depende de atributos ou pseudo-classes
+    /// representadas por atributos (`:checked`, `:disabled`, etc.).
+    has_attribute_selectors: bool,
 }
 
 /// A âncora do compound-alvo (último compound) de um seletor. Id > Class > Tag; se
@@ -79,6 +82,20 @@ impl RuleIndex {
         }
         idx.covered = rules.len();
         idx.has_custom_rules = rules.iter().any(|r| !r.decls.custom.is_empty());
+        idx.has_attribute_selectors = rules.iter().any(|rule| {
+            rule.selector.compounds.iter().any(|compound| {
+                compound.parts.iter().any(|part| matches!(
+                    part,
+                    SimpleSelector::Attr { .. }
+                        | SimpleSelector::Pseudo(
+                            super::selector::PseudoClass::Checked
+                                | super::selector::PseudoClass::Disabled
+                                | super::selector::PseudoClass::Enabled
+                                | super::selector::PseudoClass::Required
+                        )
+                ))
+            })
+        });
         idx
     }
 
@@ -89,6 +106,10 @@ impl RuleIndex {
 
     pub fn has_custom_rules(&self) -> bool {
         self.has_custom_rules
+    }
+
+    pub fn has_attribute_selectors(&self) -> bool {
+        self.has_attribute_selectors
     }
 
     /// Os índices das regras CANDIDATAS a casar um nó `(tag, id, classes)`: a união

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -223,6 +223,12 @@ impl Stylesheet {
         self.index.borrow().has_custom_rules()
     }
 
+    /// `true` quando alguma regra depende da presença/valor de um atributo.
+    pub fn has_attribute_selectors(&self) -> bool {
+        self.ensure_rule_index();
+        self.index.borrow().has_attribute_selectors()
+    }
+
     /// `true` se não há nenhuma regra (atalho para o `computed_style` pular a
     /// cascade quando a página não tem `<style>`).
     pub fn is_empty(&self) -> bool {

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -30,8 +30,15 @@ fn rgba_to_color32(c: u32) -> egui::Color32 {
 /// o egui vai de fato pintar. Guarda o `Context` para consultar `fonts`.
 struct EguiMeasurer<'a> {
     ctx: &'a egui::Context,
-    width_cache: RefCell<HashMap<(u32, bool, bool), HashMap<String, f32>>>,
-    line_height_cache: RefCell<HashMap<u32, f32>>,
+}
+
+thread_local! {
+    /// Métricas persistentes entre relayouts. O contexto faz parte da chave para não
+    /// misturar fontes de janelas egui diferentes; o limite evita crescimento infinito.
+    static TEXT_WIDTH_CACHE: RefCell<HashMap<(usize, u32, bool, bool), HashMap<String, f32>>> =
+        RefCell::new(HashMap::new());
+    static LINE_HEIGHT_CACHE: RefCell<HashMap<(usize, u32), f32>> =
+        RefCell::new(HashMap::new());
 }
 
 impl<'a> EguiMeasurer<'a> {
@@ -53,34 +60,48 @@ impl<'a> EguiMeasurer<'a> {
 
 impl<'a> TextMeasurer for EguiMeasurer<'a> {
     fn text_width(&self, text: &str, size: f32, mono: bool, bold: bool) -> f32 {
-        let font_key = (size.to_bits(), mono, bold);
-        if let Some(width) = self
-            .width_cache
-            .borrow()
-            .get(&font_key)
-            .and_then(|bucket| bucket.get(text))
-            .copied()
-        {
+        let context_key = self.ctx as *const egui::Context as usize;
+        let font_key = (context_key, size.to_bits(), mono, bold);
+        if let Some(width) = TEXT_WIDTH_CACHE.with(|cache| {
+            cache
+                .borrow()
+                .get(&font_key)
+                .and_then(|bucket| bucket.get(text))
+                .copied()
+        }) {
             return width;
         }
         let font = Self::font_id(size, mono, bold);
         // `fonts_mut` dá um `&mut FontsView` (glyph_width exige `&mut`).
         let width = self.ctx.fonts_mut(|f| text.chars().map(|c| f.glyph_width(&font, c)).sum());
-        self.width_cache
-            .borrow_mut()
-            .entry(font_key)
-            .or_default()
-            .insert(text.to_owned(), width);
+        TEXT_WIDTH_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            let bucket = cache.entry(font_key).or_default();
+            if bucket.len() >= 8192 && !bucket.contains_key(text) {
+                if let Some(old_text) = bucket.keys().next().cloned() {
+                    bucket.remove(&old_text);
+                }
+            }
+            bucket.insert(text.to_owned(), width);
+        });
         width
     }
     fn line_height(&self, size: f32) -> f32 {
-        let key = size.to_bits();
-        if let Some(height) = self.line_height_cache.borrow().get(&key).copied() {
+        let key = (self.ctx as *const egui::Context as usize, size.to_bits());
+        if let Some(height) = LINE_HEIGHT_CACHE.with(|cache| cache.borrow().get(&key).copied()) {
             return height;
         }
         let font = Self::font_id(size, false, false);
         let height = self.ctx.fonts_mut(|f| f.row_height(&font));
-        self.line_height_cache.borrow_mut().insert(key, height);
+        LINE_HEIGHT_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            if cache.len() >= 256 && !cache.contains_key(&key) {
+                if let Some(old_key) = cache.keys().next().copied() {
+                    cache.remove(&old_key);
+                }
+            }
+            cache.insert(key, height);
+        });
         height
     }
 }
@@ -111,11 +132,7 @@ pub(crate) fn render_dom(ui: &mut egui::Ui, dom: &crate::dom::Dom) {
     let avail = ui.available_size();
     let viewport_w = avail.x.max(1.0);
     let viewport_h = ui.ctx().screen_rect().height().max(1.0);
-    let measurer = EguiMeasurer {
-        ctx: ui.ctx(),
-        width_cache: RefCell::new(HashMap::new()),
-        line_height_cache: RefCell::new(HashMap::new()),
-    };
+    let measurer = EguiMeasurer { ctx: ui.ctx() };
     let ctx = layout::LayoutCtx { viewport_w, viewport_h, measurer: &measurer };
     let key = dom.cache_identity();
     let rev = dom.render_revision();
@@ -161,11 +178,7 @@ pub(crate) fn render_dom_scrolled(
     // (cascade de todas as regras × nós — numa página Bootstrap ~2700 regras) só
     // precisa re-rodar quando o DOM/estilo MUDAM (`render_revision`) ou o viewport
     // muda. Era a "travada" ao clicar: re-layout completo por frame.
-    let measurer = EguiMeasurer {
-        ctx: ui.ctx(),
-        width_cache: RefCell::new(HashMap::new()),
-        line_height_cache: RefCell::new(HashMap::new()),
-    };
+    let measurer = EguiMeasurer { ctx: ui.ctx() };
     let lctx = layout::LayoutCtx { viewport_w, viewport_h, measurer: &measurer };
     let rev = rts_dom::store::with_dom(h, |d| d.render_revision()).unwrap_or(0);
     let mut list = LAYOUT_CACHE.with(|cache| {


### PR DESCRIPTION
## Resumo

- memoiza medidas descartáveis usadas por flex/grid/inline-block/out-of-flow;
- usa epochs locais de geometria para preservar medidas de irmãos não afetados;
- não reutiliza DisplayItems, preservando z-order, clipping, hit-test e bounding rects;
- inclui regressão para mudança de largura após aquecimento.

## Validação

- cargo test -p rts-dom --all-targets: 202 aprovados;
- cargo test -p rts-egui --all-targets: concluído;
- cargo check -p rts-cli: concluído;
- benchmark direcionado: até 39,6% menos em constraints warm.
