### PR TITLE
perf: cache intrinsic layout widths by local epoch

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -52,6 +52,18 @@ pub(crate) struct LayoutMeasureKey {
     pub(crate) measurer: u64,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct IntrinsicWidthKey {
+    pub(crate) tree: u64,
+    pub(crate) node_epoch: u64,
+    pub(crate) style_epoch: u64,
+    pub(crate) node: NodeIdx,
+    pub(crate) font_size: u32,
+    pub(crate) viewport_w: u32,
+    pub(crate) viewport_h: u32,
+    pub(crate) measurer: u64,
+}
+
 /// Contador global de gerações de árvore. Cada `Dom` novo (parse ou vazio) toma a
 /// próxima geração; assim duas árvores nunca colidem e um `NodeId` de uma árvore
 /// velha é detectável como stale na árvore atual.
@@ -261,6 +273,9 @@ pub struct Dom {
     /// flex/grid/inline-block/out-of-flow. É limpo em qualquer mutação visual para
     /// não reutilizar tamanho sob estilo ou conteúdo stale.
     layout_measure_cache: std::cell::RefCell<HashMap<LayoutMeasureKey, (f32, f32)>>,
+    /// Cache derivado de largura intrínseca (max-content), usada pelos pré-passos
+    /// de shrink-to-fit/flex/grid. A chave inclui o contexto tipográfico completo.
+    intrinsic_width_cache: std::cell::RefCell<HashMap<IntrinsicWidthKey, f32>>,
     /// Epoch local de geometria. Filhos e ancestrais são incrementados quando uma
     /// mutação pode alterar seu tamanho; irmãos independentes mantêm o valor.
     layout_epochs: Vec<u64>,
@@ -332,6 +347,7 @@ impl Dom {
             base_memo_revision: std::cell::Cell::new(u64::MAX),
             base_memo_viewport: std::cell::Cell::new((0, 0)),
             layout_measure_cache: std::cell::RefCell::new(HashMap::new()),
+            intrinsic_width_cache: std::cell::RefCell::new(HashMap::new()),
             layout_epochs: vec![0],
             viewport: std::cell::Cell::new((1280.0, 800.0)),
             memo_viewport: std::cell::Cell::new((1280.0f32.to_bits(), 800.0f32.to_bits())),
@@ -443,6 +459,7 @@ impl Dom {
         self.computed_memo.borrow_mut().clear();
         self.base_memo.borrow_mut().clear();
         self.layout_measure_cache.borrow_mut().clear();
+        self.intrinsic_width_cache.borrow_mut().clear();
     }
 
     /// Marca uma mudança que altera pixels/geometria, mas não o estilo computado.
@@ -450,6 +467,7 @@ impl Dom {
     fn touch_render_only(&mut self) {
         self.revision = self.revision.wrapping_add(1);
         self.layout_measure_cache.borrow_mut().clear();
+        self.intrinsic_width_cache.borrow_mut().clear();
     }
 
     /// Invalida estilo apenas no nó e em seus descendentes. É seguro para `style=""`
@@ -531,6 +549,20 @@ impl Dom {
         cache.insert(key, value);
     }
 
+    pub(crate) fn intrinsic_width_get(&self, key: IntrinsicWidthKey) -> Option<f32> {
+        self.intrinsic_width_cache.borrow().get(&key).copied()
+    }
+
+    pub(crate) fn intrinsic_width_put(&self, key: IntrinsicWidthKey, value: f32) {
+        let mut cache = self.intrinsic_width_cache.borrow_mut();
+        if cache.len() >= 4096 && !cache.contains_key(&key) {
+            if let Some(old_key) = cache.keys().next().copied() {
+                cache.remove(&old_key);
+            }
+        }
+        cache.insert(key, value);
+    }
+
     /// A revisão de RENDER desta árvore: muda sempre que árvore/estilo/animação
     /// mudam — inclui o epoch GLOBAL de estilo por-tag (`defineStyle`/`defineBlock`,
     /// que vivem fora do `Dom`). É a chave de cache de layout do backend e da ABI:
@@ -555,6 +587,7 @@ impl Dom {
     fn touch_anim(&mut self) {
         self.anim_epoch = self.anim_epoch.wrapping_add(1);
         self.layout_measure_cache.borrow_mut().clear();
+        self.intrinsic_width_cache.borrow_mut().clear();
     }
 
     /// O ALVO-BASE (cascade sem animação) de um nó, MEMOIZADO por revisão estrutural.

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -39,7 +39,7 @@
 //!   fatia futura generaliza `layout_children_horizontal` por eixo (`column` =
 //!   main vertical, justify no Y). `flex-grow`/`shrink`/`basis` também fora.
 
-use crate::dom::{Dom, LayoutMeasureKey, NodeIdx, NodeKind};
+use crate::dom::{Dom, IntrinsicWidthKey, LayoutMeasureKey, NodeIdx, NodeKind};
 use crate::style::{ComputedStyle, ResolveCtx};
 
 /// Um retângulo em coordenadas de conteúdo (a origem é o canto da área de render;
@@ -1121,6 +1121,20 @@ fn content_natural_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -> 
 /// - texto: a largura do texto concatenado.
 /// Recursivo: a largura de um filho é a SUA intrínseca + frame (ou seu `width` fixo).
 fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -> f32 {
+    let key = IntrinsicWidthKey {
+        tree: dom.cache_identity(),
+        node_epoch: dom.layout_epoch(id),
+        style_epoch: crate::style::props::style_epoch(),
+        node: id,
+        font_size: font.to_bits(),
+        viewport_w: ctx.viewport_w.to_bits(),
+        viewport_h: ctx.viewport_h.to_bits(),
+        measurer: std::ptr::from_ref(ctx.measurer) as *const () as usize as u64,
+    };
+    if let Some(hit) = dom.intrinsic_width_get(key) {
+        return hit;
+    }
+
     // folha de texto puro → largura do texto.
     let own_text = collect_text(dom, id);
     let only_text = !dom.node(id).children.is_empty()
@@ -1135,7 +1149,9 @@ fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -
         // o peso importa p/ a largura natural: medir regular mas o wrap/paint usar bold
         // (mais largo) faz o conteúdo não caber na largura natural → quebra indevida.
         let bold = css.as_ref().and_then(|c| c.bold).unwrap_or(false);
-        return ctx.measurer.text_width(&own_text, font, mono, bold);
+        let width = ctx.measurer.text_width(&own_text, font, mono, bold);
+        dom.intrinsic_width_put(key, width);
+        return width;
     }
 
     // o EIXO em que os filhos se dispõem decide SOMA vs MAX.
@@ -1173,12 +1189,14 @@ fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -
         sum += w;
         max = max.max(w);
     }
-    if is_row {
+    let width = if is_row {
         // soma + gaps entre os itens.
         sum + (count.saturating_sub(1)) as f32 * gap
     } else {
         max
-    }
+    };
+    dom.intrinsic_width_put(key, width);
+    width
 }
 
 /// A largura OUTER intrínseca de UM filho (max-content): seu `width` fixo (+ frame),
@@ -3329,6 +3347,24 @@ mod tests {
 
         assert!((before - 100.0).abs() < 0.1);
         assert!((after - 200.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn cache_intrinseca_invalida_texto_mutado() {
+        def_div();
+        let mut dom = parse_html_to_dom(
+            "<div id='host' style='display:flex'><span id='text' style='display:inline-block'>a</span></div>",
+        );
+        let text = dom.query("#text").unwrap();
+        let text_idx = dom.resolve(text).unwrap();
+        let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+
+        let before = layout_document(&dom, &ctx).node_rects[&text_idx].w;
+        let _warm = layout_document(&dom, &ctx);
+        dom.set_text(text, "uma linha de texto bem mais comprida");
+        let after = layout_document(&dom, &ctx).node_rects[&text_idx].w;
+
+        assert!(after > before, "a largura intrínseca deve acompanhar o novo texto");
     }
 
     #[test]


### PR DESCRIPTION
## Resumo

- adiciona cache limitado de largura intrínseca por nó, epoch local, estilo, fonte, viewport e medidor;
- invalida globalmente em mutações estruturais e seletivamente por epochs em mutações locais;
- guarda somente medidas `f32`, sem reutilizar DisplayList, z-order ou hit-test.

## Validação

- 203 testes de `rts-dom` aprovados;
- `cargo check -p rts-egui -p rts-cli` aprovado;
- layout real após mutação: -21,9%; constraints warm: -6,0% na mediana A/B.