### PR TITLE
feat(dom): rts:dom no motor novo, canvas com pixels na tela, e a correção que fez a página real aparecer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,14 @@ name = "rts-dom"
 version = "0.1.0"
 
 [[package]]
+name = "rts-dom-bridge"
+version = "0.1.0"
+dependencies = [
+ "rts-core",
+ "rts-dom",
+]
+
+[[package]]
 name = "rts-egui"
 version = "0.1.0"
 dependencies = [
@@ -4499,6 +4507,7 @@ dependencies = [
  "rts-codegen",
  "rts-core",
  "rts-cranelift",
+ "rts-dom-bridge",
  "rts-node",
  "rts-physics",
  "rts-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     ".",
     "crates/rts-linker",
     "crates/rts-dom",
+    "crates/rts-dom-bridge",
     "crates/rts-input",
     "crates/rts-render",
     "crates/rts-egui",

--- a/crates/rts-dom-bridge/Cargo.toml
+++ b/crates/rts-dom-bridge/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rts-dom-bridge"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+# A ponte entre o `rts-dom` (a árvore, o layout, o estilo — que não conhece
+# motor nenhum) e a superfície de host do `rts-core` (namespaces, coerção).
+#
+# CRATE PRÓPRIO e não um módulo do `rts-ui`, porque o DOM headless é o ponto:
+# parsear, consultar e mutar HTML sem abrir janela é o que o `rts:dom` oferece,
+# e amarrá-lo à feature `ui` faria um build sem tela perder o DOM junto com a
+# janela. O `rts-ui` continua sendo a ponte da UI; esta é a do documento.
+
+[dependencies]
+rts-core = { path = "../rts-core" }
+rts-dom = { path = "../rts-dom" }

--- a/crates/rts-dom-bridge/src/lib.rs
+++ b/crates/rts-dom-bridge/src/lib.rs
@@ -1,0 +1,60 @@
+//! `rts:dom` no motor novo — a árvore de documento alcançável do TypeScript.
+//!
+//! # O que este crate é
+//!
+//! A tradução entre duas convenções que não se conhecem: o `rts-dom` fala em
+//! `Dom`, `NodeId` e `&str`; o `rts-core` fala em `(env, this, a0..a3) -> u64`.
+//! Nenhum dos dois deve aprender o outro — é a mesma divisão que mantém o
+//! `rts-cranelift` sem linguagem e o `rts-codegen` sem máquina.
+//!
+//! # Por que um crate, e não um módulo do `rts-ui`
+//!
+//! Porque o DOM headless é o ponto: parsear, consultar e mutar HTML **sem abrir
+//! janela** é o que distingue este runtime de um Node com jsdom. Pendurar o
+//! `rts:dom` na feature `ui` faria um build sem tela perder o documento junto
+//! com a janela, e um servidor que renderiza HTML não tem tela.
+//!
+//! O `rts-ui` continua sendo a ponte da UI; esta é a do documento. As duas têm
+//! a mesma forma porque o problema é o mesmo, e a duplicação de três
+//! conversores (`value.rs`) é o preço de não arrastar winit e wgpu para dentro
+//! de um parser de HTML.
+//!
+//! # As convenções da fronteira
+//!
+//! - O **handle do documento** é um `u64` opaco vindo de `parseHtml`, chave de
+//!   um `thread_local` no `rts-dom` — o motor não conhece o DOM, então o
+//!   `Entry` do runtime não ganha uma variante para ele.
+//! - Um **nó** cruza como o `NodeId` VERSIONADO empacotado num `i64`
+//!   (`(geração << 32) | índice`). A geração é o que impede um id de uma árvore
+//!   anterior de ser aplicado a um nó vivo de outra.
+//! - **`-1` é "nó nenhum"**, e não `0` nem `u64::MAX`: precisa ser exato como
+//!   `number` no TS e distinguível de qualquer id real.
+//! - Uma **lista** (querySelectorAll, filhos) cruza como `count` + `at(i)`, e
+//!   não como array: montar um array exigiria que este crate soubesse construir
+//!   um objeto do runtime a cada consulta, e a fachada em TS que consome isto
+//!   já monta o array do lado dele.
+
+use rts_core::entry::{self, Context, Provided};
+
+mod nodes;
+mod tree;
+mod value;
+
+/// Registra `rts:dom`.
+///
+/// Chamado pelo HOST e não por um construtor daqui, pela mesma razão que o
+/// `rts_std::install` e o `rts_ui::install`: quais módulos existem é uma
+/// decisão sobre o ambiente que o programa recebe.
+pub fn install(context: &mut Context) {
+    let members: Vec<(&str, Provided)> =
+        tree::MEMBERS.iter().chain(nodes::MEMBERS).copied().collect();
+    let surface = entry::make_namespace(context, &members);
+    entry::declare_module(context, "rts:dom", surface);
+}
+
+/// O prelude `.ts` da fachada ergonômica (`document`/`Element`), para o host
+/// incluir DEPOIS de registrar o namespace.
+///
+/// Vive no `rts-dom` (é dele o texto) e sai por aqui porque quem instala o
+/// namespace é quem sabe quando o prelude pode ser avaliado.
+pub const PRELUDE_TS: &str = rts_dom::DOM_TS;

--- a/crates/rts-dom-bridge/src/nodes.rs
+++ b/crates/rts-dom-bridge/src/nodes.rs
@@ -1,0 +1,259 @@
+//! Os NÓS: consultar, ler, mutar e medir.
+//!
+//! Todo membro daqui recebe `(doc, node, …)` — o handle do documento e o
+//! `NodeId` versionado. Um id de outra árvore não resolve (a geração não casa) e
+//! a chamada vira um no-op ou `-1`, que é a guarda que impede aplicar estado ao
+//! nó errado depois de um `parseHtml` novo.
+//!
+//! ## Listas cruzam como `count` + `at(i)`
+//!
+//! `querySelectorAll` responde uma contagem, e cada elemento sai por índice. É
+//! duas travessias em vez de uma, e é o que evita este crate ter de construir um
+//! array do runtime — a fachada em TS já monta o array do lado dela, onde o
+//! array é natural.
+
+use rts_core::entry::Provided;
+use rts_dom::NodeId;
+
+use crate::value::{handle, int, integer, nothing, num, string, text};
+
+pub const MEMBERS: &[(&str, Provided)] = &[
+    // consulta
+    ("querySelector", query_selector),
+    ("querySelectorAllCount", query_all_count),
+    ("querySelectorAllAt", query_all_at),
+    ("matches", matches_selector),
+    // leitura
+    ("getText", get_text),
+    ("getAttribute", get_attribute),
+    ("tagName", tag_name),
+    ("nodeType", node_type),
+    ("childCount", child_count),
+    ("childAt", child_at),
+    ("parentElement", parent_element),
+    ("innerHtml", inner_html),
+    ("outerHtml", outer_html),
+    // mutação
+    ("setText", set_text),
+    ("setAttribute", set_attribute),
+    ("removeAttribute", remove_attribute),
+    ("createElement", create_element),
+    ("createTextNode", create_text_node),
+    ("appendChild", append_child),
+    ("removeNode", remove_node),
+    ("setInnerHtml", set_inner_html),
+    // estilo e geometria
+    ("computedProperty", computed_property),
+    ("boundingRect", bounding_rect),
+    // pixels (o `<canvas>` e o `<img>` compartilham o mesmo caminho)
+    ("setPixels", set_pixels),
+];
+
+/// O `NodeId` de um argumento, ou `None` para a sentinela `-1`.
+fn node(value: u64) -> Option<NodeId> {
+    NodeId::from_abi(integer(value, -1))
+}
+
+/// `querySelector(doc, sel)` — o primeiro que casa, em ordem de documento.
+extern "C" fn query_selector(_e: u64, _t: u64, doc: u64, sel: u64, _b: u64, _c: u64) -> u64 {
+    let sel = text(sel);
+    let id = rts_dom::store::with_dom(handle(doc), |d| {
+        d.query(&sel).map(|n| n.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(id)
+}
+
+extern "C" fn query_all_count(_e: u64, _t: u64, doc: u64, sel: u64, _b: u64, _c: u64) -> u64 {
+    let sel = text(sel);
+    let n = rts_dom::store::with_dom(handle(doc), |d| d.query_all(&sel).len()).unwrap_or(0);
+    int(n as i64)
+}
+
+extern "C" fn query_all_at(_e: u64, _t: u64, doc: u64, sel: u64, i: u64, _c: u64) -> u64 {
+    let sel = text(sel);
+    let i = integer(i, 0).max(0) as usize;
+    let id = rts_dom::store::with_dom(handle(doc), |d| {
+        d.query_all(&sel).get(i).map(|n| n.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(id)
+}
+
+extern "C" fn matches_selector(_e: u64, _t: u64, doc: u64, n: u64, sel: u64, _c: u64) -> u64 {
+    let sel = text(sel);
+    let Some(id) = node(n) else { return int(0) };
+    let yes = rts_dom::store::with_dom(handle(doc), |d| d.matches_selector(id, &sel)).unwrap_or(false);
+    int(yes as i64)
+}
+
+extern "C" fn get_text(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.text_content(id).unwrap_or_default())
+        .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn get_attribute(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let name = text(name);
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.get_attr(id, &name).unwrap_or_default().to_string()
+    })
+    .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn tag_name(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.tag_name(id).unwrap_or_default().to_string()
+    })
+    .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn node_type(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    int(rts_dom::store::with_dom(handle(doc), |d| d.node_type(id)).unwrap_or(-1))
+}
+
+extern "C" fn child_count(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(0) };
+    let count = rts_dom::store::with_dom(handle(doc), |d| d.child_elements(id).len()).unwrap_or(0);
+    int(count as i64)
+}
+
+extern "C" fn child_at(_e: u64, _t: u64, doc: u64, n: u64, i: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let i = integer(i, 0).max(0) as usize;
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.child_elements(id).get(i).map(|c| c.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(out)
+}
+
+extern "C" fn parent_element(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.parent_element(id).map(|p| p.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(out)
+}
+
+extern "C" fn inner_html(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.inner_html(id).unwrap_or_default())
+        .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn outer_html(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.outer_html(id).unwrap_or_default())
+        .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn set_text(_e: u64, _t: u64, doc: u64, n: u64, s: u64, _c: u64) -> u64 {
+    let s = text(s);
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_text(id, &s));
+    nothing()
+}
+
+extern "C" fn set_attribute(_e: u64, _t: u64, doc: u64, n: u64, name: u64, v: u64) -> u64 {
+    let (name, v) = (text(name), text(v));
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_attr(id, &name, &v));
+    nothing()
+}
+
+extern "C" fn remove_attribute(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let name = text(name);
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.remove_attr(id, &name));
+    nothing()
+}
+
+extern "C" fn create_element(_e: u64, _t: u64, doc: u64, tag: u64, _b: u64, _c: u64) -> u64 {
+    let tag = text(tag);
+    let out = rts_dom::store::with_dom_mut(handle(doc), |d| d.create_element(&tag).to_abi())
+        .unwrap_or(-1);
+    int(out)
+}
+
+extern "C" fn create_text_node(_e: u64, _t: u64, doc: u64, s: u64, _b: u64, _c: u64) -> u64 {
+    let s = text(s);
+    let out = rts_dom::store::with_dom_mut(handle(doc), |d| d.create_text_node(&s).to_abi())
+        .unwrap_or(-1);
+    int(out)
+}
+
+extern "C" fn append_child(_e: u64, _t: u64, doc: u64, parent: u64, child: u64, _c: u64) -> u64 {
+    let (Some(p), Some(c)) = (node(parent), node(child)) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.append_child(p, c));
+    nothing()
+}
+
+extern "C" fn remove_node(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.remove_node(id));
+    nothing()
+}
+
+extern "C" fn set_inner_html(_e: u64, _t: u64, doc: u64, n: u64, s: u64, _c: u64) -> u64 {
+    let s = text(s);
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_inner_html(id, &s));
+    nothing()
+}
+
+/// `computedProperty(doc, node, nome)` — o valor COMPUTADO de uma propriedade
+/// CSS, no formato do browser (`getComputedStyle(el).color`).
+extern "C" fn computed_property(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let name = text(name);
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.computed_property(id, &name))
+        .unwrap_or_default();
+    string(&out)
+}
+
+/// `boundingRect(doc, node, componente)` — x, y, largura ou altura da caixa,
+/// como o `getBoundingClientRect` do browser devolve.
+///
+/// Um componente por chamada, e não um objeto: montar um objeto exigiria que
+/// este crate construísse um valor composto do runtime, e quem chama já está em
+/// TypeScript, onde `{x: r(0), y: r(1)}` é uma linha.
+extern "C" fn bounding_rect(_e: u64, _t: u64, doc: u64, n: u64, which: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return num(0.0) };
+    let which = integer(which, 0);
+    let v = rts_dom::store::with_dom(handle(doc), |d| {
+        d.bounding_component(id, which as i64)
+    })
+    .unwrap_or(0.0);
+    num(v as f64)
+}
+
+/// `setPixels(doc, node, buffer, w, h)` — os PIXELS de um nó de imagem.
+///
+/// É por aqui que um `<canvas>` ganha conteúdo: o layout emite um
+/// `DisplayItem::Image` e o backend sobe como textura. Os bytes são RGBA8, `w*h*4`
+/// deles, num `Buffer` — o mesmo caminho que o `<img>` do mini-browser usa
+/// depois de baixar e decodificar, e a razão de o canvas não precisar de um
+/// segundo mecanismo.
+extern "C" fn set_pixels(_e: u64, _t: u64, doc: u64, n: u64, buffer: u64, size: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    let (w, h) = {
+        let packed = integer(size, 0);
+        ((packed >> 16) as u32, (packed & 0xFFFF) as u32)
+    };
+    let bytes = rts_core::entry::with_runtime(|context| {
+        rts_core::entry::bytes_of(context, buffer)
+    });
+    let Some(bytes) = bytes else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_pixel_data(id, bytes, w, h));
+    nothing()
+}

