### PR TITLE
feat(dom): métricas do DOM (contadores, fases, amostras, auditoria, memória) + 3 otimizações que elas justificaram

### DIFF
--- a/crates/rts-dom/Cargo.toml
+++ b/crates/rts-dom/Cargo.toml
@@ -22,3 +22,8 @@ license.workspace = true
 # Sem ela sobram a árvore, o parser, o estilo e o LAYOUT — que é a maior parte
 # deste crate e não conhece motor nenhum.
 [features]
+# `metrics`: liga os contadores de `src/metrics.rs` (cascade/layout/invalidação).
+# Desligada por padrão porque instrumentação em caminho quente distorce o tempo —
+# um número de relógio medido COM ela não é comparável a um sem. Ligue para
+# responder ONDE o trabalho acontece; desligue para medir QUANTO ele custa.
+metrics = []

--- a/crates/rts-dom/examples/dom_metrics/main.rs
+++ b/crates/rts-dom/examples/dom_metrics/main.rs
@@ -150,6 +150,12 @@ fn bench_file(path: &str, o: &Options, baseline: Option<&str>) -> Option<String>
     println!("\n═══ {path}");
     println!("    {} bytes de HTML · viewport {}×{}", html.len(), o.vw as u32, o.vh as u32);
     print!("{}", audit.report());
+    print!("{}", metrics::footprint(&probe).report());
+    // O tamanho dos TIPOS é sobre o código, não sobre a página — e é o que
+    // explica os outros números (um clone de 1 KB tem a mesma cara de um de 8 B).
+    let sizes: Vec<String> =
+        metrics::footprint::type_sizes().iter().map(|(n, b)| format!("{n} {b} B")).collect();
+    println!("    tamanhos: {}", sizes.join(" · "));
     drop(probe);
 
     let runs = scenarios::page(&html, o.vw, o.vh, o.iters, &m);

--- a/crates/rts-dom/examples/dom_metrics/main.rs
+++ b/crates/rts-dom/examples/dom_metrics/main.rs
@@ -1,0 +1,231 @@
+//! HARNESS de métricas do DOM: roda cenários fixos sobre páginas HTML reais e
+//! diz, por cenário, quanto tempo levou, o que aconteceu por dentro e se a
+//! árvore terminou CONSISTENTE.
+//!
+//! ```bash
+//! # o que aconteceu por dentro (contadores e fases valem; o tempo desta execução não)
+//! cargo run --release -q -p rts-dom --features metrics --example dom_metrics -- pagina.html
+//!
+//! # quanto custou (tempo vale; contadores saem zerados, e o harness diz isso)
+//! cargo run --release -q -p rts-dom --example dom_metrics -- pagina.html
+//!
+//! # gravar um baseline e comparar depois — é o diff de CONTADORES que acusa
+//! # mudança de comportamento; tempo varia com a máquina, contador não.
+//! … --features metrics … -- pagina.html --json base.json
+//! … --features metrics … -- pagina.html --baseline base.json
+//! ```
+//!
+//! Opções: `--viewport 1280x800`, `--iters 20`, `--build 4000`, `--json <arq>`,
+//! `--baseline <arq>`, `--tolerance 5` (% de variação ignorada no diff).
+//!
+//! Nunca em build de debug: um número de debug não é um número.
+
+mod report;
+mod scenarios;
+
+use report::Run;
+use rts_dom::metrics;
+use rts_dom::parse_html_to_dom;
+use scenarios::CountingMeasurer;
+
+struct Options {
+    files: Vec<String>,
+    vw: f32,
+    vh: f32,
+    iters: u32,
+    build_n: u32,
+    json_out: Option<String>,
+    baseline: Option<String>,
+    tolerance: f64,
+}
+
+fn parse_args() -> Options {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut o = Options {
+        files: Vec::new(),
+        vw: 1280.0,
+        vh: 800.0,
+        iters: 20,
+        build_n: 2000,
+        json_out: None,
+        baseline: None,
+        tolerance: 5.0,
+    };
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--viewport" => {
+                if let Some((w, h)) = it.next().and_then(|v| v.split_once('x').map(|(a, b)| (a.to_string(), b.to_string()))) {
+                    o.vw = w.parse().unwrap_or(o.vw);
+                    o.vh = h.parse().unwrap_or(o.vh);
+                }
+            }
+            "--iters" => o.iters = it.next().and_then(|v| v.parse().ok()).unwrap_or(o.iters),
+            "--build" => o.build_n = it.next().and_then(|v| v.parse().ok()).unwrap_or(o.build_n),
+            "--json" => o.json_out = it.next().cloned(),
+            "--baseline" => o.baseline = it.next().cloned(),
+            "--tolerance" => o.tolerance = it.next().and_then(|v| v.parse().ok()).unwrap_or(o.tolerance),
+            other => o.files.push(other.to_string()),
+        }
+    }
+    o
+}
+
+fn main() {
+    let o = parse_args();
+    println!("rts-dom · métricas");
+    if metrics::enabled() {
+        println!(
+            "instrumentação LIGADA — contadores e fases valem; o TEMPO desta execução\n\
+             não é comparável a um build sem `--features metrics`."
+        );
+    } else {
+        println!(
+            "instrumentação DESLIGADA — os tempos valem; contadores e fases saem zerados.\n\
+             Rode com `--features metrics` para ver o que aconteceu por dentro."
+        );
+    }
+    if o.files.is_empty() {
+        println!(
+            "\nuso: dom_metrics <arquivo.html>… [--viewport 1280x800] [--iters 20]\n\
+             \x20            [--build 2000] [--json saida.json] [--baseline base.json]"
+        );
+    }
+
+    let baseline = o.baseline.as_ref().and_then(|p| match std::fs::read_to_string(p) {
+        Ok(text) => Some(text),
+        Err(e) => {
+            eprintln!("!! baseline {p}: {e}");
+            None
+        }
+    });
+
+    let mut json_blocks: Vec<String> = Vec::new();
+    for f in &o.files {
+        if let Some(block) = bench_file(f, &o, baseline.as_deref()) {
+            json_blocks.push(block);
+        }
+    }
+    let m = CountingMeasurer::new();
+    println!("\n═══ construção programática ({} elementos)", o.build_n);
+    let runs = scenarios::build(o.build_n, o.vw, o.vh, &m);
+    for r in &runs {
+        r.print();
+    }
+    json_blocks.push(json_group("build", &runs));
+
+    if let Some(path) = &o.json_out {
+        let text = format!("[\n{}\n]\n", json_blocks.join(",\n"));
+        match std::fs::write(path, text) {
+            Ok(()) => println!("\nJSON gravado em {path}"),
+            Err(e) => eprintln!("!! não gravou {path}: {e}"),
+        }
+    }
+}
+
+/// Um grupo (arquivo ou `build`) como um objeto JSON com seus cenários dentro.
+fn json_group(name: &str, runs: &[Run]) -> String {
+    let inner: Vec<String> = runs.iter().map(|r| indent(&r.to_json())).collect();
+    format!("  {{\n    \"group\": \"{name}\",\n    \"runs\": [\n{}\n    ]\n  }}", inner.join(",\n"))
+}
+
+fn indent(s: &str) -> String {
+    s.lines().map(|l| format!("      {l}")).collect::<Vec<_>>().join("\n")
+}
+
+fn bench_file(path: &str, o: &Options, baseline: Option<&str>) -> Option<String> {
+    let html = match std::fs::read_to_string(path) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("!! {path}: {e}");
+            return None;
+        }
+    };
+    let m = CountingMeasurer::new();
+
+    // Uma árvore só para DESCREVER a página: a forma é o denominador de tudo o
+    // mais (4000 cascades é muito ou pouco depende de quantos elementos há).
+    let probe = parse_html_to_dom(&html);
+    let audit = metrics::audit(&probe);
+    println!("\n═══ {path}");
+    println!("    {} bytes de HTML · viewport {}×{}", html.len(), o.vw as u32, o.vh as u32);
+    print!("{}", audit.report());
+    drop(probe);
+
+    let runs = scenarios::page(&html, o.vw, o.vh, o.iters, &m);
+    for r in &runs {
+        r.print();
+    }
+
+    // Normaliza pelo tamanho da árvore — é o que permite comparar páginas.
+    if let Some(cold) = runs.iter().find(|r| r.name == "layout frio") {
+        let t = cold.timing();
+        println!(
+            "\n  layout frio: {:.2} µs por nó · {:.2} µs por elemento",
+            t.avg * 1000.0 / audit.shape.nodes.max(1) as f64,
+            t.avg * 1000.0 / audit.shape.elements.max(1) as f64,
+        );
+    }
+
+    if let Some(text) = baseline {
+        print_baseline_diff(text, path, &runs, o.tolerance);
+    }
+    Some(json_group(path, &runs))
+}
+
+/// Diff contra o baseline, cenário a cenário. Compara CONTADORES: são
+/// determinísticos, então uma diferença é sempre mudança de comportamento — ao
+/// contrário do tempo, que pode ser a máquina.
+fn print_baseline_diff(baseline: &str, group: &str, runs: &[Run], tolerance: f64) {
+    println!("\n  diff contra o baseline (contadores, |Δ| ≥ {tolerance:.0}%)");
+    let Some(group_block) = find_block(baseline, &format!("\"group\": \"{group}\"")) else {
+        println!("    (o baseline não tem este arquivo)");
+        return;
+    };
+    let mut any = false;
+    for r in runs {
+        let Some(block) = find_block(group_block, &format!("\"scenario\": \"{}\"", r.name)) else {
+            continue;
+        };
+        let before = metrics::DomMetrics::from_json(block);
+        let before_iters = read_int(block, "\"iters\"").unwrap_or(1);
+        let d = report::diff_counters(
+            &r.counters,
+            r.samples.len(),
+            &before,
+            before_iters,
+            tolerance,
+        );
+        if !d.is_empty() {
+            any = true;
+            println!("  ▸ {}", r.name);
+            print!("{d}");
+        }
+    }
+    if !any {
+        println!("    nada mudou além da tolerância");
+    }
+}
+
+/// Lê um inteiro `"chave": N` de um bloco. Mesma razão do `find_block`: reler o
+/// que este harness grava não justifica uma dependência de JSON num crate que
+/// não tem nenhuma.
+fn read_int(text: &str, key: &str) -> Option<usize> {
+    let at = text.find(key)?;
+    let rest = &text[at + key.len()..];
+    let colon = rest.find(':')?;
+    let digits: String =
+        rest[colon + 1..].trim_start().chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// Recorta o pedaço de texto que começa numa marca e vai até a próxima
+/// ocorrência da MESMA chave — bom o bastante para reler o que este harness
+/// grava, e sem trazer uma dependência de JSON a um crate que não tem nenhuma.
+fn find_block<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
+    let start = text.find(marker)?;
+    let rest = &text[start..];
+    let key = marker.split(':').next().unwrap_or(marker);
+    let end = rest[marker.len()..].find(key).map(|e| e + marker.len()).unwrap_or(rest.len());
+    Some(&rest[..end])
+}

--- a/crates/rts-dom/examples/dom_metrics/report.rs
+++ b/crates/rts-dom/examples/dom_metrics/report.rs
@@ -1,0 +1,213 @@
+//! O RESULTADO de um cenário e como ele é impresso, serializado e comparado.
+//!
+//! Três formas da mesma medição, e cada uma existe por um motivo diferente: a
+//! tabela é para ler agora, o JSON é para comparar depois, e o diff contra um
+//! baseline é o único que responde "isto piorou?" — que é a pergunta que uma
+//! tabela sozinha nunca responde, porque ninguém lembra o número da semana
+//! passada.
+
+use rts_dom::metrics::{AuditReport, DomMetrics, Phases, Samples};
+use std::time::Duration;
+
+/// Uma execução medida: N amostras de tempo mais o que aconteceu por dentro.
+pub struct Run {
+    pub name: &'static str,
+    /// O que UMA iteração representa ("página", "frame", "consulta").
+    pub unit: &'static str,
+    /// Uma duração POR iteração — guardadas todas, porque a média sozinha
+    /// esconde o pico, e é o pico que faz uma página parecer travada.
+    pub samples: Vec<Duration>,
+    pub counters: DomMetrics,
+    pub phases: Phases,
+    /// QUAIS foram os casos por trás dos contadores de descarte (seletores
+    /// recusados, propriedades ignoradas): a lista de trabalho que um número
+    /// sozinho não dá.
+    pub notes: Samples,
+    /// `(text_width, line_height)` — o único trabalho do layout que sai do crate.
+    pub text_measures: (u64, u64),
+    /// A árvore ao FIM do cenário. `None` quando o cenário não deixa uma (o
+    /// `parse` descarta cada árvore que cria).
+    pub audit: Option<AuditReport>,
+}
+
+/// Estatísticas de tempo de uma execução, em milissegundos.
+pub struct Timing {
+    pub calls: usize,
+    pub min: f64,
+    pub p50: f64,
+    pub p95: f64,
+    pub max: f64,
+    pub avg: f64,
+    pub total: f64,
+}
+
+impl Run {
+    pub fn timing(&self) -> Timing {
+        let mut ms: Vec<f64> = self.samples.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
+        ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let n = ms.len();
+        let at = |q: f64| -> f64 {
+            if n == 0 {
+                return 0.0;
+            }
+            ms[(((n - 1) as f64) * q).round() as usize]
+        };
+        Timing {
+            calls: n,
+            min: ms.first().copied().unwrap_or(0.0),
+            p50: at(0.5),
+            p95: at(0.95),
+            max: ms.last().copied().unwrap_or(0.0),
+            avg: if n == 0 { 0.0 } else { ms.iter().sum::<f64>() / n as f64 },
+            total: ms.iter().sum(),
+        }
+    }
+
+    pub fn print(&self) {
+        let t = self.timing();
+        println!(
+            "\n▸ {:<26} {:.3} ms/{}  (p50 {:.3} · p95 {:.3} · máx {:.3} · {} iter)",
+            self.name, t.avg, self.unit, t.p50, t.p95, t.max, t.calls
+        );
+        let report = self.counters.report();
+        if report.is_empty() {
+            println!("    (sem contadores — compile com --features metrics)");
+        } else {
+            print!("{report}");
+        }
+        if !self.phases.is_empty() {
+            println!("  fases (% sobre o tempo do cenário; fases se aninham)");
+            print!("{}", self.phases.report_over(t.total));
+        }
+        if !self.notes.is_empty() {
+            println!("  amostras");
+            print!("{}", self.notes.report());
+        }
+        if self.text_measures.0 + self.text_measures.1 > 0 {
+            println!(
+                "  medição de texto\n    {:<38} {:>13}\n    {:<38} {:>13}",
+                "text_width", self.text_measures.0, "line_height", self.text_measures.1
+            );
+        }
+        self.print_ratios();
+        if let Some(a) = &self.audit {
+            if a.bugs() > 0 || a.leaks() > 0 || a.page_issues() > 0 {
+                println!("  consistência ao FIM do cenário");
+                print!("{}", a.report());
+            }
+        }
+    }
+
+    /// As RAZÕES: um número absoluto de hits não diz se o cache está
+    /// funcionando; a fração diz. E a razão por ELEMENTO é o que permite
+    /// comparar páginas de tamanhos diferentes.
+    fn print_ratios(&self) {
+        let c = &self.counters;
+        let mut lines: Vec<String> = Vec::new();
+        if c.computed_calls > 0 {
+            lines.push(format!(
+                "estilo servido pelo memo: {:.1}%  ({} cascades completas)",
+                pct(c.computed_memo_hits, c.computed_calls),
+                c.cascade_runs
+            ));
+        }
+        if c.measure_calls > 0 {
+            lines.push(format!("measure_block do cache: {:.1}%", pct(c.measure_hits, c.measure_calls)));
+        }
+        if c.intrinsic_calls > 0 {
+            lines.push(format!(
+                "largura intrínseca do cache: {:.1}%",
+                pct(c.intrinsic_hits, c.intrinsic_calls)
+            ));
+        }
+        if c.cascade_runs > 0 && c.rules_considered > 0 {
+            lines.push(format!(
+                "regras testadas por cascade: {:.1} (casaram {:.1})",
+                c.rules_considered as f64 / c.cascade_runs as f64,
+                c.rules_matched as f64 / c.cascade_runs as f64,
+            ));
+        }
+        if c.query_calls > 0 {
+            lines.push(format!(
+                "nós visitados por consulta: {:.0}",
+                c.query_nodes_visited as f64 / c.query_calls as f64
+            ));
+        }
+        if c.touch_global > 0 && c.memo_cleared_entries > 0 {
+            lines.push(format!(
+                "memos jogados fora por touch() global: {:.0} em média",
+                c.memo_cleared_entries as f64 / c.touch_global as f64
+            ));
+        }
+        if !lines.is_empty() {
+            println!("  razões");
+            for l in lines {
+                println!("    {l}");
+            }
+        }
+    }
+
+    /// Um objeto JSON com tempo, contadores e fases deste cenário.
+    pub fn to_json(&self) -> String {
+        let t = self.timing();
+        format!(
+            "{{\n  \"scenario\": \"{}\",\n  \"unit\": \"{}\",\n  \"iters\": {},\n  \
+             \"ms\": {{ \"avg\": {:.6}, \"p50\": {:.6}, \"p95\": {:.6}, \"min\": {:.6}, \"max\": {:.6} }},\n  \
+             \"counters\": {},\n  \"phases\": {}\n}}",
+            self.name,
+            self.unit,
+            t.calls,
+            t.avg,
+            t.p50,
+            t.p95,
+            t.min,
+            t.max,
+            self.counters.to_json(),
+            self.phases.to_json(),
+        )
+    }
+}
+
+pub fn pct(part: u64, total: u64) -> f64 {
+    if total == 0 { 0.0 } else { part as f64 * 100.0 / total as f64 }
+}
+
+/// Compara os CONTADORES de um cenário com os de um baseline, POR ITERAÇÃO, e
+/// imprime só o que mudou. Duas decisões aqui, e as duas são sobre não gerar
+/// alarme falso:
+///
+/// - **contadores, não tempos**: um contador é determinístico, então uma
+///   diferença nele é sempre mudança de COMPORTAMENTO; uma diferença de tempo
+///   pode ser a máquina.
+/// - **por iteração**: um baseline gravado com `--iters 8` comparado a uma
+///   execução com `--iters 4` acusaria −50% em TODAS as linhas. A taxa por
+///   iteração é o que é comparável entre execuções.
+pub fn diff_counters(
+    now: &DomMetrics,
+    now_iters: usize,
+    base: &DomMetrics,
+    base_iters: usize,
+    tolerance_pct: f64,
+) -> String {
+    let mut out = String::new();
+    let (ni, bi) = (now_iters.max(1) as f64, base_iters.max(1) as f64);
+    let base_rows = base.rows();
+    for (i, (_, label, key, value)) in now.rows().iter().enumerate() {
+        let Some((_, _, base_key, before)) = base_rows.get(i) else { continue };
+        debug_assert_eq!(base_key, key);
+        let (a, b) = (*before as f64 / bi, *value as f64 / ni);
+        if (a - b).abs() < 1e-9 {
+            continue;
+        }
+        let change = if a == 0.0 { 100.0 } else { (b - a) * 100.0 / a };
+        if change.abs() < tolerance_pct {
+            continue;
+        }
+        out.push_str(&format!(
+            "    {:<38} {:>12.1} → {:<12.1} {:+.1}%  (por iteração)
+",
+            label, a, b, change
+        ));
+    }
+    out
+}

--- a/crates/rts-dom/examples/dom_metrics/report.rs
+++ b/crates/rts-dom/examples/dom_metrics/report.rs
@@ -6,7 +6,7 @@
 //! tabela sozinha nunca responde, porque ninguém lembra o número da semana
 //! passada.
 
-use rts_dom::metrics::{AuditReport, DomMetrics, Phases, Samples};
+use rts_dom::metrics::{AuditReport, DomMetrics, Footprint, Phases, Samples};
 use std::time::Duration;
 
 /// Uma execução medida: N amostras de tempo mais o que aconteceu por dentro.
@@ -28,6 +28,9 @@ pub struct Run {
     /// A árvore ao FIM do cenário. `None` quando o cenário não deixa uma (o
     /// `parse` descarta cada árvore que cria).
     pub audit: Option<AuditReport>,
+    /// A PEGADA ao fim do cenário, quando há árvore. Comparada com a do início,
+    /// é o que mostra o estado derivado crescendo sem a árvore crescer.
+    pub footprint: Option<(Footprint, Footprint)>,
 }
 
 /// Estatísticas de tempo de uma execução, em milissegundos.
@@ -90,6 +93,18 @@ impl Run {
             );
         }
         self.print_ratios();
