### PR TITLE
perf: reduce selector matching allocations

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -2030,13 +2030,10 @@ impl Dom {
             _ => return false,
         };
         let id = self.nodes[idx].attr("id");
-        let classes: Vec<&str> = self.nodes[idx]
-            .attr("class")
-            .map(|c| c.split_whitespace().collect())
-            .unwrap_or_default();
-        let attr = |name: &str| self.nodes[idx].attr(name).map(str::to_string);
+        let class_attr = self.nodes[idx].attr("class");
+        let attr = |name: &str| self.nodes[idx].attr(name);
         let pseudo = |pc: &crate::style::PseudoClass| self.pseudo_matches(idx, pc);
-        crate::style::compound_matches(compound, tag, id, &classes, &attr, &pseudo)
+        crate::style::compound_matches_borrowed(compound, tag, id, class_attr, &attr, &pseudo)
     }
 
     /// Resolve uma pseudo-classe contra o nó (posição entre irmãos / atributo de estado).

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -56,8 +56,8 @@ pub use props::{
     SLOT_TEXT_ALIGN, SLOT_TEXT_DECORATION, SLOT_WIDTH,
 };
 pub use selector::{
-    compound_matches, parse_selector, parse_selector_list, AttrOp, Combinator, ComplexSelector,
-    CompoundSelector, PseudoClass, Selector, SimpleSelector,
+    compound_matches, compound_matches_borrowed, parse_selector, parse_selector_list, AttrOp, Combinator,
+    ComplexSelector, CompoundSelector, PseudoClass, Selector, SimpleSelector,
 };
 pub use stylesheet::{parse_rules, DeclBlock, MediaQuery, Rule, Stylesheet};
 pub use values::{

--- a/crates/rts-dom/src/style/ruleindex.rs
+++ b/crates/rts-dom/src/style/ruleindex.rs
@@ -34,6 +34,9 @@ pub struct RuleIndex {
     by_class: HashMap<String, Vec<usize>>,
     by_tag: HashMap<String, Vec<usize>>,
     universal: Vec<usize>,
+    /// Especificidade pré-computada por índice de regra; evita percorrer todos os
+    /// compounds novamente em cada cascade de nó.
+    specificity: Vec<u32>,
     /// Nº de regras que o índice cobre — se `rules.len()` diverge, o índice está
     /// stale e é reconstruído.
     covered: usize,
@@ -80,6 +83,7 @@ impl RuleIndex {
                 Key::Universal => idx.universal.push(i),
             }
         }
+        idx.specificity = rules.iter().map(|r| r.selector.specificity()).collect();
         idx.covered = rules.len();
         idx.has_custom_rules = rules.iter().any(|r| !r.decls.custom.is_empty());
         idx.has_attribute_selectors = rules.iter().any(|rule| {
@@ -112,6 +116,10 @@ impl RuleIndex {
         self.has_attribute_selectors
     }
 
+    pub fn specificity(&self, rule: usize) -> u32 {
+        self.specificity.get(rule).copied().unwrap_or(0)
+    }
+
     /// Os índices das regras CANDIDATAS a casar um nó `(tag, id, classes)`: a união
     /// dos buckets do id, de cada classe, da tag e do universal. Cada regra foi
     /// indexada por uma única âncora (`key_of`), portanto não há duplicatas entre
@@ -125,6 +133,18 @@ impl RuleIndex {
             .sum();
         let tag_len = self.by_tag.get(tag).map_or(0, Vec::len);
         let mut out = Vec::with_capacity(self.universal.len() + id_len + class_len + tag_len);
+        self.candidates_into(tag, id, classes, &mut out);
+        out
+    }
+
+    pub fn candidates_into(
+        &self,
+        tag: &str,
+        id: Option<&str>,
+        classes: &[&str],
+        out: &mut Vec<usize>,
+    ) {
+        out.clear();
         out.extend_from_slice(&self.universal);
         if let Some(id) = id {
             if let Some(v) = self.by_id.get(id) {
@@ -139,6 +159,5 @@ impl RuleIndex {
         if let Some(v) = self.by_tag.get(tag) {
             out.extend_from_slice(v);
         }
-        out
     }
 }

--- a/crates/rts-dom/src/style/selector.rs
+++ b/crates/rts-dom/src/style/selector.rs
@@ -403,6 +403,33 @@ pub fn compound_matches(
     })
 }
 
+/// Matcher usado pelo DOM no caminho quente: lê classes e atributos por empréstimo,
+/// sem criar `Vec<&str>` ou `String` para cada candidato de regra.
+pub fn compound_matches_borrowed<'a, F, P>(
+    compound: &CompoundSelector,
+    tag: &str,
+    id: Option<&str>,
+    class_attr: Option<&str>,
+    attr: &F,
+    pseudo: &P,
+) -> bool
+where
+    F: Fn(&str) -> Option<&'a str>,
+    P: Fn(&PseudoClass) -> bool,
+{
+    compound.parts.iter().all(|p| match p {
+        SimpleSelector::Universal => true,
+        SimpleSelector::Tag(t) => t == tag,
+        SimpleSelector::Id(i) => id == Some(i.as_str()),
+        SimpleSelector::Class(c) => class_attr
+            .is_some_and(|raw| raw.split_whitespace().any(|class| class == c)),
+        SimpleSelector::Attr { name, op, value } => attr(name)
+            .map(|actual| attr_op_matches(*op, actual, value))
+            .unwrap_or(false),
+        SimpleSelector::Pseudo(pc) => pseudo(pc),
+    })
+}
+
 /// Aplica o operador de um seletor de atributo `[attr OP value]` ao valor real.
 fn attr_op_matches(op: AttrOp, actual: &str, expected: &str) -> bool {
     match op {

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -181,6 +181,10 @@ pub struct Stylesheet {
     /// do índice detecta). Estado DERIVADO — fora do `PartialEq` (que compara só
     /// `rules`).
     index: std::cell::RefCell<super::ruleindex::RuleIndex>,
+    /// Buffer derivado reutilizado por uma cascade por vez; evita criar um Vec de
+    /// índices candidatos para cada elemento. O stylesheet já usa RefCell para o
+    /// índice lazy e a cascade é chamada de forma síncrona pelo DOM.
+    candidate_scratch: std::cell::RefCell<Vec<usize>>,
 }
 
 // PartialEq manual (Keyframes tem f32, não derivamos Eq; o diff de árvore só compara
@@ -198,6 +202,7 @@ impl Stylesheet {
             rules: Vec::new(),
             keyframes: std::collections::HashMap::new(),
             index: std::cell::RefCell::new(super::ruleindex::RuleIndex::default()),
+            candidate_scratch: std::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -213,9 +218,16 @@ impl Stylesheet {
 
     /// Garante o índice e devolve os índices das regras CANDIDATAS a casar um nó
     /// `(tag, id, classes)` — a base do fast-path da cascade.
-    fn candidate_indices(&self, tag: &str, id: Option<&str>, classes: &[&str]) -> Vec<usize> {
+    fn candidate_indices(
+        &self,
+        tag: &str,
+        id: Option<&str>,
+        classes: &[&str],
+    ) -> std::cell::RefMut<'_, Vec<usize>> {
         self.ensure_rule_index();
-        self.index.borrow().candidates(tag, id, classes)
+        let mut scratch = self.candidate_scratch.borrow_mut();
+        self.index.borrow().candidates_into(tag, id, classes, &mut scratch);
+        scratch
     }
 
     fn has_custom_rules(&self) -> bool {
@@ -295,15 +307,19 @@ impl Stylesheet {
         // FAST PATH: só as regras cuja chave-alvo o nó pode satisfazer (índice), em
         // vez de TODAS as regras. O `matches` completo (navega a árvore) ainda decide.
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
-        let mut matched: Vec<&Rule> = cand
+        let index = self.index.borrow();
+        let mut matched: Vec<(u32, u32, &Rule)> = cand
             .iter()
-            .map(|&i| &self.rules[i])
-            .filter(|r| r.media.map(|m| m.matches(viewport_w)).unwrap_or(true))
-            .filter(|r| matches(&r.selector))
+            .filter_map(|&i| {
+                let r = &self.rules[i];
+                (r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
+                    && matches(&r.selector))
+                    .then(|| (index.specificity(i), r.order, r))
+            })
             .collect();
-        matched.sort_by_key(|r| (r.selector.specificity(), r.order));
+        matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
         let mut out = DeclBlock::default();
-        for r in &matched {
+        for (_, _, r) in &matched {
             out.normal.merge_over(&r.decls.normal);
             // declarações PENDENTES (`prop: …var(--x)…`) resolvem AQUI, na posição
             // da regra na cascade, contra as custom props do ELEMENTO (#1779).
@@ -315,7 +331,7 @@ impl Stylesheet {
                 }
             }
         }
-        for r in &matched {
+        for (_, _, r) in &matched {
             out.important.merge_over(&r.decls.important);
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {
@@ -343,15 +359,19 @@ impl Stylesheet {
             return Vec::new();
         }
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
-        let mut matched: Vec<&Rule> = cand
+        let index = self.index.borrow();
+        let mut matched: Vec<(u32, u32, &Rule)> = cand
             .iter()
-            .map(|&i| &self.rules[i])
-            .filter(|r| !r.decls.custom.is_empty())
-            .filter(|r| r.media.map(|m| m.matches(viewport_w)).unwrap_or(true))
-            .filter(|r| matches(&r.selector))
+            .filter_map(|&i| {
+                let r = &self.rules[i];
+                (!r.decls.custom.is_empty()
+                    && r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
+                    && matches(&r.selector))
+                    .then(|| (index.specificity(i), r.order, r))
+            })
             .collect();
-        matched.sort_by_key(|r| (r.selector.specificity(), r.order));
-        matched.iter().flat_map(|r| r.decls.custom.iter().cloned()).collect()
+        matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
+        matched.iter().flat_map(|(_, _, r)| r.decls.custom.iter().cloned()).collect()
     }
 
     /// Conveniência: computa o estilo para um elemento dado SÓ tag/id/classes (sem


### PR DESCRIPTION
## Resumo

- usa matching de classes e atributos por empréstimo, sem `Vec`/`String` temporários por candidato;
- pré-computa especificidade no RuleIndex;
- reutiliza o buffer de índices candidatos por cascade.

## Validação

- 202 testes de `rts-dom` aprovados;
- `cargo check -p rts-egui -p rts-cli` aprovado;
- query `.c17[data-state=on]`: 0,114 ms → 0,080 ms na mediana A/B.