--- a/crates/rts-dom-bridge/src/tree.rs
+++ b/crates/rts-dom-bridge/src/tree.rs
@@ -1,0 +1,69 @@
+//! O DOCUMENTO: criar, liberar, alimentar com CSS e alcançar a raiz.
+//!
+//! Um documento vive no store do `rts-dom` e é nomeado por um handle `u64`. O
+//! programa recebe esse handle de `parseHtml` e o passa de volta em cada
+//! chamada — a mesma forma que a janela do `rts:egui` usa, e pela mesma razão:
+//! o motor não conhece nem janela nem documento, então nenhum dos dois pode ser
+//! uma variante do `Entry` do runtime.
+
+use rts_core::entry::Provided;
+
+use crate::value::{handle, int, nothing, string, text};
+
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("parseHtml", parse_html),
+    ("createDocument", create_document),
+    ("free", free),
+    ("rootId", root_id),
+    ("addStylesheet", add_stylesheet),
+    ("dump", dump),
+    ("nodeCount", node_count),
+];
+
+/// `parseHtml(source)` — o handle do documento (0 em falha).
+extern "C" fn parse_html(_e: u64, _t: u64, source: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let dom = rts_dom::parse_html_to_dom(&text(source));
+    int(rts_dom::store::insert(dom) as i64)
+}
+
+/// `createDocument()` — um documento VAZIO, com só a raiz `#document`.
+///
+/// Existe separado do `parseHtml("")` porque é o caminho de quem monta a árvore
+/// por código (`createElement`/`appendChild`), e passar por um parser para
+/// obter uma árvore vazia é uma indireção que só confunde quem lê a chamada.
+extern "C" fn create_document(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    let dom = rts_dom::parse_html_to_dom("");
+    int(rts_dom::store::insert(dom) as i64)
+}
+
+/// `free(doc)` — solta o documento. O handle fica inválido.
+extern "C" fn free(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    rts_dom::store::remove(handle(doc));
+    nothing()
+}
+
+/// `rootId(doc)` — o `NodeId` da raiz `#document`, versionado.
+extern "C" fn root_id(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let id = rts_dom::store::with_dom(handle(doc), |d| d.root_id().to_abi()).unwrap_or(-1);
+    int(id)
+}
+
+/// `addStylesheet(doc, css)` — acrescenta regras de autor ao documento.
+extern "C" fn add_stylesheet(_e: u64, _t: u64, doc: u64, css: u64, _b: u64, _c: u64) -> u64 {
+    let css = text(css);
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.add_stylesheet(&css));
+    nothing()
+}
+
+/// `dump(doc)` — a árvore como texto indentado. Diagnóstico, não formato.
+extern "C" fn dump(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.dump()).unwrap_or_default();
+    string(&out)
+}
+
+/// `nodeCount(doc)` — quantos nós a arena tem. Inclui os desanexados: é uma
+/// medida de MEMÓRIA, não da árvore visível.
+extern "C" fn node_count(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let n = rts_dom::store::with_dom(handle(doc), |d| d.nodes.len()).unwrap_or(0);
+    int(n as i64)
+}

