### PR TITLE
perf(dom): campanha de otimização — cascade, consulta e representação das regras CSS

### DIFF
--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -1137,16 +1137,24 @@ impl Dom {
         let parent_css_for_vars = self
             .element_parent_idx(idx)
             .and_then(|p| self.base_style_idx(p));
-        let own_customs: Vec<(String, String)> = if self.stylesheet.is_empty() {
-            inline.custom.clone()
+        // As regras que casam este nó, casadas UMA vez e usadas nos DOIS passes
+        // (custom properties e declarações). Antes cada passe refazia o
+        // matching completo — e o matching navega a árvore.
+        let matched = if self.stylesheet.is_empty() {
+            style::MatchedRules::default()
         } else {
-            let mut v = self.stylesheet.custom_for_node(
+            self.stylesheet.matched_for_node(
                 self.viewport.get().0,
                 &tag,
                 node_id.as_deref(),
                 &class_refs,
                 |sel| self.matches_complex(idx, sel),
-            );
+            )
+        };
+        let own_customs: Vec<(String, String)> = if self.stylesheet.is_empty() {
+            inline.custom.clone()
+        } else {
+            let mut v = self.stylesheet.custom_from(&matched);
             v.extend(inline.custom.iter().cloned());
             v
         };
@@ -1183,14 +1191,7 @@ impl Dom {
         let author = if self.stylesheet.is_empty() {
             style::DeclBlock::default()
         } else {
-            self.stylesheet.computed_for_node(
-                self.viewport.get().0,
-                &tag,
-                node_id.as_deref(),
-                &class_refs,
-                Some(vars_ref),
-                |sel| self.matches_complex(idx, sel),
-            )
+            self.stylesheet.declarations_from(&matched, Some(vars_ref))
         };
         let override_node = self.style_overrides.get(&idx);
 
@@ -1842,10 +1843,11 @@ impl Dom {
             return Vec::new();
         }
         let Some(root_idx) = self.resolve(root) else { return Vec::new() };
+        let keys: Vec<TargetKey> = selectors.iter().map(TargetKey::of).collect();
         let mut out = Vec::new();
         // só os DESCENDENTES (o próprio nó não casa a si mesmo no querySelector).
         for &child in &self.nodes[root_idx].children {
-            self.query_all_into(child, &selectors, &mut out);
+            self.query_all_into(child, &selectors, &keys, &mut out);
         }
         out
     }
@@ -2216,8 +2218,15 @@ impl Dom {
             return Vec::new();
         }
         crate::bump!(query_calls);
+        // CHAVE-ALVO por seletor (a tag/classe/id do último compound, que é o
+        // que o seletor casa). O teste completo NAVEGA a árvore para os
+        // combinadores; comparar a chave primeiro descarta a maioria dos nós com
+        // uma comparação de string. É a mesma ideia do `RuleIndex` da cascade,
+        // que a consulta não usava: 5007 nós × 14 seletores eram 70 090 chamadas
+        // ao matcher completo numa página de 3000 elementos.
+        let keys: Vec<TargetKey> = selectors.iter().map(TargetKey::of).collect();
         let mut out = Vec::new();
-        self.query_all_into(self.root, &selectors, &mut out);
+        self.query_all_into(self.root, &selectors, &keys, &mut out);
         out
     }
 
@@ -2225,14 +2234,24 @@ impl Dom {
         &self,
         idx: NodeIdx,
         selectors: &[crate::style::ComplexSelector],
+        keys: &[TargetKey],
         out: &mut Vec<NodeId>,
     ) {
         crate::bump!(query_nodes_visited);
-        if idx != self.root && selectors.iter().any(|sel| self.matches_complex(idx, sel)) {
-            out.push(self.make_id(idx));
+        if idx != self.root {
+            if let NodeKind::Element { tag } = &self.nodes[idx].kind {
+                let id = self.nodes[idx].attr("id");
+                let class_attr = self.nodes[idx].attr("class");
+                let hit = selectors.iter().zip(keys).any(|(sel, key)| {
+                    key.can_match(tag, id, class_attr) && self.matches_complex(idx, sel)
+                });
+                if hit {
+                    out.push(self.make_id(idx));
+                }
+            }
         }
         for &child in &self.nodes[idx].children {
-            self.query_all_into(child, selectors, out);
+            self.query_all_into(child, selectors, keys, out);
         }
     }
 
@@ -2974,6 +2993,57 @@ fn parse_attrs(raw: &str) -> Vec<Attr> {
         }
     }
     attrs
+}
+
+/// A CHAVE-ALVO de um seletor: o que o último compound exige do nó que ele casa.
+/// Um filtro barato antes do matcher completo (que navega a árvore) — a mesma
+/// ideia do `RuleIndex` da cascade, aplicada às consultas.
+///
+/// Só uma chave por seletor, e a mais seletiva disponível: `#id` descarta quase
+/// tudo, `.classe` descarta muito, a tag descarta o resto. `Any` (universal,
+/// `[attr]`, pseudo) não descarta nada e cai direto no matcher — é o caso em que
+/// o filtro não ajuda, e ele não pode ATRAPALHAR respondendo "não" por engano.
+enum TargetKey {
+    Id(String),
+    Class(String),
+    Tag(String),
+    Any,
+}
+
+impl TargetKey {
+    fn of(sel: &crate::style::ComplexSelector) -> TargetKey {
+        use crate::style::SimpleSelector as S;
+        let Some(last) = sel.compounds.last() else { return TargetKey::Any };
+        for p in &last.parts {
+            if let S::Id(v) = p {
+                return TargetKey::Id(v.clone());
+            }
+        }
+        for p in &last.parts {
+            if let S::Class(v) = p {
+                return TargetKey::Class(v.clone());
+            }
+        }
+        for p in &last.parts {
+            if let S::Tag(v) = p {
+                return TargetKey::Tag(v.clone());
+            }
+        }
+        TargetKey::Any
+    }
+
+    /// `false` só quando o nó NÃO pode casar — um falso negativo aqui perderia
+    /// um resultado, então cada braço espelha exatamente o que o matcher exige.
+    fn can_match(&self, tag: &str, id: Option<&str>, class_attr: Option<&str>) -> bool {
+        match self {
+            TargetKey::Any => true,
+            TargetKey::Tag(t) => t == tag,
+            TargetKey::Id(want) => id == Some(want.as_str()),
+            TargetKey::Class(want) => class_attr
+                .map(|c| c.split_whitespace().any(|x| x == want))
+                .unwrap_or(false),
+        }
+    }
 }
 
 /// Parseia HTML para uma árvore retida. Reusa o tokenizador de `html.rs`; a

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -59,7 +59,7 @@ pub use selector::{
     compound_matches, compound_matches_borrowed, parse_selector, parse_selector_list, AttrOp, Combinator,
     ComplexSelector, CompoundSelector, PseudoClass, Selector, SimpleSelector,
 };
