### PR TITLE
perf(dom): layout incremental + saída em árvore — a mutação de texto passa o Chrome

### DIFF
--- a/crates/rts-dom/examples/dom_metrics/main.rs
+++ b/crates/rts-dom/examples/dom_metrics/main.rs
@@ -158,6 +158,16 @@ fn bench_file(path: &str, o: &Options, baseline: Option<&str>) -> Option<String>
     println!("    tamanhos: {}", sizes.join(" · "));
     drop(probe);
 
+    // EQUIVALÊNCIA em página REAL: o reuso de fragmentos é o mecanismo mais
+    // fácil de deixar sutilmente errado, e o teste unitário roda numa árvore de
+    // dez nós. Aqui a mesma pergunta é feita sobre a página inteira que acabou
+    // de ser medida: o que o reuso devolve tem de ser o que o cálculo do zero
+    // devolveria.
+    match scenarios::verificar_equivalencia(&html, o.vw, o.vh, &m) {
+        Ok(itens) => println!("    equivalência do reuso: OK ({itens} itens conferidos)"),
+        Err(divergencia) => println!("    ⚠ EQUIVALÊNCIA QUEBRADA: {divergencia}"),
+    }
+
     let runs = scenarios::page(&html, o.vw, o.vh, o.iters, &m);
     for r in &runs {
         r.print();

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -183,6 +183,24 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     }));
     drop(dom);
 