--- a/crates/rts-dom-bridge/src/value.rs
+++ b/crates/rts-dom-bridge/src/value.rs
@@ -1,0 +1,67 @@
+//! Ler um argumento que atravessou a fronteira, e devolver um valor para ela.
+//!
+//! Mesma forma que o `rts-ui` usa, pela mesma razão: um nativo do motor novo
+//! recebe `(env, this, a0, a1, a2, a3)` e devolve um `u64` opaco, e cada
+//! conversão precisa decidir o que fazer com um argumento que não é do tipo
+//! esperado. Aqui a resposta é sempre um DEFAULT, nunca um pânico — a fronteira
+//! de um nativo é `extern "C"` e um pânico dentro dela não desenrola.
+//!
+//! ## O que este módulo NÃO duplica
+//!
+//! O `rts-ui::value` existe e tem funções de nome igual. Não são reusadas
+//! porque isto teria de depender do `rts-ui`, e o `rts-ui` depende de janela,
+//! GPU e winit — o DOM headless perderia a razão de ser. As três funções aqui
+//! são as três que este crate usa, e não a superfície inteira daquele: `fields`
+//! (o objeto de opções de treze parâmetros do `drawMesh`) não tem análogo aqui,
+//! porque nenhum primitivo do DOM passa de quatro argumentos.
+
+use rts_core::entry;
+
+/// O número que um valor carrega, ou o default quando não carrega nenhum.
+pub fn number(value: u64, default: f64) -> f64 {
+    match entry::number_of(value) {
+        Some(number) if number.is_finite() => number,
+        _ => default,
+    }
+}
+
+/// O mesmo, truncado. Contagens, índices e o `NodeId` versionado cruzam como
+/// `i64` — e `-1` é a sentinela "nó nenhum" da ABI, que precisa sobreviver ao
+/// arredondamento (por isso truncar e não envolver).
+pub fn integer(value: u64, default: i64) -> i64 {
+    number(value, default as f64) as i64
+}
+
+/// Um handle de documento. Contador pequeno, cabe exato num double.
+pub fn handle(value: u64) -> u64 {
+    number(value, 0.0).max(0.0) as u64
+}
+
+/// O texto de um valor que É uma string, vazio para qualquer outro.
+///
+/// `string_in` e não `text_in` pela mesma razão do `rts-ui`: o segundo
+/// responderia `"42"` para o número 42, transformando um argumento trocado num
+/// nome de tag plausível em vez de num vazio visível.
+pub fn text(value: u64) -> String {
+    entry::with_runtime(|context| entry::string_in(context, value)).unwrap_or_default()
+}
+
+/// Um número como valor de retorno.
+pub fn num(v: f64) -> u64 {
+    entry::make_number(v)
+}
+
+/// Um inteiro como valor de retorno (contagens, ids, booleanos-como-0/1).
+pub fn int(v: i64) -> u64 {
+    entry::make_number(v as f64)
+}
+
+/// Uma string como valor de retorno.
+pub fn string(s: &str) -> u64 {
+    entry::with_runtime(|context| entry::make_string(context, s))
+}
+
+/// `undefined` — o retorno de quem não devolve nada.
+pub fn nothing() -> u64 {
+    entry::undefined_value()
+}

--- a/crates/rts-dom/examples/dom_metrics/main.rs
+++ b/crates/rts-dom/examples/dom_metrics/main.rs
@@ -37,6 +37,9 @@ struct Options {
     json_out: Option<String>,
     baseline: Option<String>,
     tolerance: f64,
+    /// `--explique`: por que a página desenha o que desenha — quais elementos
+    /// receberam geometria e quais não, e o motivo.
+    explicar: bool,
 }
 
 fn parse_args() -> Options {
@@ -50,6 +53,7 @@ fn parse_args() -> Options {
         json_out: None,
         baseline: None,
         tolerance: 5.0,
+        explicar: false,
     };
     let mut it = args.iter();
     while let Some(a) = it.next() {
@@ -65,6 +69,7 @@ fn parse_args() -> Options {
             "--json" => o.json_out = it.next().cloned(),
             "--baseline" => o.baseline = it.next().cloned(),
             "--tolerance" => o.tolerance = it.next().and_then(|v| v.parse().ok()).unwrap_or(o.tolerance),
+            "--explique" => o.explicar = true,
             other => o.files.push(other.to_string()),
         }
     }
@@ -166,6 +171,10 @@ fn bench_file(path: &str, o: &Options, baseline: Option<&str>) -> Option<String>
     match scenarios::verificar_equivalencia(&html, o.vw, o.vh, &m) {
         Ok(itens) => println!("    equivalência do reuso: OK ({itens} itens conferidos)"),
         Err(divergencia) => println!("    ⚠ EQUIVALÊNCIA QUEBRADA: {divergencia}"),
+    }
+
+    if o.explicar {
+        scenarios::explicar_pagina(&html, o.vw, o.vh, &m);
     }
 
     let runs = scenarios::page(&html, o.vw, o.vh, o.iters, &m);

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -344,6 +344,128 @@ pub fn page(html: &str, vw: f32, vh: f32, iters: u32, m: &CountingMeasurer) -> V
     runs
 }
 
+/// POR QUE a página desenha o que desenha: quais elementos receberam geometria,
+/// quais não, e o que os que não receberam têm em comum.
+///
+/// Uma página que abre em branco não diz onde falhou — o layout não reclama,
+/// ele só não emite. Esta visão é o que transforma "ficou branco" numa lista de
+/// causas: `display:none`, fora do fluxo, tamanho zero, ou tag que o motor pula.
+pub fn explicar_pagina(html: &str, vw: f32, vh: f32, m: &CountingMeasurer) {
+    use std::collections::BTreeMap;
+    let dom = parse_html_to_dom(html);
+    let lista = rts_dom::layout::layout_document(&dom, &ctx(m, vw, vh));
+    let geo = lista.geometry();
+
+    let mut com_caixa = 0usize;
+    let mut sem_caixa = 0usize;
+    let mut zerados = 0usize;
+    let mut por_motivo: BTreeMap<String, usize> = BTreeMap::new();
+    let mut exemplos: Vec<String> = Vec::new();
+
+    for idx in 0..dom.nodes.len() {
+        let rts_dom::NodeKind::Element { tag } = &dom.node(idx).kind else { continue };
+        let css = dom.computed_style_idx(idx);
+        let display = css.as_ref().and_then(|c| c.effective_display());
+        match geo.rects.get(&idx) {
+            Some(r) if r.w > 0.5 && r.h > 0.5 => com_caixa += 1,
+            Some(_) => {
+                zerados += 1;
+                *por_motivo.entry(format!("caixa 0×0 ({tag}, display {display:?})")).or_default() += 1;
+            }
+            None => {
+                sem_caixa += 1;
+                let motivo = match display {
+                    Some(rts_dom::style::DisplayKind::None) => "display:none".to_string(),
+                    _ => {
+                        let pos = css.as_ref().and_then(|c| c.position);
+                        match pos {
+                            Some(p) if p.out_of_flow() => format!("fora do fluxo ({p:?})"),
+                            _ => format!("sem geometria ({tag}, display {display:?})"),
+                        }
+                    }
+                };
+                if exemplos.len() < 8 && motivo.starts_with("sem geometria") {
+                    exemplos.push(format!("{tag}#{idx} — {motivo}"));
+                }
+                *por_motivo.entry(motivo).or_default() += 1;
+            }
+        }
+    }
+
+    println!("    por que a página desenha o que desenha");
+    println!("      elementos com caixa visível        {com_caixa}");
+    println!("      elementos com caixa 0×0            {zerados}");
+    println!("      elementos SEM geometria            {sem_caixa}");
+    let mut motivos: Vec<(&String, &usize)> = por_motivo.iter().collect();
+    motivos.sort_by_key(|(_, n)| std::cmp::Reverse(**n));
+    for (motivo, n) in motivos.into_iter().take(8) {
+        println!("        {n:>5}× {motivo}");
+    }
+    for e in exemplos {
+        println!("        · {e}");
+    }
+
+    // O que de fato vai para a tela: uma página pode ter caixas e ainda assim
+    // abrir em branco se tudo o que ela emite for da cor do fundo.
+    use rts_dom::layout::DisplayItem as D;
+    let mut retangulos = 0usize;
+    let mut bordas = 0usize;
+    let mut textos: Vec<String> = Vec::new();
+    let mut cores: std::collections::BTreeMap<u32, usize> = Default::default();
+    lista.walk(|item, _, _| match item {
+        D::SolidRect { color, rect, .. } => {
+            retangulos += 1;
+            if rect.w > 1.0 && rect.h > 1.0 {
+                *cores.entry(*color).or_default() += 1;
+            }
+        }
+        D::Border { .. } => bordas += 1,
+        D::Text { text, x, y, .. } => {
+            if textos.len() < 10 && !text.trim().is_empty() {
+                textos.push(format!("({x:.0},{y:.0}) {:?}", text.chars().take(40).collect::<String>()));
+            }
+        }
+        _ => {}
+    });
+    println!("      itens pintados: {retangulos} retângulos, {bordas} bordas, {} textos", textos.len());
+    // ORDEM de pintura: um fundo que venha DEPOIS do texto apaga o texto.
+    println!("      ordem (primeiros 22):");
+    let mut n = 0usize;
+    lista.walk(|item, dx, dy| {
+        if n >= 22 {
+            return;
+        }
+        n += 1;
+        let descricao = match item {
+            D::SolidRect { rect, color, .. } => format!(
+                "rect ({:.0},{:.0}) {:.0}x{:.0} #{color:08X}",
+                rect.x + dx, rect.y + dy, rect.w, rect.h
+            ),
+            D::Border { rect, color, .. } => {
+                format!("borda ({:.0},{:.0}) #{color:08X}", rect.x + dx, rect.y + dy)
+            }
+            D::Text { x, y, text, color, .. } => format!(
+                "texto ({:.0},{:.0}) #{color:08X} {:?}",
+                x + dx,
+                y + dy,
+                text.chars().take(24).collect::<String>()
+            ),
+            D::BeginClip { rect, .. } => format!("clip ({:.0},{:.0}) {:.0}x{:.0}", rect.x + dx, rect.y + dy, rect.w, rect.h),
+            D::EndClip => "fim-clip".to_string(),
+            outro => format!("{outro:?}").chars().take(40).collect(),
+        };
+        println!("        {n:>3}. {descricao}");
+    });
+    let mut cores: Vec<(u32, usize)> = cores.into_iter().collect();
+    cores.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    for (cor, n) in cores.into_iter().take(5) {
+        println!("        {n:>4}× cor #{cor:08X}");
+    }
+    for t in textos {
+        println!("        texto {t}");
+    }
+}
+
 /// Confere, numa página REAL, que o layout com reuso de fragmentos é o mesmo
 /// que o layout calculado do zero — depois de uma sequência de mutações que
 /// exercita os caminhos de invalidação.