-pub use stylesheet::{parse_rules, DeclBlock, HoverReach, MediaQuery, Rule, Stylesheet};
+pub use stylesheet::{parse_rules, DeclBlock, HoverReach, MatchedRules, MediaQuery, Rule, Stylesheet};
 pub use values::{
     clamp_size, AlignItems, BorderStyle, CalcLen, Dimension, DisplayKind, Edges, FlexDirection, FloatSide, GridTrack,
     JustifyContent, LineHeight, Position, ResolveCtx, Rgba, Side, TextAlign, TextTransform,

--- a/crates/rts-dom/src/style/parse.rs
+++ b/crates/rts-dom/src/style/parse.rs
@@ -24,6 +24,7 @@ pub fn parse_inline(style: &str) -> ComputedStyle {
 /// separando as camadas normal/important (MDN estágio 1). Ignora
 /// propriedades/valores desconhecidos sem panicar (robustez de parser real).
 pub fn parse_inline_block(style: &str) -> DeclBlock {
+    let _phase = crate::metrics::phases::scope("parse-decls");
     let mut block = DeclBlock::default();
     for decl in style.split(';') {
         let mut it = decl.splitn(2, ':');

--- a/crates/rts-dom/src/style/props.rs
+++ b/crates/rts-dom/src/style/props.rs
@@ -80,10 +80,77 @@ macro_rules! css_props {
             pub grid_justify_items: Option<crate::style::AlignItems>,
         }
 
+        /// UMA declaração CSS resolvida — o par (propriedade, valor) que uma
+        /// regra guarda. Variante por campo, gerada da mesma tabela: aplicar a
+        /// lista sobre um `ComputedStyle` dá exatamente o que o `merge_over`
+        /// daria com a struct inteira, e é isso que permite guardar as regras
+        /// esparsas sem uma segunda definição do que é uma propriedade.
+        ///
+        /// Nomes de variante em snake_case (iguais aos campos) de propósito: a
+        /// macro não tem como converter para CamelCase, e um nome que não casa
+        /// com o campo seria a porta para os dois divergirem.
+        #[allow(non_camel_case_types)]
+        #[derive(Clone, Debug, PartialEq)]
+        pub enum Decl {
+            $( $ofield(Option<$oty>), )*
+            $( $efield(Edges), )*
+            grid_template_columns(Option<std::sync::Arc<Vec<crate::style::GridTrack>>>),
+            grid_template_rows(Option<std::sync::Arc<Vec<crate::style::GridTrack>>>),
+            grid_auto_rows(Option<crate::style::GridTrack>),
+            grid_justify_items(Option<crate::style::AlignItems>),
+            custom_props(Option<std::sync::Arc<std::collections::HashMap<String, String>>>),
+        }
+
+        impl Decl {
+            /// Aplica esta declaração sobre um estilo — a precedência é de quem
+            /// chama (aplicar depois vence), como no `merge_over`.
+            pub fn apply(&self, target: &mut ComputedStyle) {
+                match self {
+                    $( Decl::$ofield(v) => target.$ofield = v.clone(), )*
+                    $( Decl::$efield(v) => target.$efield.merge_over(v), )*
+                    Decl::grid_template_columns(v) => target.grid_template_columns = v.clone(),
+                    Decl::grid_template_rows(v) => target.grid_template_rows = v.clone(),
+                    Decl::grid_auto_rows(v) => target.grid_auto_rows = *v,
+                    Decl::grid_justify_items(v) => target.grid_justify_items = *v,
+                    Decl::custom_props(v) => target.custom_props = v.clone(),
+                }
+            }
+        }
+
         impl ComputedStyle {
             /// Sobrepõe as propriedades `Some` de `other` sobre `self` (precedência
             /// CSS: `other` vence onde está setado; `None` mantém `self`). Edges
             /// mesclam POR LADO (longhand vence shorthand). Gerado da tabela.
+            /// As declarações NÃO-VAZIAS deste bloco, como lista esparsa.
+            ///
+            /// É como uma REGRA guarda o que declara. Um `ComputedStyle` tem
+            /// 1000 bytes (`metrics::footprint::type_sizes`) e uma regra CSS
+            /// declara 2,1 propriedades em média — guardar a struct inteira por
+            /// regra é o que fazia o stylesheet do Bootstrap ocupar 5,9 MiB.
+            /// Gerado da mesma tabela que gera a struct: uma propriedade nova
+            /// entra aqui sozinha.
+            pub fn to_decls(&self) -> Vec<Decl> {
+                let mut out = Vec::new();
+                $( if self.$ofield.is_some() { out.push(Decl::$ofield(self.$ofield.clone())); } )*
+                $( if self.$efield.any_set() { out.push(Decl::$efield(self.$efield)); } )*
+                if self.grid_template_columns.is_some() {
+                    out.push(Decl::grid_template_columns(self.grid_template_columns.clone()));
+                }
+                if self.grid_template_rows.is_some() {
+                    out.push(Decl::grid_template_rows(self.grid_template_rows.clone()));
+                }
+                if self.grid_auto_rows.is_some() {
+                    out.push(Decl::grid_auto_rows(self.grid_auto_rows));
+                }
+                if self.grid_justify_items.is_some() {
+                    out.push(Decl::grid_justify_items(self.grid_justify_items));
+                }
+                if self.custom_props.is_some() {
+                    out.push(Decl::custom_props(self.custom_props.clone()));
+                }
+                out
+            }
+
             pub fn merge_over(&mut self, other: &ComputedStyle) {
                 $( if other.$ofield.is_some() { self.$ofield = other.$ofield.clone(); } )*
                 $( self.$efield.merge_over(&other.$efield); )*

--- a/crates/rts-dom/src/style/selector.rs
+++ b/crates/rts-dom/src/style/selector.rs
@@ -218,6 +218,7 @@ impl ComplexSelector {
 
     /// Parseia um seletor completo (compostos + combinadores). `None` se inválido.
     pub(crate) fn parse(s: &str) -> Option<ComplexSelector> {
+        let _phase = crate::metrics::phases::scope("parse-selector");
         let s = s.trim();
         if s.is_empty() {
             return None;

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -136,7 +136,7 @@ pub struct Rule {
     /// vez de 2120, e o retorno recursivo do parse de `@media` para de carregar
     /// megabytes. Medido: a emissão de regras era 29% do `parse-css`, que era
     /// 86% do custo de ABRIR uma página Bootstrap.
-    pub decls: std::rc::Rc<DeclBlock>,
+    pub decls: std::rc::Rc<RuleDecls>,
     /// Posição da regra no fonte (0-based) — desempate da cascade.
     pub order: u32,
     /// A condição `@media` que ENVOLVE a regra (None = sempre aplica). Avaliada
@@ -163,6 +163,57 @@ pub struct DeclBlock {
     /// (contra as custom props computadas dele): `(prop, valor-cru, important)`.
     /// Resolvidas na posição da regra em [`Stylesheet::computed_for_node`].
     pub pending: Vec<(String, String, bool)>,
+}
+
+/// O que uma REGRA guarda: o mesmo conteúdo de um [`DeclBlock`], mas com as
+/// duas camadas em LISTA ESPARSA.
+///
+/// Um `ComputedStyle` tem 1000 bytes e uma regra CSS declara 2,1 propriedades em
+/// média — guardar duas structs inteiras por regra fazia o stylesheet do
+/// Bootstrap ocupar 5,9 MiB, e o parse zerar 2 KB por regra. O `DeclBlock` segue
+/// existindo para o `style=""` INLINE, onde a struct é o formato natural (é
+/// lida uma vez, por elemento, e a cascade a consome direto).
+#[derive(Clone, Default, PartialEq, Debug)]
+pub struct RuleDecls {
+    pub normal: Box<[super::props::Decl]>,
+    pub important: Box<[super::props::Decl]>,
+    pub custom: Vec<(String, String)>,
+    pub pending: Vec<(String, String, bool)>,
+}
+
+impl RuleDecls {
+    /// Converte o bloco recém-parseado na forma esparsa. A conversão acontece
+    /// UMA vez, no parse; a cascade só aplica.
+    pub fn from_block(block: DeclBlock) -> RuleDecls {
+        RuleDecls {
+            normal: block.normal.to_decls().into_boxed_slice(),
+            important: block.important.to_decls().into_boxed_slice(),
+            custom: block.custom,
+            pending: block.pending,
+        }
+    }
+
+    /// Aplica as declarações normais sobre um estilo (mesma precedência do
+    /// `merge_over`: quem aplica depois vence).
+    pub fn apply_normal(&self, target: &mut ComputedStyle) {
+        for d in &self.normal {
+            d.apply(target);
+        }
+    }
+
+    pub fn apply_important(&self, target: &mut ComputedStyle) {
+        for d in &self.important {
+            d.apply(target);
+        }
+    }
+
+    /// Bytes ESTIMADOS deste bloco (para `metrics::footprint`).
+    pub fn estimated_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + (self.normal.len() + self.important.len()) * std::mem::size_of::<super::props::Decl>()
+            + self.custom.iter().map(|(k, v)| k.capacity() + v.capacity()).sum::<usize>()
+            + self.pending.iter().map(|(k, v, _)| k.capacity() + v.capacity()).sum::<usize>()
+    }
 }
 
 impl DeclBlock {
@@ -408,7 +459,7 @@ impl Stylesheet {
         // mesma regra (`a, b { … }`), então contá-los por regra contaria o mesmo
         // bloco várias vezes — e uma estimativa que infla é tão inútil quanto uma
         // que subestima. Distintos por PONTEIRO.
-        let mut seen: Vec<*const DeclBlock> = Vec::new();
+        let mut seen: Vec<*const RuleDecls> = Vec::new();
         for r in &self.rules {
             total += r.selector.estimated_bytes();
             let ptr = std::rc::Rc::as_ptr(&r.decls);
@@ -419,14 +470,7 @@ impl Stylesheet {
             // Um DeclBlock carrega dois ComputedStyle inteiros (normal +
             // important) mais as listas de pendentes/custom, que são as que têm
             // String de verdade.
-            total += std::mem::size_of::<DeclBlock>();
-            total += r.decls.custom.iter().map(|(k, v)| k.capacity() + v.capacity()).sum::<usize>();
-            total += r
-                .decls
-                .pending
-                .iter()
-                .map(|(k, v, _)| k.capacity() + v.capacity())
-                .sum::<usize>();
+            total += r.decls.estimated_bytes();
         }
         total += self.keyframes.len()
             * (std::mem::size_of::<crate::anim::Keyframes>() + std::mem::size_of::<String>());
@@ -547,7 +591,7 @@ impl Stylesheet {
         let mut out = DeclBlock::default();
         for (_, _, i) in &matched.rules {
             let r = &self.rules[*i];
-            out.normal.merge_over(&r.decls.normal);
+            r.decls.apply_normal(&mut out.normal);
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {
                     if !important {
@@ -558,7 +602,7 @@ impl Stylesheet {
         }
         for (_, _, i) in &matched.rules {
             let r = &self.rules[*i];
-            out.important.merge_over(&r.decls.important);
+            r.decls.apply_important(&mut out.important);
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {
                     if *important {
@@ -672,7 +716,7 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
         let decls = parse_inline_block(body); // reusa o parser de declarações (normal+important).
         // `a, b, .c { }` → uma regra por seletor (lista separada por vírgula).
         let _emit = crate::metrics::phases::scope("css-rule-emit");
-        let decls = std::rc::Rc::new(decls);
+        let decls = std::rc::Rc::new(RuleDecls::from_block(decls));
         for sel_str in selectors_raw.split(',') {
             if let Some(selector) = ComplexSelector::parse(sel_str) {
                 rules.push(Rule {

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -127,7 +127,16 @@ fn parse_media_len(v: &str) -> Option<f32> {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Rule {
     pub selector: Selector,
-    pub decls: DeclBlock,
+    /// As declarações, COMPARTILHADAS: `Rc` e não valor.
+    ///
+    /// Um `DeclBlock` tem 2120 bytes (dois `ComputedStyle` inteiros, medido por
+    /// `metrics::footprint::type_sizes`), e `a, b, .c { … }` vira uma regra POR
+    /// SELETOR — que clonava os 2 KB a cada uma. Com o `Rc`, os seletores de uma
+    /// mesma regra dividem um bloco, o `Vec<Rule>` realoca movendo 8 bytes em
+    /// vez de 2120, e o retorno recursivo do parse de `@media` para de carregar
+    /// megabytes. Medido: a emissão de regras era 29% do `parse-css`, que era
+    /// 86% do custo de ABRIR uma página Bootstrap.
+    pub decls: std::rc::Rc<DeclBlock>,
     /// Posição da regra no fonte (0-based) — desempate da cascade.
     pub order: u32,
     /// A condição `@media` que ENVOLVE a regra (None = sempre aplica). Avaliada
@@ -395,11 +404,22 @@ impl Stylesheet {
     /// RSS do processo.
     pub fn estimated_bytes(&self) -> usize {
         let mut total = self.rules.capacity() * std::mem::size_of::<Rule>();
+        // Os blocos de declarações são COMPARTILHADOS entre os seletores de uma
+        // mesma regra (`a, b { … }`), então contá-los por regra contaria o mesmo
+        // bloco várias vezes — e uma estimativa que infla é tão inútil quanto uma
+        // que subestima. Distintos por PONTEIRO.
+        let mut seen: Vec<*const DeclBlock> = Vec::new();
         for r in &self.rules {
             total += r.selector.estimated_bytes();
+            let ptr = std::rc::Rc::as_ptr(&r.decls);
+            if seen.contains(&ptr) {
+                continue;
+            }
+            seen.push(ptr);
             // Um DeclBlock carrega dois ComputedStyle inteiros (normal +
             // important) mais as listas de pendentes/custom, que são as que têm
             // String de verdade.
+            total += std::mem::size_of::<DeclBlock>();
             total += r.decls.custom.iter().map(|(k, v)| k.capacity() + v.capacity()).sum::<usize>();
             total += r
                 .decls
@@ -439,6 +459,7 @@ impl Stylesheet {
     /// Acha cada `@keyframes nome { ... }`, parseia os stops e guarda; devolve o CSS
     /// SEM os blocos de keyframes (p/ o parser de regras não tropeçar neles).
     fn extract_keyframes(&mut self, css: &str) -> String {
+        let _phase = crate::metrics::phases::scope("css-keyframes+strip");
         let css = strip_css_comments(css);
         let mut out = String::new();
         let mut rest = css.as_str();
@@ -572,7 +593,11 @@ impl Stylesheet {
 /// regras malformadas (sem `{`/`}`, seletor desconhecido) são puladas sem panicar;
 /// `a, b { ... }` vira uma regra por seletor (mesmas declarações).
 pub fn parse_rules(css: &str) -> Vec<Rule> {
-    let css = strip_css_comments(css);
+    let _phase = crate::metrics::phases::scope("css-parse-rules");
+    let css = {
+        let _strip = crate::metrics::phases::scope("css-strip-comments");
+        strip_css_comments(css)
+    };
     let mut rules = Vec::new();
     let bytes = css.as_bytes();
     let mut i = 0usize;
@@ -646,9 +671,16 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
         };
         let decls = parse_inline_block(body); // reusa o parser de declarações (normal+important).
         // `a, b, .c { }` → uma regra por seletor (lista separada por vírgula).
+        let _emit = crate::metrics::phases::scope("css-rule-emit");
+        let decls = std::rc::Rc::new(decls);
         for sel_str in selectors_raw.split(',') {
             if let Some(selector) = ComplexSelector::parse(sel_str) {
-                rules.push(Rule { selector, decls: decls.clone(), order: 0, media: None });
+                rules.push(Rule {
+                    selector,
+                    decls: std::rc::Rc::clone(&decls),
+                    order: 0,
+                    media: None,
+                });
             } else if !sel_str.trim().is_empty() {
                 // Um seletor que o parser recusa é uma regra que a página tem e o
                 // motor NÃO aplica — a diferença mais comum entre "parece o

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -201,6 +201,20 @@ pub struct Stylesheet {
     position_sensitive: std::cell::RefCell<Option<bool>>,
 }
 
+/// As regras que casaram um nó, ordenadas pela cascade. Opaco de propósito: o
+/// que quem chama precisa é passá-lo aos dois passes, não ler o conteúdo.
+#[derive(Debug, Default)]
+pub struct MatchedRules {
+    /// `(especificidade, ordem, índice da regra)`, crescente.
+    rules: Vec<(u32, u32, usize)>,
+}
+
+impl MatchedRules {
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}
+
 /// Até onde uma mudança de `:hover` pode mexer no estilo desta folha.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HoverReach {
@@ -452,36 +466,67 @@ impl Stylesheet {
     /// casa (decidido pelo `matches` fornecido — o `Dom` passa um que navega a
     /// árvore p/ os combinadores). Retorna um [`DeclBlock`] (normal + important
     /// separados). Dentro de cada camada, ordem de (especificidade, order) crescente.
-    pub fn computed_for_node(
+    /// As regras que casam um nó, JÁ ORDENADAS pela cascade (especificidade,
+    /// depois ordem de documento).
+    ///
+    /// Existe porque o matching acontecia DUAS vezes por nó: uma no passe das
+    /// custom properties (que precisa vir antes, para resolver `var()`) e outra
+    /// no das declarações — sobre o mesmo conjunto candidato e com a mesma
+    /// resposta. E `matches` não é barato: NAVEGA a árvore para os
+    /// combinadores. Numa página Bootstrap são 149 candidatas por nó, e metade
+    /// do trabalho era repetição exata.
+    pub fn matched_for_node(
         &self,
         viewport_w: f32,
         node_tag: &str,
         node_id: Option<&str>,
         node_classes: &[&str],
-        vars: Option<&std::collections::HashMap<String, String>>,
         matches: impl Fn(&ComplexSelector) -> bool,
-    ) -> DeclBlock {
-        // FAST PATH: só as regras cuja chave-alvo o nó pode satisfazer (índice), em
-        // vez de TODAS as regras. O `matches` completo (navega a árvore) ainda decide.
+    ) -> MatchedRules {
+        // FAST PATH: só as regras cuja chave-alvo o nó pode satisfazer (índice),
+        // em vez de TODAS. O `matches` completo ainda decide.
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
         crate::bump!(rules_considered, cand.len());
         let index = self.index.borrow();
-        let mut matched: Vec<(u32, u32, &Rule)> = cand
+        let mut rules: Vec<(u32, u32, usize)> = cand
             .iter()
             .filter_map(|&i| {
                 let r = &self.rules[i];
-                (r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
-                    && matches(&r.selector))
-                    .then(|| (index.specificity(i), r.order, r))
+                (r.media.map(|m| m.matches(viewport_w)).unwrap_or(true) && matches(&r.selector))
+                    .then(|| (index.specificity(i), r.order, i))
             })
             .collect();
-        crate::bump!(rules_matched, matched.len());
-        matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
+        crate::bump!(rules_matched, rules.len());
+        rules.sort_by_key(|(specificity, order, _)| (*specificity, *order));
+        MatchedRules { rules }
+    }
+
+    /// PASS A do `var()` por elemento (#1779): as declarações de CUSTOM
+    /// PROPERTIES (`--x: v`) das regras que casaram, na ordem da cascade (a
+    /// última vence por nome, no consumidor).
+    pub fn custom_from(&self, matched: &MatchedRules) -> Vec<(String, String)> {
+        if !self.has_custom_rules() {
+            return Vec::new();
+        }
+        matched
+            .rules
+            .iter()
+            .flat_map(|(_, _, i)| self.rules[*i].decls.custom.iter().cloned())
+            .collect()
+    }
+
+    /// PASS B: as declarações normais e `!important` das regras que casaram, com
+    /// as pendentes (`prop: …var(--x)…`) resolvidas na POSIÇÃO da regra contra
+    /// as custom props do elemento.
+    pub fn declarations_from(
+        &self,
+        matched: &MatchedRules,
+        vars: Option<&std::collections::HashMap<String, String>>,
+    ) -> DeclBlock {
         let mut out = DeclBlock::default();
-        for (_, _, r) in &matched {
+        for (_, _, i) in &matched.rules {
+            let r = &self.rules[*i];
             out.normal.merge_over(&r.decls.normal);
-            // declarações PENDENTES (`prop: …var(--x)…`) resolvem AQUI, na posição
-            // da regra na cascade, contra as custom props do ELEMENTO (#1779).
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {
                     if !important {
@@ -490,7 +535,8 @@ impl Stylesheet {
                 }
             }
         }
-        for (_, _, r) in &matched {
+        for (_, _, i) in &matched.rules {
+            let r = &self.rules[*i];
             out.important.merge_over(&r.decls.important);
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {
@@ -503,38 +549,6 @@ impl Stylesheet {
         out
     }
 
-    /// PASS A do var() por elemento (#1779): coleta as declarações de CUSTOM
-    /// PROPERTIES (`--x: v`) das regras que casam, na ordem da cascade
-    /// (especificidade + ordem — a última vence por nome no consumidor).
-    pub fn custom_for_node(
-        &self,
-        viewport_w: f32,
-        node_tag: &str,
-        node_id: Option<&str>,
-        node_classes: &[&str],
-        matches: impl Fn(&ComplexSelector) -> bool,
-    ) -> Vec<(String, String)> {
-        if !self.has_custom_rules() {
-            return Vec::new();
-        }
-        let cand = self.candidate_indices(node_tag, node_id, node_classes);
-        crate::bump!(rules_considered, cand.len());
-        let index = self.index.borrow();
-        let mut matched: Vec<(u32, u32, &Rule)> = cand
-            .iter()
-            .filter_map(|&i| {
-                let r = &self.rules[i];
-                (!r.decls.custom.is_empty()
-                    && r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
-                    && matches(&r.selector))
-                    .then(|| (index.specificity(i), r.order, r))
-            })
-            .collect();
-        crate::bump!(rules_matched, matched.len());
-        matched.sort_by_key(|(specificity, order, _)| (*specificity, *order));
-        matched.iter().flat_map(|(_, _, r)| r.decls.custom.iter().cloned()).collect()
-    }
-
     /// Conveniência: computa o estilo para um elemento dado SÓ tag/id/classes (sem
     /// árvore). Casa apenas seletores de UM compound (sem combinadores nem pseudo/
     /// atributo dependentes de posição — esses retornam false aqui). Usado em testes
@@ -544,11 +558,12 @@ impl Stylesheet {
         let no_pseudo = |_: &PseudoClass| false;
         // viewport de referência 1280 (helper sem árvore/viewport — testes);
         // sem vars (pendentes com var() não resolvem aqui).
-        self.computed_for_node(1280.0, tag, id, classes, None, |sel| {
+        let matched = self.matched_for_node(1280.0, tag, id, classes, |sel| {
             // só seletores de 1 compound casam sem a árvore.
             sel.compounds.len() == 1
                 && compound_matches(&sel.compounds[0], tag, id, classes, &no_attr, &no_pseudo)
-        })
+        });
+        self.declarations_from(&matched, None)
     }
 }
 

--- a/crates/rts-dom/src/style/tests.rs
+++ b/crates/rts-dom/src/style/tests.rs
@@ -538,10 +538,11 @@ fn at_rules_nao_corrompem_o_parse() {
         Some(Dimension::Px(40.0))
     );
     // …e NÃO aplicam quando não casa (viewport 800 < 1200).
-    let no_match = sheet.computed_for_node(800.0, "h1", None, &[], None, |sel| {
+    let matched = sheet.matched_for_node(800.0, "h1", None, &[], |sel| {
         sel.compounds.len() == 1
             && compound_matches(&sel.compounds[0], "h1", None, &[], &|_| None, &|_| false)
     });
+    let no_match = sheet.declarations_from(&matched, None);
     assert_eq!(no_match.normal.font_size, None);
     assert_eq!(no_match.normal.color, Some(0xFF0000FF), "a regra fora do @media segue");
     // feature desconhecida (prefers-*) nunca casa.


### PR DESCRIPTION
Continuação do #2328: as métricas apontaram, estas são as correções. Cada uma com o falsificador medido antes, a guarda que a torna correta, e comparação por cenário.

## As quatro mudanças

| # | achado das métricas | mudança |
|---|---|---|
| 1 | o matching de regras rodava **2× por nó** (passe das custom properties + passe das declarações), e `matches` navega a árvore | `matched_for_node` casa uma vez; `custom_from`/`declarations_from` consomem |
| 2 | `querySelectorAll` testava **todo nó contra todo seletor** (70 090 chamadas ao matcher em 5 consultas) | `TargetKey` filtra pela chave do último compound antes do matcher |
| 3 | `Rule` = **2120 B**, clonado por seletor de `a, b, .c {}` e movido em cada realocação | `Rc<RuleDecls>` compartilhado entre os seletores da mesma regra |
| 4 | uma regra declara **2,1 propriedades** e guardava duas structs de 1000 B | `Decl` esparso, gerado pela mesma `css_props!` que gera `ComputedStyle` |

## Resultado — `--release`, --iters 30, 2026-08-18

| cenário | claude-ai-site | cover + bootstrap (232 KB CSS) | sintética 3005 el |
|---|---|---|---|
| parse | 0,438 → 0,376 ms | **17,8 → 8,90 ms** | 5,14 → 4,68 ms |
| layout frio | 1,169 → 0,899 ms | **23,1 → 11,1 ms** | **26,7 → 14,5 ms** |
| relayout parado | 0,171 → 0,121 ms | 0,075 → 0,051 ms | 6,97 → 5,09 ms |
| texto + relayout | 0,321 → 0,234 ms | 0,375 → 0,247 ms | 6,63 → 5,10 ms |
| classe + relayout | 0,210 → 0,156 ms | 0,096 → 0,057 ms | 6,67 → 5,04 ms |
| hover + relayout | 0,172 → 0,121 ms | **1,618 → 0,132 ms** | 6,60 → 5,06 ms |
| querySelectorAll | 0,011 → 0,006 ms | 0,015 → 0,009 ms | **0,399 → 0,218 ms** |
| append + layout /100 | — | — | 67,6 → 36,5 ms |
| remove × N | — | — | 2,22 → 1,36 ms |

**Memória da página Bootstrap: 9,59 → 2,01 MiB** (`size_of::<Rule>()` 2120 → 80 B).

Nenhum cenário piorou. Contadores (determinísticos, imunes ao ruído da máquina): regras candidatas testadas por nó caíram pela metade, `matches_complex` da consulta 70 090 → 8 000.

## Correções de honestidade no próprio instrumento

A estimativa de pegada contava um bloco de declarações **por regra**; com o compartilhamento ela passaria a contar o mesmo bloco várias vezes e mostraria uma queda maior do que a real. Passou a contar os distintos por ponteiro — sem isso, o número teria sido 1,25 MiB em vez dos 1,74 MiB reais.

Também entram as fases que decompõem o `parse-css` (`css-parse-rules`, `css-rule-emit`, `css-strip-comments`, `parse-decls`, `parse-selector`): sem elas o parse era uma barra só, e "86% do tempo" não é um alvo.

## Verificação

- `cargo test --release -p rts-dom` → 216
- `cargo test --release -p rts-dom --features metrics` → 221
- `cargo test --release -p rts-egui` → 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GjdssWEr2NgWZv21N93By