+        if let Some((antes, depois)) = &self.footprint {
+            println!("  memória (fim do cenário)");
+            print!("{}", depois.report());
+            let (a, d) = (antes.total(), depois.total());
+            if d != a {
+                println!(
+                    "      Δ desde o início do cenário: {:+.1} KiB ({:+.1}%)",
+                    (d as f64 - a as f64) / 1024.0,
+                    (d as f64 - a as f64) * 100.0 / a.max(1) as f64
+                );
+            }
+        }
         if let Some(a) = &self.audit {
             if a.bugs() > 0 || a.leaks() > 0 || a.page_issues() > 0 {
                 println!("  consistência ao FIM do cenário");

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -81,6 +81,7 @@ pub fn run<F: FnMut()>(
         notes: metrics::samples::snapshot(),
         text_measures: m.take(),
         audit: None,
+        footprint: None,
     }
 }
 
@@ -146,6 +147,9 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
     let leaf = deepest_element(&dom);
     let mut tick = 0u32;
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("texto + relayout", "frame", iters, m, || {
         tick += 1;
         if let Some(t) = leaf {
@@ -154,6 +158,7 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
         std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
     drop(dom);
 
@@ -165,6 +170,9 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
     let leaf = deepest_element(&dom);
     let mut flip = false;
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("classe + relayout", "frame", iters, m, || {
         flip = !flip;
         if let Some(t) = leaf {
@@ -173,6 +181,7 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
         std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
     drop(dom);
 
@@ -224,6 +233,9 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
     let host = biggest_container(&dom);
     let mut i = 0u32;
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("innerHTML + relayout", "frame", iters, m, || {
         i += 1;
         if let Some(h) = host {
@@ -232,6 +244,7 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
         std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
 
     runs
@@ -246,6 +259,9 @@ pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
 
     let mut dom = parse_html_to_dom(host_html);
     let host = dom.query("#host").expect("host");
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("append × N", "árvore", 1, m, || {
         for i in 0..n {
             let li = dom.create_element("li");
@@ -256,6 +272,7 @@ pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
         }
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
 
     // O MESMO trabalho, lendo o layout a cada 100 inserções — o padrão real de
@@ -264,6 +281,9 @@ pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
     // proporcional à primeira, a invalidação é quadrática.
     let mut dom = parse_html_to_dom(host_html);
     let host = dom.query("#host").expect("host");
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("append + layout /100", "árvore", 1, m, || {
         for i in 0..n {
             let li = dom.create_element("li");
@@ -277,6 +297,7 @@ pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
         }
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
 
     // REMOÇÃO em massa — o inverso, e o cenário que revela o estado derivado
@@ -293,12 +314,16 @@ pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
         criados.push(li);
     }
     let mut it = criados.into_iter();
+    // A pegada ANTES do cenário: o Δ contra a do fim é o que mostra o estado
+    // derivado crescendo sem a árvore crescer.
+    let antes = metrics::footprint(&dom);
     let mut r = run("remove × N", "árvore", 1, m, || {
         for id in it.by_ref() {
             dom.remove_node(id);
         }
     });
     r.audit = Some(metrics::audit(&dom));
+    r.footprint = Some((antes, metrics::footprint(&dom)));
     runs.push(r);
 
     runs

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -1,0 +1,305 @@
+//! Os CENÁRIOS — cada um isola um caminho que um cronômetro sozinho mistura.
+//!
+//! A regra de um cenário aqui: ele responde a uma pergunta que os outros não
+//! respondem. `layout frio` e `relayout parado` medem a mesma função e existem
+//! separados porque a diferença entre os dois É a resposta (o que os caches
+//! cobrem). Um cenário que só repete outro com números maiores não entra.
+
+use crate::report::Run;
+use rts_dom::layout::{ApproxMeasurer, LayoutCtx, TextMeasurer};
+use rts_dom::metrics;
+use rts_dom::{parse_html_to_dom, Dom, NodeId, NodeKind};
+use std::time::Instant;
+
+/// Medidor que CONTA as medições além de responder. `text_width` é o único
+/// trabalho do layout que sai do crate (o backend real mede pela fonte), então
+/// contá-lo separa "o layout está lento" de "o layout pede muita medição".
+pub struct CountingMeasurer {
+    inner: ApproxMeasurer,
+    widths: std::cell::Cell<u64>,
+    lines: std::cell::Cell<u64>,
+}
+
+impl CountingMeasurer {
+    pub fn new() -> Self {
+        Self { inner: ApproxMeasurer, widths: 0.into(), lines: 0.into() }
+    }
+    fn take(&self) -> (u64, u64) {
+        let v = (self.widths.get(), self.lines.get());
+        self.widths.set(0);
+        self.lines.set(0);
+        v
+    }
+}
+
+impl TextMeasurer for CountingMeasurer {
+    fn text_width(&self, text: &str, size: f32, mono: bool, bold: bool) -> f32 {
+        self.widths.set(self.widths.get() + 1);
+        self.inner.text_width(text, size, mono, bold)
+    }
+    fn line_height(&self, size: f32) -> f32 {
+        self.lines.set(self.lines.get() + 1);
+        self.inner.line_height(size)
+    }
+}
+
+pub fn ctx<'a>(m: &'a CountingMeasurer, w: f32, h: f32) -> LayoutCtx<'a> {
+    LayoutCtx { viewport_w: w, viewport_h: h, measurer: m }
+}
+
+/// Roda `f` `iters` vezes, guardando o tempo de CADA iteração (p95 e máximo só
+/// existem porque as amostras são guardadas; uma média acumulada não os teria).
+/// `audit_of` devolve a árvore final quando o cenário deixa uma — é o que
+/// permite dizer, junto com o tempo, se ele terminou com a árvore consistente.
+pub fn run<F: FnMut()>(
+    name: &'static str,
+    unit: &'static str,
+    iters: u32,
+    m: &CountingMeasurer,
+    mut f: F,
+) -> Run {
+    m.take();
+    let before = metrics::counters::snapshot();
+    // Fases e amostras são ZERADAS por cenário em vez de subtraídas: `min`/`max`
+    // de uma fase não são subtraíveis (o pico do cenário anterior sobreviveria ao
+    // delta e apareceria como pico deste), e uma amostra repetida não voltaria a
+    // ser coletada depois que o teto do cenário anterior fechou a lista.
+    metrics::phases::reset();
+    metrics::samples::reset();
+    let mut samples = Vec::with_capacity(iters as usize);
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed());
+    }
+    Run {
+        name,
+        unit,
+        samples,
+        counters: metrics::counters::snapshot().delta(&before),
+        phases: metrics::phase_snapshot(),
+        notes: metrics::samples::snapshot(),
+        text_measures: m.take(),
+        audit: None,
+    }
+}
+
+/// O elemento mais PROFUNDO — a folha cuja mutação tem o menor alcance
+/// possível. Se até ela invalidar a página inteira, a invalidação é global de
+/// fato, e não por subárvore como a API sugere.
+pub fn deepest_element(dom: &Dom) -> Option<NodeId> {
+    let mut best: Option<(usize, usize)> = None;
+    let mut stack = vec![(0usize, 0usize)];
+    while let Some((idx, depth)) = stack.pop() {
+        if matches!(dom.node(idx).kind, NodeKind::Element { .. })
+            && best.map(|(_, d)| depth > d).unwrap_or(true)
+        {
+            best = Some((idx, depth));
+        }
+        stack.extend(dom.node(idx).children.iter().map(|&c| (c, depth + 1)));
+    }
+    best.map(|(idx, _)| dom.id_of_idx(idx))
+}
+
+/// O elemento com MAIS filhos — o container que um `innerHTML` ou uma remoção
+/// em massa realmente atinge numa página real.
+fn biggest_container(dom: &Dom) -> Option<NodeId> {
+    let mut best: Option<(usize, usize)> = None;
+    for idx in 0..dom.nodes.len() {
+        if matches!(dom.node(idx).kind, NodeKind::Element { .. })
+            && best.map(|(_, n)| dom.node(idx).children.len() > n).unwrap_or(true)
+        {
+            best = Some((idx, dom.node(idx).children.len()));
+        }
+    }
+    best.map(|(idx, _)| dom.id_of_idx(idx))
+}
+
+/// Todos os cenários de uma página. `iters` é por cenário.
+pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> Vec<Run> {
+    let mut runs = Vec::new();
+
+    // 1. PARSE puro — tokenizer + árvore + índices + o CSS dos `<style>`.
+    runs.push(run("parse", "parse", iters, m, || {
+        std::hint::black_box(parse_html_to_dom(html));
+    }));
+
+    // 2. LAYOUT FRIO — árvore recém-parseada, todo cache vazio: o que a página
+    //    paga ao abrir, e o único cenário em que a cascade roda de verdade.
+    runs.push(run("layout frio", "página", iters, m, || {
+        let d = parse_html_to_dom(html);
+        std::hint::black_box(rts_dom::layout::layout_document(&d, &ctx(m, vw, vh)));
+    }));
+
+    // 3. RELAYOUT SEM MUTAÇÃO — o teto dos caches: nada mudou, então o que
+    //    sobra é trabalho que nenhum memo cobre (o custo de um frame parado).
+    let dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    runs.push(run("relayout parado", "frame", iters, m, || {
+        std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
+    // 4. TEXTO de uma folha + relayout — o contador, o relógio, o campo que
+    //    digita. Mede o que a invalidação PRESERVA.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    let leaf = deepest_element(&dom);
+    let mut tick = 0u32;
+    let mut r = run("texto + relayout", "frame", iters, m, || {
+        tick += 1;
+        if let Some(t) = leaf {
+            dom.set_text(t, &format!("tick {tick}"));
+        }
+        std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+    drop(dom);
+
+    // 5. CLASSE de uma folha + relayout — o caminho de todo estado visual
+    //    (`.active`, `.open`): muda o ESTILO, não só o conteúdo, então re-roda
+    //    a cascade que o cenário 4 preserva. A diferença entre os dois é o
+    //    preço de uma classe.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    let leaf = deepest_element(&dom);
+    let mut flip = false;
+    let mut r = run("classe + relayout", "frame", iters, m, || {
+        flip = !flip;
+        if let Some(t) = leaf {
+            dom.set_attr(t, "class", if flip { "active" } else { "" });
+        }
+        std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+    drop(dom);
+
+    // 6. HOVER — o backend informa o nó sob o cursor a cada frame. Deve custar
+    //    ZERO numa página sem regra `:hover` (há uma guarda para isso); este
+    //    cenário é o que prova que a guarda continua valendo.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    let mut n = 0usize;
+    runs.push(run("hover + relayout", "frame", iters, m, || {
+        n = (n + 7) % dom.nodes.len().max(1);
+        dom.set_hovered(Some(n));
+        std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
+    // 7-8. CONSULTAS: a genérica (lista de seletores) e a por `#id`, que tem
+    //    índice. As duas juntas dizem se o índice está sendo usado.
+    let dom = parse_html_to_dom(html);
+    runs.push(run("querySelectorAll", "consulta", iters, m, || {
+        std::hint::black_box(dom.query_all(".btn, div, a[href]"));
+    }));
+    let first_id = (0..dom.nodes.len())
+        .find_map(|i| dom.node(i).attr("id").map(str::to_string))
+        .unwrap_or_else(|| "nao-existe".into());
+    let sel = format!("#{first_id}");
+    runs.push(run("querySelector #id", "consulta", iters, m, || {
+        std::hint::black_box(dom.query(&sel));
+    }));
+    drop(dom);
+
+    // 9. EVENTO com bubbling — o caminho de todo clique: sobe a árvore
+    //    coletando callbacks. Custa em profundidade, não em tamanho de página.
+    let mut dom = parse_html_to_dom(html);
+    let leaf = deepest_element(&dom);
+    if let Some(t) = leaf {
+        dom.add_event_listener_cb(t, "click", 1);
+    }
+    runs.push(run("clique + bubbling", "evento", iters, m, || {
+        if let Some(t) = leaf {
+            std::hint::black_box(dom.dispatch_event_collect(t, "click", true));
+        }
+    }));
+    drop(dom);
+
+    // 10. innerHTML num container real — re-parse de subárvore, o padrão de
+    //     toda renderização de lista feita por script.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    let host = biggest_container(&dom);
+    let mut i = 0u32;
+    let mut r = run("innerHTML + relayout", "frame", iters, m, || {
+        i += 1;
+        if let Some(h) = host {
+            dom.set_inner_html(h, &format!("<p class=\"row\">linha {i}</p><p>outra</p>"));
+        }
+        std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+
+    runs
+}
+
+/// CONSTRUÇÃO programática — `createElement` + `appendChild` × N, o caminho de
+/// qualquer script que monta uma lista. Independe de arquivo: é sobre a
+/// estrutura, não sobre uma página.
+pub fn build(n: u32, vw: f32, vh: f32, m: &CountingMeasurer) -> Vec<Run> {
+    let mut runs = Vec::new();
+    let host_html = "<html><body><ul id=\"host\"></ul></body></html>";
+
+    let mut dom = parse_html_to_dom(host_html);
+    let host = dom.query("#host").expect("host");
+    let mut r = run("append × N", "árvore", 1, m, || {
+        for i in 0..n {
+            let li = dom.create_element("li");
+            dom.set_attr(li, "class", "item");
+            let txt = dom.create_text_node(&format!("item {i}"));
+            dom.append_child(li, txt);
+            dom.append_child(host, li);
+        }
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+
+    // O MESMO trabalho, lendo o layout a cada 100 inserções — o padrão real de
+    // um script que mede enquanto constrói. Separa o custo da CONSTRUÇÃO do
+    // custo da INVALIDAÇÃO que ela dispara: se a segunda linha não for
+    // proporcional à primeira, a invalidação é quadrática.
+    let mut dom = parse_html_to_dom(host_html);
+    let host = dom.query("#host").expect("host");
+    let mut r = run("append + layout /100", "árvore", 1, m, || {
+        for i in 0..n {
+            let li = dom.create_element("li");
+            dom.set_attr(li, "class", "item");
+            let txt = dom.create_text_node(&format!("item {i}"));
+            dom.append_child(li, txt);
+            dom.append_child(host, li);
+            if i % 100 == 99 {
+                std::hint::black_box(rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)));
+            }
+        }
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+
+    // REMOÇÃO em massa — o inverso, e o cenário que revela o estado derivado
+    // que sobrevive ao nó (índices, listeners): a auditoria ao fim é a métrica,
+    // não o tempo.
+    let mut dom = parse_html_to_dom(host_html);
+    let host = dom.query("#host").expect("host");
+    let mut criados: Vec<NodeId> = Vec::new();
+    for i in 0..n {
+        let li = dom.create_element("li");
+        dom.set_attr(li, "id", &format!("i{i}"));
+        dom.set_attr(li, "class", "item");
+        dom.append_child(host, li);
+        criados.push(li);
+    }
+    let mut it = criados.into_iter();
+    let mut r = run("remove × N", "árvore", 1, m, || {
+        for id in it.by_ref() {
+            dom.remove_node(id);
+        }
+    });
+    r.audit = Some(metrics::audit(&dom));
+    runs.push(r);
+
+    runs
+}

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -546,6 +546,72 @@ impl Dom {
         }
     }
 
+    /// Invalidação de uma mudança de ESTRUTURA (inserir, mover, remover).
+    ///
+    /// Um `appendChild` chamava o `touch()` global: o memo de estilo de TODOS os
+    /// nós ia fora, e o próximo layout re-cascadeava a página. Montar uma lista
+    /// de 4000 itens lendo o layout de vez em quando custava 82 120 cascades
+    /// completas — quadrático, medido.
+    ///
+    /// Sem seletor sensível a POSIÇÃO no stylesheet, inserir um nó não muda o
+    /// estilo de nenhum outro: basta invalidar a subárvore que entrou/saiu e os
+    /// ancestrais (que podem mudar de tamanho), que é o que `touch_subtrees`
+    /// faz. Com `:nth-child`/`:first-child`/`:empty`/`+`/`~`, os irmãos mudam
+    /// de verdade e o global é a resposta certa — a guarda está em
+    /// [`Stylesheet::position_sensitive`](crate::style::Stylesheet::position_sensitive).
+    /// `moved` é o nó que entrou/saiu (a subárvore dele é o que muda de estilo);
+    /// `former_parent` é o pai anterior, quando houve um, para os epochs de
+    /// layout dele subirem também.
+    ///
+    /// Escrito sem `HashSet`, ao contrário do `touch_subtrees`: com UMA raiz não
+    /// há sobreposição a deduplicar numa árvore acíclica, e a alocação por
+    /// chamada aparece — um `append` × 4000 são 4000 chamadas destas. A primeira
+    /// versão reusava `touch_subtrees(pai)` e ficou 118× MAIS LENTA na remoção:
+    /// varrer a subárvore do PAI por nó removido é quadrático, e é o pai que tem
+    /// 2000 filhos, não o nó que saiu.
+    fn touch_structural(&mut self, moved: NodeIdx, former_parent: Option<NodeIdx>) {
+        if self.stylesheet.position_sensitive() {
+            self.touch();
+            return;
+        }
+        self.revision = self.revision.wrapping_add(1);
+        crate::bump!(touch_subtree_calls);
+        // CONSTRUÇÃO PURA (montar a árvore antes de ler qualquer estilo): não há
+        // memo nem cache preenchido, então não há o que invalidar — nem os
+        // epochs, que só existem para invalidar CHAVES já guardadas. Sem este
+        // atalho, um `append` × 4000 pagava a varredura e dois `borrow_mut` por
+        // nó, e ficava 40% mais lento do que o `touch()` global que substituiu.
+        if self.computed_memo.borrow().is_empty()
+            && self.base_memo.borrow().is_empty()
+            && self.layout_measure_cache.borrow().is_empty()
+            && self.intrinsic_width_cache.borrow().is_empty()
+        {
+            return;
+        }
+        let mut computed = self.computed_memo.borrow_mut();
+        let mut base = self.base_memo.borrow_mut();
+        let mut stack = vec![moved];
+        let mut visited = 0u64;
+        while let Some(node) = stack.pop() {
+            visited += 1;
+            computed.remove(&node);
+            base.remove(&node);
+            self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+            stack.extend(self.nodes[node].children.iter().copied());
+        }
+        crate::bump!(touch_subtree_nodes, visited);
+        drop(computed);
+        drop(base);
+        // Ancestrais: só o EPOCH — o estilo deles não mudou, o tamanho pode ter.
+        for start in [self.nodes[moved].parent, former_parent].into_iter().flatten() {
+            let mut cur = Some(start);
+            while let Some(node) = cur {
+                self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+                cur = self.nodes[node].parent;
+            }
+        }
+    }
+
     pub(crate) fn layout_epoch(&self, idx: NodeIdx) -> u64 {
         self.layout_epochs[idx]
     }
@@ -2416,7 +2482,6 @@ impl Dom {
     /// filho de `parent`, anexa ao fim (semântica do DOM). Move `child` do pai
     /// antigo; ignora ids inválidos/ciclos.
     pub fn insert_before(&mut self, parent: NodeId, child: NodeId, reference: Option<NodeId>) {
-        self.touch();
         let (Some(parent), Some(child)) = (self.resolve(parent), self.resolve(child)) else {
             return;
         };
@@ -2429,20 +2494,24 @@ impl Dom {
         if ref_idx == Some(child) {
             // já garante o parent (caso o nó fosse solto) e mantém a ordem.
             if self.nodes[child].parent != Some(parent) {
+                let old_parent = self.nodes[child].parent;
                 self.detach(child);
                 self.nodes[child].parent = Some(parent);
                 self.nodes[parent].children.push(child);
+                self.touch_structural(child, old_parent);
             }
             return;
         }
         // captura a posição da referência ANTES do detach (o detach pode mexer na
         // lista de filhos do pai se o child já era irmão da referência).
+        let old_parent = self.nodes[child].parent;
         self.detach(child);
         self.nodes[child].parent = Some(parent);
         let pos = ref_idx
             .and_then(|r| self.nodes[parent].children.iter().position(|&c| c == r))
             .unwrap_or(self.nodes[parent].children.len());
         self.nodes[parent].children.insert(pos, child);
+        self.touch_structural(child, old_parent);
     }
 
     /// `node.nodeType` — código numérico do DOM: Element=1, Text=3, Comment=8,
@@ -2473,7 +2542,6 @@ impl Dom {
     /// Move `child` para o fim dos filhos de `parent` (`parent.appendChild`).
     /// Remove `child` do pai antigo, se tiver. Ignora ids inválidos ou ciclos.
     pub fn append_child(&mut self, parent: NodeId, child: NodeId) {
-        self.touch();
         let (Some(parent), Some(child)) = (self.resolve(parent), self.resolve(child)) else {
             return;
         };
@@ -2483,19 +2551,29 @@ impl Dom {
         if self.is_ancestor(child, parent) {
             return; // evita criar ciclo (child seria ancestral de parent)
         }
+        // O pai ANTIGO também muda (perdeu um filho) — capturado antes do detach.
+        let old_parent = self.nodes[child].parent;
         self.detach(child);
         self.nodes[child].parent = Some(parent);
         self.nodes[parent].children.push(child);
+        self.touch_structural(child, old_parent);
     }
 
     /// Desliga um nó do pai (`element.remove`). O nó continua na arena (lixo).
     pub fn remove_node(&mut self, id: NodeId) {
-        self.touch();
-        if let Some(idx) = self.resolve(id) {
-            if idx != self.root {
-                self.detach(idx);
-            }
+        let Some(idx) = self.resolve(id) else { return };
+        if idx == self.root {
+            return;
         }
+        // A subárvore que sai já não é alcançável depois do detach, então o
+        // ANTIGO PAI é quem carrega a invalidação (o `touch_subtrees` desce por
+        // ele e sobe pelos ancestrais).
+        // ANTES do detach: a raiz da invalidação é o nó que SAI (a subárvore
+        // dele), e os ancestrais precisam estar alcançáveis para os epochs
+        // subirem — depois do detach o nó já não tem pai.
+        let parent = self.nodes[idx].parent;
+        self.touch_structural(idx, parent);
+        self.detach(idx);
     }
 
     /// Aloca um nó sem pai (usado por create_element / set_text). Índice cru.

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -456,6 +456,11 @@ impl Dom {
     /// podem atravessar a árvore.
     fn touch(&mut self) {
         self.revision = self.revision.wrapping_add(1);
+        crate::bump!(touch_global);
+        crate::bump!(
+            memo_cleared_entries,
+            self.computed_memo.borrow().len() + self.base_memo.borrow().len()
+        );
         self.computed_memo.borrow_mut().clear();
         self.base_memo.borrow_mut().clear();
         self.layout_measure_cache.borrow_mut().clear();
@@ -466,6 +471,7 @@ impl Dom {
     /// O cache de cascade pode continuar válido para o próximo layout.
     fn touch_render_only(&mut self) {
         self.revision = self.revision.wrapping_add(1);
+        crate::bump!(touch_render_only);
         self.layout_measure_cache.borrow_mut().clear();
         self.intrinsic_width_cache.borrow_mut().clear();
     }
@@ -474,6 +480,7 @@ impl Dom {
     /// e overrides locais porque a mudança pode afetar propriedades herdadas.
     fn touch_subtree(&mut self, idx: NodeIdx) {
         self.revision = self.revision.wrapping_add(1);
+        crate::bump!(touch_subtree_calls);
         let mut affected = HashSet::new();
         let mut stack = vec![idx];
         while let Some(node) = stack.pop() {
@@ -481,6 +488,7 @@ impl Dom {
                 stack.extend(self.nodes[node].children.iter().copied());
             }
         }
+        crate::bump!(touch_subtree_nodes, affected.len());
         let mut computed = self.computed_memo.borrow_mut();
         let mut base = self.base_memo.borrow_mut();
         for &node in &affected {
@@ -503,6 +511,7 @@ impl Dom {
         I: IntoIterator<Item = NodeIdx>,
     {
         self.revision = self.revision.wrapping_add(1);
+        crate::bump!(touch_subtree_calls);
         let roots: Vec<NodeIdx> = roots.into_iter().collect();
         let mut affected = HashSet::new();
         let mut stack = roots.clone();
@@ -519,6 +528,7 @@ impl Dom {
                 ancestor = self.nodes[node].parent;
             }
         }
+        crate::bump!(touch_subtree_nodes, affected.len());
         let mut computed = self.computed_memo.borrow_mut();
         let mut base = self.base_memo.borrow_mut();
         for node in affected {
@@ -535,6 +545,47 @@ impl Dom {
         self.layout_epochs[idx]
     }
 
+    /// Os dois índices de consulta, para a AUDITORIA (`metrics::audit`) poder
+    /// confrontá-los com a árvore. Só de leitura, e `pub(crate)`: um índice que
+    /// saísse do crate viraria uma segunda fonte de verdade sobre quem tem qual
+    /// classe.
+    pub(crate) fn debug_indices(
+        &self,
+    ) -> (&HashMap<String, Vec<NodeIdx>>, &HashMap<String, Vec<NodeIdx>>) {
+        (&self.id_index, &self.class_index)
+    }
+
+    /// Todo estado DERIVADO indexado por nó, como `(nome do mapa, índice)`. A
+    /// auditoria só precisa saber que existe uma entrada para um nó — não o que
+    /// há nela — e enumerar os mapas AQUI (uma vez, ao lado dos campos) é o que
+    /// impede que um mapa novo passe a vazar sem ninguém notar: quem esquecer de
+    /// acrescentá-lo aqui não ganha auditoria, mas quem o remover não deixa a
+    /// auditoria mentindo sobre um campo que já não existe.
+    pub(crate) fn derived_node_state(&self) -> Vec<(&'static str, NodeIdx)> {
+        let mut out = Vec::new();
+        let mut push = |label: &'static str, it: &mut dyn Iterator<Item = NodeIdx>| {
+            for idx in it {
+                out.push((label, idx));
+            }
+        };
+        push("style_overrides", &mut self.style_overrides.keys().copied());
+        push("listeners", &mut self.listeners.keys().copied());
+        push("listener_cbs", &mut self.listener_cbs.keys().map(|(idx, _)| *idx));
+        push("input_values", &mut self.input_values.keys().copied());
+        push("image_pixels", &mut self.image_pixels.keys().copied());
+        push("active_transitions", &mut self.active_transitions.keys().copied());
+        push("anim_override", &mut self.anim_override.keys().copied());
+        push("prev_computed", &mut self.prev_computed.keys().copied());
+        push("focused_input", &mut self.focused_input.into_iter());
+        out
+    }
+
+    /// O tamanho da tabela de epochs de layout — deve andar junto com a arena, e
+    /// a auditoria compara os dois.
+    pub(crate) fn layout_epoch_len(&self) -> usize {
+        self.layout_epochs.len()
+    }
+
     pub(crate) fn layout_measure_get(&self, key: LayoutMeasureKey) -> Option<(f32, f32)> {
         self.layout_measure_cache.borrow().get(&key).copied()
     }
@@ -542,6 +593,7 @@ impl Dom {
     pub(crate) fn layout_measure_put(&self, key: LayoutMeasureKey, value: (f32, f32)) {
         let mut cache = self.layout_measure_cache.borrow_mut();
         if cache.len() >= 4096 && !cache.contains_key(&key) {
+            crate::bump!(measure_cache_evictions);
             if let Some(old_key) = cache.keys().next().copied() {
                 cache.remove(&old_key);
             }
@@ -556,6 +608,7 @@ impl Dom {
     pub(crate) fn intrinsic_width_put(&self, key: IntrinsicWidthKey, value: f32) {
         let mut cache = self.intrinsic_width_cache.borrow_mut();
         if cache.len() >= 4096 && !cache.contains_key(&key) {
+            crate::bump!(intrinsic_cache_evictions);
             if let Some(old_key) = cache.keys().next().copied() {
                 cache.remove(&old_key);
             }
@@ -586,6 +639,7 @@ impl Dom {
     /// `touch()`, para o `base_memo` sobreviver ao frame.
     fn touch_anim(&mut self) {
         self.anim_epoch = self.anim_epoch.wrapping_add(1);
+        crate::bump!(touch_anim);
         self.layout_measure_cache.borrow_mut().clear();
         self.intrinsic_width_cache.borrow_mut().clear();
     }
@@ -603,7 +657,9 @@ impl Dom {
             self.base_memo_revision.set(style_epoch);
             self.base_memo_viewport.set(vp_key);
         }
+        crate::bump!(base_calls);
         if let Some(hit) = self.base_memo.borrow().get(&idx) {
+            crate::bump!(base_memo_hits);
             return Some(hit.clone());
         }
         let computed = self.computed_style_idx_inner(idx)?;
@@ -615,6 +671,9 @@ impl Dom {
     /// (chamado pelo parser ao encontrar um `RawElement` de `style`). Vários
     /// `<style>` acumulam, com as regras posteriores desempatando por cima.
     pub fn add_stylesheet(&mut self, css: &str) {
+        let _phase = crate::metrics::phases::scope("parse-css");
+        crate::bump!(stylesheets_added);
+        crate::bump!(css_bytes, css.len());
         self.touch();
         self.stylesheet.append_css(css);
         // guarda o bruto p/ os pseudo-elementos ::-webkit-scrollbar* (#1744).
@@ -654,6 +713,14 @@ impl Dom {
         if id.generation == self.generation && idx < self.nodes.len() {
             Some(idx)
         } else {
+            // Distinguir os dois é o que separa "id de uma árvore ANTERIOR"
+            // (uso-após-troca, quase sempre um bug do chamador) de "índice fora
+            // da arena" (id corrompido ou forjado na travessia da ABI).
+            if id.generation != self.generation {
+                crate::bump!(resolve_stale);
+            } else {
+                crate::bump!(resolve_out_of_range);
+            }
             None
         }
     }
@@ -665,6 +732,7 @@ impl Dom {
 
     /// Registra um nó nos índices a partir de seus atributos `id`/`class`.
     fn deindex_node(&mut self, id: NodeIdx) {
+        crate::bump!(index_removes);
         let old_id = self.nodes[id].attr("id").map(str::to_owned);
         let old_classes: Vec<String> = self.nodes[id]
             .attr("class")
@@ -707,9 +775,11 @@ impl Dom {
             .unwrap_or_default();
         if let Some(k) = id_attr {
             self.id_index.entry(k).or_default().push(id);
+            crate::bump!(index_inserts);
         }
         for c in classes {
             self.class_index.entry(c).or_default().push(id);
+            crate::bump!(index_inserts);
         }
     }
 
@@ -725,6 +795,8 @@ impl Dom {
         self.layout_epochs.push(0);
         self.index_node(id);
         self.nodes[parent].children.push(id);
+        crate::bump!(nodes_created);
+        crate::bump!(tree_links);
         id
     }
 
@@ -758,6 +830,7 @@ impl Dom {
     /// Núcleo do `query` em índices crus (interno). O `query` público embrulha o
     /// resultado no `NodeId` versionado.
     fn query_idx(&self, sel: &str) -> Option<NodeIdx> {
+        crate::bump!(query_calls);
         let selectors = crate::style::parse_selector_list(sel);
         if selectors.is_empty() {
             return None;
@@ -834,6 +907,7 @@ impl Dom {
     /// Substitui TODO o conteúdo de um elemento por um único nó de texto (o
     /// equivalente a `element.textContent = txt`). Não faz nada num nó de texto.
     pub fn set_text(&mut self, id: NodeId, text: &str) {
+        crate::bump!(set_text);
         let Some(idx) = self.resolve(id) else { return };
         if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
             return;
@@ -887,7 +961,9 @@ impl Dom {
             self.memo_style_epoch.set(style_epoch);
             self.memo_viewport.set(vp_key);
         }
+        crate::bump!(computed_calls);
         if let Some(hit) = self.computed_memo.borrow().get(&idx) {
+            crate::bump!(computed_memo_hits);
             return Some(hit.clone());
         }
         // O estilo COM animação = a BASE (cascade sem anim, memoizada por revisão
@@ -912,6 +988,8 @@ impl Dom {
             NodeKind::Element { tag } => tag.as_str(),
             _ => return None,
         };
+        crate::bump!(cascade_runs);
+        let _phase = crate::metrics::phases::scope("cascade");
         // id/classes só são materializados quando há regras de autor para testar.
         // Em páginas sem `<style>`, o layout ainda computa cada nó, mas não precisa
         // alocar strings que nunca serão consultadas pelo RuleIndex.
@@ -960,6 +1038,7 @@ impl Dom {
             match (parent_vars, own_customs.is_empty()) {
                 (p, true) => p, // só herda: compartilha o Arc (O(1))
                 (p, false) => {
+                    crate::bump!(custom_maps_built);
                     let mut m = p.map(|a| (*a).clone()).unwrap_or_default();
                     // o valor de uma custom pode conter var() de OUTRA — a
                     // substituição recursiva do consumidor resolve; guarda cru.
@@ -1051,6 +1130,7 @@ impl Dom {
         // foram declaradas neste nó descem do PAI-elemento. É o que faz o texto pegar
         // a cor do body sem cada elemento redeclarar (sem isto, texto fica preto).
         if let Some(parent_css) = &parent_css {
+            crate::bump!(inherit_steps);
             css.inherit_from(parent_css);
         }
 
@@ -1124,6 +1204,7 @@ impl Dom {
     /// (O handler real é guardado no lado TS, indexado por (nó, tipo).) Idempotente:
     /// não duplica o mesmo tipo. O tipo é CASE-SENSITIVE (spec DOM: `click`≠`CLICK`).
     pub fn add_event_listener(&mut self, id: NodeId, event_type: &str) {
+        crate::bump!(listeners_added);
         let Some(idx) = self.resolve(id) else { return };
         let types = self.listeners.entry(idx).or_default();
         let t = event_type.to_string();
@@ -1150,6 +1231,7 @@ impl Dom {
     /// `element.removeEventListener(type)`: para de escutar `type` neste nó.
     /// (Remove também os callbacks registrados do tipo.)
     pub fn remove_event_listener(&mut self, id: NodeId, event_type: &str) {
+        crate::bump!(listeners_removed);
         let Some(idx) = self.resolve(id) else { return };
         if let Some(types) = self.listeners.get_mut(&idx) {
             types.retain(|x| x != event_type);
@@ -1169,12 +1251,14 @@ impl Dom {
     /// que escuta, enfileira `(nó, tipo)` para o loop TS via `poll_event`. Devolve
     /// quantos listeners foram enfileirados. Tipo CASE-SENSITIVE.
     pub fn dispatch_event(&mut self, target: NodeId, event_type: &str, bubbles: bool) -> i64 {
+        crate::bump!(dispatches);
         let mut count = 0;
         let mut cur = Some(target);
         let mut first = true;
         while let Some(node) = cur {
             let Some(idx) = self.resolve(node) else { break };
             if self.listeners.get(&idx).map(|v| v.iter().any(|x| x == event_type)).unwrap_or(false) {
+                crate::bump!(dispatch_targets);
                 self.event_queue.push_back((idx, event_type.to_string()));
                 count += 1;
             }
@@ -1227,6 +1311,7 @@ impl Dom {
         // Mantém o contrato do polling também (contadores/fila do modelo #1760):
         // um app antigo que só usa pumpEvents continua vendo o evento.
         self.dispatch_event(target, event_type, bubbles);
+        crate::bump!(callbacks_collected, self.last_dispatch.len());
         self.last_dispatch.len() as i64
     }
 
@@ -1293,6 +1378,8 @@ impl Dom {
     /// Devolve `true` se há QUALQUER animação ativa (o backend deve continuar
     /// repintando — pedir o próximo frame).
     pub fn advance(&mut self, now_ms: f32) -> bool {
+        crate::bump!(anim_frames);
+        let _phase = crate::metrics::phases::scope("animate");
         // todos os elementos da árvore (a animação só vale p/ elementos).
         let mut elements = Vec::new();
         self.collect_all_element_idxs(self.root, &mut elements);
@@ -1350,6 +1437,7 @@ impl Dom {
                         .get(&idx)
                         .cloned()
                         .unwrap_or_else(|| prev_style.clone());
+                    crate::bump!(transitions_started);
                     self.active_transitions.insert(
                         idx,
                         crate::anim::ActiveTransition { from, start_ms: now_ms, spec },
@@ -1402,6 +1490,7 @@ impl Dom {
     /// val)` é interpretado pelo `apply_slot` do `ComputedStyle` (nunca casa string
     /// CSS aqui). Ignora id que não resolve.
     pub fn set_node_style_slot(&mut self, id: NodeId, slot: i64, val: i64) {
+        crate::bump!(style_overrides_set);
         let Some(idx) = self.resolve(id) else { return };
         self.touch_subtree(idx);
         self.style_overrides.entry(idx).or_default().apply_slot(slot, val);
@@ -1413,6 +1502,7 @@ impl Dom {
     /// slot1, val1, …]` (o jeito que o buffer GC chega da ABI). Triplas com id
     /// inválido são ignoradas (robustez).
     pub fn apply_style_batch(&mut self, triples: &[i64]) {
+        crate::bump!(style_overrides_set, triples.len() / 3);
         let mut updates = Vec::with_capacity(triples.len() / 3);
         for t in triples.chunks_exact(3) {
             if let Some(node) = NodeId::from_abi(t[0]) {
@@ -1612,6 +1702,7 @@ impl Dom {
     /// `getElementsByTagName(tag)`: todos os descendentes da árvore com a tag.
     /// (`"*"` casa qualquer elemento.) Reusa o matcher de `query_all`.
     pub fn get_elements_by_tag_name(&self, tag: &str) -> Vec<NodeId> {
+        crate::bump!(tag_scans);
         let tag = tag.trim();
         if tag == "*" {
             // todos os elementos em ordem de documento.
@@ -1687,6 +1778,7 @@ impl Dom {
     /// filhos); `deep=true` clona a subárvore inteira. O clone é SOLTO (sem pai) —
     /// anexe-o com appendChild/insertBefore. Devolve o `NodeId` do clone.
     pub fn clone_node(&mut self, id: NodeId, deep: bool) -> Option<NodeId> {
+        crate::bump!(clones);
         let idx = self.resolve(id)?;
         let new_idx = self.clone_subtree(idx, deep);
         Some(self.make_id(new_idx))
@@ -1863,6 +1955,7 @@ impl Dom {
     /// `element.removeAttribute(name)`: remove o atributo (no-op se ausente).
     /// Limpa os índices id/class para o nó (a busca revalida, mas evita stale).
     pub fn remove_attr(&mut self, id: NodeId, name: &str) {
+        crate::bump!(remove_attr);
         let Some(idx) = self.resolve(id) else { return };
         let name_lc = name.to_ascii_lowercase();
         let Some(old_value) = self.nodes[idx]
@@ -1971,6 +2064,7 @@ impl Dom {
         if selectors.is_empty() {
             return Vec::new();
         }
+        crate::bump!(query_calls);
         let mut out = Vec::new();
         self.query_all_into(self.root, &selectors, &mut out);
         out
@@ -1982,6 +2076,7 @@ impl Dom {
         selectors: &[crate::style::ComplexSelector],
         out: &mut Vec<NodeId>,
     ) {
+        crate::bump!(query_nodes_visited);
         if idx != self.root && selectors.iter().any(|sel| self.matches_complex(idx, sel)) {
             out.push(self.make_id(idx));
         }
@@ -2004,6 +2099,7 @@ impl Dom {
     /// combinadores. O ÚLTIMO compound casa `idx`; os anteriores casam ancestrais/
     /// irmãos conforme o combinador (matching da direita p/ a esquerda).
     fn matches_complex(&self, idx: NodeIdx, sel: &crate::style::ComplexSelector) -> bool {
+        crate::bump!(selector_matches);
         let n = sel.compounds.len();
         if !self.compound_matches_idx(idx, &sel.compounds[n - 1]) {
             return false;
@@ -2158,6 +2254,7 @@ impl Dom {
     /// Define/atualiza um atributo (`element.setAttribute`). Cria se não existir.
     /// Reindexa `id`/`class` para que mudanças de valor não deixem candidatos stale.
     pub fn set_attr(&mut self, id: NodeId, name: &str, value: &str) {
+        crate::bump!(set_attr);
         let Some(idx) = self.resolve(id) else { return };
         let name_lc = name.to_ascii_lowercase();
         if self.nodes[idx]
@@ -2297,12 +2394,14 @@ impl Dom {
         let id = self.nodes.len();
         self.nodes.push(Node { kind, attrs: Vec::new(), parent: None, children: Vec::new() });
         self.layout_epochs.push(0);
+        crate::bump!(nodes_created);
         id
     }
 
     /// Remove `idx` da lista de filhos do seu pai atual (se houver).
     fn detach(&mut self, idx: NodeIdx) {
         if let Some(p) = self.nodes[idx].parent.take() {
+            crate::bump!(nodes_detached);
             self.nodes[p].children.retain(|&c| c != idx);
         }
     }
@@ -2400,6 +2499,8 @@ impl Dom {
     /// parseados são COPIADOS para esta arena (re-parentados sob `id`), atualizando
     /// os índices id/class. Não faz nada num nó que não é elemento ou não resolve.
     pub fn set_inner_html(&mut self, id: NodeId, html: &str) {
+        crate::bump!(inner_html_sets);
+        let _phase = crate::metrics::phases::scope("set-inner-html");
         self.touch();
         let Some(idx) = self.resolve(id) else { return };
         if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
@@ -2676,10 +2777,13 @@ fn parse_attrs(raw: &str) -> Vec<Attr> {
         };
         // No HTML, um atributo duplicado é ignorado depois da primeira ocorrência.
         if !attrs.iter().any(|a: &Attr| a.name == name) {
+            crate::bump!(attrs_parsed);
             attrs.push(Attr {
                 name,
                 value: crate::html::decode_entities(&value),
             });
+        } else {
+            crate::bump!(attrs_duplicated);
         }
     }
     attrs
@@ -2703,7 +2807,9 @@ pub fn parse_html_to_dom(html: &str) -> Dom {
     // vez — em Rust, como DADOS (tabela em block.rs), rodando só quando há DOM. NÃO é
     // mais um prelude `.ts` (isso quebrava todo programa: o `ua.ts` chamava `dom.*`
     // no top-level e `dom` é unbound sem `import "rts:dom"`). Idempotente.
+    let _phase = crate::metrics::phases::scope("load-html");
     crate::block::install_ua_defaults();
+    crate::bump!(html_bytes, html.len());
     let mut dom = Dom::new();
     // Pilha de (índice cru aberto, nome da tag). Começa na raiz Document.
     let mut open: Vec<(NodeIdx, String)> = vec![(dom.root, String::new())];
@@ -2715,7 +2821,11 @@ pub fn parse_html_to_dom(html: &str) -> Dom {
                     // Pop até encontrar a tag de nome igual (tolerante).
                     if let Some(pos) = open.iter().rposition(|(_, n)| *n == name) {
                         // Fecha esse nível e quaisquer filhos mal-fechados acima.
+                        crate::bump!(tags_unclosed_at_eof, open.len().saturating_sub(pos + 1));
                         open.truncate(pos);
+                    } else {
+                        crate::bump!(tags_orphan_close);
+                        crate::note!("tag-de-fechamento-orfa", format!("</{name}>"));
                     }
                     // `</x>` órfão (sem abertura): ignora, não mexe na pilha.
                 } else {
@@ -2727,12 +2837,15 @@ pub fn parse_html_to_dom(html: &str) -> Dom {
                     // um container (ver `implicitly_closes`). O guard `> 1`
                     // preserva a raiz `#document`.
                     while open.len() > 1 && implicitly_closes(&name, &open.last().unwrap().1) {
+                        crate::bump!(tags_implicitly_closed);
                         open.pop();
                     }
                     let parent = open.last().unwrap().0;
                     let attrs = parse_attrs(&attrs_raw);
                     let id = dom.push(NodeKind::Element { tag: name.clone() }, attrs, parent);
-                    if !is_void(&name) {
+                    if is_void(&name) {
+                        crate::bump!(tags_void);
+                    } else {
                         open.push((id, name));
                     }
                 }

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -254,7 +254,12 @@ pub struct Dom {
     /// (todas as regras × seletores) rodava várias vezes POR NÓ num único layout
     /// (pré-pass de medição + pintura + intrínsecas). Invalidado quando a revisão
     /// muda. `RefCell` porque `computed_style_idx` é `&self` (chamado do layout).
-    computed_memo: std::cell::RefCell<HashMap<NodeIdx, crate::style::ComputedStyle>>,
+    /// O valor é `Rc` e não `ComputedStyle`: um `ComputedStyle` tem 1000 bytes
+    /// (medido por `metrics::footprint::type_sizes`), e um hit de memo devolvia
+    /// uma CÓPIA deles. Num relayout de 3000 elementos isso eram ~12 MB de
+    /// memcpy por frame com 100% de acerto de cache — o cache funcionando e
+    /// custando. Com `Rc`, um hit é um incremento de contador.
+    computed_memo: std::cell::RefCell<HashMap<NodeIdx, std::rc::Rc<crate::style::ComputedStyle>>>,
     /// O epoch de animação em que o `computed_memo` foi preenchido. Mutações locais
     /// de conteúdo não invalidam esse cache; animações continuam invalidando o estilo
     /// final interpolado.
@@ -265,7 +270,7 @@ pub struct Dom {
     /// `advance` consulta por nó a cada frame. Invalida por epoch global de estilo,
     /// viewport ou dirty bit local — então frames de animação que só bumpam
     /// `anim_epoch` o REUSAM, tornando o `advance` barato.
-    base_memo: std::cell::RefCell<HashMap<NodeIdx, crate::style::ComputedStyle>>,
+    base_memo: std::cell::RefCell<HashMap<NodeIdx, std::rc::Rc<crate::style::ComputedStyle>>>,
     /// A revisão estrutural em que o `base_memo` foi preenchido.
     base_memo_revision: std::cell::Cell<u64>,
     base_memo_viewport: std::cell::Cell<(u32, u32)>,
@@ -586,6 +591,36 @@ impl Dom {
         self.layout_epochs.len()
     }
 
+    /// `(entradas nos memos de estilo, entradas nos caches de layout)` — o
+    /// estado DERIVADO que cresce sem a árvore crescer. Enumerado aqui, ao lado
+    /// dos campos, pela mesma razão do [`derived_node_state`](Self::derived_node_state).
+    pub(crate) fn derived_cache_sizes(&self) -> (usize, usize) {
+        (
+            self.computed_memo.borrow().len() + self.base_memo.borrow().len(),
+            self.layout_measure_cache.borrow().len() + self.intrinsic_width_cache.borrow().len(),
+        )
+    }
+
+    /// Bytes estimados dos caches de layout: chave + valor por entrada, vezes a
+    /// CAPACIDADE do mapa (um `HashMap` reserva além do que usa, e ignorar isso
+    /// subestima justamente a área que enche).
+    pub(crate) fn layout_cache_bytes(&self) -> usize {
+        let measure = self.layout_measure_cache.borrow();
+        let intrinsic = self.intrinsic_width_cache.borrow();
+        measure.capacity()
+            * (std::mem::size_of::<LayoutMeasureKey>() + std::mem::size_of::<(f32, f32)>())
+            + intrinsic.capacity()
+                * (std::mem::size_of::<IntrinsicWidthKey>() + std::mem::size_of::<f32>())
+    }
+
+    /// Bytes estimados do stylesheet de autor mais o CSS bruto guardado para os
+    /// pseudo-elementos de scrollbar. Numa página com o Bootstrap inteiro num
+    /// `<style>`, esta é a maior área do `Dom` — e ela não some quando a árvore
+    /// muda, o que é o motivo de estar separada da árvore no relatório.
+    pub(crate) fn stylesheet_bytes(&self) -> usize {
+        self.raw_css.capacity() + self.stylesheet.estimated_bytes()
+    }
+
     pub(crate) fn layout_measure_get(&self, key: LayoutMeasureKey) -> Option<(f32, f32)> {
         self.layout_measure_cache.borrow().get(&key).copied()
     }
@@ -648,7 +683,7 @@ impl Dom {
     /// O `advance` consulta isto a cada frame; entre frames de animação (revisão
     /// estrutural estável) é um hit de cache — a cascade não re-roda. `None` p/
     /// não-elemento.
-    fn base_style_idx(&self, idx: NodeIdx) -> Option<crate::style::ComputedStyle> {
+    fn base_style_idx(&self, idx: NodeIdx) -> Option<std::rc::Rc<crate::style::ComputedStyle>> {
         let style_epoch = crate::style::props::style_epoch();
         let (vw, vh) = self.viewport.get();
         let vp_key = (vw.to_bits(), vh.to_bits());
@@ -660,10 +695,10 @@ impl Dom {
         crate::bump!(base_calls);
         if let Some(hit) = self.base_memo.borrow().get(&idx) {
             crate::bump!(base_memo_hits);
-            return Some(hit.clone());
+            return Some(std::rc::Rc::clone(hit));
         }
-        let computed = self.computed_style_idx_inner(idx)?;
-        self.base_memo.borrow_mut().insert(idx, computed.clone());
+        let computed = std::rc::Rc::new(self.computed_style_idx_inner(idx)?);
+        self.base_memo.borrow_mut().insert(idx, std::rc::Rc::clone(&computed));
         Some(computed)
     }
 
@@ -931,7 +966,10 @@ impl Dom {
     /// resolve ou não é elemento. (A herança de color/font-size é aplicada por quem
     /// desce a árvore; aqui só o estilo PRÓPRIO do nó.)
     pub fn computed_style(&self, id: NodeId) -> Option<crate::style::ComputedStyle> {
-        self.computed_style_idx(self.resolve(id)?)
+        // A API pública devolve VALOR: quem chama de fora (a ABI, o `getComputedStyle`)
+        // quer um dado próprio, e é uma chamada por vez — o `Rc` existe para o
+        // caminho interno do layout, que pede o mesmo estilo dezenas de vezes.
+        self.computed_style_idx(self.resolve(id)?).map(|rc| (*rc).clone())
     }
 
     /// Igual a [`computed_style`](Dom::computed_style), mas por `NodeIdx` cru — o
@@ -943,7 +981,11 @@ impl Dom {
     ///   autor < `style=""` inline < override por-nó (`setStyleBatch`).
     /// - **Important**, por cima de tudo, na mesma ordem de origem: `<style>`
     ///   important < inline important < override (tratado como mais forte).
-    pub fn computed_style_idx(&self, idx: NodeIdx) -> Option<crate::style::ComputedStyle> {
+    /// Devolve um `Rc`: ver a nota no campo `computed_memo` — o valor tem 1 KB e
+    /// o layout o pede várias vezes por nó. Quem precisa MUTAR faz
+    /// `(*rc).clone()`, o que é exatamente o ponto (a cópia passa a ser
+    /// explícita e rara em vez de implícita e por acesso).
+    pub fn computed_style_idx(&self, idx: NodeIdx) -> Option<std::rc::Rc<crate::style::ComputedStyle>> {
         // MEMO por revisão: dentro de um mesmo estado da árvore, a cascade de um nó
         // é determinística — e o layout a consulta várias vezes por nó (medição +
         // pintura). Um clone do ComputedStyle é muito mais barato que re-rodar
@@ -964,18 +1006,27 @@ impl Dom {
         crate::bump!(computed_calls);
         if let Some(hit) = self.computed_memo.borrow().get(&idx) {
             crate::bump!(computed_memo_hits);
-            return Some(hit.clone());
+            return Some(std::rc::Rc::clone(hit));
         }
         // O estilo COM animação = a BASE (cascade sem anim, memoizada por revisão
         // estrutural via `base_style_idx`) + a camada de `anim_override` por cima. Não
         // re-roda a cascade a cada frame de animação: só clona a base cacheada e
         // sobrepõe o override interpolado — o que torna o RELAYOUT durante animação
         // barato (era o gargalo restante depois de acelerar o `advance`).
-        let mut computed = self.base_style_idx(idx)?;
-        if let Some(anim) = self.anim_override.get(&idx) {
-            computed.merge_over(anim);
-        }
-        self.computed_memo.borrow_mut().insert(idx, computed.clone());
+        let base = self.base_style_idx(idx)?;
+        // SEM animação, o computado É a base: compartilha o mesmo `Rc` em vez de
+        // materializar uma segunda cópia de 1 KB por nó. Só quem anima paga a
+        // cópia, que é quando ela é de fato necessária (o override interpolado
+        // muda a cada frame).
+        let computed = match self.anim_override.get(&idx) {
+            None => base,
+            Some(anim) => {
+                let mut c = (*base).clone();
+                c.merge_over(anim);
+                std::rc::Rc::new(c)
+            }
+        };
+        self.computed_memo.borrow_mut().insert(idx, std::rc::Rc::clone(&computed));
         Some(computed)
     }
 
@@ -1422,7 +1473,7 @@ impl Dom {
                         }
                     }
                 }
-                self.prev_computed.insert(idx, target.clone());
+                self.prev_computed.insert(idx, (*target).clone());
                 continue; // animation tem prioridade sobre transition neste nó
             } else {
                 self.anim_start.remove(&idx);
@@ -1444,7 +1495,7 @@ impl Dom {
                     );
                 }
             }
-            self.prev_computed.insert(idx, target.clone());
+            self.prev_computed.insert(idx, (*target).clone());
 
             if let Some(active) = self.active_transitions.get(&idx).cloned() {
                 let interp = active.current(&target, now_ms);

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -1372,19 +1372,53 @@ impl Dom {
     /// quando o hovered realmente MUDA **e** o stylesheet tem alguma regra
     /// `:hover` — mover o mouse numa página sem :hover custa zero.
     pub fn set_hovered(&mut self, idx: Option<NodeIdx>) {
-        if self.hovered.get() == idx {
+        let previous = self.hovered.get();
+        if previous == idx {
             return;
         }
         self.hovered.set(idx);
-        let has_hover_rule = self.stylesheet.rules.iter().any(|r| {
-            r.selector.compounds.iter().any(|c| {
-                c.parts
-                    .iter()
-                    .any(|p| matches!(p, crate::style::SimpleSelector::Pseudo(crate::style::PseudoClass::Hover)))
-            })
-        });
-        if has_hover_rule {
+        // O ALCANCE de `:hover` é derivado das regras UMA vez (cacheado no
+        // stylesheet). Antes, cada movimento do mouse varria todas as regras
+        // para responder "há alguma :hover?" — 2643 delas numa página Bootstrap,
+        // por frame, antes mesmo de decidir o que invalidar.
+        let reach = self.stylesheet.hover_reach();
+        if reach == crate::style::HoverReach::None {
+            return;
+        }
+        // `:hover` casa o nó sob o cursor E seus ancestrais (`pseudo_matches`),
+        // então a mudança é a diferença entre as duas CADEIAS. Invalidar a
+        // página inteira era o que se fazia; a cadeia é o conjunto de nós cujo
+        // estilo pode ter mudado, e ela tem a profundidade da árvore, não o
+        // tamanho dela.
+        if reach == crate::style::HoverReach::Siblings {
+            // `.a:hover + .b` alcança FORA da subárvore de quem casa, e uma
+            // invalidação por subárvore não a cobre. Fallback declarado — pagar
+            // o global aqui é o preço de não responder errado.
             self.touch();
+            return;
+        }
+        // Da cadeia, só entram os nós que PODERIAM casar uma regra de hover. O
+        // `<body>` é ancestral de tudo e não casa `.btn:hover`; deixá-lo entrar
+        // faria a subárvore suja ser a página, que é de onde se estava partindo.
+        let hover_compounds = self.stylesheet.hover_compounds();
+        let mut roots: Vec<NodeIdx> = Vec::new();
+        for start in [previous, idx].into_iter().flatten() {
+            let mut cur = Some(start);
+            while let Some(node) = cur {
+                if node != self.root
+                    && !roots.contains(&node)
+                    && self.could_match_hover(node, &hover_compounds)
+                {
+                    roots.push(node);
+                }
+                cur = self.nodes[node].parent;
+            }
+        }
+        if !roots.is_empty() {
+            // Subárvore e não só o nó: uma propriedade HERDADA declarada num
+            // `:hover` (o caso comum é `color`) desce para os filhos, que não
+            // casam regra nenhuma e mudam mesmo assim.
+            self.touch_subtrees(roots);
         }
     }
 
@@ -2214,6 +2248,30 @@ impl Dom {
         let attr = |name: &str| self.nodes[idx].attr(name);
         let pseudo = |pc: &crate::style::PseudoClass| self.pseudo_matches(idx, pc);
         crate::style::compound_matches_borrowed(compound, tag, id, class_attr, &attr, &pseudo)
+    }
+
+    /// `true` se o nó casaria algum compound com `:hover` SE estivesse sob o
+    /// cursor — o `:hover` é respondido como verdadeiro e o resto do compound
+    /// (tag, classe, id, atributo, outras pseudo) é testado de verdade. É a
+    /// pergunta do invalidation set: "o hover pode mudar o estilo DESTE nó?".
+    fn could_match_hover(
+        &self,
+        idx: NodeIdx,
+        compounds: &[&crate::style::CompoundSelector],
+    ) -> bool {
+        let tag = match &self.nodes[idx].kind {
+            NodeKind::Element { tag } => tag.as_str(),
+            _ => return false,
+        };
+        let id = self.nodes[idx].attr("id");
+        let class_attr = self.nodes[idx].attr("class");
+        let attr = |name: &str| self.nodes[idx].attr(name);
+        let pseudo = |pc: &crate::style::PseudoClass| {
+            matches!(pc, crate::style::PseudoClass::Hover) || self.pseudo_matches(idx, pc)
+        };
+        compounds.iter().any(|c| {
+            crate::style::compound_matches_borrowed(c, tag, id, class_attr, &attr, &pseudo)
+        })
     }
 
     /// Resolve uma pseudo-classe contra o nó (posição entre irmãos / atributo de estado).
@@ -4411,5 +4469,68 @@ mod tests {
         // conteúdo real chegou: o h1 do template.
         let h1 = dom.query("h1").unwrap();
         assert_eq!(dom.text_content(h1).unwrap(), "Cover your page.");
+    }
+
+    /// O ALCANCE de `:hover` decide o que a mudança de hover invalida, e os
+    /// quatro casos exigem coisas diferentes — trocar um pelo outro ou invalida
+    /// demais (a página inteira, o que era o comportamento) ou de menos (um
+    /// irmão que fica com estilo velho).
+    #[test]
+    fn alcance_de_hover_por_forma_do_seletor() {
+        use crate::style::HoverReach;
+        let caso = |css: &str| {
+            let mut sheet = crate::style::Stylesheet::new();
+            sheet.append_css(css);
+            sheet.hover_reach()
+        };
+        assert_eq!(caso(".btn { color: red }"), HoverReach::None);
+        assert_eq!(caso(".btn:hover { color: red }"), HoverReach::SelfOnly);
+        assert_eq!(caso(".card:hover .title { color: red }"), HoverReach::Subtree);
+        assert_eq!(caso(".a:hover + .b { color: red }"), HoverReach::Siblings);
+    }
+
+    /// Passar o mouse não pode invalidar o estilo de um ramo que o `:hover` não
+    /// alcança. É o teste do INVALIDATION SET: sem ele a implementação correta e
+    /// a que re-cascadeia a página inteira são indistinguíveis por asserção.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn hover_recascadeia_a_cadeia_e_nao_a_pagina() {
+        let filhos: String = (0..50).map(|i| format!("<p class=\"linha\">l{i}</p>")).collect();
+        let mut dom = parse_html_to_dom(&format!(
+            "<style>.btn:hover {{ color: red }}</style>             <div id=\"lado\">{filhos}</div><a class=\"btn\" id=\"alvo\">x</a>"
+        ));
+        // Preenche os memos de todos os nós.
+        for idx in 0..dom.nodes.len() {
+            let _ = dom.computed_style_idx(idx);
+        }
+        let alvo = dom.resolve(dom.query("#alvo").unwrap()).unwrap();
+        crate::metrics::counters::reset();
+        dom.set_hovered(Some(alvo));
+        for idx in 0..dom.nodes.len() {
+            let _ = dom.computed_style_idx(idx);
+        }
+        let cascades = crate::metrics::snapshot().cascade_runs;
+        assert!(
+            cascades < 10,
+            "hover re-cascadeou {cascades} nós; a cadeia do alvo tem 2 e a página tem 50+"
+        );
+    }
+
+    /// O caso que obriga o fallback: `.a:hover + .b` muda um nó FORA da subárvore
+    /// de quem casa, e uma invalidação por subárvore o deixaria com estilo velho.
+    #[test]
+    fn hover_com_irmao_invalida_o_irmao() {
+        let mut dom = parse_html_to_dom(
+            "<style>.a:hover + .b { color: #ff0000 }</style>             <div><span class=\"a\">a</span><span class=\"b\">b</span></div>",
+        );
+        let b = dom.resolve(dom.query(".b").unwrap()).unwrap();
+        assert_eq!(dom.computed_style_idx(b).unwrap().color, None);
+        let a = dom.resolve(dom.query(".a").unwrap()).unwrap();
+        dom.set_hovered(Some(a));
+        assert_eq!(
+            dom.computed_style_idx(b).unwrap().color,
+            Some(0xFF0000FF),
+            "o irmão precisa reagir ao hover do anterior"
+        );
     }
 }

--- a/crates/rts-dom/src/html.rs
+++ b/crates/rts-dom/src/html.rs
@@ -44,6 +44,7 @@ fn is_raw_text_tag(tag: &str) -> bool {
 
 /// Tokeniza o HTML char a char. Ao ver `<`, lê até `>`; senão acumula texto.
 pub(crate) fn tokenize(html: &str) -> Vec<Token> {
+    let _phase = crate::metrics::phases::scope("tokenize-html");
     let mut tokens = Vec::new();
     let bytes = html.as_bytes();
     let mut i = 0usize;
@@ -65,6 +66,7 @@ pub(crate) fn tokenize(html: &str) -> Vec<Token> {
                     Some(end) => (&rest[..end], 4 + end + 3), // `<!--` + corpo + `-->`
                     None => (rest, html.len() - i),            // sem fechar: vai até o fim
                 };
+                crate::bump!(comments_parsed);
                 tokens.push(Token::Comment(content.to_string()));
                 i += advance;
                 continue;
@@ -129,9 +131,15 @@ pub(crate) fn tokenize(html: &str) -> Vec<Token> {
                         Some(end) => (&html[i..i + end], end + close_tag.len()),
                         None => (&html[i..], html.len() - i), // sem fechar: até o fim.
                     };
+                    crate::bump!(raw_elements);
                     tokens.push(Token::RawElement { tag: name, attrs: attrs_raw, content: content.to_string() });
                     i += advance;
                     continue;
+                }
+                if close {
+                    crate::bump!(tags_close);
+                } else {
+                    crate::bump!(tags_open);
                 }
                 tokens.push(Token::Tag { name, attrs_raw, close });
             }
@@ -145,6 +153,7 @@ pub(crate) fn tokenize(html: &str) -> Vec<Token> {
     if !text.is_empty() {
         tokens.push(Token::Text(decode_entities(&text)));
     }
+    crate::bump!(html_tokens, tokens.len());
     tokens
 }
 
@@ -175,11 +184,14 @@ pub(crate) fn decode_entities(s: &str) -> String {
             Some(rel) => {
                 let body = &s[i + 1..i + 1 + rel];
                 if let Some(ch) = decode_one_entity(body) {
+                    crate::bump!(entities_decoded);
                     out.push(ch);
                     i += 1 + rel + 1; // pula `&body;`
                     continue;
                 }
                 // Desconhecida: deixa o `&` literal e segue.
+                crate::bump!(entities_unknown);
+                crate::note!("entidade-desconhecida", format!("&{};", &s[i + 1..i + 1 + rel]));
                 out.push('&');
                 i += 1;
             }

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -3085,7 +3085,7 @@ fn collect_runs(
                 let color = css.as_ref().and_then(|c| c.color).unwrap_or(inherited_color);
                 let tt = css.as_ref().and_then(|c| c.text_transform).or(inherited_tt);
                 let bold = css.as_ref().and_then(|c| c.bold).unwrap_or(inherited_bold);
-                let deco = match css.as_ref().map(decoration_code) {
+                let deco = match css.as_deref().map(decoration_code) {
                     Some(d) if d != 0 => d,
                     _ => inherited_deco,
                 };

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -256,7 +256,9 @@ fn measure_block(
         viewport_h: ctx.viewport_h.to_bits(),
         measurer,
     };
+    crate::bump!(measure_calls);
     if let Some(size) = dom.layout_measure_get(key) {
+        crate::bump!(measure_hits);
         return size;
     }
     let mut scratch = DisplayList::default();
@@ -281,6 +283,8 @@ fn measure_block(
 /// entrada do motor: percorre os filhos de `#document` como blocos empilhados na
 /// largura do viewport, resolvendo box model e emitindo os itens de pintura.
 pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
+    crate::bump!(documents);
+    let _phase = crate::metrics::phases::scope("layout");
     // informa o viewport à CASCADE (base de vw/vh no font-size fluido/calc; o
     // memo de estilo do Dom invalida sozinho se mudou).
     dom.set_viewport(ctx.viewport_w, ctx.viewport_h);
@@ -329,6 +333,7 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // pelo fluxo normal (o ancestral positioned já foi pintado). Clona antes do
     // empréstimo mutável de `list`.
     let flow_rects = list.node_rects.clone();
+    crate::bump!(out_of_flow, out_of_flow.len());
     for id in &out_of_flow {
         layout_out_of_flow(dom, *id, ctx, &flow_rects, &mut list);
     }
@@ -337,6 +342,9 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // crescente de z-index (o último pintado fica no topo).
     // A ordem de pintura já foi registrada durante as inserções de retângulos:
     // fluxo normal durante a descida e out-of-flow na ordem de z-index acima.
+    crate::bump!(display_items, list.items.len());
+    crate::bump!(node_rects, list.node_rects.len());
+    crate::bump!(scroll_regions, list.scroll_regions.len());
     list
 }
 
@@ -634,6 +642,7 @@ fn layout_block(
     ctx: &LayoutCtx,
     list: &mut DisplayList,
 ) -> (f32, f32) {
+    crate::bump!(block_calls);
     // Nós não-elemento no nível de bloco (texto solto, comentário): trata o texto
     // como uma linha; comentário não pinta.
     let css = match &dom.node(id).kind {
@@ -1131,7 +1140,9 @@ fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -
         viewport_h: ctx.viewport_h.to_bits(),
         measurer: std::ptr::from_ref(ctx.measurer) as *const () as usize as u64,
     };
+    crate::bump!(intrinsic_calls);
     if let Some(hit) = dom.intrinsic_width_get(key) {
+        crate::bump!(intrinsic_hits);
         return hit;
     }
 
@@ -3020,6 +3031,7 @@ fn collect_runs(
                     Some(tt) => tt.apply(t),
                     None => t.clone(),
                 };
+                crate::bump!(inline_runs);
                 out.push(InlineRun {
                     text,
                     color: inherited_color,
@@ -3054,7 +3066,8 @@ fn collect_runs(
                     let (ww, wh) = inline_widget_size(dom, id, &itype, ctx);
                     let mut owners = inherited_owners.to_vec();
                     owners.push(id);
-                    out.push(InlineRun {
+                    crate::bump!(inline_runs);
+                out.push(InlineRun {
                         text: String::new(),
                         color: inherited_color,
                         bold: false,

--- a/crates/rts-dom/src/lib.rs
+++ b/crates/rts-dom/src/lib.rs
@@ -45,6 +45,12 @@ pub mod layout;
 /// Egui-free; o tick por frame é dirigido pelo loop de render.
 pub mod anim;
 
+/// MÉTRICAS de instrumentação (feature `metrics`): contadores por operação do
+/// parse, da cascade, do layout e da invalidação. Desligada, os `bump!` somem —
+/// o crate compila exatamente como antes. É o que responde "onde o trabalho
+/// acontece" antes de qualquer otimização (skill `perf-claim`).
+pub mod metrics;
+
 /// Estilo da SCROLLBAR via CSS (#1744): `scrollbar-width`/`scrollbar-color` (padrão)
 /// + `::-webkit-scrollbar*` (WebKit). Produz um `ScrollbarStyle` neutro que o backend
 /// (egui) lê e aplica — o motor não conhece o egui.

--- a/crates/rts-dom/src/metrics/audit.rs
+++ b/crates/rts-dom/src/metrics/audit.rs
@@ -1,0 +1,474 @@
+//! AUDITORIA de consistência da árvore — a pergunta que nenhum número de
+//! desempenho responde: o que foi medido estava CERTO?
+//!
+//! Um índice `.classe` apontando para um nó já desligado não fica lento; fica
+//! errado, e o sintoma aparece longe da causa (um `querySelector` devolve um nó
+//! que não está na página). O mesmo vale para o estado derivado por nó
+//! (listeners, valores de input, transições): quando um nó sai da árvore e a
+//! entrada fica, o vazamento é silencioso até alguém reusar o índice da arena.
+//!
+//! Esta varredura é O(n) e **não** é instrumentação: roda sob demanda, sem a
+//! feature `metrics`, sobre uma árvore parada. Serve em teste, no harness de
+//! métricas e depois de qualquer mudança na invalidação — é ela que separa
+//! "ficou mais rápido" de "parou de fazer o trabalho".
+
+use crate::dom::{Dom, NodeIdx, NodeKind};
+
+/// A gravidade de um achado. A distinção existe porque as três exigem ações
+/// diferentes, e tratá-las como uma só é o que faz um relatório de consistência
+/// virar ruído que ninguém lê.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    /// Invariante do motor violada — a árvore está inconsistente consigo mesma e
+    /// alguma consulta PODE responder errado.
+    Bug,
+    /// Estado derivado que sobreviveu ao nó: por DESIGN as consultas filtram por
+    /// `is_attached` (o índice é um superconjunto, não a verdade), então nada
+    /// responde errado — mas a entrada nunca é recolhida, e uma página que
+    /// remove 10 000 nós carrega 10 000 entradas mortas até trocar de árvore.
+    /// É a diferença entre "está errado" e "cresce sem limite".
+    Leak,
+    /// A PÁGINA faz algo malformado ou ambíguo (dois `id="x"`); o motor tolera, e
+    /// quem corrige é o autor do documento.
+    Page,
+}
+
+/// Um achado da auditoria.
+#[derive(Clone, Debug)]
+pub struct Finding {
+    pub severity: Severity,
+    /// Categoria curta e estável — é por ela que um baseline compara.
+    pub kind: &'static str,
+    /// O nó envolvido, quando há um.
+    pub node: Option<NodeIdx>,
+    pub detail: String,
+}
+
+/// Estatísticas de FORMA da árvore. Não são erros: são o denominador de todo o
+/// resto (4000 cascades é muito ou pouco? depende de quantos elementos há) e o
+/// que revela uma árvore patológica — profunda demais, ou com um nó de 20 000
+/// filhos que faz toda inserção varrer um `Vec` gigante.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Shape {
+    pub nodes: usize,
+    pub elements: usize,
+    pub text_nodes: usize,
+    pub comments: usize,
+    pub depth_max: usize,
+    pub fanout_max: usize,
+    pub fanout_max_node: Option<NodeIdx>,
+    pub attrs: usize,
+    pub distinct_tags: usize,
+    pub distinct_classes: usize,
+    pub ids: usize,
+    /// Nós presentes na arena e INALCANÇÁVEIS a partir da raiz — memória viva
+    /// que nada pode alcançar (o DOM não compacta a arena; um `createElement`
+    /// nunca anexado fica aqui, o que é legítimo, e é por isso que este número é
+    /// forma e não achado).
+    pub unreachable: usize,
+}
+
+/// O resultado completo de uma auditoria.
+#[derive(Clone, Debug, Default)]
+pub struct AuditReport {
+    pub shape: Shape,
+    pub findings: Vec<Finding>,
+}
+
+impl AuditReport {
+    pub fn bugs(&self) -> usize {
+        self.findings.iter().filter(|f| f.severity == Severity::Bug).count()
+    }
+
+    pub fn leaks(&self) -> usize {
+        self.findings.iter().filter(|f| f.severity == Severity::Leak).count()
+    }
+
+    pub fn page_issues(&self) -> usize {
+        self.findings.iter().filter(|f| f.severity == Severity::Page).count()
+    }
+
+    /// Relatório legível. Achados iguais são agrupados por categoria com um
+    /// exemplo: uma página com 300 ids duplicados deve render três linhas, não
+    /// trezentas.
+    pub fn report(&self) -> String {
+        let s = &self.shape;
+        let mut out = format!(
+            "    forma: {} nós ({} elementos, {} texto, {} comentários), \
+             profundidade {}, fan-out máx {}\n           \
+             {} atributos, {} tags distintas, {} classes distintas, {} ids, {} inalcançáveis\n",
+            s.nodes,
+            s.elements,
+            s.text_nodes,
+            s.comments,
+            s.depth_max,
+            s.fanout_max,
+            s.attrs,
+            s.distinct_tags,
+            s.distinct_classes,
+            s.ids,
+            s.unreachable,
+        );
+        if self.findings.is_empty() {
+            out.push_str("    consistência: OK (nenhum achado)\n");
+            return out;
+        }
+        let mut kinds: Vec<(&'static str, Severity, usize, String)> = Vec::new();
+        for f in &self.findings {
+            match kinds.iter_mut().find(|(k, _, _, _)| *k == f.kind) {
+                Some((_, _, n, _)) => *n += 1,
+                None => kinds.push((f.kind, f.severity, 1, f.detail.clone())),
+            }
+        }
+        for (kind, sev, n, example) in kinds {
+            let tag = match sev {
+                Severity::Bug => "BUG   ",
+                Severity::Leak => "vaza  ",
+                Severity::Page => "página",
+            };
+            out.push_str(&format!("    {tag} {kind} ×{n} — ex.: {example}\n"));
+        }
+        out
+    }
+}
+
+/// Varre a árvore e confronta cada invariante. O(n) sobre a arena, mais O(total
+/// de entradas) sobre os índices.
+pub fn audit(dom: &Dom) -> AuditReport {
+    let mut r = AuditReport::default();
+    let n = dom.nodes.len();
+    r.shape.nodes = n;
+
+    // ── 1. Travessia a partir da RAIZ: alcançabilidade, profundidade, ciclos ──
+    let mut reached = vec![false; n];
+    let mut stack = vec![(dom.root, 0usize)];
+    let mut guard = 0usize;
+    while let Some((idx, depth)) = stack.pop() {
+        guard += 1;
+        if guard > n * 4 {
+            r.findings.push(Finding {
+                severity: Severity::Bug,
+                kind: "ciclo-na-arvore",
+                node: Some(idx),
+                detail: "a travessia visitou mais nós do que a arena tem — há um ciclo".into(),
+            });
+            break;
+        }
+        if reached[idx] {
+            r.findings.push(Finding {
+                severity: Severity::Bug,
+                kind: "no-com-dois-pais",
+                node: Some(idx),
+                detail: format!("nó {idx} alcançado por mais de um caminho"),
+            });
+            continue;
+        }
+        reached[idx] = true;
+        r.shape.depth_max = r.shape.depth_max.max(depth);
+        let node = &dom.nodes[idx];
+        if node.children.len() > r.shape.fanout_max {
+            r.shape.fanout_max = node.children.len();
+            r.shape.fanout_max_node = Some(idx);
+        }
+        for &c in &node.children {
+            if c >= n {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "filho-fora-da-arena",
+                    node: Some(idx),
+                    detail: format!("nó {idx} lista o filho {c}, fora da arena de {n}"),
+                });
+                continue;
+            }
+            if dom.nodes[c].parent != Some(idx) {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "elo-pai-filho-quebrado",
+                    node: Some(c),
+                    detail: format!(
+                        "nó {c} é filho de {idx} mas seu parent é {:?}",
+                        dom.nodes[c].parent
+                    ),
+                });
+            }
+            stack.push((c, depth + 1));
+        }
+    }
+
+    // ── 2. Por nó: tipo, atributos, contagens de forma ───────────────────────
+    let mut tags: std::collections::HashSet<&str> = Default::default();
+    let mut classes: std::collections::HashSet<String> = Default::default();
+    let mut ids_seen: std::collections::HashMap<&str, usize> = Default::default();
+    for (idx, node) in dom.nodes.iter().enumerate() {
+        if !reached[idx] {
+            r.shape.unreachable += 1;
+        }
+        r.shape.attrs += node.attrs.len();
+        match &node.kind {
+            NodeKind::Element { tag } => {
+                r.shape.elements += 1;
+                tags.insert(tag.as_str());
+                if tag.is_empty() {
+                    r.findings.push(Finding {
+                        severity: Severity::Bug,
+                        kind: "elemento-sem-tag",
+                        node: Some(idx),
+                        detail: format!("nó {idx} é Element com tag vazia"),
+                    });
+                }
+                if tag.chars().any(|c| c.is_ascii_uppercase()) {
+                    r.findings.push(Finding {
+                        severity: Severity::Bug,
+                        kind: "tag-nao-normalizada",
+                        node: Some(idx),
+                        detail: format!("tag `{tag}` não está em minúsculas — seletores não casam"),
+                    });
+                }
+            }
+            NodeKind::Text(_) => r.shape.text_nodes += 1,
+            NodeKind::Comment(_) => r.shape.comments += 1,
+            NodeKind::Document => {}
+        }
+        let is_element = matches!(node.kind, NodeKind::Element { .. });
+        if !is_element && !node.attrs.is_empty() {
+            r.findings.push(Finding {
+                severity: Severity::Bug,
+                kind: "atributo-em-nao-elemento",
+                node: Some(idx),
+                detail: format!("nó {idx} não é elemento e tem {} atributos", node.attrs.len()),
+            });
+        }
+        if matches!(node.kind, NodeKind::Text(_) | NodeKind::Comment(_))
+            && !node.children.is_empty()
+        {
+            r.findings.push(Finding {
+                severity: Severity::Bug,
+                kind: "folha-com-filhos",
+                node: Some(idx),
+                detail: format!("nó de texto/comentário {idx} tem {} filhos", node.children.len()),
+            });
+        }
+        for (i, a) in node.attrs.iter().enumerate() {
+            if node.attrs[..i].iter().any(|b| b.name == a.name) {
+                r.findings.push(Finding {
+                    severity: Severity::Page,
+                    kind: "atributo-duplicado",
+                    node: Some(idx),
+                    detail: format!("nó {idx} repete o atributo `{}`", a.name),
+                });
+            }
+            if a.name.chars().any(|c| c.is_ascii_uppercase()) {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "atributo-nao-normalizado",
+                    node: Some(idx),
+                    detail: format!("atributo `{}` não está em minúsculas", a.name),
+                });
+            }
+        }
+        if let Some(id) = node.attr("id") {
+            if reached[idx] {
+                *ids_seen.entry(id).or_default() += 1;
+            }
+        }
+        if let Some(cl) = node.attr("class") {
+            for c in cl.split_whitespace() {
+                classes.insert(c.to_string());
+            }
+        }
+    }
+    r.shape.distinct_tags = tags.len();
+    r.shape.distinct_classes = classes.len();
+    r.shape.ids = ids_seen.len();
+    for (id, count) in ids_seen {
+        if count > 1 {
+            r.findings.push(Finding {
+                severity: Severity::Page,
+                kind: "id-duplicado",
+                node: None,
+                detail: format!("`#{id}` aparece {count} vezes — a consulta devolve o primeiro"),
+            });
+        }
+    }
+
+    // ── 3. Os ÍNDICES contra a árvore, nos dois sentidos ─────────────────────
+    let (id_index, class_index) = dom.debug_indices();
+    for (key, bucket) in id_index {
+        for &idx in bucket {
+            if idx >= n {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "indice-id-fora-da-arena",
+                    node: Some(idx),
+                    detail: format!("id_index[{key}] aponta para {idx}, fora da arena"),
+                });
+                continue;
+            }
+            if dom.nodes[idx].attr("id") != Some(key.as_str()) {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "indice-id-stale",
+                    node: Some(idx),
+                    detail: format!("id_index[{key}] aponta para {idx}, que já não tem esse id"),
+                });
+            } else if !reached[idx] {
+                r.findings.push(Finding {
+                    severity: Severity::Leak,
+                    kind: "indice-id-desanexado",
+                    node: Some(idx),
+                    detail: format!("id_index[{key}] aponta para {idx}, fora da árvore"),
+                });
+            }
+        }
+    }
+    for (key, bucket) in class_index {
+        for &idx in bucket {
+            if idx >= n {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "indice-classe-fora-da-arena",
+                    node: Some(idx),
+                    detail: format!("class_index[{key}] aponta para {idx}, fora da arena"),
+                });
+                continue;
+            }
+            let has = dom.nodes[idx]
+                .attr("class")
+                .map(|c| c.split_whitespace().any(|x| x == key))
+                .unwrap_or(false);
+            if !has {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "indice-classe-stale",
+                    node: Some(idx),
+                    detail: format!("class_index[{key}] aponta para {idx}, que não tem a classe"),
+                });
+            } else if !reached[idx] {
+                r.findings.push(Finding {
+                    severity: Severity::Leak,
+                    kind: "indice-classe-desanexado",
+                    node: Some(idx),
+                    detail: format!("class_index[{key}] aponta para {idx}, fora da árvore"),
+                });
+            }
+        }
+    }
+    // …e o sentido inverso: um nó com id/classe que o índice NÃO conhece é a
+    // falha que faz `querySelector` devolver `null` numa página correta.
+    for (idx, node) in dom.nodes.iter().enumerate() {
+        if !reached[idx] {
+            continue;
+        }
+        if let Some(id) = node.attr("id") {
+            if !id_index.get(id).map(|b| b.contains(&idx)).unwrap_or(false) {
+                r.findings.push(Finding {
+                    severity: Severity::Bug,
+                    kind: "no-com-id-fora-do-indice",
+                    node: Some(idx),
+                    detail: format!("nó {idx} tem id `{id}` e não está no id_index"),
+                });
+            }
+        }
+        if let Some(cl) = node.attr("class") {
+            for c in cl.split_whitespace() {
+                if !class_index.get(c).map(|b| b.contains(&idx)).unwrap_or(false) {
+                    r.findings.push(Finding {
+                        severity: Severity::Bug,
+                        kind: "no-com-classe-fora-do-indice",
+                        node: Some(idx),
+                        detail: format!("nó {idx} tem a classe `{c}` e não está no class_index"),
+                    });
+                }
+            }
+        }
+    }
+
+    // ── 4. Estado DERIVADO por nó: entradas órfãs ────────────────────────────
+    for (label, idx) in dom.derived_node_state() {
+        if idx >= n {
+            r.findings.push(Finding {
+                severity: Severity::Bug,
+                kind: "estado-derivado-fora-da-arena",
+                node: Some(idx),
+                detail: format!("{label} tem entrada para o nó {idx}, fora da arena de {n}"),
+            });
+        } else if !reached[idx] {
+            r.findings.push(Finding {
+                severity: Severity::Leak,
+                kind: "estado-derivado-orfao",
+                node: Some(idx),
+                detail: format!("{label} guarda o nó {idx}, que já não está na árvore"),
+            });
+        }
+    }
+
+    // ── 5. Tabelas paralelas à arena ─────────────────────────────────────────
+    if dom.layout_epoch_len() != n {
+        r.findings.push(Finding {
+            severity: Severity::Bug,
+            kind: "tabela-paralela-dessincronizada",
+            node: None,
+            detail: format!("layout_epochs tem {} entradas para {n} nós", dom.layout_epoch_len()),
+        });
+    }
+
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_html_to_dom;
+
+    /// Uma página bem formada não produz achado NENHUM. Sem isto, a auditoria
+    /// que sempre acusa algo vira ruído e ninguém a lê.
+    #[test]
+    fn pagina_sa_nao_gera_achados() {
+        let dom = parse_html_to_dom(
+            "<html><body><div id=\"a\" class=\"x y\"><p>oi</p></div><!-- c --></body></html>",
+        );
+        let r = audit(&dom);
+        assert_eq!(r.bugs(), 0, "{}", r.report());
+        assert_eq!(r.leaks(), 0, "{}", r.report());
+        assert_eq!(r.page_issues(), 0, "{}", r.report());
+        assert!(r.shape.elements >= 4);
+        assert!(r.shape.depth_max >= 3);
+    }
+
+    /// Dois `id` iguais são problema da PÁGINA, não do motor — e a distinção
+    /// entre as duas gravidades é o que decide quem tem de consertar.
+    #[test]
+    fn id_duplicado_e_problema_da_pagina() {
+        let dom = parse_html_to_dom("<div id=\"a\"></div><div id=\"a\"></div>");
+        let r = audit(&dom);
+        assert_eq!(r.bugs(), 0, "{}", r.report());
+        assert_eq!(r.page_issues(), 1);
+        assert!(r.report().contains("id-duplicado"));
+    }
+
+    /// Um nó criado e nunca anexado não é um erro — é forma. Confundir os dois
+    /// faria a auditoria acusar todo `createElement` que ainda não foi inserido.
+    #[test]
+    fn no_criado_e_nao_anexado_conta_como_inalcancavel_sem_ser_bug() {
+        let mut dom = parse_html_to_dom("<div id=\"host\"></div>");
+        let _solto = dom.create_element("span");
+        let r = audit(&dom);
+        assert_eq!(r.bugs(), 0, "{}", r.report());
+        assert_eq!(r.shape.unreachable, 1);
+    }
+
+    /// Remover um nó indexado deixa a entrada no índice — por DESIGN (a consulta
+    /// filtra por `is_attached`, o comentário em `query_idx` diz isso). O que a
+    /// auditoria pina aqui é a fronteira: nada responde errado (`bugs() == 0`) e
+    /// a entrada morta é contada como VAZAMENTO. Se um dia a remoção passar a
+    /// deindexar, este teste é o que avisa que a classificação mudou.
+    #[test]
+    fn remocao_deixa_entrada_de_indice_como_vazamento_nao_como_bug() {
+        let mut dom = parse_html_to_dom("<div id=\"a\" class=\"card\"></div><p>x</p>");
+        let alvo = dom.query("#a").expect("nó");
+        dom.remove_node(alvo);
+        let r = audit(&dom);
+        assert_eq!(r.bugs(), 0, "{}", r.report());
+        assert_eq!(r.leaks(), 2, "id e classe: {}", r.report());
+    }
+}

--- a/crates/rts-dom/src/metrics/counters.rs
+++ b/crates/rts-dom/src/metrics/counters.rs
@@ -1,0 +1,329 @@
+//! CONTADORES por operação — quantas vezes cada coisa aconteceu.
+//!
+//! A tabela [`dom_metrics!`] é a fonte única: campo, grupo e rótulo declarados
+//! UMA vez geram a struct, o `delta`, o relatório de texto e a serialização JSON.
+//! É a mesma razão da `css_props!` do `style/props.rs` — listas paralelas
+//! (campo, nome impresso, ordem, chave do JSON) dessincronizam, e a que
+//! dessincroniza calada é a que mente num relatório.
+//!
+//! Três grupos NÃO são de desempenho e existem para achar INCONSISTÊNCIA:
+//! `parser` (o que o HTML tinha de malformado), `css` (o que o parser de CSS
+//! descartou) e `anomalias` (id stale resolvido, seletor inválido, cache
+//! evictado). Um número diferente de zero ali não é lentidão: é a página, ou
+//! nós, fazendo algo que o motor não modela.
+
+/// Declara a tabela de contadores e gera struct + delta + relatório + JSON.
+macro_rules! dom_metrics {
+    ( $( $group:literal { $( $(#[$d:meta])* $field:ident : $label:literal ; )* } )* ) => {
+        /// Um instantâneo dos contadores desta thread. Monotônicos — só a
+        /// DIFERENÇA entre dois snapshots tem sentido (o parse do arquivo
+        /// anterior já contou os nós dele).
+        #[derive(Clone, Default, Debug, PartialEq, Eq)]
+        pub struct DomMetrics {
+            $( $( $(#[$d])* pub $field: u64, )* )*
+        }
+
+        impl DomMetrics {
+            /// `self - base`, campo a campo (saturante — um snapshot mais velho
+            /// nunca vira um negativo silencioso).
+            pub fn delta(&self, base: &Self) -> Self {
+                Self { $( $( $field: self.$field.saturating_sub(base.$field), )* )* }
+            }
+
+            /// Soma de dois intervalos (para acumular cenários).
+            pub fn add(&self, other: &Self) -> Self {
+                Self { $( $( $field: self.$field.wrapping_add(other.$field), )* )* }
+            }
+
+            /// Todos os contadores como `(grupo, rótulo, chave, valor)` — a forma
+            /// que o relatório e o JSON consomem, para nenhum dos dois ter uma
+            /// lista própria que possa divergir desta.
+            pub fn rows(&self) -> Vec<(&'static str, &'static str, &'static str, u64)> {
+                let mut v = Vec::new();
+                $( $( v.push(($group, $label, stringify!($field), self.$field)); )* )*
+                v
+            }
+
+            /// Relatório legível, agrupado. Linhas em zero são omitidas: um
+            /// relatório de 60 linhas com 50 zeros esconde as 10 que importam.
+            pub fn report(&self) -> String {
+                let mut out = String::new();
+                let mut current = "";
+                for (group, label, _, value) in self.rows() {
+                    if value == 0 {
+                        continue;
+                    }
+                    if group != current {
+                        out.push_str(&format!("  {group}\n"));
+                        current = group;
+                    }
+                    out.push_str(&format!("    {:<38} {:>13}\n", label, group_digits(value)));
+                }
+                out
+            }
+
+            /// JSON plano `{"campo": valor, …}` — inclusive os zeros, porque um
+            /// baseline precisa da chave presente para o diff acusar o que
+            /// APARECEU, não só o que cresceu.
+            pub fn to_json(&self) -> String {
+                let rows = self.rows();
+                let body: Vec<String> = rows
+                    .iter()
+                    .map(|(_, _, key, value)| format!("    \"{key}\": {value}"))
+                    .collect();
+                format!("{{\n{}\n  }}", body.join(",\n"))
+            }
+
+            /// Lê de volta um JSON plano gerado por [`to_json`](Self::to_json).
+            /// Parser deliberadamente ingênuo (pares `"chave": inteiro`): a
+            /// alternativa era uma dependência, e este crate não tem nenhuma.
+            pub fn from_json(text: &str) -> Self {
+                let mut out = Self::default();
+                for (_, _, key, _) in Self::default().rows() {
+                    let needle = format!("\"{key}\"");
+                    if let Some(at) = text.find(&needle) {
+                        let rest = &text[at + needle.len()..];
+                        if let Some(colon) = rest.find(':') {
+                            let digits: String = rest[colon + 1..]
+                                .trim_start()
+                                .chars()
+                                .take_while(char::is_ascii_digit)
+                                .collect();
+                            if let Ok(v) = digits.parse::<u64>() {
+                                out.set_by_key(key, v);
+                            }
+                        }
+                    }
+                }
+                out
+            }
+
+            /// Escreve um campo pelo nome — usado só pelo [`from_json`](Self::from_json).
+            fn set_by_key(&mut self, key: &str, value: u64) {
+                match key {
+                    $( $( stringify!($field) => self.$field = value, )* )*
+                    _ => {}
+                }
+            }
+        }
+    };
+}
+
+dom_metrics! {
+    "parser HTML" {
+        html_bytes: "bytes de HTML";
+        html_tokens: "tokens emitidos";
+        tags_open: "tags de abertura";
+        tags_close: "tags de fechamento";
+        tags_void: "tags void (<br>, <img>…)";
+        tags_implicitly_closed: "fechadas por omissão (<li>, <tr>…)";
+        tags_orphan_close: "</x> sem abertura — HTML malformado";
+        tags_unclosed_at_eof: "abertas e nunca fechadas";
+        raw_elements: "<style>/<script> como raw";
+        comments_parsed: "comentários";
+        entities_decoded: "entidades decodificadas";
+        entities_unknown: "entidades DESCONHECIDAS mantidas cruas";
+        attrs_parsed: "atributos parseados";
+        attrs_duplicated: "atributos repetidos na mesma tag";
+    }
+    "parser CSS" {
+        css_bytes: "bytes de CSS";
+        css_rules: "regras acrescentadas";
+        css_rules_dropped: "regras DESCARTADAS (seletor inválido)";
+        css_keyframes: "blocos @keyframes";
+        css_media_rules: "regras dentro de @media";
+        css_declarations: "declarações";
+        css_declarations_unknown: "declarações de propriedade DESCONHECIDA";
+        css_custom_declarations: "declarações de custom property (--x)";
+        css_var_refs: "declarações pendentes por var()";
+    }
+    "construção" {
+        nodes_created: "nós criados";
+        tree_links: "ligações pai↔filho";
+        index_inserts: "entradas de índice (#id/.classe)";
+        index_removes: "entradas de índice removidas";
+        nodes_detached: "nós desligados da árvore";
+        inner_html_sets: "innerHTML= (re-parse de subárvore)";
+        clones: "cloneNode";
+    }
+    "mutação" {
+        set_attr: "setAttribute";
+        remove_attr: "removeAttribute";
+        set_text: "setText/textContent";
+        style_overrides_set: "setStyleBatch/estilo por-nó";
+        stylesheets_added: "<style> acrescentados";
+    }
+    "invalidação" {
+        touch_global: "touch() GLOBAL (limpa tudo)";
+        touch_render_only: "touch() só-render";
+        touch_anim: "touch() de animação";
+        touch_subtree_calls: "touch() de subárvore";
+        touch_subtree_nodes: "nós varridos por essas subárvores";
+        memo_cleared_entries: "entradas de memo descartadas";
+        measure_cache_evictions: "evicções do cache de medição (teto 4096)";
+        intrinsic_cache_evictions: "evicções do cache de intrínseca";
+    }
+    "estilo" {
+        computed_calls: "computed_style pedido";
+        computed_memo_hits: "…servido pelo memo";
+        base_calls: "estilo-base pedido";
+        base_memo_hits: "…servido pelo memo";
+        cascade_runs: "CASCADE completa executada";
+        rules_considered: "regras candidatas testadas";
+        rules_matched: "regras que casaram";
+        selector_matches: "matches_complex (navega a árvore)";
+        custom_maps_built: "mapas de custom props materializados";
+        inherit_steps: "heranças aplicadas do pai";
+    }
+    "layout" {
+        documents: "layout_document";
+        block_calls: "layout_block";
+        inline_runs: "linhas inline montadas";
+        measure_calls: "measure_block (pré-passo)";
+        measure_hits: "…servido pelo cache";
+        intrinsic_calls: "largura intrínseca pedida";
+        intrinsic_hits: "…servida pelo cache";
+        out_of_flow: "nós fora do fluxo posicionados";
+        display_items: "itens de display emitidos";
+        node_rects: "retângulos por nó registrados";
+        scroll_regions: "regiões roláveis emitidas";
+    }
+    "eventos" {
+        listeners_added: "addEventListener";
+        listeners_removed: "removeEventListener";
+        dispatches: "dispatchEvent";
+        dispatch_targets: "alvos notificados (com bubbling)";
+        callbacks_collected: "callbacks coletados p/ o TS";
+        anim_frames: "frames de animação processados";
+        transitions_started: "transições iniciadas";
+    }
+    "consulta" {
+        query_calls: "querySelector/All";
+        query_nodes_visited: "nós visitados por essas consultas";
+        query_index_hits: "consultas servidas por índice";
+        tag_scans: "varreduras por tag (getElementsByTagName)";
+    }
+    "anomalias" {
+        resolve_stale: "NodeId de geração ERRADA resolvido";
+        resolve_out_of_range: "NodeId fora da arena";
+        selector_parse_failures: "seletor não parseado";
+        style_parse_failures: "valor de estilo não parseado";
+    }
+}
+
+/// Separador de milhar — é exatamente na ordem de grandeza de 6-7 dígitos que
+/// esses contadores param de ser legíveis sem ele.
+fn group_digits(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push('.');
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(feature = "metrics")]
+thread_local! {
+    static METRICS: std::cell::RefCell<DomMetrics> =
+        std::cell::RefCell::new(DomMetrics::default());
+}
+
+/// Incrementa um contador: `bump!(campo)` soma 1, `bump!(campo, n)` soma `n`.
+/// SEM a feature `metrics` expande para nada — inclusive o `n`, que por isso
+/// nunca pode ser uma expressão com efeito colateral.
+#[macro_export]
+macro_rules! bump {
+    ($field:ident) => { $crate::bump!($field, 1) };
+    ($field:ident, $n:expr) => {{
+        #[cfg(feature = "metrics")]
+        $crate::metrics::counters::add(|m| m.$field = m.$field.wrapping_add($n as u64));
+    }};
+}
+
+/// Aplica uma mutação ao snapshot corrente. A closure só mexe em inteiros — é o
+/// que garante que um `bump!` nunca reentre noutro e estoure o `borrow_mut`.
+#[cfg(feature = "metrics")]
+pub fn add(f: impl FnOnce(&mut DomMetrics)) {
+    METRICS.with(|m| {
+        if let Ok(mut m) = m.try_borrow_mut() {
+            f(&mut m);
+        }
+    });
+}
+
+/// O estado corrente dos contadores desta thread. Com a feature desligada
+/// devolve tudo zero — o chamador deve DIZER isso em vez de imprimir a tabela
+/// vazia como se fosse uma medição.
+pub fn snapshot() -> DomMetrics {
+    #[cfg(feature = "metrics")]
+    {
+        METRICS.with(|m| m.borrow().clone())
+    }
+    #[cfg(not(feature = "metrics"))]
+    {
+        DomMetrics::default()
+    }
+}
+
+/// Zera os contadores desta thread.
+pub fn reset() {
+    #[cfg(feature = "metrics")]
+    METRICS.with(|m| *m.borrow_mut() = DomMetrics::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// O delta é o que se lê: contadores acumulam entre cenários, e um snapshot
+    /// absoluto misturaria o parse do arquivo anterior com o layout deste.
+    #[test]
+    fn delta_isola_o_intervalo() {
+        let a = DomMetrics { cascade_runs: 10, block_calls: 4, ..Default::default() };
+        let b = DomMetrics { cascade_runs: 25, block_calls: 4, ..Default::default() };
+        let d = b.delta(&a);
+        assert_eq!(d.cascade_runs, 15);
+        assert_eq!(d.block_calls, 0);
+    }
+
+    /// Linhas em zero somem — o relatório mostra o que aconteceu, não o catálogo.
+    #[test]
+    fn relatorio_omite_contadores_zerados() {
+        let m = DomMetrics { cascade_runs: 3, ..Default::default() };
+        let r = m.report();
+        assert!(r.contains("CASCADE completa executada"));
+        assert!(!r.contains("layout_block"));
+    }
+
+    /// O JSON precisa sobreviver ao round-trip para um baseline valer como
+    /// baseline: gravar e reler tem de dar o mesmo número, ou o diff acusa
+    /// diferença onde não houve mudança nenhuma.
+    #[test]
+    fn json_round_trip_preserva_os_valores() {
+        let m = DomMetrics {
+            cascade_runs: 7,
+            html_bytes: 1234,
+            tags_orphan_close: 2,
+            ..Default::default()
+        };
+        let back = DomMetrics::from_json(&m.to_json());
+        assert_eq!(back, m);
+    }
+
+    /// Um baseline com uma chave AUSENTE não pode virar um valor inventado.
+    #[test]
+    fn json_sem_a_chave_le_zero() {
+        let back = DomMetrics::from_json("{ \"cascade_runs\": 5 }");
+        assert_eq!(back.cascade_runs, 5);
+        assert_eq!(back.html_bytes, 0);
+    }
+
+    #[test]
+    fn milhares_ficam_legiveis() {
+        assert_eq!(group_digits(1_234_567), "1.234.567");
+        assert_eq!(group_digits(42), "42");
+    }
+}

--- a/crates/rts-dom/src/metrics/footprint.rs
+++ b/crates/rts-dom/src/metrics/footprint.rs
@@ -1,0 +1,217 @@
+//! PEGADA de memória — quanto uma árvore ocupa, e onde.
+//!
+//! Contadores dizem quanto trabalho houve; fases, quanto tempo levou. Nenhum dos
+//! dois vê o terceiro consumo: uma página de 5000 nós que fica aberta paga
+//! memória a cada frame de animação, a cada classe trocada e a cada nó removido
+//! — e paga em lugares que não são a árvore. Metade dos campos do `Dom` é
+//! estado DERIVADO (memos, caches, índices, estilos interpolados), e é
+//! exatamente aí que uma invalidação preguiçosa aparece como bytes em vez de
+//! milissegundos.
+//!
+//! ## É uma ESTIMATIVA, e diz o que estima
+//!
+//! Não há alocador instrumentado aqui: o número é somado do que as estruturas
+//! declaram — `size_of` do elemento vezes a CAPACIDADE do `Vec`/`HashMap`, mais
+//! o conteúdo de cada `String` alcançável. Isso ignora o overhead do alocador e
+//! a fragmentação, e um `HashMap` reserva mais do que a capacidade lógica; o
+//! valor é um piso comparável entre execuções, não o RSS do processo. Para o
+//! que ele serve — comparar páginas, e ver o derivado crescer sem a árvore
+//! crescer — um piso comparável é o suficiente, e um número que se diz exato
+//! sem ser é pior do que nenhum.
+
+use crate::dom::{Dom, NodeKind};
+
+/// Bytes por área, e a contagem que os produziu.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Footprint {
+    /// A arena: os `Node` mais os `Vec` de filhos e de atributos.
+    pub arena: usize,
+    /// O TEXTO propriamente dito: tags, valores de atributo, nós de texto.
+    pub strings: usize,
+    /// Índices `#id`/`.classe`.
+    pub indices: usize,
+    /// Memos de estilo (`computed_memo` + `base_memo`).
+    pub style_memos: usize,
+    /// Caches de layout (medição de bloco + largura intrínseca).
+    pub layout_caches: usize,
+    /// O stylesheet de autor parseado + o CSS bruto guardado.
+    pub stylesheet: usize,
+    /// Estado por nó que não é a árvore: listeners, inputs, imagens, animação.
+    pub derived: usize,
+    /// Quantas ENTRADAS há em cada área derivada, para ler o byte ao lado de um
+    /// "quantos": 3 MB de memo é muito ou pouco dependendo de quantos nós há.
+    pub entries_style_memos: usize,
+    pub entries_layout_caches: usize,
+    pub entries_indices: usize,
+    pub entries_derived: usize,
+    pub nodes: usize,
+}
+
+impl Footprint {
+    pub fn total(&self) -> usize {
+        self.arena
+            + self.strings
+            + self.indices
+            + self.style_memos
+            + self.layout_caches
+            + self.stylesheet
+            + self.derived
+    }
+
+    /// Relatório legível, ordenado do maior para o menor: a primeira linha é
+    /// onde a memória está, que é a única pergunta que um total não responde.
+    pub fn report(&self) -> String {
+        let mut areas: Vec<(&str, usize, String)> = vec![
+            ("árvore (arena)", self.arena, format!("{} nós", self.nodes)),
+            ("texto (tags/attrs/conteúdo)", self.strings, String::new()),
+            ("índices #id/.classe", self.indices, format!("{} entradas", self.entries_indices)),
+            (
+                "memos de estilo",
+                self.style_memos,
+                format!("{} entradas", self.entries_style_memos),
+            ),
+            (
+                "caches de layout",
+                self.layout_caches,
+                format!("{} entradas", self.entries_layout_caches),
+            ),
+            ("stylesheet + CSS bruto", self.stylesheet, String::new()),
+            ("estado derivado por nó", self.derived, format!("{} entradas", self.entries_derived)),
+        ];
+        areas.sort_by_key(|(_, b, _)| std::cmp::Reverse(*b));
+        let total = self.total().max(1);
+        let mut out = format!(
+            "    pegada estimada: {} ({:.0} B por nó)\n",
+            human(self.total()),
+            self.total() as f64 / self.nodes.max(1) as f64
+        );
+        for (name, bytes, note) in areas {
+            if bytes == 0 {
+                continue;
+            }
+            out.push_str(&format!(
+                "      {:<30} {:>10}  {:>5.1}%  {}\n",
+                name,
+                human(bytes),
+                bytes as f64 * 100.0 / total as f64,
+                note
+            ));
+        }
+        out
+    }
+}
+
+/// O TAMANHO das estruturas-chave, em bytes. Não é sobre uma página: é sobre o
+/// código, e é o número que explica os outros — um `ComputedStyle` de 1 KB
+/// significa que cada hit de memo copia 1 KB, e que cada regra CSS carrega dois
+/// deles. Um clone barato e um clone caro têm exatamente a mesma cara no código.
+pub fn type_sizes() -> Vec<(&'static str, usize)> {
+    use crate::dom::{Attr, Node};
+    use crate::style::ComputedStyle;
+    vec![
+        ("Node", std::mem::size_of::<Node>()),
+        ("Attr", std::mem::size_of::<Attr>()),
+        ("ComputedStyle", std::mem::size_of::<ComputedStyle>()),
+        ("Rule (CSS)", crate::style::stylesheet::rule_size()),
+        ("DisplayItem", std::mem::size_of::<crate::layout::DisplayItem>()),
+    ]
+}
+
+fn human(bytes: usize) -> String {
+    match bytes {
+        b if b < 1024 => format!("{b} B"),
+        b if b < 1024 * 1024 => format!("{:.1} KiB", b as f64 / 1024.0),
+        b => format!("{:.2} MiB", b as f64 / (1024.0 * 1024.0)),
+    }
+}
+
+/// Soma a pegada de uma árvore. O(n) sobre a arena.
+pub fn footprint(dom: &Dom) -> Footprint {
+    use crate::dom::{Attr, Node, NodeIdx};
+    use crate::style::ComputedStyle;
+
+    let mut f = Footprint { nodes: dom.nodes.len(), ..Default::default() };
+    f.arena = dom.nodes.capacity() * std::mem::size_of::<Node>()
+        + dom.layout_epoch_len() * std::mem::size_of::<u64>();
+
+    for node in &dom.nodes {
+        f.arena += node.children.capacity() * std::mem::size_of::<NodeIdx>()
+            + node.attrs.capacity() * std::mem::size_of::<Attr>();
+        f.strings += match &node.kind {
+            NodeKind::Element { tag } => tag.capacity(),
+            NodeKind::Text(t) | NodeKind::Comment(t) => t.capacity(),
+            NodeKind::Document => 0,
+        };
+        for a in &node.attrs {
+            f.strings += a.name.capacity() + a.value.capacity();
+        }
+    }
+
+    let (id_index, class_index) = dom.debug_indices();
+    for (key, bucket) in id_index.iter().chain(class_index.iter()) {
+        f.entries_indices += bucket.len();
+        f.indices += key.capacity()
+            + bucket.capacity() * std::mem::size_of::<NodeIdx>()
+            + std::mem::size_of::<String>();
+    }
+
+    // Memos e caches: o `Dom` enumera os próprios (tamanho de entrada + quantas),
+    // pela mesma razão do `derived_node_state` — um campo novo que não for
+    // acrescentado lá não ganha contagem, mas um removido não deixa esta
+    // varredura mentindo sobre um campo que já não existe.
+    let (memo_entries, cache_entries) = dom.derived_cache_sizes();
+    f.entries_style_memos = memo_entries;
+    f.style_memos =
+        memo_entries * (std::mem::size_of::<ComputedStyle>() + std::mem::size_of::<NodeIdx>());
+    f.entries_layout_caches = cache_entries;
+    f.layout_caches = dom.layout_cache_bytes();
+
+    f.stylesheet = dom.stylesheet_bytes();
+
+    let derived = dom.derived_node_state();
+    f.entries_derived = derived.len();
+    // Uma entrada de estado derivado guarda pelo menos a chave e um valor do
+    // tamanho de um `ComputedStyle` no pior caso (anim_override/prev_computed,
+    // que são os maiores). Estimar pelo maior evita um número que parece pequeno
+    // justamente na área que cresce sozinha.
+    f.derived = derived.len() * (std::mem::size_of::<NodeIdx>() + std::mem::size_of::<ComputedStyle>());
+
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse_html_to_dom;
+
+    /// A pegada acompanha a árvore: uma página maior ocupa mais, e o texto
+    /// aparece separado da arena (senão "o DOM ocupa X" não diz se o problema é
+    /// a estrutura ou o conteúdo).
+    #[test]
+    fn a_pegada_cresce_com_a_arvore_e_separa_texto_de_estrutura() {
+        let pequena = footprint(&parse_html_to_dom("<p>a</p>"));
+        let grande = footprint(&parse_html_to_dom(
+            &"<div class=\"c\"><p>texto um pouco maior</p></div>".repeat(50),
+        ));
+        assert!(grande.total() > pequena.total() * 10);
+        assert!(grande.strings > 0 && grande.arena > 0);
+        assert!(grande.report().contains("por nó"));
+    }
+
+    /// O estado DERIVADO é o que cresce sem a árvore crescer — é o ponto todo
+    /// desta medição. Um layout preenche memos; a árvore não muda.
+    #[test]
+    fn o_derivado_cresce_sem_a_arvore_crescer() {
+        let dom = parse_html_to_dom("<div><p>um</p><p>dois</p></div>");
+        let antes = footprint(&dom);
+        let ctx = crate::layout::LayoutCtx {
+            viewport_w: 800.0,
+            viewport_h: 600.0,
+            measurer: &crate::layout::ApproxMeasurer,
+        };
+        let _ = crate::layout::layout_document(&dom, &ctx);
+        let depois = footprint(&dom);
+        assert_eq!(antes.arena, depois.arena, "a árvore não mudou");
+        assert!(depois.style_memos > antes.style_memos, "os memos encheram");
+    }
+}

--- a/crates/rts-dom/src/metrics/mod.rs
+++ b/crates/rts-dom/src/metrics/mod.rs
@@ -1,0 +1,53 @@
+//! MÉTRICAS do motor de DOM — o que aconteceu por dentro, em três formas.
+//!
+//! | módulo | responde |
+//! |---|---|
+//! | [`counters`] | QUANTAS vezes cada operação aconteceu (parse, cascade, layout, invalidação) |
+//! | [`phases`] | QUANTO TEMPO cada fase nomeada levou — inclusive fases de fora deste crate (render, loop, script) |
+//! | [`samples`] | QUAIS foram os casos — os nomes por trás de um contador (quais seletores caíram, quais propriedades faltam) |
+//! | [`audit`] | se a árvore está CONSISTENTE consigo mesma: índices, elos de parentesco, ids duplicados |
+//!
+//! ## Por que as três e não só um cronômetro
+//!
+//! Um tempo diz que algo está lento; não diz o quê. As perguntas que este crate
+//! não conseguia responder eram todas de CONTAGEM, e cada uma tem um cache no
+//! caminho — e cache se avalia por RAZÃO (hits/chamadas), que é um par de
+//! contadores, nunca um relógio. Já a auditoria responde a outra pergunta, que
+//! nenhum número de desempenho responde: se o que foi medido estava CERTO. Um
+//! índice `.classe` apontando para um nó removido não fica lento — fica errado, e
+//! só uma varredura que compara o índice com a árvore acha isso.
+//!
+//! ## Custo quando desligada: zero
+//!
+//! Contadores e fases passam por macros que, sem a feature `metrics`, expandem
+//! para nada — nem a leitura do `thread_local` sobra. A [`audit`] é diferente: é
+//! uma varredura sob demanda, sempre disponível, porque não é instrumentação de
+//! caminho quente e sim uma pergunta que se faz a uma árvore parada.
+//!
+//! Um número de RELÓGIO medido COM a instrumentação não é comparável a um sem
+//! ela. O harness (`examples/dom_metrics.rs`) imprime de que lado está.
+
+pub mod audit;
+pub mod counters;
+pub mod phases;
+pub mod samples;
+
+pub use audit::{audit, AuditReport, Finding};
+pub use counters::{snapshot, DomMetrics};
+pub use phases::{phase_snapshot, PhaseStats, Phases};
+pub use samples::Samples;
+
+/// Zera contadores, fases E amostras desta thread. A auditoria não tem estado a
+/// zerar: ela pergunta a uma árvore, não acumula nada.
+pub fn reset() {
+    counters::reset();
+    phases::reset();
+    samples::reset();
+}
+
+/// `true` quando o crate foi compilado com a instrumentação (feature `metrics`).
+/// Um relatório que não diz isto é um relatório de zeros indistinguível de um
+/// trabalho que não houve.
+pub const fn enabled() -> bool {
+    cfg!(feature = "metrics")
+}

--- a/crates/rts-dom/src/metrics/mod.rs
+++ b/crates/rts-dom/src/metrics/mod.rs
@@ -6,6 +6,7 @@
 //! | [`phases`] | QUANTO TEMPO cada fase nomeada levou — inclusive fases de fora deste crate (render, loop, script) |
 //! | [`samples`] | QUAIS foram os casos — os nomes por trás de um contador (quais seletores caíram, quais propriedades faltam) |
 //! | [`audit`] | se a árvore está CONSISTENTE consigo mesma: índices, elos de parentesco, ids duplicados |
+//! | [`footprint`] | QUANTA MEMÓRIA a árvore ocupa, e em qual área — o consumo que nem contador nem relógio vê |
 //!
 //! ## Por que as três e não só um cronômetro
 //!
@@ -29,10 +30,12 @@
 
 pub mod audit;
 pub mod counters;
+pub mod footprint;
 pub mod phases;
 pub mod samples;
 
 pub use audit::{audit, AuditReport, Finding};
+pub use footprint::{footprint, Footprint};
 pub use counters::{snapshot, DomMetrics};
 pub use phases::{phase_snapshot, PhaseStats, Phases};
 pub use samples::Samples;

--- a/crates/rts-dom/src/metrics/phases.rs
+++ b/crates/rts-dom/src/metrics/phases.rs
@@ -1,0 +1,291 @@
+//! FASES cronometradas — quanto tempo cada etapa nomeada levou, e quantas vezes.
+//!
+//! Um contador diz quantas vezes a cascade rodou; uma fase diz quanto do frame
+//! ela levou. As duas juntas respondem a pergunta que nenhuma responde sozinha:
+//! *4000 cascades são caras?* — só se `cascade` for uma fatia grande do frame.
+//!
+//! ## Por que o registro de fases mora AQUI e não em quem mede
+//!
+//! As fases interessantes atravessam crates: `load-html` e `cascade` são deste
+//! crate, `layout` é deste mas quem o chama por frame é o `rts-egui`, e `paint`,
+//! `frame` e o tempo de um callback de página são de fora. Um registro por crate
+//! daria três relatórios que não somam — e a pergunta "o que come o frame" só
+//! existe se todas as fatias estiverem na MESMA conta. O `rts-dom` é o crate
+//! comum a todos eles (e o único sem dependências), então o registro é aqui e
+//! os de fora chamam [`scope`].
+//!
+//! Nomes são `&'static str` de propósito: uma fase é um ponto do CÓDIGO, não um
+//! dado. Um nome montado em tempo de execução criaria uma linha nova por
+//! iteração e o relatório viraria um log.
+//!
+//! ## Reentrância
+//!
+//! `layout` chamado de dentro de `frame` acumula nos DOIS — as fases se aninham
+//! e a soma delas passa de 100% do tempo de parede. É intencional: é o que
+//! permite ler "`layout` é 80% de `frame`". [`PhaseStats::depth_max`] registra o
+//! aninhamento máximo visto, que é como se percebe uma recursão inesperada.
+
+/// O acumulado de UMA fase.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct PhaseStats {
+    /// Quantas vezes a fase começou e terminou.
+    pub calls: u64,
+    /// Soma dos tempos, em nanossegundos.
+    pub total_ns: u64,
+    /// A execução mais rápida.
+    pub min_ns: u64,
+    /// A mais lenta — o que um pico de frame realmente custou.
+    pub max_ns: u64,
+    /// Maior aninhamento observado (1 = nunca reentrou).
+    pub depth_max: u32,
+}
+
+impl PhaseStats {
+    /// Média em milissegundos. Média SEM o `max_ns` ao lado engana: um frame
+    /// médio de 4 ms com pico de 90 ms é uma página que trava, não uma suave.
+    pub fn avg_ms(&self) -> f64 {
+        if self.calls == 0 { 0.0 } else { self.total_ns as f64 / self.calls as f64 / 1e6 }
+    }
+    pub fn total_ms(&self) -> f64 {
+        self.total_ns as f64 / 1e6
+    }
+    pub fn max_ms(&self) -> f64 {
+        self.max_ns as f64 / 1e6
+    }
+    pub fn min_ms(&self) -> f64 {
+        self.min_ns as f64 / 1e6
+    }
+}
+
+/// Todas as fases vistas, na ordem em que apareceram pela primeira vez — que é a
+/// ordem do PIPELINE quando a instrumentação segue o caminho do dado, e vale
+/// mais do que a alfabética.
+#[derive(Clone, Debug, Default)]
+pub struct Phases {
+    entries: Vec<(&'static str, PhaseStats)>,
+}
+
+impl Phases {
+    pub fn get(&self, name: &str) -> Option<PhaseStats> {
+        self.entries.iter().find(|(n, _)| *n == name).map(|(_, s)| *s)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, PhaseStats)> + '_ {
+        self.entries.iter().copied()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// `self - base`, fase a fase — o intervalo entre dois snapshots. `min`/`max`
+    /// não são subtraíveis: ficam os do snapshot atual, e o relatório os rotula
+    /// como acumulados desde o último `reset`.
+    pub fn delta(&self, base: &Phases) -> Phases {
+        let mut out = Phases::default();
+        for (name, s) in self.iter() {
+            let b = base.get(name).unwrap_or_default();
+            out.entries.push((
+                name,
+                PhaseStats {
+                    calls: s.calls.saturating_sub(b.calls),
+                    total_ns: s.total_ns.saturating_sub(b.total_ns),
+                    min_ns: s.min_ns,
+                    max_ns: s.max_ns,
+                    depth_max: s.depth_max,
+                },
+            ));
+        }
+        out
+    }
+
+    /// Tabela legível, com a fatia de cada fase sobre a MAIOR delas.
+    pub fn report(&self) -> String {
+        let widest = self.iter().map(|(_, s)| s.total_ns).max().unwrap_or(0);
+        self.report_over(widest as f64 / 1e6)
+    }
+
+    /// Tabela legível com a fatia calculada sobre um total EXTERNO — o tempo de
+    /// parede do cenário, que é a referência certa: sem ela, uma fase de 3 ms
+    /// não diz se comeu o frame ou se foi ruído dentro de 300 ms. As fases se
+    /// aninham, então a soma das fatias pode passar de 100% — é o que permite
+    /// ler "layout é 80% do frame E cascade é 60% do layout".
+    pub fn report_over(&self, total_ms: f64) -> String {
+        if self.entries.is_empty() {
+            return String::new();
+        }
+        let root = (total_ms * 1e6).max(1.0) as u64;
+        let mut out = format!(
+            "    {:<22} {:>7} {:>11} {:>10} {:>10} {:>7}\n",
+            "fase", "vezes", "total ms", "média ms", "máx ms", "% total"
+        );
+        for (name, s) in self.iter() {
+            if s.calls == 0 {
+                continue;
+            }
+            out.push_str(&format!(
+                "    {:<22} {:>7} {:>11.3} {:>10.3} {:>10.3} {:>6.1}%\n",
+                name,
+                s.calls,
+                s.total_ms(),
+                s.avg_ms(),
+                s.max_ms(),
+                s.total_ns as f64 * 100.0 / root as f64,
+            ));
+        }
+        out
+    }
+
+    /// JSON `{"fase": {"calls":…, "total_ns":…, …}, …}`.
+    pub fn to_json(&self) -> String {
+        let body: Vec<String> = self
+            .iter()
+            .map(|(name, s)| {
+                format!(
+                    "    \"{name}\": {{ \"calls\": {}, \"total_ns\": {}, \"min_ns\": {}, \"max_ns\": {}, \"depth_max\": {} }}",
+                    s.calls, s.total_ns, s.min_ns, s.max_ns, s.depth_max
+                )
+            })
+            .collect();
+        format!("{{\n{}\n  }}", body.join(",\n"))
+    }
+}
+
+#[cfg(feature = "metrics")]
+thread_local! {
+    static PHASES: std::cell::RefCell<Phases> = std::cell::RefCell::new(Phases::default());
+    /// Profundidade corrente por fase — para medir aninhamento sem procurar na
+    /// pilha de chamadas.
+    static DEPTH: std::cell::RefCell<Vec<(&'static str, u32)>> =
+        std::cell::RefCell::new(Vec::new());
+}
+
+/// Guarda RAII de uma fase: começa a contar ao ser criada, fecha ao sair do
+/// escopo — inclusive por `?` ou por pânico, que é o motivo de ser um guard e
+/// não um par `begin`/`end` (um `end` esquecido num caminho de erro produz uma
+/// fase que nunca fecha e um relatório que mente).
+#[must_use = "a fase é medida enquanto o guard vive; descartá-lo a fecha na hora"]
+pub struct Scope {
+    #[cfg(feature = "metrics")]
+    name: &'static str,
+    #[cfg(feature = "metrics")]
+    start: std::time::Instant,
+}
+
+impl Drop for Scope {
+    fn drop(&mut self) {
+        #[cfg(feature = "metrics")]
+        {
+            let ns = self.start.elapsed().as_nanos() as u64;
+            let depth = DEPTH.with(|d| {
+                let mut d = d.borrow_mut();
+                let cur = d
+                    .iter_mut()
+                    .find(|(n, _)| *n == self.name)
+                    .map(|(_, c)| {
+                        *c = c.saturating_sub(1);
+                        *c + 1
+                    })
+                    .unwrap_or(1);
+                cur
+            });
+            PHASES.with(|p| {
+                let mut p = p.borrow_mut();
+                let name = self.name;
+                if let Some((_, s)) = p.entries.iter_mut().find(|(n, _)| *n == name) {
+                    s.calls += 1;
+                    s.total_ns = s.total_ns.wrapping_add(ns);
+                    s.min_ns = if s.min_ns == 0 { ns } else { s.min_ns.min(ns) };
+                    s.max_ns = s.max_ns.max(ns);
+                    s.depth_max = s.depth_max.max(depth);
+                } else {
+                    p.entries.push((
+                        name,
+                        PhaseStats { calls: 1, total_ns: ns, min_ns: ns, max_ns: ns, depth_max: depth },
+                    ));
+                }
+            });
+        }
+    }
+}
+
+/// Abre uma fase. Guarde o retorno numa variável — soltá-lo imediatamente
+/// (`let _ = scope("x")`) mede zero, e é o erro que o `#[must_use]` pega.
+///
+/// ```ignore
+/// let _t = rts_dom::metrics::phases::scope("layout");
+/// ```
+pub fn scope(name: &'static str) -> Scope {
+    #[cfg(feature = "metrics")]
+    {
+        DEPTH.with(|d| {
+            let mut d = d.borrow_mut();
+            match d.iter_mut().find(|(n, _)| *n == name) {
+                Some((_, c)) => *c += 1,
+                None => d.push((name, 1)),
+            }
+        });
+        Scope { name, start: std::time::Instant::now() }
+    }
+    #[cfg(not(feature = "metrics"))]
+    {
+        let _ = name;
+        Scope {}
+    }
+}
+
+/// O acumulado de fases desta thread.
+pub fn phase_snapshot() -> Phases {
+    #[cfg(feature = "metrics")]
+    {
+        PHASES.with(|p| p.borrow().clone())
+    }
+    #[cfg(not(feature = "metrics"))]
+    {
+        Phases::default()
+    }
+}
+
+/// Zera as fases desta thread.
+pub fn reset() {
+    #[cfg(feature = "metrics")]
+    {
+        PHASES.with(|p| *p.borrow_mut() = Phases::default());
+        DEPTH.with(|d| d.borrow_mut().clear());
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::*;
+
+    /// Uma fase fechada aparece com a contagem certa — e o relatório sem fases
+    /// não imprime cabeçalho nenhum (o harness distingue "não mediu" de "mediu
+    /// zero").
+    #[test]
+    fn fase_acumula_e_o_vazio_nao_imprime() {
+        reset();
+        assert!(phase_snapshot().report().is_empty());
+        {
+            let _t = scope("teste");
+        }
+        {
+            let _t = scope("teste");
+        }
+        let p = phase_snapshot();
+        assert_eq!(p.get("teste").unwrap().calls, 2);
+        assert!(p.report().contains("teste"));
+    }
+
+    /// Aninhar a MESMA fase é reentrância legítima (layout dentro de layout) e
+    /// precisa aparecer, senão uma recursão inesperada passa despercebida.
+    #[test]
+    fn aninhamento_e_registrado() {
+        reset();
+        {
+            let _a = scope("rec");
+            let _b = scope("rec");
+        }
+        assert_eq!(phase_snapshot().get("rec").unwrap().depth_max, 2);
+    }
+}

--- a/crates/rts-dom/src/metrics/samples.rs
+++ b/crates/rts-dom/src/metrics/samples.rs
@@ -1,0 +1,149 @@
+//! AMOSTRAS nomeadas — um contador diz *quantos*, isto diz *quais*.
+//!
+//! "2632 regras descartadas" é um número acionável só depois de virar
+//! "`:is(...)`, `::before`, `[data-x=y i]`". A diferença entre os dois é o que
+//! separa um relatório de desempenho de uma lista de trabalho, e é por isso que
+//! as duas coisas existem lado a lado: o contador é barato e completo, a
+//! amostra é cara e limitada.
+//!
+//! ## O limite é a razão de isto ser seguro
+//!
+//! Cada categoria guarda no máximo [`MAX_PER_KIND`] amostras DISTINTAS e para.
+//! Um `<style>` do Bootstrap descarta milhares de seletores; guardar todos
+//! transformaria a instrumentação num log e o custo dela na medição. Trinta e
+//! duas amostras distintas já dizem de que TIPO é o problema — que é a pergunta
+//! — e a contagem completa continua no contador ao lado.
+//!
+//! Sem a feature `metrics`, [`note!`] não avalia nem a string: o `format!` que
+//! monta a amostra é a parte cara, e ele não acontece.
+
+/// Teto de amostras distintas por categoria. Trinta e duas cobrem a variedade
+/// sem virar log; a contagem exata vive no contador correspondente.
+pub const MAX_PER_KIND: usize = 32;
+
+/// As amostras coletadas, por categoria, na ordem em que apareceram.
+#[derive(Clone, Debug, Default)]
+pub struct Samples {
+    entries: Vec<(&'static str, Vec<String>, u64)>,
+}
+
+impl Samples {
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// As amostras de uma categoria e quantas vezes ela ocorreu ao todo.
+    pub fn get(&self, kind: &str) -> Option<(&[String], u64)> {
+        self.entries.iter().find(|(k, _, _)| *k == kind).map(|(_, v, n)| (v.as_slice(), *n))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, &[String], u64)> + '_ {
+        self.entries.iter().map(|(k, v, n)| (*k, v.as_slice(), *n))
+    }
+
+    /// Relatório legível: a categoria, o total, e as amostras distintas.
+    /// Diz explicitamente quando truncou — uma lista cortada que não avisa é
+    /// uma lista que mente sobre a variedade do problema.
+    pub fn report(&self) -> String {
+        let mut out = String::new();
+        for (kind, list, total) in self.iter() {
+            out.push_str(&format!("    {kind} (×{total}):\n"));
+            for s in list {
+                out.push_str(&format!("      · {s}\n"));
+            }
+            if list.len() >= MAX_PER_KIND {
+                out.push_str(&format!(
+                    "      … só as {MAX_PER_KIND} primeiras distintas; o total está acima\n"
+                ));
+            }
+        }
+        out
+    }
+}
+
+#[cfg(feature = "metrics")]
+thread_local! {
+    static SAMPLES: std::cell::RefCell<Samples> = std::cell::RefCell::new(Samples::default());
+}
+
+/// Registra uma amostra: `note!("seletor-descartado", format!("{sel}"))`.
+/// Sem a feature, NADA é avaliado — nem a expressão que monta o texto.
+#[macro_export]
+macro_rules! note {
+    ($kind:literal, $text:expr) => {{
+        #[cfg(feature = "metrics")]
+        $crate::metrics::samples::record($kind, || $text);
+    }};
+}
+
+/// Guarda uma amostra distinta na categoria, respeitando o teto. A closure só é
+/// chamada enquanto há espaço: passado o teto, o custo por ocorrência volta a
+/// ser um incremento.
+#[cfg(feature = "metrics")]
+pub fn record(kind: &'static str, text: impl FnOnce() -> String) {
+    SAMPLES.with(|s| {
+        let Ok(mut s) = s.try_borrow_mut() else { return };
+        match s.entries.iter_mut().find(|(k, _, _)| *k == kind) {
+            Some((_, list, total)) => {
+                *total += 1;
+                if list.len() >= MAX_PER_KIND {
+                    return;
+                }
+                let t = text();
+                if !list.contains(&t) {
+                    list.push(t);
+                }
+            }
+            None => s.entries.push((kind, vec![text()], 1)),
+        }
+    });
+}
+
+/// As amostras desta thread.
+pub fn snapshot() -> Samples {
+    #[cfg(feature = "metrics")]
+    {
+        SAMPLES.with(|s| s.borrow().clone())
+    }
+    #[cfg(not(feature = "metrics"))]
+    {
+        Samples::default()
+    }
+}
+
+/// Esquece as amostras desta thread.
+pub fn reset() {
+    #[cfg(feature = "metrics")]
+    SAMPLES.with(|s| *s.borrow_mut() = Samples::default());
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::*;
+
+    /// Repetição não infla a lista, mas conta no total — é o que faz "×2632"
+    /// caber ao lado de três exemplos.
+    #[test]
+    fn distintas_na_lista_todas_no_total() {
+        reset();
+        crate::note!("t", "a".to_string());
+        crate::note!("t", "a".to_string());
+        crate::note!("t", "b".to_string());
+        let taken = snapshot();
+        let (list, total) = taken.get("t").unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(total, 3);
+    }
+
+    /// Passado o teto, a coleta para e o relatório AVISA que parou.
+    #[test]
+    fn o_teto_e_declarado_no_relatorio() {
+        reset();
+        for i in 0..(MAX_PER_KIND + 10) {
+            crate::note!("t", format!("s{i}"));
+        }
+        let s = snapshot();
+        assert_eq!(s.get("t").unwrap().0.len(), MAX_PER_KIND);
+        assert!(s.report().contains("primeiras distintas"));
+    }
+}

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -59,7 +59,7 @@ pub use selector::{
     compound_matches, compound_matches_borrowed, parse_selector, parse_selector_list, AttrOp, Combinator,
     ComplexSelector, CompoundSelector, PseudoClass, Selector, SimpleSelector,
 };
-pub use stylesheet::{parse_rules, DeclBlock, MediaQuery, Rule, Stylesheet};
+pub use stylesheet::{parse_rules, DeclBlock, HoverReach, MediaQuery, Rule, Stylesheet};
 pub use values::{
     clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection, FloatSide, GridTrack,
     JustifyContent, LineHeight, Position, ResolveCtx, Rgba, Side, TextAlign, TextTransform,

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -31,12 +31,14 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
             (Some(p), Some(v)) => (p.trim().to_ascii_lowercase(), v.trim()),
             _ => continue,
         };
+        crate::bump!(css_declarations);
         // Destaca o sufixo `!important` (case-insensitive) do valor; a camada de
         // destino depende dele.
         let (val, important) = split_important(val_raw);
         // CUSTOM PROPERTY (`--nome: valor`): guarda o valor CRU no bloco — a
         // cascade por elemento resolve (#1779). Importância ignorada (v1).
         if prop.starts_with("--") {
+            crate::bump!(css_custom_declarations);
             block.custom.push((prop.clone(), val.to_string()));
             continue;
         }
@@ -44,6 +46,7 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
         // cascade resolve POR ELEMENTO (contra as custom props dele) na posição
         // desta regra.
         if val.contains("var(") {
+            crate::bump!(css_var_refs);
             block.pending.push((prop.clone(), val.to_string(), important));
             continue;
         }
@@ -227,7 +230,13 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
             "left" => css.inset_left = parse_inset(val),
             "transition" => css.transition = crate::anim::TransitionSpec::parse(val),
             "animation" => css.animation = crate::anim::AnimationSpec::parse(val),
-            _ => {}
+            // Uma propriedade que nenhum braço reconhece é CSS que a página
+            // escreveu e o motor ignora em silêncio. Contá-la é o que transforma
+            // "o layout não bate com o Chrome" numa lista de nomes a implementar.
+            _ => {
+                crate::bump!(css_declarations_unknown);
+                crate::note!("propriedade-ignorada", prop.clone());
+            }
         }
     }
     block

--- a/crates/rts-dom/src/style/selector.rs
+++ b/crates/rts-dom/src/style/selector.rs
@@ -105,6 +105,19 @@ pub struct ComplexSelector {
 }
 
 impl SimpleSelector {
+    /// Bytes ESTIMADOS das strings deste simples — a parte do seletor que
+    /// realmente aloca. Usado por [`crate::metrics::footprint`].
+    pub fn estimated_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + match self {
+                SimpleSelector::Tag(s) | SimpleSelector::Class(s) | SimpleSelector::Id(s) => {
+                    s.capacity()
+                }
+                SimpleSelector::Attr { name, value, .. } => name.capacity() + value.capacity(),
+                SimpleSelector::Universal | SimpleSelector::Pseudo(_) => 0,
+            }
+    }
+
     fn specificity(&self) -> u32 {
         match self {
             SimpleSelector::Id(_) => 100,
@@ -188,6 +201,21 @@ pub(crate) fn split_top_level_commas(s: &str) -> Vec<&str> {
 }
 
 impl ComplexSelector {
+    /// Bytes ESTIMADOS deste seletor completo (todos os compounds e suas
+    /// strings). Ver [`crate::metrics::footprint`].
+    pub fn estimated_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.combinators.capacity() * std::mem::size_of::<Combinator>()
+            + self
+                .compounds
+                .iter()
+                .map(|c| {
+                    std::mem::size_of::<CompoundSelector>()
+                        + c.parts.iter().map(SimpleSelector::estimated_bytes).sum::<usize>()
+                })
+                .sum::<usize>()
+    }
+
     /// Parseia um seletor completo (compostos + combinadores). `None` se inválido.
     pub(crate) fn parse(s: &str) -> Option<ComplexSelector> {
         let s = s.trim();

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -262,6 +262,7 @@ impl Stylesheet {
         // 2) as regras normais do resto.
         let base = self.rules.len() as u32;
         for (i, rule) in parse_rules(&css_without_kf).into_iter().enumerate() {
+            crate::bump!(css_rules);
             self.rules.push(Rule { order: base + i as u32, ..rule });
         }
     }
@@ -283,6 +284,7 @@ impl Stylesheet {
             let Some(body_end) = find_matching_brace(&rest[body_start..]) else { break };
             let body = &rest[body_start..body_start + body_end];
             if !name.is_empty() {
+                crate::bump!(css_keyframes);
                 self.keyframes.insert(name, parse_keyframe_body(body));
             }
             rest = &rest[body_start + body_end + 1..];
@@ -307,6 +309,7 @@ impl Stylesheet {
         // FAST PATH: só as regras cuja chave-alvo o nó pode satisfazer (índice), em
         // vez de TODAS as regras. O `matches` completo (navega a árvore) ainda decide.
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
+        crate::bump!(rules_considered, cand.len());
         let index = self.index.borrow();
         let mut matched: Vec<(u32, u32, &Rule)> = cand
             .iter()
@@ -317,6 +320,7 @@ impl Stylesheet {
                     .then(|| (index.specificity(i), r.order, r))
             })
             .collect();
+        crate::bump!(rules_matched, matched.len());
         matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
         let mut out = DeclBlock::default();
         for (_, _, r) in &matched {
@@ -359,6 +363,7 @@ impl Stylesheet {
             return Vec::new();
         }
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
+        crate::bump!(rules_considered, cand.len());
         let index = self.index.borrow();
         let mut matched: Vec<(u32, u32, &Rule)> = cand
             .iter()
@@ -370,6 +375,7 @@ impl Stylesheet {
                     .then(|| (index.specificity(i), r.order, r))
             })
             .collect();
+        crate::bump!(rules_matched, matched.len());
         matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
         matched.iter().flat_map(|(_, _, r)| r.decls.custom.iter().cloned()).collect()
     }
@@ -427,6 +433,7 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
                             if let Some(cond) = header.strip_prefix("@media") {
                                 let outer = MediaQuery::parse(cond.trim());
                                 for mut rule in parse_rules(inner_css) {
+                                    crate::bump!(css_media_rules);
                                     // aninhamento @media-em-@media: AND das queries.
                                     rule.media = Some(match rule.media {
                                         Some(inner) => inner.and(outer),
@@ -472,6 +479,13 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
         for sel_str in selectors_raw.split(',') {
             if let Some(selector) = ComplexSelector::parse(sel_str) {
                 rules.push(Rule { selector, decls: decls.clone(), order: 0, media: None });
+            } else if !sel_str.trim().is_empty() {
+                // Um seletor que o parser recusa é uma regra que a página tem e o
+                // motor NÃO aplica — a diferença mais comum entre "parece o
+                // Chrome" e "não parece", e invisível sem contá-la.
+                crate::bump!(css_rules_dropped);
+                crate::bump!(selector_parse_failures);
+                crate::note!("seletor-recusado", sel_str.trim().to_string());
             }
         }
         i = next;

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -166,6 +166,13 @@ impl DeclBlock {
     }
 }
 
+/// `size_of::<Rule>()` — exposto porque `Rule` é privado do módulo e o número
+/// dele é o que explica a pegada de um stylesheet grande (cada regra carrega um
+/// `DeclBlock`, que carrega dois `ComputedStyle` inteiros).
+pub fn rule_size() -> usize {
+    std::mem::size_of::<Rule>()
+}
+
 /// Um stylesheet de autor (o conteúdo de um `<style>`), já parseado em regras
 /// ordenadas. Egui-free como o resto. É anexado ao `Dom` e consultado na cascade
 /// de `computed_style`.
@@ -245,6 +252,31 @@ impl Stylesheet {
     /// cascade quando a página não tem `<style>`).
     pub fn is_empty(&self) -> bool {
         self.rules.is_empty()
+    }
+
+    /// Bytes ESTIMADOS deste stylesheet: as regras com seus seletores e blocos
+    /// de declarações, mais os keyframes. Estimativa por estrutura (sem
+    /// alocador instrumentado), como todo o [`crate::metrics::footprint`] —
+    /// serve para comparar páginas e ver a área crescer, não para casar com o
+    /// RSS do processo.
+    pub fn estimated_bytes(&self) -> usize {
+        let mut total = self.rules.capacity() * std::mem::size_of::<Rule>();
+        for r in &self.rules {
+            total += r.selector.estimated_bytes();
+            // Um DeclBlock carrega dois ComputedStyle inteiros (normal +
+            // important) mais as listas de pendentes/custom, que são as que têm
+            // String de verdade.
+            total += r.decls.custom.iter().map(|(k, v)| k.capacity() + v.capacity()).sum::<usize>();
+            total += r
+                .decls
+                .pending
+                .iter()
+                .map(|(k, v, _)| k.capacity() + v.capacity())
+                .sum::<usize>();
+        }
+        total += self.keyframes.len()
+            * (std::mem::size_of::<crate::anim::Keyframes>() + std::mem::size_of::<String>());
+        total
     }
 
     /// Os `@keyframes` de um nome, se existir.

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -192,6 +192,25 @@ pub struct Stylesheet {
     /// índices candidatos para cada elemento. O stylesheet já usa RefCell para o
     /// índice lazy e a cascade é chamada de forma síncrona pelo DOM.
     candidate_scratch: std::cell::RefCell<Vec<usize>>,
+    /// Cache de [`hover_reach`](Stylesheet::hover_reach) — a resposta é uma
+    /// varredura de todas as regras, e a pergunta é feita a cada movimento do
+    /// mouse. Invalidado junto com o índice, em `append_css`.
+    hover_reach: std::cell::RefCell<Option<HoverReach>>,
+}
+
+/// Até onde uma mudança de `:hover` pode mexer no estilo desta folha.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HoverReach {
+    /// Nenhuma regra usa `:hover` — mover o mouse não muda estilo nenhum.
+    None,
+    /// Só o elemento que casa (`.btn:hover`). A subárvore dele ainda entra, por
+    /// causa das propriedades HERDADAS (`color` num `:hover` desce aos filhos).
+    SelfOnly,
+    /// `.card:hover .title` — desce pela subárvore do que casa.
+    Subtree,
+    /// `.a:hover + .b` — sai da subárvore. A invalidação por subárvore não
+    /// cobre isto, então este caso cai no fallback global, declarado.
+    Siblings,
 }
 
 // PartialEq manual (Keyframes tem f32, não derivamos Eq; o diff de árvore só compara
@@ -210,6 +229,7 @@ impl Stylesheet {
             keyframes: std::collections::HashMap::new(),
             index: std::cell::RefCell::new(super::ruleindex::RuleIndex::default()),
             candidate_scratch: std::cell::RefCell::new(Vec::new()),
+            hover_reach: std::cell::RefCell::new(None),
         }
     }
 
@@ -240,6 +260,65 @@ impl Stylesheet {
     fn has_custom_rules(&self) -> bool {
         self.ensure_rule_index();
         self.index.borrow().has_custom_rules()
+    }
+
+    /// As regras que contêm `:hover`, e se alguma delas ALCANÇA outros nós além
+    /// do que casa o compound com `:hover`.
+    ///
+    /// É o que transforma "mover o mouse invalida a página" em "mover o mouse
+    /// invalida os nós que podem mudar": sem esta separação, `set_hovered` só
+    /// tinha a opção grossa. Derivado das regras e recalculado quando elas
+    /// mudam, porque a alternativa era varrer 2643 regras a cada frame de mouse
+    /// — o que o `set_hovered` fazia.
+    pub fn hover_reach(&self) -> HoverReach {
+        self.ensure_rule_index();
+        if let Some(cached) = *self.hover_reach.borrow() {
+            return cached;
+        }
+        let mut reach = HoverReach::None;
+        for r in &self.rules {
+            let n = r.selector.compounds.len();
+            for (i, c) in r.selector.compounds.iter().enumerate() {
+                let has_hover = c.parts.iter().any(|p| {
+                    matches!(p, super::SimpleSelector::Pseudo(super::PseudoClass::Hover))
+                });
+                if !has_hover {
+                    continue;
+                }
+                // O `:hover` no ÚLTIMO compound afeta só quem casa (`.btn:hover`).
+                // Antes do último, o alcance depende do combinador que o segue:
+                // descendente/filho desce na subárvore, irmão sai dela — e sair
+                // dela é o caso que a invalidação por subárvore NÃO cobre.
+                let next = if i + 1 < n { r.selector.combinators.get(i) } else { None };
+                reach = reach.max(match next {
+                    None => HoverReach::SelfOnly,
+                    Some(super::Combinator::Descendant | super::Combinator::Child) => {
+                        HoverReach::Subtree
+                    }
+                    Some(_) => HoverReach::Siblings,
+                });
+            }
+        }
+        *self.hover_reach.borrow_mut() = Some(reach);
+        reach
+    }
+
+    /// Os COMPOUNDS que contêm `:hover`, um por regra que o usa. É contra estes
+    /// que se pergunta "este nó poderia casar uma regra de hover?", e a resposta
+    /// é o que separa o `<body>` (ancestral de tudo, casa nada) do `.btn` — sem
+    /// essa pergunta, invalidar a cadeia de ancestrais é invalidar a página.
+    pub fn hover_compounds(&self) -> Vec<&super::CompoundSelector> {
+        let mut out = Vec::new();
+        for r in &self.rules {
+            for c in &r.selector.compounds {
+                if c.parts.iter().any(|p| {
+                    matches!(p, super::SimpleSelector::Pseudo(super::PseudoClass::Hover))
+                }) {
+                    out.push(c);
+                }
+            }
+        }
+        out
     }
 
     /// `true` quando alguma regra depende da presença/valor de um atributo.
@@ -297,6 +376,8 @@ impl Stylesheet {
             crate::bump!(css_rules);
             self.rules.push(Rule { order: base + i as u32, ..rule });
         }
+        // As regras mudaram: o alcance de `:hover` derivado delas não vale mais.
+        *self.hover_reach.borrow_mut() = None;
     }
 
     /// Acha cada `@keyframes nome { ... }`, parseia os stops e guarda; devolve o CSS

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -196,6 +196,9 @@ pub struct Stylesheet {
     /// varredura de todas as regras, e a pergunta é feita a cada movimento do
     /// mouse. Invalidado junto com o índice, em `append_css`.
     hover_reach: std::cell::RefCell<Option<HoverReach>>,
+    /// Cache de [`position_sensitive`](Stylesheet::position_sensitive), pelo
+    /// mesmo motivo do `hover_reach` — a pergunta é por mutação de árvore.
+    position_sensitive: std::cell::RefCell<Option<bool>>,
 }
 
 /// Até onde uma mudança de `:hover` pode mexer no estilo desta folha.
@@ -230,6 +233,7 @@ impl Stylesheet {
             index: std::cell::RefCell::new(super::ruleindex::RuleIndex::default()),
             candidate_scratch: std::cell::RefCell::new(Vec::new()),
             hover_reach: std::cell::RefCell::new(None),
+            position_sensitive: std::cell::RefCell::new(None),
         }
     }
 
@@ -301,6 +305,43 @@ impl Stylesheet {
         }
         *self.hover_reach.borrow_mut() = Some(reach);
         reach
+    }
+
+    /// `true` quando o estilo de um nó pode depender da POSIÇÃO dele entre os
+    /// irmãos — `:first-child`, `:last-child`, `:only-child`, `:nth-child()`,
+    /// `:empty`, ou um combinador de irmão (`+`, `~`).
+    ///
+    /// É a guarda da invalidação por subárvore na INSERÇÃO e na REMOÇÃO: sem
+    /// nenhuma dessas formas, acrescentar um `<li>` não muda o estilo de nenhum
+    /// outro nó, e invalidar a página (o que se fazia) é jogar fora o memo de
+    /// todos os nós a cada `appendChild`. Com alguma delas, os irmãos mudam de
+    /// verdade e o global é o que responde certo. Derivado das regras e
+    /// cacheado — a pergunta é feita a cada mutação de árvore.
+    pub fn position_sensitive(&self) -> bool {
+        if let Some(cached) = *self.position_sensitive.borrow() {
+            return cached;
+        }
+        use super::{Combinator, PseudoClass as P, SimpleSelector as S};
+        let answer = self.rules.iter().any(|r| {
+            r.selector.combinators.iter().any(|c| {
+                matches!(c, Combinator::NextSibling | Combinator::SubsequentSibling)
+            }) || r.selector.compounds.iter().any(|c| {
+                c.parts.iter().any(|p| {
+                    matches!(
+                        p,
+                        S::Pseudo(
+                            P::FirstChild
+                                | P::LastChild
+                                | P::OnlyChild
+                                | P::Empty
+                                | P::NthChild(_, _)
+                        )
+                    )
+                })
+            })
+        });
+        *self.position_sensitive.borrow_mut() = Some(answer);
+        answer
     }
 
     /// Os COMPOUNDS que contêm `:hover`, um por regra que o usa. É contra estes
@@ -376,8 +417,9 @@ impl Stylesheet {
             crate::bump!(css_rules);
             self.rules.push(Rule { order: base + i as u32, ..rule });
         }
-        // As regras mudaram: o alcance de `:hover` derivado delas não vale mais.
+        // As regras mudaram: o que foi derivado delas não vale mais.
         *self.hover_reach.borrow_mut() = None;
+        *self.position_sensitive.borrow_mut() = None;
     }
 
     /// Acha cada `@keyframes nome { ... }`, parseia os stops e guarda; devolve o CSS

--- a/crates/rts-egui/Cargo.toml
+++ b/crates/rts-egui/Cargo.toml
@@ -115,3 +115,9 @@ glow-backend = ["dep:egui_glow", "dep:glow", "dep:glutin", "dep:glutin-winit", "
 gpu-dx12 = ["wgpu/dx12"]
 gpu-metal = ["wgpu/metal"]
 gpu-vulkan = ["wgpu/vulkan"]
+# Repassa a instrumentação do rts-dom: com ela, as fases `render-dom` e `paint`
+# deste crate entram na MESMA conta que `layout`, `cascade` e `load-html`. Sem
+# ela os `scope()` daqui somem junto com os de lá — a fatia do frame só existe
+# se todas as fatias forem medidas pelo mesmo registro (ver
+# `rts_dom::metrics::phases`).
+metrics = ["rts-dom/metrics"]

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -129,6 +129,10 @@ thread_local! {
 /// na altura total do conteúdo (para o layout do egui ao redor — scroll, etc —
 /// saber o tamanho ocupado).
 pub(crate) fn render_dom(ui: &mut egui::Ui, dom: &crate::dom::Dom) {
+    // FASE: o frame de render de um DOM, do ponto de vista do backend. O layout
+    // tem fase própria (dentro do rts-dom) e o `paint` é o que sobra — é assim
+    // que "o frame está lento" vira "o layout é 80% dele" ou "não é".
+    let _phase = rts_dom::metrics::phases::scope("render-dom");
     let avail = ui.available_size();
     let viewport_w = avail.x.max(1.0);
     let viewport_h = ui.ctx().screen_rect().height().max(1.0);
@@ -170,6 +174,7 @@ pub(crate) fn render_dom_scrolled(
     scroll_y: bool,
     force: bool,
 ) {
+    let _phase = rts_dom::metrics::phases::scope("render-dom");
     let avail = ui.available_size();
     let viewport_w = avail.x.max(1.0);
     let viewport_h = avail.y.max(1.0);
@@ -436,6 +441,7 @@ fn process_scroll_regions(
 /// absolutas (conteúdo + origem do `ui`). A ordem da lista É o z-order (o que vem
 /// depois pinta por cima). Reserva o espaço da altura total para o `ui` pai.
 fn paint_list(ui: &mut egui::Ui, list: &DisplayList, offset_y: f32) {
+    let _phase = rts_dom::metrics::phases::scope("paint");
     // origem do conteúdo + a translação de scroll da PÁGINA (offset_y negativo sobe).
     let base_origin = ui.max_rect().min + egui::vec2(0.0, offset_y);
     // PILHA para o scroll container interno (#1744): cada BeginClip empilha (painter

--- a/docs/ui/dom-crate.md
+++ b/docs/ui/dom-crate.md
@@ -86,3 +86,11 @@ crates/rts-egui/       only the RENDER (frame/render.rs reads rts_dom::Dom)
   of the web-engine roadmap, invariant 5 — `.ts` lib via prelude).
 - `getText(node) → Handle` (text read) — prerequisite for the facade.
 ```
+
+## Measuring it
+
+`docs/ui/dom-metrics.md` — the counters/phases/samples/audit system in
+`src/metrics/` and the `dom_metrics` harness, plus the first measurement over
+real pages (2026-08-17). Read it before optimizing anything here, and after any
+change to the invalidation: the audit is what separates "got faster" from
+"stopped doing the work".

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -21,6 +21,7 @@ gets wrong — so the system has four parts, not one.
 | part | answers | cost when off |
 |---|---|---|
 | `counters` | how many times each operation happened | nothing — `bump!` expands to nothing |
+| `footprint` | how much memory the tree holds, and in which area | always available (it is a scan) |
 | `phases` | how long each named phase took, across crates | nothing — `scope()` is an empty struct |
 | `samples` | *which* cases were behind a counter (which selectors were dropped, which properties are missing) | nothing — the `format!` never runs |
 | `audit` | whether the tree is consistent with itself | always available (it is a scan, not instrumentation) |
@@ -186,3 +187,69 @@ where `text_width` hits a font atlas instead of multiplying a character count;
 the 55 000 calls per idle frame are a *count*, and their cost under the real
 measurer is unmeasured. Nothing here has been optimized yet: these are the
 falsifiers, recorded before any change.
+
+---
+
+## What the measurement paid for — the optimizations it justified (2026-08-18)
+
+Three changes, each with its falsifier recorded above, each measured per
+scenario against the previous binary. Numbers on this machine vary ±20% between
+runs of the *same* build (measured: 36.7 / 39.2 / 39.2 ms for one scenario), so
+the claims below lean on counters where the time difference is smaller than that.
+
+### 1. The style memo returns `Rc`
+
+`footprint::type_sizes()` said `ComputedStyle` is **1000 B** and `Rule` is
+**2120 B**. `computed_style_idx` returned it by value, so every memo *hit* copied
+1 KB — 12 016 hits per frame on an idle relayout of the 3005-element page, about
+12 MB of memcpy per frame with a 100% cache hit rate. The cache was working and
+costing.
+
+Both memos now hold `Rc<ComputedStyle>`, and without animation the computed
+value *is* the base, sharing one `Rc` instead of materializing a second copy.
+`computed_style` (the public API) still returns a value: callers from outside
+want their own data and call once.
+
+Cold layout −23% to −41%, idle relayout −22% to −35%, text/class mutations
+−20% to −35%. The one number that went up (idle relayout on the 182-node page,
+0.075 → 0.091 ms) is `unwrap_or_default()` allocating an `Rc` where a stack
+default used to do — stated rather than hidden in the net.
+
+### 2. Hover invalidates the set that can change
+
+`set_hovered` scanned every rule to ask "is there a `:hover`?" (2643 of them)
+and then called the global `touch()`. `Stylesheet::hover_reach()` now answers
+that once, cached, and classifies the reach: `None`, `SelfOnly`, `Subtree`
+(`.card:hover .title`) or `Siblings` (`.a:hover + .b` — the one case that
+escapes the subtree, and the declared fallback to the global). The dirty roots
+are the nodes on the `hovered→root` chain that *could* match a `:hover` compound
+— without that filter the `<body>` joins the chain and its subtree is the page,
+which is where we started.
+
+**Hover on the Bootstrap page: 1.618 → 0.146 ms per frame (11×.)**
+
+### 3. Insertion and removal invalidate the subtree that moved
+
+Same shape, different guard: `Stylesheet::position_sensitive()` —
+`:first-child`, `:nth-child()`, `:empty`, `+`, `~`. Without any of them,
+appending a node changes no other node's style.
+
+**Building 2000 elements while reading layout: 21 060 → 2 003 full cascades**
+(one per element created; the quadratic is gone), removal −34%.
+
+Two mistakes the harness caught before the commit, both recorded in the commit
+message: reusing `touch_subtrees(parent)` on removal was **118× slower** (it
+walks the parent's subtree per removed node), and the `HashSet` inherited from
+`touch_subtrees` cost an allocation per call.
+
+### Still open, measured and not yet done
+
+- **`parse-css` is 86% of opening a Bootstrap page** (19 ms of 22), and the
+  parsed sheet is 9.22 MiB for 232 KB of CSS — each `Rule` carries a `DeclBlock`
+  with two whole `ComputedStyle`.
+- **`candidate_indices` runs twice per element per cascade** (`custom_for_node`
+  and `computed_for_node`).
+- **`query_all` ignores the `#id`/`.class` indices** it maintains.
+- **12.4% of Bootstrap's rules are dropped at parse** — pseudo-elements and
+  compound `:not()` lead the list.
+- **Removing a node leaves its index entries** (the audit reports it as a leak).

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -1,0 +1,188 @@
+# Measuring the DOM engine
+
+> `crates/rts-dom/src/metrics/` (counters, phases, samples, audit — feature
+> `metrics`) + `crates/rts-dom/examples/dom_metrics/` (the harness).
+> First measurement: **2026-08-17**.
+
+## Why not just a clock
+
+A clock says something is slow; it does not say what. Every open question this
+crate had was a question of **count**, and each has a cache on the path — and a
+cache is judged by a ratio, which is a pair of counters, never a stopwatch:
+
+- how many times does the full cascade run per element in one layout?
+- how many blocks are measured twice (pre-pass, then paint)?
+- how many nodes does a *local* mutation invalidate?
+
+And one question no performance number answers at all: was what we measured
+**correct**? A `.class` index pointing at a detached node does not get slow, it
+gets wrong — so the system has four parts, not one.
+
+| part | answers | cost when off |
+|---|---|---|
+| `counters` | how many times each operation happened | nothing — `bump!` expands to nothing |
+| `phases` | how long each named phase took, across crates | nothing — `scope()` is an empty struct |
+| `samples` | *which* cases were behind a counter (which selectors were dropped, which properties are missing) | nothing — the `format!` never runs |
+| `audit` | whether the tree is consistent with itself | always available (it is a scan, not instrumentation) |
+
+This is what the `perf-claim` skill asks for **before** an optimization: the
+falsifier. "The cascade is the bottleneck" dies the moment `cascade_runs` equals
+the element count and the time has not moved.
+
+## Running it
+
+```bash
+# what happened inside — counters/phases/samples valid, time NOT comparable
+cargo run --release -q -p rts-dom --features metrics --example dom_metrics -- page.html
+
+# how much it cost — time valid, counters all zero (and the harness says so)
+cargo run --release -q -p rts-dom --example dom_metrics -- page.html
+
+# record a baseline, then compare later
+… --features metrics … -- page.html --json base.json
+… --features metrics … -- page.html --baseline base.json
+```
+
+Options: `--viewport 1280x800`, `--iters 20`, `--build 4000`, `--json <file>`,
+`--baseline <file>`, `--tolerance 5`.
+
+Never a debug build: a debug number is not a number. The baseline diff compares
+**counters, per iteration** — a counter is deterministic, so a difference in one
+is always a change in behaviour, while a difference in time can be the machine.
+
+### Phases across crates
+
+`phases` lives in `rts-dom` because it is the crate everything else depends on,
+and the question "what eats the frame" only exists if every slice is in the
+*same* account. `rts-egui` opts in with its own `metrics` feature (which just
+forwards `rts-dom/metrics`) and contributes `render-dom` and `paint`; any host
+or loop can add its own with `rts_dom::metrics::phases::scope("name")`.
+
+Phases nest on purpose — `cascade` inside `layout` inside `render-dom` — so the
+percentages sum to more than 100%. That is what lets you read "layout is 97% of
+the frame **and** cascade is 71% of it".
+
+Currently instrumented: `load-html`, `tokenize-html`, `parse-css`, `cascade`,
+`layout`, `animate`, `set-inner-html` (rts-dom); `render-dom`, `paint`
+(rts-egui). **Not** instrumented: the time inside a page's own JavaScript. The
+hook exists (any crate can open a phase), but `rts:dom` has not been ported to
+the new engine yet, so there is no TS-side surface to call it from — when that
+lands, a `script` phase joins the same table.
+
+## The scenarios
+
+| scenario | isolates |
+|---|---|
+| `parse` | tokenizer + arena + indices + the CSS in `<style>` |
+| `layout frio` | opening the page: every cache empty, the only run where the cascade really executes |
+| `relayout parado` | the ceiling of the caches: nothing changed, so what remains is work no memo covers |
+| `texto + relayout` | a text leaf changes — what the invalidation preserves |
+| `classe + relayout` | a class changes — the price of restyling instead of just re-laying-out |
+| `hover + relayout` | the backend reporting the node under the cursor, every frame |
+| `querySelectorAll` / `querySelector #id` | the generic walk vs. the indexed path — together they say whether the index is used |
+| `clique + bubbling` | the event walk up the tree |
+| `innerHTML + relayout` | re-parsing a subtree, the shape of every script-rendered list |
+| `append × N` / `append + layout /100` / `remove × N` | building and tearing down programmatically; the audit at the end is the metric, not the time |
+
+## First measurement — 2026-08-17
+
+`cargo run --release`, one process, `--iters 20`, viewport 1280×800, on this
+tree. Corpus: `examples/claude-ai-site.html` (hand-written, small inline CSS),
+the Bootstrap `cover` example with `bootstrap.min.css` **inlined** into a
+`<style>` (232 KB of CSS, 21 144 rules — what the mini-browser really builds
+after fetching the `<link>`), and a synthetic page of 3005 elements with a
+trivial stylesheet.
+
+| scenario | claude-ai-site (177 nodes) | cover + bootstrap (182 nodes) | synthetic (5007 nodes) |
+|---|---|---|---|
+| parse | 0.45 ms | 19.0 ms | 4.9 ms |
+| layout cold | 1.19 ms | 21.4 ms | 22.9 ms |
+| idle relayout | 0.17 ms | 0.08 ms | 7.6 ms |
+| text + relayout | 0.33 ms | 0.37 ms | 6.7 ms |
+| class + relayout | 0.21 ms | 0.09 ms | 6.7 ms |
+| **hover + relayout** | 0.17 ms | **1.60 ms** | 6.6 ms |
+| querySelectorAll | 0.011 ms | 0.015 ms | 0.40 ms |
+| querySelector `#id` | 0.001 ms | 0.001 ms | 0.001 ms |
+
+Programmatic, 4000 elements: append only **4.1 ms**, append with a layout read
+every 100 insertions **261 ms**, remove all **6.8 ms**.
+
+### What the counters found
+
+**The cascade is not the suspect.** `cascade_runs` came out at exactly one per
+element on a cold layout, and 0 on an idle relayout (100% style-memo hits). The
+memoization by structural revision does what it claims.
+
+**Hovering a Bootstrap page re-runs the cascade every frame.** 1.60 ms/frame
+against 0.08 ms idle — 20×. Per frame: one global `touch()`, 98 memo entries
+dropped, **49 full cascades**, 7310 candidate rules tested, and 71% of the frame
+inside the `cascade` phase. The guard in `set_hovered` (only invalidate when the
+hovered node changes *and* the sheet has a `:hover` rule) holds on a page
+without `:hover` — the synthetic page costs the same as idle — but a real
+stylesheet has `:hover`, and then the invalidation is the whole tree rather than
+the two nodes whose state changed.
+
+**Insertion invalidates globally, and it is quadratic.** `append_child`,
+`insert_before`, `prepend_child` and `remove_node` call the global `touch()`,
+which clears `computed_memo`, `base_memo`, `layout_measure_cache` and
+`intrinsic_width_cache` *whole*. The granularity exists — `set_attr`/`set_text`
+use `touch_subtree` — it just is not on the insertion path. Measured: building
+4000 elements while reading layout every 100 gives **82 120 full cascades** and
+**156 234 memo entries thrown away**; doubling the items quadrupled the time
+(2000 → 71 ms, 4000 → 261 ms).
+
+**An idle frame re-runs the whole layout.** On the 3005-element page, an idle
+relayout costs 7.6 ms with 15 015 `layout_block` calls and 55 000 `text_width`
+calls, with nothing changed and 100% style-memo hits. The caches cover
+*measurement*, not the paint walk — there is no per-node display-list reuse
+inside `rts-dom`. The real app does not pay this today because `rts-egui` caches
+the whole `DisplayList` by `render_revision`; the headless path (`rts:dom` from
+TS) pays it in full, once per call.
+
+**The stylesheet, not the tree, is what makes Bootstrap expensive.** Same page
+size (182 vs 177 nodes), 42× the parse and 18× the cold layout: 118 µs per node
+against 6.7 µs. `parse-css` alone is **86% of the parse** phase. Per cascade:
+149 candidate rules tested, 3.2 matched.
+
+**`candidate_indices` runs twice per element** — once in `custom_for_node` (the
+`var()` pass) and once in `computed_for_node`, for the same node in the same
+cascade. Half of that 149 is a repeat.
+
+**`query_all` ignores the indices it maintains.** It walks all nodes in
+pre-order and runs `matches_complex` on each: 182 nodes visited per query on the
+Bootstrap page, 5007 on the synthetic one (0.40 ms). `querySelector('#id')`, which
+does consult the index, is 400× faster on the same tree.
+
+### What the samples found (fidelity, not speed)
+
+Of Bootstrap's 21 144 rules, **2632 (12.4%) are dropped at parse** because the
+selector is refused, and 4336 of 44 712 declarations (9.7%) name a property no
+branch handles. The samples name them, which turns a number into a work list:
+
+- pseudo-elements at all: `::before`, `::after`, `::file-selector-button`
+- `:not()` with a compound or chained argument: `a:not([href]):not([class])`,
+  `.table > :not(caption) > * > *`
+- vendor pseudo-elements: `::-webkit-*`, `::-moz-focus-inner` (safe to ignore)
+- ignored properties: `list-style`, `content`, `filter`, `clear`,
+  `border-top-width`/`border-bottom-width` (longhands), `outline-offset`
+
+### What the audit found
+
+The tree is structurally sound: no broken parent↔child links, no cycles, no
+stale index entries on a live node, no ids missing from the index — on every
+page in the corpus.
+
+What it does report is a **leak**, and the severity is its own for a reason:
+removing a node leaves its `#id` and `.class` entries in the indices. Nothing
+answers wrong (queries filter by `is_attached`, and the code says so), but
+nothing recollects them either — removing 2000 nodes leaves 4000 dead entries.
+The same holds for per-node derived state (listeners, input values, transitions).
+
+### What this measurement does NOT say
+
+One process, one machine, three pages, and `ApproxMeasurer` — not the egui text
+measurer. It says nothing about how these numbers move under a real backend,
+where `text_width` hits a font atlas instead of multiplying a character count;
+the 55 000 calls per idle frame are a *count*, and their cost under the real
+measurer is unmeasured. Nothing here has been optimized yet: these are the
+falsifiers, recorded before any change.


### PR DESCRIPTION
## O sistema de métricas

Instrumentação do `rts-dom` para responder **onde o trabalho acontece**, **quanta memória ele custa** e **se o que foi medido estava certo** — antes de otimizar (skill `perf-claim`). Cinco partes em `crates/rts-dom/src/metrics/`, custo ZERO quando a feature `metrics` está desligada:

| parte | responde |
|---|---|
| `counters` | ~70 contadores por operação (parse HTML, parse CSS, cascade, layout, invalidação, eventos, consultas, anomalias) |
| `phases` | tempo por fase nomeada, num registro COMUM a todos os crates (`rts-egui` contribui `render-dom` e `paint`) |
| `samples` | *quais* foram os casos por trás de um contador — quais seletores caíram, quais propriedades faltam |
| `audit` | invariantes da árvore: elos, alcançabilidade, índices nos dois sentidos, estado derivado órfão |
| `footprint` | memória por área + `type_sizes()` (o número que explica os outros) |

Harness `examples/dom_metrics/`: 13 cenários com p50/p95/máx, auditoria e pegada ao fim, JSON e diff contra baseline por iteração.

## As otimizações que elas justificaram

| # | achado | mudança | resultado medido |
|---|---|---|---|
| 1 | `ComputedStyle` = **1000 B**, e um hit de memo copiava — ~12 MB de memcpy por frame ocioso | memos guardam `Rc`; sem animação o computado compartilha o `Rc` da base | layout frio −23% a −41%, relayout −22% a −35% |
| 2 | hover numa página Bootstrap = `touch()` global + varredura de 2643 regras **por frame** | `hover_reach()` cacheado + invalidation set da cadeia filtrada por quem casa `:hover`; `+`/`~` cai no global, declarado | **1,618 → 0,146 ms/frame (11×)** |
| 3 | `appendChild`/`remove` = `touch()` global ⇒ quadrático | `position_sensitive()` como guarda; invalida a subárvore que moveu; atalho para construção pura | **21 060 → 2 003 cascades** (2000 elementos), remoção −34% |

Nas duas primeiras tentativas da #3 o harness pegou regressões antes do commit: `touch_subtrees(pai)` na remoção ficou **118× mais lento**, e o `HashSet` herdado custava uma alocação por chamada. Estão descritas no commit.

## O que fica medido e aberto

- `parse-css` é **86%** do custo de abrir a página do Bootstrap; o sheet parseado ocupa 9,22 MiB para 232 KB de CSS (cada `Rule` carrega dois `ComputedStyle`)
- `candidate_indices` roda **2× por elemento** em cada cascade
- `query_all` ignora os índices `#id`/`.classe` que mantém
- **12,4% das regras do Bootstrap são descartadas no parse** — as amostras nomeiam: `::before`/`::after`, `:not()` composto
- remover nós deixa as entradas de índice (a auditoria classifica como vazamento, não bug: as consultas filtram por `is_attached`)

Detalhes e números em `docs/ui/dom-metrics.md`.

## Nota sobre a máquina

Esta máquina varia ±20% entre execuções da **mesma** build (medido: 36,7 / 39,2 / 39,2 ms num mesmo cenário). Por isso as reivindicações se apoiam em **contadores** quando a diferença de tempo é menor que isso.

## Verificação

- `cargo test --release -p rts-dom` → 216 passam
- `cargo test --release -p rts-dom --features metrics` → 221 passam
- `cargo test --release -p rts-egui` → 6 passam

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GjdssWEr2NgWZv21N93By