--- a/crates/rts-dom/examples/dom_metrics/scenarios.rs
+++ b/crates/rts-dom/examples/dom_metrics/scenarios.rs
@@ -427,6 +427,70 @@ pub fn explicar_pagina(html: &str, vw: f32, vh: f32, m: &CountingMeasurer) {
         }
         _ => {}
     });
+    // Os elementos com caixa, na ordem da árvore: é aqui que se vê um container
+    // sair para o lado quando devia ficar por cima.
+    println!("      caixas (as 14 primeiras, em ordem de documento):");
+    let mut mostradas = 0usize;
+    for idx in 0..dom.nodes.len() {
+        if mostradas >= 14 {
+            break;
+        }
+        let rts_dom::NodeKind::Element { tag } = &dom.node(idx).kind else { continue };
+        let Some(r) = geo.rects.get(&idx) else { continue };
+        if r.w < 1.0 || r.h < 1.0 {
+            continue;
+        }
+        let css = dom.computed_style_idx(idx);
+        let display = css.as_ref().and_then(|c| c.effective_display());
+        let position = css.as_ref().and_then(|c| c.position);
+        let largura = css.as_ref().and_then(|c| c.width);
+        mostradas += 1;
+        println!(
+            "        {tag:<8} ({:>6.0},{:>5.0}) {:>5.0}x{:<5.0} display {display:?} position {position:?} width {largura:?}",
+            r.x, r.y, r.w, r.h
+        );
+    }
+    // O primeiro elemento MAIS LARGO que a viewport, com a cadeia até a raiz: um
+    // estouro nasce em um nó e é herdado pelos filhos, e a cadeia mostra em qual
+    // deles a conta virou.
+    if let Some(culpado) = (0..dom.nodes.len()).find(|&idx| {
+        matches!(dom.node(idx).kind, rts_dom::NodeKind::Element { .. })
+            && geo.rects.get(&idx).map(|r| r.w > vw + 1.0).unwrap_or(false)
+    }) {
+        println!("      primeiro estouro de largura (viewport {vw:.0}):");
+        let mut cadeia = vec![culpado];
+        let mut cur = dom.node(culpado).parent;
+        while let Some(p) = cur {
+            cadeia.push(p);
+            cur = dom.node(p).parent;
+        }
+        cadeia.reverse();
+        // O HTML do trecho, para reproduzir o caso fora da página inteira.
+        if let Some(&pai) = cadeia.iter().rev().nth(1) {
+            let id_pai = dom.id_of_idx(pai);
+            if let Some(fonte) = dom.outer_html(id_pai) {
+                println!("      trecho (pai do estouro, 600 chars):");
+                println!("        {}", fonte.chars().take(600).collect::<String>());
+            }
+        }
+        for idx in cadeia {
+            let tag = match &dom.node(idx).kind {
+                rts_dom::NodeKind::Element { tag } => tag.clone(),
+                _ => "#doc".to_string(),
+            };
+            let css = dom.computed_style_idx(idx);
+            let w = geo.rects.get(&idx).map(|r| r.w).unwrap_or(-1.0);
+
+            println!(
+                "        {tag:<8} largura {w:>7.0}  display {:?} dir {:?} align {:?} width {:?} shrink {:?}",
+                css.as_ref().and_then(|c| c.effective_display()),
+                css.as_ref().and_then(|c| c.flex_direction),
+                css.as_ref().and_then(|c| c.align_items),
+                css.as_ref().and_then(|c| c.width),
+                css.as_ref().and_then(|c| c.flex_shrink),
+            );
+        }
+    }
     println!("      itens pintados: {retangulos} retângulos, {bordas} bordas, {} textos", textos.len());
     // ORDEM de pintura: um fundo que venha DEPOIS do texto apaga o texto.
     println!("      ordem (primeiros 22):");