+    // 3f. CLASSE QUE SÓ MUDA COR + frame — o toggle mais comum de um app
+    //     (`.active`, `.selected`, `:hover` traduzido para classe): muda o que
+    //     se PINTA sem mudar o que se MEDE. É o caso que a costura de container
+    //     existe para servir, e o que um browser resolve em microssegundos.
+    let mut dom = parse_html_to_dom(html);
+    dom.add_stylesheet(".rts-realce{color:#ff0000}");
+    let _ = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+    let leaf3 = deepest_element(&dom);
+    let mut flip3 = false;
+    runs.push(run("classe de cor + frame", "frame", iters, m, || {
+        flip3 = !flip3;
+        if let Some(t) = leaf3 {
+            dom.set_attr(t, "class", if flip3 { "rts-realce" } else { "" });
+        }
+        std::hint::black_box(rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
     // 3e. CLASSE QUE CASA + frame com cache — o `classList.toggle` que de fato
     //     muda estilo, pelo caminho que um app percorre (o layout é PEDIDO, não
     //     forçado). É o número comparável ao do browser; o cenário `classe +

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -292,6 +292,84 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     runs
 }
 
+/// Confere, numa página REAL, que o layout com reuso de fragmentos é o mesmo
+/// que o layout calculado do zero — depois de uma sequência de mutações que
+/// exercita os caminhos de invalidação.
+///
+/// Devolve quantos itens foram conferidos, ou a primeira divergência. A
+/// tolerância é a mesma do teste unitário e pela mesma razão: reusar deslocando
+/// é somar, e somar não dá bit a bit o mesmo que calcular do zero.
+pub fn verificar_equivalencia(
+    html: &str,
+    vw: f32,
+    vh: f32,
+    m: &CountingMeasurer,
+) -> Result<usize, String> {
+    const TOL: f32 = 0.05;
+    let mut dom = parse_html_to_dom(html);
+    let alvo = deepest_element(&dom);
+    let mut conferidos = 0usize;
+    for passo in 0..4 {
+        match passo {
+            1 => {
+                if let Some(t) = alvo {
+                    dom.set_text(t, "texto trocado pelo verificador");
+                }
+            }
+            2 => {
+                if let Some(t) = alvo {
+                    dom.set_attr(t, "class", "verificador-classe");
+                }
+            }
+            3 => {
+                if let Some(t) = alvo {
+                    dom.remove_node(t);
+                }
+            }
+            _ => {}
+        }
+        let reusado = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+        dom.clear_fragment_cache();
+        let zero = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+        if reusado.items.len() != zero.items.len() {
+            return Err(format!(
+                "passo {passo}: {} itens com reuso, {} sem",
+                reusado.items.len(),
+                zero.items.len()
+            ));
+        }
+        for (i, (a, b)) in reusado.items.iter().zip(&zero.items).enumerate() {
+            if !item_equivalente(a, b, TOL) {
+                return Err(format!("passo {passo}, item {i}:
+      reuso: {a:?}
+      zero:  {b:?}"));
+            }
+            conferidos += 1;
+        }
+    }
+    Ok(conferidos)
+}
+
+/// Igualdade de item com tolerância só na GEOMETRIA — texto, cor e tipo têm de
+/// bater exatamente.
+fn item_equivalente(a: &rts_dom::layout::DisplayItem, b: &rts_dom::layout::DisplayItem, tol: f32) -> bool {
+    use rts_dom::layout::DisplayItem as D;
+    match (a, b) {
+        (D::Text { x: xa, y: ya, text: ta, color: ca, .. }, D::Text { x: xb, y: yb, text: tb, color: cb, .. }) => {
+            (xa - xb).abs() < tol && (ya - yb).abs() < tol && ta == tb && ca == cb
+        }
+        (D::SolidRect { rect: ra, color: ca, .. }, D::SolidRect { rect: rb, color: cb, .. })
+        | (D::Border { rect: ra, color: ca, .. }, D::Border { rect: rb, color: cb, .. }) => {
+            (ra.x - rb.x).abs() < tol
+                && (ra.y - rb.y).abs() < tol
+                && (ra.w - rb.w).abs() < tol
+                && (ra.h - rb.h).abs() < tol
+                && ca == cb
+        }
+        _ => a == b,
+    }
+}
+
 /// CONSTRUÇÃO programática — `createElement` + `appendChild` × N, o caminho de
 /// qualquer script que monta uma lista. Independe de arquivo: é sobre a
 /// estrutura, não sobre uma página.

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -167,6 +167,22 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     }));
     drop(dom);
 
+    // 3d. CLASSE INERTE + frame com cache — `classList.toggle('x')` com uma
+    //     classe que nenhuma regra cita. Um browser resolve isto em microssegundos
+    //     porque não invalida nada; é o cenário que mede se nós também.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+    let leaf1 = deepest_element(&dom);
+    let mut flip0 = false;
+    runs.push(run("classe inerte + frame", "frame", iters, m, || {
+        flip0 = !flip0;
+        if let Some(t) = leaf1 {
+            dom.set_attr(t, "class", if flip0 { "rts-classe-inexistente" } else { "" });
+        }
+        std::hint::black_box(rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
     // 4. TEXTO de uma folha + relayout — o contador, o relógio, o campo que
     //    digita. Mede o que a invalidação PRESERVA.
     let mut dom = parse_html_to_dom(html);

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -141,6 +141,32 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     }));
     drop(dom);
 
+    // 3b. FRAME PARADO COM CACHE — o caminho que um app real percorre: nada
+    //     mudou, então o layout inteiro é reusado. A diferença para o cenário
+    //     acima é o preço de NÃO ter o cache, e é ele que diz quanto um
+    //     `getBoundingClientRect` custava no caminho headless.
+    let dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+    runs.push(run("frame parado (cache)", "frame", iters, m, || {
+        std::hint::black_box(rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
+    // 3c. MUTAÇÃO + frame com cache — o cache é invalidado por revisão, então
+    //     aqui ele NÃO ajuda: é o custo real de um frame que muda algo.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+    let leaf0 = deepest_element(&dom);
+    let mut t0 = 0u32;
+    runs.push(run("mutação + frame (cache)", "frame", iters, m, || {
+        t0 += 1;
+        if let Some(t) = leaf0 {
+            dom.set_text(t, &format!("t {t0}"));
+        }
+        std::hint::black_box(rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
     // 4. TEXTO de uma folha + relayout — o contador, o relógio, o campo que
     //    digita. Mede o que a invalidação PRESERVA.
     let mut dom = parse_html_to_dom(html);

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -406,21 +406,38 @@ pub fn verificar_equivalencia(
 
 /// Igualdade de item com tolerância só na GEOMETRIA — texto, cor e tipo têm de
 /// bater exatamente.
+///
+/// TODAS as variantes com retângulo entram: a primeira versão só tratava texto,
+/// fundo e borda, e o resto caía em igualdade ESTRITA — o que acusou uma
+/// divergência falsa num `BeginClip` de página real (17.599998 contra
+/// 17.599976, dois centésimos de milésimo de pixel). Um verificador que dá
+/// alarme falso é pior que nenhum: ensina a ignorá-lo.
 fn item_equivalente(a: &rts_dom::layout::DisplayItem, b: &rts_dom::layout::DisplayItem, tol: f32) -> bool {
     use rts_dom::layout::DisplayItem as D;
+    let perto = |x: f32, y: f32| (x - y).abs() < tol;
+    let rects = |ra: &rts_dom::layout::Rect, rb: &rts_dom::layout::Rect| {
+        perto(ra.x, rb.x) && perto(ra.y, rb.y) && perto(ra.w, rb.w) && perto(ra.h, rb.h)
+    };
     match (a, b) {
         (D::Text { x: xa, y: ya, text: ta, color: ca, .. }, D::Text { x: xb, y: yb, text: tb, color: cb, .. }) => {
-            (xa - xb).abs() < tol && (ya - yb).abs() < tol && ta == tb && ca == cb
+            perto(*xa, *xb) && perto(*ya, *yb) && ta == tb && ca == cb
         }
         (D::SolidRect { rect: ra, color: ca, .. }, D::SolidRect { rect: rb, color: cb, .. })
-        | (D::Border { rect: ra, color: ca, .. }, D::Border { rect: rb, color: cb, .. }) => {
-            (ra.x - rb.x).abs() < tol
-                && (ra.y - rb.y).abs() < tol
-                && (ra.w - rb.w).abs() < tol
-                && (ra.h - rb.h).abs() < tol
-                && ca == cb
+        | (D::Border { rect: ra, color: ca, .. }, D::Border { rect: rb, color: cb, .. })
+        | (D::Shadow { rect: ra, color: ca, .. }, D::Shadow { rect: rb, color: cb, .. }) => {
+            rects(ra, rb) && ca == cb
         }
-        _ => a == b,
+        (D::GradientRect { rect: ra, c0: a0, c1: a1, .. }, D::GradientRect { rect: rb, c0: b0, c1: b1, .. }) => {
+            rects(ra, rb) && a0 == b0 && a1 == b1
+        }
+        (D::Image { rect: ra, pixels_handle: ha, .. }, D::Image { rect: rb, pixels_handle: hb, .. }) => {
+            rects(ra, rb) && ha == hb
+        }
+        (D::BeginClip { rect: ra, node: na, .. }, D::BeginClip { rect: rb, node: nb, .. }) => {
+            rects(ra, rb) && na == nb
+        }
+        (D::EndClip, D::EndClip) => true,
+        _ => false,
     }
 }
 

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -246,6 +246,17 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     runs.push(run("querySelectorAll", "consulta", iters, m, || {
         std::hint::black_box(dom.query_all(".btn, div, a[href]"));
     }));
+    // A consulta por CLASSE é a que um app faz o tempo todo, e a única forma
+    // que os índices podem servir — a de cima tem `div` (tag) e cai na varredura.
+    let classe = (0..dom.nodes.len())
+        .find_map(|i| {
+            dom.node(i).attr("class").and_then(|c| c.split_whitespace().next().map(str::to_string))
+        })
+        .unwrap_or_else(|| "nao-existe".into());
+    let sel_classe = format!(".{classe}");
+    runs.push(run("querySelectorAll .classe", "consulta", iters, m, || {
+        std::hint::black_box(dom.query_all(&sel_classe));
+    }));
     let first_id = (0..dom.nodes.len())
         .find_map(|i| dom.node(i).attr("id").map(str::to_string))
         .unwrap_or_else(|| "nao-existe".into());

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -183,6 +183,29 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     }));
     drop(dom);
 
+    // 3e. CLASSE QUE CASA + frame com cache — o `classList.toggle` que de fato
+    //     muda estilo, pelo caminho que um app percorre (o layout é PEDIDO, não
+    //     forçado). É o número comparável ao do browser; o cenário `classe +
+    //     relayout` abaixo força o layout completo e mede outra coisa.
+    let mut dom = parse_html_to_dom(html);
+    let _ = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+    let leaf2 = deepest_element(&dom);
+    // uma classe que o stylesheet da página realmente cita
+    let citada = (0..dom.nodes.len())
+        .filter_map(|i| dom.node(i).attr("class").map(str::to_string))
+        .flat_map(|c| c.split_whitespace().map(str::to_string).collect::<Vec<_>>())
+        .find(|c| dom.stylesheet().mentions_class(c))
+        .unwrap_or_default();
+    let mut flip2 = false;
+    runs.push(run("classe que casa + frame", "frame", iters, m, || {
+        flip2 = !flip2;
+        if let Some(t) = leaf2 {
+            dom.set_attr(t, "class", if flip2 { &citada } else { "" });
+        }
+        std::hint::black_box(rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)));
+    }));
+    drop(dom);
+
     // 4. TEXTO de uma folha + relayout — o contador, o relógio, o campo que
     //    digita. Mede o que a invalidação PRESERVA.
     let mut dom = parse_html_to_dom(html);

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -380,17 +380,19 @@ pub fn verificar_equivalencia(
             }
             _ => {}
         }
-        let reusado = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh));
+        // PLANAS: com a saída em ÁRVORE, os itens de uma subárvore reusada não
+        // estão no buffer próprio — comparar `items` compararia o que sobrou.
+        let reusado = rts_dom::layout::layout_cached(&dom, &ctx(m, vw, vh)).materialized();
         dom.clear_fragment_cache();
-        let zero = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
-        if reusado.items.len() != zero.items.len() {
+        let zero = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh)).materialized();
+        if reusado.len() != zero.len() {
             return Err(format!(
                 "passo {passo}: {} itens com reuso, {} sem",
-                reusado.items.len(),
-                zero.items.len()
+                reusado.len(),
+                zero.len()
             ));
         }
-        for (i, (a, b)) in reusado.items.iter().zip(&zero.items).enumerate() {
+        for (i, (a, b)) in reusado.iter().zip(&zero).enumerate() {
             if !item_equivalente(a, b, TOL) {
                 return Err(format!("passo {passo}, item {i}:
       reuso: {a:?}

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -306,6 +306,12 @@ pub struct Dom {
     /// Buffer, offset dos pixels, w, h)`. Setado pelo browser via `setImage` depois
     /// de baixar+decodificar; o layout emite `DisplayItem::Image`. DERIVADO, fora do Eq.
     image_pixels: HashMap<NodeIdx, (u64, u32, u32, u32)>,
+    /// A ÚLTIMA `DisplayList` calculada, com a chave que a validou — o layout
+    /// inteiro reusado enquanto nada que o afete mudar (ver
+    /// [`crate::layout::layout_cached`]). Um só slot: o padrão é reperguntar
+    /// pelo MESMO estado (uma consulta de geometria atrás da outra, um frame
+    /// atrás do outro), não alternar entre viewports.
+    display_cache: std::cell::RefCell<Option<(DisplayKey, std::rc::Rc<crate::layout::DisplayList>)>>,
     /// Qual `<input>` tem o FOCO (recebe as teclas). `None` = nenhum. Setado por
     /// `focus_input` (o loop TS chama após um clique dentro da caixa de um input).
     /// DERIVADO, fora do `PartialEq`.
@@ -364,6 +370,7 @@ impl Dom {
             input_values: HashMap::new(),
             image_pixels: HashMap::new(),
             focused_input: None,
+            display_cache: std::cell::RefCell::new(None),
         }
     }
 
@@ -620,6 +627,23 @@ impl Dom {
     fn memo_entries(&self) -> usize {
         self.computed_memo.borrow().iter().filter(|s| s.is_some()).count()
             + self.base_memo.borrow().iter().filter(|s| s.is_some()).count()
+    }
+
+    pub(crate) fn display_cache_get(
+        &self,
+        key: DisplayKey,
+    ) -> Option<std::rc::Rc<crate::layout::DisplayList>> {
+        let cache = self.display_cache.borrow();
+        let (k, list) = cache.as_ref()?;
+        (*k == key).then(|| std::rc::Rc::clone(list))
+    }
+
+    pub(crate) fn display_cache_put(
+        &self,
+        key: DisplayKey,
+        list: &std::rc::Rc<crate::layout::DisplayList>,
+    ) {
+        *self.display_cache.borrow_mut() = Some((key, std::rc::Rc::clone(list)));
     }
 
     pub(crate) fn layout_epoch(&self, idx: NodeIdx) -> u64 {
@@ -3030,6 +3054,11 @@ fn memo_put(
     }
     memo[idx] = Some(std::rc::Rc::clone(value));
 }
+
+/// A chave do cache de layout: `(revisão de render, viewport w/h em bits,
+/// medidor)`. Ver [`crate::layout::layout_cached`] para por que cada parte
+/// entra.
+pub(crate) type DisplayKey = (u64, u32, u32, u64);
 
 /// A CHAVE-ALVO de um seletor: o que o último compound exige do nó que ele casa.
 /// Um filtro barato antes do matcher completo (que navega a árvore) — a mesma

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -2393,6 +2393,31 @@ impl Dom {
         })
     }
 
+    /// `true` se trocar o `class` deste nó para `novo` não pode mudar estilo
+    /// nenhum: toda classe que ENTRA ou SAI está fora do conjunto de classes
+    /// citadas pelo stylesheet.
+    ///
+    /// Só as que MUDAM: as que ficam não afetam nada por definição, e uma delas
+    /// citada não torna a troca relevante.
+    fn class_change_is_inert(&self, idx: NodeIdx, novo: &str) -> bool {
+        let antigo = self.nodes[idx].attr("class").unwrap_or_default();
+        let mudou = antigo
+            .split_whitespace()
+            .filter(|c| !novo.split_whitespace().any(|n| n == *c))
+            .chain(
+                novo.split_whitespace()
+                    .filter(|c| !antigo.split_whitespace().any(|a| a == *c)),
+            );
+        let mut alguma = false;
+        for c in mudou {
+            alguma = true;
+            if self.stylesheet.mentions_class(c) {
+                return false;
+            }
+        }
+        alguma
+    }
+
     /// Resolve uma pseudo-classe contra o nó (posição entre irmãos / atributo de estado).
     fn pseudo_matches(&self, idx: NodeIdx, pc: &crate::style::PseudoClass) -> bool {
         use crate::style::PseudoClass as P;
@@ -2494,14 +2519,28 @@ impl Dom {
             return;
         }
         let affects_index = matches!(name_lc.as_str(), "id" | "class");
-        let affects_parent_selectors =
-            affects_index || self.stylesheet.has_attribute_selectors();
-        let dirty_root = if affects_parent_selectors {
-            self.nodes[idx].parent.unwrap_or(idx)
-        } else {
-            idx
-        };
-        self.touch_subtree(dirty_root);
+        // DESCARTE PRECOCE (o que um browser chama de invalidation set): trocar
+        // uma classe que NENHUMA regra cita não muda o estilo de nó nenhum, e
+        // invalidar por ela é refazer a cascade e o layout da página inteira
+        // por nada. É o caso mais comum de app — `el.classList.toggle('x')` —
+        // e o Chrome o resolve em 5 µs onde nós gastávamos 2,9 ms numa página
+        // de 3000 elementos.
+        //
+        // A guarda: só vale para `class`, e cai fora se houver seletor de
+        // ATRIBUTO no stylesheet (um `[class*=…]` reage a qualquer classe).
+        let style_unaffected = name_lc == "class"
+            && !self.stylesheet.has_attribute_selectors()
+            && self.class_change_is_inert(idx, value);
+        if !style_unaffected {
+            let affects_parent_selectors =
+                affects_index || self.stylesheet.has_attribute_selectors();
+            let dirty_root = if affects_parent_selectors {
+                self.nodes[idx].parent.unwrap_or(idx)
+            } else {
+                idx
+            };
+            self.touch_subtree(dirty_root);
+        }
         if affects_index {
             self.deindex_node(idx);
         }

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -259,7 +259,12 @@ pub struct Dom {
     /// uma CÓPIA deles. Num relayout de 3000 elementos isso eram ~12 MB de
     /// memcpy por frame com 100% de acerto de cache — o cache funcionando e
     /// custando. Com `Rc`, um hit é um incremento de contador.
-    computed_memo: std::cell::RefCell<HashMap<NodeIdx, std::rc::Rc<crate::style::ComputedStyle>>>,
+    /// Indexado pelo índice da arena, e não um `HashMap`: a arena é DENSA, e
+    /// o layout pede o estilo ~2,4 vezes por nó por passada — eram 12 000
+    /// lookups com SipHash por frame numa página de 3000 elementos, para
+    /// responder o que um índice de vetor responde sem hash nenhum. `None` =
+    /// não memoizado; o vetor cresce sob demanda até `nodes.len()`.
+    computed_memo: std::cell::RefCell<Vec<Option<std::rc::Rc<crate::style::ComputedStyle>>>>,
     /// O epoch de animação em que o `computed_memo` foi preenchido. Mutações locais
     /// de conteúdo não invalidam esse cache; animações continuam invalidando o estilo
     /// final interpolado.
@@ -270,7 +275,7 @@ pub struct Dom {
     /// `advance` consulta por nó a cada frame. Invalida por epoch global de estilo,
     /// viewport ou dirty bit local — então frames de animação que só bumpam
     /// `anim_epoch` o REUSAM, tornando o `advance` barato.
-    base_memo: std::cell::RefCell<HashMap<NodeIdx, std::rc::Rc<crate::style::ComputedStyle>>>,
+    base_memo: std::cell::RefCell<Vec<Option<std::rc::Rc<crate::style::ComputedStyle>>>>,
     /// A revisão estrutural em que o `base_memo` foi preenchido.
     base_memo_revision: std::cell::Cell<u64>,
     base_memo_viewport: std::cell::Cell<(u32, u32)>,
@@ -345,10 +350,10 @@ impl Dom {
             anim_start: HashMap::new(),
             revision: 0,
             anim_epoch: 0,
-            computed_memo: std::cell::RefCell::new(HashMap::new()),
+            computed_memo: std::cell::RefCell::new(Vec::new()),
             memo_revision: std::cell::Cell::new(0),
             memo_style_epoch: std::cell::Cell::new(crate::style::props::style_epoch()),
-            base_memo: std::cell::RefCell::new(HashMap::new()),
+            base_memo: std::cell::RefCell::new(Vec::new()),
             base_memo_revision: std::cell::Cell::new(u64::MAX),
             base_memo_viewport: std::cell::Cell::new((0, 0)),
             layout_measure_cache: std::cell::RefCell::new(HashMap::new()),
@@ -462,10 +467,7 @@ impl Dom {
     fn touch(&mut self) {
         self.revision = self.revision.wrapping_add(1);
         crate::bump!(touch_global);
-        crate::bump!(
-            memo_cleared_entries,
-            self.computed_memo.borrow().len() + self.base_memo.borrow().len()
-        );
+        crate::bump!(memo_cleared_entries, self.memo_entries());
         self.computed_memo.borrow_mut().clear();
         self.base_memo.borrow_mut().clear();
         self.layout_measure_cache.borrow_mut().clear();
@@ -497,8 +499,8 @@ impl Dom {
         let mut computed = self.computed_memo.borrow_mut();
         let mut base = self.base_memo.borrow_mut();
         for &node in &affected {
-            computed.remove(&node);
-            base.remove(&node);
+            memo_forget(&mut computed, node);
+            memo_forget(&mut base, node);
             self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
         }
         let mut ancestor = self.nodes[idx].parent;
@@ -537,8 +539,8 @@ impl Dom {
         let mut computed = self.computed_memo.borrow_mut();
         let mut base = self.base_memo.borrow_mut();
         for node in affected {
-            computed.remove(&node);
-            base.remove(&node);
+            memo_forget(&mut computed, node);
+            memo_forget(&mut base, node);
             self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
         }
         for node in ancestors {
@@ -581,8 +583,7 @@ impl Dom {
         // epochs, que só existem para invalidar CHAVES já guardadas. Sem este
         // atalho, um `append` × 4000 pagava a varredura e dois `borrow_mut` por
         // nó, e ficava 40% mais lento do que o `touch()` global que substituiu.
-        if self.computed_memo.borrow().is_empty()
-            && self.base_memo.borrow().is_empty()
+        if self.memo_entries() == 0
             && self.layout_measure_cache.borrow().is_empty()
             && self.intrinsic_width_cache.borrow().is_empty()
         {
@@ -594,8 +595,8 @@ impl Dom {
         let mut visited = 0u64;
         while let Some(node) = stack.pop() {
             visited += 1;
-            computed.remove(&node);
-            base.remove(&node);
+            memo_forget(&mut computed, node);
+            memo_forget(&mut base, node);
             self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
             stack.extend(self.nodes[node].children.iter().copied());
         }
@@ -610,6 +611,15 @@ impl Dom {
                 cur = self.nodes[node].parent;
             }
         }
+    }
+
+    /// Quantos nós têm estilo memoizado (as duas camadas somadas). É a contagem
+    /// que o `HashMap` dava de graça e um vetor esparso não dá — usada só por
+    /// métricas e pelo atalho da construção pura, ambos fora do caminho quente
+    /// de um layout.
+    fn memo_entries(&self) -> usize {
+        self.computed_memo.borrow().iter().filter(|s| s.is_some()).count()
+            + self.base_memo.borrow().iter().filter(|s| s.is_some()).count()
     }
 
     pub(crate) fn layout_epoch(&self, idx: NodeIdx) -> u64 {
@@ -662,7 +672,7 @@ impl Dom {
     /// dos campos, pela mesma razão do [`derived_node_state`](Self::derived_node_state).
     pub(crate) fn derived_cache_sizes(&self) -> (usize, usize) {
         (
-            self.computed_memo.borrow().len() + self.base_memo.borrow().len(),
+            self.memo_entries(),
             self.layout_measure_cache.borrow().len() + self.intrinsic_width_cache.borrow().len(),
         )
     }
@@ -759,12 +769,12 @@ impl Dom {
             self.base_memo_viewport.set(vp_key);
         }
         crate::bump!(base_calls);
-        if let Some(hit) = self.base_memo.borrow().get(&idx) {
+        if let Some(Some(hit)) = self.base_memo.borrow().get(idx) {
             crate::bump!(base_memo_hits);
             return Some(std::rc::Rc::clone(hit));
         }
         let computed = std::rc::Rc::new(self.computed_style_idx_inner(idx)?);
-        self.base_memo.borrow_mut().insert(idx, std::rc::Rc::clone(&computed));
+        memo_put(&mut self.base_memo.borrow_mut(), idx, self.nodes.len(), &computed);
         Some(computed)
     }
 
@@ -1070,7 +1080,7 @@ impl Dom {
             self.memo_viewport.set(vp_key);
         }
         crate::bump!(computed_calls);
-        if let Some(hit) = self.computed_memo.borrow().get(&idx) {
+        if let Some(Some(hit)) = self.computed_memo.borrow().get(idx) {
             crate::bump!(computed_memo_hits);
             return Some(std::rc::Rc::clone(hit));
         }
@@ -1092,7 +1102,7 @@ impl Dom {
                 std::rc::Rc::new(c)
             }
         };
-        self.computed_memo.borrow_mut().insert(idx, std::rc::Rc::clone(&computed));
+        memo_put(&mut self.computed_memo.borrow_mut(), idx, self.nodes.len(), &computed);
         Some(computed)
     }
 
@@ -2995,6 +3005,32 @@ fn parse_attrs(raw: &str) -> Vec<Attr> {
     attrs
 }
 
+/// Esquece o estilo memoizado de um nó. O vetor é esparso por índice, então
+/// "esquecer" é apagar o slot — e um índice além do fim já não tem nada.
+fn memo_forget(
+    memo: &mut Vec<Option<std::rc::Rc<crate::style::ComputedStyle>>>,
+    idx: NodeIdx,
+) {
+    if let Some(slot) = memo.get_mut(idx) {
+        *slot = None;
+    }
+}
+
+/// Guarda o estilo memoizado, crescendo o vetor até caber o índice. `capacity`
+/// é o tamanho da arena: crescer até ele de uma vez evita um `resize` por nó na
+/// primeira passada.
+fn memo_put(
+    memo: &mut Vec<Option<std::rc::Rc<crate::style::ComputedStyle>>>,
+    idx: NodeIdx,
+    capacity: usize,
+    value: &std::rc::Rc<crate::style::ComputedStyle>,
+) {
+    if idx >= memo.len() {
+        memo.resize(capacity.max(idx + 1), None);
+    }
+    memo[idx] = Some(std::rc::Rc::clone(value));
+}
+
 /// A CHAVE-ALVO de um seletor: o que o último compound exige do nó que ele casa.
 /// Um filtro barato antes do matcher completo (que navega a árvore) — a mesma
 /// ideia do `RuleIndex` da cascade, aplicada às consultas.
@@ -3147,6 +3183,14 @@ pub fn parse_html_to_dom(html: &str) -> Dom {
 mod tests {
     use super::*;
 
+    /// `true` se o nó tem estilo memoizado — o memo é um vetor esparso por
+    /// índice da arena, então "tem entrada" é "o slot existe e está cheio".
+    fn memoizado(dom: &Dom, idx: NodeIdx) -> bool {
+        dom.computed_memo.borrow().get(idx).map(Option::is_some).unwrap_or(false)
+    }
+
+    use super::*;
+
     /// Helper: nome de tag de um nó Element por índice cru (panica se não for
     /// elemento) — só para deixar os asserts curtos.
     fn tag(dom: &Dom, idx: NodeIdx) -> &str {
@@ -3263,14 +3307,14 @@ mod tests {
         // Preenche os dois memos antes da mutação.
         let _ = dom.computed_style(a);
         let _ = dom.computed_style(b);
-        assert!(dom.computed_memo.borrow().contains_key(&a_idx));
-        assert!(dom.computed_memo.borrow().contains_key(&b_idx));
+        assert!(memoizado(&dom, a_idx));
+        assert!(memoizado(&dom, b_idx));
 
         let before_noop = dom.render_revision();
         dom.set_attr(a, "data-state", "on");
         assert_ne!(dom.render_revision(), before_noop);
-        assert!(!dom.computed_memo.borrow().contains_key(&a_idx));
-        assert!(dom.computed_memo.borrow().contains_key(&b_idx));
+        assert!(!memoizado(&dom, a_idx));
+        assert!(memoizado(&dom, b_idx));
 
         // Repetir o mesmo setAttribute é um no-op e não cria nova invalidação.
         let before_repeat = dom.render_revision();
@@ -3333,18 +3377,18 @@ mod tests {
 
         assert!(dom.advance(0.0));
         let base_revision = dom.base_memo_revision.get();
-        let base_before = dom.base_memo.borrow().get(&node_idx).cloned();
+        let base_before = dom.base_memo.borrow().get(node_idx).cloned().flatten();
         assert!(base_before.is_some());
         let _ = dom.computed_style(node);
-        assert!(dom.computed_memo.borrow().contains_key(&node_idx));
+        assert!(memoizado(&dom, node_idx));
 
         assert!(dom.advance(50.0));
         assert_eq!(dom.base_memo_revision.get(), base_revision);
-        assert_eq!(dom.base_memo.borrow().get(&node_idx), base_before.as_ref());
+        assert_eq!(dom.base_memo.borrow().get(node_idx).cloned().flatten(), base_before);
         // O epoch de animação muda, portanto o memo interpolado é recalculado sob
         // demanda; o alvo-base continua sendo o mesmo objeto lógico.
         let _ = dom.computed_style(node);
-        assert!(dom.computed_memo.borrow().contains_key(&node_idx));
+        assert!(memoizado(&dom, node_idx));
     }
 
     #[test]

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -328,6 +328,12 @@ pub struct Dom {
     /// Buffer, offset dos pixels, w, h)`. Setado pelo browser via `setImage` depois
     /// de baixar+decodificar; o layout emite `DisplayItem::Image`. DERIVADO, fora do Eq.
     image_pixels: HashMap<NodeIdx, (u64, u32, u32, u32)>,
+    /// A posição de cada nó em ORDEM DOCUMENTAL (pré-ordem), numerada sob
+    /// demanda e reusada enquanto a árvore não muda. É o que permite responder
+    /// uma consulta a partir dos ÍNDICES `#id`/`.classe` — que dão os candidatos
+    /// em ordem de arena — sem perder a ordem que o `querySelectorAll` promete.
+    /// `u64` = a revisão em que foi numerada.
+    doc_order: std::cell::RefCell<(u64, Vec<u32>)>,
     /// FRAGMENTOS de layout por subárvore — o desenho de um bloco com certas
     /// constraints, guardado em coordenadas relativas à origem em que foi posto.
     /// É o que torna o layout INCREMENTAL: mudar uma folha invalida o epoch dela
@@ -400,6 +406,7 @@ impl Dom {
             focused_input: None,
             display_cache: std::cell::RefCell::new(None),
             fragment_cache: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
+            doc_order: std::cell::RefCell::new((u64::MAX, Vec::new())),
         }
     }
 
@@ -686,6 +693,24 @@ impl Dom {
     fn memo_entries(&self) -> usize {
         self.computed_memo.borrow().iter().filter(|s| s.is_some()).count()
             + self.base_memo.borrow().iter().filter(|s| s.is_some()).count()
+    }
+
+    /// A posição de `idx` em ordem documental, renumerando se a árvore mudou.
+    /// O(n) na primeira consulta depois de uma mutação, O(1) nas seguintes.
+    fn document_positions(&self) -> std::cell::Ref<'_, (u64, Vec<u32>)> {
+        if self.doc_order.borrow().0 != self.revision {
+            let mut order = vec![u32::MAX; self.nodes.len()];
+            let mut next = 0u32;
+            let mut stack = vec![self.root];
+            while let Some(node) = stack.pop() {
+                order[node] = next;
+                next += 1;
+                // pilha: empilha ao contrário para visitar os filhos na ordem.
+                stack.extend(self.nodes[node].children.iter().rev().copied());
+            }
+            *self.doc_order.borrow_mut() = (self.revision, order);
+        }
+        self.doc_order.borrow()
     }
 
     pub(crate) fn fragment_get(
@@ -2360,9 +2385,67 @@ impl Dom {
         // que a consulta não usava: 5007 nós × 14 seletores eram 70 090 chamadas
         // ao matcher completo numa página de 3000 elementos.
         let keys: Vec<TargetKey> = selectors.iter().map(TargetKey::of).collect();
+        // Quando TODA chave é `#id` ou `.classe`, os índices dão os candidatos
+        // direto e a árvore inteira não precisa ser andada — é o que o browser
+        // faz. A ordem sai da numeração documental, porque os índices guardam
+        // ordem de ARENA e `querySelectorAll` promete ordem de documento
+        // (`appendChild` reordena a segunda sem mexer na primeira).
+        // Um seletor que é SÓ a chave (`.card`, `#topo`) já está inteiramente
+        // respondido pelo índice: o candidato tem a classe/id por construção, e
+        // chamar o matcher para reconfirmar é refazer a pergunta que o bucket
+        // respondeu. Com combinador, pseudo ou compound, o matcher decide.
+        let exatos = selectors.iter().all(|sel| {
+            sel.compounds.len() == 1
+                && sel.compounds[0].parts.len() == 1
+                && matches!(
+                    sel.compounds[0].parts[0],
+                    crate::style::SimpleSelector::Class(_) | crate::style::SimpleSelector::Id(_)
+                )
+        });
+        if let Some(candidatos) = self.candidatos_por_indice(&keys) {
+            crate::bump!(query_index_hits);
+            let positions = self.document_positions();
+            // A numeração documental já responde "está na árvore?": um nó
+            // inalcançável nunca foi visitado e ficou com `u32::MAX`. É O(1),
+            // contra o `is_attached`, que sobe até a raiz por candidato — e são
+            // mil candidatos numa consulta de página grande.
+            let mut casaram: Vec<NodeIdx> = candidatos
+                .into_iter()
+                .filter(|&idx| {
+                    crate::bump!(query_nodes_visited);
+                    positions.1.get(idx).copied().unwrap_or(u32::MAX) != u32::MAX
+                        && (exatos || selectors.iter().any(|sel| self.matches_complex(idx, sel)))
+                })
+                .collect();
+            casaram.sort_unstable_by_key(|&idx| positions.1[idx]);
+            drop(positions);
+            return casaram.into_iter().map(|idx| self.make_id(idx)).collect();
+        }
         let mut out = Vec::new();
         self.query_all_into(self.root, &selectors, &keys, &mut out);
         out
+    }
+
+    /// Os candidatos de uma lista de seletores a partir dos índices, ou `None`
+    /// quando algum seletor não tem chave indexada (tag, universal, atributo) —
+    /// nesse caso a varredura em pré-ordem é a única resposta completa.
+    fn candidatos_por_indice(&self, keys: &[TargetKey]) -> Option<Vec<NodeIdx>> {
+        let mut out: Vec<NodeIdx> = Vec::new();
+        for key in keys {
+            let bucket = match key {
+                TargetKey::Id(v) => self.id_index.get(v),
+                TargetKey::Class(v) => self.class_index.get(v),
+                TargetKey::Tag(_) | TargetKey::Any => return None,
+            };
+            if let Some(bucket) = bucket {
+                out.extend_from_slice(bucket);
+            }
+        }
+        // Um nó pode entrar por dois seletores da lista (`.a, .b` num nó com as
+        // duas): o `querySelectorAll` devolve cada nó UMA vez.
+        out.sort_unstable();
+        out.dedup();
+        Some(out)
     }
 
     fn query_all_into(
@@ -4830,6 +4913,49 @@ mod tests {
         // conteúdo real chegou: o h1 do template.
         let h1 = dom.query("h1").unwrap();
         assert_eq!(dom.text_content(h1).unwrap(), "Cover your page.");
+    }
+
+    /// A consulta por índice devolve em ordem DOCUMENTAL, não em ordem de
+    /// arena — e as duas divergem assim que um `appendChild` reordena. É a
+    /// armadilha que o comentário do `query_idx` sempre alertou, e agora que os
+    /// índices respondem de verdade, é ela que precisa de teste.
+    #[test]
+    fn consulta_por_indice_respeita_a_ordem_documental() {
+        let mut dom = parse_html_to_dom(
+            "<div id='host'><p class='x' id='a'>a</p><p class='x' id='b'>b</p></div>",
+        );
+        let host = dom.query("#host").unwrap();
+        let a = dom.query("#a").unwrap();
+        // move o PRIMEIRO para o fim: ordem de arena continua a,b; a documental
+        // vira b,a.
+        dom.append_child(host, a);
+        let ids: Vec<String> = dom
+            .query_all(".x")
+            .into_iter()
+            .map(|n| dom.get_attr(n, "id").unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(ids, vec!["b", "a"], "ordem documental depois do reparent");
+
+        // Um nó REMOVIDO não pode aparecer, mesmo com a entrada de índice viva
+        // (o índice é superconjunto por design — ver a auditoria).
+        let b = dom.query("#b").unwrap();
+        dom.remove_node(b);
+        let ids: Vec<String> = dom
+            .query_all(".x")
+            .into_iter()
+            .map(|n| dom.get_attr(n, "id").unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(ids, vec!["a"], "o removido não entra");
+
+        // E um nó com DUAS classes da lista entra uma vez só.
+        let mut dom2 = parse_html_to_dom("<p class='x y' id='u'></p><p class='y' id='v'></p>");
+        let ids: Vec<String> = dom2
+            .query_all(".x, .y")
+            .into_iter()
+            .map(|n| dom2.get_attr(n, "id").unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(ids, vec!["u", "v"], "sem duplicata e em ordem");
+        let _ = &mut dom2;
     }
 
     /// O ALCANCE de `:hover` decide o que a mudança de hover invalida, e os

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -52,6 +52,28 @@ pub(crate) struct LayoutMeasureKey {
     pub(crate) measurer: u64,
 }
 
+/// A chave de um FRAGMENTO de layout: o desenho de uma subárvore posta com
+/// certas constraints.
+///
+/// É a `LayoutMeasureKey` sem a posição — porque a posição é justamente o que se
+/// corrige ao reusar (o desenho é o mesmo, deslocado). Os campos são os mesmos
+/// pela mesma razão: cada um protege uma dependência do resultado. `node_epoch`
+/// cobre mudanças na subárvore, `style_epoch` as globais de estilo, o viewport e
+/// o medidor cobrem o resto do ambiente.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct FragmentKey {
+    pub(crate) tree: u64,
+    pub(crate) node_epoch: u64,
+    pub(crate) style_epoch: u64,
+    pub(crate) anim_epoch: u64,
+    pub(crate) node: NodeIdx,
+    pub(crate) avail_w: u32,
+    pub(crate) avail_h: Option<u32>,
+    pub(crate) viewport_w: u32,
+    pub(crate) viewport_h: u32,
+    pub(crate) measurer: u64,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) struct IntrinsicWidthKey {
     pub(crate) tree: u64,
@@ -306,6 +328,12 @@ pub struct Dom {
     /// Buffer, offset dos pixels, w, h)`. Setado pelo browser via `setImage` depois
     /// de baixar+decodificar; o layout emite `DisplayItem::Image`. DERIVADO, fora do Eq.
     image_pixels: HashMap<NodeIdx, (u64, u32, u32, u32)>,
+    /// FRAGMENTOS de layout por subárvore — o desenho de um bloco com certas
+    /// constraints, guardado em coordenadas relativas à origem em que foi posto.
+    /// É o que torna o layout INCREMENTAL: mudar uma folha invalida o epoch dela
+    /// e dos ancestrais, e todo irmão intacto reusa o fragmento em vez de
+    /// recalcular cascade, medição de texto e box model.
+    fragment_cache: std::cell::RefCell<crate::fasthash::FastMap<FragmentKey, std::rc::Rc<crate::layout::Fragment>>>,
     /// A ÚLTIMA `DisplayList` calculada, com a chave que a validou — o layout
     /// inteiro reusado enquanto nada que o afete mudar (ver
     /// [`crate::layout::layout_cached`]). Um só slot: o padrão é reperguntar
@@ -371,6 +399,7 @@ impl Dom {
             image_pixels: HashMap::new(),
             focused_input: None,
             display_cache: std::cell::RefCell::new(None),
+            fragment_cache: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
         }
     }
 
@@ -477,15 +506,38 @@ impl Dom {
         crate::bump!(memo_cleared_entries, self.memo_entries());
         self.computed_memo.borrow_mut().clear();
         self.base_memo.borrow_mut().clear();
+        // Os FRAGMENTOS são chaveados por epoch de nó, e o `touch()` global é
+        // exatamente o caso em que não se sabe QUAIS nós mudaram (stylesheet
+        // novo, mutação sem alvo). Esvaziar é o fallback seguro; as invalidações
+        // com alvo bumpam epoch e preservam o resto do cache.
+        self.fragment_cache.borrow_mut().clear();
         self.layout_measure_cache.borrow_mut().clear();
         self.intrinsic_width_cache.borrow_mut().clear();
     }
 
     /// Marca uma mudança que altera pixels/geometria, mas não o estilo computado.
     /// O cache de cascade pode continuar válido para o próximo layout.
-    fn touch_render_only(&mut self) {
+    /// Mudança que altera PIXELS/geometria mas não o estilo computado — trocar
+    /// o texto de um elemento é o caso.
+    ///
+    /// `node` é obrigatório porque o reuso de fragmentos exige saber ONDE a
+    /// geometria mudou: sem bumpar o epoch da subárvore (e dos ancestrais, que
+    /// podem mudar de tamanho), um fragmento com o texto ANTIGO continuaria
+    /// casando a chave. Foi assim que o teste de equivalência pegou este caminho
+    /// na primeira mutação.
+    fn touch_render_only(&mut self, node: NodeIdx) {
         self.revision = self.revision.wrapping_add(1);
         crate::bump!(touch_render_only);
+        let mut stack = vec![node];
+        while let Some(n) = stack.pop() {
+            self.layout_epochs[n] = self.layout_epochs[n].wrapping_add(1);
+            stack.extend(self.nodes[n].children.iter().copied());
+        }
+        let mut ancestor = self.nodes[node].parent;
+        while let Some(n) = ancestor {
+            self.layout_epochs[n] = self.layout_epochs[n].wrapping_add(1);
+            ancestor = self.nodes[n].parent;
+        }
         self.layout_measure_cache.borrow_mut().clear();
         self.intrinsic_width_cache.borrow_mut().clear();
     }
@@ -590,7 +642,12 @@ impl Dom {
         // epochs, que só existem para invalidar CHAVES já guardadas. Sem este
         // atalho, um `append` × 4000 pagava a varredura e dois `borrow_mut` por
         // nó, e ficava 40% mais lento do que o `touch()` global que substituiu.
-        if self.memo_entries() == 0
+        // O(1): um vetor de memo VAZIO é "nunca houve layout", que é o caso da
+        // construção pura. Contar os slots preenchidos é O(n) e estava sendo
+        // pago POR MUTAÇÃO — foi o que deixou a remoção de 2000 nós 2,8× mais
+        // lenta assim que o layout passou a preencher os memos.
+        if self.computed_memo.borrow().is_empty()
+            && self.base_memo.borrow().is_empty()
             && self.layout_measure_cache.borrow().is_empty()
             && self.intrinsic_width_cache.borrow().is_empty()
         {
@@ -608,6 +665,8 @@ impl Dom {
             stack.extend(self.nodes[node].children.iter().copied());
         }
         crate::bump!(touch_subtree_nodes, visited);
+        // Sem a feature `metrics` o `bump!` some e a contagem fica sem leitor.
+        let _ = visited;
         drop(computed);
         drop(base);
         // Ancestrais: só o EPOCH — o estilo deles não mudou, o tamanho pode ter.
@@ -627,6 +686,42 @@ impl Dom {
     fn memo_entries(&self) -> usize {
         self.computed_memo.borrow().iter().filter(|s| s.is_some()).count()
             + self.base_memo.borrow().iter().filter(|s| s.is_some()).count()
+    }
+
+    pub(crate) fn fragment_get(
+        &self,
+        key: FragmentKey,
+    ) -> Option<std::rc::Rc<crate::layout::Fragment>> {
+        self.fragment_cache.borrow().get(&key).cloned()
+    }
+
+    pub(crate) fn fragment_put(
+        &self,
+        key: FragmentKey,
+        fragment: std::rc::Rc<crate::layout::Fragment>,
+    ) {
+        let mut cache = self.fragment_cache.borrow_mut();
+        // Teto igual ao dos outros caches de layout: uma página que rola muito
+        // acumula fragmentos de nós que já saíram de cena, e o epoch na chave
+        // impede que um stale seja SERVIDO, não que ele ocupe memória.
+        if cache.len() >= 4096 && !cache.contains_key(&key) {
+            if let Some(old) = cache.keys().next().copied() {
+                cache.remove(&old);
+            }
+        }
+        cache.insert(key, fragment);
+    }
+
+    /// Esquece todos os fragmentos. Existe para o TESTE de equivalência poder
+    /// recalcular do zero e comparar com o que o reuso devolveu: sem isso, o
+    /// teste compararia o cache consigo mesmo, que é o mesmo que não testar.
+    pub fn clear_fragment_cache(&self) {
+        self.fragment_cache.borrow_mut().clear();
+    }
+
+    /// Quantos fragmentos estão guardados (métricas e teste).
+    pub(crate) fn fragment_count(&self) -> usize {
+        self.fragment_cache.borrow().len()
     }
 
     pub(crate) fn display_cache_get(
@@ -755,6 +850,12 @@ impl Dom {
     /// mudam — inclui o epoch GLOBAL de estilo por-tag (`defineStyle`/`defineBlock`,
     /// que vivem fora do `Dom`). É a chave de cache de layout do backend e da ABI:
     /// mesma revisão + mesmo viewport ⇒ a DisplayList anterior ainda vale.
+    /// O epoch de ANIMAÇÃO — entra nas chaves de cache de layout, porque um
+    /// frame de interpolação muda o estilo sem mudar a estrutura.
+    pub(crate) fn anim_epoch(&self) -> u64 {
+        self.anim_epoch
+    }
+
     pub fn render_revision(&self) -> u64 {
         self.revision
             .wrapping_add(self.anim_epoch)
@@ -1047,7 +1148,7 @@ impl Dom {
         if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
             return;
         }
-        self.touch_render_only();
+        self.touch_render_only(idx);
         // Descarta os filhos atuais (arena não compacta; vira lixo inacessível —
         // ok para o uso atual, a árvore é reconstruída a cada `html()`). Zera o
         // `parent` de cada um para `is_attached`/query não os acharem.

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -334,6 +334,18 @@ pub struct Dom {
     /// em ordem de arena — sem perder a ordem que o `querySelectorAll` promete.
     /// `u64` = a revisão em que foi numerada.
     doc_order: std::cell::RefCell<(u64, Vec<u32>)>,
+    /// Por ANCESTRAL, quais filhos DIRETOS têm sujeira abaixo — anotado durante
+    /// a subida que a invalidação já faz. É o que permite refazer só o ramo que
+    /// mudou em vez de percorrer o container inteiro.
+    dirty_children: std::cell::RefCell<crate::fasthash::FastMap<NodeIdx, Vec<NodeIdx>>>,
+    /// Os nós que foram ALVO DIRETO de uma invalidação. O desenho deles não pode
+    /// ser aproveitado do anterior; o dos ancestrais pode.
+    dirty_self: std::cell::RefCell<std::collections::HashSet<NodeIdx>>,
+    /// O ÚLTIMO fragmento de cada nó, com a chave que o validava — a pergunta
+    /// "o que este nó desenhou da última vez?", que o cache por chave não responde.
+    last_fragment: std::cell::RefCell<
+        crate::fasthash::FastMap<NodeIdx, (FragmentKey, std::rc::Rc<crate::layout::Fragment>)>,
+    >,
     /// FRAGMENTOS de layout por subárvore — o desenho de um bloco com certas
     /// constraints, guardado em coordenadas relativas à origem em que foi posto.
     /// É o que torna o layout INCREMENTAL: mudar uma folha invalida o epoch dela
@@ -346,6 +358,13 @@ pub struct Dom {
     /// pelo MESMO estado (uma consulta de geometria atrás da outra, um frame
     /// atrás do outro), não alternar entre viewports.
     display_cache: std::cell::RefCell<Option<(DisplayKey, std::rc::Rc<crate::layout::DisplayList>)>>,
+    /// Algum `style=""` inline desta árvore menciona `position`.
+    ///
+    /// Junto com [`Stylesheet::has_out_of_flow`](crate::style::Stylesheet::has_out_of_flow),
+    /// responde "esta página PODE ter elemento fora do fluxo?" — e quando a
+    /// resposta é não, a passada que procura por eles (uma varredura da árvore
+    /// inteira pedindo o estilo computado de cada nó) não precisa acontecer.
+    inline_position: std::cell::Cell<bool>,
     /// Qual `<input>` tem o FOCO (recebe as teclas). `None` = nenhum. Setado por
     /// `focus_input` (o loop TS chama após um clique dentro da caixa de um input).
     /// DERIVADO, fora do `PartialEq`.
@@ -404,8 +423,12 @@ impl Dom {
             input_values: HashMap::new(),
             image_pixels: HashMap::new(),
             focused_input: None,
+            inline_position: std::cell::Cell::new(false),
             display_cache: std::cell::RefCell::new(None),
             fragment_cache: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
+            dirty_children: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
+            dirty_self: std::cell::RefCell::new(std::collections::HashSet::new()),
+            last_fragment: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
             doc_order: std::cell::RefCell::new((u64::MAX, Vec::new())),
         }
     }
@@ -518,6 +541,11 @@ impl Dom {
         // novo, mutação sem alvo). Esvaziar é o fallback seguro; as invalidações
         // com alvo bumpam epoch e preservam o resto do cache.
         self.fragment_cache.borrow_mut().clear();
+        self.last_fragment.borrow_mut().clear();
+        // Sem alvo não há "quais filhos": marcar todos seria o mesmo que não
+        // marcar nenhum.
+        self.dirty_children.borrow_mut().clear();
+        self.dirty_self.borrow_mut().clear();
         self.layout_measure_cache.borrow_mut().clear();
         self.intrinsic_width_cache.borrow_mut().clear();
     }
@@ -540,9 +568,13 @@ impl Dom {
             self.layout_epochs[n] = self.layout_epochs[n].wrapping_add(1);
             stack.extend(self.nodes[n].children.iter().copied());
         }
+        self.mark_self_dirty(node);
+        let mut filho = node;
         let mut ancestor = self.nodes[node].parent;
         while let Some(n) = ancestor {
             self.layout_epochs[n] = self.layout_epochs[n].wrapping_add(1);
+            self.mark_dirty_child(n, filho);
+            filho = n;
             ancestor = self.nodes[n].parent;
         }
         self.layout_measure_cache.borrow_mut().clear();
@@ -569,9 +601,15 @@ impl Dom {
             memo_forget(&mut base, node);
             self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
         }
+        // Sobe anotando por onde passou: cada ancestral fica sabendo qual filho
+        // dele tem sujeira abaixo.
+        self.mark_self_dirty(idx);
+        let mut filho = idx;
         let mut ancestor = self.nodes[idx].parent;
         while let Some(node) = ancestor {
             self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+            self.mark_dirty_child(node, filho);
+            filho = node;
             ancestor = self.nodes[node].parent;
         }
     }
@@ -595,9 +633,13 @@ impl Dom {
         }
         let mut ancestors = HashSet::new();
         for root in roots {
+            self.mark_self_dirty(root);
+            let mut filho = root;
             let mut ancestor = self.nodes[root].parent;
             while let Some(node) = ancestor {
                 ancestors.insert(node);
+                self.mark_dirty_child(node, filho);
+                filho = node;
                 ancestor = self.nodes[node].parent;
             }
         }
@@ -677,10 +719,14 @@ impl Dom {
         drop(computed);
         drop(base);
         // Ancestrais: só o EPOCH — o estilo deles não mudou, o tamanho pode ter.
+        self.mark_self_dirty(moved);
         for start in [self.nodes[moved].parent, former_parent].into_iter().flatten() {
+            let mut filho = moved;
             let mut cur = Some(start);
             while let Some(node) = cur {
                 self.layout_epochs[node] = self.layout_epochs[node].wrapping_add(1);
+                self.mark_dirty_child(node, filho);
+                filho = node;
                 cur = self.nodes[node].parent;
             }
         }
@@ -713,6 +759,45 @@ impl Dom {
         self.doc_order.borrow()
     }
 
+    fn mark_dirty_child(&self, pai: NodeIdx, filho: NodeIdx) {
+        let mut map = self.dirty_children.borrow_mut();
+        let entry = map.entry(pai).or_default();
+        // Lista curta: o caso que interessa é um ou dois filhos sujos. Acima de
+        // um punhado, refazer o container sai mais barato do que comparar.
+        if entry.len() < 8 && !entry.contains(&filho) {
+            entry.push(filho);
+        } else if entry.len() >= 8 {
+            entry.push(filho); // marca "muitos"; o consumidor olha o tamanho
+        }
+    }
+
+    fn mark_self_dirty(&self, node: NodeIdx) {
+        self.dirty_self.borrow_mut().insert(node);
+    }
+
+    pub(crate) fn dirty_children_of(&self, pai: NodeIdx) -> Option<Vec<NodeIdx>> {
+        let map = self.dirty_children.borrow();
+        let list = map.get(&pai)?;
+        (list.len() <= 8).then(|| list.clone())
+    }
+
+    pub(crate) fn is_self_dirty(&self, node: NodeIdx) -> bool {
+        self.dirty_self.borrow().contains(&node)
+    }
+
+    /// Esquece as marcas — por passada de layout, que é quem as consome.
+    pub(crate) fn clear_dirty(&self) {
+        self.dirty_children.borrow_mut().clear();
+        self.dirty_self.borrow_mut().clear();
+    }
+
+    pub(crate) fn last_fragment_of(
+        &self,
+        node: NodeIdx,
+    ) -> Option<(FragmentKey, std::rc::Rc<crate::layout::Fragment>)> {
+        self.last_fragment.borrow().get(&node).cloned()
+    }
+
     pub(crate) fn fragment_get(
         &self,
         key: FragmentKey,
@@ -725,6 +810,7 @@ impl Dom {
         key: FragmentKey,
         fragment: std::rc::Rc<crate::layout::Fragment>,
     ) {
+        self.last_fragment.borrow_mut().insert(key.node, (key, std::rc::Rc::clone(&fragment)));
         let mut cache = self.fragment_cache.borrow_mut();
         // Teto igual ao dos outros caches de layout: uma página que rola muito
         // acumula fragmentos de nós que já saíram de cena, e o epoch na chave
@@ -742,6 +828,7 @@ impl Dom {
     /// teste compararia o cache consigo mesmo, que é o mesmo que não testar.
     pub fn clear_fragment_cache(&self) {
         self.fragment_cache.borrow_mut().clear();
+        self.last_fragment.borrow_mut().clear();
     }
 
     /// Quantos fragmentos estão guardados (métricas e teste).
@@ -764,6 +851,22 @@ impl Dom {
         list: &std::rc::Rc<crate::layout::DisplayList>,
     ) {
         *self.display_cache.borrow_mut() = Some((key, std::rc::Rc::clone(list)));
+    }
+
+    /// `true` se esta árvore PODE ter algum elemento fora do fluxo. Falso
+    /// negativo é impossível: qualquer `position` inline liga a flag e qualquer
+    /// regra com `absolute`/`fixed` (ou uma pendente com `var()`) liga a do
+    /// stylesheet.
+    pub(crate) fn may_have_out_of_flow(&self) -> bool {
+        self.inline_position.get() || self.stylesheet.has_out_of_flow()
+    }
+
+    /// Anota que um `style=""` menciona `position` — chamado no parse e em toda
+    /// escrita de atributo.
+    fn note_inline_position(&self, value: &str) {
+        if value.contains("position") {
+            self.inline_position.set(true);
+        }
     }
 
     pub(crate) fn layout_epoch(&self, idx: NodeIdx) -> u64 {
@@ -1046,6 +1149,9 @@ impl Dom {
 
     /// Aloca um nó (com seus atributos) como filho de `parent`; devolve o índice.
     fn push(&mut self, kind: NodeKind, attrs: Vec<Attr>, parent: NodeIdx) -> NodeIdx {
+        if let Some(style) = attrs.iter().find(|a| a.name == "style") {
+            self.note_inline_position(&style.value);
+        }
         let id = self.nodes.len();
         self.nodes.push(Node {
             kind,
@@ -2694,6 +2800,9 @@ impl Dom {
         crate::bump!(set_attr);
         let Some(idx) = self.resolve(id) else { return };
         let name_lc = name.to_ascii_lowercase();
+        if name_lc == "style" {
+            self.note_inline_position(value);
+        }
         if self.nodes[idx]
             .attrs
             .iter()

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -282,10 +282,10 @@ pub struct Dom {
     /// Cache derivado de medições de bloco feitas em listas descartáveis durante
     /// flex/grid/inline-block/out-of-flow. É limpo em qualquer mutação visual para
     /// não reutilizar tamanho sob estilo ou conteúdo stale.
-    layout_measure_cache: std::cell::RefCell<HashMap<LayoutMeasureKey, (f32, f32)>>,
+    layout_measure_cache: std::cell::RefCell<crate::fasthash::FastMap<LayoutMeasureKey, (f32, f32)>>,
     /// Cache derivado de largura intrínseca (max-content), usada pelos pré-passos
     /// de shrink-to-fit/flex/grid. A chave inclui o contexto tipográfico completo.
-    intrinsic_width_cache: std::cell::RefCell<HashMap<IntrinsicWidthKey, f32>>,
+    intrinsic_width_cache: std::cell::RefCell<crate::fasthash::FastMap<IntrinsicWidthKey, f32>>,
     /// Epoch local de geometria. Filhos e ancestrais são incrementados quando uma
     /// mutação pode alterar seu tamanho; irmãos independentes mantêm o valor.
     layout_epochs: Vec<u64>,
@@ -362,8 +362,8 @@ impl Dom {
             base_memo: std::cell::RefCell::new(Vec::new()),
             base_memo_revision: std::cell::Cell::new(u64::MAX),
             base_memo_viewport: std::cell::Cell::new((0, 0)),
-            layout_measure_cache: std::cell::RefCell::new(HashMap::new()),
-            intrinsic_width_cache: std::cell::RefCell::new(HashMap::new()),
+            layout_measure_cache: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
+            intrinsic_width_cache: std::cell::RefCell::new(crate::fasthash::FastMap::default()),
             layout_epochs: vec![0],
             viewport: std::cell::Cell::new((1280.0, 800.0)),
             memo_viewport: std::cell::Cell::new((1280.0f32.to_bits(), 800.0f32.to_bits())),

--- a/crates/rts-dom/src/fasthash.rs
+++ b/crates/rts-dom/src/fasthash.rs
@@ -1,0 +1,116 @@
+//! Hasher rápido para as chaves INTERNAS do motor — índices de nó e chaves de
+//! cache de layout.
+//!
+//! O `SipHash` que a `std` usa por padrão é resistente a colisão adversária,
+//! porque um `HashMap` da biblioteca padrão pode acabar recebendo chaves vindas
+//! da rede. Nenhuma das chaves aqui vem de fora: são índices da arena e tuplas
+//! de números que o próprio layout monta. Pagar SipHash por elas é pagar por uma
+//! propriedade que não se usa — e paga-se muitas vezes: um layout de página
+//! grande insere milhares de retângulos por nó e consulta os caches de medição
+//! outras tantas.
+//!
+//! O algoritmo é o mesmo do `rustc` (FxHash): multiplicação por uma constante
+//! ímpar e rotação, absorvendo 8 bytes por vez. Não é criptográfico e não deve
+//! ser usado para nada que venha de fora do processo.
+
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// Multiplicador ímpar de 64 bits (o mesmo do `rustc-hash`): espalha os bits
+/// altos para os baixos, que é o que um `HashMap` lê primeiro.
+const SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+
+/// Hasher de multiplicação-e-rotação. Ver a nota do módulo para quando NÃO usar.
+#[derive(Default, Clone, Copy)]
+pub struct FastHasher {
+    hash: u64,
+}
+
+impl FastHasher {
+    #[inline]
+    fn absorb(&mut self, word: u64) {
+        self.hash = (self.hash.rotate_left(5) ^ word).wrapping_mul(SEED);
+    }
+}
+
+impl Hasher for FastHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut chunks = bytes.chunks_exact(8);
+        for c in &mut chunks {
+            self.absorb(u64::from_ne_bytes(c.try_into().unwrap()));
+        }
+        let rest = chunks.remainder();
+        if !rest.is_empty() {
+            let mut buf = [0u8; 8];
+            buf[..rest.len()].copy_from_slice(rest);
+            self.absorb(u64::from_ne_bytes(buf));
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, n: u8) {
+        self.absorb(n as u64);
+    }
+    #[inline]
+    fn write_u32(&mut self, n: u32) {
+        self.absorb(n as u64);
+    }
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        self.absorb(n);
+    }
+    #[inline]
+    fn write_usize(&mut self, n: usize) {
+        self.absorb(n as u64);
+    }
+}
+
+/// `HashMap` com o hasher acima. Mesmo tipo e mesma API do da `std` — só o
+/// hasher muda.
+pub type FastMap<K, V> = std::collections::HashMap<K, V, BuildHasherDefault<FastHasher>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::hash::Hash;
+
+    fn hash_of<T: Hash>(v: &T) -> u64 {
+        let mut h = FastHasher::default();
+        v.hash(&mut h);
+        h.finish()
+    }
+
+    /// Determinístico e sensível ao valor — o mínimo que um hasher precisa
+    /// entregar para um mapa responder certo.
+    #[test]
+    fn mesmo_valor_mesmo_hash_valores_diferentes_hashes_diferentes() {
+        assert_eq!(hash_of(&42u64), hash_of(&42u64));
+        assert_ne!(hash_of(&42u64), hash_of(&43u64));
+        assert_ne!(hash_of(&(1u32, 2u32)), hash_of(&(2u32, 1u32)));
+    }
+
+    /// Índices vizinhos (o padrão de uma arena) não podem cair no mesmo balde —
+    /// é exatamente o caso de uso, e um hasher que só somasse falharia aqui.
+    #[test]
+    fn indices_vizinhos_espalham() {
+        let hashes: std::collections::HashSet<u64> =
+            (0usize..1000).map(|i| hash_of(&i) >> 56).collect();
+        assert!(hashes.len() > 100, "só {} baldes altos distintos", hashes.len());
+    }
+
+    #[test]
+    fn funciona_como_mapa() {
+        let mut m: FastMap<usize, &str> = FastMap::default();
+        for i in 0..1000 {
+            m.insert(i, "x");
+        }
+        assert_eq!(m.len(), 1000);
+        assert_eq!(m.get(&999), Some(&"x"));
+        assert_eq!(m.get(&1000), None);
+    }
+}

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -190,6 +190,20 @@ pub trait TextMeasurer {
     /// Altura de UMA linha em `size` (line-height). Aproximação aceitável: `size *
     /// fator`; o backend pode dar o valor exato da fonte.
     fn line_height(&self, size: f32) -> f32;
+
+    /// IDENTIDADE deste medidor: dois medidores com a mesma identidade têm de
+    /// dar a mesma largura para o mesmo texto.
+    ///
+    /// Entra na chave de todo cache de layout, porque a mesma árvore no mesmo
+    /// viewport se dispõe diferente com outra fonte. Era o ENDEREÇO do `dyn`
+    /// que servia de identidade — e um medidor construído na pilha por frame
+    /// (o do egui é) pode mudar de endereço sem mudar de comportamento, ou
+    /// reusar o endereço de outro que mudou: as duas falhas em direções
+    /// opostas. O default `0` serve a um medidor sem estado; um backend cujo
+    /// resultado dependa de fonte/escala DEVE derivar disto o que muda.
+    fn identity(&self) -> u64 {
+        0
+    }
 }
 
 /// Medidor APROXIMADO, sem backend — para teste e para o caminho headless puro
@@ -241,7 +255,7 @@ fn measure_block(
     shrink_to_fit: bool,
     ctx: &LayoutCtx,
 ) -> (f32, f32) {
-    let measurer = std::ptr::from_ref(ctx.measurer) as *const () as usize as u64;
+    let measurer = ctx.measurer.identity();
     let key = LayoutMeasureKey {
         tree: dom.cache_identity(),
         node_epoch: dom.layout_epoch(id),
@@ -277,6 +291,38 @@ fn measure_block(
     );
     dom.layout_measure_put(key, size);
     size
+}
+
+/// O layout de um `Dom`, REUSADO enquanto nada que o afete mudar.
+///
+/// Um browser não recalcula layout quando nada mudou, e o caminho headless
+/// (`rts:dom` a partir do TS) chamava [`layout_document`] por consulta de
+/// geometria — uma passada completa por `getBoundingClientRect`. O `rts-egui`
+/// já tinha um cache assim, por frame, dentro dele: dois caches para a mesma
+/// pergunta, e só um dos consumidores servido.
+///
+/// A chave é `(revisão de render, viewport, medidor)`. A revisão cobre árvore,
+/// estilo e animação (todo mutador a incrementa); o viewport porque o layout
+/// depende dele; e o MEDIDOR porque a mesma árvore no mesmo viewport se dispõe
+/// diferente com uma fonte diferente — é o mesmo componente que já entra nas
+/// chaves dos caches de medição.
+///
+/// Devolve `Rc` e não valor: uma `DisplayList` de página grande são 15 000
+/// itens e milhares de `String`, e clonar isso por consulta desfaria o ganho.
+pub fn layout_cached(dom: &Dom, ctx: &LayoutCtx) -> std::rc::Rc<DisplayList> {
+    let key = (
+        dom.render_revision(),
+        ctx.viewport_w.to_bits(),
+        ctx.viewport_h.to_bits(),
+        ctx.measurer.identity(),
+    );
+    if let Some(hit) = dom.display_cache_get(key) {
+        crate::bump!(display_cache_hits);
+        return hit;
+    }
+    let fresh = std::rc::Rc::new(layout_document(dom, ctx));
+    dom.display_cache_put(key, &fresh);
+    fresh
 }
 
 /// Calcula o layout de um `Dom` inteiro e devolve a [`DisplayList`]. Ponto de
@@ -1138,7 +1184,7 @@ fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -
         font_size: font.to_bits(),
         viewport_w: ctx.viewport_w.to_bits(),
         viewport_h: ctx.viewport_h.to_bits(),
-        measurer: std::ptr::from_ref(ctx.measurer) as *const () as usize as u64,
+        measurer: ctx.measurer.identity(),
     };
     crate::bump!(intrinsic_calls);
     if let Some(hit) = dom.intrinsic_width_get(key) {
@@ -3430,6 +3476,28 @@ fn collect_text(dom: &Dom, id: NodeIdx) -> String {
 mod tests {
     use super::*;
     use crate::dom::parse_html_to_dom;
+
+    /// O cache de layout devolve a MESMA lista enquanto nada muda, e uma NOVA
+    /// depois de qualquer mutação. Sem a segunda metade, "o frame parado custa
+    /// zero" seria só outra forma de dizer que a página parou de atualizar.
+    #[test]
+    fn cache_de_layout_reusa_e_invalida() {
+        let mut dom = parse_html_to_dom("<div id='a'><p>um</p></div>");
+        let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+        let first = layout_cached(&dom, &ctx);
+        let again = layout_cached(&dom, &ctx);
+        assert!(std::rc::Rc::ptr_eq(&first, &again), "nada mudou: a lista é a mesma");
+
+        let alvo = dom.query("#a").unwrap();
+        dom.set_text(alvo, "outro");
+        let after = layout_cached(&dom, &ctx);
+        assert!(!std::rc::Rc::ptr_eq(&first, &after), "o texto mudou: lista nova");
+
+        // Viewport diferente também é outro layout.
+        let narrow = LayoutCtx { viewport_w: 300.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+        let small = layout_cached(&dom, &narrow);
+        assert!(!std::rc::Rc::ptr_eq(&after, &small));
+    }
 
     /// Registra `<div>` como bloco vertical (os testes precisam que a tag tenha
     /// layout de bloco para entrar no caminho `layout_block` dos filhos).

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -140,7 +140,7 @@ pub struct DisplayList {
     /// layout: cada bloco registra seu retângulo (margin EXCLUÍDA — border-box, como
     /// o `getBoundingClientRect` do browser); elementos inline recebem a união dos
     /// fragmentos de linha; nós de texto não entram.
-    pub node_rects: std::collections::HashMap<NodeIdx, Rect>,
+    pub node_rects: crate::fasthash::FastMap<NodeIdx, Rect>,
     /// Containers roláveis internos (divs com `overflow`) — o backend gerencia o
     /// offset de cada região e recorta. Vazio quando a página não tem scroll interno.
     pub scroll_regions: Vec<ScrollRegion>,
@@ -401,7 +401,7 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
 fn containing_block_rect(
     dom: &Dom,
     id: NodeIdx,
-    flow_rects: &std::collections::HashMap<NodeIdx, Rect>,
+    flow_rects: &crate::fasthash::FastMap<NodeIdx, Rect>,
 ) -> Option<Rect> {
     let mut cur = dom.node(id).parent;
     while let Some(p) = cur {
@@ -439,7 +439,7 @@ fn layout_out_of_flow(
     dom: &Dom,
     id: NodeIdx,
     ctx: &LayoutCtx,
-    flow_rects: &std::collections::HashMap<NodeIdx, Rect>,
+    flow_rects: &crate::fasthash::FastMap<NodeIdx, Rect>,
     list: &mut DisplayList,
 ) {
     let css = dom.computed_style_idx(id).unwrap_or_default();
@@ -2903,7 +2903,11 @@ fn layout_inline_flow(
     // quebra os runs em LINHAS, cada linha = sequência de pedaços coloridos (word).
     let lines = wrap_runs(&runs, wrap_w, font_size, mono, ctx.measurer);
     let mut cy = y;
-    for line in &lines {
+    // CONSUMINDO as linhas: o texto de cada segmento vai direto para o
+    // `DisplayItem`, em vez de ser clonado. Eram milhares de `String` alocadas
+    // por passada de layout, uma por segmento, para copiar algo que ninguém mais
+    // usaria depois.
+    for line in lines {
         // largura total da linha (texto no SEU peso + widgets) p/ text-align.
         let line_w: f32 = line
             .iter()
@@ -2926,6 +2930,7 @@ fn layout_inline_flow(
         };
         // pinta cada pedaço NA SUA COR e PESO, avançando o x.
         for seg in line {
+            let seg: Segment = seg;
             if let Some(w_idx) = seg.widget {
                 // WIDGET inline: pinta a caixa no lugar (botão via layout_button;
                 // campo de texto via layout_input com o avail da linha).
@@ -2952,7 +2957,7 @@ fn layout_inline_flow(
             list.items.push(DisplayItem::Text {
                 x: seg_x,
                 y: cy,
-                text: seg.text.clone(),
+                text: seg.text,
                 color: seg.color,
                 size: font_size,
                 mono,

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -1119,17 +1119,19 @@ fn layout_block(
 /// `shrink_to_fit`. Os outros caminhos dependem de negociação com os irmãos, e
 /// um fragmento que ignorasse isso responderia errado.
 #[allow(clippy::too_many_arguments)]
-fn layout_block_reusing(
+/// A chave do fragmento de um nó com certas constraints. Extraída porque o laço
+/// do fluxo vertical CONSULTA o cache antes de classificar o filho: um fragmento
+/// só existe para bloco-normal, então encontrá-lo já responde o que a
+/// classificação responderia — e a classificação custa estilo computado,
+/// `block::lookup` e a margem resolvida, mil vezes por frame.
+fn fragment_key(
     dom: &Dom,
     id: NodeIdx,
-    x: f32,
-    y: f32,
     avail_w: f32,
     avail_h: Option<f32>,
     ctx: &LayoutCtx,
-    list: &mut DisplayList,
-) -> (f32, f32) {
-    let key = crate::dom::FragmentKey {
+) -> crate::dom::FragmentKey {
+    crate::dom::FragmentKey {
         tree: dom.cache_identity(),
         node_epoch: dom.layout_epoch(id),
         style_epoch: crate::style::props::style_epoch(),
@@ -1140,13 +1142,33 @@ fn layout_block_reusing(
         viewport_w: ctx.viewport_w.to_bits(),
         viewport_h: ctx.viewport_h.to_bits(),
         measurer: ctx.measurer.identity(),
-    };
+    }
+}
+
+fn emit_fragment(fragment: &Fragment, list: &mut DisplayList, x: f32, y: f32) {
+    let _phase = crate::metrics::phases::scope("fragment-emit");
+    fragment.emit_at(list, x, y);
+}
+
+fn layout_block_reusing(
+    dom: &Dom,
+    id: NodeIdx,
+    x: f32,
+    y: f32,
+    avail_w: f32,
+    avail_h: Option<f32>,
+    margem_de_topo: impl FnOnce() -> f32,
+    ctx: &LayoutCtx,
+    list: &mut DisplayList,
+) -> ((f32, f32), f32) {
+    let key = fragment_key(dom, id, avail_w, avail_h, ctx);
     if let Some(fragment) = dom.fragment_get(key) {
         crate::bump!(fragment_hits);
-        fragment.emit_at(list, x, y);
-        return fragment.size;
+        emit_fragment(&fragment, list, x, y);
+        return (fragment.size, fragment.margin_top);
     }
     crate::bump!(fragment_misses);
+    let _phase = crate::metrics::phases::scope("fragment-build");
     // Lista PRÓPRIA: o fragmento precisa saber exatamente quais itens são dele,
     // e a única forma de saber isso é não misturá-los com os dos irmãos.
     let mut own = DisplayList::default();
@@ -1158,10 +1180,11 @@ fn layout_block_reusing(
         items: std::mem::take(&mut own.items),
         origin: (x, y),
         size,
+        margin_top: margem_de_topo(),
     });
     dom.fragment_put(key, std::rc::Rc::clone(&fragment));
     fragment.emit_at(list, x, y);
-    size
+    (fragment.size, fragment.margin_top)
 }
 
 /// O DESENHO de uma subárvore posta com certas constraints, guardado para ser
@@ -1187,6 +1210,14 @@ pub struct Fragment {
     /// Tamanho externo devolvido pelo `layout_block` (o que o chamador usa para
     /// avançar o cursor).
     pub size: (f32, f32),
+    /// A MARGEM DE TOPO resolvida deste bloco, para o colapso com o irmão
+    /// anterior.
+    ///
+    /// Guardada junto porque o laço a calculava ANTES de descobrir que o
+    /// fragmento servia: resolver a margem pede o estilo computado, o
+    /// `font-size` do contexto e um `ResolveCtx` — por filho, mil vezes por
+    /// frame, para um valor que não muda enquanto o epoch do nó não muda.
+    pub margin_top: f32,
 }
 
 impl Fragment {
@@ -2010,6 +2041,25 @@ fn layout_children_vertical(
         };
     }
     for &child in &dom.node(id).children {
+        // CAMINHO RÁPIDO: se existe fragmento para este filho com estas
+        // constraints, ele já foi classificado como BLOCO NORMAL quando foi
+        // criado — é o único caminho que produz fragmento. Encontrá-lo responde
+        // a classificação inteira, que custaria estilo computado,
+        // `block::lookup` e a margem resolvida por filho: mil vezes por frame
+        // numa lista, para redescobrir o que não mudou.
+        if matches!(dom.node(child).kind, NodeKind::Element { .. }) {
+            let key = fragment_key(dom, child, content_w, avail_h, ctx);
+            if let Some(fragment) = dom.fragment_get(key) {
+                crate::bump!(fragment_hits);
+                flush_inline!(child_y);
+                close_floats!(child_y);
+                child_y -= prev_margin.min(fragment.margin_top);
+                emit_fragment(&fragment, list, content_x, child_y);
+                child_y += fragment.size.1;
+                prev_margin = fragment.margin_top;
+                continue;
+            }
+        }
         let child_css = match &dom.node(child).kind {
             NodeKind::Element { .. } => Some(dom.computed_style_idx(child).unwrap_or_default()),
             _ => None,
@@ -2097,8 +2147,8 @@ fn layout_children_vertical(
                     .unwrap_or(0.0);
                 // Colapsa com o bloco anterior: recua o overlap antes de posicionar.
                 child_y -= prev_margin.min(m);
-                let (_, h) = layout_block_reusing(
-                    dom, child, content_x, child_y, content_w, avail_h, ctx, list,
+                let ((_, h), _) = layout_block_reusing(
+                    dom, child, content_x, child_y, content_w, avail_h, || m, ctx, list,
                 );
                 child_y += h;
                 prev_margin = m;

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -137,6 +137,14 @@ pub struct ScrollRegion {
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct DisplayList {
     pub items: Vec<DisplayItem>,
+    /// Subárvores emitidas por REFERÊNCIA, com a posição no meio dos itens
+    /// próprios e o deslocamento a aplicar.
+    ///
+    /// É o que torna a saída uma ÁRVORE em vez de uma lista: um frame que mexe
+    /// numa folha não reconstrói os 30 000 itens da página, aponta para os
+    /// fragmentos que já existiam. Quem pinta anda a árvore ([`iter`]); quem
+    /// precisa mutar ou comparar achata ([`materialize`]).
+    pub children: Vec<ChildRef>,
     /// Altura total ocupada pelo conteúdo (para o backend dimensionar o scroll).
     pub content_height: f32,
     /// Geometria por NÓ (border-box, em coordenadas de conteúdo) — a base do
@@ -155,6 +163,45 @@ pub struct DisplayList {
 }
 
 impl DisplayList {
+    /// Todos os itens a pintar, em z-order, cada um com o deslocamento a somar.
+    ///
+    /// Anda a ÁRVORE de fragmentos: um item de uma subárvore reusada sai daqui
+    /// sem nunca ter sido copiado. Quem pinta já somava uma origem, então somar
+    /// mais um deslocamento é grátis — foi o que permitiu a saída deixar de ser
+    /// uma lista plana refeita por frame.
+    pub fn walk(&self, mut f: impl FnMut(&DisplayItem, f32, f32)) {
+        walk_items(&self.items, &self.children, 0.0, 0.0, &mut f);
+    }
+
+    /// A lista PLANA. Para quem precisa MUTAR itens (o `transform` do CSS, o
+    /// offset de scroll no `BeginClip`) ou comparar duas listas.
+    pub fn materialized(&self) -> Vec<DisplayItem> {
+        let mut out = Vec::with_capacity(self.total_items());
+        self.walk(|item, dx, dy| {
+            let mut item = item.clone();
+            if dx != 0.0 || dy != 0.0 {
+                translate_item(&mut item, dx, dy);
+            }
+            out.push(item);
+        });
+        out
+    }
+
+    /// Achata esta lista em itens próprios, esquecendo a árvore.
+    pub fn materialize(&mut self) {
+        if self.children.is_empty() {
+            return;
+        }
+        self.items = self.materialized();
+        self.children.clear();
+    }
+
+    /// Quantos itens esta lista pinta ao todo.
+    pub fn total_items(&self) -> usize {
+        self.items.len()
+            + self.children.iter().map(|c| c.fragment.total_items()).sum::<usize>()
+    }
+
     /// HIT-TEST: o nó sob o ponto `(x, y)` em COORDENADAS DE CONTEÚDO (o backend
     /// converte tela→conteúdo somando o offset de scroll antes de chamar). Quando a
     /// lista foi produzida por `layout_document`, a ordem de pintura respeita
@@ -392,7 +439,7 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // crescente de z-index (o último pintado fica no topo).
     // A ordem de pintura já foi registrada durante as inserções de retângulos:
     // fluxo normal durante a descida e out-of-flow na ordem de z-index acima.
-    crate::bump!(display_items, list.items.len());
+    crate::bump!(display_items, list.total_items());
     crate::bump!(node_rects, list.node_rects.len());
     crate::bump!(scroll_regions, list.scroll_regions.len());
     list
@@ -1005,7 +1052,7 @@ fn layout_block(
         let mut at = box_index;
         // SOMBRA primeiro (atrás de tudo): box-shadow.
         if let Some(sh) = css.box_shadow {
-            list.items.insert(at, DisplayItem::Shadow {
+            insert_item(list, at, DisplayItem::Shadow {
                 rect: box_rect,
                 dx: sh.dx,
                 dy: sh.dy,
@@ -1018,7 +1065,7 @@ fn layout_block(
         }
         // FUNDO: gradiente (se houver) OU cor sólida.
         if let Some(g) = css.gradient {
-            list.items.insert(at, DisplayItem::GradientRect {
+            insert_item(list, at, DisplayItem::GradientRect {
                 rect: box_rect,
                 c0: apply_opacity(g.c0, op),
                 c1: apply_opacity(g.c1, op),
@@ -1028,7 +1075,7 @@ fn layout_block(
             at += 1;
         } else if let Some(color) = css.bg {
             let color = apply_opacity(color, op);
-            list.items.insert(at, DisplayItem::SolidRect { rect: box_rect, color, radius });
+            insert_item(list, at, DisplayItem::SolidRect { rect: box_rect, color, radius });
             at += 1;
         }
         // A borda só pinta se tem largura E um `border-style` VISÍVEL. O default
@@ -1037,7 +1084,7 @@ fn layout_block(
         let style_visible = css.border_style.map(|s| s.is_visible()).unwrap_or(false);
         if border > 0.0 && style_visible {
             let color = apply_opacity(css.border_color.unwrap_or(0x808080FF), op);
-            list.items.insert(at, DisplayItem::Border { rect: box_rect, width: border, color, radius });
+            insert_item(list, at, DisplayItem::Border { rect: box_rect, width: border, color, radius });
         }
     }
 
@@ -1064,7 +1111,8 @@ fn layout_block(
         };
         let children_start = box_index + box_items;
         // offset 0 aqui; o backend injeta o offset rolado por região antes de pintar.
-        list.items.insert(
+        insert_item(
+            list,
             children_start,
             DisplayItem::BeginClip { rect: content_rect, node: id, offset_x: 0.0, offset_y: 0.0 },
         );
@@ -1093,6 +1141,10 @@ fn layout_block(
             let tx = tf.tx + tf.tx_pct * box_rect.w;
             let ty = tf.ty + tf.ty_pct * box_rect.h;
             let (sin, cos) = tf.rot_deg.to_radians().sin_cos();
+            // Um transform MUTA itens, e um item de subárvore reusada é
+            // COMPARTILHADO — mutá-lo no lugar mudaria o desenho de todo mundo
+            // que aponta para ele. Achata primeiro; é raro e local.
+            list.materialize();
             for it in list.items[box_index..].iter_mut() {
                 apply_transform_to_item(it, cx, cy, tx, ty, tf.sx, tf.sy, sin, cos);
             }
@@ -1145,7 +1197,27 @@ fn fragment_key(
     }
 }
 
-fn emit_fragment(fragment: &Fragment, list: &mut DisplayList, x: f32, y: f32) {
+/// Insere um item numa posição, corrigindo o ponto de entrada das SUBÁRVORES.
+///
+/// O box model emite os filhos primeiro e insere o fundo e a borda atrás deles;
+/// as subárvores reusadas guardam o índice antes do qual entram, e sem esta
+/// correção elas passariam a ser pintadas na frente do próprio fundo. Foi o que
+/// um teste de altura percentual acusou, ao ver os retângulos na ordem trocada.
+fn insert_item(list: &mut DisplayList, at: usize, item: DisplayItem) {
+    list.items.insert(at, item);
+    for child in &mut list.children {
+        if child.at >= at {
+            child.at += 1;
+        }
+    }
+}
+
+fn emit_fragment(
+    fragment: &std::rc::Rc<Fragment>,
+    list: &mut DisplayList,
+    x: f32,
+    y: f32,
+) {
     let _phase = crate::metrics::phases::scope("fragment-emit");
     fragment.emit_at(list, x, y);
 }
@@ -1178,6 +1250,7 @@ fn layout_block_reusing(
         hit_order: std::mem::take(&mut own.hit_order),
         scroll_regions: std::mem::take(&mut own.scroll_regions),
         items: std::mem::take(&mut own.items),
+        children: std::mem::take(&mut own.children),
         origin: (x, y),
         size,
         margin_top: margem_de_topo(),
@@ -1185,6 +1258,29 @@ fn layout_block_reusing(
     dom.fragment_put(key, std::rc::Rc::clone(&fragment));
     fragment.emit_at(list, x, y);
     (fragment.size, fragment.margin_top)
+}
+
+/// Uma subárvore emitida por referência dentro de uma lista ou de outro
+/// fragmento.
+#[derive(Clone, Debug)]
+pub struct ChildRef {
+    /// Posição em `items` ANTES da qual esta subárvore é pintada.
+    pub at: usize,
+    pub fragment: std::rc::Rc<Fragment>,
+    pub dx: f32,
+    pub dy: f32,
+}
+
+impl PartialEq for ChildRef {
+    /// Compara CONTEÚDO — duas listas equivalentes podem ter chegado ao mesmo
+    /// desenho por caminhos diferentes.
+    fn eq(&self, other: &Self) -> bool {
+        self.at == other.at
+            && self.dx == other.dx
+            && self.dy == other.dy
+            && self.fragment.items == other.fragment.items
+            && self.fragment.children == other.fragment.children
+    }
 }
 
 /// O DESENHO de uma subárvore posta com certas constraints, guardado para ser
@@ -1197,8 +1293,10 @@ fn layout_block_reusing(
 /// altura), e aí a soma é zero e nem se percorre.
 #[derive(Clone, Debug, Default)]
 pub struct Fragment {
-    /// Itens de pintura da subárvore, na ordem em que foram emitidos.
+    /// Itens de pintura PRÓPRIOS desta subárvore.
     pub items: Vec<DisplayItem>,
+    /// As subárvores que ela reusou, por referência — o desenho é uma árvore.
+    pub children: Vec<ChildRef>,
     /// Geometria por nó (o que alimenta `getBoundingClientRect`).
     pub rects: Vec<(NodeIdx, Rect)>,
     /// Ordem de pintura para o hit-test (ancestral antes de descendente).
@@ -1222,17 +1320,19 @@ pub struct Fragment {
 
 impl Fragment {
     /// Emite este fragmento numa `DisplayList`, deslocado para `(x, y)`.
-    pub fn emit_at(&self, list: &mut DisplayList, x: f32, y: f32) {
+    pub fn emit_at(self: &std::rc::Rc<Self>, list: &mut DisplayList, x: f32, y: f32) {
         let (dx, dy) = (x - self.origin.0, y - self.origin.1);
+        // APONTA, não copia: os itens desta subárvore já existem e não mudaram.
+        // Os RETÂNGULOS abaixo continuam sendo materializados, porque a consulta
+        // de geometria é por nó e precisa do valor pronto — são 16 bytes contra
+        // os 48 de um item, numa quantidade menor.
+        list.children.push(ChildRef {
+            at: list.items.len(),
+            fragment: std::rc::Rc::clone(self),
+            dx,
+            dy,
+        });
         let moved = dx != 0.0 || dy != 0.0;
-        list.items.reserve(self.items.len());
-        for item in &self.items {
-            let mut item = item.clone();
-            if moved {
-                translate_item(&mut item, dx, dy);
-            }
-            list.items.push(item);
-        }
         for (idx, rect) in &self.rects {
             let mut rect = *rect;
             if moved {
@@ -1250,6 +1350,38 @@ impl Fragment {
             }
             list.scroll_regions.push(region);
         }
+    }
+}
+
+impl Fragment {
+    /// Quantos itens este fragmento pinta, contando as subárvores que ele reusa.
+    pub fn total_items(&self) -> usize {
+        self.items.len()
+            + self.children.iter().map(|c| c.fragment.total_items()).sum::<usize>()
+    }
+}
+
+/// Percorre itens próprios e subárvores na ordem de pintura, acumulando o
+/// deslocamento. Recursivo pela mesma razão que a estrutura é uma árvore: um
+/// fragmento pode ter reusado outro.
+fn walk_items(
+    items: &[DisplayItem],
+    children: &[ChildRef],
+    dx: f32,
+    dy: f32,
+    f: &mut impl FnMut(&DisplayItem, f32, f32),
+) {
+    let mut next_child = 0usize;
+    for (i, item) in items.iter().enumerate() {
+        while next_child < children.len() && children[next_child].at <= i {
+            let c = &children[next_child];
+            walk_items(&c.fragment.items, &c.fragment.children, dx + c.dx, dy + c.dy, f);
+            next_child += 1;
+        }
+        f(item, dx, dy);
+    }
+    for c in &children[next_child..] {
+        walk_items(&c.fragment.items, &c.fragment.children, dx + c.dx, dy + c.dy, f);
     }
 }
 
@@ -3797,11 +3929,11 @@ mod tests {
             dom.clear_fragment_cache();
             let zero = layout_document(&dom, &ctx);
             assert_eq!(
-                reusado.items.len(),
-                zero.items.len(),
+                reusado.materialized().len(),
+                zero.materialized().len(),
                 "passo {passo}: nº de itens diverge"
             );
-            for (i, (a, b)) in reusado.items.iter().zip(&zero.items).enumerate() {
+            for (i, (a, b)) in reusado.materialized().iter().zip(&zero.materialized()).enumerate() {
                 assert!(
                     itens_equivalentes(a, b),
                     "passo {passo}, item {i}:
@@ -3839,11 +3971,11 @@ mod tests {
             dom.clear_fragment_cache();
             let recalculado = layout_document(dom, &ctx);
             assert_eq!(
-                cacheado.items.len(),
-                recalculado.items.len(),
+                cacheado.materialized().len(),
+                recalculado.materialized().len(),
                 "quantidade de itens diverge no passo {passo}"
             );
-            for (i, (a, b)) in cacheado.items.iter().zip(&recalculado.items).enumerate() {
+            for (i, (a, b)) in cacheado.materialized().iter().zip(&recalculado.materialized()).enumerate() {
                 assert!(
                     itens_equivalentes(a, b),
                     "item {i} diverge no passo {passo}:
@@ -4066,8 +4198,8 @@ mod tests {
     fn fundo_vem_antes_do_texto_filho_no_zorder() {
         // O SolidRect (fundo) deve estar ANTES do Text na lista (pinta atrás).
         let list = layout("<div style='background:#222222; padding:8'>oi</div>", 600.0);
-        let i_rect = list.items.iter().position(|it| matches!(it, DisplayItem::SolidRect { .. }));
-        let i_text = list.items.iter().position(|it| matches!(it, DisplayItem::Text { .. }));
+        let i_rect = list.materialized().iter().position(|it| matches!(it, DisplayItem::SolidRect { .. }));
+        let i_text = list.materialized().iter().position(|it| matches!(it, DisplayItem::Text { .. }));
         assert!(i_rect < i_text, "fundo (idx {i_rect:?}) deve vir antes do texto (idx {i_text:?})");
     }
 
@@ -4177,7 +4309,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let rects: Vec<Rect> = list.items.iter().filter_map(|it| match it {
+        let rects: Vec<Rect> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some(*rect),
             _ => None,
         }).collect();
@@ -4206,7 +4338,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let rects: Vec<Rect> = list.items.iter().filter_map(|it| match it {
+        let rects: Vec<Rect> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some(*rect),
             _ => None,
         }).collect();
@@ -4262,7 +4394,7 @@ mod tests {
         let dom = parse_html_to_dom("<style>#c{text-align:center;width:400px}#r{text-align:right;width:400px}</style><div id=\"c\">x</div><div id=\"r\">y</div>");
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let texts: Vec<(String, f32)> = list.items.iter().filter_map(|it| match it {
+        let texts: Vec<(String, f32)> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::Text { text, x, .. } => Some((text.to_string(), *x)),
             _ => None,
         }).collect();
@@ -4376,7 +4508,7 @@ mod tests {
         let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 800.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
         // o span azul: canto direito da caixa (x=100, w=400 → 500) menos a largura.
-        let sp = list.items.iter().find_map(|it| match it {
+        let sp = list.materialized().iter().find_map(|it| match it {
             DisplayItem::SolidRect { rect, color, .. } if *color == 0x0000FFFF => Some(*rect),
             _ => None,
         }).expect("span absolute");
@@ -4392,7 +4524,7 @@ mod tests {
         let dom = parse_html_to_dom("<p>antes <a href=x>link</a> depois</p>");
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let segs: Vec<(String, u32, u8)> = list.items.iter().filter_map(|it| match it {
+        let segs: Vec<(String, u32, u8)> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::Text { text, color, decoration, .. } => {
                 Some((text.to_string(), *color, *decoration))
             }
@@ -4413,7 +4545,7 @@ mod tests {
         let dom = parse_html_to_dom("<style>div{line-height:3;text-transform:uppercase}</style><div>oi</div><div>tchau</div>");
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let texts: Vec<(String, f32)> = list.items.iter().filter_map(|it| match it {
+        let texts: Vec<(String, f32)> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::Text { text, y, .. } => Some((text.to_string(), *y)),
             _ => None,
         }).collect();
@@ -4443,7 +4575,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 900.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let rects: Vec<Rect> = list.items.iter().filter_map(|it| match it {
+        let rects: Vec<Rect> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some(*rect),
             _ => None,
         }).collect();
@@ -4452,7 +4584,7 @@ mod tests {
         assert!(rects[0].x < rects[1].x && rects[1].x < rects[2].x, "lado a lado: {rects:?}");
         assert!(rects.iter().all(|r| r.y == rects[0].y), "mesma linha: {rects:?}");
         // display:none → o texto "invisível" NÃO está na lista.
-        let has_invisivel = list.items.iter().any(|it| matches!(it, DisplayItem::Text { text, .. } if text.contains("invisível")));
+        let has_invisivel = list.materialized().iter().any(|it| matches!(it, DisplayItem::Text { text, .. } if text.contains("invisível")));
         assert!(!has_invisivel, "display:none não renderiza o conteúdo");
     }
 
@@ -4466,7 +4598,7 @@ mod tests {
         let dom = parse_html_to_dom("<p>um</p><p>dois</p>");
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let texts: Vec<(f32, f32)> = list.items.iter().filter_map(|it| match it {
+        let texts: Vec<(f32, f32)> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::Text { x, y, .. } => Some((*x, *y)),
             _ => None,
         }).collect();
@@ -4536,7 +4668,7 @@ mod tests {
         let dom = parse_html_to_dom(&html);
         let ctx = LayoutCtx { viewport_w: vw, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let mut rects: Vec<Rect> = list.items.iter().filter_map(|it| match it {
+        let mut rects: Vec<Rect> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some(*rect),
             _ => None,
         }).collect();
@@ -4682,7 +4814,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let ys: Vec<f32> = list.items.iter().filter_map(|it| match it {
+        let ys: Vec<f32> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some(rect.y),
             _ => None,
         }).collect();
@@ -4700,7 +4832,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let rects: Vec<(f32, f32)> = list.items.iter().filter_map(|it| match it {
+        let rects: Vec<(f32, f32)> = list.materialized().iter().filter_map(|it| match it {
             DisplayItem::SolidRect { rect, .. } => Some((rect.x, rect.y)),
             _ => None,
         }).collect();
@@ -4754,7 +4886,9 @@ mod tests {
     /// Coleta todos os SolidRect da lista, em ordem (container primeiro, filhos
     /// depois — o fundo do container é inserido ATRÁS dos filhos).
     fn all_rects(list: &DisplayList) -> Vec<Rect> {
-        list.items
+        // PLANA: os itens de uma subárvore reusada não estão no buffer próprio,
+        // e um teste que lesse só ele veria a página pela metade.
+        list.materialized()
             .iter()
             .filter_map(|it| match it {
                 DisplayItem::SolidRect { rect, .. } => Some(*rect),

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -2829,6 +2829,7 @@ fn layout_inline_flow(
     ctx: &LayoutCtx,
     list: &mut DisplayList,
 ) -> f32 {
+    let _phase = crate::metrics::phases::scope("layout-inline");
     // coleta os RUNS (cada pedaço de texto com a SUA cor/bold herdada do span que
     // o contém) de TODOS os nós do grupo, em ordem de documento.
     let mut runs = Vec::new();
@@ -3000,6 +3001,7 @@ fn collect_runs(
     parent_css: &ComputedStyle,
     ctx: &LayoutCtx,
 ) -> Vec<InlineRun> {
+    let _phase = crate::metrics::phases::scope("collect-runs");
     let mut runs = Vec::new();
     walk(
         dom,
@@ -3140,6 +3142,66 @@ struct Segment {
 /// ORIGINAL tinha whitespace ali (colapsado p/ 1) — inclusive ATRAVÉS de runs
 /// (`<a>Bootstrap</a>, by` NÃO ganha espaço antes da vírgula; antes toda palavra
 /// ganhava espaço e a pontuação descolava).
+/// Colapsa o whitespace de um run como o fluxo inline faz: sequências viram um
+/// espaço só, o do fim some (o separador seguinte o recria) e o do início só
+/// entra quando havia palavra antes na linha. É a normalização que o scanner
+/// palavra-a-palavra produz implicitamente — o fast path precisa dela explícita
+/// para que os dois caminhos gerem o MESMO texto.
+fn collapse_ws(text: &str, leading_space: bool) -> std::borrow::Cow<'_, str> {
+    // O caso comum é o texto JÁ normalizado (uma palavra, ou palavras separadas
+    // por um espaço só, sem borda) — devolver emprestado evita uma alocação por
+    // run, e um relayout de página grande são milhares deles.
+    let needs_work = leading_space && text.starts_with(char::is_whitespace)
+        || text.starts_with(char::is_whitespace)
+        || text.ends_with(char::is_whitespace)
+        || text.contains("  ")
+        || text.chars().any(|c| c.is_whitespace() && c != ' ');
+    if !needs_work {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    if leading_space && text.starts_with(char::is_whitespace) {
+        out.push(' ');
+    }
+    let mut first = true;
+    for word in text.split_whitespace() {
+        if !first {
+            out.push(' ');
+        }
+        out.push_str(word);
+        first = false;
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+/// Acrescenta texto à linha, juntando ao último segmento quando o estilo é o
+/// mesmo (é o que evita um segmento por palavra na hora de pintar).
+fn push_segment(cur: &mut Vec<Segment>, run: &InlineRun, text: &str, width: f32) {
+    if let Some(last) = cur.last_mut() {
+        if last.widget.is_none()
+            && last.color == run.color
+            && last.bold == run.bold
+            && last.deco == run.deco
+            && last.owners == run.owners
+        {
+            last.text.push_str(text);
+            last.text_width += width;
+            return;
+        }
+    }
+    cur.push(Segment {
+        text: text.to_string(),
+        text_width: width,
+        color: run.color,
+        bold: run.bold,
+        deco: run.deco,
+        owners: run.owners.clone(),
+        widget: None,
+        ww: 0.0,
+        wh: 0.0,
+    });
+}
+
 fn wrap_runs(
     runs: &[InlineRun],
     max_w: f32,
@@ -3147,7 +3209,14 @@ fn wrap_runs(
     mono: bool,
     m: &dyn TextMeasurer,
 ) -> Vec<Vec<Segment>> {
-    let space_w = m.text_width(" ", font_size, mono, false);
+    let _phase = crate::metrics::phases::scope("wrap-runs");
+    // A largura do espaço só interessa ao caminho palavra-a-palavra. Medida
+    // sempre, era metade de todas as medições de texto de um relayout — uma por
+    // chamada, mesmo quando o fast path respondia sozinho.
+    let mut space_w_memo: Option<f32> = None;
+    let mut space_w = |m: &dyn TextMeasurer| -> f32 {
+        *space_w_memo.get_or_insert_with(|| m.text_width(" ", font_size, mono, false))
+    };
     let mut lines: Vec<Vec<Segment>> = Vec::new();
     let mut cur: Vec<Segment> = Vec::new();
     let mut cur_w = 0.0f32;
@@ -3159,7 +3228,7 @@ fn wrap_runs(
         // WIDGET: uma "palavra" inquebrável de run.ww pontos, segmento próprio.
         if let Some(w_idx) = run.widget {
             let with_space = pending_space && !at_line_start;
-            let need = if with_space { space_w + run.ww } else { run.ww };
+            let need = if with_space { space_w(m) + run.ww } else { run.ww };
             if !at_line_start && cur_w + need > max_w {
                 lines.push(std::mem::take(&mut cur));
                 cur_w = 0.0;
@@ -3176,10 +3245,42 @@ fn wrap_runs(
                 ww: run.ww,
                 wh: run.wh,
             });
-            cur_w += if pending_space && !at_line_start { space_w + run.ww } else { run.ww };
+            cur_w += if pending_space && !at_line_start { space_w(m) + run.ww } else { run.ww };
             at_line_start = false;
             pending_space = false;
             continue;
+        }
+        // FAST PATH: o run INTEIRO cabe na linha corrente.
+        //
+        // O scanner abaixo mede palavra por palavra — e medir texto é a única
+        // coisa que o layout pede ao backend, que com uma fonte real faz shaping
+        // em vez de multiplicar um contador de caracteres. Medido no medidor
+        // barato: `wrap-runs` era 38% de um relayout de página grande, com 11 000
+        // `text_width` por frame. Quando o run cabe (o caso comum: quase todo
+        // texto de página não quebra), uma medição responde por todas.
+        //
+        // Medir a string inteira também é o que um browser faz, então a largura
+        // resultante é MAIS fiel e não menos: soma de palavras ignora o que a
+        // fonte faz nas junções.
+        if run.widget.is_none() {
+            let leading = pending_space && !at_line_start;
+            let normalized = collapse_ws(&run.text, leading);
+            if normalized.is_empty() {
+                // só whitespace: vira separador pendente e não abre segmento.
+                if run.text.chars().any(char::is_whitespace) {
+                    pending_space = true;
+                }
+                continue;
+            }
+            let w = m.text_width(&normalized, font_size, mono, run.bold);
+            if at_line_start || cur_w + w <= max_w {
+                let trailing_space = run.text.ends_with(char::is_whitespace);
+                push_segment(&mut cur, run, &normalized, w);
+                cur_w += w;
+                at_line_start = false;
+                pending_space = trailing_space;
+                continue;
+            }
         }
         // scanner ws/palavra preservando a fronteira original.
         let mut rest = run.text.as_str();
@@ -3195,7 +3296,7 @@ fn wrap_runs(
 
             let ww = m.text_width(word, font_size, mono, run.bold);
             let with_space = pending_space && !at_line_start;
-            let need = if with_space { space_w + ww } else { ww };
+            let need = if with_space { space_w(m) + ww } else { ww };
             if !at_line_start && cur_w + need > max_w {
                 // não cabe: fecha a linha.
                 lines.push(std::mem::take(&mut cur));
@@ -3203,8 +3304,12 @@ fn wrap_runs(
                 at_line_start = true;
             }
             let sep = pending_space && !at_line_start;
-            let piece_w = if sep { space_w + ww } else { ww };
-            let piece = if sep { format!(" {word}") } else { word.to_string() };
+            let piece_w = if sep { space_w(m) + ww } else { ww };
+            let mut piece = String::with_capacity(word.len() + usize::from(sep));
+            if sep {
+                piece.push(' ');
+            }
+            piece.push_str(word);
             // junta no último segmento se mesma cor E peso (e não-widget), senão novo.
             if let Some(last) = cur.last_mut() {
                 if last.widget.is_none()
@@ -3301,6 +3406,7 @@ fn wrap_text(text: &str, max_w: f32, font_size: f32, mono: bool, m: &dyn TextMea
 
 /// Concatena o texto de todos os descendentes de `id` (ordem de documento).
 fn collect_text(dom: &Dom, id: NodeIdx) -> String {
+    let _phase = crate::metrics::phases::scope("collect-text");
     let mut out = String::new();
     collect_into(dom, id, &mut out);
     return out;

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -3482,6 +3482,60 @@ mod tests {
     use super::*;
     use crate::dom::parse_html_to_dom;
 
+    /// O caminho CACHEADO e o cálculo do zero produzem a mesma coisa, depois de
+    /// cada mutação de uma sequência que passa por texto, atributo, classe,
+    /// inserção e remoção.
+    ///
+    /// É o guarda de qualquer reuso de geometria: um cache que devolve a lista
+    /// errada tem exatamente a mesma cara de um cache rápido, e o único jeito de
+    /// distinguir os dois é recalcular e comparar. Vale hoje (o reuso é
+    /// tudo-ou-nada) e continua valendo quando o reuso for por subárvore.
+    #[test]
+    fn o_layout_reusado_e_igual_ao_recalculado() {
+        let mut dom = parse_html_to_dom(
+            "<style>.card{padding:8px;margin:4px}.t{font-size:18px}.hi{color:#ff0000}</style>             <main id='root'>               <div class='card'><h3 class='t'>Um titulo</h3><p>texto de exemplo aqui</p></div>               <div class='card'><h3 class='t'>Outro</h3><p>mais texto <b>em negrito</b> junto</p></div>               <ul id='lista'><li>a</li><li>b</li><li>c</li></ul>             </main>",
+        );
+        let ctx = LayoutCtx { viewport_w: 640.0, viewport_h: 480.0, measurer: &ApproxMeasurer };
+        let alvo = dom.query("p").unwrap();
+        let card = dom.query(".card").unwrap();
+        let lista = dom.query("#lista").unwrap();
+
+        let mut passo = 0;
+        let mut conferir = |dom: &Dom, passo: &mut i32| {
+            let cacheado = layout_cached(dom, &ctx);
+            let recalculado = layout_document(dom, &ctx);
+            assert_eq!(cacheado.items, recalculado.items, "itens divergem no passo {passo}");
+            assert_eq!(
+                cacheado.content_height, recalculado.content_height,
+                "altura divergente no passo {passo}"
+            );
+            let mut a: Vec<_> = cacheado.node_rects.iter().collect();
+            let mut b: Vec<_> = recalculado.node_rects.iter().collect();
+            a.sort_by_key(|(idx, _)| **idx);
+            b.sort_by_key(|(idx, _)| **idx);
+            assert_eq!(a, b, "retângulos divergem no passo {passo}");
+            *passo += 1;
+        };
+
+        conferir(&dom, &mut passo);
+        dom.set_text(alvo, "outro texto bem mais longo do que o anterior era");
+        conferir(&dom, &mut passo);
+        dom.set_attr(alvo, "class", "hi");
+        conferir(&dom, &mut passo);
+        dom.set_attr(alvo, "class", "classe-que-ninguem-cita");
+        conferir(&dom, &mut passo);
+        let novo = dom.create_element("li");
+        let txt = dom.create_text_node("d");
+        dom.append_child(novo, txt);
+        dom.append_child(lista, novo);
+        conferir(&dom, &mut passo);
+        dom.remove_node(card);
+        conferir(&dom, &mut passo);
+        dom.set_inner_html(lista, "<li>x</li><li>y</li>");
+        conferir(&dom, &mut passo);
+        assert_eq!(passo, 7, "todos os passos foram conferidos");
+    }
+
     /// O cache de layout devolve a MESMA lista enquanto nada muda, e uma NOVA
     /// depois de qualquer mutação. Sem a segunda metade, "o frame parado custa
     /// zero" seria só outra forma de dizer que a página parou de atualizar.

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -3681,6 +3681,87 @@ mod tests {
         }
     }
 
+    /// SEQUÊNCIA LONGA de mutações sorteadas: o reuso tem de bater com o cálculo
+    /// do zero em todas elas.
+    ///
+    /// O teste dirigido acima cobre os caminhos que eu sabia listar; este cobre
+    /// as COMBINAÇÕES, que é onde um cache erra — invalidar A e depois B, mexer
+    /// num nó recém-inserido, remover o que acabou de mudar. O gerador é um LCG
+    /// com semente fixa: a sequência é sempre a mesma, então uma falha é
+    /// reproduzível e o teste nunca fica intermitente.
+    #[test]
+    fn sequencia_longa_de_mutacoes_mantem_a_equivalencia() {
+        let mut dom = parse_html_to_dom(
+            "<style>.a{padding:4px}.b{margin:2px}.t{font-size:14px}</style>             <main id='root'>               <div class='a'><p class='t'>um</p><p>dois</p></div>               <div class='b'><span>tres</span> quatro <b>cinco</b></div>               <ul id='l'><li>x</li><li>y</li></ul>             </main>",
+        );
+        let ctx = LayoutCtx { viewport_w: 500.0, viewport_h: 400.0, measurer: &ApproxMeasurer };
+        let raiz = dom.query("#root").unwrap();
+        let lista = dom.query("#l").unwrap();
+        let mut semente = 0x2545_F491_4F6C_DD1Du64;
+        let mut sorteia = move |n: u64| {
+            semente = semente.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (semente >> 33) % n
+        };
+        let mut vivos: Vec<crate::dom::NodeId> = dom.query_all("p, li, span, b");
+
+        for passo in 0..120 {
+            match sorteia(5) {
+                0 => {
+                    if !vivos.is_empty() {
+                        let alvo = vivos[sorteia(vivos.len() as u64) as usize];
+                        dom.set_text(alvo, &format!("t{passo}"));
+                    }
+                }
+                1 => {
+                    if !vivos.is_empty() {
+                        let alvo = vivos[sorteia(vivos.len() as u64) as usize];
+                        let classe = ["a", "b", "t", "sem-regra"][sorteia(4) as usize];
+                        dom.set_attr(alvo, "class", classe);
+                    }
+                }
+                2 => {
+                    let novo = dom.create_element(if passo % 2 == 0 { "li" } else { "p" });
+                    let txt = dom.create_text_node(&format!("novo {passo}"));
+                    dom.append_child(novo, txt);
+                    let pai = if passo % 3 == 0 { lista } else { raiz };
+                    dom.append_child(pai, novo);
+                    vivos.push(novo);
+                }
+                3 => {
+                    if vivos.len() > 3 {
+                        let i = sorteia(vivos.len() as u64) as usize;
+                        let alvo = vivos.remove(i);
+                        dom.remove_node(alvo);
+                    }
+                }
+                _ => {
+                    if vivos.len() > 2 {
+                        // move um nó para o fim da lista (reordena irmãos)
+                        let alvo = vivos[sorteia(vivos.len() as u64) as usize];
+                        dom.append_child(lista, alvo);
+                    }
+                }
+            }
+
+            let reusado = layout_cached(&dom, &ctx);
+            dom.clear_fragment_cache();
+            let zero = layout_document(&dom, &ctx);
+            assert_eq!(
+                reusado.items.len(),
+                zero.items.len(),
+                "passo {passo}: nº de itens diverge"
+            );
+            for (i, (a, b)) in reusado.items.iter().zip(&zero.items).enumerate() {
+                assert!(
+                    itens_equivalentes(a, b),
+                    "passo {passo}, item {i}:
+  reuso: {a:?}
+  zero:  {b:?}"
+                );
+            }
+        }
+    }
+
     /// O caminho CACHEADO e o cálculo do zero produzem a mesma coisa, depois de
     /// cada mutação de uma sequência que passa por texto, atributo, classe,
     /// inserção e remoção.
@@ -3700,7 +3781,7 @@ mod tests {
         let lista = dom.query("#lista").unwrap();
 
         let mut passo = 0;
-        let mut conferir = |dom: &Dom, passo: &mut i32| {
+        let conferir = |dom: &Dom, passo: &mut i32| {
             let cacheado = layout_cached(dom, &ctx);
             // Do ZERO: sem os fragmentos, nada é reusado e o resultado é o que o
             // layout produz quando calcula tudo. Comparar o reuso com ele mesmo

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -1103,6 +1103,148 @@ fn layout_block(
     (outer_w, outer_h)
 }
 
+/// Põe um filho-bloco do fluxo normal, REUSANDO o desenho dele quando nada que
+/// o afete mudou.
+///
+/// É o layout incremental: `layout_epochs[nó]` sobe quando a subárvore muda (e
+/// nos ancestrais dela), então um irmão intacto casa a chave e só precisa ser
+/// deslocado. Numa lista de mil cartões em que um texto mudou, 999 cartões são
+/// uma cópia de itens em vez de cascade + medição de texto + box model.
+///
+/// Só o fluxo VERTICAL normal entra aqui — sem `forced_outer_*` (flex) e sem
+/// `shrink_to_fit`. Os outros caminhos dependem de negociação com os irmãos, e
+/// um fragmento que ignorasse isso responderia errado.
+#[allow(clippy::too_many_arguments)]
+fn layout_block_reusing(
+    dom: &Dom,
+    id: NodeIdx,
+    x: f32,
+    y: f32,
+    avail_w: f32,
+    avail_h: Option<f32>,
+    ctx: &LayoutCtx,
+    list: &mut DisplayList,
+) -> (f32, f32) {
+    let key = crate::dom::FragmentKey {
+        tree: dom.cache_identity(),
+        node_epoch: dom.layout_epoch(id),
+        style_epoch: crate::style::props::style_epoch(),
+        anim_epoch: dom.anim_epoch(),
+        node: id,
+        avail_w: avail_w.to_bits(),
+        avail_h: avail_h.map(f32::to_bits),
+        viewport_w: ctx.viewport_w.to_bits(),
+        viewport_h: ctx.viewport_h.to_bits(),
+        measurer: ctx.measurer.identity(),
+    };
+    if let Some(fragment) = dom.fragment_get(key) {
+        crate::bump!(fragment_hits);
+        fragment.emit_at(list, x, y);
+        return fragment.size;
+    }
+    crate::bump!(fragment_misses);
+    // Lista PRÓPRIA: o fragmento precisa saber exatamente quais itens são dele,
+    // e a única forma de saber isso é não misturá-los com os dos irmãos.
+    let mut own = DisplayList::default();
+    let size = layout_block(dom, id, x, y, avail_w, avail_h, None, None, false, ctx, &mut own);
+    let fragment = std::rc::Rc::new(Fragment {
+        rects: own.node_rects.iter().map(|(idx, rect)| (*idx, *rect)).collect(),
+        hit_order: std::mem::take(&mut own.hit_order),
+        scroll_regions: std::mem::take(&mut own.scroll_regions),
+        items: std::mem::take(&mut own.items),
+        origin: (x, y),
+        size,
+    });
+    dom.fragment_put(key, std::rc::Rc::clone(&fragment));
+    fragment.emit_at(list, x, y);
+    size
+}
+
+/// O DESENHO de uma subárvore posta com certas constraints, guardado para ser
+/// reusado numa posição diferente.
+///
+/// Coordenadas ABSOLUTAS, como saíram do layout: a origem em que foi calculado
+/// fica registrada em `origin`, e reusar é somar a diferença. Guardar já
+/// relativo daria na mesma e custaria uma passada extra na hora de gravar — o
+/// caso comum é justamente reusar na MESMA posição (nada acima dele mudou de
+/// altura), e aí a soma é zero e nem se percorre.
+#[derive(Clone, Debug, Default)]
+pub struct Fragment {
+    /// Itens de pintura da subárvore, na ordem em que foram emitidos.
+    pub items: Vec<DisplayItem>,
+    /// Geometria por nó (o que alimenta `getBoundingClientRect`).
+    pub rects: Vec<(NodeIdx, Rect)>,
+    /// Ordem de pintura para o hit-test (ancestral antes de descendente).
+    pub hit_order: Vec<NodeIdx>,
+    /// Regiões roláveis internas descobertas dentro da subárvore.
+    pub scroll_regions: Vec<ScrollRegion>,
+    /// Onde este fragmento foi calculado.
+    pub origin: (f32, f32),
+    /// Tamanho externo devolvido pelo `layout_block` (o que o chamador usa para
+    /// avançar o cursor).
+    pub size: (f32, f32),
+}
+
+impl Fragment {
+    /// Emite este fragmento numa `DisplayList`, deslocado para `(x, y)`.
+    pub fn emit_at(&self, list: &mut DisplayList, x: f32, y: f32) {
+        let (dx, dy) = (x - self.origin.0, y - self.origin.1);
+        let moved = dx != 0.0 || dy != 0.0;
+        list.items.reserve(self.items.len());
+        for item in &self.items {
+            let mut item = item.clone();
+            if moved {
+                translate_item(&mut item, dx, dy);
+            }
+            list.items.push(item);
+        }
+        for (idx, rect) in &self.rects {
+            let mut rect = *rect;
+            if moved {
+                rect.x += dx;
+                rect.y += dy;
+            }
+            list.node_rects.insert(*idx, rect);
+        }
+        list.hit_order.extend_from_slice(&self.hit_order);
+        for region in &self.scroll_regions {
+            let mut region = *region;
+            if moved {
+                region.visible.x += dx;
+                region.visible.y += dy;
+            }
+            list.scroll_regions.push(region);
+        }
+    }
+}
+
+/// DESLOCA um item de pintura por `(dx, dy)`.
+///
+/// É a operação que torna um fragmento de layout REUSÁVEL: o desenho de uma
+/// subárvore cujo conteúdo e constraints não mudaram é o mesmo desenho, na
+/// posição nova. Tudo o que um item carrega é geometria absoluta em coordenadas
+/// de conteúdo, então deslocar é somar — exceto o que é tamanho (`radius`,
+/// `blur`, `size` do texto), que não se move.
+fn translate_item(it: &mut DisplayItem, dx: f32, dy: f32) {
+    let shift = |r: &mut Rect| {
+        r.x += dx;
+        r.y += dy;
+    };
+    match it {
+        DisplayItem::SolidRect { rect, .. }
+        | DisplayItem::Shadow { rect, .. }
+        | DisplayItem::GradientRect { rect, .. }
+        | DisplayItem::Border { rect, .. }
+        | DisplayItem::Image { rect, .. }
+        | DisplayItem::BeginClip { rect, .. } => shift(rect),
+        DisplayItem::Text { x, y, .. } => {
+            *x += dx;
+            *y += dy;
+        }
+        DisplayItem::EndClip => {}
+    }
+}
+
 /// Aplica um transform (translate `tx,ty` + escala `sx,sy` + rotação `sin,cos`) em
 /// torno do centro `(cx,cy)` a um DisplayItem, mutando suas coords. Rects escalam de
 /// tamanho; a rotação move o canto (aproximação: rotaciona a posição, não o próprio
@@ -1951,7 +2093,9 @@ fn layout_children_vertical(
                     .unwrap_or(0.0);
                 // Colapsa com o bloco anterior: recua o overlap antes de posicionar.
                 child_y -= prev_margin.min(m);
-                let (_, h) = layout_block(dom, child, content_x, child_y, content_w, avail_h, None, None, false, ctx, list);
+                let (_, h) = layout_block_reusing(
+                    dom, child, content_x, child_y, content_w, avail_h, ctx, list,
+                );
                 child_y += h;
                 prev_margin = m;
             }
@@ -3482,6 +3626,57 @@ mod tests {
     use super::*;
     use crate::dom::parse_html_to_dom;
 
+    /// Tolerância da comparação reuso × cálculo.
+    ///
+    /// Reusar um fragmento numa posição nova é somar um deslocamento às
+    /// coordenadas, e somar não dá bit a bit o mesmo que calcular a posição do
+    /// zero: `67.4` calculado vira `67.399994` deslocado. É a mesma aritmética
+    /// que qualquer motor de layout com reuso tem, a diferença é da ordem de
+    /// 1e-5 pontos — invisível em tela e irrelevante para hit-test. O que o
+    /// teste NÃO tolera é diferença de conteúdo, de contagem ou de ordem.
+    const TOL: f32 = 0.01;
+
+    fn rects_equivalentes(a: &Rect, b: &Rect) -> bool {
+        (a.x - b.x).abs() < TOL
+            && (a.y - b.y).abs() < TOL
+            && (a.w - b.w).abs() < TOL
+            && (a.h - b.h).abs() < TOL
+    }
+
+    /// Dois itens de pintura iguais a menos da tolerância acima. Texto, cor e
+    /// tipo têm de bater EXATAMENTE: só a geometria admite o erro do
+    /// deslocamento.
+    fn itens_equivalentes(a: &DisplayItem, b: &DisplayItem) -> bool {
+        use DisplayItem as D;
+        match (a, b) {
+            (D::SolidRect { rect: ra, color: ca, radius: da }, D::SolidRect { rect: rb, color: cb, radius: db }) => {
+                rects_equivalentes(ra, rb) && ca == cb && (da - db).abs() < TOL
+            }
+            (D::Border { rect: ra, width: wa, color: ca, radius: da }, D::Border { rect: rb, width: wb, color: cb, radius: db }) => {
+                rects_equivalentes(ra, rb) && (wa - wb).abs() < TOL && ca == cb && (da - db).abs() < TOL
+            }
+            (
+                D::Text { x: xa, y: ya, text: ta, color: ca, size: sa, mono: ma, bold: ba, letter_spacing: la, decoration: dea },
+                D::Text { x: xb, y: yb, text: tb, color: cb, size: sb, mono: mb, bold: bb, letter_spacing: lb, decoration: deb },
+            ) => {
+                (xa - xb).abs() < TOL
+                    && (ya - yb).abs() < TOL
+                    && ta == tb
+                    && ca == cb
+                    && (sa - sb).abs() < TOL
+                    && ma == mb
+                    && ba == bb
+                    && (la - lb).abs() < TOL
+                    && dea == deb
+            }
+            (D::EndClip, D::EndClip) => true,
+            // As demais variantes não aparecem neste corpus; comparar por
+            // igualdade estrita aqui é o certo — se um dia aparecerem com
+            // deslocamento, o teste falha e o braço é escrito.
+            _ => a == b,
+        }
+    }
+
     /// O caminho CACHEADO e o cálculo do zero produzem a mesma coisa, depois de
     /// cada mutação de uma sequência que passa por texto, atributo, classe,
     /// inserção e remoção.
@@ -3503,17 +3698,37 @@ mod tests {
         let mut passo = 0;
         let mut conferir = |dom: &Dom, passo: &mut i32| {
             let cacheado = layout_cached(dom, &ctx);
+            // Do ZERO: sem os fragmentos, nada é reusado e o resultado é o que o
+            // layout produz quando calcula tudo. Comparar o reuso com ele mesmo
+            // seria o mesmo que não comparar.
+            dom.clear_fragment_cache();
             let recalculado = layout_document(dom, &ctx);
-            assert_eq!(cacheado.items, recalculado.items, "itens divergem no passo {passo}");
             assert_eq!(
-                cacheado.content_height, recalculado.content_height,
+                cacheado.items.len(),
+                recalculado.items.len(),
+                "quantidade de itens diverge no passo {passo}"
+            );
+            for (i, (a, b)) in cacheado.items.iter().zip(&recalculado.items).enumerate() {
+                assert!(
+                    itens_equivalentes(a, b),
+                    "item {i} diverge no passo {passo}:
+  reuso: {a:?}
+  cálculo: {b:?}"
+                );
+            }
+            assert!(
+                (cacheado.content_height - recalculado.content_height).abs() < TOL,
                 "altura divergente no passo {passo}"
             );
-            let mut a: Vec<_> = cacheado.node_rects.iter().collect();
-            let mut b: Vec<_> = recalculado.node_rects.iter().collect();
-            a.sort_by_key(|(idx, _)| **idx);
-            b.sort_by_key(|(idx, _)| **idx);
-            assert_eq!(a, b, "retângulos divergem no passo {passo}");
+            let mut a: Vec<_> = cacheado.node_rects.iter().map(|(i, r)| (*i, *r)).collect();
+            let mut b: Vec<_> = recalculado.node_rects.iter().map(|(i, r)| (*i, *r)).collect();
+            a.sort_by_key(|(idx, _)| *idx);
+            b.sort_by_key(|(idx, _)| *idx);
+            assert_eq!(a.len(), b.len(), "nº de retângulos diverge no passo {passo}");
+            for ((ia, ra), (ib, rb)) in a.iter().zip(&b) {
+                assert_eq!(ia, ib, "nós diferentes no passo {passo}");
+                assert!(rects_equivalentes(ra, rb), "rect de {ia} diverge no passo {passo}");
+            }
             *passo += 1;
         };
 

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -176,7 +176,7 @@ pub struct Geometry {
 /// Acumula a geometria de um fragmento e das subárvores dele, deslocada.
 fn collect_geometry(fragment: &Fragment, dx: f32, dy: f32, out: &mut Geometry) {
     let moved = dx != 0.0 || dy != 0.0;
-    for (idx, rect) in &fragment.rects {
+    for (idx, rect) in fragment.rects.iter() {
         let mut rect = *rect;
         if moved {
             rect.x += dx;
@@ -193,7 +193,7 @@ fn collect_geometry(fragment: &Fragment, dx: f32, dy: f32, out: &mut Geometry) {
         collect_geometry(&child.fragment, dx + child.dx, dy + child.dy, out);
     }
     out.hit_order.extend_from_slice(&fragment.hit_order[next.min(fragment.hit_order.len())..]);
-    for region in &fragment.scroll_regions {
+    for region in fragment.scroll_regions.iter() {
         let mut region = *region;
         if moved {
             region.visible.x += dx;
@@ -502,7 +502,12 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // containing block é sempre a viewport (o de `absolute` — ancestral positioned
     // — e o "fica fixo ao rolar" do `fixed` são a v2).
     let mut out_of_flow = Vec::new();
-    collect_out_of_flow(dom, dom.root, &mut out_of_flow);
+    // Só varre se a página PODE ter algum: a varredura pede o estilo computado
+    // de cada nó da árvore, e era 78% de um frame de mutação numa página que não
+    // tem um único posicionado.
+    if dom.may_have_out_of_flow() {
+        collect_out_of_flow(dom, dom.root, &mut out_of_flow);
+    }
     // Z-INDEX: ordena por z-index (menor pinta primeiro = fica atrás). Sort ESTÁVEL:
     // z-index igual (ou ambos auto=0) preserva a ordem do documento. Cobre o caso
     // comum (modais/dropdowns/overlays posicionados que se sobrepõem).
@@ -525,6 +530,10 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // A ordem de pintura já foi registrada durante as inserções de retângulos:
     // fluxo normal durante a descida e out-of-flow na ordem de z-index acima.
     crate::bump!(display_items, list.total_items());
+    // As marcas de sujeira são POR PASSADA: quem as consome é este layout, e
+    // acumulá-las entre frames faria a lista de filhos sujos de um container
+    // crescer até o teto — e aí a costura desistiria sempre.
+    dom.clear_dirty();
     crate::bump!(node_rects, list.node_rects.len());
     crate::bump!(scroll_regions, list.scroll_regions.len());
     list
@@ -1334,14 +1343,126 @@ fn insert_item(list: &mut DisplayList, at: usize, item: DisplayItem) {
     }
 }
 
+/// Reconstrói o fragmento de um container trocando SÓ as subárvores sujas.
+///
+/// Devolve `None` — e o chamador refaz tudo — quando alguma premissa não vale:
+/// o próprio nó foi alvo da invalidação (o estilo DELE pode ter mudado); não há
+/// desenho anterior ou ele não tinha subárvores; a sujeira não tem alvo ou está
+/// espalhada demais; a lista de filhos mudou; ou a subárvore refeita mudou de
+/// ALTURA ou de margem, e aí tudo abaixo dela desloca.
+fn costurar(
+    dom: &Dom,
+    id: NodeIdx,
+    key: crate::dom::FragmentKey,
+    ctx: &LayoutCtx,
+) -> Option<std::rc::Rc<Fragment>> {
+    if dom.is_self_dirty(id) {
+        return None;
+    }
+    let (antiga, anterior) = dom.last_fragment_of(id)?;
+    // Só o epoch do nó pode diferir: viewport, constraints, estilo global e
+    // animação mudam o desenho inteiro, não uma parte dele.
+    if (antiga.tree, antiga.avail_w, antiga.avail_h, antiga.viewport_w, antiga.viewport_h)
+        != (key.tree, key.avail_w, key.avail_h, key.viewport_w, key.viewport_h)
+        || (antiga.style_epoch, antiga.anim_epoch, antiga.measurer)
+            != (key.style_epoch, key.anim_epoch, key.measurer)
+    {
+        return None;
+    }
+    if anterior.children.is_empty() {
+        return None;
+    }
+    let sujos = dom.dirty_children_of(id)?;
+    // A SEQUÊNCIA de filhos precisa ser a mesma, não só o tamanho: inserção,
+    // remoção e reordenação mudam quem desenha o quê, e trocar uma referência
+    // não daria conta. Comparar índice a índice é uma passada de leitura.
+    if !mesma_sequencia_de_filhos(dom, id, &anterior.children) {
+        return None;
+    }
+    let _phase = crate::metrics::phases::scope("fragment-patch");
+
+    let mut children = anterior.children.clone();
+    let mut trocou = false;
+    for child in &mut children {
+        if !sujos.contains(&child.node) {
+            continue;
+        }
+        let mut own = DisplayList::default();
+        // Onde o filho FOI POSTO: a origem em que o fragmento dele foi calculado
+        // mais o deslocamento com que entrou aqui. Somar à origem do PAI daria
+        // uma posição sem sentido — foi o que o teste de equivalência mostrou,
+        // com o texto reaparecendo em (0,16) em vez de (12, 67.4).
+        let origem = (child.fragment.origin.0 + child.dx, child.fragment.origin.1 + child.dy);
+        let margem = child.margin_top;
+        let ((_, altura), nova_margem) = layout_block_reusing(
+            dom,
+            child.node,
+            origem.0,
+            origem.1,
+            child.avail_w,
+            child.avail_h,
+            || margem,
+            ctx,
+            &mut own,
+        );
+        if (altura - child.height).abs() > 0.001 || (nova_margem - child.margin_top).abs() > 0.001 {
+            return None;
+        }
+        // O `layout_block_reusing` emitiu numa lista própria; o que interessa é a
+        // referência que ele acabou de registrar para este nó.
+        let novo = own.children.first()?.fragment.clone();
+        child.fragment = novo;
+        trocou = true;
+    }
+    if !trocou {
+        return None;
+    }
+    let fragment = std::rc::Rc::new(Fragment {
+        node: id,
+        // Compartilha o que NÃO mudou — só a lista de subárvores é nova.
+        items: std::rc::Rc::clone(&anterior.items),
+        children,
+        rects: std::rc::Rc::clone(&anterior.rects),
+        hit_order: std::rc::Rc::clone(&anterior.hit_order),
+        scroll_regions: anterior.scroll_regions.clone(),
+        origin: anterior.origin,
+        size: anterior.size,
+        margin_top: anterior.margin_top,
+    });
+    dom.fragment_put(key, std::rc::Rc::clone(&fragment));
+    Some(fragment)
+}
+
+/// `true` se os filhos-elemento do nó são exatamente os que o desenho anterior
+/// referencia, na mesma ordem. Uma passada de leitura; o que não é barato é o
+/// layout deles.
+fn mesma_sequencia_de_filhos(dom: &Dom, id: NodeIdx, children: &[ChildRef]) -> bool {
+    let mut esperados = children.iter().map(|c| c.node);
+    let mut atuais = dom
+        .node(id)
+        .children
+        .iter()
+        .copied()
+        .filter(|&c| matches!(dom.node(c).kind, NodeKind::Element { .. }));
+    loop {
+        match (esperados.next(), atuais.next()) {
+            (None, None) => return true,
+            (Some(a), Some(b)) if a == b => continue,
+            _ => return false,
+        }
+    }
+}
+
 fn emit_fragment(
     fragment: &std::rc::Rc<Fragment>,
     list: &mut DisplayList,
     x: f32,
     y: f32,
+    avail_w: f32,
+    avail_h: Option<f32>,
 ) {
     let _phase = crate::metrics::phases::scope("fragment-emit");
-    fragment.emit_at(list, x, y);
+    fragment.emit_at(list, x, y, avail_w, avail_h);
 }
 
 fn layout_block_reusing(
@@ -1358,7 +1479,16 @@ fn layout_block_reusing(
     let key = fragment_key(dom, id, avail_w, avail_h, ctx);
     if let Some(fragment) = dom.fragment_get(key) {
         crate::bump!(fragment_hits);
-        emit_fragment(&fragment, list, x, y);
+        emit_fragment(&fragment, list, x, y, avail_w, avail_h);
+        return (fragment.size, fragment.margin_top);
+    }
+    // COSTURA: trocar no desenho anterior só a subárvore que ficou suja. Agora
+    // que a saída é uma ÁRVORE, costurar é substituir uma REFERÊNCIA num vetor
+    // de mil entradas de 48 bytes — a primeira versão disto (revertida) copiava
+    // 3000 itens com String e por isso não ganhava nada.
+    if let Some(fragment) = costurar(dom, id, key, ctx) {
+        crate::bump!(fragment_patches);
+        emit_fragment(&fragment, list, x, y, avail_w, avail_h);
         return (fragment.size, fragment.margin_top);
     }
     crate::bump!(fragment_misses);
@@ -1368,17 +1498,18 @@ fn layout_block_reusing(
     let mut own = DisplayList::default();
     let size = layout_block(dom, id, x, y, avail_w, avail_h, None, None, false, ctx, &mut own);
     let fragment = std::rc::Rc::new(Fragment {
-        rects: own.node_rects.iter().map(|(idx, rect)| (*idx, *rect)).collect(),
-        hit_order: std::mem::take(&mut own.hit_order),
+        node: id,
+        rects: std::rc::Rc::new(own.node_rects.iter().map(|(idx, rect)| (*idx, *rect)).collect()),
+        hit_order: std::rc::Rc::new(std::mem::take(&mut own.hit_order)),
         scroll_regions: std::mem::take(&mut own.scroll_regions),
-        items: std::mem::take(&mut own.items),
+        items: std::rc::Rc::new(std::mem::take(&mut own.items)),
         children: std::mem::take(&mut own.children),
         origin: (x, y),
         size,
         margin_top: margem_de_topo(),
     });
     dom.fragment_put(key, std::rc::Rc::clone(&fragment));
-    fragment.emit_at(list, x, y);
+    fragment.emit_at(list, x, y, avail_w, avail_h);
     (fragment.size, fragment.margin_top)
 }
 
@@ -1386,6 +1517,17 @@ fn layout_block_reusing(
 /// fragmento.
 #[derive(Clone, Debug)]
 pub struct ChildRef {
+    /// O nó que esta subárvore desenha — a costura precisa saber quem é.
+    pub node: NodeIdx,
+    /// Altura externa que ele ocupou e a margem de topo resolvida: se qualquer
+    /// uma mudar ao refazê-lo, tudo abaixo desloca e a costura não serve.
+    pub height: f32,
+    pub margin_top: f32,
+    /// As CONSTRAINTS com que ele foi layoutado — as do CONTEÚDO do pai, não as
+    /// do pai. Refazer um filho com a largura do container em vez da do conteúdo
+    /// dá uma caixa larga demais pela soma do padding e da margem.
+    pub avail_w: f32,
+    pub avail_h: Option<f32>,
     /// Posição em `items` ANTES da qual esta subárvore é pintada.
     pub at: usize,
     /// Posição em `hit_order` antes da qual a ordem de hit-test dela entra.
@@ -1423,14 +1565,20 @@ impl PartialEq for ChildRef {
 /// altura), e aí a soma é zero e nem se percorre.
 #[derive(Clone, Debug, Default)]
 pub struct Fragment {
+    /// O nó que este fragmento desenha.
+    pub node: NodeIdx,
     /// Itens de pintura PRÓPRIOS desta subárvore.
-    pub items: Vec<DisplayItem>,
+    ///
+    /// Os três vetores grandes são `Rc`: quando um container é COSTURADO, só a
+    /// lista de subárvores muda, e clonar retângulos e ordem de hit-test de um
+    /// container de mil filhos custaria mais do que a costura economiza.
+    pub items: std::rc::Rc<Vec<DisplayItem>>,
     /// As subárvores que ela reusou, por referência — o desenho é uma árvore.
     pub children: Vec<ChildRef>,
     /// Geometria por nó (o que alimenta `getBoundingClientRect`).
-    pub rects: Vec<(NodeIdx, Rect)>,
+    pub rects: std::rc::Rc<Vec<(NodeIdx, Rect)>>,
     /// Ordem de pintura para o hit-test (ancestral antes de descendente).
-    pub hit_order: Vec<NodeIdx>,
+    pub hit_order: std::rc::Rc<Vec<NodeIdx>>,
     /// Regiões roláveis internas descobertas dentro da subárvore.
     pub scroll_regions: Vec<ScrollRegion>,
     /// Onde este fragmento foi calculado.
@@ -1450,13 +1598,25 @@ pub struct Fragment {
 
 impl Fragment {
     /// Emite este fragmento numa `DisplayList`, deslocado para `(x, y)`.
-    pub fn emit_at(self: &std::rc::Rc<Self>, list: &mut DisplayList, x: f32, y: f32) {
+    pub fn emit_at(
+        self: &std::rc::Rc<Self>,
+        list: &mut DisplayList,
+        x: f32,
+        y: f32,
+        avail_w: f32,
+        avail_h: Option<f32>,
+    ) {
         let (dx, dy) = (x - self.origin.0, y - self.origin.1);
         // APONTA, não copia: os itens desta subárvore já existem e não mudaram.
         // Os RETÂNGULOS abaixo continuam sendo materializados, porque a consulta
         // de geometria é por nó e precisa do valor pronto — são 16 bytes contra
         // os 48 de um item, numa quantidade menor.
         list.children.push(ChildRef {
+            node: self.node,
+            height: self.size.1,
+            margin_top: self.margin_top,
+            avail_w,
+            avail_h,
             at: list.items.len(),
             hit_at: list.hit_order.len(),
             fragment: std::rc::Rc::clone(self),
@@ -2307,7 +2467,7 @@ fn layout_children_vertical(
                 flush_inline!(child_y);
                 close_floats!(child_y);
                 child_y -= prev_margin.min(fragment.margin_top);
-                emit_fragment(&fragment, list, content_x, child_y);
+                emit_fragment(&fragment, list, content_x, child_y, content_w, avail_h);
                 child_y += fragment.size.1;
                 prev_margin = fragment.margin_top;
                 continue;

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -90,7 +90,11 @@ pub enum DisplayItem {
     Text {
         x: f32,
         y: f32,
-        text: String,
+        /// `Rc<str>` e não `String`: um item de texto é CLONADO toda vez que um
+        /// fragmento de layout é reusado, e clonar a string por item era o custo
+        /// dominante do reuso. Compartilhar o buffer torna o clone um
+        /// incremento. O backend só lê.
+        text: std::rc::Rc<str>,
         color: u32,
         size: f32,
         mono: bool,
@@ -759,7 +763,7 @@ fn layout_block(
             list.items.push(DisplayItem::Text {
                 x,
                 y,
-                text: t.clone(),
+                text: t.as_str().into(),
                 color: 0x000000FF,
                 size,
                 mono: false,
@@ -1702,7 +1706,7 @@ fn layout_button(
     list.items.push(DisplayItem::Text {
         x: x + pad_h,
         y: y + pad_v,
-        text: label,
+        text: label.into(),
         color: fg,
         size: font,
         mono: false,
@@ -1804,7 +1808,7 @@ fn layout_input(
         list.items.push(DisplayItem::Text {
             x: text_x,
             y: text_y,
-            text: shown.clone(),
+            text: shown.as_str().into(),
             color: tcolor,
             size: font,
             mono: false,
@@ -2463,7 +2467,7 @@ fn layout_children_horizontal(
                 list.items.push(DisplayItem::Text {
                     x,
                     y: item_y,
-                    text,
+                    text: text.into(),
                     color,
                     size: font_size,
                     mono: false,
@@ -2838,7 +2842,7 @@ fn layout_children_column(
             list.items.push(DisplayItem::Text {
                 x: content_x,
                 y,
-                text,
+                text: text.into(),
                 color: css.color.unwrap_or(0x000000FF),
                 size: font_size,
                 mono: false,
@@ -3101,7 +3105,7 @@ fn layout_inline_flow(
             list.items.push(DisplayItem::Text {
                 x: seg_x,
                 y: cy,
-                text: seg.text,
+                text: seg.text.into(),
                 color: seg.color,
                 size: font_size,
                 mono,
@@ -4128,7 +4132,7 @@ mod tests {
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
         let texts: Vec<(String, f32)> = list.items.iter().filter_map(|it| match it {
-            DisplayItem::Text { text, x, .. } => Some((text.clone(), *x)),
+            DisplayItem::Text { text, x, .. } => Some((text.to_string(), *x)),
             _ => None,
         }).collect();
         // "x" (1 char, ~8px = 16×0.5) centrado em 400 → x ≈ (400-8)/2 = 196.
@@ -4258,7 +4262,9 @@ mod tests {
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
         let segs: Vec<(String, u32, u8)> = list.items.iter().filter_map(|it| match it {
-            DisplayItem::Text { text, color, decoration, .. } => Some((text.clone(), *color, *decoration)),
+            DisplayItem::Text { text, color, decoration, .. } => {
+                Some((text.to_string(), *color, *decoration))
+            }
             _ => None,
         }).collect();
         let link = segs.iter().find(|(t, ..)| t.contains("link")).expect("run do link");
@@ -4277,7 +4283,7 @@ mod tests {
         let ctx = LayoutCtx { viewport_w: 600.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
         let texts: Vec<(String, f32)> = list.items.iter().filter_map(|it| match it {
-            DisplayItem::Text { text, y, .. } => Some((text.clone(), *y)),
+            DisplayItem::Text { text, y, .. } => Some((text.to_string(), *y)),
             _ => None,
         }).collect();
         // uppercase aplicado.
@@ -4757,7 +4763,7 @@ mod tests {
             .iter()
             .filter_map(|it| match it {
                 DisplayItem::Text { text, x, y, color, .. } => {
-                    Some((text.clone(), *x, *y, *color))
+                    Some((text.to_string(), *x, *y, *color))
                 }
                 _ => None,
             })

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -160,6 +160,47 @@ pub struct DisplayList {
     /// irmãos na ordem documental e elementos fora do fluxo por `z-index` crescente.
     /// O último nó que contém o ponto é o que está visualmente no topo.
     pub hit_order: Vec<NodeIdx>,
+    /// A geometria completa, montada sob demanda a partir da árvore. Não entra
+    /// no `PartialEq` nem no `Clone` lógico: é derivada.
+    geometry_cache: std::cell::RefCell<Option<std::rc::Rc<Geometry>>>,
+}
+
+/// A geometria de uma passada de layout, já com as subárvores reusadas somadas.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Geometry {
+    pub rects: crate::fasthash::FastMap<NodeIdx, Rect>,
+    pub hit_order: Vec<NodeIdx>,
+    pub scroll_regions: Vec<ScrollRegion>,
+}
+
+/// Acumula a geometria de um fragmento e das subárvores dele, deslocada.
+fn collect_geometry(fragment: &Fragment, dx: f32, dy: f32, out: &mut Geometry) {
+    let moved = dx != 0.0 || dy != 0.0;
+    for (idx, rect) in &fragment.rects {
+        let mut rect = *rect;
+        if moved {
+            rect.x += dx;
+            rect.y += dy;
+        }
+        out.rects.insert(*idx, rect);
+    }
+    let mut next = 0usize;
+    for child in &fragment.children {
+        while next < child.hit_at && next < fragment.hit_order.len() {
+            out.hit_order.push(fragment.hit_order[next]);
+            next += 1;
+        }
+        collect_geometry(&child.fragment, dx + child.dx, dy + child.dy, out);
+    }
+    out.hit_order.extend_from_slice(&fragment.hit_order[next.min(fragment.hit_order.len())..]);
+    for region in &fragment.scroll_regions {
+        let mut region = *region;
+        if moved {
+            region.visible.x += dx;
+            region.visible.y += dy;
+        }
+        out.scroll_regions.push(region);
+    }
 }
 
 impl DisplayList {
@@ -202,6 +243,47 @@ impl DisplayList {
             + self.children.iter().map(|c| c.fragment.total_items()).sum::<usize>()
     }
 
+    /// A geometria COMPLETA desta lista: os retângulos próprios mais os das
+    /// subárvores reusadas, já deslocados. Construída na primeira consulta e
+    /// guardada — o layout mesmo só a pede quando há elemento fora do fluxo.
+    pub fn geometry(&self) -> std::rc::Rc<Geometry> {
+        if let Some(g) = self.geometry_cache.borrow().as_ref() {
+            return std::rc::Rc::clone(g);
+        }
+        let g = std::rc::Rc::new(self.geometry_now());
+        *self.geometry_cache.borrow_mut() = Some(std::rc::Rc::clone(&g));
+        g
+    }
+
+    /// A geometria SEM cachear — para uso DURANTE a montagem da lista, quando
+    /// ainda vão entrar itens (a passada de fora do fluxo). Cachear ali deixaria
+    /// o hit-test lendo uma geometria anterior aos `position:absolute`, que foi
+    /// exatamente o que um teste de `z-index` acusou.
+    pub fn geometry_now(&self) -> Geometry {
+        let mut g = Geometry {
+            rects: self.node_rects.clone(),
+            hit_order: Vec::with_capacity(self.hit_order.len()),
+            scroll_regions: self.scroll_regions.clone(),
+        };
+        // Intercala a ordem de hit-test pelo ponto de entrada de cada subárvore:
+        // a ordem É o z-order, e concatenar inverteria quem está por cima.
+        let mut next = 0usize;
+        for child in &self.children {
+            while next < child.hit_at && next < self.hit_order.len() {
+                g.hit_order.push(self.hit_order[next]);
+                next += 1;
+            }
+            collect_geometry(&child.fragment, child.dx, child.dy, &mut g);
+        }
+        g.hit_order.extend_from_slice(&self.hit_order[next.min(self.hit_order.len())..]);
+        g
+    }
+
+    /// O retângulo de um nó, se ele foi desenhado.
+    pub fn rect_of(&self, node: NodeIdx) -> Option<Rect> {
+        self.geometry().rects.get(&node).copied()
+    }
+
     /// HIT-TEST: o nó sob o ponto `(x, y)` em COORDENADAS DE CONTEÚDO (o backend
     /// converte tela→conteúdo somando o offset de scroll antes de chamar). Quando a
     /// lista foi produzida por `layout_document`, a ordem de pintura respeita
@@ -209,15 +291,16 @@ impl DisplayList {
     /// ponto é o elemento visualmente no topo. Listas antigas sem `hit_order` usam o
     /// fallback por menor área para manter compatibilidade.
     pub fn hit_test(&self, x: f32, y: f32) -> Option<NodeIdx> {
-        if !self.hit_order.is_empty() {
-            return self.hit_order.iter().rev().copied().find(|&idx| {
-                self.node_rects.get(&idx).is_some_and(|r| {
+        let g = self.geometry();
+        if !g.hit_order.is_empty() {
+            return g.hit_order.iter().rev().copied().find(|&idx| {
+                g.rects.get(&idx).is_some_and(|r| {
                     x >= r.x && x < r.x + r.w && y >= r.y && y < r.y + r.h
                 })
             });
         }
         let mut best: Option<(NodeIdx, f32)> = None;
-        for (&idx, r) in &self.node_rects {
+        for (&idx, r) in &g.rects {
             if x >= r.x && x < r.x + r.w && y >= r.y && y < r.y + r.h {
                 let area = r.w * r.h;
                 if best.map(|(_, a)| area < a).unwrap_or(true) {
@@ -429,7 +512,9 @@ pub fn layout_document(dom: &Dom, ctx: &LayoutCtx) -> DisplayList {
     // O rect do containing block de cada abs é lido do `node_rects` JÁ preenchido
     // pelo fluxo normal (o ancestral positioned já foi pintado). Clona antes do
     // empréstimo mutável de `list`.
-    let flow_rects = list.node_rects.clone();
+    // A geometria COMPLETA (com as subárvores reusadas): o containing block de
+    // um `absolute` pode ser um ancestral cujo retângulo veio de um fragmento.
+    let flow_rects = list.geometry_now().rects;
     crate::bump!(out_of_flow, out_of_flow.len());
     for id in &out_of_flow {
         layout_out_of_flow(dom, *id, ctx, &flow_rects, &mut list);
@@ -704,7 +789,7 @@ fn find_body_bg(dom: &Dom, idx: NodeIdx) -> Option<u32> {
 /// Roda o layout inteiro (O(n)); para várias consultas no mesmo frame, reuse a
 /// `DisplayList` de `layout_document` e leia `node_rects` direto.
 pub fn bounding_rect(dom: &Dom, node: NodeIdx, ctx: &LayoutCtx) -> Option<Rect> {
-    layout_document(dom, ctx).node_rects.get(&node).copied()
+    layout_document(dom, ctx).rect_of(node)
 }
 
 /// Faz o layout de UM nó-bloco a partir de `(x, y)`, com `avail_w` de largura
@@ -1183,17 +1268,54 @@ fn fragment_key(
     avail_h: Option<f32>,
     ctx: &LayoutCtx,
 ) -> crate::dom::FragmentKey {
-    crate::dom::FragmentKey {
-        tree: dom.cache_identity(),
-        node_epoch: dom.layout_epoch(id),
-        style_epoch: crate::style::props::style_epoch(),
-        anim_epoch: dom.anim_epoch(),
-        node: id,
-        avail_w: avail_w.to_bits(),
-        avail_h: avail_h.map(f32::to_bits),
-        viewport_w: ctx.viewport_w.to_bits(),
-        viewport_h: ctx.viewport_h.to_bits(),
-        measurer: ctx.measurer.identity(),
+    KeyBase::new(dom, avail_w, avail_h, ctx).key(dom, id)
+}
+
+/// A parte da chave de fragmento que NÃO varia entre os filhos de um container:
+/// identidade da árvore, epochs globais, viewport, medidor e as constraints.
+///
+/// Montar a chave inteira por filho relia um `thread_local` (o epoch de estilo)
+/// e refazia as conversões mil vezes por container — o laço do fluxo vertical
+/// pergunta o mesmo a cada iteração e só o nó muda.
+#[derive(Clone, Copy)]
+struct KeyBase {
+    tree: u64,
+    style_epoch: u64,
+    anim_epoch: u64,
+    avail_w: u32,
+    avail_h: Option<u32>,
+    viewport_w: u32,
+    viewport_h: u32,
+    measurer: u64,
+}
+
+impl KeyBase {
+    fn new(dom: &Dom, avail_w: f32, avail_h: Option<f32>, ctx: &LayoutCtx) -> KeyBase {
+        KeyBase {
+            tree: dom.cache_identity(),
+            style_epoch: crate::style::props::style_epoch(),
+            anim_epoch: dom.anim_epoch(),
+            avail_w: avail_w.to_bits(),
+            avail_h: avail_h.map(f32::to_bits),
+            viewport_w: ctx.viewport_w.to_bits(),
+            viewport_h: ctx.viewport_h.to_bits(),
+            measurer: ctx.measurer.identity(),
+        }
+    }
+
+    fn key(&self, dom: &Dom, id: NodeIdx) -> crate::dom::FragmentKey {
+        crate::dom::FragmentKey {
+            tree: self.tree,
+            node_epoch: dom.layout_epoch(id),
+            style_epoch: self.style_epoch,
+            anim_epoch: self.anim_epoch,
+            node: id,
+            avail_w: self.avail_w,
+            avail_h: self.avail_h,
+            viewport_w: self.viewport_w,
+            viewport_h: self.viewport_h,
+            measurer: self.measurer,
+        }
     }
 }
 
@@ -1266,6 +1388,14 @@ fn layout_block_reusing(
 pub struct ChildRef {
     /// Posição em `items` ANTES da qual esta subárvore é pintada.
     pub at: usize,
+    /// Posição em `hit_order` antes da qual a ordem de hit-test dela entra.
+    ///
+    /// Separada do `at` porque as duas sequências crescem por motivos
+    /// diferentes: nem todo item de pintura registra um nó, e nem todo nó
+    /// registrado pinta um item. Montar a ordem de hit-test com os próprios
+    /// primeiro e os das subárvores depois inverte o z-order — foi o que o teste
+    /// de `z-index` acusou.
+    pub hit_at: usize,
     pub fragment: std::rc::Rc<Fragment>,
     pub dx: f32,
     pub dy: f32,
@@ -1328,28 +1458,16 @@ impl Fragment {
         // os 48 de um item, numa quantidade menor.
         list.children.push(ChildRef {
             at: list.items.len(),
+            hit_at: list.hit_order.len(),
             fragment: std::rc::Rc::clone(self),
             dx,
             dy,
         });
-        let moved = dx != 0.0 || dy != 0.0;
-        for (idx, rect) in &self.rects {
-            let mut rect = *rect;
-            if moved {
-                rect.x += dx;
-                rect.y += dy;
-            }
-            list.node_rects.insert(*idx, rect);
-        }
-        list.hit_order.extend_from_slice(&self.hit_order);
-        for region in &self.scroll_regions {
-            let mut region = *region;
-            if moved {
-                region.visible.x += dx;
-                region.visible.y += dy;
-            }
-            list.scroll_regions.push(region);
-        }
+        // A GEOMETRIA da subárvore (retângulos, ordem de hit-test, regiões
+        // roláveis) também fica na referência: materializá-la aqui era metade do
+        // custo de um frame parado — três inserções em mapa por fragmento, mil
+        // fragmentos. Quem precisa dela chama `geometry()`, que percorre a
+        // árvore uma vez e guarda o resultado.
     }
 }
 
@@ -2113,6 +2231,9 @@ fn layout_children_vertical(
     list: &mut DisplayList,
 ) -> f32 {
     let mut child_y = content_y;
+    // A base da chave de fragmento é a mesma para todos os filhos deste
+    // container — só o nó e o epoch dele mudam.
+    let key_base = KeyBase::new(dom, content_w, avail_h, ctx);
     // MARGIN-COLLAPSE (versão simples, fiel ao caso comum): margins verticais de
     // blocos ADJACENTES colapsam para o MAIOR, não somam (regra do CSS). Como o
     // `outer_h` de cada bloco já inclui seu margin nos dois lados, ao empilhar dois
@@ -2180,7 +2301,7 @@ fn layout_children_vertical(
         // `block::lookup` e a margem resolvida por filho: mil vezes por frame
         // numa lista, para redescobrir o que não mudou.
         if matches!(dom.node(child).kind, NodeKind::Element { .. }) {
-            let key = fragment_key(dom, child, content_w, avail_h, ctx);
+            let key = key_base.key(dom, child);
             if let Some(fragment) = dom.fragment_get(key) {
                 crate::bump!(fragment_hits);
                 flush_inline!(child_y);
@@ -3987,8 +4108,8 @@ mod tests {
                 (cacheado.content_height - recalculado.content_height).abs() < TOL,
                 "altura divergente no passo {passo}"
             );
-            let mut a: Vec<_> = cacheado.node_rects.iter().map(|(i, r)| (*i, *r)).collect();
-            let mut b: Vec<_> = recalculado.node_rects.iter().map(|(i, r)| (*i, *r)).collect();
+            let mut a: Vec<_> = cacheado.geometry().rects.iter().map(|(i, r)| (*i, *r)).collect();
+            let mut b: Vec<_> = recalculado.geometry().rects.iter().map(|(i, r)| (*i, *r)).collect();
             a.sort_by_key(|(idx, _)| *idx);
             b.sort_by_key(|(idx, _)| *idx);
             assert_eq!(a.len(), b.len(), "nº de retângulos diverge no passo {passo}");
@@ -4069,9 +4190,9 @@ mod tests {
 
         let first = layout_document(&dom, &ctx);
         let _warm = layout_document(&dom, &ctx);
-        let before = first.node_rects[&card_idx].w;
+        let before = first.geometry().rects[&card_idx].w;
         dom.set_style_property(card, "width", "200px");
-        let after = layout_document(&dom, &ctx).node_rects[&card_idx].w;
+        let after = layout_document(&dom, &ctx).geometry().rects[&card_idx].w;
 
         assert!((before - 100.0).abs() < 0.1);
         assert!((after - 200.0).abs() < 0.1);
@@ -4087,10 +4208,10 @@ mod tests {
         let text_idx = dom.resolve(text).unwrap();
         let ctx = LayoutCtx { viewport_w: 800.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
 
-        let before = layout_document(&dom, &ctx).node_rects[&text_idx].w;
+        let before = layout_document(&dom, &ctx).geometry().rects[&text_idx].w;
         let _warm = layout_document(&dom, &ctx);
         dom.set_text(text, "uma linha de texto bem mais comprida");
-        let after = layout_document(&dom, &ctx).node_rects[&text_idx].w;
+        let after = layout_document(&dom, &ctx).geometry().rects[&text_idx].w;
 
         assert!(after > before, "a largura intrínseca deve acompanhar o novo texto");
     }
@@ -4110,11 +4231,11 @@ mod tests {
         let filho = dom.query("#filho").unwrap();
         let pai_idx = dom.resolve(pai).unwrap();
         let filho_idx = dom.resolve(filho).unwrap();
-        let fr = list.node_rects[&filho_idx];
+        let fr = list.geometry().rects[&filho_idx];
         let hit = list.hit_test(fr.x + fr.w / 2.0, fr.y + fr.h / 2.0);
         assert_eq!(hit, Some(filho_idx));
         // canto do pai (dentro do padding, fora do filho).
-        let pr = list.node_rects[&pai_idx];
+        let pr = list.geometry().rects[&pai_idx];
         let hit2 = list.hit_test(pr.x + 5.0, pr.y + 5.0);
         assert_eq!(hit2, Some(pai_idx));
         // fora de tudo.
@@ -4128,7 +4249,8 @@ mod tests {
         let list = layout_document(&dom, &ctx);
         let span = dom.query("#s").unwrap();
         let span_idx = dom.resolve(span).unwrap();
-        let rect = list.node_rects.get(&span_idx).expect("inline deveria ter rect");
+        let geo = list.geometry();
+        let rect = geo.rects.get(&span_idx).expect("inline deveria ter rect");
         assert!(rect.w > 0.0);
         assert!(rect.h > 0.0);
     }
@@ -4416,7 +4538,7 @@ mod tests {
         );
         let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 800.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
-        let r = |sel: &str| list.node_rects[&dom.resolve(dom.query(sel).unwrap()).unwrap()];
+        let r = |sel: &str| list.geometry().rects[&dom.resolve(dom.query(sel).unwrap()).unwrap()];
         let logo = r("#logo");
         assert!((logo.w - 272.0).abs() < 1.0 && (logo.h - 92.0).abs() < 1.0, "logo: {}x{}", logo.w, logo.h);
         let ico = r("#ico");
@@ -4434,7 +4556,7 @@ mod tests {
         let list = layout_document(&dom, &ctx);
         let rect = |sel: &str| {
             let idx = dom.resolve(dom.query(sel).unwrap()).unwrap();
-            list.node_rects[&idx]
+            list.geometry().rects[&idx]
         };
         let a = rect("#a"); let b = rect("#b"); let c = rect("#c");
         assert!((a.w - 200.0).abs() < 1.0, "col px: {}", a.w);
@@ -4454,7 +4576,7 @@ mod tests {
         let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 800.0, measurer: &ApproxMeasurer };
         let list = layout_document(&dom, &ctx);
         let idx = dom.resolve(dom.query("#logo").unwrap()).unwrap();
-        let r = list.node_rects[&idx];
+        let r = list.geometry().rects[&idx];
         assert!((r.y - 74.0).abs() < 2.0, "y centralizado: {} (esperado 74=(240-92)/2)", r.y);
         assert!((r.h - 92.0).abs() < 2.0, "altura preservada: {}", r.h);
     }
@@ -4472,8 +4594,8 @@ mod tests {
         let list = layout_document(&dom, &ctx);
         let c = dom.query("#c").unwrap();
         let idx = dom.resolve(c).unwrap();
-        assert!((list.node_rects[&idx].h - 240.0).abs() < 2.0,
-            "calc height: {} (esperado 240 = 800-560)", list.node_rects[&idx].h);
+        assert!((list.geometry().rects[&idx].h - 240.0).abs() < 2.0,
+            "calc height: {} (esperado 240 = 800-560)", list.geometry().rects[&idx].h);
     }
 
     #[test]
@@ -4490,7 +4612,7 @@ mod tests {
         let list = layout_document(&dom, &ctx);
         let alvo = dom.query("#alvo").unwrap();
         let idx = dom.resolve(alvo).unwrap();
-        let r = list.node_rects[&idx];
+        let r = list.geometry().rects[&idx];
         assert!((r.h - 740.0).abs() < 2.0, "altura do filho 100%: {} (esperado 740)", r.h);
         assert!((r.y - 60.0).abs() < 2.0, "y do filho: {}", r.y);
     }

--- a/crates/rts-dom/src/lib.rs
+++ b/crates/rts-dom/src/lib.rs
@@ -20,6 +20,10 @@
 //! (`Document`/`Element`) é TS. Depende só de `rts-engine`.
 
 mod dom;
+/// Hasher rápido para as chaves INTERNAS (índices de nó, chaves de cache de
+/// layout): nenhuma delas vem de fora do processo, e o SipHash da `std` cobra
+/// uma resistência que não se usa. Ver as ressalvas no módulo.
+pub mod fasthash;
 mod html;
 /// Estado de ESTILO (egui-free): `ComputedStyle`, slots opacos, parse do `style=""`
 /// inline, e o registro por-tag (`defineStyle`). O DOM é dono do estilo; o renderer

--- a/crates/rts-dom/src/metrics/counters.rs
+++ b/crates/rts-dom/src/metrics/counters.rs
@@ -177,6 +177,7 @@ dom_metrics! {
     }
     "layout" {
         documents: "layout_document";
+        display_cache_hits: "…reusado do cache de display list";
         block_calls: "layout_block";
         inline_runs: "linhas inline montadas";
         measure_calls: "measure_block (pré-passo)";

--- a/crates/rts-dom/src/metrics/counters.rs
+++ b/crates/rts-dom/src/metrics/counters.rs
@@ -180,6 +180,7 @@ dom_metrics! {
         display_cache_hits: "…reusado do cache de display list";
         fragment_hits: "subárvores REUSADAS (layout incremental)";
         fragment_misses: "subárvores recalculadas";
+        fragment_patches: "containers COSTURADOS (troca de referência)";
         block_calls: "layout_block";
         inline_runs: "linhas inline montadas";
         measure_calls: "measure_block (pré-passo)";

--- a/crates/rts-dom/src/metrics/counters.rs
+++ b/crates/rts-dom/src/metrics/counters.rs
@@ -178,6 +178,8 @@ dom_metrics! {
     "layout" {
         documents: "layout_document";
         display_cache_hits: "…reusado do cache de display list";
+        fragment_hits: "subárvores REUSADAS (layout incremental)";
+        fragment_misses: "subárvores recalculadas";
         block_calls: "layout_block";
         inline_runs: "linhas inline montadas";
         measure_calls: "measure_block (pré-passo)";

--- a/crates/rts-dom/src/style/ruleindex.rs
+++ b/crates/rts-dom/src/style/ruleindex.rs
@@ -44,6 +44,14 @@ pub struct RuleIndex {
     /// Há seletores cuja correspondência depende de atributos ou pseudo-classes
     /// representadas por atributos (`:checked`, `:disabled`, etc.).
     has_attribute_selectors: bool,
+    /// TODAS as classes citadas em QUALQUER compound de qualquer regra — não só
+    /// as que servem de chave-alvo. Uma classe fora deste conjunto não pode
+    /// mudar o estilo de nó nenhum, e trocá-la não precisa invalidar nada. É a
+    /// versão mínima do "invalidation set" que os browsers mantêm.
+    ///
+    /// TODAS e não só as chaves: em `.a.b { }` a chave é `.a`, mas trocar `b`
+    /// muda o resultado do mesmo jeito.
+    mentioned_classes: std::collections::HashSet<String>,
 }
 
 /// A âncora do compound-alvo (último compound) de um seletor. Id > Class > Tag; se
@@ -83,6 +91,17 @@ impl RuleIndex {
                 Key::Universal => idx.universal.push(i),
             }
         }
+        for rule in rules {
+            for compound in &rule.selector.compounds {
+                for part in &compound.parts {
+                    if let SimpleSelector::Class(c) = part {
+                        if !idx.mentioned_classes.contains(c) {
+                            idx.mentioned_classes.insert(c.clone());
+                        }
+                    }
+                }
+            }
+        }
         idx.specificity = rules.iter().map(|r| r.selector.specificity()).collect();
         idx.covered = rules.len();
         idx.has_custom_rules = rules.iter().any(|r| !r.decls.custom.is_empty());
@@ -110,6 +129,11 @@ impl RuleIndex {
 
     pub fn has_custom_rules(&self) -> bool {
         self.has_custom_rules
+    }
+
+    /// `true` se alguma regra CITA esta classe (em qualquer posição).
+    pub fn mentions_class(&self, class: &str) -> bool {
+        self.mentioned_classes.contains(class)
     }
 
     pub fn has_attribute_selectors(&self) -> bool {

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -436,6 +436,13 @@ impl Stylesheet {
         out
     }
 
+    /// `true` se alguma regra CITA esta classe. Ver
+    /// [`RuleIndex::mentions_class`](super::ruleindex::RuleIndex::mentions_class).
+    pub fn mentions_class(&self, class: &str) -> bool {
+        self.ensure_rule_index();
+        self.index.borrow().mentions_class(class)
+    }
+
     /// `true` quando alguma regra depende da presença/valor de um atributo.
     pub fn has_attribute_selectors(&self) -> bool {
         self.ensure_rule_index();

--- a/crates/rts-dom/src/style/stylesheet.rs
+++ b/crates/rts-dom/src/style/stylesheet.rs
@@ -259,6 +259,8 @@ pub struct Stylesheet {
     /// Cache de [`position_sensitive`](Stylesheet::position_sensitive), pelo
     /// mesmo motivo do `hover_reach` — a pergunta é por mutação de árvore.
     position_sensitive: std::cell::RefCell<Option<bool>>,
+    /// Cache de [`has_out_of_flow`](Stylesheet::has_out_of_flow).
+    out_of_flow: std::cell::RefCell<Option<bool>>,
 }
 
 /// As regras que casaram um nó, ordenadas pela cascade. Opaco de propósito: o
@@ -308,6 +310,7 @@ impl Stylesheet {
             candidate_scratch: std::cell::RefCell::new(Vec::new()),
             hover_reach: std::cell::RefCell::new(None),
             position_sensitive: std::cell::RefCell::new(None),
+            out_of_flow: std::cell::RefCell::new(None),
         }
     }
 
@@ -436,6 +439,33 @@ impl Stylesheet {
         out
     }
 
+    /// `true` se alguma regra pode tirar um elemento do fluxo
+    /// (`position: absolute` ou `fixed`).
+    ///
+    /// Derivado das regras e cacheado: sem nenhuma delas — e sem `style=""`
+    /// inline com `position` —, a passada de fora do fluxo não tem o que achar,
+    /// e ela percorre a ÁRVORE INTEIRA pedindo o estilo computado de cada nó.
+    /// Era 78% de um frame de mutação numa página de 3000 elementos que não tem
+    /// um único posicionado.
+    pub fn has_out_of_flow(&self) -> bool {
+        if let Some(cached) = *self.out_of_flow.borrow() {
+            return cached;
+        }
+        use super::props::Decl;
+        let fora = |d: &Decl| {
+            matches!(d, Decl::position(Some(super::Position::Absolute | super::Position::Fixed)))
+        };
+        let answer = self.rules.iter().any(|r| {
+            r.decls.normal.iter().any(fora)
+                || r.decls.important.iter().any(fora)
+                // uma pendente com var() pode virar qualquer coisa: conta como
+                // possível, que é o lado seguro.
+                || r.decls.pending.iter().any(|(prop, _, _)| prop == "position")
+        });
+        *self.out_of_flow.borrow_mut() = Some(answer);
+        answer
+    }
+
     /// `true` se alguma regra CITA esta classe. Ver
     /// [`RuleIndex::mentions_class`](super::ruleindex::RuleIndex::mentions_class).
     pub fn mentions_class(&self, class: &str) -> bool {
@@ -505,6 +535,7 @@ impl Stylesheet {
         // As regras mudaram: o que foi derivado delas não vale mais.
         *self.hover_reach.borrow_mut() = None;
         *self.position_sensitive.borrow_mut() = None;
+        *self.out_of_flow.borrow_mut() = None;
     }
 
     /// Acha cada `@keyframes nome { ... }`, parseia os stops e guarda; devolve o CSS

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -317,11 +317,14 @@ fn process_scroll_regions(
     sb: &rts_dom::scrollbar::ScrollbarStyle,
     page_dy: f32,
 ) {
-    if list.scroll_regions.is_empty() {
+    // As regiões roláveis podem ter vindo de uma subárvore REUSADA: a lista
+    // guarda as próprias, e a `geometry()` junta as das subárvores.
+    let geometria = list.geometry();
+    if geometria.scroll_regions.is_empty() {
         return;
     }
     let base = ui.max_rect().min;
-    let regions = list.scroll_regions.clone();
+    let regions = geometria.scroll_regions.clone();
     for region in &regions {
         let max_x = (region.content_w - region.visible.w).max(0.0);
         let max_y = (region.content_h - region.visible.h).max(0.0);

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -397,6 +397,10 @@ fn process_scroll_regions(
         ui.ctx().memory_mut(|m| m.data.insert_temp(oid, off));
 
         // injeta o offset no BeginClip desta região (acha pelo node).
+        // Mutar um item exige a lista PLANA: um `BeginClip` pode estar dentro de
+        // uma subárvore compartilhada, e escrever nele afetaria todos os nós que
+        // a reusam.
+        list.materialize();
         for it in list.items.iter_mut() {
             if let layout::DisplayItem::BeginClip { node, offset_x, offset_y, .. } = it {
                 if *node == region.node_idx {
@@ -423,12 +427,19 @@ fn paint_list(ui: &mut egui::Ui, list: &DisplayList, offset_y: f32) {
     // painter do topo e a SOMA dos offsets extra (a região rolada). Base = ui.
     let base = ui.painter().clone();
     let mut stack: Vec<(egui::Painter, egui::Vec2)> = Vec::new();
-    for (idx, item) in list.items.iter().enumerate() {
+    // `walk` anda a ÁRVORE de fragmentos: os itens de uma subárvore reusada
+    // chegam aqui sem nunca terem sido copiados, com o deslocamento a somar — e
+    // somar uma origem já era o que este laço fazia.
+    let mut idx = 0usize;
+    list.walk(|item, dx, dy| {
+        idx += 1;
+        let idx = idx - 1;
         let (painter, extra) = stack
             .last()
             .map(|(p, o)| (p.clone(), *o))
             .unwrap_or_else(|| (base.clone(), egui::Vec2::ZERO));
-        let origin = base_origin + extra; // origem da página + translação da região
+        // origem da página + translação da região + deslocamento do fragmento
+        let origin = base_origin + extra + egui::vec2(dx, dy);
         match item {
             DisplayItem::SolidRect { rect, color, radius } => {
                 let r = egui::Rect::from_min_size(
@@ -569,7 +580,7 @@ fn paint_list(ui: &mut egui::Ui, list: &DisplayList, offset_y: f32) {
                 stack.pop();
             }
         }
-    }
+    });
 }
 
 /// Pinta um GRADIENTE LINEAR de 2 cores num retângulo, como mesh de 4 vértices. A cor

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -59,6 +59,15 @@ impl<'a> EguiMeasurer<'a> {
 }
 
 impl<'a> TextMeasurer for EguiMeasurer<'a> {
+    /// O `Context` do egui identifica as fontes; o `pixels_per_point` identifica
+    /// a escala, e mudar o zoom MUDA a largura do texto. Este medidor é
+    /// construído na pilha a cada frame, então o endereço dele não serve — ver a
+    /// nota em `TextMeasurer::identity`.
+    fn identity(&self) -> u64 {
+        let context = self.ctx as *const egui::Context as usize as u64;
+        context ^ ((self.ctx.pixels_per_point().to_bits() as u64) << 32)
+    }
+
     fn text_width(&self, text: &str, size: f32, mono: bool, bold: bool) -> f32 {
         let context_key = self.ctx as *const egui::Context as usize;
         let font_key = (context_key, size.to_bits(), mono, bold);
@@ -107,19 +116,10 @@ impl<'a> TextMeasurer for EguiMeasurer<'a> {
 }
 
 
-thread_local! {
-    /// Cache da DisplayList BASE (pré-barra/pré-offset) por DOM handle: chave =
-    /// (render_revision do Dom, viewport_w/h em bits). A barra de scroll e os
-    /// offsets são aplicados por-frame SOBRE a lista cacheada (mutações baratas);
-    /// só a mudança real de DOM/estilo/viewport re-roda o layout.
-    static LAYOUT_CACHE: std::cell::RefCell<std::collections::HashMap<u64, (u64, u32, u32, layout::DisplayList)>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
-    /// Cache equivalente para o caminho sem scroll, que recebe `&Dom` diretamente
-    /// em vez de um handle. A identidade da árvore evita reutilizar uma lista de
-    /// outro DOM quando a alocação de memória for reaproveitada.
-    static DIRECT_LAYOUT_CACHE: std::cell::RefCell<std::collections::HashMap<u64, (u64, u32, u32, layout::DisplayList)>> =
-        std::cell::RefCell::new(std::collections::HashMap::new());
-}
+// Os dois caches de DisplayList que viviam aqui foram para o `rts-dom`
+// (`layout::layout_cached`): eram a mesma pergunta — "o layout mudou?" — feita
+// duas vezes neste crate, e nenhuma das duas servia o caminho HEADLESS, que
+// chamava `layout_document` por consulta de geometria.
 
 /// Renderiza um `Dom` inteiro: reutiliza ou calcula o layout (rts-dom) e PINTA a display list.
 ///
@@ -138,24 +138,7 @@ pub(crate) fn render_dom(ui: &mut egui::Ui, dom: &crate::dom::Dom) {
     let viewport_h = ui.ctx().screen_rect().height().max(1.0);
     let measurer = EguiMeasurer { ctx: ui.ctx() };
     let ctx = layout::LayoutCtx { viewport_w, viewport_h, measurer: &measurer };
-    let key = dom.cache_identity();
-    let rev = dom.render_revision();
-    let list = DIRECT_LAYOUT_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some((c_rev, c_w, c_h, cached)) = cache.get(&key) {
-            if *c_rev == rev && *c_w == viewport_w.to_bits() && *c_h == viewport_h.to_bits() {
-                return cached.clone();
-            }
-        }
-        let fresh = layout::layout_document(dom, &ctx);
-        if cache.len() >= 64 && !cache.contains_key(&key) {
-            if let Some(old_key) = cache.keys().next().copied() {
-                cache.remove(&old_key);
-            }
-        }
-        cache.insert(key, (rev, viewport_w.to_bits(), viewport_h.to_bits(), fresh.clone()));
-        fresh
-    });
+    let list = layout::layout_cached(dom, &ctx);
     paint_list(ui, &list, 0.0);
     // reserva a altura total ocupada (p/ o egui ao redor dimensionar).
     ui.allocate_space(egui::vec2(ui.available_width(), list.content_height));
@@ -185,19 +168,10 @@ pub(crate) fn render_dom_scrolled(
     // muda. Era a "travada" ao clicar: re-layout completo por frame.
     let measurer = EguiMeasurer { ctx: ui.ctx() };
     let lctx = layout::LayoutCtx { viewport_w, viewport_h, measurer: &measurer };
-    let rev = rts_dom::store::with_dom(h, |d| d.render_revision()).unwrap_or(0);
-    let mut list = LAYOUT_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some((c_rev, c_w, c_h, cached)) = cache.get(&h) {
-            if *c_rev == rev && *c_w == viewport_w.to_bits() && *c_h == viewport_h.to_bits() {
-                return cached.clone(); // clone da lista pronta ≪ re-layout
-            }
-        }
-        let fresh = rts_dom::store::with_dom(h, |d| layout::layout_document(d, &lctx))
-            .unwrap_or_default();
-        cache.insert(h, (rev, viewport_w.to_bits(), viewport_h.to_bits(), fresh.clone()));
-        fresh
-    });
+    // A barra e o offset são aplicados SOBRE a lista, então esta cópia é
+    // necessária — mas ela agora parte de uma lista cacheada pelo próprio DOM.
+    let mut list = rts_dom::store::with_dom(h, |d| (*layout::layout_cached(d, &lctx)).clone())
+        .unwrap_or_default();
     let content_h = list.content_height;
 
     // OFFSET de scroll: estado por-handle no egui (input é do backend). Acumula a roda

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -508,3 +508,51 @@ change — comparing old and new computed style to classify what actually change
 and having a drawing that can be repainted without being rebuilt.
 
 In absolute terms, 0.27 ms on a 3000-element page is 1.6% of a 60 fps frame.
+
+---
+
+## Final scoreboard (2026-08-18)
+
+3005-element synthetic page, Chrome on the same machine, four runs:
+
+| operation | Chrome | rts-dom (start → end) | |
+|---|---|---|---|
+| **text on a leaf + frame** | 0.369 ms | 6.63 → **0.157 ms** | **2.3× faster than Chrome** |
+| colour-only class + frame | 0.0053 ms | 6.67 → 0.170 ms | 32× |
+| inert class + frame | — | 6.67 → 0.013 ms | — |
+| idle frame | 0.00045 ms | 6.97 → 0.000 ms | par |
+| full relayout | 8.5 ms | 6.97 → 0.121 ms | we win |
+| `querySelectorAll('.card')` | 0.0105 ms | → 0.010 ms | par |
+| append 2000, layout every 100 | 32.5 ms | 67.6 → ~10 ms | we win |
+
+Bootstrap cover: parse 17.8 → 9.2 ms · cold layout 23.1 → 11.9 ms · text 0.375 →
+0.042 ms · class 0.096 → 0.017 ms · hover 1.618 → 0.098 ms · memory 9.59 → 2.0 MiB.
+
+**WhatsApp Web, the real page** (captured from Chrome with its CSS inlined:
+1.25 MB of HTML, 298 elements, 24 levels deep, 6.8 MiB of parsed stylesheet):
+parse 38 ms, cold layout 51 ms, idle frame 0.004 ms, text mutation 0.15 ms,
+`querySelectorAll` 0.078 ms. Chrome on the same page: DOM interactive 106 ms,
+text mutation 0.0062 ms.
+
+### What the last two changes were, and what they cost to find
+
+The **container patch** replaces one subtree reference inside the parent's
+drawing instead of rebuilding the parent. It was built once before, over the
+flat list, and reverted — copying 3000 items to swap one stretch cost exactly
+what it saved. Over the tree it is a pointer swap, and the fragment's big
+vectors became `Rc` so the patched container shares everything unchanged.
+
+The **out-of-flow guard** came from the phases: 78% of a mutation frame was in
+no phase at all — it was the pass that looks for `position:absolute`, walking
+the whole tree asking for each node's computed style, on a page with none.
+
+### What is left, and why it is a different problem
+
+A colour-only class change is 32× Chrome. Our invalidation is per NODE; Chrome's
+is per PROPERTY — it knows `color` cannot move a box and never reflows, it
+repaints. The infrastructure for that (a `paint` flag on the property table, a
+`differs_in_layout` derived from it) was written and then REMOVED from this
+branch: without a repaint path that skips layout entirely it had no consumer,
+and unused machinery is worse than none. It is the next frontier, named.
+
+In absolute terms 0.17 ms on a 3000-element page is 1% of a 60 fps frame.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -301,3 +301,55 @@ gap left, and it is what the next work attacks.
 `querySelectorAll` being 2× slower is a separate, smaller gap: we walk the tree
 in document order and filter by target key, while Chrome starts from the
 `.class` bucket when the selector's key allows it.
+
+---
+
+## Incremental layout, and the scoreboard after it (2026-08-18)
+
+The reference above said the gap was one thing: Chrome relayouts the subtree
+that changed, we relayouted the document. `layout_block_reusing` closes it for
+the normal vertical flow — a `Fragment` holds what a subtree produced (items,
+per-node rects, hit order, scroll regions, size) and reusing it is emitting
+those items shifted by the difference in position. The key is the measurement
+key without the position, because position is exactly what gets corrected.
+
+Per frame of a text mutation on a 3005-element page: **1000 subtrees reused, 4
+recalculated**, 5 `layout_block` calls and 1 text measurement — against 15 015
+and 11 000 at the start of the campaign.
+
+### Where we stand now
+
+3005-element page, same machine:
+
+| operation | Chrome | rts-dom (start → now) | remaining gap |
+|---|---|---|---|
+| text on a leaf + layout | 0.369 ms | 6.63 → **0.724 ms** | 2.0× |
+| class on a leaf + layout | 0.0053 ms | 6.67 → **0.187 ms** | 35× |
+| inert class toggle + frame | — | 6.67 → **0.030 ms** | — |
+| idle frame | 0.00045 ms | 6.97 → **0.000 ms** (cached) | par |
+| full relayout, no cache | 8.5 ms | 6.97 → 0.168 ms | we win |
+| `querySelectorAll` | 0.097 ms | 0.399 → 0.213 ms | 2.2× |
+| cold layout | — | 26.7 → 15.8 ms | — |
+| append 2000, layout every 100 | 32.5 ms | 67.6 → ~17 ms | we win |
+
+Bootstrap cover page: parse 17.8 → 8.9 ms, cold layout 23.1 → 11.6 ms, text
+mutation 0.375 → 0.050 ms, class 0.096 → 0.017 ms, hover 1.618 → 0.083 ms,
+memory 9.59 → 2.0 MiB.
+
+### What still separates us from Chrome, measured
+
+**Class mutation is 35× slower and the cause is structural, not incremental.**
+We reuse the *computation* of each untouched subtree but still rebuild the flat
+`DisplayList` every frame — 15 000 items copied so the backend can consume one
+contiguous list. Chrome keeps a retained tree and repaints the damaged part. A
+retained display list (a list of `Rc<Fragment>` instead of items) is the next
+structural step; `Rc<str>` on text items was the first half of it, and took the
+text mutation from 1.31 to 0.724 ms.
+
+**`querySelectorAll` is 2.2× slower**, unchanged in nature since the first
+measurement: we walk in document order filtering by target key; Chrome starts
+from the class bucket when the selector allows.
+
+**And the caveat from the first comparison still holds**: where we win, we are
+doing less work — character-count text metrics against real shaping, no subpixel
+positioning, no accessibility tree, a much smaller CSS surface.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -339,13 +339,24 @@ memory 9.59 → 2.0 MiB.
 
 ### What still separates us from Chrome, measured
 
-**Class mutation is 35× slower and the cause is structural, not incremental.**
-We reuse the *computation* of each untouched subtree but still rebuild the flat
-`DisplayList` every frame — 15 000 items copied so the backend can consume one
-contiguous list. Chrome keeps a retained tree and repaints the damaged part. A
-retained display list (a list of `Rc<Fragment>` instead of items) is the next
-structural step; `Rc<str>` on text items was the first half of it, and took the
-text mutation from 1.31 to 0.724 ms.
+**Class mutation is 35× slower, and the obvious explanation was WRONG.**
+
+We reuse the computation of each untouched subtree but still rebuild the flat
+`DisplayList` every frame — 30 000 items copied per frame on the synthetic page.
+That looked like the remaining cost, so it was built: a `SharedChunk` holding
+`Rc<Fragment>` plus an offset, an iterator that interleaves own items and shared
+ones, and a backend that adds the offset while painting instead of copying.
+
+**It did not get faster.** Text mutation 0.724 → 0.809 ms, class 0.187 → 0.171 ms
+— inside the machine's noise — and the *cold* layout got worse (15.8 → 16.9 ms),
+because every cache miss now has to flatten the fragment it just built. The work
+was reverted; what stayed is this paragraph.
+
+So the copy was not the bottleneck. The remaining cost is in producing a
+fragment the first time and in the per-frame walk itself, not in moving the
+items around. Whatever closes the last 35× is not "stop copying" — that
+hypothesis is dead, and the next attempt should start by measuring where a
+missed fragment actually spends its time.
 
 **`querySelectorAll` by class now beats Chrome**: 0.009 ms against 0.0105 ms for
 `.card` over 1000 matches, after the query started from the `.class` index

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -409,3 +409,47 @@ instead of a display list rebuilt from it.
 
 In absolute terms 0.8 ms is under 5% of a 60 fps frame on a page of 3000
 elements, so this is a margin question, not a viability one.
+
+---
+
+## The floor, found by two failed attempts (2026-08-18)
+
+After the incremental layout, the remaining gap on a class toggle (150× Chrome)
+looked like it had two possible causes. Both were built, measured and reverted.
+
+**Attempt 1 — retained display list.** `SharedChunk` holding `Rc<Fragment>` plus
+an offset, an iterator interleaving own and shared items, the backend adding the
+offset while painting instead of copying. Text mutation 0.724 → 0.809 ms, class
+0.187 → 0.171 ms — inside the machine's noise — and the cold layout got *worse*,
+because every miss now flattens the fragment it just built.
+
+**Attempt 2 — container patching.** Track which direct children are dirty
+(marked while the invalidation already walks the ancestor chain), keep per-child
+item spans in the parent's fragment, and on a miss rebuild only the dirty child
+and splice its items into the previous drawing. It worked — the counters showed
+containers being patched instead of walked — and the timing was **identical**:
+0.689 ms with patching against 0.676 ms with it disabled by an env switch, on
+the same build.
+
+Both failed for the same reason, and that reason is the finding:
+
+> **The cost is proportional to the number of ITEMS the page produces, not to
+> the layout work avoided.** A page of 3005 elements emits ~30 000 display items;
+> whether we re-walk the children, copy fragments, or splice a previous vector,
+> we still materialize that list every frame. Skipping the layout of a thousand
+> untouched subtrees was worth 9× (that is the incremental layout, and it stayed).
+> Skipping the *copy* is worth nothing while the output is a flat list rebuilt
+> per frame.
+
+What would actually move it is the consumer accepting a hierarchy instead of a
+list — the backend walking a tree of fragments and painting from it, with no
+flat `DisplayList` in the middle. That is a change to the contract between
+`rts-dom` and every renderer, not an optimization inside the layout, and it is
+where the next attempt should start. Attempt 1 went in that direction but kept
+materializing at every point that mutates items (CSS `transform`, the scroll
+`BeginClip`, the tests), which is why it paid the cost twice.
+
+Both attempts are reverted; what stays is this section, the scenarios that
+measure the cases (`classe de cor + frame`, `classe que casa + frame`), and the
+number that bounds the next attempt: **0.17 ms is the floor for any frame that
+rebuilds this page's list**, measured with every subtree reused.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -369,3 +369,43 @@ Chrome's 0.097 ms — because for those the walk is the only complete answer.
 **And the caveat from the first comparison still holds**: where we win, we are
 doing less work — character-count text metrics against real shaping, no subpixel
 positioning, no accessibility tree, a much smaller CSS surface.
+
+---
+
+## Final scoreboard of this campaign (2026-08-18)
+
+3005-element synthetic page, Chrome on the same machine, `--iters 30`:
+
+| operation | Chrome | rts-dom (campaign start → now) | gap |
+|---|---|---|---|
+| text on a leaf + frame | 0.369 ms | 6.63 → **0.619 ms** | 1.7× |
+| **class that matches a rule + frame** | 0.0053 ms | 6.67 → **0.797 ms** | 150× |
+| class that matches nothing + frame | — | 6.67 → **0.022 ms** | — |
+| idle frame | 0.00045 ms | 6.97 → **0.000 ms** | par |
+| full relayout | 8.5 ms | 6.97 → 0.175 ms | we win |
+| `querySelectorAll('.card')` | 0.0105 ms | → **0.010 ms** | par |
+| `querySelectorAll` (tag + attr) | 0.097 ms | 0.399 → 0.222 ms | 2.3× |
+| append 2000, layout every 100 | 32.5 ms | 67.6 → **11.7 ms** | we win |
+| cold layout | — | 26.7 → 16.3 ms | — |
+
+Bootstrap cover page: parse 17.8 → 9.6 ms · cold layout 23.1 → 13.3 ms · text
+0.375 → 0.047 ms · class 0.096 → 0.017 ms · hover 1.618 → 0.089 ms · memory
+9.59 → 2.0 MiB.
+
+### The one number that is still 150×, and what it would take
+
+A class change that actually matches a rule invalidates the node and its
+ancestors, so the container is rebuilt — and rebuilding a container means
+WALKING its thousand children, even though 999 of them hit the fragment cache
+and cost only an emit. Chrome does not walk: it keeps a retained layout tree
+with positions and reflows the path that changed.
+
+That is the architecture difference, and it is the honest name for the remaining
+gap. Everything cheaper than it has been done: the fragment cache removes the
+recomputation, the fast path removes the reclassification, the display cache
+removes the whole frame when nothing moved. What is left is not an optimization,
+it is a different data structure — a layout tree that survives between frames
+instead of a display list rebuilt from it.
+
+In absolute terms 0.8 ms is under 5% of a 60 fps frame on a page of 3000
+elements, so this is a margin question, not a viability one.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -253,3 +253,51 @@ walks the parent's subtree per removed node), and the `HashSet` inherited from
 - **12.4% of Bootstrap's rules are dropped at parse** — pseudo-elements and
   compound `:not()` lead the list.
 - **Removing a node leaves its index entries** (the audit reports it as a leak).
+
+---
+
+## The reference: Chrome on the same pages (2026-08-18)
+
+The goal is a DOM fast enough to stand next to a real browser, so the only
+honest way to know where we are is to run the same operations in one. Chrome on
+the same machine, same two files opened over `file://`, timing with
+`performance.now()` over batches (a single mutation is below that clock's ~0.1 ms
+resolution, so each number is a batch of 300–2000 divided by the count).
+
+Synthetic page, 3005 elements:
+
+| operation | Chrome | rts-dom | ratio |
+|---|---|---|---|
+| class toggle on a leaf + layout | 0.0053 ms | 2.9 ms → **0.133 ms** after the early-out | 25× |
+| text change on a leaf + layout | 0.369 ms | 2.9 ms | 8× |
+| idle frame | 0.00045 ms | 0.000 ms (cached) | par |
+| `querySelectorAll('.btn, div, a[href]')` | 0.097 ms | 0.207 ms | 2.1× |
+| append 2000 nodes, layout every 100 | 32.5 ms | 30.2 ms | **we win** |
+| full forced relayout (padding on root) | 8.5 ms | 2.6 ms | **we win** |
+
+Bootstrap cover page (68 elements, 232 KB of CSS):
+
+| operation | Chrome | rts-dom |
+|---|---|---|
+| parse + DOM interactive | 21.9 ms | 8.9 ms |
+| class toggle + layout | 0.0006 ms | 0.038 ms |
+| text change + layout | 0.0010 ms | 0.160 ms |
+| `querySelectorAll` | 0.0028 ms | 0.009 ms |
+
+### How to read this, honestly
+
+**Where we "win" we are doing less work.** Our text measurement multiplies a
+character count; Chrome shapes real fonts with kerning and ligatures, does
+subpixel positioning, builds an accessibility tree, and handles a CSS surface
+several times larger. A full relayout being 3× faster than Chrome's is a
+statement about scope, not about quality.
+
+**Where we lose, the comparison is fair, and it is the same cause twice.**
+Chrome is 25× faster on a class toggle and 8× on a text change because it
+relayouts *the subtree that changed*. We relayout the document: `layout_document`
+walks the whole tree every time the revision moves. That is the one structural
+gap left, and it is what the next work attacks.
+
+`querySelectorAll` being 2× slower is a separate, smaller gap: we walk the tree
+in document order and filter by target key, while Chrome starts from the
+`.class` bucket when the selector's key allows it.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -473,3 +473,38 @@ existed to avoid. Here the tree is a tree all the way down.
 | append 2000, layout every 100 | ~17 ms | **10.7 ms** | 32.5 ms |
 
 Text mutation is now **1.25× Chrome**, from 18× at the start of the campaign.
+
+---
+
+## Where the campaign ended (2026-08-18)
+
+3005-element page, medians of five runs, Chrome on the same machine:
+
+| operation | Chrome | rts-dom (start → end) | |
+|---|---|---|---|
+| **text on a leaf + frame** | 0.369 ms | 6.63 → **0.258 ms** | **we pass Chrome** |
+| colour-only class + frame | 0.0053 ms | 6.67 → 0.271 ms | 51× |
+| inert class + frame | — | 6.67 → 0.020 ms | — |
+| idle frame | 0.00045 ms | 6.97 → 0.000 ms | par |
+| full relayout | 8.5 ms | 6.97 → 0.195 ms | we win |
+| `querySelectorAll('.card')` | 0.0105 ms | → 0.010 ms | par |
+| append 2000, layout every 100 | 32.5 ms | 67.6 → 10.2 ms | we win |
+| cold layout | — | 26.7 → 16.3 ms | — |
+
+Bootstrap cover page: parse 17.8 → 9.4 ms · cold layout 23.1 → 13.1 ms · text
+0.375 → 0.042 ms · class 0.096 → 0.016 ms · hover 1.618 → 0.100 ms · memory
+9.59 → 2.0 MiB.
+
+### The last gap, and why it is a different problem
+
+A colour-only class change is still 51× Chrome, and it is no longer about
+layout: we already skip the layout of every untouched subtree, and we no longer
+copy items or geometry. What remains is that we rebuild the container's drawing
+*at all* — because our invalidation is per NODE and Chrome's is per PROPERTY. It
+knows `color` cannot move a box, so it never reflows: it repaints.
+
+Paint-only invalidation is the next frontier, and it is a different kind of
+change — comparing old and new computed style to classify what actually changed,
+and having a drawing that can be repainted without being rebuilt.
+
+In absolute terms, 0.27 ms on a 3000-element page is 1.6% of a 60 fps frame.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -449,7 +449,27 @@ where the next attempt should start. Attempt 1 went in that direction but kept
 materializing at every point that mutates items (CSS `transform`, the scroll
 `BeginClip`, the tests), which is why it paid the cost twice.
 
-Both attempts are reverted; what stays is this section, the scenarios that
-measure the cases (`classe de cor + frame`, `classe que casa + frame`), and the
-number that bounds the next attempt: **0.17 ms is the floor for any frame that
-rebuilds this page's list**, measured with every subtree reused.
+Both attempts were reverted, and then the third one — the actual hierarchy —
+worked.
+
+## The hierarchy, and the third attempt (2026-08-18)
+
+`Fragment` now keeps the subtrees it reused **by reference** (`ChildRef` with an
+entry point and an offset), and so does `DisplayList`. Nothing on the common
+path copies an item any more: `walk` traverses the tree yielding
+`(item, dx, dy)`, and the backend — which already added an origin — adds one
+more offset. Mutating (`transform`, the scroll `BeginClip`) or comparing (the
+tests) calls `materialize`, which is rare and local.
+
+The difference from attempt 1 is one line of design: there, a fragment FLATTENED
+its grandchildren when built, so every miss paid the copy the optimization
+existed to avoid. Here the tree is a tree all the way down.
+
+| scenario (3005 elements) | flat list | tree | Chrome |
+|---|---|---|---|
+| text + relayout | 0.616 ms | **0.463–0.474 ms** | 0.369 ms |
+| colour-only class + frame | 0.700 ms | **0.481–0.516 ms** | 0.0053 ms |
+| idle relayout | 0.171 ms | **0.138 ms** | — |
+| append 2000, layout every 100 | ~17 ms | **10.7 ms** | 32.5 ms |
+
+Text mutation is now **1.25× Chrome**, from 18× at the start of the campaign.

--- a/docs/ui/dom-metrics.md
+++ b/docs/ui/dom-metrics.md
@@ -328,7 +328,8 @@ and 11 000 at the start of the campaign.
 | inert class toggle + frame | — | 6.67 → **0.030 ms** | — |
 | idle frame | 0.00045 ms | 6.97 → **0.000 ms** (cached) | par |
 | full relayout, no cache | 8.5 ms | 6.97 → 0.168 ms | we win |
-| `querySelectorAll` | 0.097 ms | 0.399 → 0.213 ms | 2.2× |
+| `querySelectorAll('.card')` | 0.0105 ms | — → **0.009 ms** | we win |
+| `querySelectorAll` (tag + attr in the list) | 0.097 ms | 0.399 → 0.212 ms | 2.2× |
 | cold layout | — | 26.7 → 15.8 ms | — |
 | append 2000, layout every 100 | 32.5 ms | 67.6 → ~17 ms | we win |
 
@@ -346,9 +347,13 @@ retained display list (a list of `Rc<Fragment>` instead of items) is the next
 structural step; `Rc<str>` on text items was the first half of it, and took the
 text mutation from 1.31 to 0.724 ms.
 
-**`querySelectorAll` is 2.2× slower**, unchanged in nature since the first
-measurement: we walk in document order filtering by target key; Chrome starts
-from the class bucket when the selector allows.
+**`querySelectorAll` by class now beats Chrome**: 0.009 ms against 0.0105 ms for
+`.card` over 1000 matches, after the query started from the `.class` index
+instead of walking the tree. What made the index usable was numbering the tree
+in document order (revalidated by revision), because the index keeps arena
+order and the API promises document order. A list that mixes in a tag or an
+attribute selector (`.btn, div, a[href]`) still walks — 0.212 ms against
+Chrome's 0.097 ms — because for those the walk is the only complete answer.
 
 **And the caveat from the first comparison still holds**: where we win, we are
 doing less work — character-count text metrics against real shaping, no subpixel


### PR DESCRIPTION
Continuação de #2328/#2329. Meta: um DOM rápido o bastante para ficar ao lado de um browser, com o **Chrome medido na mesma máquina** como referência.

## Resultado (3005 elementos, medianas de cinco execuções)

| operação | Chrome | rts-dom (início → agora) | |
|---|---|---|---|
| **texto numa folha + frame** | 0,369 ms | 6,63 → **0,258 ms** | **passamos o Chrome** |
| classe só de cor + frame | 0,0053 ms | 6,67 → 0,271 ms | 51× |
| classe inerte + frame | — | 6,67 → 0,020 ms | — |
| frame parado | 0,00045 ms | 6,97 → **0,000 ms** | par |
| relayout completo | 8,5 ms | 6,97 → 0,195 ms | ganhamos |
| `querySelectorAll('.card')` | 0,0105 ms | → 0,010 ms | par |
| append 2000 + layout/100 | 32,5 ms | 67,6 → **10,2 ms** | ganhamos |

Bootstrap: parse 17,8 → 9,4 ms · layout frio 23,1 → 13,1 ms · texto 0,375 → 0,042 ms · hover 1,618 → 0,100 ms · **memória 9,59 → 2,0 MiB**.

## As mudanças

| # | achado medido | mudança |
|---|---|---|
| 1 | medição de texto palavra a palavra — 11 000/frame | mede o run inteiro quando cabe |
| 2 | 12 000 lookups SipHash/frame no memo de estilo | `Vec` indexado |
| 3 | layout por consulta de geometria; dois caches no egui | `layout_cached` + `TextMeasurer::identity()` |
| 4 | SipHash nas chaves internas | `fasthash::FastMap` |
| 5 | classe que nenhuma regra cita invalidava tudo | descarte precoce |
| 6 | **documento inteiro refeito por mutação** | **layout incremental por `Fragment`** |
| 7 | `String` por item de texto | `Rc<str>` |
| 8 | consulta andava a árvore com o índice parado ao lado | numeração documental + índice |
| 9 | o laço reclassificava os mil filhos | consulta o fragmento antes |
| 10 | **a saída era uma lista plana refeita por frame** | **árvore de fragmentos** (`walk`) |
| 11 | a geometria da subárvore era copiada por frame | `geometry()` sob demanda |

## Método — o que foi refutado, e não escondido

- **Reservar as coleções**: sem efeito, não entrou.
- **Display list retida, tentativa 1**: implementada inteira e **revertida** — achatava os netos no miss, então pagava a cópia que evitava.
- **Costura de container**: implementada, funcionou pelos contadores, e o tempo ficou **idêntico** (0,689 vs 0,676 ms com ela desligada). Revertida.
- Foram essas três que levaram à décima mudança, que é a que funcionou.

## Correção

Teste de equivalência (reuso × cálculo do zero) a cada mutação; 120 mutações sorteadas com semente fixa; verificação nas páginas reais do harness. Pegaram, antes do commit: `set_text` servindo o texto **velho**, `touch()` sem alvo, tolerância de float na translação, ordem de `hit_order` invertida (z-order), geometria cacheada antes dos `position:absolute`, e pontos de entrada não corrigidos na inserção do fundo.

## O último gap, com o nome certo

Uma classe que só muda cor ainda é 51× o Chrome — e já não é sobre layout. É que a nossa invalidação é por **nó** e a do Chrome é por **propriedade**: ele sabe que `color` não move caixa e nem reflui. Invalidação só-de-pintura é a próxima fronteira. Em absoluto são 0,27 ms, 1,6% de um frame de 60 fps.

## Verificação

`cargo test --release -p rts-dom` → 223 · `--features metrics` → 228 · `-p rts-egui` → 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GjdssWEr2NgWZv21N93By