--- a/crates/rts-dom/src/dom.rs
+++ b/crates/rts-dom/src/dom.rs
@@ -328,6 +328,9 @@ pub struct Dom {
     /// Buffer, offset dos pixels, w, h)`. Setado pelo browser via `setImage` depois
     /// de baixar+decodificar; o layout emite `DisplayItem::Image`. DERIVADO, fora do Eq.
     image_pixels: HashMap<NodeIdx, (u64, u32, u32, u32)>,
+    /// Pixels que o PRÓPRIO documento guarda (o `<canvas>` que um programa
+    /// pintou). Distinto do `image_pixels`, que aponta para um buffer de fora.
+    own_pixels: HashMap<NodeIdx, (std::rc::Rc<Vec<u8>>, u32, u32)>,
     /// A posição de cada nó em ORDEM DOCUMENTAL (pré-ordem), numerada sob
     /// demanda e reusada enquanto a árvore não muda. É o que permite responder
     /// uma consulta a partir dos ÍNDICES `#id`/`.classe` — que dão os candidatos
@@ -422,6 +425,7 @@ impl Dom {
             memo_viewport: std::cell::Cell::new((1280.0f32.to_bits(), 800.0f32.to_bits())),
             input_values: HashMap::new(),
             image_pixels: HashMap::new(),
+            own_pixels: HashMap::new(),
             focused_input: None,
             inline_position: std::cell::Cell::new(false),
             display_cache: std::cell::RefCell::new(None),
@@ -484,6 +488,30 @@ impl Dom {
 
     /// Associa a um `<img>` os pixels RGBA já decodificados (handle do Buffer +
     /// offset + w + h). O browser chama após baixar+decodificar. Bumpa a revisão.
+    /// Os PIXELS de um nó, guardados no PRÓPRIO documento.
+    ///
+    /// Existe ao lado do [`set_image`](Dom::set_image) — que aponta para um
+    /// buffer de FORA por handle — porque um `<canvas>` desenhado pelo programa
+    /// não tem dono externo: quem pintou foi o próprio programa, e o desenho
+    /// precisa sobreviver à chamada que o produziu. É a mesma razão de o texto
+    /// de um nó ser copiado para dentro da árvore em vez de referenciado.
+    ///
+    /// RGBA8, `w * h * 4` bytes. Um buffer CURTO é recusado: lido como imagem,
+    /// ele é uma leitura fora dos limites dentro do backend.
+    pub fn set_pixel_data(&mut self, id: NodeId, bytes: Vec<u8>, w: u32, h: u32) {
+        let Some(idx) = self.resolve(id) else { return };
+        if bytes.len() < (w as usize) * (h as usize) * 4 {
+            return;
+        }
+        self.own_pixels.insert(idx, (std::rc::Rc::new(bytes), w, h));
+        self.touch_render_only(idx);
+    }
+
+    /// Os pixels próprios de um nó, se ele tem.
+    pub fn pixel_data_of(&self, idx: NodeIdx) -> Option<(std::rc::Rc<Vec<u8>>, u32, u32)> {
+        self.own_pixels.get(&idx).map(|(b, w, h)| (std::rc::Rc::clone(b), *w, *h))
+    }
+
     pub fn set_image(&mut self, id: NodeId, handle: u64, off: u32, w: u32, h: u32) {
         if let Some(idx) = self.resolve(id) {
             self.image_pixels.insert(idx, (handle, off, w, h));
@@ -1056,6 +1084,29 @@ impl Dom {
     /// O stylesheet de autor acumulado (regras dos `<style>`). Exposto p/ inspeção/teste.
     pub fn stylesheet(&self) -> &crate::style::Stylesheet {
         &self.stylesheet
+    }
+
+    /// `getBoundingClientRect(el)[componente]` — 0=x, 1=y, 2=largura, 3=altura.
+    ///
+    /// Faz o layout com o medidor APROXIMADO: sem janela não há fonte real, e
+    /// devolver zero seria pior do que a aproximação que o layout headless já
+    /// usa em todo o resto. Quem tem janela lê a geometria exata da
+    /// `DisplayList` do backend.
+    pub fn bounding_component(&self, id: NodeId, which: i64) -> f32 {
+        let Some(idx) = self.resolve(id) else { return 0.0 };
+        let (vw, vh) = self.viewport.get();
+        let ctx = crate::layout::LayoutCtx {
+            viewport_w: vw,
+            viewport_h: vh,
+            measurer: &crate::layout::ApproxMeasurer,
+        };
+        let Some(rect) = crate::layout::bounding_rect(self, idx, &ctx) else { return 0.0 };
+        match which {
+            0 => rect.x,
+            1 => rect.y,
+            2 => rect.w,
+            _ => rect.h,
+        }
     }
 
     /// A geração desta árvore (para o render/ABI compor `NodeId` versionados).

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -1035,12 +1035,22 @@ fn layout_block(
     let ov_x = css.overflow_x.unwrap_or(crate::scrollbar::Overflow::Visible);
     let ov_y = css.overflow_y.unwrap_or(crate::scrollbar::Overflow::Visible);
     let scrolls_x = ov_x.scrollable() || ov_x == crate::scrollbar::Overflow::Hidden;
-    let children_w = if scrolls_x {
+    // A inflação vale para o eixo do FLUXO HORIZONTAL, que é onde a compressão
+    // aconteceria (o flex encolhe os itens até caberem). Nos demais layouts ela
+    // vira base de PORCENTAGEM dos filhos, e aí está errada: `width:100%` dentro
+    // de um container que rola é 100% da CAIXA, não do conteúdo transbordado.
+    //
+    // Medido na página real do WhatsApp Web, que aninha vários containers com
+    // `overflow-y:auto`: cada nível multiplicava a largura do seguinte, e o
+    // conteúdo terminava em x = 2300 numa janela de 1100 — a tela abria vazia
+    // com tudo desenhado fora dela.
+    let scroll_children_w = if scrolls_x {
         // largura que o conteúdo QUER (sem comprimir) — pode exceder content_w.
         intrinsic_content_width(dom, id, font_size, ctx).max(content_w)
     } else {
         content_w
     };
+    let children_w = content_w;
 
     // `height` EXPLÍCITO resolve ANTES dos filhos (não depende deles): eles o
     // recebem como containing-block height (base do `height:%` deles), e o flex
@@ -1090,7 +1100,7 @@ fn layout_block(
         }
         // horizontal (flex-row sem wrap): lado a lado, encolhe pra caber, não quebra.
         d if d == crate::block::DISPLAY_HORIZONTAL => {
-            layout_children_horizontal(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, false, None, ctx, list)
+            layout_children_horizontal(dom, id, content_x, content_y, scroll_children_w, avail_children, &css, font_size, false, None, ctx, list)
         }
         // GRID REAL: track-sizing (px/fr/auto/%) + auto-placement row-by-row +
         // alinhamento de célula (align-items/justify-items). Só quando é
@@ -1100,7 +1110,7 @@ fn layout_block(
         }
         // wrap (inline-block flow): lado a lado E QUEBRA linha quando enche.
         d if d == crate::block::DISPLAY_WRAP => {
-            layout_children_horizontal(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, true, None, ctx, list)
+            layout_children_horizontal(dom, id, content_x, content_y, scroll_children_w, avail_children, &css, font_size, true, None, ctx, list)
         }
         // vertical (block): empilha.
         _ => layout_children_vertical(dom, id, content_x, content_y, children_w, avail_children, &css, font_size, ctx, list),
@@ -1216,7 +1226,7 @@ fn layout_block(
             list.scroll_regions.push(ScrollRegion {
                 node_idx: id,
                 visible: content_rect,
-                content_w: children_w.max(content_w),
+                content_w: scroll_children_w.max(content_w),
                 content_h: content_h_natural,
                 overflow_x: ov_x,
                 overflow_y: ov_y,
@@ -4142,6 +4152,40 @@ mod tests {
             // deslocamento, o teste falha e o braço é escrito.
             _ => a == b,
         }
+    }
+
+    /// Dentro de um container que ROLA, `width:%` de um filho é a porcentagem da
+    /// CAIXA — não do conteúdo transbordado.
+    ///
+    /// O layout de um scroll container usa a largura NATURAL do conteúdo para
+    /// dispor os filhos (senão o flex os comprimiria e nada transbordaria), e
+    /// essa largura estava servindo também de base para as porcentagens. Numa
+    /// página que aninha vários `overflow:auto` — o WhatsApp Web é uma —, cada
+    /// nível multiplicava o seguinte, e o conteúdo terminava desenhado fora da
+    /// janela: a tela abria vazia com tudo pintado à direita dela.
+    #[test]
+    fn porcentagem_dentro_de_scroll_e_da_caixa() {
+        let dom = parse_html_to_dom(
+            "<div style='overflow-y:auto; padding-left:40px; padding-right:40px'>               <div id='meio' style='width:100%'>                 <div style='width:3000px'>conteudo bem mais largo que a caixa</div>               </div>             </div>",
+        );
+        let ctx = LayoutCtx { viewport_w: 1000.0, viewport_h: 600.0, measurer: &ApproxMeasurer };
+        let lista = layout_document(&dom, &ctx);
+        let meio = dom.resolve(dom.query("#meio").unwrap()).unwrap();
+        let rect = lista.geometry().rects[&meio];
+        assert!(
+            (rect.w - 920.0).abs() < 1.0,
+            "100% da caixa (1000 - 80 de padding) e não do conteúdo: {rect:?}"
+        );
+        // E o conteúdo largo continua transbordando — o container rola, não corta.
+        let geo = lista.geometry();
+        let largo = dom
+            .node(meio)
+            .children
+            .iter()
+            .copied()
+            .find(|c| matches!(dom.node(*c).kind, NodeKind::Element { .. }))
+            .expect("o filho largo");
+        assert!(geo.rects[&largo].w > 2900.0, "o filho largo mantém a largura dele");
     }
 
     /// SEQUÊNCIA LONGA de mutações sorteadas: o reuso tem de bater com o cálculo

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -83,6 +83,15 @@ pub enum DisplayItem {
     /// `rect` (escalando). Decodificação/download acontecem ANTES (no browser .ts,
     /// via fetchBytes+imgdec); o rts-dom só carrega o handle+dims — segue wasm-safe.
     Image { rect: Rect, pixels_handle: u64, pixels_off: u32, img_w: u32, img_h: u32 },
+    /// PIXELS que o próprio documento carrega (um `<canvas>` que o programa
+    /// pintou), RGBA8, `w*h*4` bytes.
+    ///
+    /// Variante separada da `Image` porque a fonte é outra: aquela aponta para
+    /// um `Buffer` de fora por handle — o `<img>` que o mini-browser baixou e
+    /// decodificou — e esta CARREGA os bytes, porque quem pintou foi o programa
+    /// e o desenho não tem outro dono. Um `Rc` para que passar a lista adiante
+    /// não copie a imagem.
+    Pixels { rect: Rect, data: std::rc::Rc<Vec<u8>>, w: u32, h: u32 },
     /// Texto numa posição (canto superior-esquerdo). `mono` escolhe a família
     /// monoespaçada. `letter_spacing` = espaço extra entre glifos (px). `decoration`
     /// = linha decorativa (0=nenhuma, 1=underline, 2=line-through, 3=overline). O
@@ -873,6 +882,15 @@ fn layout_block(
             }
             // `<img>` com pixels decodificados: emite a imagem no rect (tamanho do CSS
             // width/height, senão o natural da imagem). Void — sem filhos.
+            // `<canvas>`: elemento REPLACED cujo conteúdo é uma superfície de
+            // pixels. A caixa vem dos atributos `width`/`height` (ou do CSS), e
+            // o desenho aparece quando o programa pinta — antes disso a caixa
+            // existe e fica vazia, que é o que o browser também faz.
+            if tag == "canvas" {
+                if let Some(r) = layout_canvas(dom, id, &css, x, y, avail_w, ctx, list) {
+                    return r;
+                }
+            }
             if tag == "img" {
                 if let Some(img) = layout_image(dom, id, &css, x, y, avail_w, ctx, list) {
                     return img;
@@ -1691,6 +1709,7 @@ fn translate_item(it: &mut DisplayItem, dx: f32, dy: f32) {
         | DisplayItem::GradientRect { rect, .. }
         | DisplayItem::Border { rect, .. }
         | DisplayItem::Image { rect, .. }
+        | DisplayItem::Pixels { rect, .. }
         | DisplayItem::BeginClip { rect, .. } => shift(rect),
         DisplayItem::Text { x, y, .. } => {
             *x += dx;
@@ -1730,7 +1749,8 @@ fn apply_transform_to_item(
         | DisplayItem::Border { rect, .. }
         | DisplayItem::GradientRect { rect, .. }
         | DisplayItem::Shadow { rect, .. }
-        | DisplayItem::Image { rect, .. } => {
+        | DisplayItem::Image { rect, .. }
+        | DisplayItem::Pixels { rect, .. } => {
             let (nx, ny) = xf(rect.x, rect.y);
             rect.x = nx;
             rect.y = ny;
@@ -1903,6 +1923,13 @@ fn is_block_level(dom: &Dom, id: NodeIdx) -> bool {
             // intrínseco) → precisa de layout_block p/ emitir o DisplayItem::Image,
             // mesmo sem CSS de caixa.
             if tag == "img" && dom.image_of(id).is_some() {
+                return true;
+            }
+            // `<canvas>` é REPLACED como o `<img>`: a caixa vem dos atributos
+            // `width`/`height` e o conteúdo são pixels. Sem esta linha ele cai no
+            // fluxo inline, onde não há quem emita a superfície — e um canvas
+            // pintado não aparecia na tela, com o resto da página intacto.
+            if tag == "canvas" {
                 return true;
             }
             // `<svg>` é replaced: layout_svg_placeholder reserva a caixa (logo/
@@ -2119,6 +2146,57 @@ fn layout_image(
         img_w: iw,
         img_h: ih,
     });
+    Some((w + margin_left + margin_right, h + margin_top + margin_bottom))
+}
+
+/// Layout de um `<canvas>`: a caixa dos atributos `width`/`height` (o padrão do
+/// HTML é 300×150) ou do CSS, e o `DisplayItem::Pixels` quando há desenho.
+///
+/// Sem pixels a caixa é reservada e nada é pintado — um canvas em branco é um
+/// canvas em branco, não um buraco no layout. É essa reserva que faz o resto da
+/// página se dispor no lugar certo antes de o programa desenhar.
+fn layout_canvas(
+    dom: &Dom,
+    id: NodeIdx,
+    css: &ComputedStyle,
+    x: f32,
+    y: f32,
+    avail_w: f32,
+    ctx: &LayoutCtx,
+    list: &mut DisplayList,
+) -> Option<(f32, f32)> {
+    let font = font_px(css, DEFAULT_FONT_SIZE);
+    let resolve = ResolveCtx {
+        parent_content_w: avail_w,
+        node_font_size: font,
+        root_font_size: DEFAULT_FONT_SIZE,
+        viewport_w: ctx.viewport_w,
+        viewport_h: ctx.viewport_h,
+    };
+    let attr_px = |name: &str| -> Option<f32> {
+        dom.node(id)
+            .attr(name)
+            .and_then(|v| v.trim().trim_end_matches("px").trim().parse::<f32>().ok())
+            .filter(|v| *v >= 0.0)
+    };
+    // 300×150 é o default do HTML para um canvas sem dimensões.
+    let w = css.width.and_then(|d| d.resolve(&resolve)).or_else(|| attr_px("width")).unwrap_or(300.0);
+    let h = css.height.and_then(|d| d.resolve(&resolve)).or_else(|| attr_px("height")).unwrap_or(150.0);
+    let m = &css.margin;
+    let margin_left = m.left.resolve(&resolve).unwrap_or(0.0);
+    let margin_right = m.right.resolve(&resolve).unwrap_or(0.0);
+    let margin_top = m.top.resolve(&resolve).unwrap_or(0.0);
+    let margin_bottom = m.bottom.resolve(&resolve).unwrap_or(0.0);
+    let rect = Rect::new(x + margin_left, y + margin_top, w, h);
+    record_node_rect(list, id, rect);
+    if let Some(color) = css.bg {
+        list.items.push(DisplayItem::SolidRect { rect, color, radius: 0.0 });
+    }
+    if let Some((data, pw, ph)) = dom.pixel_data_of(id) {
+        if pw > 0 && ph > 0 {
+            list.items.push(DisplayItem::Pixels { rect, data, w: pw, h: ph });
+        }
+    }
     Some((w + margin_left + margin_right, h + margin_top + margin_bottom))
 }
 
@@ -2498,7 +2576,9 @@ fn layout_children_vertical(
             .unwrap_or(crate::style::FloatSide::None);
         let (child_block, child_inline_block) = match &dom.node(child).kind {
             NodeKind::Element { tag } => {
-                let replaced = (tag == "img" && dom.image_of(child).is_some()) || tag == "svg";
+                let replaced = (tag == "img" && dom.image_of(child).is_some())
+                    || tag == "svg"
+                    || tag == "canvas";
                 let effective = child_css.as_ref().and_then(|c| c.effective_display());
                 let explicit_block = effective
                     .map(|d| d != crate::style::DisplayKind::Inline)

--- a/crates/rts-egui/src/frame/render.rs
+++ b/crates/rts-egui/src/frame/render.rs
@@ -567,6 +567,31 @@ fn paint_list(ui: &mut egui::Ui, list: &DisplayList, offset_y: f32) {
                     );
                 }
             }
+            DisplayItem::Pixels { rect, data, w, h } => {
+                // Os bytes vêm DENTRO da lista (um `<canvas>` que o programa
+                // pintou), então não há handle a resolver — sobe direto como
+                // textura efêmera. O nome da textura inclui o índice do item
+                // para que dois canvas no mesmo frame não disputem a mesma.
+                let ci = egui::ColorImage::from_rgba_unmultiplied(
+                    [*w as usize, *h as usize],
+                    data,
+                );
+                let tex = painter.ctx().load_texture(
+                    format!("__rts_canvas_{idx}"),
+                    ci,
+                    egui::TextureOptions::LINEAR,
+                );
+                let r = egui::Rect::from_min_size(
+                    origin + egui::vec2(rect.x, rect.y),
+                    egui::vec2(rect.w, rect.h),
+                );
+                painter.image(
+                    tex.id(),
+                    r,
+                    egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+                    egui::Color32::WHITE,
+                );
+            }
             DisplayItem::BeginClip { rect, offset_x, offset_y, .. } => {
                 // o RECT do container é FIXO (não rola) — posiciona com `origin` (que
                 // já inclui o extra do pai, mas não o desta região). Os FILHOS dentro

--- a/crates/rts-host/Cargo.toml
+++ b/crates/rts-host/Cargo.toml
@@ -41,6 +41,10 @@ rts-physics = { path = "../rts-physics", optional = true }
 # DISPONIBILIDADE — não existe em wasm nem num build headless — e um alvo sem
 # ela não deve carregar wgpu/winit no grafo para descobrir isso.
 rts-ui = { path = "../rts-ui", optional = true }
+# O `rts:dom` — a árvore de documento alcançável do TypeScript. NÃO é opcional
+# como a UI: um DOM headless não precisa de tela, e é justamente sem tela que
+# ele se distingue de um Node com jsdom.
+rts-dom-bridge = { path = "../rts-dom-bridge" }
 
 [features]
 # `ui` E PADRAO. A razao de ela ter ficado de fora morreu com o crate que a

--- a/crates/rts-host/src/run.rs
+++ b/crates/rts-host/src/run.rs
@@ -408,6 +408,12 @@ fn run_region(
         let _timing = rts_cranelift::probe::Phase::start("install-physics");
         rts_physics::install(&mut context);
     }
+    {
+        // `rts:dom` vem ANTES da UI e sem feature: o documento é headless por
+        // natureza, e um build sem tela continua parseando e consultando HTML.
+        let _timing = rts_cranelift::probe::Phase::start("install-dom");
+        rts_dom_bridge::install(&mut context);
+    }
     #[cfg(feature = "ui")]
     rts_ui::install(&mut context);
     // The modules a program may import. Registered by the HOST rather than by

--- a/crates/rts-ui/src/draw.rs
+++ b/crates/rts-ui/src/draw.rs
@@ -24,6 +24,7 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     ("horizontalBegin", horizontal_begin),
     ("horizontalEnd", horizontal_end),
     ("html", html),
+    ("render", render),
     ("drawImage", draw_image),
 ];
 
@@ -176,13 +177,18 @@ extern "C" fn horizontal_end(_e: u64, _t: u64, win: u64, _a: u64, _b: u64, _c: u
     value::nothing()
 }
 
-/// `html(win, source)` — parseia e desenha, com a árvore retida na janela.
+/// `render(win, doc)` — desenha um DOCUMENTO do `rts:dom` (por handle).
 ///
-/// O caminho por handle de DOM (`render(win, dom)`) NÃO está aqui: ele lê o
-/// store do `rts-dom`, que é alcançado pelo namespace `rts:dom` — e esse ainda
-/// não existe no motor novo. Registrá-lo agora daria uma função que sempre
-/// desenha nada, que é o modo de falhar que `rts-std` já recusou uma vez ao
-/// não registrar um `rts:egui` de fachada.
+/// A diferença para o `html(win, fonte)` é de quem é a árvore: aquele parseia a
+/// string e guarda a árvore DENTRO da janela; este pinta uma árvore que o
+/// programa criou e mutou pelo `rts:dom`. As duas terminam no mesmo lugar — o
+/// layout do `rts-dom` e a display list que o backend pinta.
+extern "C" fn render(_e: u64, _t: u64, win: u64, doc: u64, _b: u64, _c: u64) -> u64 {
+    rts_egui::render(handle(win), handle(doc));
+    value::nothing()
+}
+
+/// `html(win, source)` — parseia e desenha, com a árvore retida na janela.
 extern "C" fn html(_e: u64, _t: u64, win: u64, source: u64, _b: u64, _c: u64) -> u64 {
     rts_egui::html(handle(win), &text(source));
     value::nothing()

--- a/examples/claude-canvas.ts
+++ b/examples/claude-canvas.ts
@@ -1,0 +1,79 @@
+// CANVAS no nosso DOM: o programa pinta os pixels, o DOM os carrega, o egui os
+// desenha. É o pipeline inteiro — documento → display list → tela — com o
+// conteúdo vindo de código em vez de de uma tag.
+//
+//   cargo run --release -p rts-host --features ui --example ui_fixture -- \
+//       examples/claude-canvas.ts
+
+import {
+  openWindow, pump, isOpen, close, beginFrame, endFrame, render, drawText,
+} from "rts:egui";
+import { parseHtml, querySelector, setPixels, setText } from "rts:dom";
+
+const LADO = 260;
+
+const doc = parseHtml(
+  "<html><head><style>" +
+  "body{background:#faf7f2}" +
+  "h1{font-size:26px;color:#1d1f1f}" +
+  ".cartao{background:#ffffff;padding:24px;margin:24px}" +
+  "p{color:#555555}" +
+  "</style></head><body><div class='cartao'>" +
+  "<h1>Canvas pintado por código</h1>" +
+  "<p id='legenda'>os pixels abaixo saíram de um laço TypeScript</p>" +
+  "<canvas id='tela' width='" + LADO + "' height='" + LADO + "'></canvas>" +
+  "</div></body></html>"
+);
+
+const tela = querySelector(doc, "#tela");
+const legenda = querySelector(doc, "#legenda");
+
+// RGBA8, `lado*lado*4` bytes. Um Buffer é o que o `setPixels` lê — o mesmo
+// caminho que o `<img>` do mini-browser usa depois de decodificar um PNG.
+const pixels = Buffer.alloc(LADO * LADO * 4);
+
+// Um padrão xadrez com um degradê: mostra que cada pixel veio do laço, e não de
+// um retângulo que o layout desenhou.
+function pintar(fase: number): void {
+  let y = 0;
+  while (y < LADO) {
+    let x = 0;
+    while (x < LADO) {
+      const i = (y * LADO + x) * 4;
+      const quadro = (((x + fase) / 20) | 0) + (((y + fase) / 20) | 0);
+      const claro = (quadro % 2) === 0;
+      pixels[i] = claro ? 255 - ((x * 255 / LADO) | 0) : 20;
+      pixels[i + 1] = claro ? 200 - ((y * 120 / LADO) | 0) : 200 - ((x * 60 / LADO) | 0);
+      pixels[i + 2] = claro ? 90 : 120;
+      pixels[i + 3] = 255;
+      x = x + 1;
+    }
+    y = y + 1;
+  }
+}
+
+const win = openWindow("rts-dom — canvas", 900, 700, 0);
+if (win <= 0) {
+  console.log("não abriu a janela");
+} else {
+  let frames = 0;
+  while (isOpen(win)) {
+    pump(win);
+    // repinta a cada 6 frames: prova que o caminho pixels→DOM→egui é vivo, e
+    // não uma textura carregada uma vez.
+    if (frames % 6 === 0) {
+      pintar((frames / 6) | 0);
+      // largura e altura empacotadas num inteiro (16 bits cada) — a fronteira
+      // de um nativo tem quatro argumentos, e três já foram.
+      setPixels(doc, tela, pixels, (LADO << 16) | LADO);
+      setText(doc, legenda, "quadro " + ((frames / 6) | 0) + " — " + (LADO * LADO) + " pixels por laço TypeScript");
+    }
+    beginFrame(win);
+    render(win, doc);
+    drawText(win, "rts-dom · canvas · frame " + frames, 0);
+    endFrame(win);
+    frames = frames + 1;
+  }
+  close(win);
+  console.log("fechou depois de", frames, "frames");
+}

--- a/examples/claude-dom-ns.ts
+++ b/examples/claude-dom-ns.ts
@@ -1,0 +1,40 @@
+// O namespace `rts:dom` no motor NOVO: parse, consulta, mutação e geometria de
+// um documento — sem abrir janela.
+import {
+  parseHtml, free, rootId, querySelector, querySelectorAllCount, querySelectorAllAt,
+  getText, setText, getAttribute, setAttribute, createElement, appendChild,
+  tagName, childCount, computedProperty, boundingRect, dump, nodeCount,
+} from "rts:dom";
+
+const doc = parseHtml("<html><body><main id='r'><p class='t'>um</p><p class='t'>dois</p></main></body></html>");
+console.log("documento:", doc, "| nós:", nodeCount(doc), "| raiz:", rootId(doc));
+
+const main = querySelector(doc, "#r");
+console.log("#r é", tagName(doc, main), "com", childCount(doc, main), "filhos");
+
+const n = querySelectorAllCount(doc, ".t");
+console.log("querySelectorAll('.t') →", n);
+let i = 0;
+while (i < n) {
+  const el = querySelectorAllAt(doc, ".t", i);
+  console.log("  [" + i + "]", tagName(doc, el), "=", getText(doc, el));
+  i = i + 1;
+}
+
+const primeiro = querySelector(doc, ".t");
+setText(doc, primeiro, "TROCADO");
+setAttribute(doc, primeiro, "data-x", "42");
+console.log("depois de mutar:", getText(doc, primeiro), "| data-x =", getAttribute(doc, primeiro, "data-x"));
+
+const novo = createElement(doc, "span");
+setText(doc, novo, "criado por codigo");
+appendChild(doc, main, novo);
+console.log("filhos agora:", childCount(doc, main), "| ultimo:", getText(doc, novo));
+
+console.log("cor computada do p:", computedProperty(doc, primeiro, "color"));
+console.log("caixa do #r: x", boundingRect(doc, main, 0), "y", boundingRect(doc, main, 1),
+            "w", boundingRect(doc, main, 2), "h", boundingRect(doc, main, 3));
+
+console.log("--- árvore ---");
+console.log(dump(doc));
+free(doc);

--- a/examples/claude-dom-viewer.ts
+++ b/examples/claude-dom-viewer.ts
@@ -1,0 +1,42 @@
+// Visualizador de HTML na janela, pelo motor NOVO — o DOM do `rts-dom` na tela.
+//
+//   cargo run --release -p rts-host --features ui --example ui_fixture -- \
+//       examples/claude-dom-viewer.ts
+//
+// O caminho da página vai na constante abaixo porque o `ui_fixture` já usa o
+// primeiro argumento para o próprio `.ts`. Trocar a página é editar a linha e
+// rodar de novo — sem recompilar nada, que é a razão de o `ui_fixture` existir.
+//
+// O que se vê aqui é o mesmo caminho que as métricas medem: `egui.html` parseia
+// para a árvore retida do `rts-dom` (com cache por hash, então o loop não
+// re-parseia), o layout calcula a geometria e o egui só pinta a display list.
+
+import {
+  openWindow, pump, isOpen, close, beginFrame, endFrame,
+  html, drawText, winWidth, winHeight,
+} from "rts:egui";
+import { readFileSync } from "node:fs";
+
+const PAGINA = "examples/claude-ai-site.html";
+
+const fonte = readFileSync(PAGINA, "utf8");
+console.log("página:", PAGINA, "|", fonte.length, "bytes");
+
+const win = openWindow("rts-dom — " + PAGINA, 1100, 780, 0);
+if (win <= 0) {
+  console.log("não abriu a janela");
+} else {
+  let frames = 0;
+  while (isOpen(win)) {
+    pump(win);
+    beginFrame(win);
+    html(win, fonte);
+    // Rodapé com o tamanho real da área: confirma que a página está sendo
+    // disposta contra a janela, e não contra um viewport fixo.
+    drawText(win, "rts-dom · " + winWidth(win) + "x" + winHeight(win) + " · frame " + frames, 0);
+    endFrame(win);
+    frames = frames + 1;
+  }
+  close(win);
+  console.log("fechou depois de", frames, "frames");
+}

--- a/examples/claude-dom-viewer.ts
+++ b/examples/claude-dom-viewer.ts
@@ -17,7 +17,7 @@ import {
 } from "rts:egui";
 import { readFileSync } from "node:fs";
 
-const PAGINA = "examples/claude-ai-site.html";
+const PAGINA = "C:/Users/Marcos/AppData/Local/Temp/claude/E--rts/d593fce5-3573-494d-aca3-b8987bf358c6/scratchpad/whatsapp.html";
 
 const fonte = readFileSync(PAGINA, "utf8");
 console.log("página:", PAGINA, "|", fonte.length, "bytes");

--- a/examples/claude-dom-viewer.ts
+++ b/examples/claude-dom-viewer.ts
@@ -13,7 +13,7 @@
 
 import {
   openWindow, pump, isOpen, close, beginFrame, endFrame,
-  html, drawText, winWidth, winHeight,
+  html, drawText, winWidth, winHeight, snapshot,
 } from "rts:egui";
 import { readFileSync } from "node:fs";
 
@@ -36,6 +36,13 @@ if (win <= 0) {
     drawText(win, "rts-dom · " + winWidth(win) + "x" + winHeight(win) + " · frame " + frames, 0);
     endFrame(win);
     frames = frames + 1;
+    // Um PNG do que a janela está mostrando, para poder ser olhado fora dela.
+    // No frame 30 (não no 1) porque o egui leva alguns frames para assentar
+    // fontes e tamanho de janela.
+    if (frames === 30) {
+      snapshot(win, "target/render-dom.png");
+      console.log("snapshot salvo em target/render-dom.png");
+    }
   }
   close(win);
   console.log("fechou depois de", frames, "frames");

--- a/examples/claude-web-viewer.ts
+++ b/examples/claude-web-viewer.ts
@@ -1,0 +1,63 @@
+// Baixa uma PÁGINA DA WEB e a mostra na janela, pelo motor novo.
+//
+//   cargo run --release -p rts-host --features ui --example ui_fixture -- \
+//       examples/claude-web-viewer.ts
+//
+// O caminho: `node:https` busca o HTML, os `<link rel=stylesheet>` são buscados
+// e embutidos (o `rts-dom` faz a cascata sobre `<style>`, não sobre links), e
+// `egui.html` parseia para a árvore retida e a pinta.
+//
+// # O que isto NÃO faz, e por que importa aqui
+//
+// Não executa o JavaScript da página. Num site que renderiza no servidor isso é
+// quase invisível; num que monta o DOM inteiro no cliente — o WhatsApp Web é o
+// caso extremo — o que chega é o SHELL, e o shell é quase vazio de propósito.
+// Ver o app exige rodar o JS dele, que é outro problema (o `runScripts` do motor
+// antigo; no motor novo o `rts:dom` ainda não foi portado).
+
+import {
+  openWindow, pump, isOpen, close, beginFrame, endFrame,
+  html, drawText, winWidth,
+} from "rts:egui";
+import { get } from "node:https";
+
+const HOST = "web.whatsapp.com";
+const CAMINHO = "/";
+
+/// Baixa um recurso e devolve o corpo como texto. Síncrono na aparência: o loop
+/// de frames só começa depois que a página chegou.
+function baixar(host: string, caminho: string): string {
+  let corpo = "";
+  let pronto = false;
+  const req = get({ host: host, path: caminho }, (res: any) => {
+    res.on("data", (pedaco: any) => { corpo = corpo + pedaco; });
+    res.on("end", () => { pronto = true; });
+  });
+  req.on("error", (e: any) => { console.log("erro:", e); pronto = true; });
+  // espera ativa: este exemplo roda na thread da janela e não tem outro trabalho
+  // a fazer antes de a página chegar.
+  let voltas = 0;
+  while (!pronto && voltas < 2000000) { voltas = voltas + 1; }
+  return corpo;
+}
+
+console.log("baixando https://" + HOST + CAMINHO);
+let fonte = baixar(HOST, CAMINHO);
+console.log("recebido:", fonte.length, "bytes");
+
+const win = openWindow("rts-dom — https://" + HOST + CAMINHO, 1100, 780, 0);
+if (win <= 0) {
+  console.log("não abriu a janela");
+} else {
+  let frames = 0;
+  while (isOpen(win)) {
+    pump(win);
+    beginFrame(win);
+    html(win, fonte);
+    drawText(win, "rts-dom · " + HOST + " · " + fonte.length + " bytes · frame " + frames, 0);
+    endFrame(win);
+    frames = frames + 1;
+  }
+  close(win);
+  console.log("fechou depois de", frames, "frames");
+}


### PR DESCRIPTION
Três coisas que se puxaram em sequência, cada uma achada pela anterior.

## 1. A página real do WhatsApp Web abria em BRANCO — e não era falta de processamento

O `--explique` (novo, no harness) mostrou: 873 cascades, 89 elementos com caixa, os textos certos, a cor `#25D366`. Era **posição** — os itens saíam em x = 1140, 1852, 2286 numa janela de 1100.

**Causa**: um container com `overflow` layouta os filhos com a largura NATURAL do conteúdo — e precisa mesmo, senão o flex os comprimiria e nada transbordaria. Só que essa largura inflada servia também de base para as PORCENTAGENS: `width:100%` virava 100% do conteúdo transbordado. O WhatsApp aninha vários `overflow:auto`, e cada nível multiplicava o seguinte.

**Correção**: a inflação vale só para o fluxo horizontal (onde a compressão aconteceria). Isolado por bisseção sobre a página real — extraí o trecho e as 26 regras que o alcançam, e desliguei uma propriedade por vez.

## 2. `rts:dom` no motor novo

Crate `rts-dom-bridge`, instalado pelo host **sem** a feature `ui`: DOM headless é o ponto — parsear e consultar HTML sem tela é o que distingue isto de um Node com jsdom.

```
documento: 1 | nós: 8 | raiz: 4294967296
#r é main com 2 filhos
querySelectorAll('.t') → 2
depois de mutar: TROCADO | data-x = 42
caixa do #r: x 0 y 0 w 1280 h 110.4
```

Convenções herdadas da ABI antiga porque continuam certas: handle opaco para o documento, `NodeId` versionado num `i64` (a geração impede aplicar id velho a nó vivo), `-1` como "nó nenhum", listas como `count` + `at(i)`.

## 3. `<canvas>` com pixels que chegam à tela

`set_pixel_data` guarda os bytes **dentro** do documento — diferente do `<img>`, que aponta para um buffer externo por handle. A diferença é de dono: quem pintou o canvas foi o programa, e o desenho tem que sobreviver à chamada.

O caminho completo, sem browser nenhum envolvido:

```
laço TypeScript pinta 67 600 pixels
  → rts:dom (setPixels) guarda no nó <canvas>
  → layout emite DisplayItem::Pixels
  → egui sobe como textura e desenha
```

Um bug que a demo revelou: `<canvas>` é **inline** por padrão no HTML, então caía no fluxo de texto e ninguém emitia a superfície — a página aparecia inteira menos o canvas. Agora é replaced element, como `<img>` e `<svg>`.

Junto vai `egui.render(win, doc)`, que pinta um documento criado e mutado pelo programa; o comentário que dizia "esse caminho não existe no motor novo" saiu.

## Verificação

- `cargo test --release -p rts-dom` → 224 · `-p rts-egui` → 6 · build release limpo
- `examples/claude-dom-ns.ts` — o namespace headless
- `examples/claude-canvas.ts` — o canvas animando na janela
- `examples/claude-dom-viewer.ts` — uma página HTML na janela
- `examples/claude-web-viewer.ts` — baixa por `node:https`; **não funciona** e fica como o caso que mostra os dois bugs de rede do motor (handshake TLS não completa; `node:http` entra em pânico com `RefCell already borrowed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GjdssWEr2NgWZv21N93By