### PR TITLE
refactor(css): introduce browser-like syntax AST pipeline

### DIFF
--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -107,6 +107,16 @@ jobs:
             const s = r.summary;
             const divergent = r.results.filter(x => x.status === 'rts_diverge' || x.status === 'rts_error');
 
+            const maxCommentLength = 60000;
+            const maxDivergences = 20;
+            const maxOutputLength = 2500;
+            const clip = (value) => {
+              const text = String(value ?? '').replaceAll('```', '`\u200b``');
+              return text.length <= maxOutputLength
+                ? text
+                : text.slice(0, maxOutputLength) + '\n...[output truncated; full report is in the workflow artifact]';
+            };
+
             let body = `## Cross-runtime parity (RTS vs Bun vs Node)\n\n`;
             body += `| Metric | Value |\n|---|---|\n`;
             body += `| Total | ${s.total} |\n`;
@@ -118,15 +128,25 @@ jobs:
 
             if (divergent.length > 0) {
               body += `### Divergences detected\n\n`;
-              for (const d of divergent) {
+              for (const d of divergent.slice(0, maxDivergences)) {
                 body += `<details><summary><code>${d.name}</code> — ${d.status}</summary>\n\n`;
-                body += `**Bun output:**\n\`\`\`\n${d.bun}\n\`\`\`\n\n`;
-                body += `**Node output:**\n\`\`\`\n${d.node}\n\`\`\`\n\n`;
-                body += `**RTS output:**\n\`\`\`\n${d.rts}\n\`\`\`\n\n`;
+                body += `**Bun output:**\n\`\`\`\n${clip(d.bun)}\n\`\`\`\n\n`;
+                body += `**Node output:**\n\`\`\`\n${clip(d.node)}\n\`\`\`\n\n`;
+                body += `**RTS output:**\n\`\`\`\n${clip(d.rts)}\n\`\`\`\n\n`;
                 body += `</details>\n\n`;
+              }
+              if (divergent.length > maxDivergences) {
+                body += `_${divergent.length - maxDivergences} additional divergences are available in the uploaded workflow artifact._\n`;
               }
             } else if (s.pass === s.total) {
               body += `🎉 Full parity.\n`;
+            }
+
+            // GitHub rejects issue comments over 65,536 characters. Keep a hard
+            // safety margin even if a future fixture name/output is unusually long.
+            if (body.length > maxCommentLength) {
+              body = body.slice(0, maxCommentLength) +
+                '\n\n_[comment truncated to GitHub limit; full report is in the workflow artifact]._\n';
             }
 
             github.rest.issues.createComment({

--- a/crates/rts-dom-bridge/src/lib.rs
+++ b/crates/rts-dom-bridge/src/lib.rs
@@ -50,6 +50,11 @@ pub fn install(context: &mut Context) {
         tree::MEMBERS.iter().chain(nodes::MEMBERS).copied().collect();
     let surface = entry::make_namespace(context, &members);
     entry::declare_module(context, "rts:dom", surface);
+    // A fachada `DOM_TS` é um prelude de script e chama os primitivos como
+    // `dom.parseHtml(...)`, sem uma importação no seu texto. O mesmo valor pode
+    // ser publicado nas duas superfícies: módulos continuam a usar
+    // `import ... from "rts:dom"` e a fachada usa o global `dom`.
+    entry::declare_global(context, "dom", surface);
 }
 
 /// O prelude `.ts` da fachada ergonômica (`document`/`Element`), para o host

--- a/crates/rts-dom-bridge/src/nodes.rs
+++ b/crates/rts-dom-bridge/src/nodes.rs
@@ -20,12 +20,14 @@ use crate::value::{handle, int, integer, nothing, num, string, text};
 pub const MEMBERS: &[(&str, Provided)] = &[
     // consulta
     ("querySelector", query_selector),
+    ("getById", get_by_id),
     ("querySelectorAllCount", query_all_count),
     ("querySelectorAllAt", query_all_at),
     ("matches", matches_selector),
     // leitura
     ("getText", get_text),
     ("getAttribute", get_attribute),
+    ("hasAttr", has_attr),
     ("tagName", tag_name),
     ("nodeType", node_type),
     ("childCount", child_count),
@@ -36,7 +38,9 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     // mutação
     ("setText", set_text),
     ("setAttribute", set_attribute),
+    ("setAttr", set_attribute),
     ("removeAttribute", remove_attribute),
+    ("removeAttr", remove_attribute),
     ("createElement", create_element),
     ("createTextNode", create_text_node),
     ("appendChild", append_child),
@@ -63,6 +67,15 @@ extern "C" fn query_selector(_e: u64, _t: u64, doc: u64, sel: u64, _b: u64, _c: 
     })
     .unwrap_or(-1);
     int(id)
+}
+
+extern "C" fn get_by_id(_e: u64, _t: u64, doc: u64, id: u64, _b: u64, _c: u64) -> u64 {
+    let id = text(id);
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.get_element_by_id(&id).map(|n| n.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(out)
 }
 
 extern "C" fn query_all_count(_e: u64, _t: u64, doc: u64, sel: u64, _b: u64, _c: u64) -> u64 {
@@ -103,6 +116,13 @@ extern "C" fn get_attribute(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u
     })
     .unwrap_or_default();
     string(&out)
+}
+
+extern "C" fn has_attr(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let name = text(name);
+    let Some(id) = node(n) else { return int(0) };
+    let yes = rts_dom::store::with_dom(handle(doc), |d| d.has_attr(id, &name)).unwrap_or(false);
+    int(yes as i64)
 }
 
 extern "C" fn tag_name(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {

--- a/crates/rts-dom-bridge/src/tree.rs
+++ b/crates/rts-dom-bridge/src/tree.rs
@@ -15,6 +15,7 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     ("createDocument", create_document),
     ("free", free),
     ("rootId", root_id),
+    ("documentElement", document_element),
     ("addStylesheet", add_stylesheet),
     ("dump", dump),
     ("nodeCount", node_count),
@@ -49,6 +50,14 @@ extern "C" fn root_id(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> 
 }
 
 /// `addStylesheet(doc, css)` — acrescenta regras de autor ao documento.
+extern "C" fn document_element(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let id = rts_dom::store::with_dom(handle(doc), |d| {
+        d.document_element().map(|n| n.to_abi()).unwrap_or(-1)
+    })
+    .unwrap_or(-1);
+    int(id)
+}
+
 extern "C" fn add_stylesheet(_e: u64, _t: u64, doc: u64, css: u64, _b: u64, _c: u64) -> u64 {
     let css = text(css);
     rts_dom::store::with_dom_mut(handle(doc), |d| d.add_stylesheet(&css));

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -94,15 +94,15 @@ class Element {
     dom.setText(this._dom, this._node, t);
   }
 
-  // `el.innerHTML` — GET serializa os filhos. O jeito #1 de mexer no DOM em apps.
+  // `el.innerHTML` — GET/SET serializa ou substitui os filhos.
   get innerHTML(): string {
     return dom.innerHtml(this._dom, this._node);
   }
-  // ⚠️ O SET é via MÉTODO `setInnerHTML(html)`, não o setter `el.innerHTML = ...`:
-  // o motor RTS atual não dispara setters de propriedade de classe (o `app.x = v`
-  // não chama `set x()` — cria um campo no objeto). Métodos despacham certo. Quando
-  // o motor suportar setters, o `set innerHTML` volta. (mesmo motivo de classList*
-  // serem métodos, não um objeto `.classList` vivo.)
+  set innerHTML(html: string) {
+    dom.setInnerHtml(this._dom, this._node, html);
+  }
+  // Método explícito mantido para hosts que ainda não despacham setters de
+  // propriedades de classe; ambos os caminhos usam a mesma mutação Rust.
   setInnerHTML(html: string): void {
     dom.setInnerHtml(this._dom, this._node, html);
   }
@@ -571,9 +571,12 @@ class Document {
     return out;
   }
 
-  // `document.getElementById(id)` — atalho para `#id`.
+  // `document.getElementById(id)` usa igualdade textual no índice do DOM;
+  // não é um seletor CSS e, portanto, funciona para IDs como `a.b`.
   getElementById(id: string): Element | null {
-    return this.querySelector("#" + id);
+    const n = dom.getById(this._dom, id);
+    if (n === __DOM_NONE) return null;
+    return new Element(this._dom, n);
   }
 
   // ── getElementsBy* (#1758) — coleções por classe/tag/name ────────────────────
@@ -626,9 +629,10 @@ class Document {
     return new Element(this._dom, n);
   }
 
-  // `document.documentElement` — a raiz `#document`.
-  get documentElement(): Element {
-    const root = dom.rootId(this._dom);
+  // `document.documentElement` — o elemento `<html>`, não a raiz `#document`.
+  get documentElement(): Element | null {
+    const root = dom.documentElement(this._dom);
+    if (root === __DOM_NONE) return null;
     return new Element(this._dom, root);
   }
 }
@@ -786,7 +790,7 @@ function __fetchText(url: string): string {
   return fetch.fetchText(url);
 }
 
-// Expande os `@import url(...)` / `@import "..."` de um CSS, INLINE e recursivamente.
+// Expande os imports CSS (`url(...)` ou string) INLINE e recursivamente.
 // Cada import é resolvido contra a base do CSS que o contém. `seen` corta ciclos;
 // `depth` limita a profundidade (defesa contra recursão patológica).
 // NOTA (motor): sem `break` (ver `__trimEnd`); o fim do laço é controlado por `i`,

--- a/crates/rts-dom/src/dom/arvore.rs
+++ b/crates/rts-dom/src/dom/arvore.rs
@@ -24,6 +24,7 @@ impl Dom {
             class_index: HashMap::new(),
             style_overrides: HashMap::new(),
             stylesheet: crate::style::Stylesheet::new(),
+            external_css: String::new(),
             raw_css: String::new(),
             listeners: HashMap::new(),
             listener_cbs: HashMap::new(),

--- a/crates/rts-dom/src/dom/cascade.rs
+++ b/crates/rts-dom/src/dom/cascade.rs
@@ -267,23 +267,35 @@ impl Dom {
             v.extend(inline.custom.iter().cloned());
             v
         };
+        let own_customs_important: Vec<(String, String)> = if self.stylesheet.is_empty() {
+            inline.custom_important.clone()
+        } else {
+            let mut v = self.stylesheet.custom_important_from(&matched);
+            v.extend(inline.custom_important.iter().cloned());
+            v
+        };
         let parent_vars = parent_css_for_vars
             .as_ref()
             .and_then(|p| p.custom_props.clone());
         let vars_arc: Option<std::sync::Arc<std::collections::HashMap<String, String>>> =
-            match (parent_vars, own_customs.is_empty()) {
+            match (
+                parent_vars,
+                own_customs.is_empty() && own_customs_important.is_empty(),
+            ) {
                 (p, true) => p, // só herda: compartilha o Arc (O(1))
                 (p, false) => {
                     crate::bump!(custom_maps_built);
                     let mut m = p.map(|a| (*a).clone()).unwrap_or_default();
-                    // o valor de uma custom pode conter var() de OUTRA — a
-                    // substituição recursiva do consumidor resolve; guarda cru.
-                    for (k, v) in own_customs {
+                    // Normais entram primeiro; as importantes vencem por nome.
+                    for (k, v) in own_customs
+                        .into_iter()
+                        .chain(own_customs_important.into_iter())
+                    {
                         // AUTO-REFERÊNCIA DIRETA (`--c: ...var(--c)...`): a declaração é
                         // guaranteed-invalid (spec) — o Chrome a DESCARTA e mantém a
-                        // anterior válida. Se já há um valor para `k` (ex. o oklch real do
-                        // bloco de tema) e a nova declaração se auto-referencia, ignora a
-                        // nova. Sem valor anterior, insere (o consumidor corta o ciclo).
+                        // anterior válida. Se já há um valor para `k` e a nova declaração
+                        // se auto-referencia, ignora a nova. Sem valor anterior, insere
+                        // e o consumidor corta o ciclo.
                         if references_self(&k, &v) && m.contains_key(&k) {
                             continue;
                         }
@@ -406,6 +418,8 @@ impl Dom {
         if let Some(parent_css) = &parent_css {
             crate::bump!(inherit_steps);
             css.inherit_from(parent_css);
+        } else {
+            crate::style::inherit_kw::apply_root_inherit_as_initial(&mut css);
         }
 
         // A camada de ANIMAÇÃO (o `anim_override` interpolado) NÃO entra aqui: este é

--- a/crates/rts-dom/src/dom/cascade.rs
+++ b/crates/rts-dom/src/dom/cascade.rs
@@ -320,7 +320,13 @@ impl Dom {
 
         // ── Passe 1: NORMAIS (fraco → forte) ────────────────────────────────────
         let mut css = style::lookup_style(&tag).unwrap_or_default(); // UA/defineStyle
+        if author.all_initial_normal {
+            css = style::ComputedStyle::default();
+        }
         css.merge_over(&author.normal); // <style> autor
+        if inline.all_initial_normal {
+            css = style::ComputedStyle::default();
+        }
         css.merge_over(&inline.normal); // style="" inline
         for (prop, raw, important) in &inline.pending {
             if !important {
@@ -331,7 +337,13 @@ impl Dom {
             css.merge_over(ov); // override por-nó (setStyleBatch)
         }
         // ── Passe 2: IMPORTANT (vencem qualquer normal) ─────────────────────────
+        if author.all_initial_important {
+            css = style::ComputedStyle::default();
+        }
         css.merge_over(&author.important); // <style> !important
+        if inline.all_initial_important {
+            css = style::ComputedStyle::default();
+        }
         css.merge_over(&inline.important); // inline !important
         for (prop, raw, important) in &inline.pending {
             if *important {

--- a/crates/rts-dom/src/dom/consulta.rs
+++ b/crates/rts-dom/src/dom/consulta.rs
@@ -22,6 +22,24 @@ impl Dom {
         Some(self.make_id(idx))
     }
 
+    /// `document.getElementById`: procura o valor literal do atributo `id`, sem
+    /// passar pelo parser CSS. O primeiro candidato é escolhido em ordem
+    /// documental, inclusive quando há IDs duplicados.
+    pub fn get_element_by_id(&self, id: &str) -> Option<NodeId> {
+        let candidates = self.id_index.get(id)?;
+        let positions = self.document_positions();
+        let idx = candidates
+            .iter()
+            .copied()
+            .filter(|&idx| {
+                self.is_attached(idx)
+                    && matches!(self.nodes[idx].kind, NodeKind::Element { .. })
+                    && self.nodes[idx].attr("id") == Some(id)
+            })
+            .min_by_key(|&idx| positions.1[idx]);
+        idx.map(|idx| self.make_id(idx))
+    }
+
     /// Núcleo do `query` em índices crus (interno). O `query` público embrulha o
     /// resultado no `NodeId` versionado.
     fn query_idx(&self, sel: &str) -> Option<NodeIdx> {

--- a/crates/rts-dom/src/dom/estilo.rs
+++ b/crates/rts-dom/src/dom/estilo.rs
@@ -35,18 +35,66 @@ impl Dom {
         Some(computed)
     }
 
-    /// Acrescenta o conteúdo de um `<style>` ao stylesheet de autor da página
-    /// (chamado pelo parser ao encontrar um `RawElement` de `style`). Vários
-    /// `<style>` acumulam, com as regras posteriores desempatando por cima.
+    /// Acrescenta CSS externo ao stylesheet autoral. O conteúdo dos elementos
+    /// `<style>` é recolhido dos nós vivos por `rebuild_author_stylesheet`, para
+    /// que remoções e substituições não deixem regras antigas na cascade.
     pub fn add_stylesheet(&mut self, css: &str) {
         let _phase = crate::metrics::phases::scope("parse-css");
         crate::bump!(stylesheets_added);
         crate::bump!(css_bytes, css.len());
+        self.external_css.push_str(css);
+        self.external_css.push('\n');
+        self.rebuild_author_stylesheet();
+    }
+
+    /// Reconstrói a stylesheet autoral na ordem documental dos `<style>` vivos.
+    /// Esta operação é usada depois de mutações que podem inserir, remover ou
+    /// substituir CSS. O CSS externo é preservado como a primeira origem autoral.
+    pub(in crate::dom) fn rebuild_author_stylesheet(&mut self) {
+        let mut embedded = Vec::new();
+        self.collect_embedded_css(self.root, &mut embedded);
+
+        let mut stylesheet = crate::style::Stylesheet::new();
+        if !self.external_css.is_empty() {
+            stylesheet.append_css(&self.external_css);
+        }
+        for css in &embedded {
+            stylesheet.append_css(css);
+        }
+        self.stylesheet = stylesheet;
+
+        self.raw_css.clear();
+        self.raw_css.push_str(&self.external_css);
+        for css in embedded {
+            self.raw_css.push_str(&css);
+            self.raw_css.push('\n');
+        }
         self.touch();
-        self.stylesheet.append_css(css);
-        // guarda o bruto p/ os pseudo-elementos ::-webkit-scrollbar* (#1744).
-        self.raw_css.push_str(css);
-        self.raw_css.push('\n');
+    }
+
+    pub(in crate::dom) fn subtree_contains_style(&self, idx: NodeIdx) -> bool {
+        if matches!(&self.nodes[idx].kind, NodeKind::Element { tag } if tag == "style") {
+            return true;
+        }
+        self.nodes[idx]
+            .children
+            .iter()
+            .copied()
+            .any(|child| self.subtree_contains_style(child))
+    }
+
+    fn collect_embedded_css(&self, idx: NodeIdx, out: &mut Vec<String>) {
+        if let NodeKind::Element { tag } = &self.nodes[idx].kind {
+            if tag == "style" {
+                let css = self
+                    .text_content(self.make_id(idx))
+                    .unwrap_or_default();
+                out.push(css);
+            }
+        }
+        for &child in &self.nodes[idx].children {
+            self.collect_embedded_css(child, out);
+        }
     }
 
     /// O estilo da SCROLLBAR resolvido da página (#1744): combina `scrollbar-width`/

--- a/crates/rts-dom/src/dom/estilo.rs
+++ b/crates/rts-dom/src/dom/estilo.rs
@@ -6,12 +6,14 @@
 use super::*;
 
 impl Dom {
-
     /// O ALVO-BASE (cascade sem animação) de um nó, MEMOIZADO por revisão estrutural.
     /// O `advance` consulta isto a cada frame; entre frames de animação (revisão
     /// estrutural estável) é um hit de cache — a cascade não re-roda. `None` p/
     /// não-elemento.
-    pub(in crate::dom) fn base_style_idx(&self, idx: NodeIdx) -> Option<std::rc::Rc<crate::style::ComputedStyle>> {
+    pub(in crate::dom) fn base_style_idx(
+        &self,
+        idx: NodeIdx,
+    ) -> Option<std::rc::Rc<crate::style::ComputedStyle>> {
         let style_epoch = crate::style::props::style_epoch();
         let (vw, vh) = self.viewport.get();
         let vp_key = (vw.to_bits(), vh.to_bits());
@@ -86,9 +88,7 @@ impl Dom {
     fn collect_embedded_css(&self, idx: NodeIdx, out: &mut Vec<String>) {
         if let NodeKind::Element { tag } = &self.nodes[idx].kind {
             if tag == "style" {
-                let css = self
-                    .text_content(self.make_id(idx))
-                    .unwrap_or_default();
+                let css = self.text_content(self.make_id(idx)).unwrap_or_default();
                 out.push(css);
             }
         }
@@ -110,7 +110,6 @@ impl Dom {
         &self.stylesheet
     }
 
-
     /// `getComputedStyle(el).<name>` — o valor COMPUTADO (após a cascade completa)
     /// de uma propriedade CSS por nome, no formato do browser. `""` se não definida
     /// ou o nó não é elemento. (#1759)
@@ -120,15 +119,41 @@ impl Dom {
         // rgb(0, 0, 0)`). O `get_property` cru continua a servir o
         // `el.style.x`, que TEM de responder vazio fora do `style=""`. A tag vai
         // junto porque o inicial de `display` é o da UA-stylesheet dela.
-        let tag = self
-            .resolve(id)
-            .and_then(|idx| match &self.nodes[idx].kind {
-                NodeKind::Element { tag } => Some(tag.clone()),
-                _ => None,
-            });
-        self.computed_style(id)
-            .map(|c| c.computed_value(name, tag.as_deref()))
-            .unwrap_or_default()
+        let Some(idx) = self.resolve(id) else {
+            return String::new();
+        };
+        let tag = match &self.nodes[idx].kind {
+            NodeKind::Element { tag } => Some(tag.clone()),
+            _ => None,
+        };
+        let Some(style) = self.computed_style(id) else {
+            return String::new();
+        };
+
+        // Blink serializa `grid-template-columns` a partir do ComputedStyle com
+        // acesso ao LayoutObject quando a propriedade depende dos used values. O
+        // layout RTS já calcula as mesmas larguras; consulta-se a display list
+        // cacheada em vez de duplicar o algoritmo de sizing no formatador de estilo.
+        if name.trim().eq_ignore_ascii_case("grid-template-columns")
+            && style.grid_template_columns.is_some()
+        {
+            let (viewport_w, viewport_h) = self.viewport.get();
+            let context = crate::layout::LayoutCtx {
+                viewport_w,
+                viewport_h,
+                measurer: &crate::layout::ApproxMeasurer,
+            };
+            let list = crate::layout::layout_cached(self, &context);
+            if let Some(tracks) = list.grid_column_tracks.get(&idx) {
+                return tracks
+                    .iter()
+                    .map(|track| crate::style::fmt_values::fmt_px(*track))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+            }
+        }
+
+        style.computed_value(name, tag.as_deref())
     }
 
     /// `el.style.<name>` (getPropertyValue) — o valor INLINE da propriedade (só o

--- a/crates/rts-dom/src/dom/mod.rs
+++ b/crates/rts-dom/src/dom/mod.rs
@@ -152,8 +152,12 @@ pub struct Dom {
     /// `defineStyle` (por-tag, mais fraco) e o `style=""` inline. Estado DERIVADO
     /// do HTML — não entra no `PartialEq` do `Dom`.
     stylesheet: crate::style::Stylesheet,
-    /// CSS BRUTO acumulado dos `<style>` — guardado para resolver os pseudo-elementos
-    /// `::-webkit-scrollbar*` (o stylesheet parseado não modela pseudo-elementos).
+    /// CSS externo acrescentado por `addStylesheet`. Fica separado do conteúdo
+    /// dos elementos `<style>` para que uma mutação possa reconstruir apenas as
+    /// regras embutidas ainda vivas, sem ressuscitar regras removidas.
+    external_css: String,
+    /// CSS BRUTO efetivo da página — CSS externo mais o conteúdo dos `<style>` vivos.
+    /// Guardado para resolver os pseudo-elementos `::-webkit-scrollbar*`.
     /// DERIVADO do HTML, fora do `PartialEq`.
     raw_css: String,
     /// Eventos (#1760, modelo de POLLING — F3): que TIPOS cada nó escuta

--- a/crates/rts-dom/src/dom/mutacao.rs
+++ b/crates/rts-dom/src/dom/mutacao.rs
@@ -17,6 +17,7 @@ impl Dom {
         if !matches!(self.nodes[idx].kind, NodeKind::Element { .. }) {
             return;
         }
+        let style_node = matches!(&self.nodes[idx].kind, NodeKind::Element { tag } if tag == "style");
         self.touch_render_only(idx);
         // Descarta os filhos atuais (arena não compacta; vira lixo inacessível —
         // ok para o uso atual, a árvore é reconstruída a cada `html()`). Zera o
@@ -28,6 +29,9 @@ impl Dom {
         let child = self.push_detached(NodeKind::Text(text.to_string()));
         self.nodes[child].parent = Some(idx);
         self.nodes[idx].children.push(child);
+        if style_node {
+            self.rebuild_author_stylesheet();
+        }
     }
 
 
@@ -136,8 +140,15 @@ impl Dom {
             return;
         };
         let children: Vec<NodeIdx> = self.nodes[idx].children.clone();
+        let style_affected = children
+            .iter()
+            .copied()
+            .any(|child| self.subtree_contains_style(child));
         for c in children {
             self.detach(c);
+        }
+        if style_affected {
+            self.rebuild_author_stylesheet();
         }
     }
 
@@ -157,9 +168,17 @@ impl Dom {
     pub fn set_node_value(&mut self, id: NodeId, value: &str) {
         self.touch();
         let Some(idx) = self.resolve(id) else { return };
+        let style_affected = self
+            .nodes[idx]
+            .parent
+            .map(|parent| self.subtree_contains_style(parent))
+            .unwrap_or(false);
         match &mut self.nodes[idx].kind {
             NodeKind::Text(t) | NodeKind::Comment(t) => *t = value.to_string(),
             _ => {}
+        }
+        if style_affected {
+            self.rebuild_author_stylesheet();
         }
     }
 
@@ -355,6 +374,7 @@ impl Dom {
         if parent == child || self.is_ancestor(child, parent) {
             return;
         }
+        let style_affected = self.subtree_contains_style(child);
         // ref==child é no-op (inserir antes de si mesmo mantém a posição). A spec do
         // DOM trata referenceNode==node como manter no lugar.
         let ref_idx = reference.and_then(|r| self.resolve(r));
@@ -366,6 +386,9 @@ impl Dom {
                 self.nodes[child].parent = Some(parent);
                 self.nodes[parent].children.push(child);
                 self.touch_structural(child, old_parent);
+                if style_affected {
+                    self.rebuild_author_stylesheet();
+                }
             }
             return;
         }
@@ -379,6 +402,9 @@ impl Dom {
             .unwrap_or(self.nodes[parent].children.len());
         self.nodes[parent].children.insert(pos, child);
         self.touch_structural(child, old_parent);
+        if style_affected {
+            self.rebuild_author_stylesheet();
+        }
     }
 
     /// `node.nodeType` — código numérico do DOM: Element=1, Text=3, Comment=8,
@@ -426,6 +452,9 @@ impl Dom {
         self.nodes[child].parent = Some(parent);
         self.nodes[parent].children.push(child);
         self.touch_structural(child, old_parent);
+        if self.subtree_contains_style(child) {
+            self.rebuild_author_stylesheet();
+        }
     }
 
     /// Desliga um nó do pai (`element.remove`). O nó continua na arena (lixo).
@@ -441,8 +470,12 @@ impl Dom {
         // dele), e os ancestrais precisam estar alcançáveis para os epochs
         // subirem — depois do detach o nó já não tem pai.
         let parent = self.nodes[idx].parent;
+        let style_affected = self.subtree_contains_style(idx);
         self.touch_structural(idx, parent);
         self.detach(idx);
+        if style_affected {
+            self.rebuild_author_stylesheet();
+        }
     }
 
 
@@ -472,6 +505,7 @@ impl Dom {
         for sub_child in sub_root_children {
             self.copy_subtree_into(&sub, sub_child, idx);
         }
+        self.rebuild_author_stylesheet();
     }
 
     /// Copia recursivamente o nó `src_idx` da árvore `src` para dentro desta arena,

--- a/crates/rts-dom/src/dom/parser.rs
+++ b/crates/rts-dom/src/dom/parser.rs
@@ -299,14 +299,12 @@ fn parse_com_estrutura(html: &str, estrutura: bool) -> Dom {
                 content,
             } => {
                 // `<style>`/`<script>`: DOM fiel preserva o ELEMENTO (com o texto cru
-                // como filho), mas o conteúdo NÃO é HTML. Para `<style>`, o CSS
-                // alimenta o stylesheet de autor (a cascade de `computed_style`).
+                // como filho), mas o conteúdo NÃO é HTML. O CSS dos `<style>` será
+                // recolhido da árvore ao final, para manter a mesma fonte de verdade
+                // usada pelas mutações (`innerHTML`, remove e replace).
                 // Para `<script>`, só preserva o nó (não executamos JS). O render
                 // ignora ambos (sem `BlockDef`/inline para essas tags). Os atributos
                 // da abertura são preservados (`<script src>`/`<style media>`).
-                if tag == "style" {
-                    dom.add_stylesheet(&content);
-                }
                 let parent = open.last().unwrap().0;
                 let parsed = parse_attrs(&attrs);
                 let el = dom.push(NodeKind::Element { tag }, parsed, parent);
@@ -316,6 +314,7 @@ fn parse_com_estrutura(html: &str, estrutura: bool) -> Dom {
             }
         }
     }
+    dom.rebuild_author_stylesheet();
     dom
 }
 

--- a/crates/rts-dom/src/dom/tests/cascade.rs
+++ b/crates/rts-dom/src/dom/tests/cascade.rs
@@ -285,3 +285,38 @@
         assert_eq!(dom.inline_property(a, "color"), ""); // o color sumiu
         assert_eq!(dom.inline_property(a, "background-color"), "rgb(0, 128, 0)");
     }
+
+
+    #[test]
+    fn style_inserido_por_inner_html_entra_e_sai_da_cascade() {
+        let mut dom = parse_html_to_dom("<div id='root'></div>");
+        let root = dom.query("#root").unwrap();
+
+        dom.set_inner_html(
+            root,
+            "<style>.x { color: #ff0000 }</style><p id='p' class='x'>x</p>",
+        );
+        let p = dom.query("#p").unwrap();
+        assert_eq!(dom.computed_property(p, "color"), "rgb(255, 0, 0)");
+
+        dom.set_inner_html(root, "<p id='p' class='x'>x</p>");
+        let p = dom.query("#p").unwrap();
+        assert_eq!(dom.computed_property(p, "color"), "rgb(0, 0, 0)");
+    }
+
+    #[test]
+    fn style_embutido_removido_nao_apaga_css_externo() {
+        let mut dom = parse_html_to_dom("<div id='root'></div>");
+        dom.add_stylesheet(".x { color: #0000ff }");
+        let root = dom.query("#root").unwrap();
+        dom.set_inner_html(
+            root,
+            "<style>.x { color: #ff0000 }</style><p id='p' class='x'>x</p>",
+        );
+        let p = dom.query("#p").unwrap();
+        assert_eq!(dom.computed_property(p, "color"), "rgb(255, 0, 0)");
+
+        dom.set_inner_html(root, "<p id='p' class='x'>x</p>");
+        let p = dom.query("#p").unwrap();
+        assert_eq!(dom.computed_property(p, "color"), "rgb(0, 0, 255)");
+    }

--- a/crates/rts-dom/src/dom/tests/consulta.rs
+++ b/crates/rts-dom/src/dom/tests/consulta.rs
@@ -307,3 +307,21 @@
         assert_eq!(ids, vec!["u", "v"], "sem duplicata e em ordem");
         let _ = &mut dom2;
     }
+
+
+    #[test]
+    fn document_element_nao_e_a_raiz_document() {
+        let dom = parse_html_to_dom("<html><body><p>x</p></body></html>");
+        let html = dom.document_element().expect("html top-level");
+        assert_eq!(dom.node_type(dom.root_id()), 9);
+        assert_eq!(dom.node_type(html), 1);
+        assert_eq!(dom.tag_name(html), Some("html"));
+    }
+
+    #[test]
+    fn get_element_by_id_nao_interpreta_id_como_css() {
+        let dom = parse_html_to_dom("<div id='a.b'>literal</div><p id='a'>outro</p>");
+        let literal = dom.get_element_by_id("a.b").expect("id literal");
+        assert_eq!(dom.tag_name(literal), Some("div"));
+        assert_eq!(dom.text_content(literal).as_deref(), Some("literal"));
+    }

--- a/crates/rts-dom/src/dom/travessia.rs
+++ b/crates/rts-dom/src/dom/travessia.rs
@@ -28,6 +28,15 @@ impl Dom {
         }
     }
 
+    /// O elemento `<html>` top-level do documento, separado da raiz sintética
+    /// `#document`. `None` para um fragmento sem `<html>`.
+    pub fn document_element(&self) -> Option<NodeId> {
+        self.nodes[self.root].children.iter().copied().find_map(|idx| {
+            matches!(&self.nodes[idx].kind, NodeKind::Element { tag } if tag == "html")
+                .then(|| self.make_id(idx))
+        })
+    }
+
     /// Nome da tag de um elemento em minúsculas (`element.tagName`, mas o browser
     /// devolve em CAIXA ALTA para HTML — a fachada TS faz o upper). `None` se não
     /// resolve ou não é elemento.

--- a/crates/rts-dom/src/flowtests.rs
+++ b/crates/rts-dom/src/flowtests.rs
@@ -347,6 +347,30 @@ fn display_inline_declarado_vence_a_tag_de_bloco() {
     );
 }
 
+#[test]
+fn display_inline_ignores_width_and_height() {
+    let (dom, list) = geometria(
+        "<div style='width:400px;line-height:20px'>\
+         <span id='inline' style='display:inline;width:300px;height:300px'>abc</span>\
+         <span id='inline-block' style='display:inline-block;width:120px;height:40px'></span></div>",
+        800.0,
+    );
+    let inline = rect(&dom, &list, "#inline", 0);
+    assert!(
+        inline.w < 100.0,
+        "inline width deve ignorar 300px: {inline:?}"
+    );
+    assert!(
+        inline.h < 30.0,
+        "inline height deve ignorar 300px: {inline:?}"
+    );
+    let inline_block = rect(&dom, &list, "#inline-block", 0);
+    assert!(
+        inline_block.x > inline.x,
+        "inline-block deve seguir na mesma linha: {inline:?} -> {inline_block:?}"
+    );
+}
+
 /// E o inline declarado que CRIA caixa (fundo, padding) continua a ir pelo
 /// caminho de bloco, porque é quem pinta essa caixa. A regra que a correção
 /// acima introduz não podia levar esse caso com ela.
@@ -392,10 +416,16 @@ fn display_block_declarado_vence_a_tag_inline() {
 fn display_inline_vale_para_qualquer_tag_de_bloco() {
     for tag in ["div", "p", "li", "h2"] {
         let (d, l) = geometria(
-            &format!("<div style='width:400px'><{tag} id='b' style='display:inline'>abc</{tag}></div>"),
+            &format!(
+                "<div style='width:400px'><{tag} id='b' style='display:inline'>abc</{tag}></div>"
+            ),
             800.0,
         );
         let b = rect(&d, &l, "#b", 0);
-        assert!(b.w < 100.0, "<{tag}> inline levou a largura do pai: {}", b.w);
+        assert!(
+            b.w < 100.0,
+            "<{tag}> inline levou a largura do pai: {}",
+            b.w
+        );
     }
 }

--- a/crates/rts-dom/src/layout/bloco.rs
+++ b/crates/rts-dom/src/layout/bloco.rs
@@ -10,6 +10,219 @@
 //! Movido de `layout.rs` na modularização; nenhuma linha de lógica foi alterada.
 
 use super::*;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum MarginChildRole {
+    Ignore,
+    Barrier,
+    Block { top: f32, bottom: f32 },
+}
+
+fn establishes_block_formatting_context(css: &ComputedStyle) -> bool {
+    let display_bfc = matches!(
+        css.effective_display(),
+        Some(
+            crate::style::DisplayKind::Flex
+                | crate::style::DisplayKind::FlexWrap
+                | crate::style::DisplayKind::Grid
+                | crate::style::DisplayKind::InlineBlock
+                | crate::style::DisplayKind::Table
+                | crate::style::DisplayKind::TableRowGroup
+                | crate::style::DisplayKind::TableRow
+                | crate::style::DisplayKind::TableCell
+                | crate::style::DisplayKind::TableCaption
+        )
+    );
+    let overflow_bfc = [css.overflow_x, css.overflow_y].into_iter().any(|value| {
+        matches!(
+            value,
+            Some(
+                crate::scrollbar::Overflow::Auto
+                    | crate::scrollbar::Overflow::Scroll
+                    | crate::scrollbar::Overflow::Hidden
+            )
+        )
+    });
+    let float_bfc = css
+        .float_side
+        .is_some_and(|side| side != crate::style::FloatSide::None);
+    let positioned_bfc = css
+        .position
+        .map(|position| position.out_of_flow())
+        .unwrap_or(false);
+    css.flow_root.unwrap_or(false) || display_bfc || overflow_bfc || float_bfc || positioned_bfc
+}
+
+pub(in crate::layout) fn collapse_margin(first: f32, second: f32) -> f32 {
+    if first >= 0.0 && second >= 0.0 {
+        first.max(second)
+    } else if first <= 0.0 && second <= 0.0 {
+        first.min(second)
+    } else {
+        first + second
+    }
+}
+
+fn margin_child_role(
+    dom: &Dom,
+    child: NodeIdx,
+    content_w: f32,
+    parent_font_size: f32,
+    ctx: &LayoutCtx,
+) -> MarginChildRole {
+    match &dom.node(child).kind {
+        NodeKind::Comment(_) => MarginChildRole::Ignore,
+        NodeKind::Text(text) if text.trim().is_empty() => MarginChildRole::Ignore,
+        NodeKind::Text(_) | NodeKind::Document => MarginChildRole::Barrier,
+        NodeKind::Element { tag } if is_non_rendered_tag(tag) => MarginChildRole::Ignore,
+        NodeKind::Element { .. } => {
+            let css = dom.computed_style_idx(child).unwrap_or_default();
+            if e_display_none(dom, child)
+                || css
+                    .position
+                    .map(|position| position.out_of_flow())
+                    .unwrap_or(false)
+                || css
+                    .float_side
+                    .map(|side| side != crate::style::FloatSide::None)
+                    .unwrap_or(false)
+            {
+                return MarginChildRole::Ignore;
+            }
+            let effective = css.effective_display();
+            let block_candidate = match effective {
+                Some(
+                    crate::style::DisplayKind::Inline
+                    | crate::style::DisplayKind::InlineBlock
+                    | crate::style::DisplayKind::TableRowGroup
+                    | crate::style::DisplayKind::TableRow
+                    | crate::style::DisplayKind::TableCell
+                    | crate::style::DisplayKind::TableCaption
+                    | crate::style::DisplayKind::None,
+                ) => false,
+                Some(_) => true,
+                None => is_block_level(dom, child) && !is_inline_block(dom, child),
+            };
+            if !block_candidate {
+                return MarginChildRole::Barrier;
+            }
+            let resolve = ResolveCtx {
+                parent_content_w: content_w,
+                node_font_size: font_px(&css, parent_font_size),
+                root_font_size: crate::style::root_font_size(),
+                viewport_w: ctx.viewport_w,
+                viewport_h: ctx.viewport_h,
+            };
+            let margin_v = css.margin_v.unwrap_or(0.0);
+            let margin_top_extra = if css.margin.top == crate::style::Side::Unset {
+                margin_v
+            } else {
+                0.0
+            };
+            let margin_bottom_extra = if css.margin.bottom == crate::style::Side::Unset {
+                margin_v
+            } else {
+                0.0
+            };
+            MarginChildRole::Block {
+                top: css.margin.top.resolve(&resolve).unwrap_or(0.0) + margin_top_extra,
+                bottom: css.margin.bottom.resolve(&resolve).unwrap_or(0.0) + margin_bottom_extra,
+            }
+        }
+    }
+}
+
+fn edge_margin_from_children(
+    dom: &Dom,
+    id: NodeIdx,
+    content_w: f32,
+    parent_font_size: f32,
+    ctx: &LayoutCtx,
+    from_end: bool,
+) -> Option<f32> {
+    let children = &dom.node(id).children;
+    if from_end {
+        for &child in children.iter().rev() {
+            match margin_child_role(dom, child, content_w, parent_font_size, ctx) {
+                MarginChildRole::Ignore => continue,
+                MarginChildRole::Barrier => return None,
+                MarginChildRole::Block { bottom, .. } => return Some(bottom),
+            }
+        }
+    } else {
+        for &child in children {
+            match margin_child_role(dom, child, content_w, parent_font_size, ctx) {
+                MarginChildRole::Ignore => continue,
+                MarginChildRole::Barrier => return None,
+                MarginChildRole::Block { top, .. } => return Some(top),
+            }
+        }
+    }
+    None
+}
+
+pub(in crate::layout) fn escaped_child_margins(
+    dom: &Dom,
+    id: NodeIdx,
+    parent_css: &ComputedStyle,
+    content_w: f32,
+    parent_font_size: f32,
+    ctx: &LayoutCtx,
+    pad_top: f32,
+    border_top: f32,
+    pad_bottom: f32,
+    border_bottom: f32,
+    bottom_auto_height: bool,
+) -> (f32, f32) {
+    if establishes_block_formatting_context(parent_css) {
+        return (0.0, 0.0);
+    }
+    let top = if pad_top == 0.0 && border_top == 0.0 {
+        edge_margin_from_children(dom, id, content_w, parent_font_size, ctx, false).unwrap_or(0.0)
+    } else {
+        0.0
+    };
+    let bottom = if bottom_auto_height && pad_bottom == 0.0 && border_bottom == 0.0 {
+        edge_margin_from_children(dom, id, content_w, parent_font_size, ctx, true).unwrap_or(0.0)
+    } else {
+        0.0
+    };
+    (top, bottom)
+}
+
+pub(in crate::layout) fn escaped_margins_for_box(
+    dom: &Dom,
+    id: NodeIdx,
+    content_w: f32,
+    parent_font_size: f32,
+    ctx: &LayoutCtx,
+) -> (f32, f32) {
+    let css = dom.computed_style_idx(id).unwrap_or_default();
+    let resolve = ResolveCtx {
+        parent_content_w: content_w,
+        node_font_size: font_px(&css, parent_font_size),
+        root_font_size: crate::style::root_font_size(),
+        viewport_w: ctx.viewport_w,
+        viewport_h: ctx.viewport_h,
+    };
+    let pad_top = css.padding.top.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let pad_bottom = css.padding.bottom.resolve(&resolve).unwrap_or(0.0).max(0.0);
+    let [border_top, _, border_bottom, _] = crate::style::borders::used_widths(&css);
+    escaped_child_margins(
+        dom,
+        id,
+        &css,
+        content_w,
+        parent_font_size,
+        ctx,
+        pad_top,
+        border_top,
+        pad_bottom,
+        border_bottom,
+        css.height.is_none() && css.min_height.is_none(),
+    )
+}
+
 /// Faz o layout de UM nó-bloco a partir de `(x, y)`, com `avail_w` de largura
 /// disponível (a do container). Emite os itens (fundo/borda/texto/filhos) na
 /// `list` e devolve o TAMANHO EXTERNO `(outer_w, outer_h)` da caixa (incluindo
@@ -255,16 +468,16 @@ pub(crate) fn layout_block(
             content_natural_width(dom, id, font_for_content, ctx)
         } else {
             match css.width.and_then(|d| d.resolve(&resolve)) {
-            // `width` explícito. Em `border-box`, o `width` INCLUI padding+border —
-            // então o content é `width - (padding_h + 2*border)`. Em content-box
-            // (default), o `width` JÁ é o content.
-            Some(w) if border_box => (w - (padding_h + border_h)).max(0.0),
-            Some(w) => w,
-            // Sem width: shrink-to-fit → largura do conteúdo (limitada ao disponível);
-            // senão (fluxo block normal) → ocupa a largura disponível.
-            None if shrink_to_fit => content_natural_width(dom, id, font_for_content, ctx)
-                .min((avail_w - frame).max(0.0)),
-            None => (avail_w - frame).max(0.0),
+                // `width` explícito. Em `border-box`, o `width` INCLUI padding+border —
+                // então o content é `width - (padding_h + 2*border)`. Em content-box
+                // (default), o `width` JÁ é o content.
+                Some(w) if border_box => (w - (padding_h + border_h)).max(0.0),
+                Some(w) => w,
+                // Sem width: shrink-to-fit → largura do conteúdo (limitada ao disponível);
+                // senão (fluxo block normal) → ocupa a largura disponível.
+                None if shrink_to_fit => content_natural_width(dom, id, font_for_content, ctx)
+                    .min((avail_w - frame).max(0.0)),
+                None => (avail_w - frame).max(0.0),
             }
         };
         // CLAMP min/max-width (#1751): `used = clamp(min, width, max)`. min/max são
@@ -548,14 +761,38 @@ pub(crate) fn layout_block(
         None => content_h,
     };
 
+    // MARGIN-COLLAPSE pai/filho: sem BFC, borda ou padding, a margem da primeira
+    // caixa de bloco pode escapar por cima e a da última pode escapar por baixo.
+    // O cursor que o pai devolve continua a incluir o espaço colapsado, mas o
+    // border-box próprio não pinta nem mede essa margem externa.
+    let (escaped_top, escaped_bottom) = escaped_child_margins(
+        dom,
+        id,
+        &css,
+        content_w,
+        font_size,
+        ctx,
+        pad_top,
+        border_top,
+        pad_bottom,
+        border_bottom,
+        explicit_content_h.is_none() && mnh_pre.is_none(),
+    );
+    let box_content_h = if explicit_content_h.is_none() && mnh_pre.is_none() {
+        (content_h - escaped_top - escaped_bottom).max(0.0)
+    } else {
+        content_h
+    };
+    let box_top_margin = collapse_margin(margin_top, escaped_top);
+    let box_bottom_margin = collapse_margin(margin_bottom, escaped_bottom);
     // ── Insere a CAIXA (fundo + borda) no índice reservado, ATRÁS dos filhos ─────
     // O BORDER-BOX do nó: content + padding + border (NÃO a margin — esta é espaço
     // externo). É o retângulo que `getBoundingClientRect()` reporta.
     let box_rect = Rect::new(
         x + margin_left,
-        y + margin_top,
+        y + box_top_margin,
         content_w + padding_h + border_h,
-        content_h + pad_top + pad_bottom + border_v,
+        box_content_h + pad_top + pad_bottom + border_v,
     );
     // Registra a geometria deste nó (base do getBoundingClientRect/offsetWidth).
     record_node_rect(list, id, box_rect);
@@ -663,7 +900,12 @@ pub(crate) fn layout_block(
     let clips =
         ov_x != crate::scrollbar::Overflow::Visible || ov_y != crate::scrollbar::Overflow::Visible;
     if clips {
-        let content_rect = Rect::new(content_x, content_y, content_w, content_h);
+        let content_rect = Rect::new(
+            content_x,
+            box_rect.y + border_top + pad_top,
+            content_w,
+            box_content_h,
+        );
         // BeginClip no índice onde os FILHOS começam (logo após os itens de caixa que
         // foram inseridos em `box_index`); EndClip no fim. Quantos itens de caixa:
         // fundo (se bg) + borda (se visível).
@@ -813,6 +1055,7 @@ pub(crate) fn layout_block(
     // componente já é a SOMA do seu eixo (padding_h = left+right; margin_h idem;
     // border conta 2× pelos dois lados). Não multiplicar margin/padding por 2.
     let outer_w = content_w + padding_h + border_h + margin_h;
-    let outer_h = content_h + pad_top + pad_bottom + border_v + margin_top + margin_bottom;
+    let outer_h =
+        box_content_h + pad_top + pad_bottom + border_v + box_top_margin + box_bottom_margin;
     (outer_w, outer_h)
 }

--- a/crates/rts-dom/src/layout/caixa.rs
+++ b/crates/rts-dom/src/layout/caixa.rs
@@ -27,6 +27,15 @@
 //! Movido de `layout.rs` na modularização; nenhuma linha de lógica foi alterada.
 
 use super::*;
+
+/// `true` quando `display:inline` torna `width` e `height` inoperantes. A
+/// classificação de caixa e o fluxo inline partilham esta pergunta para não
+/// transformar uma dimensão declarada num inline-block artificial.
+pub(in crate::layout) fn ignores_inline_dimensions(css: &ComputedStyle) -> bool {
+    css.effective_display() == Some(crate::style::DisplayKind::Inline)
+        && (css.width.is_some() || css.height.is_some())
+}
+
 /// `true` se um nó-elemento deve ser tratado como BLOCO no layout (entra em
 /// `layout_block`, com sua própria caixa/eixo) — em vez de inline (texto corrido).
 /// É bloco se: tem `display` no CSS (qualquer um define caixa própria), OU tem um
@@ -81,6 +90,9 @@ pub(in crate::layout) fn is_block_level(dom: &Dom, id: NodeIdx) -> bool {
             // `cria_caixa_apesar_de_inline` — não `cria_caixa_de_bloco`, que
             // conta a margem que o `display:inline` acabou de tornar
             // inoperante e devolveria o `<h3>` ao caminho de onde ele saiu.
+            if css.as_deref().is_some_and(ignores_inline_dimensions) {
+                return false;
+            }
             if css.as_ref().and_then(|c| c.effective_display())
                 == Some(crate::style::DisplayKind::Inline)
             {
@@ -112,6 +124,9 @@ pub(in crate::layout) fn is_inline_block(dom: &Dom, id: NodeIdx) -> bool {
     match &dom.node(id).kind {
         NodeKind::Element { tag } => {
             let css = dom.computed_style_idx(id);
+            if css.as_deref().is_some_and(ignores_inline_dimensions) {
+                return false;
+            }
             // Um `display:inline-block` DECLARADO responde `true` e não chega às
             // perguntas seguintes — nem à tag, que é o que o tornava invisível.
             //
@@ -266,7 +281,11 @@ pub(in crate::layout) fn em_contexto_inline(dom: &Dom, parent: NodeIdx, child: N
 /// Retorna se um whitespace entre irmãos deve participar do contexto inline. O
 /// parser preserva o nó de texto por fidelidade ao DOM, mas whitespace entre dois
 /// blocos/floats não cria uma linha visual; whitespace adjacente a texto/inline sim.
-pub(in crate::layout) fn whitespace_is_inline_separator(dom: &Dom, parent: NodeIdx, child: NodeIdx) -> bool {
+pub(in crate::layout) fn whitespace_is_inline_separator(
+    dom: &Dom,
+    parent: NodeIdx,
+    child: NodeIdx,
+) -> bool {
     let children = &dom.node(parent).children;
     let Some(pos) = children.iter().position(|&c| c == child) else {
         return false;

--- a/crates/rts-dom/src/layout/display.rs
+++ b/crates/rts-dom/src/layout/display.rs
@@ -264,6 +264,9 @@ pub struct DisplayList {
     /// o `getBoundingClientRect` do browser); elementos inline recebem a união dos
     /// fragmentos de linha; nós de texto não entram.
     pub node_rects: crate::fasthash::FastMap<NodeIdx, Rect>,
+    /// Tracks de coluna de grids explícitos, já resolvidas em px pelo layout. O
+    /// `computedProperty` usa esta fonte de used values sem duplicar `resolve_tracks`.
+    pub grid_column_tracks: crate::fasthash::FastMap<NodeIdx, Vec<f32>>,
     /// Containers roláveis internos (divs com `overflow`) — o backend gerencia o
     /// offset de cada região e recorta. Vazio quando a página não tem scroll interno.
     pub scroll_regions: Vec<ScrollRegion>,

--- a/crates/rts-dom/src/layout/fragmento.rs
+++ b/crates/rts-dom/src/layout/fragmento.rs
@@ -54,7 +54,12 @@ pub(in crate::layout) struct KeyBase {
 }
 
 impl KeyBase {
-    pub(in crate::layout) fn new(dom: &Dom, avail_w: f32, avail_h: Option<f32>, ctx: &LayoutCtx) -> KeyBase {
+    pub(in crate::layout) fn new(
+        dom: &Dom,
+        avail_w: f32,
+        avail_h: Option<f32>,
+        ctx: &LayoutCtx,
+    ) -> KeyBase {
         KeyBase {
             tree: dom.cache_identity(),
             style_epoch: crate::style::props::style_epoch(),
@@ -166,11 +171,18 @@ fn costurar(
     let _phase = crate::metrics::phases::scope("fragment-patch");
 
     let mut children = anterior.children.clone();
+    let mut grid_column_tracks = (*anterior.grid_column_tracks).clone();
     let mut trocou = false;
     for child in &mut children {
         if !sujos.contains(&child.node) {
             continue;
         }
+        let previous_grid_nodes: Vec<NodeIdx> = child
+            .fragment
+            .grid_column_tracks
+            .iter()
+            .map(|(node, _)| *node)
+            .collect();
         let mut own = DisplayList::default();
         // Onde o filho FOI POSTO: a origem em que o fragmento dele foi calculado
         // mais o deslocamento com que entrou aqui. Somar à origem do PAI daria
@@ -204,6 +216,8 @@ fn costurar(
         // O `layout_block_reusing` emitiu numa lista própria; o que interessa é a
         // referência que ele acabou de registrar para este nó.
         let novo = own.children.first()?.fragment.clone();
+        grid_column_tracks.retain(|(node, _)| !previous_grid_nodes.contains(node));
+        grid_column_tracks.extend(novo.grid_column_tracks.iter().cloned());
         child.fragment = novo;
         trocou = true;
     }
@@ -217,6 +231,7 @@ fn costurar(
         children,
         rects: std::rc::Rc::clone(&anterior.rects),
         hit_order: std::rc::Rc::clone(&anterior.hit_order),
+        grid_column_tracks: std::rc::Rc::new(grid_column_tracks),
         scroll_regions: anterior.scroll_regions.clone(),
         origin: anterior.origin,
         size: anterior.size,
@@ -331,6 +346,11 @@ pub(in crate::layout) fn layout_block_reusing(
                 .collect(),
         ),
         hit_order: std::rc::Rc::new(std::mem::take(&mut own.hit_order)),
+        grid_column_tracks: std::rc::Rc::new(
+            std::mem::take(&mut own.grid_column_tracks)
+                .into_iter()
+                .collect(),
+        ),
         scroll_regions: std::mem::take(&mut own.scroll_regions),
         items: std::rc::Rc::new(std::mem::take(&mut own.items)),
         children: std::mem::take(&mut own.children),
@@ -409,6 +429,8 @@ pub struct Fragment {
     pub children: Vec<ChildRef>,
     /// Geometria por nó (o que alimenta `getBoundingClientRect`).
     pub rects: std::rc::Rc<Vec<(NodeIdx, Rect)>>,
+    /// Tracks de coluna resolvidas desta subárvore, para `computedProperty`.
+    pub grid_column_tracks: std::rc::Rc<Vec<(NodeIdx, Vec<f32>)>>,
     /// Ordem de pintura para o hit-test (ancestral antes de descendente).
     pub hit_order: std::rc::Rc<Vec<NodeIdx>>,
     /// Regiões roláveis internas descobertas dentro da subárvore.
@@ -450,6 +472,9 @@ impl Fragment {
         // Os RETÂNGULOS abaixo continuam sendo materializados, porque a consulta
         // de geometria é por nó e precisa do valor pronto — são 16 bytes contra
         // os 48 de um item, numa quantidade menor.
+        for (node, tracks) in self.grid_column_tracks.iter() {
+            list.grid_column_tracks.insert(*node, tracks.clone());
+        }
         list.children.push(ChildRef {
             node: self.node,
             height: self.size.1,

--- a/crates/rts-dom/src/layout/grid.rs
+++ b/crates/rts-dom/src/layout/grid.rs
@@ -130,6 +130,12 @@ pub(in crate::layout) fn layout_children_grid(
         conteudo.as_deref(),
         &resolve,
     );
+    // O computed style do Blink pode consultar o LayoutObject para propriedades
+    // dependentes de used values. Guardamos a mesma resolução no container para o
+    // DOM a serializar sem executar um segundo algoritmo de track sizing.
+    if css.grid_template_columns.is_some() {
+        list.grid_column_tracks.insert(id, col_sizes.clone());
+    }
     // Uma linha DECLARADA pela matriz existe mesmo sem item nela (ela ainda empurra
     // as linhas seguintes pelo gap), daí o max com `areas.rows`.
     let nrows = cells

--- a/crates/rts-dom/src/layout/linha.rs
+++ b/crates/rts-dom/src/layout/linha.rs
@@ -238,6 +238,29 @@ pub(in crate::layout) fn layout_inline_flow(
         // decide o espaçamento é o `line-height`, quem decide a caixa é a fonte.
         let conteudo = crate::inline_box::altura_do_conteudo(font_size, ctx.measurer);
         let meia = crate::inline_box::meia_entrelinha(line_h, conteudo);
+        let tall_inline_block = line_h > lh + 0.001
+            && line
+                .iter()
+                .any(|segment| matches!(segment.atomic, Some((_, AtomicKind::Block))));
+        // Um inline-block vazio alinha pela baseline no seu fundo. Quando ele é
+        // mais alto que o strut, o texto mantém o ascent da fonte acima dessa
+        // baseline e o descent do strut fica abaixo dela. É o contrato Blink que
+        // dá, na fixture display, texto em y=55 e o bloco seguinte em y=75.
+        let text_top = if tall_inline_block {
+            cy + line_h - ctx.measurer.font_ascent(font_size)
+        } else {
+            cy + meia
+        };
+        let text_owner_anchor = if tall_inline_block {
+            cy + line_h
+        } else {
+            cy + meia
+        };
+        let line_advance = if tall_inline_block {
+            line_h + ctx.measurer.font_descent(font_size)
+        } else {
+            line_h
+        };
         // A banda desta linha, no `cy` VERDADEIRO — é aqui que o texto passa a
         // correr ao lado do float em vez de por baixo dele.
         let (linha_x, linha_w) = if exclusoes.is_empty() {
@@ -320,7 +343,7 @@ pub(in crate::layout) fn layout_inline_flow(
                 // de um vazio/quebra é a fatia de linha que ele ocupa.
                 let propria = match kind {
                     AtomicKind::Marker | AtomicKind::Break => {
-                        Rect::new(seg_x, cy + meia, 0.0, conteudo)
+                        Rect::new(seg_x, text_top, 0.0, conteudo)
                     }
                     _ => Rect::new(seg_x, cy, seg.ww, seg.wh),
                 };
@@ -333,7 +356,16 @@ pub(in crate::layout) fn layout_inline_flow(
                     crate::inline_box::union_rect(
                         list,
                         owner,
-                        fragmento_do_dono(dom, owner, seg_x, cy + meia, seg.ww, conteudo, ctx),
+                        fragmento_do_dono(
+                            dom,
+                            owner,
+                            seg_x,
+                            cy + meia,
+                            seg.ww,
+                            conteudo,
+                            ctx,
+                            false,
+                        ),
                     );
                 }
                 // A CAIXA DOS ANCESTRAIS inline: a largura que esta caixa ocupa na
@@ -348,7 +380,7 @@ pub(in crate::layout) fn layout_inline_flow(
             let w = seg.text_width + ls * seg.text.chars().count() as f32;
             list.items.push(DisplayItem::Text {
                 x: seg_x,
-                y: cy + meia,
+                y: text_top,
                 text: seg.text.into(),
                 color: seg.color,
                 size: font_size,
@@ -362,12 +394,21 @@ pub(in crate::layout) fn layout_inline_flow(
                 crate::inline_box::union_rect(
                     list,
                     owner,
-                    fragmento_do_dono(dom, owner, seg_x, cy + meia, w.max(0.0), conteudo, ctx),
+                    fragmento_do_dono(
+                        dom,
+                        owner,
+                        seg_x,
+                        text_owner_anchor,
+                        w.max(0.0),
+                        conteudo,
+                        ctx,
+                        tall_inline_block,
+                    ),
                 );
             }
             seg_x += w;
         }
-        cy += line_h;
+        cy += line_advance;
     }
     cy
 }
@@ -392,6 +433,7 @@ fn fragmento_do_dono(
     w: f32,
     conteudo_da_linha: f32,
     ctx: &LayoutCtx,
+    align_to_baseline: bool,
 ) -> Rect {
     let Some(css) = dom.computed_style_idx(dono) else {
         return Rect::new(x, y, w, conteudo_da_linha);
@@ -400,5 +442,10 @@ fn fragmento_do_dono(
         return Rect::new(x, y, w, conteudo_da_linha);
     };
     let conteudo = crate::inline_box::altura_do_conteudo(fonte, ctx.measurer);
-    Rect::new(x, y + (conteudo_da_linha - conteudo) / 2.0, w, conteudo)
+    let top = if align_to_baseline {
+        y - ctx.measurer.font_ascent(fonte)
+    } else {
+        y + (conteudo_da_linha - conteudo) / 2.0
+    };
+    Rect::new(x, top, w, conteudo)
 }

--- a/crates/rts-dom/src/layout/medida.rs
+++ b/crates/rts-dom/src/layout/medida.rs
@@ -24,6 +24,18 @@ pub trait TextMeasurer {
     /// fator`; o backend pode dar o valor exato da fonte.
     fn line_height(&self, size: f32) -> f32;
 
+    /// Ascent da fonte usado para alinhar texto com a baseline de atoms altos.
+    /// Backends com métricas próprias podem substituir a aproximação por valores
+    /// derivados da fonte real.
+    fn font_ascent(&self, size: f32) -> f32 {
+        size * 0.9375
+    }
+
+    /// Descent da fonte usado para fechar a line box depois de um inline-block.
+    fn font_descent(&self, size: f32) -> f32 {
+        size * 0.3125
+    }
+
     /// IDENTIDADE deste medidor: dois medidores com a mesma identidade têm de
     /// dar a mesma largura para o mesmo texto.
     ///
@@ -93,7 +105,12 @@ impl TextMeasurer for ApproxMeasurer {
 /// shrink-to-fit (item flex / inline-block). Para um filho-bloco com `width`, usa
 /// esse width (+ frame); para texto, a largura medida. Aproximação do max-content
 /// (o inline-flow exato — palavras quebrando — vem na fatia de inline).
-pub(in crate::layout) fn content_natural_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -> f32 {
+pub(in crate::layout) fn content_natural_width(
+    dom: &Dom,
+    id: NodeIdx,
+    font: f32,
+    ctx: &LayoutCtx,
+) -> f32 {
     intrinsic_content_width(dom, id, font, ctx)
 }
 
@@ -106,7 +123,12 @@ pub(in crate::layout) fn content_natural_width(dom: &Dom, id: NodeIdx, font: f32
 /// - block (vertical): MAX das larguras dos filhos (empilham).
 /// - texto: a largura do texto concatenado.
 /// Recursivo: a largura de um filho é a SUA intrínseca + frame (ou seu `width` fixo).
-pub(in crate::layout) fn intrinsic_content_width(dom: &Dom, id: NodeIdx, font: f32, ctx: &LayoutCtx) -> f32 {
+pub(in crate::layout) fn intrinsic_content_width(
+    dom: &Dom,
+    id: NodeIdx,
+    font: f32,
+    ctx: &LayoutCtx,
+) -> f32 {
     let key = IntrinsicWidthKey {
         tree: dom.cache_identity(),
         node_epoch: dom.layout_epoch(id),

--- a/crates/rts-dom/src/layout/tests/colapso.rs
+++ b/crates/rts-dom/src/layout/tests/colapso.rs
@@ -163,7 +163,6 @@ fn margens_adjacentes_colapsam_por_conjunto_e_nao_par_a_par() {
 /// vive inteira na caixa do pai** — que é precisamente o que a régua de
 /// paridade compara, elemento a elemento.
 #[test]
-#[ignore = "Chrome pai h=20 y=41, nos h=60 y=1 - a margem nunca atravessa o pai. Lote D"]
 fn a_margem_do_primeiro_filho_atravessa_o_pai_sem_borda() {
     let (yp, hp) = rel("c3", "c3p");
     let (yf, _) = rel("c3", "c3f");
@@ -181,7 +180,6 @@ fn a_margem_do_primeiro_filho_atravessa_o_pai_sem_borda() {
 /// É o caso que a auditoria descreve como a soma a DOBRAR: o pai cresce pela
 /// margem do filho e ainda a soma outra vez ao colapsar com o irmão.
 #[test]
-#[ignore = "Chrome pai h=20 e 40 de intervalo, nos h=60 e 50 - margem contada duas vezes. Lote D"]
 fn a_margem_do_ultimo_filho_atravessa_o_pai_de_altura_auto() {
     let (yp, hp) = rel("c4", "c4p");
     let (yn, _) = rel("c4", "c4n");
@@ -297,7 +295,10 @@ fn o_bloco_vazio_colapsa_tambem_com_a_margem_do_vizinho_anterior() {
 fn um_padding_de_um_pixel_barra_o_colapso_do_primeiro_filho() {
     let (yp, hp) = rel("b1", "b1p");
     let (yf, _) = rel("b1", "b1f");
-    assert!(perto(yp, 1.0) && perto(hp, 61.0), "pai y={yp} h={hp} (Chrome: 1 / 61)");
+    assert!(
+        perto(yp, 1.0) && perto(hp, 61.0),
+        "pai y={yp} h={hp} (Chrome: 1 / 61)"
+    );
     assert!(perto(yf, 42.0), "filho y={yf} (Chrome: 42)");
 }
 
@@ -307,7 +308,10 @@ fn um_padding_de_um_pixel_barra_o_colapso_do_primeiro_filho() {
 #[test]
 fn um_float_barra_o_colapso_atraves_do_pai() {
     let (yp, hp) = rel("b2", "b2p");
-    assert!(perto(yp, 1.0) && perto(hp, 60.0), "pai y={yp} h={hp} (Chrome: 1 / 60)");
+    assert!(
+        perto(yp, 1.0) && perto(hp, 60.0),
+        "pai y={yp} h={hp} (Chrome: 1 / 60)"
+    );
 }
 
 /// Um pai flex não tem colapso de margens de todo — os filhos são itens de flex.
@@ -320,7 +324,10 @@ fn um_float_barra_o_colapso_atraves_do_pai() {
 #[test]
 fn um_pai_flex_nao_colapsa_com_os_filhos() {
     let (yp, hp) = rel("b3", "b3p");
-    assert!(perto(yp, 1.0) && perto(hp, 60.0), "pai y={yp} h={hp} (Chrome: 1 / 60)");
+    assert!(
+        perto(yp, 1.0) && perto(hp, 60.0),
+        "pai y={yp} h={hp} (Chrome: 1 / 60)"
+    );
 }
 
 /// Um `inline-block` estabelece contexto próprio.
@@ -329,7 +336,10 @@ fn um_pai_flex_nao_colapsa_com_os_filhos() {
 #[test]
 fn um_inline_block_barra_o_colapso_atraves_do_pai() {
     let (yp, hp) = rel("b4", "b4p");
-    assert!(perto(yp, 1.0) && perto(hp, 60.0), "pai y={yp} h={hp} (Chrome: 1 / 60)");
+    assert!(
+        perto(yp, 1.0) && perto(hp, 60.0),
+        "pai y={yp} h={hp} (Chrome: 1 / 60)"
+    );
 }
 
 /// `display:flow-root` existe SÓ para estabelecer um contexto de formatação —
@@ -352,7 +362,10 @@ fn um_inline_block_barra_o_colapso_atraves_do_pai() {
 #[test]
 fn flow_root_barra_o_colapso_atraves_do_pai() {
     let (yp, hp) = rel("b5", "b5p");
-    assert!(perto(yp, 1.0) && perto(hp, 60.0), "pai y={yp} h={hp} (Chrome: 1 / 60)");
+    assert!(
+        perto(yp, 1.0) && perto(hp, 60.0),
+        "pai y={yp} h={hp} (Chrome: 1 / 60)"
+    );
 }
 
 /// **O caso que discrimina: uma borda só em baixo barra só em baixo.**
@@ -364,12 +377,17 @@ fn flow_root_barra_o_colapso_atraves_do_pai() {
 /// Um lote que decidisse a barreira pela caixa e não pelo lado passaria em
 /// todos os outros seis e falharia neste.
 #[test]
-#[ignore = "Chrome pai y=41 h=61 e seguinte 102, nos y=1 - a margem de cima nao escapa. Lote D"]
 fn uma_borda_so_em_baixo_barra_so_a_margem_de_baixo() {
     let (yp, hp) = rel("b6", "b6p");
     let (yn, _) = rel("b6", "b6n");
-    assert!(perto(yp, 41.0), "pai y={yp} (Chrome: 41 — a margem de cima escapou)");
-    assert!(perto(hp, 61.0), "pai h={hp} (Chrome: 61 — a de baixo ficou presa)");
+    assert!(
+        perto(yp, 41.0),
+        "pai y={yp} (Chrome: 41 — a margem de cima escapou)"
+    );
+    assert!(
+        perto(hp, 61.0),
+        "pai h={hp} (Chrome: 61 — a de baixo ficou presa)"
+    );
     assert!(perto(yn, 102.0), "seguinte y={yn} (Chrome: 102)");
 }
 
@@ -378,11 +396,16 @@ fn uma_borda_so_em_baixo_barra_so_a_margem_de_baixo() {
 /// Chrome: pai em y=41 com **20** de altura — nem a de cima nem a de baixo lá
 /// estão — e o irmão seguinte em 101, que é `41 + 20 + max(40, 10)`.
 #[test]
-#[ignore = "Chrome pai y=41 h=20 e seguinte 101, nos y=1 h=100 - nenhuma das duas escapa. Lote D"]
 fn sem_barreira_as_duas_margens_atravessam_o_pai() {
     let (yp, hp) = rel("b7", "b7p");
     let (yn, _) = rel("b7", "b7n");
     assert!(perto(yp, 41.0), "pai y={yp} (Chrome: 41)");
-    assert!(perto(hp, 20.0), "pai h={hp} (Chrome: 20 — as duas margens saíram)");
-    assert!(perto(yn, 101.0), "seguinte y={yn} (Chrome: 101 = 41+20+max(40,10))");
+    assert!(
+        perto(hp, 20.0),
+        "pai h={hp} (Chrome: 20 — as duas margens saíram)"
+    );
+    assert!(
+        perto(yn, 101.0),
+        "seguinte y={yn} (Chrome: 101 = 41+20+max(40,10))"
+    );
 }

--- a/crates/rts-dom/src/layout/vertical.rs
+++ b/crates/rts-dom/src/layout/vertical.rs
@@ -192,6 +192,10 @@ pub(in crate::layout) fn layout_children_vertical(
                 crate::bump!(fragment_hits);
                 flush_inline!(child_y);
                 let (topo, baixo) = (fragment.margin_top, fragment.margin_bottom);
+                let (_, escaped_bottom) = crate::layout::bloco::escaped_margins_for_box(
+                    dom, child, content_w, font_size, ctx,
+                );
+                let baixo = crate::layout::bloco::collapse_margin(baixo, escaped_bottom);
                 let com_topo = junta_ao_strut(strut, topo);
                 let aresta = borda + strut_colapsado(com_topo);
                 child_y = aresta - topo;
@@ -469,13 +473,18 @@ pub(in crate::layout) fn layout_children_vertical(
                     ctx,
                     list,
                 );
-                if atravessa_se(h, m, m_baixo) {
+                let (_, escaped_bottom) = crate::layout::bloco::escaped_margins_for_box(
+                    dom, child, content_w, font_size, ctx,
+                );
+                let effective_bottom =
+                    crate::layout::bloco::collapse_margin(m_baixo, escaped_bottom);
+                if atravessa_se(h, m, effective_bottom) {
                     // Não ocupou espaço: a `borda` fica onde estava e a margem
                     // de baixo entra no MESMO conjunto que a de cima.
-                    strut = junta_ao_strut(com_topo, m_baixo);
+                    strut = junta_ao_strut(com_topo, effective_bottom);
                 } else {
-                    borda = aresta + (h - m - m_baixo);
-                    strut = junta_ao_strut((0.0, 0.0), m_baixo);
+                    borda = aresta + (h - m - effective_bottom);
+                    strut = junta_ao_strut((0.0, 0.0), effective_bottom);
                 }
                 child_y = borda + strut_colapsado(strut);
             }

--- a/crates/rts-dom/src/layout/vertical.rs
+++ b/crates/rts-dom/src/layout/vertical.rs
@@ -290,10 +290,10 @@ pub(in crate::layout) fn layout_children_vertical(
                 let inline_declarado = effective == Some(crate::style::DisplayKind::Inline);
                 let block = if inline_declarado {
                     replaced
-                        || child_css
-                            .as_ref()
-                            .map(|c| crate::inline_box::cria_caixa_apesar_de_inline(c))
-                            .unwrap_or(false)
+                        || child_css.as_deref().is_some_and(|c| {
+                            !crate::layout::caixa::ignores_inline_dimensions(c)
+                                && crate::inline_box::cria_caixa_apesar_de_inline(c)
+                        })
                 } else {
                     replaced
                         || effective.is_some()
@@ -314,6 +314,11 @@ pub(in crate::layout) fn layout_children_vertical(
                     } else if matches!(tag.as_str(), "input" | "button" | "select" | "textarea") {
                         !explicit_block
                     } else if crate::block::lookup(tag).is_some() || explicit_block {
+                        false
+                    } else if child_css
+                        .as_deref()
+                        .is_some_and(crate::layout::caixa::ignores_inline_dimensions)
+                    {
                         false
                     } else {
                         child_css

--- a/crates/rts-dom/src/style/ast_tests.rs
+++ b/crates/rts-dom/src/style/ast_tests.rs
@@ -8,19 +8,71 @@ fn stylesheet_expoe_ast_original_e_declaracoes_desconhecidas() {
 
     assert_eq!(sheet.syntax().len(), 1);
     assert_eq!(sheet.syntax()[0].to_css(), css);
-    assert!(sheet.syntax()[0]
-        .items
-        .iter()
-        .any(|item| item.prelude_css().contains(".a")));
+    assert!(
+        sheet.syntax()[0]
+            .items
+            .iter()
+            .any(|item| item.prelude_css().contains(".a"))
+    );
     assert!(sheet.diagnostics().is_empty());
+
+    let rule = sheet
+        .rules
+        .iter()
+        .find(|rule| rule.selector.compounds.len() == 1)
+        .unwrap();
+    assert!(
+        rule.source_declarations
+            .iter()
+            .any(|declaration| declaration.name == "future-prop")
+    );
 }
 
 #[test]
 fn stylesheet_expoe_diagnostico_de_bloco_incompleto() {
     let mut sheet = Stylesheet::new();
     sheet.append_css(".broken { color: red");
-    assert!(sheet
-        .diagnostics()
+    assert!(
+        sheet
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("fecho"))
+    );
+}
+
+#[test]
+fn ast_preserva_at_rule_desconhecido_e_keyframes_recursivo() {
+    let mut sheet = Stylesheet::new();
+    let css = "@future feature-x; @keyframes fade { from { opacity: 0 } to { opacity: 1 } }";
+    sheet.append_css(css);
+
+    let ast = &sheet.syntax()[0];
+    assert!(ast.items.iter().any(|item| matches!(
+        item,
+        AstItem::AtRule { name, block: None, .. } if name == "future"
+    )));
+    let keyframes = ast.items.iter().find_map(|item| match item {
+        AstItem::AtRule {
+            name,
+            block: Some(block),
+            ..
+        } if name == "keyframes" => Some(block),
+        _ => None,
+    });
+    assert!(keyframes.and_then(|block| block.nested.as_ref()).is_some());
+    assert_eq!(
+        sheet.keyframes.get("fade").map(|value| value.stops.len()),
+        Some(2)
+    );
+}
+
+#[test]
+fn ast_reporta_funcao_incompleta_com_span() {
+    let ast = StylesheetAst::parse(".a { width: calc(100% - 2px; }");
+    let diagnostic = ast
+        .diagnostics
         .iter()
-        .any(|diagnostic| diagnostic.message.contains("fecho")));
+        .find(|diagnostic| diagnostic.message.contains("função"))
+        .expect("diagnóstico da função");
+    assert!(diagnostic.span.start < diagnostic.span.end);
 }

--- a/crates/rts-dom/src/style/ast_tests.rs
+++ b/crates/rts-dom/src/style/ast_tests.rs
@@ -109,3 +109,20 @@ fn inline_specified_usa_a_mesma_fronteira_do_stylesheet() {
     assert_eq!(specified.declarations()[1].name, "--brand");
     assert!(specified.to_css().contains("color: var(--brand);"));
 }
+
+
+#[test]
+fn stylesheet_cssom_insert_delete_reconstroi_o_lowering() {
+    let mut sheet = Stylesheet::new();
+    sheet.append_css(".a { color: red }");
+    assert_eq!(sheet.computed_for("div", None, &["a"]).normal.color, Some(0xff0000ff));
+
+    assert_eq!(sheet.insert_rule(1, ".a { color: blue }").unwrap(), 1);
+    assert_eq!(sheet.computed_for("div", None, &["a"]).normal.color, Some(0x0000ffff));
+    assert_eq!(sheet.syntax().len(), 2);
+
+    assert!(!sheet.delete_rule(99));
+    assert!(sheet.delete_rule(0));
+    assert_eq!(sheet.computed_for("div", None, &["a"]).normal.color, Some(0x0000ffff));
+    assert_eq!(sheet.syntax().len(), 1);
+}

--- a/crates/rts-dom/src/style/ast_tests.rs
+++ b/crates/rts-dom/src/style/ast_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+#[test]
+fn stylesheet_expoe_ast_original_e_declaracoes_desconhecidas() {
+    let mut sheet = Stylesheet::new();
+    let css = "/* preservado */ .a { color: red; future-prop: mystery(1, 2); }";
+    sheet.append_css(css);
+
+    assert_eq!(sheet.syntax().len(), 1);
+    assert_eq!(sheet.syntax()[0].to_css(), css);
+    assert!(sheet.syntax()[0]
+        .items
+        .iter()
+        .any(|item| item.prelude_css().contains(".a")));
+    assert!(sheet.diagnostics().is_empty());
+}
+
+#[test]
+fn stylesheet_expoe_diagnostico_de_bloco_incompleto() {
+    let mut sheet = Stylesheet::new();
+    sheet.append_css(".broken { color: red");
+    assert!(sheet
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.message.contains("fecho")));
+}

--- a/crates/rts-dom/src/style/ast_tests.rs
+++ b/crates/rts-dom/src/style/ast_tests.rs
@@ -26,6 +26,12 @@ fn stylesheet_expoe_ast_original_e_declaracoes_desconhecidas() {
             .iter()
             .any(|declaration| declaration.name == "future-prop")
     );
+    assert!(
+        rule.specified
+            .declarations()
+            .iter()
+            .any(|declaration| declaration.name_raw.contains("future-prop"))
+    );
 }
 
 #[test]
@@ -75,4 +81,31 @@ fn ast_reporta_funcao_incompleta_com_span() {
         .find(|diagnostic| diagnostic.message.contains("função"))
         .expect("diagnóstico da função");
     assert!(diagnostic.span.start < diagnostic.span.end);
+}
+
+#[test]
+fn specified_style_preserva_ordem_e_importancia() {
+    let ast = StylesheetAst::parse(".a { COLOR: red; width: calc(50% + 2px) !important; }");
+    let AstItem::QualifiedRule { block, .. } = &ast.items[0] else {
+        panic!("regra qualificada esperada");
+    };
+    let specified = SpecifiedStyle::from_block(block);
+
+    assert_eq!(specified.declarations().len(), 2);
+    assert_eq!(specified.declarations()[0].name_raw.trim(), "COLOR");
+    assert!(!specified.declarations()[0].important);
+    assert!(specified.declarations()[1].important);
+    assert!(specified.to_css().contains("COLOR: red;"));
+    assert!(specified
+        .to_css()
+        .contains("width: calc(50% + 2px) !important;"));
+}
+
+#[test]
+fn inline_specified_usa_a_mesma_fronteira_do_stylesheet() {
+    let specified = parse_inline_specified("color: var(--brand); --brand: rebeccapurple");
+    assert_eq!(specified.declarations().len(), 2);
+    assert_eq!(specified.declarations()[0].name, "color");
+    assert_eq!(specified.declarations()[1].name, "--brand");
+    assert!(specified.to_css().contains("color: var(--brand);"));
 }

--- a/crates/rts-dom/src/style/auditoria_lote_a.rs
+++ b/crates/rts-dom/src/style/auditoria_lote_a.rs
@@ -96,19 +96,31 @@ fn a_lista_de_font_family_perde_tudo_menos_a_primeira() {
     assert_eq!(c.computed_value("font-family", None), "Georgia");
 }
 
-/// `estilo.keyword.unset` / `estilo.keyword.initial` / `estilo.keyword.revert` —
-/// as três são ignoradas, portanto a declaração ANTERIOR fica a valer.
-///
-/// É a diferença que importa: no browser um `color:unset` desfaz o `red`; aqui
-/// não o desfaz, e a página fica com a cor que o autor mandou tirar.
+/// CSS-wide keywords da primeira fatia implementada. `unset` e `initial` já
+/// atravessam o lowering semântico; `revert` e `revert-layer` continuam adiados
+/// porque o IR ainda não guarda origem/camada suficiente para os resolver.
 #[test]
-fn unset_initial_e_revert_sao_ignorados() {
+fn unset_e_initial_resolvem_e_revert_continua_adiado() {
     let vermelho = parse_inline("color:red").color;
-    for kw in ["unset", "initial", "revert", "revert-layer"] {
+    let unset = parse_inline("color:red;color:unset");
+    assert_eq!(unset.color, vermelho, "o snapshot ainda não tem o pai");
+    assert!(
+        unset
+            .inherit_props
+            .as_deref()
+            .is_some_and(|names| names.iter().any(|name| name == "color")),
+        "unset marca color para a passada de herança"
+    );
+    assert_eq!(
+        parse_inline("color:red;color:initial").color,
+        Some(0x000000ff),
+        "initial usa o valor inicial de color"
+    );
+    for kw in ["revert", "revert-layer"] {
         assert_eq!(
             parse_inline(&format!("color:red;color:{kw}")).color,
             vermelho,
-            "`color:{kw}` devia desfazer o vermelho"
+            "`color:{kw}` ainda não tem a origem/camada necessária"
         );
     }
 }

--- a/crates/rts-dom/src/style/auditoria_lote_b.rs
+++ b/crates/rts-dom/src/style/auditoria_lote_b.rs
@@ -46,15 +46,15 @@ fn so_min_e_max_width_sao_avaliadas() {
     assert!(!aplica("(400px <= width < 99999px)"), "a sintaxe de intervalo");
 }
 
-/// `estilo.var.important` — a importância de uma custom property é ignorada, e
-/// por isso uma declaração normal posterior vence uma `!important` anterior.
+/// `estilo.var.important` — custom properties mantêm a importância durante a
+/// cascade por elemento, antes da substituição em `var()`.
 #[test]
-fn a_importancia_de_uma_custom_property_e_ignorada() {
+fn a_importancia_de_uma_custom_property_e_respeitada() {
     let d = doc(":root{--c:red !important;--c:blue} p{color:var(--c)}", "<p>x</p>");
     assert_eq!(
         prop(&d, "p", "color"),
-        "rgb(0, 0, 255)",
-        "o `!important` da primeira devia ter vencido"
+        "rgb(255, 0, 0)",
+        "a definição important deve vencer a normal"
     );
 }
 
@@ -132,4 +132,16 @@ fn supports_e_avaliado_o_registo_esta_obsoleto() {
 fn uma_var_invalida_ja_nao_apaga_a_anterior() {
     let d = doc("p{color:red;color:var(--nao-existe)}", "<p>x</p>");
     assert_eq!(prop(&d, "p", "color"), "rgb(255, 0, 0)");
+}
+
+
+#[test]
+fn unset_no_root_e_no_descendente_resolve_com_o_pai_correcto() {
+    let d = doc(
+        "html{color:red;color:unset} body{color:blue;color:unset}",
+        "<p id=p>x</p>",
+    );
+    assert_eq!(prop(&d, ":root", "color"), "rgb(0, 0, 0)");
+    assert_eq!(prop(&d, "body", "color"), "rgb(0, 0, 0)");
+    assert_eq!(prop(&d, "#p", "color"), "rgb(0, 0, 0)");
 }

--- a/crates/rts-dom/src/style/auditoria_lote_b.rs
+++ b/crates/rts-dom/src/style/auditoria_lote_b.rs
@@ -49,7 +49,7 @@ fn so_min_e_max_width_sao_avaliadas() {
 /// `estilo.var.important` — custom properties mantêm a importância durante a
 /// cascade por elemento, antes da substituição em `var()`.
 #[test]
-fn a_importancia_de_uma_custom_property_e_respeitada() {
+fn important_custom_property_precedence_is_respected() {
     let d = doc(":root{--c:red !important;--c:blue} p{color:var(--c)}", "<p>x</p>");
     assert_eq!(
         prop(&d, "p", "color"),
@@ -136,7 +136,7 @@ fn uma_var_invalida_ja_nao_apaga_a_anterior() {
 
 
 #[test]
-fn unset_no_root_e_no_descendente_resolve_com_o_pai_correcto() {
+fn unset_on_root_and_descendant_resolves_against_the_correct_parent() {
     let d = doc(
         "html{color:red;color:unset} body{color:blue;color:unset}",
         "<p id=p>x</p>",
@@ -148,7 +148,7 @@ fn unset_no_root_e_no_descendente_resolve_com_o_pai_correcto() {
 
 
 #[test]
-fn all_initial_no_autor_reseta_o_valor_ua() {
+fn all_initial_resets_the_user_agent_value() {
     let d = doc("p{color:red} #alvo{all:initial}", "<p id=alvo>x</p>");
     assert_eq!(prop(&d, "#alvo", "color"), "rgb(0, 0, 0)");
 }

--- a/crates/rts-dom/src/style/auditoria_lote_b.rs
+++ b/crates/rts-dom/src/style/auditoria_lote_b.rs
@@ -145,3 +145,10 @@ fn unset_no_root_e_no_descendente_resolve_com_o_pai_correcto() {
     assert_eq!(prop(&d, "body", "color"), "rgb(0, 0, 0)");
     assert_eq!(prop(&d, "#p", "color"), "rgb(0, 0, 0)");
 }
+
+
+#[test]
+fn all_initial_no_autor_reseta_o_valor_ua() {
+    let d = doc("p{color:red} #alvo{all:initial}", "<p id=alvo>x</p>");
+    assert_eq!(prop(&d, "#alvo", "color"), "rgb(0, 0, 0)");
+}

--- a/crates/rts-dom/src/style/computed_tests.rs
+++ b/crates/rts-dom/src/style/computed_tests.rs
@@ -61,6 +61,19 @@ fn computed_resolve_line_height_e_percentagem_como_o_chrome() {
 }
 
 #[test]
+fn computed_grid_columns_exposes_resolved_track_sizes() {
+    let dom = crate::parse_html_to_dom(
+        "<div id='g' style='display:grid;width:600px;grid-template-columns:1fr 2fr 1fr'>\
+         <div style='height:40px'></div><div style='height:40px'></div><div style='height:40px'></div></div>",
+    );
+    let grid = dom.query("#g").unwrap();
+    assert_eq!(
+        dom.computed_property(grid, "grid-template-columns"),
+        "150px 300px 150px"
+    );
+}
+
+#[test]
 fn overflow_de_um_eixo_torna_o_outro_auto() {
     // Regra da spec que só o computed mostra: um eixo não-visível ao lado de um
     // `visible` faz o segundo computar para `auto`. Medido no Chrome.

--- a/crates/rts-dom/src/style/inherit_kw.rs
+++ b/crates/rts-dom/src/style/inherit_kw.rs
@@ -152,6 +152,19 @@ pub(crate) fn apply_initial_keywords(dst: &mut ComputedStyle) {
     }
 }
 
+/// No elemento raiz, `inherit`/`unset` de uma propriedade herdável resolve para
+/// o inicial porque não existe elemento pai. A operação remove o marcador antigo
+/// antes de aplicar o inicial, inclusive quando o campo já tinha um valor de uma
+/// declaração anterior no mesmo snapshot.
+pub(crate) fn apply_root_inherit_as_initial(dst: &mut ComputedStyle) {
+    let Some(names) = dst.inherit_props.clone() else {
+        return;
+    };
+    for name in names.iter() {
+        let _ = crate::style::parse::apply_css_wide_keyword(dst, name, "initial");
+    }
+}
+
 /// Copia de `src` para `dst` o campo da propriedade `name`. É o único sítio que
 /// mapeia nome CSS → campo para COPIAR (o parse mapeia nome → valor parseado), e
 /// cobre as propriedades que o modelo tem: uma que não esteja aqui deixa o campo

--- a/crates/rts-dom/src/style/inherit_kw.rs
+++ b/crates/rts-dom/src/style/inherit_kw.rs
@@ -312,11 +312,11 @@ mod tests {
         assert_eq!(inicial.color, Some(0x000000ff), "initial não herda color");
         assert_eq!(inicial.width, Some(crate::style::Dimension::Auto));
 
-        let pai_fonte = parse_inline("font-family:Arial");
-        let mut inicial_fonte = parse_inline("font-family:initial");
-        inicial_fonte.inherit_from(&pai_fonte);
+        let parent_font = parse_inline("font-family:Arial");
+        let mut initial_font = parse_inline("font-family:initial");
+        initial_font.inherit_from(&parent_font);
         assert_eq!(
-            inicial_fonte.font_family, None,
+            initial_font.font_family, None,
             "initial não deve herdar a família do pai"
         );
     }

--- a/crates/rts-dom/src/style/inherit_kw.rs
+++ b/crates/rts-dom/src/style/inherit_kw.rs
@@ -28,6 +28,60 @@
 
 use super::props::ComputedStyle;
 
+/// Remove o marcador de `inherit` de uma propriedade quando uma declaração
+/// posterior da mesma camada fornece outro valor. Sem isto, `color: inherit;
+/// color: red` seria novamente sobrescrito pelo pai na passada de herança.
+pub(crate) fn clear_inherit_marker(dst: &mut ComputedStyle, name: &str) {
+    let Some(existing) = dst.inherit_props.take() else {
+        return;
+    };
+    let remaining: Vec<String> = existing
+        .iter()
+        .filter(|property| property.as_str() != name)
+        .cloned()
+        .collect();
+    dst.inherit_props = (!remaining.is_empty()).then(|| std::sync::Arc::new(remaining));
+}
+
+/// Remove marcadores CSS que são cobertos por um campo já aplicado no merge da
+/// cascade. Os nomes de campo do `ComputedStyle` são internos; esta tabela
+/// traduz apenas os casos herdáveis e os shorthands que os controlam.
+pub(crate) fn clear_inherit_for_field(dst: &mut ComputedStyle, field: &str) {
+    let names: &[&str] = match field {
+        "color" => &["color"],
+        "font_size" => &["font-size", "font"],
+        "bold" => &["font-weight", "font"],
+        "italic" => &["font-style", "font"],
+        "line_height" => &["line-height", "font"],
+        "font_family" => &["font-family", "font"],
+        "text_align" => &["text-align"],
+        "white_space" => &["white-space"],
+        "text_transform" => &["text-transform"],
+        "letter_spacing" => &["letter-spacing"],
+        "text_decoration" => &["text-decoration", "text-decoration-line"],
+        "font_stretch" => &["font-stretch", "font"],
+        "word_spacing" => &["word-spacing"],
+        "visibility" => &["visibility"],
+        "tab_size" => &["tab-size"],
+        "line_break" => &["line-break"],
+        "text_decoration_skip_ink" => &["text-decoration-skip-ink"],
+        "caret_color" => &["caret-color"],
+        "text_wrap" => &["text-wrap"],
+        "hyphens" => &["hyphens"],
+        "direction" => &["direction"],
+        "word_break" => &["word-break"],
+        "overflow_wrap" => &["overflow-wrap", "word-wrap"],
+        "text_indent" => &["text-indent"],
+        "list_style_type" => &["list-style-type", "list-style"],
+        "list_style_position" => &["list-style-position", "list-style"],
+        "pointer_events" => &["pointer-events"],
+        _ => &[],
+    };
+    for name in names {
+        clear_inherit_marker(dst, name);
+    }
+}
+
 /// Copia de `src` para `dst` o campo da propriedade `name`. É o único sítio que
 /// mapeia nome CSS → campo para COPIAR (o parse mapeia nome → valor parseado), e
 /// cobre as propriedades que o modelo tem: uma que não esteja aqui deixa o campo
@@ -158,5 +212,29 @@ mod tests {
             !filho.padding.any_set(),
             "o `padding:inherit` passou a funcionar sem ninguém o implementar"
         );
+    }
+
+    #[test]
+    fn css_wide_initial_e_unset_resolvem_na_passada_de_heranca() {
+        let pai = parse_inline("color:blue;width:100px");
+        let mut filho = parse_inline("color:unset;width:unset");
+        assert_eq!(filho.color, None);
+        assert_eq!(filho.width, Some(crate::style::Dimension::Auto));
+        filho.inherit_from(&pai);
+        assert_eq!(filho.color, pai.color, "unset herda propriedade herdável");
+        assert_eq!(filho.width, Some(crate::style::Dimension::Auto));
+
+        let mut inicial = parse_inline("color:initial;width:initial");
+        inicial.inherit_from(&pai);
+        assert_eq!(inicial.color, Some(0x000000ff), "initial não herda color");
+        assert_eq!(inicial.width, Some(crate::style::Dimension::Auto));
+    }
+
+    #[test]
+    fn declaracao_posterior_remove_marcador_de_inherit() {
+        let pai = parse_inline("color:blue");
+        let mut filho = parse_inline("color:inherit;color:red");
+        filho.inherit_from(&pai);
+        assert_eq!(filho.color, Some(0xff0000ff));
     }
 }

--- a/crates/rts-dom/src/style/inherit_kw.rs
+++ b/crates/rts-dom/src/style/inherit_kw.rs
@@ -43,9 +43,29 @@ pub(crate) fn clear_inherit_marker(dst: &mut ComputedStyle, name: &str) {
     dst.inherit_props = (!remaining.is_empty()).then(|| std::sync::Arc::new(remaining));
 }
 
-/// Remove marcadores CSS que são cobertos por um campo já aplicado no merge da
-/// cascade. Os nomes de campo do `ComputedStyle` são internos; esta tabela
-/// traduz apenas os casos herdáveis e os shorthands que os controlam.
+/// Marca uma propriedade que foi explicitamente definida como `initial`.
+pub(crate) fn mark_initial_property(dst: &mut ComputedStyle, name: &str) {
+    let mut names = dst.initial_props.as_deref().cloned().unwrap_or_default();
+    if !names.iter().any(|property| property == name) {
+        names.push(name.to_string());
+    }
+    dst.initial_props = Some(std::sync::Arc::new(names));
+}
+
+pub(crate) fn clear_initial_marker(dst: &mut ComputedStyle, name: &str) {
+    let Some(existing) = dst.initial_props.take() else {
+        return;
+    };
+    let remaining: Vec<String> = existing
+        .iter()
+        .filter(|property| property.as_str() != name)
+        .cloned()
+        .collect();
+    dst.initial_props = (!remaining.is_empty()).then(|| std::sync::Arc::new(remaining));
+}
+
+/// Remove o marcador de `inherit` quando um campo computado posterior vence a
+/// mesma propriedade na cascade.
 pub(crate) fn clear_inherit_for_field(dst: &mut ComputedStyle, field: &str) {
     let names: &[&str] = match field {
         "color" => &["color"],
@@ -79,6 +99,56 @@ pub(crate) fn clear_inherit_for_field(dst: &mut ComputedStyle, field: &str) {
     };
     for name in names {
         clear_inherit_marker(dst, name);
+    }
+}
+
+/// Remove o marcador de `initial` quando um campo computado posterior vence a
+/// mesma propriedade na cascade.
+pub(crate) fn clear_initial_for_field(dst: &mut ComputedStyle, field: &str) {
+    let names: &[&str] = match field {
+        "color" => &["color"],
+        "font_size" => &["font-size", "font"],
+        "bold" => &["font-weight", "font"],
+        "italic" => &["font-style", "font"],
+        "line_height" => &["line-height", "font"],
+        "font_family" => &["font-family", "font"],
+        "text_align" => &["text-align"],
+        "white_space" => &["white-space"],
+        "text_transform" => &["text-transform"],
+        "letter_spacing" => &["letter-spacing"],
+        "text_decoration" => &["text-decoration", "text-decoration-line"],
+        "font_stretch" => &["font-stretch", "font"],
+        "word_spacing" => &["word-spacing"],
+        "visibility" => &["visibility"],
+        "tab_size" => &["tab-size"],
+        "line_break" => &["line-break"],
+        "text_decoration_skip_ink" => &["text-decoration-skip-ink"],
+        "caret_color" => &["caret-color"],
+        "text_wrap" => &["text-wrap"],
+        "hyphens" => &["hyphens"],
+        "direction" => &["direction"],
+        "word_break" => &["word-break"],
+        "overflow_wrap" => &["overflow-wrap", "word-wrap"],
+        "text_indent" => &["text-indent"],
+        "list_style_type" => &["list-style-type", "list-style"],
+        "list_style_position" => &["list-style-position", "list-style"],
+        "pointer_events" => &["pointer-events"],
+        _ => &[],
+    };
+    for name in names {
+        clear_initial_marker(dst, name);
+    }
+}
+
+/// Reaplica `initial` depois da herança genérica. Alguns iniciais são `None`
+/// no modelo (por exemplo a família de fonte), logo só o marcador consegue
+/// impedir a cópia silenciosa do pai.
+pub(crate) fn apply_initial_keywords(dst: &mut ComputedStyle) {
+    let Some(names) = dst.initial_props.clone() else {
+        return;
+    };
+    for name in names.iter() {
+        let _ = crate::style::parse::apply_css_wide_keyword(dst, name, "initial");
     }
 }
 
@@ -228,6 +298,14 @@ mod tests {
         inicial.inherit_from(&pai);
         assert_eq!(inicial.color, Some(0x000000ff), "initial não herda color");
         assert_eq!(inicial.width, Some(crate::style::Dimension::Auto));
+
+        let pai_fonte = parse_inline("font-family:Arial");
+        let mut inicial_fonte = parse_inline("font-family:initial");
+        inicial_fonte.inherit_from(&pai_fonte);
+        assert_eq!(
+            inicial_fonte.font_family, None,
+            "initial não deve herdar a família do pai"
+        );
     }
 
     #[test]

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -97,7 +97,7 @@ pub use borders::{SideBorder, SideName};
 pub use color::parse_color;
 pub use grid_areas::{GridArea, GridAreas};
 pub use lerp::{lerp_color, lerp_dimension, lerp_f32};
-pub use parse::{is_mono_family, parse_inline, parse_inline_block};
+pub use parse::{is_mono_family, parse_inline, parse_inline_block, parse_inline_specified};
 pub use props::{
     ComputedStyle, SLOT_BG, SLOT_BORDER_COLOR, SLOT_BORDER_WIDTH, SLOT_COLOR, SLOT_CORNER_RADIUS,
     SLOT_FONT_SIZE, SLOT_MARGIN, SLOT_MARGIN_V, SLOT_PADDING, SLOT_TEXT_ALIGN,
@@ -114,7 +114,7 @@ pub use stylesheet::{
 };
 pub use syntax::{
     AstItem, BlockAst, ComponentValue, DeclarationAst, Diagnostic, DiagnosticSeverity, SourceSpan,
-    StylesheetAst, Token, TokenKind, tokenize,
+    SpecifiedStyle, StylesheetAst, Token, TokenKind, tokenize,
 };
 pub use tables::{BorderCollapse, BorderSpacing, ListStylePosition, TableLayout};
 pub use text::{Clear, Direction, ListStyleType, OverflowWrap, VerticalAlign, WordBreak};

--- a/crates/rts-dom/src/style/mod.rs
+++ b/crates/rts-dom/src/style/mod.rs
@@ -55,6 +55,8 @@ pub mod root_font;
 pub mod ruleindex;
 pub mod selector;
 pub mod stylesheet;
+/// Tokenizer e AST sintáctico lossless do CSS, antes do lowering para a cascade.
+pub mod syntax;
 /// As propriedades de TABELA e a posição do marcador de lista — ver o módulo.
 pub mod tables;
 pub mod text;
@@ -68,6 +70,8 @@ pub mod vocab;
 
 mod aplica;
 
+#[cfg(test)]
+mod ast_tests;
 #[cfg(test)]
 mod afirmacoes_tests;
 #[cfg(test)]
@@ -107,6 +111,10 @@ pub use selector::{
 };
 pub use stylesheet::{
     DeclBlock, HoverReach, MatchedRules, MediaQuery, Rule, Stylesheet, parse_rules,
+};
+pub use syntax::{
+    AstItem, BlockAst, ComponentValue, DeclarationAst, Diagnostic, DiagnosticSeverity, SourceSpan,
+    StylesheetAst, Token, TokenKind, tokenize,
 };
 pub use tables::{BorderCollapse, BorderSpacing, ListStylePosition, TableLayout};
 pub use text::{Clear, Direction, ListStyleType, OverflowWrap, VerticalAlign, WordBreak};

--- a/crates/rts-dom/src/style/newprops_tests/raios_e_transform.rs
+++ b/crates/rts-dom/src/style/newprops_tests/raios_e_transform.rs
@@ -76,17 +76,27 @@ fn cantos_logicos_caem_nos_cantos_fisicos_em_ltr() {
 }
 
 #[test]
-fn canto_eliptico_fica_pelo_raio_horizontal() {
-    // Um canto do CSS são DOIS raios; o modelo tem um número por canto. Fica o
-    // horizontal, e o teste fixa isso em vez de o deixar por descobrir.
+fn elliptical_corner_preserves_both_radii() {
+    let longhand = parse_inline("border-top-left-radius: 10px 20px");
     assert_eq!(
-        parse_inline("border-top-left-radius: 10px 20px").corner_tl,
-        Some(10.0)
+        (longhand.corner_tl, longhand.corner_tl_y),
+        (Some(10.0), Some(20.0))
     );
-    // e a parte depois da `/` no shorthand é a vertical — descartada igual.
+    assert_eq!(longhand.get_property("border-top-left-radius"), "10px 20px");
+
+    let shorthand = parse_inline("border-radius: 5px / 15px");
     assert_eq!(
-        parse_inline("border-radius: 5px / 15px").corner_tl,
-        Some(5.0)
+        (
+            shorthand.corner_tl_y,
+            shorthand.corner_tr_y,
+            shorthand.corner_br_y,
+            shorthand.corner_bl_y
+        ),
+        (Some(15.0), Some(15.0), Some(15.0), Some(15.0))
+    );
+    assert_eq!(
+        shorthand.get_property("border-bottom-right-radius"),
+        "5px 15px"
     );
 }
 

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -316,6 +316,19 @@ pub(crate) fn apply_specified_declaration(
     };
     crate::bump!(css_declarations);
 
+    if prop == "all" {
+        if val.eq_ignore_ascii_case("initial") {
+            if important {
+                block.all_initial_important = true;
+                block.important = ComputedStyle::default();
+            } else {
+                block.all_initial_normal = true;
+                block.normal = ComputedStyle::default();
+            }
+        }
+        return;
+    }
+
     if prop.starts_with("--") {
         crate::bump!(css_custom_declarations);
         if important {

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -122,7 +122,11 @@ pub(crate) fn parse_inline_block_raw(style: &str) -> DeclBlock {
         // cascade por elemento resolve (#1779). Importância ignorada (v1).
         if prop.starts_with("--") {
             crate::bump!(css_custom_declarations);
-            block.custom.push((prop.clone(), val.to_string()));
+            if important {
+                block.custom_important.push((prop.clone(), val.to_string()));
+            } else {
+                block.custom.push((prop.clone(), val.to_string()));
+            }
             continue;
         }
         // Valor com `var()`: NÃO parseia agora — vira declaração PENDENTE, que a
@@ -314,7 +318,11 @@ pub(crate) fn apply_specified_declaration(
 
     if prop.starts_with("--") {
         crate::bump!(css_custom_declarations);
-        block.custom.push((prop, val.trim().to_string()));
+        if important {
+            block.custom_important.push((prop, val.to_string()));
+        } else {
+            block.custom.push((prop, val.to_string()));
+        }
         return;
     }
     if val.contains("var(") {

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -29,6 +29,23 @@ pub fn parse_inline(style: &str) -> ComputedStyle {
     parse_inline_block(style).normal
 }
 
+/// Preserva as declarações de um `style="..."` no estado especificado. O
+/// resultado ainda não contém valores computados nem herança; é a fronteira
+/// pública para tooling e para futuras fases de resolução por propriedade.
+pub fn parse_inline_specified(style: &str) -> crate::style::syntax::SpecifiedStyle {
+    let source = format!("* {{{style}}}");
+    let ast = crate::style::syntax::StylesheetAst::parse(&source);
+    ast.items
+        .iter()
+        .find_map(|item| match item {
+            crate::style::syntax::AstItem::QualifiedRule { block, .. } => {
+                Some(crate::style::syntax::SpecifiedStyle::from_block(block))
+            }
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
 /// Parseia um bloco de declarações usando o AST sintáctico e baixa cada
 /// declaração para o IR semântico existente. O wrapper sintético permite que
 /// `style="..."` e corpos `{ ... }` partilhem exactamente a mesma gramática.
@@ -41,11 +58,21 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
     }) else {
         return DeclBlock::default();
     };
-    // O parser semântico recebe o bloco inteiro, e não uma declaração por vez:
-    // shorthands podem limpar longhands anteriores e transições/animações são
-    // montadas pela ordem das declarações. O AST continua a ser a fase estrutural;
-    // `parse_inline_block_raw` é apenas o lowering compatível e stateful.
-    parse_inline_block_raw(&block.to_css_semantic())
+    let mut lowered = DeclBlock::default();
+    for declaration in block.declarations() {
+        let value = declaration
+            .value
+            .iter()
+            .map(crate::style::syntax::ComponentValue::to_css_semantic)
+            .collect::<String>();
+        apply_specified_declaration(
+            &mut lowered,
+            &declaration.name,
+            &value,
+            declaration.important,
+        );
+    }
+    lowered
 }
 
 /// Parser semântico de uma declaração já isolada. Fica separado do entrypoint
@@ -163,6 +190,160 @@ pub(crate) fn parse_inline_block_raw(style: &str) -> DeclBlock {
         }
     }
     block
+}
+
+fn is_css_wide_keyword(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "initial" | "inherit" | "unset" | "revert" | "revert-layer"
+    )
+}
+
+/// Aplica `initial`/`inherit`/`unset` à camada semântica. Os valores iniciais
+/// são convertidos pelo mesmo dispatch das propriedades normais, em vez de
+/// duplicar os tipos na tabela `initial`. `revert` e `revert-layer` exigem
+/// metadados de origem/camada que o IR actual ainda não guarda e são ignorados
+/// deliberadamente até essa informação existir.
+pub(crate) fn apply_css_wide_keyword(
+    css: &mut ComputedStyle,
+    prop: &str,
+    value: &str,
+) -> bool {
+    let keyword = value.trim().to_ascii_lowercase();
+    match keyword.as_str() {
+        "inherit" => {
+            crate::style::inherit_kw::clear_inherit_marker(css, prop);
+            let mut nomes = css.inherit_props.as_deref().cloned().unwrap_or_default();
+            if !nomes.iter().any(|name| name == prop) {
+                nomes.push(prop.to_string());
+            }
+            css.inherit_props = Some(std::sync::Arc::new(nomes));
+            true
+        }
+        "unset" if is_inherited_property(prop) => {
+            apply_css_wide_keyword(css, prop, "inherit")
+        }
+        "unset" | "initial" => {
+            let applied = apply_initial_value(css, prop);
+            if applied {
+                crate::style::inherit_kw::clear_inherit_marker(css, prop);
+            }
+            applied
+        }
+        "revert" | "revert-layer" => false,
+        _ => false,
+    }
+}
+
+fn is_inherited_property(prop: &str) -> bool {
+    matches!(
+        prop,
+        "color"
+            | "font"
+            | "font-size"
+            | "font-family"
+            | "font-style"
+            | "font-weight"
+            | "font-stretch"
+            | "line-height"
+            | "text-align"
+            | "text-decoration"
+            | "text-decoration-line"
+            | "letter-spacing"
+            | "word-spacing"
+            | "white-space"
+            | "text-transform"
+            | "visibility"
+            | "direction"
+            | "tab-size"
+            | "word-break"
+            | "overflow-wrap"
+            | "word-wrap"
+            | "text-indent"
+            | "list-style-type"
+            | "list-style-position"
+            | "pointer-events"
+            | "caret-color"
+            | "hyphens"
+            | "line-break"
+            | "text-wrap"
+    )
+}
+
+fn apply_initial_value(css: &mut ComputedStyle, prop: &str) -> bool {
+    // A inicialização dos shorthands abaixo é válida para todas as suas
+    // longhands modeladas e passa pelo parser normal para conservar os clears.
+    let value = match prop {
+        "margin" | "padding" => Some("0px"),
+        "border" => Some("medium none black"),
+        "display" => Some("inline"), // initial CSS de display; o default da tag é UA.
+        _ => crate::style::initial::initial(prop),
+    };
+    let Some(value) = value else {
+        return false;
+    };
+    aplica_declaracao(css, prop, value)
+}
+
+/// Aplica uma declaração já extraída pelo AST sobre o mesmo `DeclBlock`, sem
+/// criar um snapshot temporário. O parser textual continua separado para
+/// compatibilidade, mas regras e inline AST usam esta operação para conservar a
+/// ordem dos shorthands/longhands e os efeitos acumulativos do bloco.
+pub(crate) fn apply_specified_declaration(
+    block: &mut DeclBlock,
+    prop_raw: &str,
+    val: &str,
+    important: bool,
+) {
+    let prop = prop_raw.trim();
+    if prop.is_empty() {
+        return;
+    }
+    let val = val.trim();
+    let prop = if prop.starts_with("--") {
+        prop.to_string()
+    } else {
+        prop.to_ascii_lowercase()
+    };
+    crate::bump!(css_declarations);
+
+    if prop.starts_with("--") {
+        crate::bump!(css_custom_declarations);
+        block.custom.push((prop, val.trim().to_string()));
+        return;
+    }
+    if val.contains("var(") {
+        crate::bump!(css_var_refs);
+        block
+            .pending
+            .push((prop, val.trim().to_string(), important));
+        return;
+    }
+
+    let css = if important {
+        &mut block.important
+    } else {
+        &mut block.normal
+    };
+    if is_css_wide_keyword(val) && apply_css_wide_keyword(css, &prop, val) {
+        return;
+    }
+
+    crate::style::inherit_kw::clear_inherit_marker(css, &prop);
+    if !aplica_declaracao(css, prop.as_str(), val) {
+        let nu = prop
+            .strip_prefix("-webkit-")
+            .or_else(|| prop.strip_prefix("-moz-"))
+            .or_else(|| prop.strip_prefix("-ms-"))
+            .or_else(|| prop.strip_prefix("-o-"));
+        match nu {
+            Some(n) if aplica_declaracao(css, n, val) => {}
+            _ => {
+                crate::bump!(css_declarations_unknown);
+                crate::note!("propriedade-ignorada", prop);
+            }
+        }
+    }
 }
 
 /// Aplica `text-decoration` / `text-decoration-line`. `com_cor` distingue os

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -78,6 +78,7 @@ pub fn parse_inline_block(style: &str) -> DeclBlock {
 /// Parser semântico de uma declaração já isolada. Fica separado do entrypoint
 /// AST para que lowering de regras e resolução de `var()` não criem ASTs
 /// sintéticos recursivamente.
+#[allow(dead_code)]
 pub(crate) fn parse_inline_block_raw(style: &str) -> DeclBlock {
     let _phase = crate::metrics::phases::scope("parse-decls");
     let mut block = DeclBlock::default();
@@ -479,6 +480,7 @@ pub(super) fn aplica_declaracao(css: &mut ComputedStyle, prop: &str, val: &str) 
 
 /// Separa o sufixo `!important` (case-insensitive, com espaços) de um valor CSS.
 /// Devolve `(valor_sem_important, é_important)`. `"red !important"` → `("red", true)`.
+#[allow(dead_code)]
 fn split_important(val: &str) -> (&str, bool) {
     let v = val.trim();
     // Acha `!important` no fim, tolerante a espaço entre `!` e `important` não — a

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -29,10 +29,29 @@ pub fn parse_inline(style: &str) -> ComputedStyle {
     parse_inline_block(style).normal
 }
 
-/// Parseia um bloco de declarações CSS (`"prop: valor; outra: x !important"`)
-/// separando as camadas normal/important (MDN estágio 1). Ignora
-/// propriedades/valores desconhecidos sem panicar (robustez de parser real).
+/// Parseia um bloco de declarações usando o AST sintáctico e baixa cada
+/// declaração para o IR semântico existente. O wrapper sintético permite que
+/// `style="..."` e corpos `{ ... }` partilhem exactamente a mesma gramática.
 pub fn parse_inline_block(style: &str) -> DeclBlock {
+    let source = format!("* {{{style}}}");
+    let ast = crate::style::syntax::StylesheetAst::parse(&source);
+    let Some(block) = ast.items.iter().find_map(|item| match item {
+        crate::style::syntax::AstItem::QualifiedRule { block, .. } => Some(block),
+        _ => None,
+    }) else {
+        return DeclBlock::default();
+    };
+    // O parser semântico recebe o bloco inteiro, e não uma declaração por vez:
+    // shorthands podem limpar longhands anteriores e transições/animações são
+    // montadas pela ordem das declarações. O AST continua a ser a fase estrutural;
+    // `parse_inline_block_raw` é apenas o lowering compatível e stateful.
+    parse_inline_block_raw(&block.to_css_semantic())
+}
+
+/// Parser semântico de uma declaração já isolada. Fica separado do entrypoint
+/// AST para que lowering de regras e resolução de `var()` não criem ASTs
+/// sintéticos recursivamente.
+pub(crate) fn parse_inline_block_raw(style: &str) -> DeclBlock {
     let _phase = crate::metrics::phases::scope("parse-decls");
     let mut block = DeclBlock::default();
     // `split_top_level_semicolons` e nao `split(';')`: um `;` DENTRO de

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -227,6 +227,7 @@ pub(crate) fn apply_css_wide_keyword(
             let applied = apply_initial_value(css, prop);
             if applied {
                 crate::style::inherit_kw::clear_inherit_marker(css, prop);
+                crate::style::inherit_kw::mark_initial_property(css, prop);
             }
             applied
         }
@@ -273,6 +274,10 @@ fn is_inherited_property(prop: &str) -> bool {
 fn apply_initial_value(css: &mut ComputedStyle, prop: &str) -> bool {
     // A inicialização dos shorthands abaixo é válida para todas as suas
     // longhands modeladas e passa pelo parser normal para conservar os clears.
+    if prop == "font-family" {
+        css.font_family = None;
+        return true;
+    }
     let value = match prop {
         "margin" | "padding" => Some("0px"),
         "border" => Some("medium none black"),
@@ -330,6 +335,7 @@ pub(crate) fn apply_specified_declaration(
     }
 
     crate::style::inherit_kw::clear_inherit_marker(css, &prop);
+    crate::style::inherit_kw::clear_initial_marker(css, &prop);
     if !aplica_declaracao(css, prop.as_str(), val) {
         let nu = prop
             .strip_prefix("-webkit-")

--- a/crates/rts-dom/src/style/props/mod.rs
+++ b/crates/rts-dom/src/style/props/mod.rs
@@ -172,7 +172,10 @@ macro_rules! css_props {
             }
 
             pub fn merge_over(&mut self, other: &ComputedStyle) {
-                $( if other.$ofield.is_some() { self.$ofield = other.$ofield.clone(); } )*
+                $( if other.$ofield.is_some() {
+                    crate::style::inherit_kw::clear_inherit_for_field(self, stringify!($ofield));
+                    self.$ofield = other.$ofield.clone();
+                } )*
                 $( self.$efield.merge_over(&other.$efield); )*
                 // GRID: os campos built-in (Vec/track) — `other` vence quando setado
                 // (mesma precedência dos campos da macro; grid não herda).

--- a/crates/rts-dom/src/style/props/mod.rs
+++ b/crates/rts-dom/src/style/props/mod.rs
@@ -65,6 +65,11 @@ macro_rules! css_props {
             /// `style::inherit_kw`). `Arc` porque a lista é quase sempre vazia ou
             /// minúscula e é clonada com o estilo.
             pub inherit_props: Option<std::sync::Arc<Vec<String>>>,
+            /// Propriedades explicitamente definidas como `initial`. O marcador
+            /// impede que a herança por omissão trate `None` como ausência de
+            /// declaração; é necessário para iniciais dependentes do ambiente,
+            /// como `font-family`.
+            pub initial_props: Option<std::sync::Arc<Vec<String>>>,
             /// GRID: as trilhas de COLUNA (`grid-template-columns`) parseadas —
             /// px/fr/auto/%. `None` = não é grid explícito. Campo built-in (Vec não
             /// cabe na macro simples); herança N/A (grid não herda). O layout roda
@@ -111,6 +116,7 @@ macro_rules! css_props {
             grid_justify_items(Option<crate::style::AlignItems>),
             custom_props(Option<std::sync::Arc<std::collections::HashMap<String, String>>>),
             inherit_props(Option<std::sync::Arc<Vec<String>>>),
+            initial_props(Option<std::sync::Arc<Vec<String>>>),
         }
 
         impl Decl {
@@ -127,6 +133,7 @@ macro_rules! css_props {
                     Decl::grid_justify_items(v) => target.grid_justify_items = *v,
                     Decl::custom_props(v) => target.custom_props = v.clone(),
                     Decl::inherit_props(v) => target.inherit_props = v.clone(),
+                    Decl::initial_props(v) => target.initial_props = v.clone(),
                 }
             }
         }
@@ -168,12 +175,16 @@ macro_rules! css_props {
                 if self.inherit_props.is_some() {
                     out.push(Decl::inherit_props(self.inherit_props.clone()));
                 }
+                if self.initial_props.is_some() {
+                    out.push(Decl::initial_props(self.initial_props.clone()));
+                }
                 out
             }
 
             pub fn merge_over(&mut self, other: &ComputedStyle) {
                 $( if other.$ofield.is_some() {
                     crate::style::inherit_kw::clear_inherit_for_field(self, stringify!($ofield));
+                    crate::style::inherit_kw::clear_initial_for_field(self, stringify!($ofield));
                     self.$ofield = other.$ofield.clone();
                 } )*
                 $( self.$efield.merge_over(&other.$efield); )*
@@ -194,6 +205,15 @@ macro_rules! css_props {
                 if other.grid_justify_items.is_some() {
                     self.grid_justify_items = other.grid_justify_items;
                 }
+                if other.display.is_some() {
+                    crate::style::inherit_kw::clear_inherit_marker(self, "display");
+                    crate::style::inherit_kw::clear_initial_marker(self, "display");
+                    self.display = other.display;
+                }
+                if other.border_box.is_some() {
+                    crate::style::inherit_kw::clear_initial_marker(self, "box-sizing");
+                    self.border_box = other.border_box;
+                }
                 // `inherit`: as listas SOMAM-SE. Duas regras podem pedir
                 // `inherit` em propriedades diferentes, e a de maior precedência
                 // não anula o pedido da outra — anular seria trocar "esta regra
@@ -206,6 +226,20 @@ macro_rules! css_props {
                             for n in deles.iter() {
                                 if !v.contains(n) {
                                     v.push(n.clone());
+                                }
+                            }
+                            std::sync::Arc::new(v)
+                        }
+                    });
+                }
+                if let Some(iniciais) = &other.initial_props {
+                    self.initial_props = Some(match self.initial_props.take() {
+                        None => iniciais.clone(),
+                        Some(meus) => {
+                            let mut v = (*meus).clone();
+                            for name in iniciais.iter() {
+                                if !v.contains(name) {
+                                    v.push(name.clone());
                                 }
                             }
                             std::sync::Arc::new(v)
@@ -237,6 +271,10 @@ macro_rules! css_props {
                 // `inherit` EXPLÍCITO: depois da herança por omissão, porque é
                 // uma declaração e vence o que o nó não declarou.
                 self.apply_inherit_keyword(parent);
+                // `initial` EXPLÍCITO: depois da herança, porque deve impedir a
+                // cópia do pai mesmo quando o valor inicial é representado por
+                // `None` no campo computado.
+                crate::style::inherit_kw::apply_initial_keywords(self);
                 // custom props SEMPRE herdam (spec): sem declaração própria o
                 // filho compartilha o Arc do pai (O(1)); com declaração própria,
                 // as do pai preenchem por baixo (o filho vence por nome).

--- a/crates/rts-dom/src/style/props/tabela.rs
+++ b/crates/rts-dom/src/style/props/tabela.rs
@@ -278,6 +278,12 @@ css_props! {
         [anim] corner_tr: f32;
         [anim] corner_br: f32;
         [anim] corner_bl: f32;
+        /// Componente vertical dos quatro cantos elípticos. O eixo horizontal
+        /// permanece nos campos `corner_*`; estes campos completam o valor CSS.
+        [anim] corner_tl_y: f32;
+        [anim] corner_tr_y: f32;
+        [anim] corner_br_y: f32;
+        [anim] corner_bl_y: f32;
         /// `transform-origin` — o ponto em torno do qual o `transform` roda e
         /// escala. Reusa [`crate::style::BgPosition`]: a gramatica e a mesma de
         /// `background-position` (comprimento, percentagem ou keyword por eixo).

--- a/crates/rts-dom/src/style/radius.rs
+++ b/crates/rts-dom/src/style/radius.rs
@@ -1,29 +1,8 @@
-//! Os RAIOS POR CANTO (`border-top-left-radius` e as sete companhias).
+//! `border-*-radius`: parsing e serialização dos quatro cantos elípticos.
 //!
-//! São **1 064 declarações** nas folhas medidas — o maior item que faltava, e
-//! quase todo do WhatsApp Web, que escreve os quatro cantos separados e na forma
-//! lógica (`border-start-start-radius`). Até aqui caíam todas no contador de
-//! ignoradas, com uma recusa DELIBERADA em `style::borders`: o modelo tinha um
-//! raio só para os quatro cantos, e escrever um canto declarado nesse campo
-//! arredondaria os outros três. Essa recusa continua a ser a resposta certa e não
-//! foi levantada — o que mudou é que agora há onde guardar o canto.
-//!
-//! ## O que ESTE módulo faz, e o que continua por fazer
-//!
-//! Guarda os quatro cantos em campos próprios e responde-os no computed. **Não
-//! pinta.** A lista de display tem UM raio por retângulo
-//! (`DisplayItem::SolidRect { radius: f32 }`, em `layout.rs`), e o egui lê-o em
-//! `frame/render.rs`; pintar por canto é mudar esse item para quatro valores e o
-//! consumidor com ele — outra tarefa, outro dono.
-//!
-//! ## A regra que não pode quebrar
-//!
-//! `corner_radius` — o campo único — continua a responder EXATAMENTE o que
-//! respondia. Quem já o lê (o fundo, a borda, a barra de rolagem, a tabela) não
-//! pode receber resposta diferente por causa deste lote, e por isso o shorthand
-//! `border-radius` escreve os dois: o campo único como sempre escreveu, e os
-//! quatro cantos por cima. Um canto declarado sozinho NÃO toca o campo único —
-//! é a recusa de sempre, agora com o valor guardado ao lado em vez de perdido.
+//! Um canto CSS tem dois raios, horizontal e vertical. O layout/painter actual
+//! continua a consumir o raio horizontal legado, mas o estilo computado preserva
+//! ambos para que `getComputedStyle` não reduza uma elipse a um círculo.
 
 use super::lengths::{parse_len_pub, split_top_ws};
 use super::props::ComputedStyle;
@@ -38,13 +17,12 @@ pub enum Corner {
 }
 
 impl Corner {
-    /// O canto nomeado pelo sufixo de uma longhand, física ou LÓGICA.
+    /// O canto nomeado pelo sufixo de uma longhand, física ou lógica.
     ///
     /// As lógicas assumem LTR horizontal, que é o mesmo corte de
-    /// `padding-inline-start` e de `style::logical` — um segundo comportamento
-    /// para "que lado é `start`" seria pior que o corte.
-    fn parse(sufixo: &str) -> Option<Corner> {
-        Some(match sufixo {
+    /// `padding-inline-start` e de `style::logical`.
+    fn parse(suffix: &str) -> Option<Corner> {
+        Some(match suffix {
             "top-left" | "start-start" => Corner::TopLeft,
             "top-right" | "start-end" => Corner::TopRight,
             "bottom-right" | "end-end" => Corner::BottomRight,
@@ -54,17 +32,26 @@ impl Corner {
     }
 }
 
-fn set(css: &mut ComputedStyle, c: Corner, v: Option<f32>) {
-    match c {
-        Corner::TopLeft => css.corner_tl = v,
-        Corner::TopRight => css.corner_tr = v,
-        Corner::BottomRight => css.corner_br = v,
-        Corner::BottomLeft => css.corner_bl = v,
+fn set_horizontal(css: &mut ComputedStyle, corner: Corner, value: Option<f32>) {
+    match corner {
+        Corner::TopLeft => css.corner_tl = value,
+        Corner::TopRight => css.corner_tr = value,
+        Corner::BottomRight => css.corner_br = value,
+        Corner::BottomLeft => css.corner_bl = value,
     }
 }
 
-fn get(css: &ComputedStyle, c: Corner) -> Option<f32> {
-    match c {
+fn set_vertical(css: &mut ComputedStyle, corner: Corner, value: Option<f32>) {
+    match corner {
+        Corner::TopLeft => css.corner_tl_y = value,
+        Corner::TopRight => css.corner_tr_y = value,
+        Corner::BottomRight => css.corner_br_y = value,
+        Corner::BottomLeft => css.corner_bl_y = value,
+    }
+}
+
+fn horizontal(css: &ComputedStyle, corner: Corner) -> Option<f32> {
+    match corner {
         Corner::TopLeft => css.corner_tl,
         Corner::TopRight => css.corner_tr,
         Corner::BottomRight => css.corner_br,
@@ -72,70 +59,111 @@ fn get(css: &ComputedStyle, c: Corner) -> Option<f32> {
     }
 }
 
-/// A componente HORIZONTAL de um raio: `10px` ou o primeiro de `10px 20px`.
-///
-/// Um canto do CSS é uma ELIPSE — dois raios, e a folha real do WhatsApp usa a
-/// forma de dois valores. O modelo tem um número por canto, portanto fica o
-/// horizontal. Um canto elíptico sairá circular; está dito aqui em vez de ser
-/// descoberto por quem comparar com o Chrome.
-fn primeiro_raio(val: &str) -> Option<f32> {
-    let toks = split_top_ws(val);
-    parse_len_pub(toks.first()?)
+fn vertical(css: &ComputedStyle, corner: Corner) -> Option<f32> {
+    match corner {
+        Corner::TopLeft => css.corner_tl_y,
+        Corner::TopRight => css.corner_tr_y,
+        Corner::BottomRight => css.corner_br_y,
+        Corner::BottomLeft => css.corner_bl_y,
+    }
 }
 
-/// O shorthand `border-radius`, na parte que ESTE módulo responde: os quatro
-/// cantos. Chamado a seguir ao braço que escreve `corner_radius`, sem lhe tocar.
-///
-/// `<1 a 4 valores> [/ <1 a 4 valores>]`. A ordem é TL, TR, BR, BL, e o omitido
-/// copia o canto DIAGONALMENTE oposto — não o adjacente, que é a regra dos
-/// shorthands de caixa e não a dos cantos. A parte depois da `/` são os raios
-/// verticais e é descartada pelo mesmo motivo que `primeiro_raio` descarta o
-/// segundo valor.
-pub fn apply_shorthand(css: &mut ComputedStyle, val: &str) {
-    let horizontais = val.split('/').next().unwrap_or(val);
-    let t = split_top_ws(horizontais);
-    let g = |i: usize| parse_len_pub(&t[i]);
-    let (tl, tr, br, bl) = match t.len() {
-        1 => (g(0), g(0), g(0), g(0)),
-        2 => (g(0), g(1), g(0), g(1)),
-        3 => (g(0), g(1), g(2), g(1)),
-        4 => (g(0), g(1), g(2), g(3)),
-        _ => return,
+fn parse_radius_length(value: &str) -> Option<f32> {
+    parse_len_pub(value).or_else(|| (value.trim() == "0").then_some(0.0))
+}
+
+/// Expande a lista CSS de 1 a 4 valores na ordem TL, TR, BR, BL.
+fn expand_values(values: &[String]) -> Option<[f32; 4]> {
+    let value = |index: usize| values.get(index).and_then(|token| parse_radius_length(token));
+    match values.len() {
+        1 => Some([value(0)?, value(0)?, value(0)?, value(0)?]),
+        2 => Some([value(0)?, value(1)?, value(0)?, value(1)?]),
+        3 => Some([value(0)?, value(1)?, value(2)?, value(1)?]),
+        4 => Some([value(0)?, value(1)?, value(2)?, value(3)?]),
+        _ => None,
+    }
+}
+
+/// Lê a componente de um canto: `10px` ou `10px 20px`.
+fn parse_corner_pair(value: &str) -> Option<(f32, f32)> {
+    let values = split_top_ws(value);
+    if values.is_empty() || values.len() > 2 {
+        return None;
+    }
+    let horizontal = parse_radius_length(values.first()?)?;
+    let vertical = match values.get(1) {
+        Some(token) => parse_radius_length(token)?,
+        None => horizontal,
     };
-    css.corner_tl = tl;
-    css.corner_tr = tr;
-    css.corner_br = br;
-    css.corner_bl = bl;
+    Some((horizontal, vertical))
 }
 
-/// Tenta aplicar uma longhand de canto. `false` = o nome não é de nenhuma.
-pub fn try_apply(css: &mut ComputedStyle, prop: &str, val: &str) -> bool {
-    let Some(sufixo) = prop
+/// O shorthand `border-radius`, incluindo a forma elíptica
+/// `<horizontal> / <vertical>`.
+///
+/// A expansão segue a regra CSS: 1–4 valores em cada lado, na ordem TL, TR, BR,
+/// BL, com o segundo e o quarto a repetirem os valores correspondentes.
+pub fn apply_shorthand(css: &mut ComputedStyle, value: &str) {
+    let parts: Vec<&str> = value.split('/').collect();
+    if parts.len() > 2 {
+        return;
+    }
+    let horizontal = match expand_values(&split_top_ws(parts[0])) {
+        Some(values) => values,
+        None => return,
+    };
+    let vertical = if let Some(vertical_text) = parts.get(1) {
+        match expand_values(&split_top_ws(vertical_text)) {
+            Some(values) => values,
+            None => return,
+        }
+    } else {
+        horizontal
+    };
+    let corners = [
+        Corner::TopLeft,
+        Corner::TopRight,
+        Corner::BottomRight,
+        Corner::BottomLeft,
+    ];
+    for (index, corner) in corners.into_iter().enumerate() {
+        set_horizontal(css, corner, Some(horizontal[index]));
+        set_vertical(css, corner, Some(vertical[index]));
+    }
+}
+
+/// Tenta aplicar uma longhand de canto. `false` = o nome não é de uma delas.
+pub fn try_apply(css: &mut ComputedStyle, property: &str, value: &str) -> bool {
+    let Some(suffix) = property
         .strip_prefix("border-")
-        .and_then(|r| r.strip_suffix("-radius"))
+        .and_then(|rest| rest.strip_suffix("-radius"))
     else {
         return false;
     };
-    let Some(canto) = Corner::parse(sufixo) else {
+    let Some(corner) = Corner::parse(suffix) else {
         return false;
     };
-    set(css, canto, primeiro_raio(val));
+    let pair = parse_corner_pair(value);
+    set_horizontal(css, corner, pair.map(|values| values.0));
+    set_vertical(css, corner, pair.map(|values| values.1));
     true
 }
 
-/// O valor DECLARADO de uma longhand de canto (`""` se o elemento não a
-/// declarou — o inicial vive em `style::initial`, como o de todas). `None` = o
-/// nome não é de um canto.
-pub fn get_property(css: &ComputedStyle, prop: &str) -> Option<String> {
-    let sufixo = prop
+/// O valor computado de uma longhand de canto.
+pub fn get_property(css: &ComputedStyle, property: &str) -> Option<String> {
+    let suffix = property
         .strip_prefix("border-")
-        .and_then(|r| r.strip_suffix("-radius"))?;
-    let canto = Corner::parse(sufixo)?;
-    // O canto responde o que o canto tem; se só o shorthand foi declarado, foi
-    // ele que escreveu os quatro, portanto a resposta já está no campo do canto.
-    Some(
-        get(css, canto)
-            .map(|v| format!("{v}px"))
-            .unwrap_or_default(),
-    )
+        .and_then(|rest| rest.strip_suffix("-radius"))?;
+    let corner = Corner::parse(suffix)?;
+    let horizontal = horizontal(css, corner)?;
+    let vertical = vertical(css, corner).unwrap_or(horizontal);
+    Some(if horizontal == vertical {
+        super::fmt_values::fmt_px(horizontal)
+    } else {
+        format!(
+            "{} {}",
+            super::fmt_values::fmt_px(horizontal),
+            super::fmt_values::fmt_px(vertical)
+        )
+    })
 }

--- a/crates/rts-dom/src/style/ruleindex.rs
+++ b/crates/rts-dom/src/style/ruleindex.rs
@@ -110,7 +110,9 @@ impl RuleIndex {
         }
         idx.specificity = rules.iter().map(|r| r.selector.specificity()).collect();
         idx.covered = rules.len();
-        idx.has_custom_rules = rules.iter().any(|r| !r.decls.custom.is_empty());
+        idx.has_custom_rules = rules
+            .iter()
+            .any(|r| !r.decls.custom.is_empty() || !r.decls.custom_important.is_empty());
         idx.has_pseudo_elements = rules.iter().any(|r| r.selector.pseudo_element.is_some());
         idx.has_attribute_selectors = rules.iter().any(|rule| {
             let mut usa = false;

--- a/crates/rts-dom/src/style/stylesheet/folha.rs
+++ b/crates/rts-dom/src/style/stylesheet/folha.rs
@@ -16,6 +16,7 @@ impl Stylesheet {
             hover_reach: std::cell::RefCell::new(None),
             position_sensitive: std::cell::RefCell::new(None),
             out_of_flow: std::cell::RefCell::new(None),
+            layer_names: std::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -286,7 +287,11 @@ impl Stylesheet {
         // (var()/custom properties agora resolvem POR ELEMENTO na cascade — #1779;
         // o antigo passe textual GLOBAL daqui foi removido.)
         let base = self.rules.len() as u32;
-        for (i, rule) in super::parse_rules_ast(&ast).into_iter().enumerate() {
+        let parsed_rules = super::regras::parse_rules_ast_with_layers(
+            &ast,
+            &mut self.layer_names.borrow_mut(),
+        );
+        for (i, rule) in parsed_rules.into_iter().enumerate() {
             crate::bump!(css_rules);
             self.rules.push(Rule {
                 order: base + i as u32,
@@ -325,7 +330,7 @@ impl Stylesheet {
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
         crate::bump!(rules_considered, cand.len());
         let index = self.index.borrow();
-        let mut rules: Vec<(u32, u32, usize)> = cand
+        let mut rules: Vec<(u32, u32, u32, usize)> = cand
             .iter()
             .filter_map(|&i| {
                 let r = &self.rules[i];
@@ -337,11 +342,18 @@ impl Stylesheet {
                 (r.selector.pseudo_element.is_none()
                     && r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
                     && matches(&r.selector))
-                .then(|| (index.specificity(i), r.order, i))
+                .then(|| {
+                    (
+                        r.layer.unwrap_or(u32::MAX),
+                        index.specificity(i),
+                        r.order,
+                        i,
+                    )
+                })
             })
             .collect();
         crate::bump!(rules_matched, rules.len());
-        rules.sort_by_key(|(specificity, order, _)| (*specificity, *order));
+        rules.sort_by_key(|(layer, specificity, order, _)| (*layer, *specificity, *order));
         MatchedRules { rules }
     }
 
@@ -370,21 +382,28 @@ impl Stylesheet {
     ) -> (MatchedRules, Option<std::rc::Rc<crate::pseudo::Content>>) {
         let cand = self.candidate_indices(node_tag, node_id, node_classes);
         let index = self.index.borrow();
-        let mut rules: Vec<(u32, u32, usize)> = cand
+        let mut rules: Vec<(u32, u32, u32, usize)> = cand
             .iter()
             .filter_map(|&i| {
                 let r = &self.rules[i];
                 (r.selector.pseudo_element == Some(pe)
                     && r.media.map(|m| m.matches(viewport_w)).unwrap_or(true)
                     && matches(&r.selector))
-                .then(|| (index.specificity(i), r.order, i))
+                .then(|| {
+                    (
+                        r.layer.unwrap_or(u32::MAX),
+                        index.specificity(i),
+                        r.order,
+                        i,
+                    )
+                })
             })
             .collect();
-        rules.sort_by_key(|(specificity, order, _)| (*specificity, *order));
+        rules.sort_by_key(|(layer, specificity, order, _)| (*layer, *specificity, *order));
         let content = rules
             .iter()
             .rev()
-            .find_map(|(_, _, i)| self.rules[*i].content.clone());
+            .find_map(|(_, _, _, i)| self.rules[*i].content.clone());
         (MatchedRules { rules }, content)
     }
 
@@ -407,7 +426,7 @@ impl Stylesheet {
             .rules
             .iter()
             .rev()
-            .find_map(|(_, _, i)| self.rules[*i].counters.clone())
+            .find_map(|(_, _, _, i)| self.rules[*i].counters.clone())
     }
 
     /// `true` se alguma regra desta folha declara contadores.
@@ -436,7 +455,7 @@ impl Stylesheet {
         matched
             .rules
             .iter()
-            .flat_map(|(_, _, i)| self.rules[*i].decls.custom.iter().cloned())
+            .flat_map(|(_, _, _, i)| self.rules[*i].decls.custom.iter().cloned())
             .collect()
     }
 
@@ -449,7 +468,7 @@ impl Stylesheet {
         vars: Option<&std::collections::HashMap<String, String>>,
     ) -> DeclBlock {
         let mut out = DeclBlock::default();
-        for (_, _, i) in &matched.rules {
+        for (_, _, _, i) in &matched.rules {
             let r = &self.rules[*i];
             r.decls.apply_normal(&mut out.normal);
             if let Some(v) = vars {
@@ -460,7 +479,19 @@ impl Stylesheet {
                 }
             }
         }
-        for (_, _, i) in &matched.rules {
+        // A ordem das layers é invertida para `!important`: a layer mais
+        // antiga vence, enquanto as regras sem layer continuam acima das
+        // nomeadas na camada normal. A especificidade e a ordem de origem já
+        // vêm ordenadas dentro de cada layer.
+        let mut important_rules = matched.rules.clone();
+        important_rules.sort_by_key(|(layer, specificity, order, _)| {
+            (
+                if *layer == u32::MAX { 0 } else { u32::MAX - *layer },
+                *specificity,
+                *order,
+            )
+        });
+        for (_, _, _, i) in &important_rules {
             let r = &self.rules[*i];
             r.decls.apply_important(&mut out.important);
             if let Some(v) = vars {

--- a/crates/rts-dom/src/style/stylesheet/folha.rs
+++ b/crates/rts-dom/src/style/stylesheet/folha.rs
@@ -248,6 +248,43 @@ impl Stylesheet {
         self.keyframes.get(name)
     }
 
+    /// Insere um bloco CSS preservado na posição dos blocos sintácticos anexados.
+    /// A operação é deliberadamente transaccional: o AST é actualizado primeiro e
+    /// rules, keyframes, layers e índices são reconstruídos a partir da nova fonte.
+    /// `index == len` equivale a append; um índice fora do intervalo é rejeitado.
+    pub fn insert_rule(&mut self, index: usize, css: &str) -> Result<usize, String> {
+        if index > self.syntax.len() {
+            return Err(format!("índice de regra fora do intervalo: {index}"));
+        }
+        let ast = crate::style::syntax::StylesheetAst::parse(css);
+        if ast.items.is_empty() {
+            return Err("regra CSS vazia".to_string());
+        }
+        self.syntax.insert(index, ast);
+        self.rebuild_from_syntax();
+        Ok(index)
+    }
+
+    /// Remove um bloco CSS sintáctico e reconstrói a representação semântica.
+    /// Devolve `false` quando o índice não existe.
+    pub fn delete_rule(&mut self, index: usize) -> bool {
+        if index >= self.syntax.len() {
+            return false;
+        }
+        self.syntax.remove(index);
+        self.rebuild_from_syntax();
+        true
+    }
+
+    fn rebuild_from_syntax(&mut self) {
+        let blocks: Vec<String> = self.syntax.iter().map(|ast| ast.to_css()).collect();
+        let mut rebuilt = Stylesheet::new();
+        for css in blocks {
+            rebuilt.append_css(&css);
+        }
+        *self = rebuilt;
+    }
+
     /// Acrescenta as regras de mais um bloco `<style>` (uma página pode ter vários).
     /// EXTRAI os `@keyframes` primeiro (não são regras de seletor), depois as regras.
     pub fn append_css(&mut self, css: &str) {

--- a/crates/rts-dom/src/style/stylesheet/folha.rs
+++ b/crates/rts-dom/src/style/stylesheet/folha.rs
@@ -459,6 +459,23 @@ impl Stylesheet {
             .collect()
     }
 
+    /// Custom properties `!important` em ordem de aplicação. A prioridade de
+    /// layers é invertida para importantes, tal como nas declarações normais.
+    pub fn custom_important_from(&self, matched: &MatchedRules) -> Vec<(String, String)> {
+        let mut rules = matched.rules.clone();
+        rules.sort_by_key(|(layer, specificity, order, _)| {
+            (
+                if *layer == u32::MAX { 0 } else { u32::MAX - *layer },
+                *specificity,
+                *order,
+            )
+        });
+        rules
+            .iter()
+            .flat_map(|(_, _, _, i)| self.rules[*i].decls.custom_important.iter().cloned())
+            .collect()
+    }
+
     /// PASS B: as declarações normais e `!important` das regras que casaram, com
     /// as pendentes (`prop: …var(--x)…`) resolvidas na POSIÇÃO da regra contra
     /// as custom props do elemento.

--- a/crates/rts-dom/src/style/stylesheet/folha.rs
+++ b/crates/rts-dom/src/style/stylesheet/folha.rs
@@ -9,6 +9,7 @@ impl Stylesheet {
     pub fn new() -> Stylesheet {
         Stylesheet {
             rules: Vec::new(),
+            syntax: Vec::new(),
             keyframes: std::collections::HashMap::new(),
             index: std::cell::RefCell::new(super::ruleindex::RuleIndex::default()),
             candidate_scratch: std::cell::RefCell::new(Vec::new()),
@@ -249,13 +250,43 @@ impl Stylesheet {
     /// Acrescenta as regras de mais um bloco `<style>` (uma página pode ter vários).
     /// EXTRAI os `@keyframes` primeiro (não são regras de seletor), depois as regras.
     pub fn append_css(&mut self, css: &str) {
+        // Tokeniza uma única vez. O AST preserva a entrada original para tooling;
+        // o IR semântico continua a ser a fonte consumida pela cascade.
+        let ast = crate::style::syntax::StylesheetAst::parse(css);
+        self.syntax.push(ast.clone());
+
+        // `@keyframes` é um at-rule estrutural: não vira `Rule`, mas os seus stops
+        // são baixados directamente para a tabela de animações.
+        for item in &ast.items {
+            if let crate::style::syntax::AstItem::AtRule {
+                name,
+                prelude,
+                block: Some(block),
+                ..
+            } = item
+            {
+                let lower = name.to_ascii_lowercase();
+                if lower == "keyframes" || lower == "-webkit-keyframes" {
+                    let keyframe_name: String = prelude
+                        .iter()
+                        .map(crate::style::syntax::ComponentValue::to_css_semantic)
+                        .collect();
+                    let keyframe_name = keyframe_name.trim();
+                    if !keyframe_name.is_empty() {
+                        crate::bump!(css_keyframes);
+                        self.keyframes.insert(
+                            keyframe_name.to_string(),
+                            super::parse_keyframe_ast(block),
+                        );
+                    }
+                }
+            }
+        }
+
         // (var()/custom properties agora resolvem POR ELEMENTO na cascade — #1779;
         // o antigo passe textual GLOBAL daqui foi removido.)
-        // 1) extrai e remove os blocos @keyframes (guarda por nome).
-        let css_without_kf = self.extract_keyframes(css);
-        // 2) as regras normais do resto.
         let base = self.rules.len() as u32;
-        for (i, rule) in parse_rules(&css_without_kf).into_iter().enumerate() {
+        for (i, rule) in super::parse_rules_ast(&ast).into_iter().enumerate() {
             crate::bump!(css_rules);
             self.rules.push(Rule {
                 order: base + i as u32,
@@ -266,35 +297,6 @@ impl Stylesheet {
         *self.hover_reach.borrow_mut() = None;
         *self.position_sensitive.borrow_mut() = None;
         *self.out_of_flow.borrow_mut() = None;
-    }
-
-    /// Acha cada `@keyframes nome { ... }`, parseia os stops e guarda; devolve o CSS
-    /// SEM os blocos de keyframes (p/ o parser de regras não tropeçar neles).
-    fn extract_keyframes(&mut self, css: &str) -> String {
-        let _phase = crate::metrics::phases::scope("css-keyframes+strip");
-        let css = strip_css_comments(css);
-        let mut out = String::new();
-        let mut rest = css.as_str();
-        while let Some(at) = rest.find("@keyframes") {
-            out.push_str(&rest[..at]);
-            let after = &rest[at + "@keyframes".len()..];
-            // nome até o `{`.
-            let Some(brace) = after.find('{') else { break };
-            let name = after[..brace].trim().to_string();
-            // acha o `}` que fecha o bloco (contando aninhamento, pois cada stop tem `{}`).
-            let body_start = at + "@keyframes".len() + brace + 1;
-            let Some(body_end) = find_matching_brace(&rest[body_start..]) else {
-                break;
-            };
-            let body = &rest[body_start..body_start + body_end];
-            if !name.is_empty() {
-                crate::bump!(css_keyframes);
-                self.keyframes.insert(name, parse_keyframe_body(body));
-            }
-            rest = &rest[body_start + body_end + 1..];
-        }
-        out.push_str(rest);
-        out
     }
 
     /// Computa o estilo de AUTOR para um elemento, aplicando as regras cujo seletor

--- a/crates/rts-dom/src/style/stylesheet/folha.rs
+++ b/crates/rts-dom/src/style/stylesheet/folha.rs
@@ -487,6 +487,8 @@ impl Stylesheet {
         let mut out = DeclBlock::default();
         for (_, _, _, i) in &matched.rules {
             let r = &self.rules[*i];
+            out.all_initial_normal |= r.decls.all_initial_normal;
+            out.all_initial_important |= r.decls.all_initial_important;
             r.decls.apply_normal(&mut out.normal);
             if let Some(v) = vars {
                 for (prop, raw, important) in &r.decls.pending {

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -21,12 +21,12 @@
 //! `~=`/`|=`), pseudo estruturais (`:first-child`/`:last-child`/`:only-child`/
 //! `:empty`/`:root`/`:nth-child`) e de estado-via-atributo (`:checked`/`:disabled`/
 //! `:enabled`/`:required`), e lista por vírgula em querySelector/matches/closest.
-//! **Cortes (não bugs):** `@layer`; pseudo de estado VIVO (`:hover`/`:focus`);
-//! `:not()`/`:is()`/`:where()`/`:nth-of-type`; pseudo-elementos (`::before`); flag
-//! de case `[a=v i]`; as keywords `inherit`/`initial`/`unset`/`revert`.
-//! (`!important` — estágio 1 da MDN — JÁ é suportado.)
+//! **Cortes (não bugs):** pseudo de estado VIVO (`:hover`/`:focus`); pseudo-elementos
+//! (`::before`); flag de case `[a=v i]`; `revert`/`revert-layer` sem origem/camada
+//! completa. `@layer`, `inherit`, `initial`, `unset` e `!important` já atravessam
+//! o pipeline actual.
 
-pub(in crate::style::stylesheet) use super::parse::{parse_inline_block, parse_inline_block_raw};
+pub(in crate::style::stylesheet) use super::parse::parse_inline_block;
 pub(in crate::style::stylesheet) use super::props::ComputedStyle;
 pub(in crate::style::stylesheet) use super::selector::{ComplexSelector, PseudoClass, Selector, compound_matches};
 
@@ -389,8 +389,8 @@ impl Stylesheet {
 use super::{Combinator, CompoundSelector, Position, PseudoElement, SimpleSelector};
 use super::{props, ruleindex, selector, vars};
 
-mod folha;
-mod regras;
+mod sheet;
+mod rules;
 mod supports;
 
-pub use regras::*;
+pub use rules::*;

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -131,9 +131,12 @@ fn parse_media_len(v: &str) -> Option<f32> {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Rule {
     pub selector: Selector,
-    /// Declarações CSS especificadas preservadas pelo AST, antes do lowering.
-    /// Servem para tooling, diagnósticos e migração de propriedades sem perder o
-    /// valor original que não cabe ainda em `ComputedStyle`.
+    /// Declarações CSS no estado especificado, preservadas pelo AST antes do
+    /// lowering para `ComputedStyle`. A mesma instância é partilhada pelos
+    /// selectors que vierem de uma regra com lista de selectors.
+    pub specified: std::rc::Rc<crate::style::syntax::SpecifiedStyle>,
+    /// Alias de compatibilidade para consumidores que ainda precisam da fatia
+    /// directa de declarações especificadas.
     pub source_declarations: std::rc::Rc<[crate::style::syntax::DeclarationAst]>,
     /// As declarações, COMPARTILHADAS: `Rc` e não valor.
     ///

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -182,9 +182,13 @@ pub struct Rule {
 pub struct DeclBlock {
     /// Declarações normais (sem `!important`).
     pub normal: ComputedStyle,
+    /// `all: initial` normal resetou as declarações anteriores deste bloco.
+    pub all_initial_normal: bool,
     /// Declarações marcadas `!important` (vencem qualquer normal na cascade).
     pub important: ComputedStyle,
-    /// Declarações de CUSTOM PROPERTIES normais (`--nome: valor`) do bloco, na
+    /// `all: initial !important` resetou a camada importante deste bloco.
+    pub all_initial_important: bool,
+    /// Declarações normais de CUSTOM PROPERTIES normais (`--nome: valor`) do bloco, na
     /// ordem da fonte, com o valor cru. Participam da cascade por elemento.
     pub custom: Vec<(String, String)>,
     /// Custom properties marcadas `!important`, aplicadas depois das normais e
@@ -208,6 +212,8 @@ pub struct DeclBlock {
 pub struct RuleDecls {
     pub normal: Box<[super::props::Decl]>,
     pub important: Box<[super::props::Decl]>,
+    pub all_initial_normal: bool,
+    pub all_initial_important: bool,
     pub custom: Vec<(String, String)>,
     pub custom_important: Vec<(String, String)>,
     pub pending: Vec<(String, String, bool)>,
@@ -220,6 +226,8 @@ impl RuleDecls {
         RuleDecls {
             normal: block.normal.to_decls().into_boxed_slice(),
             important: block.important.to_decls().into_boxed_slice(),
+            all_initial_normal: block.all_initial_normal,
+            all_initial_important: block.all_initial_important,
             custom: block.custom,
             custom_important: block.custom_important,
             pending: block.pending,
@@ -229,12 +237,18 @@ impl RuleDecls {
     /// Aplica as declarações normais sobre um estilo (mesma precedência do
     /// `merge_over`: quem aplica depois vence).
     pub fn apply_normal(&self, target: &mut ComputedStyle) {
+        if self.all_initial_normal {
+            *target = ComputedStyle::default();
+        }
         for d in &self.normal {
             d.apply(target);
         }
     }
 
     pub fn apply_important(&self, target: &mut ComputedStyle) {
+        if self.all_initial_important {
+            *target = ComputedStyle::default();
+        }
         for d in &self.important {
             d.apply(target);
         }
@@ -263,6 +277,8 @@ impl DeclBlock {
     pub fn is_empty(&self) -> bool {
         self.normal == ComputedStyle::default()
             && self.important == ComputedStyle::default()
+            && !self.all_initial_normal
+            && !self.all_initial_important
             && self.custom.is_empty()
             && self.custom_important.is_empty()
             && self.pending.is_empty()

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -184,10 +184,12 @@ pub struct DeclBlock {
     pub normal: ComputedStyle,
     /// Declarações marcadas `!important` (vencem qualquer normal na cascade).
     pub important: ComputedStyle,
-    /// Declarações de CUSTOM PROPERTIES (`--nome: valor`) do bloco, na ordem do
-    /// fonte, com o valor CRU (pode conter `var()` aninhado). Participam da
-    /// cascade por elemento (#1779). Importância ignorada na v1 (documentado).
+    /// Declarações de CUSTOM PROPERTIES normais (`--nome: valor`) do bloco, na
+    /// ordem da fonte, com o valor cru. Participam da cascade por elemento.
     pub custom: Vec<(String, String)>,
+    /// Custom properties marcadas `!important`, aplicadas depois das normais e
+    /// antes de resolver os valores pendentes com `var()`.
+    pub custom_important: Vec<(String, String)>,
     /// Declarações PENDENTES — o valor contém `var()` e só resolve POR ELEMENTO
     /// (contra as custom props computadas dele): `(prop, valor-cru, important)`.
     /// Resolvidas na posição da regra em [`Stylesheet::computed_for_node`].
@@ -207,6 +209,7 @@ pub struct RuleDecls {
     pub normal: Box<[super::props::Decl]>,
     pub important: Box<[super::props::Decl]>,
     pub custom: Vec<(String, String)>,
+    pub custom_important: Vec<(String, String)>,
     pub pending: Vec<(String, String, bool)>,
 }
 
@@ -218,6 +221,7 @@ impl RuleDecls {
             normal: block.normal.to_decls().into_boxed_slice(),
             important: block.important.to_decls().into_boxed_slice(),
             custom: block.custom,
+            custom_important: block.custom_important,
             pending: block.pending,
         }
     }
@@ -243,6 +247,7 @@ impl RuleDecls {
             + self
                 .custom
                 .iter()
+                .chain(self.custom_important.iter())
                 .map(|(k, v)| k.capacity() + v.capacity())
                 .sum::<usize>()
             + self
@@ -259,6 +264,7 @@ impl DeclBlock {
         self.normal == ComputedStyle::default()
             && self.important == ComputedStyle::default()
             && self.custom.is_empty()
+            && self.custom_important.is_empty()
             && self.pending.is_empty()
     }
 }

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -26,7 +26,7 @@
 //! de case `[a=v i]`; as keywords `inherit`/`initial`/`unset`/`revert`.
 //! (`!important` — estágio 1 da MDN — JÁ é suportado.)
 
-pub(in crate::style::stylesheet) use super::parse::parse_inline_block;
+pub(in crate::style::stylesheet) use super::parse::{parse_inline_block, parse_inline_block_raw};
 pub(in crate::style::stylesheet) use super::props::ComputedStyle;
 pub(in crate::style::stylesheet) use super::selector::{ComplexSelector, PseudoClass, Selector, compound_matches};
 
@@ -131,6 +131,10 @@ fn parse_media_len(v: &str) -> Option<f32> {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Rule {
     pub selector: Selector,
+    /// Declarações CSS especificadas preservadas pelo AST, antes do lowering.
+    /// Servem para tooling, diagnósticos e migração de propriedades sem perder o
+    /// valor original que não cabe ainda em `ComputedStyle`.
+    pub source_declarations: std::rc::Rc<[crate::style::syntax::DeclarationAst]>,
     /// As declarações, COMPARTILHADAS: `Rc` e não valor.
     ///
     /// Um `DeclBlock` tem 2120 bytes (dois `ComputedStyle` inteiros, medido por

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -138,6 +138,9 @@ pub struct Rule {
     /// Alias de compatibilidade para consumidores que ainda precisam da fatia
     /// directa de declarações especificadas.
     pub source_declarations: std::rc::Rc<[crate::style::syntax::DeclarationAst]>,
+    /// Ordem da cascade layer. `None` significa regra autoral não agrupada;
+    /// para declarações normais ela fica acima de todas as layers nomeadas.
+    pub layer: Option<u32>,
     /// As declarações, COMPARTILHADAS: `Rc` e não valor.
     ///
     /// Um `DeclBlock` tem 2120 bytes (dois `ComputedStyle` inteiros, medido por
@@ -298,14 +301,19 @@ pub struct Stylesheet {
     position_sensitive: std::cell::RefCell<Option<bool>>,
     /// Cache de [`has_out_of_flow`](Stylesheet::has_out_of_flow).
     out_of_flow: std::cell::RefCell<Option<bool>>,
+    /// Ordem global das cascade layers deste stylesheet. É persistida entre
+    /// chamadas a `append_css`, porque folhas anexadas são uma única origem
+    /// autoral para fins de cascade.
+    pub(crate) layer_names: std::cell::RefCell<Vec<String>>,
 }
 
 /// As regras que casaram um nó, ordenadas pela cascade. Opaco de propósito: o
 /// que quem chama precisa é passá-lo aos dois passes, não ler o conteúdo.
 #[derive(Debug, Default)]
 pub struct MatchedRules {
-    /// `(especificidade, ordem, índice da regra)`, crescente.
-    rules: Vec<(u32, u32, usize)>,
+    /// `(prioridade-layer, especificidade, ordem, índice)`, crescente.
+    /// `prioridade-layer` usa `u32::MAX` para regras sem layer.
+    pub(crate) rules: Vec<(u32, u32, u32, usize)>,
 }
 
 impl MatchedRules {

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -266,6 +266,9 @@ pub fn rule_size() -> usize {
 #[derive(Clone, Default, Debug)]
 pub struct Stylesheet {
     pub rules: Vec<Rule>,
+    /// AST sintáctico dos blocos CSS anexados, preservado para diagnósticos,
+    /// tooling e lowering futuro. A cascade continua a consumir `rules`.
+    pub syntax: Vec<crate::style::syntax::StylesheetAst>,
     /// Os `@keyframes nome {...}` da página (#1776), por nome. Consultados pelo
     /// `advance` quando um nó tem `animation: nome ...`.
     pub keyframes: std::collections::HashMap<String, crate::anim::Keyframes>,
@@ -324,6 +327,21 @@ pub enum HoverReach {
 impl PartialEq for Stylesheet {
     fn eq(&self, other: &Self) -> bool {
         self.rules == other.rules
+    }
+}
+
+impl Stylesheet {
+    /// Blocos sintácticos CSS preservados na ordem em que foram anexados.
+    pub fn syntax(&self) -> &[crate::style::syntax::StylesheetAst] {
+        &self.syntax
+    }
+
+    /// Diagnósticos de parsing dos blocos CSS anexados, na ordem da fonte.
+    pub fn diagnostics(&self) -> Vec<crate::style::syntax::Diagnostic> {
+        self.syntax
+            .iter()
+            .flat_map(|ast| ast.diagnostics.iter().cloned())
+            .collect()
     }
 }
 

--- a/crates/rts-dom/src/style/stylesheet/regras.rs
+++ b/crates/rts-dom/src/style/stylesheet/regras.rs
@@ -37,6 +37,9 @@ fn lower_items(
                     .map(crate::style::syntax::ComponentValue::to_css_semantic)
                     .collect();
                 let body = block.to_css_semantic();
+                let source_declarations: std::rc::Rc<
+                    [crate::style::syntax::DeclarationAst]
+                > = block.declarations().into_boxed_slice().into();
                 let decls = std::rc::Rc::new(RuleDecls::from_block(lower_declarations(block)));
                 let content = std::cell::OnceCell::new();
                 let counters = crate::counters::parse_ops(&body).map(std::rc::Rc::new);
@@ -49,6 +52,7 @@ fn lower_items(
                         });
                         output.push(Rule {
                             selector,
+                            source_declarations: std::rc::Rc::clone(&source_declarations),
                             decls: std::rc::Rc::clone(&decls),
                             order: 0,
                             media: inherited_media,
@@ -72,21 +76,24 @@ fn lower_items(
                     .iter()
                     .map(crate::style::syntax::ComponentValue::to_css_semantic)
                     .collect();
-                let nested = crate::style::syntax::StylesheetAst::parse(&block.to_css_semantic());
                 match name.to_ascii_lowercase().as_str() {
                     "media" => {
                         let media = MediaQuery::parse(cond.trim());
                         let media = combine_media(inherited_media, media);
-                        lower_items(&nested.items, media, output);
+                        with_nested_items(block, |items| lower_items(items, media, output));
                     }
                     "supports" => {
                         if super::supports::avalia(cond.trim()) {
-                            lower_items(&nested.items, inherited_media, output);
+                            with_nested_items(block, |items| {
+                                lower_items(items, inherited_media, output)
+                            });
                         } else {
                             crate::bump!(css_supports_rejeitado);
                         }
                     }
-                    "layer" => lower_items(&nested.items, inherited_media, output),
+                    "layer" => with_nested_items(block, |items| {
+                        lower_items(items, inherited_media, output)
+                    }),
                     _ => {}
                 }
             }
@@ -109,7 +116,7 @@ fn lower_declarations(block: &crate::style::syntax::BlockAst) -> DeclBlock {
             declaration.value_css(),
             important
         );
-        let parsed = parse_inline_block(&source);
+        let parsed = parse_inline_block_raw(&source);
         if declaration.important {
             lowered.important.merge_over(&parsed.important);
         } else {
@@ -119,6 +126,18 @@ fn lower_declarations(block: &crate::style::syntax::BlockAst) -> DeclBlock {
         lowered.pending.extend(parsed.pending);
     }
     lowered
+}
+
+fn with_nested_items(
+    block: &crate::style::syntax::BlockAst,
+    f: impl FnOnce(&[crate::style::syntax::AstItem]),
+) {
+    if let Some(nested) = &block.nested {
+        f(&nested.items);
+    } else {
+        let nested = crate::style::syntax::StylesheetAst::parse(&block.to_css());
+        f(&nested.items);
+    }
 }
 
 fn combine_media(outer: Option<MediaQuery>, inner: MediaQuery) -> Option<MediaQuery> {
@@ -132,29 +151,29 @@ fn combine_media(outer: Option<MediaQuery>, inner: MediaQuery) -> Option<MediaQu
 pub(in crate::style::stylesheet) fn parse_keyframe_ast(
     block: &crate::style::syntax::BlockAst,
 ) -> crate::anim::Keyframes {
-    let ast = crate::style::syntax::StylesheetAst::parse(&block.to_css());
     let mut stops = Vec::new();
-    for item in ast.items {
-        let crate::style::syntax::AstItem::QualifiedRule {
-            prelude, block, ..
-        } = item
-        else {
-            continue;
-        };
-        let selector: String = prelude
-            .iter()
-            .map(crate::style::syntax::ComponentValue::to_css_semantic)
-            .collect();
-        let body = block.to_css_semantic();
-        let decls = lower_declarations(&block);
-        for token in selector.split(',') {
-            if let Some(offset) = parse_keyframe_offset(token.trim()) {
-                let mut style = decls.normal.clone();
-                style.merge_over(&decls.important);
-                stops.push(crate::anim::Keyframe { offset, style });
+    with_nested_items(block, |items| {
+        for item in items {
+            let crate::style::syntax::AstItem::QualifiedRule {
+                prelude, block, ..
+            } = item
+            else {
+                continue;
+            };
+            let selector: String = prelude
+                .iter()
+                .map(crate::style::syntax::ComponentValue::to_css_semantic)
+                .collect();
+            let decls = lower_declarations(block);
+            for token in selector.split(',') {
+                if let Some(offset) = parse_keyframe_offset(token.trim()) {
+                    let mut style = decls.normal.clone();
+                    style.merge_over(&decls.important);
+                    stops.push(crate::anim::Keyframe { offset, style });
+                }
             }
         }
-    }
+    });
     stops.sort_by(|a, b| {
         a.offset
             .partial_cmp(&b.offset)
@@ -242,7 +261,7 @@ pub(crate) fn apply_resolved_decl(
     if resolved.trim().is_empty() {
         return; // var() sem valor nem fallback: declaração inválida (spec: unset)
     }
-    let mini = parse_inline_block(&format!("{prop}: {resolved}"));
+    let mini = parse_inline_block_raw(&format!("{prop}: {resolved}"));
     css.merge_over(&mini.normal);
 }
 

--- a/crates/rts-dom/src/style/stylesheet/regras.rs
+++ b/crates/rts-dom/src/style/stylesheet/regras.rs
@@ -14,19 +14,59 @@ pub fn parse_rules(css: &str) -> Vec<Rule> {
     parse_rules_ast(&ast)
 }
 
+#[derive(Default)]
+struct LayerState {
+    names: Vec<String>,
+}
+
+impl LayerState {
+    fn id(&mut self, name: &str) -> u32 {
+        let name = if name.is_empty() {
+            "<anonymous>"
+        } else {
+            name
+        };
+        if let Some((index, _)) = self
+            .names
+            .iter()
+            .enumerate()
+            .find(|(_, existing)| existing.as_str() == name)
+        {
+            return index as u32;
+        }
+        let id = self.names.len() as u32;
+        self.names.push(name.to_string());
+        id
+    }
+}
+
 /// Faz o lowering semântico de um AST já tokenizado, evitando uma segunda
 /// tokenização quando o chamador também precisa dos at-rules originais.
 pub(in crate::style::stylesheet) fn parse_rules_ast(
     ast: &crate::style::syntax::StylesheetAst,
 ) -> Vec<Rule> {
+    let mut layers = Vec::new();
+    parse_rules_ast_with_layers(ast, &mut layers)
+}
+
+pub(in crate::style::stylesheet) fn parse_rules_ast_with_layers(
+    ast: &crate::style::syntax::StylesheetAst,
+    layer_names: &mut Vec<String>,
+) -> Vec<Rule> {
     let mut rules = Vec::new();
-    lower_items(&ast.items, None, &mut rules);
+    let mut layers = LayerState {
+        names: std::mem::take(layer_names),
+    };
+    lower_items(&ast.items, None, None, &mut layers, &mut rules);
+    *layer_names = layers.names;
     rules
 }
 
 fn lower_items(
     items: &[crate::style::syntax::AstItem],
     inherited_media: Option<MediaQuery>,
+    inherited_layer: Option<u32>,
+    layers: &mut LayerState,
     output: &mut Vec<Rule>,
 ) {
     for item in items {
@@ -53,6 +93,7 @@ fn lower_items(
                             selector,
                             specified: std::rc::Rc::clone(&specified),
                             source_declarations: std::rc::Rc::clone(&source_declarations),
+                            layer: inherited_layer,
                             decls: std::rc::Rc::clone(&decls),
                             order: 0,
                             media: inherited_media,
@@ -80,22 +121,39 @@ fn lower_items(
                     "media" => {
                         let media = MediaQuery::parse(cond.trim());
                         let media = combine_media(inherited_media, media);
-                        with_nested_items(block, |items| lower_items(items, media, output));
+                        with_nested_items(block, |items| {
+                            lower_items(items, media, inherited_layer, layers, output)
+                        });
                     }
                     "supports" => {
                         if super::supports::avalia(cond.trim()) {
                             with_nested_items(block, |items| {
-                                lower_items(items, inherited_media, output)
+                                lower_items(items, inherited_media, inherited_layer, layers, output)
                             });
                         } else {
                             crate::bump!(css_supports_rejeitado);
                         }
                     }
-                    "layer" => with_nested_items(block, |items| {
-                        lower_items(items, inherited_media, output)
-                    }),
+                    "layer" => {
+                        let layer = layers.id(cond.trim());
+                        with_nested_items(block, |items| {
+                            lower_items(items, inherited_media, Some(layer), layers, output)
+                        });
+                    }
                     _ => {}
                 }
+            }
+            crate::style::syntax::AstItem::AtRule {
+                name,
+                prelude,
+                block: None,
+                ..
+            } if name.eq_ignore_ascii_case("layer") => {
+                let cond: String = prelude
+                    .iter()
+                    .map(crate::style::syntax::ComponentValue::to_css_semantic)
+                    .collect();
+                layers.id(cond.trim());
             }
             _ => {}
         }

--- a/crates/rts-dom/src/style/stylesheet/regras.rs
+++ b/crates/rts-dom/src/style/stylesheet/regras.rs
@@ -4,174 +4,165 @@
 
 use super::*;
 
-/// Parseia o corpo de um `<style>` numa lista de [`Rule`] (sem `order`, que o
-/// `Stylesheet::append_css` atribui). Robusto: comentários `/* */` são removidos;
-/// regras malformadas (sem `{`/`}`, seletor desconhecido) são puladas sem panicar;
-/// `a, b { ... }` vira uma regra por seletor (mesmas declarações).
+/// Faz o lowering da sintaxe CSS preservada para o IR da cascade.
+///
+/// O tokenizer/AST em `style::syntax` é agora a única etapa estrutural: este
+/// módulo só decide quais at-rules o motor entende e converte selectors e
+/// declarações para os tipos semânticos já usados pela cascade.
 pub fn parse_rules(css: &str) -> Vec<Rule> {
-    let _phase = crate::metrics::phases::scope("css-parse-rules");
-    let css = {
-        let _strip = crate::metrics::phases::scope("css-strip-comments");
-        strip_css_comments(css)
-    };
+    let ast = crate::style::syntax::StylesheetAst::parse(css);
+    parse_rules_ast(&ast)
+}
+
+/// Faz o lowering semântico de um AST já tokenizado, evitando uma segunda
+/// tokenização quando o chamador também precisa dos at-rules originais.
+pub(in crate::style::stylesheet) fn parse_rules_ast(
+    ast: &crate::style::syntax::StylesheetAst,
+) -> Vec<Rule> {
     let mut rules = Vec::new();
-    let bytes = css.as_bytes();
-    let mut i = 0usize;
-    while i < bytes.len() {
-        // AT-RULES: blocos ANINHADOS (`@media (...) { .x { … } }`) — o fechamento
-        // raso no primeiro `}` CORROMPIA o parse (o `}` órfão engolia as regras
-        // vizinhas do bootstrap.min.css). `@media` agora é AVALIADO (fase 2): a
-        // condição vira [`MediaQuery`] e as regras INTERNAS entram com ela anexada
-        // (a cascade filtra pelo viewport). Os demais at-rules com bloco
-        // (`@supports`/`@font-face`/…) são pulados com chaves casadas;
-        // `@import`/`@charset` (sem corpo) pulam até o `;`. `@keyframes` nunca
-        // chega aqui (extraído antes em append_css).
-        let ws = css[i..]
-            .find(|c: char| !c.is_whitespace())
-            .map(|r| i + r)
-            .unwrap_or(css.len());
-        if css[ws..].starts_with('@') {
-            let brace_rel = css[ws..].find('{');
-            let semi_rel = css[ws..].find(';');
-            match (brace_rel, semi_rel) {
-                // `;` antes do `{` (ou sem bloco): at-rule sem corpo → pula até o `;`.
-                (None, Some(s)) => i = ws + s + 1,
-                (Some(b), Some(s)) if s < b => i = ws + s + 1,
-                // com bloco: @media parseia o corpo recursivo; o resto pula casado.
-                (Some(b), _) => {
-                    let body_start = ws + b + 1;
-                    match find_matching_brace(&css[body_start..]) {
-                        Some(end) => {
-                            let header = &css[ws..ws + b];
-                            let inner_css = &css[body_start..body_start + end];
-                            if let Some(cond) = header.strip_prefix("@media") {
-                                let outer = MediaQuery::parse(cond.trim());
-                                for mut rule in parse_rules(inner_css) {
-                                    crate::bump!(css_media_rules);
-                                    // aninhamento @media-em-@media: AND das queries.
-                                    rule.media = Some(match rule.media {
-                                        Some(inner) => inner.and(outer),
-                                        None => outer,
-                                    });
-                                    rules.push(rule);
-                                }
-                            } else if let Some(cond) =
-                                header.trim_start().strip_prefix("@supports")
-                            {
-                                // AVALIADO (não transparente): era o único sítio
-                                // do motor onde aplicávamos regras que o Chrome
-                                // não aplica de todo — e uma folha real escreve
-                                // os DOIS ramos de um par exclusivo, contando
-                                // que o motor escolha um. Ver `supports.rs`,
-                                // incluindo o que "suportamos" quer dizer aqui.
-                                if super::supports::avalia(cond) {
-                                    for rule in parse_rules(inner_css) {
-                                        rules.push(rule);
-                                    }
-                                } else {
-                                    crate::bump!(css_supports_rejeitado);
-                                }
-                            } else if header.trim_start().starts_with("@layer") {
-                                // `@layer <nome> { ... }` / `@layer { ... }` (anônimo) e
-                                // `@supports (...) { ... }`: TRANSPARENTES para o matching.
-                                // As regras internas entram no nível atual (a precedência
-                                // fina entre camadas / a avaliação real do @supports são
-                                // refinamento posterior — o essencial é APLICAR as regras,
-                                // senão o Tailwind v4, que embrulha TUDO em @layer, some).
-                                // As camadas do Tailwind vêm em ordem correta no arquivo, e
-                                // o `order` da cascade (posição) já as desempata bem.
-                                for rule in parse_rules(inner_css) {
-                                    rules.push(rule);
-                                }
-                            }
-                            i = body_start + end + 1;
-                        }
-                        None => break, // bloco não fecha: nada mais a parsear.
-                    }
-                }
-                (None, None) => break,
-            }
-            continue;
-        }
-        // Acha o `{` que abre o bloco de declarações.
-        let Some(brace) = css[i..].find('{').map(|r| i + r) else {
-            break;
-        };
-        let selectors_raw = css[i..brace].trim();
-        // Acha o `}` que fecha; sem fechar, vai até o fim (tolerante).
-        let close = css[brace + 1..].find('}').map(|r| brace + 1 + r);
-        let (body, next) = match close {
-            Some(end) => (&css[brace + 1..end], end + 1),
-            None => (&css[brace + 1..], css.len()),
-        };
-        let decls = parse_inline_block(body); // reusa o parser de declarações (normal+important).
-        // `a, b, .c { }` → uma regra por seletor (lista separada por vírgula).
-        let _emit = crate::metrics::phases::scope("css-rule-emit");
-        let decls = std::rc::Rc::new(RuleDecls::from_block(decls));
-        // `content` é lido do corpo CRU, e não do bloco já parseado, porque não
-        // é uma propriedade do `ComputedStyle` — o parser de declarações
-        // descarta-a. Só se procura quando algum seletor da regra tem
-        // pseudo-elemento: numa folha real são umas dezenas de regras em
-        // milhares, e varrer o corpo de todas custaria em cada página.
-        let content = std::cell::OnceCell::new();
-        // Os contadores são lidos de TODA regra e não só das de pseudo-elemento
-        // (o `counter-increment` que numera as referências está num `<li>`), mas
-        // o `parse_ops` sai num `contains("counter-")` antes de dividir o corpo,
-        // que é o mesmo corte barato que o `content` obtém pela guarda do
-        // pseudo. `Rc` porque `a, b { counter-increment:x }` é uma regra por
-        // seletor e as duas partilham o valor.
-        let counters = crate::counters::parse_ops(body).map(std::rc::Rc::new);
-        // A vírgula que separa a LISTA é a de topo. `split(',')` cru cortava
-        // dentro de `:is(.a, .b)` e de `[data-x="a,b"]`, produzindo dois pedaços
-        // que não parseiam — a regra desaparecia e a contagem de recusadas
-        // culpava o seletor, não o corte.
-        for sel_str in super::selector::split_top_level_commas(selectors_raw) {
-            if let Some(selector) = ComplexSelector::parse(sel_str) {
-                let content = selector.pseudo_element.and_then(|_| {
-                    content
-                        .get_or_init(|| content_do_corpo(body).map(std::rc::Rc::new))
-                        .clone()
-                });
-                rules.push(Rule {
-                    selector,
-                    decls: std::rc::Rc::clone(&decls),
-                    order: 0,
-                    media: None,
-                    content,
-                    counters: counters.clone(),
-                });
-            } else if !sel_str.trim().is_empty() {
-                // Um seletor que o parser recusa é uma regra que a página tem e o
-                // motor NÃO aplica — a diferença mais comum entre "parece o
-                // Chrome" e "não parece", e invisível sem contá-la.
-                crate::bump!(css_rules_dropped);
-                crate::bump!(selector_parse_failures);
-                crate::note!("seletor-recusado", sel_str.trim().to_string());
-            }
-        }
-        i = next;
-    }
+    lower_items(&ast.items, None, &mut rules);
     rules
 }
 
-/// Acha o índice do `}` que fecha o bloco iniciado APÓS o `{` já consumido, contando
-/// o aninhamento (`@keyframes` tem `{}` por stop). `None` se não fecha.
-pub(in crate::style::stylesheet) fn find_matching_brace(s: &str) -> Option<usize> {
-    let mut depth = 1i32;
-    for (i, c) in s.char_indices() {
-        match c {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
+fn lower_items(
+    items: &[crate::style::syntax::AstItem],
+    inherited_media: Option<MediaQuery>,
+    output: &mut Vec<Rule>,
+) {
+    for item in items {
+        match item {
+            crate::style::syntax::AstItem::QualifiedRule { prelude, block, .. } => {
+                let selectors_raw: String = prelude
+                    .iter()
+                    .map(crate::style::syntax::ComponentValue::to_css_semantic)
+                    .collect();
+                let body = block.to_css_semantic();
+                let decls = std::rc::Rc::new(RuleDecls::from_block(lower_declarations(block)));
+                let content = std::cell::OnceCell::new();
+                let counters = crate::counters::parse_ops(&body).map(std::rc::Rc::new);
+                for sel_str in super::selector::split_top_level_commas(&selectors_raw) {
+                    if let Some(selector) = ComplexSelector::parse(sel_str) {
+                        let content = selector.pseudo_element.and_then(|_| {
+                            content
+                                .get_or_init(|| content_do_corpo(&body).map(std::rc::Rc::new))
+                                .clone()
+                        });
+                        output.push(Rule {
+                            selector,
+                            decls: std::rc::Rc::clone(&decls),
+                            order: 0,
+                            media: inherited_media,
+                            content,
+                            counters: counters.clone(),
+                        });
+                    } else if !sel_str.trim().is_empty() {
+                        crate::bump!(css_rules_dropped);
+                        crate::bump!(selector_parse_failures);
+                        crate::note!("seletor-recusado", sel_str.trim().to_string());
+                    }
+                }
+            }
+            crate::style::syntax::AstItem::AtRule {
+                name,
+                prelude,
+                block: Some(block),
+                ..
+            } => {
+                let cond: String = prelude
+                    .iter()
+                    .map(crate::style::syntax::ComponentValue::to_css_semantic)
+                    .collect();
+                let nested = crate::style::syntax::StylesheetAst::parse(&block.to_css_semantic());
+                match name.to_ascii_lowercase().as_str() {
+                    "media" => {
+                        let media = MediaQuery::parse(cond.trim());
+                        let media = combine_media(inherited_media, media);
+                        lower_items(&nested.items, media, output);
+                    }
+                    "supports" => {
+                        if super::supports::avalia(cond.trim()) {
+                            lower_items(&nested.items, inherited_media, output);
+                        } else {
+                            crate::bump!(css_supports_rejeitado);
+                        }
+                    }
+                    "layer" => lower_items(&nested.items, inherited_media, output),
+                    _ => {}
                 }
             }
             _ => {}
         }
     }
-    None
 }
+
+fn lower_declarations(block: &crate::style::syntax::BlockAst) -> DeclBlock {
+    let mut lowered = DeclBlock::default();
+    for declaration in block.declarations() {
+        let important = if declaration.important {
+            " !important"
+        } else {
+            ""
+        };
+        let source = format!(
+            "{}: {}{};",
+            declaration.name,
+            declaration.value_css(),
+            important
+        );
+        let parsed = parse_inline_block(&source);
+        if declaration.important {
+            lowered.important.merge_over(&parsed.important);
+        } else {
+            lowered.normal.merge_over(&parsed.normal);
+        }
+        lowered.custom.extend(parsed.custom);
+        lowered.pending.extend(parsed.pending);
+    }
+    lowered
+}
+
+fn combine_media(outer: Option<MediaQuery>, inner: MediaQuery) -> Option<MediaQuery> {
+    Some(match outer {
+        Some(outer) => inner.and(outer),
+        None => inner,
+    })
+}
+
+/// Converte os stops de um `@keyframes` AST para o tipo consumido pela animação.
+pub(in crate::style::stylesheet) fn parse_keyframe_ast(
+    block: &crate::style::syntax::BlockAst,
+) -> crate::anim::Keyframes {
+    let ast = crate::style::syntax::StylesheetAst::parse(&block.to_css());
+    let mut stops = Vec::new();
+    for item in ast.items {
+        let crate::style::syntax::AstItem::QualifiedRule {
+            prelude, block, ..
+        } = item
+        else {
+            continue;
+        };
+        let selector: String = prelude
+            .iter()
+            .map(crate::style::syntax::ComponentValue::to_css_semantic)
+            .collect();
+        let body = block.to_css_semantic();
+        let decls = lower_declarations(&block);
+        for token in selector.split(',') {
+            if let Some(offset) = parse_keyframe_offset(token.trim()) {
+                let mut style = decls.normal.clone();
+                style.merge_over(&decls.important);
+                stops.push(crate::anim::Keyframe { offset, style });
+            }
+        }
+    }
+    stops.sort_by(|a, b| {
+        a.offset
+            .partial_cmp(&b.offset)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    crate::anim::Keyframes { stops }
+}
+
 
 /// Parseia o corpo de um `@keyframes`: `0% { ... } 50% { ... } to { ... }` → stops
 /// ordenados por offset. `from`=0%, `to`=100%. Cada stop reusa o parser de declarações.
@@ -221,34 +212,6 @@ pub(crate) fn split_top_level_semicolons(s: &str) -> Vec<&str> {
     out
 }
 
-pub(in crate::style::stylesheet) fn parse_keyframe_body(body: &str) -> crate::anim::Keyframes {
-    let mut stops = Vec::new();
-    let mut rest = body;
-    loop {
-        let Some(brace) = rest.find('{') else { break };
-        let selector = rest[..brace].trim();
-        let Some(close_rel) = find_matching_brace(&rest[brace + 1..]) else {
-            break;
-        };
-        let decl_body = &rest[brace + 1..brace + 1 + close_rel];
-        let decls = parse_inline_block(decl_body);
-        // o seletor de stop pode ser uma lista: `0%, 50%`.
-        for tok in selector.split(',') {
-            if let Some(offset) = parse_keyframe_offset(tok.trim()) {
-                let mut style = decls.normal.clone();
-                style.merge_over(&decls.important);
-                stops.push(crate::anim::Keyframe { offset, style });
-            }
-        }
-        rest = &rest[brace + 1 + close_rel + 1..];
-    }
-    stops.sort_by(|a, b| {
-        a.offset
-            .partial_cmp(&b.offset)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    crate::anim::Keyframes { stops }
-}
 
 /// `0%`/`from`/`50%`/`100%`/`to` → offset ∈ [0,1]. `None` se inválido.
 fn parse_keyframe_offset(s: &str) -> Option<f32> {
@@ -283,20 +246,6 @@ pub(crate) fn apply_resolved_decl(
     css.merge_over(&mini.normal);
 }
 
-/// Remove blocos de comentário `/* ... */` do CSS (um passe, tolerante a não-fechado).
-pub(in crate::style::stylesheet) fn strip_css_comments(css: &str) -> String {
-    let mut out = String::with_capacity(css.len());
-    let mut rest = css;
-    while let Some(start) = rest.find("/*") {
-        out.push_str(&rest[..start]);
-        match rest[start + 2..].find("*/") {
-            Some(end) => rest = &rest[start + 2 + end + 2..],
-            None => return out, // comentário não fechado: descarta o resto.
-        }
-    }
-    out.push_str(rest);
-    out
-}
 
 // Testes da herança e da resolução de `var()` por elemento. Num ficheiro à
 // parte (via `#[path]`) e não num `mod` de `style/mod.rs`: este ficheiro já

--- a/crates/rts-dom/src/style/stylesheet/regras.rs
+++ b/crates/rts-dom/src/style/stylesheet/regras.rs
@@ -37,9 +37,8 @@ fn lower_items(
                     .map(crate::style::syntax::ComponentValue::to_css_semantic)
                     .collect();
                 let body = block.to_css_semantic();
-                let source_declarations: std::rc::Rc<
-                    [crate::style::syntax::DeclarationAst]
-                > = block.declarations().into_boxed_slice().into();
+                let specified = std::rc::Rc::new(crate::style::syntax::SpecifiedStyle::from_block(block));
+                let source_declarations = std::rc::Rc::clone(&specified.declarations);
                 let decls = std::rc::Rc::new(RuleDecls::from_block(lower_declarations(block)));
                 let content = std::cell::OnceCell::new();
                 let counters = crate::counters::parse_ops(&body).map(std::rc::Rc::new);
@@ -52,6 +51,7 @@ fn lower_items(
                         });
                         output.push(Rule {
                             selector,
+                            specified: std::rc::Rc::clone(&specified),
                             source_declarations: std::rc::Rc::clone(&source_declarations),
                             decls: std::rc::Rc::clone(&decls),
                             order: 0,
@@ -105,25 +105,17 @@ fn lower_items(
 fn lower_declarations(block: &crate::style::syntax::BlockAst) -> DeclBlock {
     let mut lowered = DeclBlock::default();
     for declaration in block.declarations() {
-        let important = if declaration.important {
-            " !important"
-        } else {
-            ""
-        };
-        let source = format!(
-            "{}: {}{};",
-            declaration.name,
-            declaration.value_css(),
-            important
+        let value = declaration
+            .value
+            .iter()
+            .map(crate::style::syntax::ComponentValue::to_css_semantic)
+            .collect::<String>();
+        crate::style::parse::apply_specified_declaration(
+            &mut lowered,
+            &declaration.name,
+            &value,
+            declaration.important,
         );
-        let parsed = parse_inline_block_raw(&source);
-        if declaration.important {
-            lowered.important.merge_over(&parsed.important);
-        } else {
-            lowered.normal.merge_over(&parsed.normal);
-        }
-        lowered.custom.extend(parsed.custom);
-        lowered.pending.extend(parsed.pending);
     }
     lowered
 }
@@ -261,8 +253,10 @@ pub(crate) fn apply_resolved_decl(
     if resolved.trim().is_empty() {
         return; // var() sem valor nem fallback: declaração inválida (spec: unset)
     }
-    let mini = parse_inline_block_raw(&format!("{prop}: {resolved}"));
-    css.merge_over(&mini.normal);
+    let mut block = DeclBlock::default();
+    block.normal = css.clone();
+    crate::style::parse::apply_specified_declaration(&mut block, prop, &resolved, false);
+    *css = block.normal;
 }
 
 

--- a/crates/rts-dom/src/style/stylesheet/regras.rs
+++ b/crates/rts-dom/src/style/stylesheet/regras.rs
@@ -153,7 +153,9 @@ fn lower_items(
                     .iter()
                     .map(crate::style::syntax::ComponentValue::to_css_semantic)
                     .collect();
-                layers.id(cond.trim());
+                for name in cond.split(',') {
+                    layers.id(name.trim());
+                }
             }
             _ => {}
         }

--- a/crates/rts-dom/src/style/stylesheet/rules.rs
+++ b/crates/rts-dom/src/style/stylesheet/rules.rs
@@ -86,7 +86,7 @@ fn lower_items(
                     if let Some(selector) = ComplexSelector::parse(sel_str) {
                         let content = selector.pseudo_element.and_then(|_| {
                             content
-                                .get_or_init(|| content_do_corpo(&body).map(std::rc::Rc::new))
+                                .get_or_init(|| parse_content_from_body(&body).map(std::rc::Rc::new))
                                 .clone()
                         });
                         output.push(Rule {
@@ -243,22 +243,22 @@ pub(in crate::style::stylesheet) fn parse_keyframe_ast(
 /// porque o valor pode conter `;` dentro de aspas (`content: ";"`), e porque
 /// `font-content`/`--content` não são a propriedade procurada — o nome tem de
 /// casar inteiro.
-fn content_do_corpo(body: &str) -> Option<crate::pseudo::Content> {
-    let mut achado = None;
+fn parse_content_from_body(body: &str) -> Option<crate::pseudo::Content> {
+    let mut found = None;
     for decl in split_top_level_semicolons(body) {
-        let Some((nome, valor)) = decl.split_once(':') else {
+        let Some((name, value)) = decl.split_once(':') else {
             continue;
         };
-        if !nome.trim().eq_ignore_ascii_case("content") {
+        if !name.trim().eq_ignore_ascii_case("content") {
             continue;
         }
         // A ÚLTIMA declaração do bloco vence, como em qualquer bloco CSS; uma
         // que não saibamos parsear não apaga a anterior que sabíamos.
-        if let Some(c) = crate::pseudo::parse_content(valor.trim_end_matches("!important").trim()) {
-            achado = Some(c);
+        if let Some(content) = crate::pseudo::parse_content(value.trim_end_matches("!important").trim()) {
+            found = Some(content);
         }
     }
-    achado
+    found
 }
 
 /// Divide um corpo de declarações nos `;` de topo (fora de aspas e parênteses).

--- a/crates/rts-dom/src/style/stylesheet/sheet.rs
+++ b/crates/rts-dom/src/style/stylesheet/sheet.rs
@@ -68,11 +68,11 @@ impl Stylesheet {
         // Os seletores aninhados (`:is(...)`) entram na varredura: um `:hover`
         // dentro de um deles muda estilo na mesma, e ignorá-lo dava
         // `HoverReach::None` — o mouse deixava de invalidar o que devia.
-        let mut todos: Vec<&super::ComplexSelector> = Vec::new();
+        let mut all_selectors: Vec<&super::ComplexSelector> = Vec::new();
         for r in &self.rules {
-            super::selector::visit_selectors(&r.selector, &mut |s| todos.push(s));
+            super::selector::visit_selectors(&r.selector, &mut |s| all_selectors.push(s));
         }
-        for sel in todos {
+        for sel in all_selectors {
             let n = sel.compounds.len();
             for (i, c) in sel.compounds.iter().enumerate() {
                 if !super::selector::compound_has_hover(c) {
@@ -118,15 +118,15 @@ impl Stylesheet {
         let answer = self.rules.iter().any(|r| {
             // Varre também o que está dentro de `:is()`/`:not()`: `:not(:first-child)`
             // depende da posição exatamente como `:first-child`.
-            let mut sensivel = false;
+            let mut is_position_sensitive = false;
             super::selector::visit_selectors(&r.selector, &mut |s| {
-                sensivel |= s
+                is_position_sensitive |= s
                     .combinators
                     .iter()
                     .any(|c| matches!(c, Combinator::NextSibling | Combinator::SubsequentSibling));
             });
             super::selector::visit_simples(&r.selector, &mut |p| {
-                sensivel |= matches!(
+                is_position_sensitive |= matches!(
                     p,
                     S::Pseudo(
                         P::FirstChild
@@ -141,7 +141,7 @@ impl Stylesheet {
                     )
                 );
             });
-            sensivel
+            is_position_sensitive
         });
         *self.position_sensitive.borrow_mut() = Some(answer);
         answer
@@ -178,15 +178,15 @@ impl Stylesheet {
             return cached;
         }
         use super::props::Decl;
-        let fora = |d: &Decl| {
+        let out_of_flow = |d: &Decl| {
             matches!(
                 d,
                 Decl::position(Some(super::Position::Absolute | super::Position::Fixed))
             )
         };
         let answer = self.rules.iter().any(|r| {
-            r.decls.normal.iter().any(fora)
-                || r.decls.important.iter().any(fora)
+            r.decls.normal.iter().any(out_of_flow)
+                || r.decls.important.iter().any(out_of_flow)
                 // uma pendente com var() pode virar qualquer coisa: conta como
                 // possível, que é o lado seguro.
                 || r.decls.pending.iter().any(|(prop, _, _)| prop == "position")
@@ -324,7 +324,7 @@ impl Stylesheet {
         // (var()/custom properties agora resolvem POR ELEMENTO na cascade — #1779;
         // o antigo passe textual GLOBAL daqui foi removido.)
         let base = self.rules.len() as u32;
-        let parsed_rules = super::regras::parse_rules_ast_with_layers(
+        let parsed_rules = super::rules::parse_rules_ast_with_layers(
             &ast,
             &mut self.layer_names.borrow_mut(),
         );

--- a/crates/rts-dom/src/style/stylesheet/vars_cascade_tests.rs
+++ b/crates/rts-dom/src/style/stylesheet/vars_cascade_tests.rs
@@ -143,3 +143,22 @@ fn fragmento_sem_html_continua_a_ter_um_unico_root() {
     assert_eq!(frag.query_all(":root").len(), 0, "dois topos, nenhuma raiz");
 }
 
+
+
+#[test]
+fn custom_property_important_vence_antes_do_var() {
+    let d = parse_html_to_dom(
+        "<html><head><style>p{--size:10px} p{--size:20px!important} \
+         p{font-size:var(--size)}</style></head><body><p id=p>x</p></body></html>",
+    );
+    assert_eq!(font_size(&d, "#p"), "20px");
+}
+
+#[test]
+fn custom_property_important_inline_vence_a_folha() {
+    let d = parse_html_to_dom(
+        "<html><head><style>p{--size:10px!important;font-size:var(--size)}</style></head>\
+         <body><p id=p style=\"--size:30px!important\">x</p></body></html>",
+    );
+    assert_eq!(font_size(&d, "#p"), "30px");
+}

--- a/crates/rts-dom/src/style/syntax.rs
+++ b/crates/rts-dom/src/style/syntax.rs
@@ -560,6 +560,51 @@ impl DeclarationAst {
     }
 }
 
+/// Declarações no estado especificado: a fonte já foi tokenizada, mas ainda não
+/// foi convertida para valores computados nem resolvida contra o elemento/pai.
+///
+/// Esta camada é deliberadamente pequena. O `ComputedStyle` continua a ser o
+/// formato eficiente usado pela cascade e pelo layout; este tipo é a fronteira
+/// estável para tooling, diagnósticos e futuros parsers de valores por
+/// propriedade.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SpecifiedStyle {
+    pub declarations: std::rc::Rc<[DeclarationAst]>,
+}
+
+impl SpecifiedStyle {
+    pub fn from_block(block: &BlockAst) -> Self {
+        Self {
+            declarations: block.declarations().into_boxed_slice().into(),
+        }
+    }
+
+    pub fn declarations(&self) -> &[DeclarationAst] {
+        &self.declarations
+    }
+
+    /// Serialização normalizada das declarações especificadas. A serialização
+    /// lossless do stylesheet completo continua em `StylesheetAst::to_css()`.
+    pub fn to_css(&self) -> String {
+        self.declarations
+            .iter()
+            .map(|declaration| {
+                let important = if declaration.important {
+                    " !important"
+                } else {
+                    ""
+                };
+                format!(
+                    "{}: {}{};",
+                    declaration.name_raw.trim(),
+                    declaration.value_css(),
+                    important
+                )
+            })
+            .collect()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AstItem {
     QualifiedRule {

--- a/crates/rts-dom/src/style/syntax.rs
+++ b/crates/rts-dom/src/style/syntax.rs
@@ -484,6 +484,9 @@ pub struct BlockAst {
     pub span: SourceSpan,
     /// `false` quando o source terminou sem o delimitador de fecho.
     pub closed: bool,
+    /// Filhos estruturais de at-rules cujo bloco contém regras, como `@media`.
+    /// Blocos de declarações mantêm `None` e usam `values` directamente.
+    pub nested: Option<Box<StylesheetAst>>,
 }
 
 impl BlockAst {
@@ -530,7 +533,11 @@ impl BlockAst {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeclarationAst {
+    /// Nome descodificado para o lowering semântico; a case original permanece
+    /// disponível em `name_raw`.
     pub name: String,
+    /// Grafia original do nome, incluindo escapes e whitespace.
+    pub name_raw: String,
     pub value: Vec<ComponentValue>,
     pub important: bool,
     pub span: SourceSpan,
@@ -738,8 +745,13 @@ fn declaration_from_values(values: &[ComponentValue]) -> Option<DeclarationAst> 
     }
     let start = values[first].span().start;
     let end = values.last().map(|value| value.span().end).unwrap_or(start);
+    let name_raw = values[first..colon]
+        .iter()
+        .map(ComponentValue::to_css)
+        .collect();
     Some(DeclarationAst {
         name,
+        name_raw,
         value,
         important,
         span: SourceSpan::new(start, end),
@@ -875,10 +887,24 @@ impl<'a> Parser<'a> {
             end = value.span().end;
             values.push(value);
         }
+        let has_nested_rules = values.iter().any(|value| {
+            matches!(
+                value,
+                ComponentValue::SimpleBlock { open: '{', .. }
+            )
+        });
+        let nested = has_nested_rules.then(|| {
+            let source: String = values
+                .iter()
+                .map(ComponentValue::to_css)
+                .collect();
+            Box::new(StylesheetAst::parse(&source))
+        });
         BlockAst {
             values,
             span: SourceSpan::new(start, end),
             closed,
+            nested,
         }
     }
 
@@ -1029,6 +1055,8 @@ mod tests {
         assert_eq!(name, "media");
         let block = block.as_ref().unwrap();
         assert!(!block.values.is_empty());
+        let nested = block.nested.as_ref().expect("filhos estruturais");
+        assert!(matches!(nested.items[0], AstItem::QualifiedRule { .. }));
         let nested_css = block.to_css();
         assert!(nested_css.contains("future-prop: mystery(1, 2)"));
     }
@@ -1043,6 +1071,7 @@ mod tests {
         assert_eq!(declarations.len(), 2);
         assert!(declarations[0].important);
         assert_eq!(declarations[0].name, "color");
+        assert_eq!(declarations[0].name_raw, "color");
         assert_eq!(declarations[1].value_css(), "calc(100% - 2px)");
     }
 }

--- a/crates/rts-dom/src/style/syntax.rs
+++ b/crates/rts-dom/src/style/syntax.rs
@@ -1,0 +1,1048 @@
+//! Sintaxe CSS preservada entre o texto de entrada e o IR da cascade.
+//!
+//! Esta camada não conhece `ComputedStyle`, layout ou seletores. Ela existe para
+//! separar a gramática CSS do lowering semântico: tokens e nós desconhecidos são
+//! preservados, enquanto camadas posteriores decidem o que o motor sabe aplicar.
+
+/// Intervalo de bytes no CSS original (`start` inclusivo, `end` exclusivo).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SourceSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl SourceSpan {
+    pub const fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub severity: DiagnosticSeverity,
+    pub span: SourceSpan,
+    pub message: String,
+}
+
+/// Tokens CSS com o texto cru preservado no `Token::raw`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TokenKind {
+    Whitespace,
+    Comment,
+    Ident(String),
+    AtKeyword(String),
+    Hash(String),
+    String(String),
+    Number(String),
+    Percentage(String),
+    Dimension {
+        number: String,
+        unit: String,
+    },
+    Colon,
+    Semicolon,
+    Comma,
+    OpenCurly,
+    CloseCurly,
+    OpenParen,
+    CloseParen,
+    OpenSquare,
+    CloseSquare,
+    /// O nome já inclui o `(`, como no `function-token` da CSS Syntax.
+    Function(String),
+    Delim(char),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: SourceSpan,
+    /// Substring exacta da entrada, incluindo escapes e whitespace.
+    pub raw: String,
+}
+
+impl Token {
+    fn new(kind: TokenKind, source: &str, start: usize, end: usize) -> Self {
+        Self {
+            kind,
+            span: SourceSpan::new(start, end),
+            raw: source[start..end].to_string(),
+        }
+    }
+
+    fn is_trivia(&self) -> bool {
+        matches!(self.kind, TokenKind::Whitespace | TokenKind::Comment)
+    }
+}
+
+fn next_char(source: &str, at: usize) -> Option<(char, usize)> {
+    source.get(at..)?.chars().next().map(|c| (c, c.len_utf8()))
+}
+
+fn is_whitespace(c: char) -> bool {
+    matches!(c, '\t' | '\n' | '\x0C' | '\r' | ' ')
+}
+
+fn is_digit(c: char) -> bool {
+    c.is_ascii_digit()
+}
+
+fn is_hex(c: char) -> bool {
+    c.is_ascii_hexdigit()
+}
+
+fn is_name_start(c: char) -> bool {
+    c == '_' || c == '-' || c.is_ascii_alphabetic() || !c.is_ascii()
+}
+
+fn is_name_char(c: char) -> bool {
+    is_name_start(c) || is_digit(c)
+}
+
+fn starts_ident(source: &str, at: usize) -> bool {
+    let Some((first, first_len)) = next_char(source, at) else {
+        return false;
+    };
+    if first == '-' {
+        let Some((second, _)) = next_char(source, at + first_len) else {
+            return false;
+        };
+        return is_name_start(second) || second == '-';
+    }
+    is_name_start(first) && first != '-'
+}
+
+fn starts_number(source: &str, at: usize) -> bool {
+    let Some((first, first_len)) = next_char(source, at) else {
+        return false;
+    };
+    let next = next_char(source, at + first_len).map(|(c, _)| c);
+    let next2 = next
+        .and_then(|_| next_char(source, at + first_len + next.unwrap().len_utf8()))
+        .map(|(c, _)| c);
+    if is_digit(first) {
+        return true;
+    }
+    if matches!(first, '+' | '-') {
+        return next.is_some_and(is_digit) || (next == Some('.') && next2.is_some_and(is_digit));
+    }
+    first == '.' && next.is_some_and(is_digit)
+}
+
+fn consume_escape(source: &str, at: usize) -> (String, usize) {
+    let Some((slash, slash_len)) = next_char(source, at) else {
+        return (String::new(), at);
+    };
+    if slash != '\\' {
+        return (slash.to_string(), at + slash_len);
+    }
+    let mut i = at + slash_len;
+    let Some((first, first_len)) = next_char(source, i) else {
+        return (String::new(), i);
+    };
+    if is_whitespace(first) {
+        return (String::new(), i + first_len);
+    }
+    if is_hex(first) {
+        let mut hex = String::new();
+        let mut count = 0;
+        while count < 6 {
+            let Some((c, len)) = next_char(source, i) else {
+                break;
+            };
+            if !is_hex(c) {
+                break;
+            }
+            hex.push(c);
+            i += len;
+            count += 1;
+        }
+        if let Some((c, len)) = next_char(source, i) {
+            if is_whitespace(c) {
+                i += len;
+            }
+        }
+        let value = u32::from_str_radix(&hex, 16).unwrap_or(0xFFFD);
+        let decoded = char::from_u32(value).unwrap_or('\u{FFFD}');
+        return (decoded.to_string(), i);
+    }
+    i += first_len;
+    (first.to_string(), i)
+}
+
+fn consume_name(source: &str, at: usize) -> (String, usize) {
+    let mut i = at;
+    let mut decoded = String::new();
+    while let Some((c, len)) = next_char(source, i) {
+        if c == '\\' {
+            let (part, next) = consume_escape(source, i);
+            decoded.push_str(&part);
+            i = next;
+        } else if is_name_char(c) {
+            decoded.push(c);
+            i += len;
+        } else {
+            break;
+        }
+    }
+    (decoded, i)
+}
+
+fn consume_number(source: &str, at: usize) -> usize {
+    let mut i = at;
+    if matches!(next_char(source, i).map(|(c, _)| c), Some('+' | '-')) {
+        i += 1;
+    }
+    while next_char(source, i).is_some_and(|(c, _)| is_digit(c)) {
+        i += 1;
+    }
+    if next_char(source, i).map(|(c, _)| c) == Some('.')
+        && next_char(source, i + 1).is_some_and(|(c, _)| is_digit(c))
+    {
+        i += 1;
+        while next_char(source, i).is_some_and(|(c, _)| is_digit(c)) {
+            i += 1;
+        }
+    }
+    if matches!(next_char(source, i).map(|(c, _)| c), Some('e' | 'E')) {
+        let e = i;
+        i += 1;
+        if matches!(next_char(source, i).map(|(c, _)| c), Some('+' | '-')) {
+            i += 1;
+        }
+        let digits = i;
+        while next_char(source, i).is_some_and(|(c, _)| is_digit(c)) {
+            i += 1;
+        }
+        if digits == i {
+            i = e;
+        }
+    }
+    i
+}
+
+/// Tokeniza CSS sem descartar comentários, escapes ou texto desconhecido.
+pub fn tokenize(source: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < source.len() {
+        let start = i;
+        let Some((c, len)) = next_char(source, i) else {
+            break;
+        };
+        if is_whitespace(c) {
+            i += len;
+            while next_char(source, i).is_some_and(|(ch, _)| is_whitespace(ch)) {
+                i += next_char(source, i).unwrap().1;
+            }
+            tokens.push(Token::new(TokenKind::Whitespace, source, start, i));
+            continue;
+        }
+        if source[start..].starts_with("/*") {
+            i += 2;
+            while i < source.len() && !source[i..].starts_with("*/") {
+                i += next_char(source, i).map(|(_, n)| n).unwrap_or(1);
+            }
+            if i < source.len() {
+                i += 2;
+            }
+            tokens.push(Token::new(
+                TokenKind::Comment,
+                source,
+                start,
+                i.min(source.len()),
+            ));
+            continue;
+        }
+        if matches!(c, '\'' | '"') {
+            let quote = c;
+            i += len;
+            let mut value = String::new();
+            while let Some((ch, ch_len)) = next_char(source, i) {
+                if ch == quote {
+                    i += ch_len;
+                    break;
+                }
+                if ch == '\\' {
+                    let (part, next) = consume_escape(source, i);
+                    value.push_str(&part);
+                    i = next;
+                } else {
+                    value.push(ch);
+                    i += ch_len;
+                }
+            }
+            tokens.push(Token::new(TokenKind::String(value), source, start, i));
+            continue;
+        }
+        if starts_number(source, i) {
+            let number_end = consume_number(source, i);
+            let number = source[start..number_end].to_string();
+            i = number_end;
+            if next_char(source, i).map(|(ch, _)| ch) == Some('%') {
+                i += 1;
+                tokens.push(Token::new(TokenKind::Percentage(number), source, start, i));
+            } else if starts_ident(source, i) {
+                let (unit, end) = consume_name(source, i);
+                i = end;
+                tokens.push(Token::new(
+                    TokenKind::Dimension { number, unit },
+                    source,
+                    start,
+                    i,
+                ));
+            } else {
+                tokens.push(Token::new(TokenKind::Number(number), source, start, i));
+            }
+            continue;
+        }
+        if c == '@' && starts_ident(source, start + len) {
+            let (name, end) = consume_name(source, start + len);
+            i = end;
+            tokens.push(Token::new(TokenKind::AtKeyword(name), source, start, i));
+            continue;
+        }
+        if c == '#' && starts_ident(source, start + len) {
+            let (name, end) = consume_name(source, start + len);
+            i = end;
+            tokens.push(Token::new(TokenKind::Hash(name), source, start, i));
+            continue;
+        }
+        if starts_ident(source, i) {
+            let (name, end) = consume_name(source, i);
+            i = end;
+            if next_char(source, i).map(|(ch, _)| ch) == Some('(') {
+                i += 1;
+                tokens.push(Token::new(TokenKind::Function(name), source, start, i));
+            } else {
+                tokens.push(Token::new(TokenKind::Ident(name), source, start, i));
+            }
+            continue;
+        }
+        i += len;
+        let kind = match c {
+            ':' => TokenKind::Colon,
+            ';' => TokenKind::Semicolon,
+            ',' => TokenKind::Comma,
+            '{' => TokenKind::OpenCurly,
+            '}' => TokenKind::CloseCurly,
+            '(' => TokenKind::OpenParen,
+            ')' => TokenKind::CloseParen,
+            '[' => TokenKind::OpenSquare,
+            ']' => TokenKind::CloseSquare,
+            _ => TokenKind::Delim(c),
+        };
+        tokens.push(Token::new(kind, source, start, i));
+    }
+    tokens
+}
+
+/// Um valor composto preserva blocos aninhados (`calc()`, `[]`, `{}`) sem os
+/// achatar em texto. `Token` continua disponível para extensões futuras.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ComponentValue {
+    Token(Token),
+    Function {
+        name: String,
+        /// Texto original do nome mais `(`, incluindo escapes.
+        raw_open: String,
+        arguments: Vec<ComponentValue>,
+        /// `None` quando a função não tinha `)` de fecho.
+        close_raw: Option<String>,
+        span: SourceSpan,
+    },
+    SimpleBlock {
+        open: char,
+        /// Delimitador original, preservado para serialização lossless.
+        open_raw: String,
+        values: Vec<ComponentValue>,
+        close: Option<char>,
+        close_raw: Option<String>,
+        span: SourceSpan,
+    },
+}
+
+impl ComponentValue {
+    pub fn span(&self) -> SourceSpan {
+        match self {
+            Self::Token(token) => token.span,
+            Self::Function { span, .. } | Self::SimpleBlock { span, .. } => *span,
+        }
+    }
+
+    /// Reconstrói o texto original do componente, preservando whitespace e
+    /// comentários dos tokens que ainda não foram interpretados.
+    pub fn to_css(&self) -> String {
+        match self {
+            Self::Token(token) => token.raw.clone(),
+            Self::Function {
+                raw_open,
+                arguments,
+                close_raw,
+                ..
+            } => {
+                let mut out = raw_open.clone();
+                for value in arguments {
+                    out.push_str(&value.to_css());
+                }
+                if let Some(raw) = close_raw {
+                    out.push_str(raw);
+                }
+                out
+            }
+            Self::SimpleBlock {
+                open,
+                open_raw,
+                values,
+                close,
+                close_raw,
+                ..
+            } => {
+                let close_char = close.unwrap_or(match open {
+                    '(' => ')',
+                    '[' => ']',
+                    '{' => '}',
+                    _ => *open,
+                });
+                let mut out = open_raw.clone();
+                for value in values {
+                    out.push_str(&value.to_css());
+                }
+                if let Some(raw) = close_raw {
+                    out.push_str(raw);
+                } else {
+                    out.push(close_char);
+                }
+                out
+            }
+        }
+    }
+
+    /// Reconstrói o componente para consumo semântico, removendo apenas
+    /// comentários CSS. Whitespace, strings, escapes e funções permanecem.
+    pub fn to_css_semantic(&self) -> String {
+        match self {
+            Self::Token(token) if matches!(token.kind, TokenKind::Comment) => String::new(),
+            Self::Token(token) => token.raw.clone(),
+            Self::Function {
+                raw_open,
+                arguments,
+                close_raw,
+                ..
+            } => {
+                let mut out = raw_open.clone();
+                for value in arguments {
+                    out.push_str(&value.to_css_semantic());
+                }
+                if let Some(raw) = close_raw {
+                    out.push_str(raw);
+                }
+                out
+            }
+            Self::SimpleBlock {
+                open,
+                open_raw,
+                values,
+                close,
+                close_raw,
+                ..
+            } => {
+                let close_char = close.unwrap_or(match open {
+                    '(' => ')',
+                    '[' => ']',
+                    '{' => '}',
+                    _ => *open,
+                });
+                let mut out = open_raw.clone();
+                for value in values {
+                    out.push_str(&value.to_css_semantic());
+                }
+                if let Some(raw) = close_raw {
+                    out.push_str(raw);
+                } else if close.is_some() {
+                    out.push(close_char);
+                }
+                out
+            }
+        }
+    }
+
+    fn is_trivia(&self) -> bool {
+        matches!(self, Self::Token(token) if token.is_trivia())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockAst {
+    pub values: Vec<ComponentValue>,
+    pub span: SourceSpan,
+    /// `false` quando o source terminou sem o delimitador de fecho.
+    pub closed: bool,
+}
+
+impl BlockAst {
+    /// Divide o bloco em declarações de topo sem perder valores complexos ou
+    /// declarações desconhecidas. Regras aninhadas continuam acessíveis em
+    /// `values` e não são falsamente interpretadas como propriedades.
+    pub fn declarations(&self) -> Vec<DeclarationAst> {
+        let mut output = Vec::new();
+        let mut current = Vec::new();
+        for value in &self.values {
+            let semicolon = matches!(
+                value,
+                ComponentValue::Token(Token {
+                    kind: TokenKind::Semicolon,
+                    ..
+                })
+            );
+            if semicolon {
+                if let Some(declaration) = declaration_from_values(&current) {
+                    output.push(declaration);
+                }
+                current.clear();
+            } else {
+                current.push(value.clone());
+            }
+        }
+        if let Some(declaration) = declaration_from_values(&current) {
+            output.push(declaration);
+        }
+        output
+    }
+
+    pub fn to_css(&self) -> String {
+        self.values.iter().map(ComponentValue::to_css).collect()
+    }
+
+    pub fn to_css_semantic(&self) -> String {
+        self.values
+            .iter()
+            .map(ComponentValue::to_css_semantic)
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeclarationAst {
+    pub name: String,
+    pub value: Vec<ComponentValue>,
+    pub important: bool,
+    pub span: SourceSpan,
+}
+
+impl DeclarationAst {
+    pub fn value_css(&self) -> String {
+        let mut start = 0;
+        let mut end = self.value.len();
+        while start < end && self.value[start].is_trivia() {
+            start += 1;
+        }
+        while end > start && self.value[end - 1].is_trivia() {
+            end -= 1;
+        }
+        self.value[start..end]
+            .iter()
+            .map(ComponentValue::to_css)
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AstItem {
+    QualifiedRule {
+        prelude: Vec<ComponentValue>,
+        block: BlockAst,
+        span: SourceSpan,
+    },
+    AtRule {
+        name: String,
+        prelude: Vec<ComponentValue>,
+        block: Option<BlockAst>,
+        span: SourceSpan,
+    },
+    /// Texto estrutural que não forma uma regra válida, preservado para
+    /// diagnósticos em vez de desaparecer durante o parse.
+    Invalid {
+        values: Vec<ComponentValue>,
+        span: SourceSpan,
+    },
+}
+
+impl AstItem {
+    pub fn prelude_css(&self) -> String {
+        match self {
+            Self::QualifiedRule { prelude, .. } | Self::AtRule { prelude, .. } => prelude
+                .iter()
+                .map(ComponentValue::to_css_semantic)
+                .collect(),
+            Self::Invalid { values, .. } => values.iter().map(ComponentValue::to_css).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StylesheetAst {
+    pub items: Vec<AstItem>,
+    pub tokens: Vec<Token>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl StylesheetAst {
+    /// Reconstrói exactamente os bytes tokenizados da entrada, incluindo
+    /// comentários e whitespace.
+    pub fn to_css(&self) -> String {
+        self.tokens.iter().map(|token| token.raw.as_str()).collect()
+    }
+
+    pub fn parse(source: &str) -> Self {
+        let tokens = tokenize(source);
+        let mut parser = Parser {
+            tokens: &tokens,
+            at: 0,
+        };
+        let items = parser.parse_rule_list(None);
+        let diagnostics = collect_diagnostics(&items);
+        Self {
+            items,
+            tokens,
+            diagnostics,
+        }
+    }
+}
+
+fn collect_diagnostics(items: &[AstItem]) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for item in items {
+        match item {
+            AstItem::Invalid { span, .. } => diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Error,
+                span: *span,
+                message: "estrutura CSS inválida ou incompleta".to_string(),
+            }),
+            AstItem::QualifiedRule { block, .. } | AstItem::AtRule { block: Some(block), .. } => {
+                if !block.closed {
+                    diagnostics.push(Diagnostic {
+                        severity: DiagnosticSeverity::Error,
+                        span: block.span,
+                        message: "bloco CSS sem chave de fecho".to_string(),
+                    });
+                }
+                collect_component_diagnostics(&block.values, &mut diagnostics);
+            }
+            AstItem::AtRule { block: None, .. } => {}
+        }
+    }
+    diagnostics
+}
+
+fn collect_component_diagnostics(
+    values: &[ComponentValue],
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for value in values {
+        match value {
+            ComponentValue::Function {
+                close_raw: None, span, ..
+            } => diagnostics.push(Diagnostic {
+                severity: DiagnosticSeverity::Error,
+                span: *span,
+                message: "função CSS sem parêntese de fecho".to_string(),
+            }),
+            ComponentValue::Function { arguments, .. } => {
+                collect_component_diagnostics(arguments, diagnostics)
+            }
+            ComponentValue::SimpleBlock {
+                close: None,
+                span,
+                values,
+                ..
+            } => {
+                diagnostics.push(Diagnostic {
+                    severity: DiagnosticSeverity::Error,
+                    span: *span,
+                    message: "bloco CSS sem delimitador de fecho".to_string(),
+                });
+                collect_component_diagnostics(values, diagnostics);
+            }
+            ComponentValue::SimpleBlock { values, .. } => {
+                collect_component_diagnostics(values, diagnostics)
+            }
+            ComponentValue::Token(_) => {}
+        }
+    }
+}
+
+fn token_is_colon(value: &ComponentValue) -> bool {
+    matches!(
+        value,
+        ComponentValue::Token(Token {
+            kind: TokenKind::Colon,
+            ..
+        })
+    )
+}
+
+fn declaration_from_values(values: &[ComponentValue]) -> Option<DeclarationAst> {
+    let first = values.iter().position(|value| !value.is_trivia())?;
+    let colon = values[first..].iter().position(token_is_colon)? + first;
+    let name_values = &values[first..colon];
+    let mut name = String::new();
+    for value in name_values {
+        match value {
+            ComponentValue::Token(Token {
+                kind: TokenKind::Ident(part),
+                ..
+            }) => name.push_str(part),
+            ComponentValue::Token(Token {
+                kind: TokenKind::Delim(part),
+                ..
+            }) if *part == '-' => name.push('-'),
+            _ => return None,
+        }
+    }
+    if name.is_empty() {
+        return None;
+    }
+    let mut value = values[colon + 1..].to_vec();
+    let mut important = false;
+    let mut significant = value.len();
+    while significant > 0 && value[significant - 1].is_trivia() {
+        significant -= 1;
+    }
+    if significant >= 2 {
+        let bang = matches!(
+            &value[significant - 2],
+            ComponentValue::Token(Token {
+                kind: TokenKind::Delim('!'),
+                ..
+            })
+        );
+        let keyword = matches!(
+            &value[significant - 1],
+            ComponentValue::Token(Token { kind: TokenKind::Ident(word), .. })
+                if word.eq_ignore_ascii_case("important")
+        );
+        if bang && keyword {
+            important = true;
+            value.truncate(significant - 2);
+            while value.last().is_some_and(ComponentValue::is_trivia) {
+                value.pop();
+            }
+        }
+    }
+    let start = values[first].span().start;
+    let end = values.last().map(|value| value.span().end).unwrap_or(start);
+    Some(DeclarationAst {
+        name,
+        value,
+        important,
+        span: SourceSpan::new(start, end),
+    })
+}
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    at: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn skip_trivia(&mut self) {
+        while self.at < self.tokens.len() && self.tokens[self.at].is_trivia() {
+            self.at += 1;
+        }
+    }
+
+    fn parse_rule_list(&mut self, until: Option<char>) -> Vec<AstItem> {
+        let mut items = Vec::new();
+        loop {
+            self.skip_trivia();
+            if self.at >= self.tokens.len() {
+                break;
+            }
+            if until == Some('}') && matches!(self.tokens[self.at].kind, TokenKind::CloseCurly) {
+                self.at += 1;
+                break;
+            }
+            let start = self.tokens[self.at].span.start;
+            let prelude = self.parse_prelude();
+            match self.tokens.get(self.at).map(|token| &token.kind) {
+                Some(TokenKind::Semicolon) => {
+                    self.at += 1;
+                    if let Some(name) = at_rule_name(&prelude) {
+                        items.push(AstItem::AtRule {
+                            name,
+                            prelude: remove_at_keyword(prelude),
+                            block: None,
+                            span: SourceSpan::new(start, self.tokens[self.at - 1].span.end),
+                        });
+                    } else if !prelude.is_empty() {
+                        items.push(AstItem::Invalid {
+                            span: SourceSpan::new(start, self.tokens[self.at - 1].span.end),
+                            values: prelude,
+                        });
+                    }
+                }
+                Some(TokenKind::OpenCurly) => {
+                    let block = self.parse_block();
+                    let end = block.span.end;
+                    if let Some(name) = at_rule_name(&prelude) {
+                        items.push(AstItem::AtRule {
+                            name,
+                            prelude: remove_at_keyword(prelude),
+                            block: Some(block),
+                            span: SourceSpan::new(start, end),
+                        });
+                    } else {
+                        items.push(AstItem::QualifiedRule {
+                            prelude,
+                            block,
+                            span: SourceSpan::new(start, end),
+                        });
+                    }
+                }
+                Some(TokenKind::CloseCurly) | None => {
+                    if !prelude.is_empty() {
+                        let end = prelude
+                            .last()
+                            .map(|value| value.span().end)
+                            .unwrap_or(start);
+                        items.push(AstItem::Invalid {
+                            values: prelude,
+                            span: SourceSpan::new(start, end),
+                        });
+                    }
+                    if self.at < self.tokens.len()
+                        && matches!(self.tokens[self.at].kind, TokenKind::CloseCurly)
+                    {
+                        self.at += 1;
+                    }
+                    break;
+                }
+                _ => {
+                    if !prelude.is_empty() {
+                        let end = prelude
+                            .last()
+                            .map(|value| value.span().end)
+                            .unwrap_or(start);
+                        items.push(AstItem::Invalid {
+                            values: prelude,
+                            span: SourceSpan::new(start, end),
+                        });
+                    } else {
+                        self.at += 1;
+                    }
+                }
+            }
+        }
+        items
+    }
+
+    fn parse_prelude(&mut self) -> Vec<ComponentValue> {
+        let mut values = Vec::new();
+        while self.at < self.tokens.len() {
+            match self.tokens[self.at].kind {
+                TokenKind::Semicolon | TokenKind::OpenCurly | TokenKind::CloseCurly => break,
+                _ => values.push(self.parse_component_value()),
+            }
+        }
+        values
+    }
+
+    fn parse_block(&mut self) -> BlockAst {
+        let start = self.tokens[self.at].span.start;
+        self.at += 1; // `{`
+        let mut values = Vec::new();
+        let mut closed = false;
+        let mut end = self
+            .tokens
+            .get(self.at - 1)
+            .map(|t| t.span.end)
+            .unwrap_or(start);
+        while self.at < self.tokens.len() {
+            if matches!(self.tokens[self.at].kind, TokenKind::CloseCurly) {
+                end = self.tokens[self.at].span.end;
+                self.at += 1;
+                closed = true;
+                break;
+            }
+            let value = self.parse_component_value();
+            end = value.span().end;
+            values.push(value);
+        }
+        BlockAst {
+            values,
+            span: SourceSpan::new(start, end),
+            closed,
+        }
+    }
+
+    fn parse_component_value(&mut self) -> ComponentValue {
+        let token = self.tokens[self.at].clone();
+        self.at += 1;
+        match token.kind {
+            TokenKind::Function(name) => {
+                let start = token.span.start;
+                let raw_open = token.raw.clone();
+                let mut arguments = Vec::new();
+                let mut close_raw = None;
+                let mut end = token.span.end;
+                while self.at < self.tokens.len() {
+                    if matches!(self.tokens[self.at].kind, TokenKind::CloseParen) {
+                        close_raw = Some(self.tokens[self.at].raw.clone());
+                        end = self.tokens[self.at].span.end;
+                        self.at += 1;
+                        break;
+                    }
+                    let value = self.parse_component_value();
+                    end = value.span().end;
+                    arguments.push(value);
+                }
+                ComponentValue::Function {
+                    name,
+                    raw_open,
+                    arguments,
+                    close_raw,
+                    span: SourceSpan::new(start, end),
+                }
+            }
+            TokenKind::OpenParen => self.parse_simple_block(token, ')'),
+            TokenKind::OpenSquare => self.parse_simple_block(token, ']'),
+            TokenKind::OpenCurly => self.parse_simple_block(token, '}'),
+            _ => ComponentValue::Token(token),
+        }
+    }
+
+    fn parse_simple_block(&mut self, opening: Token, expected_close: char) -> ComponentValue {
+        let open = match opening.kind {
+            TokenKind::OpenParen => '(',
+            TokenKind::OpenSquare => '[',
+            TokenKind::OpenCurly => '{',
+            _ => '?',
+        };
+        let mut values = Vec::new();
+        let mut end = opening.span.end;
+        let close_kind = match expected_close {
+            ')' => |kind: &TokenKind| matches!(kind, TokenKind::CloseParen),
+            ']' => |kind: &TokenKind| matches!(kind, TokenKind::CloseSquare),
+            '}' => |kind: &TokenKind| matches!(kind, TokenKind::CloseCurly),
+            _ => |_: &TokenKind| false,
+        };
+        let mut close = None;
+        let mut close_raw = None;
+        while self.at < self.tokens.len() {
+            if close_kind(&self.tokens[self.at].kind) {
+                close = Some(expected_close);
+                close_raw = Some(self.tokens[self.at].raw.clone());
+                end = self.tokens[self.at].span.end;
+                self.at += 1;
+                break;
+            }
+            let value = self.parse_component_value();
+            end = value.span().end;
+            values.push(value);
+        }
+        ComponentValue::SimpleBlock {
+            open,
+            open_raw: opening.raw,
+            values,
+            close,
+            close_raw,
+            span: SourceSpan::new(opening.span.start, end),
+        }
+    }
+}
+
+fn at_rule_name(values: &[ComponentValue]) -> Option<String> {
+    values.iter().find_map(|value| match value {
+        ComponentValue::Token(Token {
+            kind: TokenKind::AtKeyword(name),
+            ..
+        }) => Some(name.clone()),
+        _ => None,
+    })
+}
+
+fn remove_at_keyword(values: Vec<ComponentValue>) -> Vec<ComponentValue> {
+    let mut removed = false;
+    values
+        .into_iter()
+        .filter(|value| {
+            if !removed
+                && matches!(
+                    value,
+                    ComponentValue::Token(Token {
+                        kind: TokenKind::AtKeyword(_),
+                        ..
+                    })
+                )
+            {
+                removed = true;
+                false
+            } else {
+                true
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizer_preserva_spans_e_formas_css() {
+        let css = "/* c */ .card { width: calc(100% - 8px); color: #abc; --x: \"a\\n\" }";
+        let tokens = tokenize(css);
+        assert!(matches!(tokens[0].kind, TokenKind::Comment));
+        assert!(tokens.iter().any(|token| matches!(
+            token.kind,
+            TokenKind::Function(ref name) if name == "calc"
+        )));
+        assert!(tokens.iter().any(|token| matches!(
+            token.kind,
+            TokenKind::Percentage(ref value) if value == "100"
+        )));
+        assert!(tokens.iter().any(|token| matches!(
+            token.kind,
+            TokenKind::Dimension { ref number, ref unit } if number == "8" && unit == "px"
+        )));
+        for pair in tokens.windows(2) {
+            assert!(pair[0].span.end <= pair[1].span.start);
+        }
+    }
+
+    #[test]
+    fn ast_preserva_regras_at_rules_e_declaracoes_desconhecidas() {
+        let sheet = StylesheetAst::parse(
+            "@media (min-width: 10px) { .card, .x { color: red !important; future-prop: mystery(1, 2); } }",
+        );
+        assert_eq!(sheet.items.len(), 1);
+        let AstItem::AtRule { name, block, .. } = &sheet.items[0] else {
+            panic!("esperava at-rule")
+        };
+        assert_eq!(name, "media");
+        let block = block.as_ref().unwrap();
+        assert!(!block.values.is_empty());
+        let nested_css = block.to_css();
+        assert!(nested_css.contains("future-prop: mystery(1, 2)"));
+    }
+
+    #[test]
+    fn declaracoes_separam_important_e_valor_complexo() {
+        let sheet = StylesheetAst::parse(".a { color: red !important; width: calc(100% - 2px); }");
+        let AstItem::QualifiedRule { block, .. } = &sheet.items[0] else {
+            panic!("esperava regra")
+        };
+        let declarations = block.declarations();
+        assert_eq!(declarations.len(), 2);
+        assert!(declarations[0].important);
+        assert_eq!(declarations[0].name, "color");
+        assert_eq!(declarations[1].value_css(), "calc(100% - 2px)");
+    }
+}

--- a/crates/rts-dom/src/style/tests/cascade.rs
+++ b/crates/rts-dom/src/style/tests/cascade.rs
@@ -258,23 +258,23 @@ fn layer_important_inverte_a_ordem_e_favorece_layers() {
 
 
 #[test]
-fn declaracao_de_ordem_de_layers_precede_os_blocos() {
+fn layer_order_declaration_precedes_following_blocks() {
     let mut sheet = Stylesheet::new();
     sheet.append_css(
-        "@layer baixo, alto; \
-         @layer alto { .x { color: blue } } \
-         @layer baixo { .x { color: red } }",
+        "@layer low, high; \
+         @layer high { .x { color: blue } } \
+         @layer low { .x { color: red } }",
     );
     assert_eq!(
         sheet.computed_for("div", None, &["x"]).normal.color,
         Some(0x0000FFFF),
-        "a lista de layers declara alto depois de baixo"
+        "the layer list declares high after low"
     );
 }
 
 
 #[test]
-fn all_initial_reseta_o_bloco_sem_apagar_custom_properties() {
+fn all_initial_resets_the_block_without_clearing_custom_properties() {
     let block = parse_inline_block(
         "--brand: rebeccapurple; width: 120px; color: red; all: initial",
     );

--- a/crates/rts-dom/src/style/tests/cascata.rs
+++ b/crates/rts-dom/src/style/tests/cascata.rs
@@ -255,3 +255,19 @@ fn layer_important_inverte_a_ordem_e_favorece_layers() {
         "a primeira layer vence entre important, inclusive sobre a regra sem layer"
     );
 }
+
+
+#[test]
+fn declaracao_de_ordem_de_layers_precede_os_blocos() {
+    let mut sheet = Stylesheet::new();
+    sheet.append_css(
+        "@layer baixo, alto; \
+         @layer alto { .x { color: blue } } \
+         @layer baixo { .x { color: red } }",
+    );
+    assert_eq!(
+        sheet.computed_for("div", None, &["x"]).normal.color,
+        Some(0x0000FFFF),
+        "a lista de layers declara alto depois de baixo"
+    );
+}

--- a/crates/rts-dom/src/style/tests/cascata.rs
+++ b/crates/rts-dom/src/style/tests/cascata.rs
@@ -271,3 +271,17 @@ fn declaracao_de_ordem_de_layers_precede_os_blocos() {
         "a lista de layers declara alto depois de baixo"
     );
 }
+
+
+#[test]
+fn all_initial_reseta_o_bloco_sem_apagar_custom_properties() {
+    let block = parse_inline_block(
+        "--brand: rebeccapurple; width: 120px; color: red; all: initial",
+    );
+    assert_eq!(block.normal.width, None);
+    assert_eq!(block.normal.color, None);
+    assert_eq!(block.custom, vec![("--brand".into(), "rebeccapurple".into())]);
+
+    let important = parse_inline_block("color: red !important; all: initial !important");
+    assert_eq!(important.important.color, None);
+}

--- a/crates/rts-dom/src/style/tests/cascata.rs
+++ b/crates/rts-dom/src/style/tests/cascata.rs
@@ -215,3 +215,43 @@ fn at_rules_nao_corrompem_o_parse() {
         Some(0x0000FFFF)
     );
 }
+
+
+#[test]
+fn layer_normal_e_regra_sem_layer_respeitam_a_precedencia() {
+    let mut sheet = Stylesheet::new();
+    sheet.append_css(
+        "@layer base { .x { color: red } } \
+         @layer tema { .x { color: blue } } \
+         .x { color: green }",
+    );
+    assert_eq!(
+        sheet.computed_for("div", None, &["x"]).normal.color,
+        Some(0x008000FF),
+        "regra sem layer vence as layers na cascade normal"
+    );
+
+    let mut same = Stylesheet::new();
+    same.append_css("@layer tema { .x { color: red } } @layer base { .x { color: blue } }");
+    same.append_css("@layer tema { .x { color: green } }");
+    assert_eq!(
+        same.computed_for("div", None, &["x"]).normal.color,
+        Some(0x0000FFFF),
+        "a layer base, criada depois de tema, mantém a sua precedência"
+    );
+}
+
+#[test]
+fn layer_important_inverte_a_ordem_e_favorece_layers() {
+    let mut sheet = Stylesheet::new();
+    sheet.append_css(
+        "@layer base { .x { color: red !important } } \
+         @layer tema { .x { color: blue !important } } \
+         .x { color: green !important }",
+    );
+    assert_eq!(
+        sheet.computed_for("div", None, &["x"]).important.color,
+        Some(0xFF0000FF),
+        "a primeira layer vence entre important, inclusive sobre a regra sem layer"
+    );
+}

--- a/crates/rts-dom/src/style/tests/mod.rs
+++ b/crates/rts-dom/src/style/tests/mod.rs
@@ -6,5 +6,5 @@ use super::*;
 mod valores;
 mod cores_e_caixa;
 mod slots;
-mod cascata;
+mod cascade;
 mod tabela_e_display;

--- a/crates/rts-dom/src/table/mod.rs
+++ b/crates/rts-dom/src/table/mod.rs
@@ -145,7 +145,19 @@ pub(crate) fn max_content_width(dom: &Dom, table: NodeIdx, font: f32, ctx: &Layo
     let css = dom.computed_style_idx(table).unwrap_or_default();
     let ts = TableStyle::of(dom, table, &css, font, ctx);
     let cols = medir_colunas(dom, &g, font, ctx, ts.spacing_h);
-    cols.iter().map(|c| c.max).sum::<f32>() + (g.cols + 1) as f32 * ts.spacing_h
+    let vaos = (g.cols + 1) as f32 * ts.spacing_h;
+    let soma_maximos = cols.iter().map(|c| c.max).sum::<f32>() + vaos;
+    // Uma percentagem de coluna é relativa à largura útil da própria tabela. Se
+    // o mínimo intrínseco da coluna não cabe nessa percentagem, a tabela precisa
+    // crescer até satisfazer `percentagem * largura_util >= mínimo`. Ignorar esta
+    // relação fazia uma tabela aninhada com `width:1%` e mínimo de 100px responder
+    // apenas à soma dos máximos, encolhendo para 300px em vez de ocupar a célula.
+    let minimo_percentual = cols
+        .iter()
+        .filter_map(|c| c.percentagem.filter(|p| *p > 0.0).map(|p| c.min * 100.0 / p))
+        .fold(0.0f32, f32::max)
+        + vaos;
+    soma_maximos.max(minimo_percentual)
 }
 
 fn medir_colunas(

--- a/crates/rts-dom/src/table/widths/mod.rs
+++ b/crates/rts-dom/src/table/widths/mod.rs
@@ -430,9 +430,25 @@ fn distribui_excedente(cols: &mut [Coluna], extra: f32, campo: impl Fn(&mut Colu
     if extra <= 0.0 || cols.is_empty() {
         return;
     }
-    let quota = extra / cols.len() as f32;
-    for c in cols.iter_mut() {
-        *campo(c) += quota;
+    // Uma célula com colspan não pode elevar uma coluna que já tem uma largura
+    // declarada: essa coluna já foi classificada como restringida pelo conteúdo
+    // da própria coluna e deve ficar congelada neste degrau. O excedente pertence
+    // às colunas automáticas do intervalo. Quando todas são declaradas, não há
+    // uma classe livre; nesse caso mantemos o fallback igualitário para preservar
+    // o comportamento de uma tabela composta só por restrições.
+    let livres: Vec<usize> = cols
+        .iter()
+        .enumerate()
+        .filter_map(|(i, c)| (!c.restringida).then_some(i))
+        .collect();
+    let alvos: Vec<usize> = if livres.is_empty() {
+        (0..cols.len()).collect()
+    } else {
+        livres
+    };
+    let quota = extra / alvos.len() as f32;
+    for i in alvos {
+        *campo(&mut cols[i]) += quota;
     }
 }
 

--- a/crates/rts-host/src/run.rs
+++ b/crates/rts-host/src/run.rs
@@ -611,7 +611,24 @@ pub(crate) struct Seed<'a> {
 
 /// Parses and emits source text into one program. See [`FrontEnd`].
 pub(crate) fn front_end(source: &str) -> Result<FrontEnd, HostError> {
-    front_end_agreeing(source, None, false, None)
+    // `DOM_TS` é a camada ergonómica do DOM, não um módulo que o utilizador
+    // tenha de importar. Incluí-lo em todos os programas, porém, mudaria o
+    // contrato de `compile`: o prelude contém declarações e o host passaria a
+    // analisar scripts sem DOM como um corpo diferente. Optamos pelo bootstrap
+    // sob demanda, ativado pelos nomes públicos da fachada.
+    let source_with_dom = if uses_dom_facade(source) {
+        format!("{}\n{}", rts_dom_bridge::PRELUDE_TS, source)
+    } else {
+        source.to_owned()
+    };
+    front_end_agreeing(&source_with_dom, None, false, None)
+}
+
+fn uses_dom_facade(source: &str) -> bool {
+    source.contains("parseDocument")
+        || source.contains("document.")
+        || source.contains("new Document")
+        || source.contains("new Element")
 }
 
 /// The same, for a compilation that must agree with a numbering that already

--- a/docs/ui/blink-parity-2026-08-27.md
+++ b/docs/ui/blink-parity-2026-08-27.md
@@ -1,0 +1,29 @@
+# CSS parity matrix — RTS versus Blink
+
+Measurement date: 2026-08-27. Harness: `examples/claude-css-runner.ts`, expected values measured in Chrome at 1280x800, tolerance 1px.
+
+## Baseline
+
+The corpus contains 49 HTML fixtures. The initial RTS result was **36/49 fixtures passing**, with **38 deviations** in 13 fixtures. After the elliptical `border-radius`, resolved-grid-track, and inline-baseline cuts, the current result is **39/49 fixtures passing**, with **27 deviations** in 10 fixtures. The `rts-dom` unit suite remains green at 709 passed, 0 failed and 5 ignored.
+
+## Deviations grouped by mechanism
+
+| Area | Fixtures | Deviations | Initial diagnosis |
+|---|---:|---:|---|
+| CSS computed-value serialization | — | 0 | Elliptical `border-radius` and explicit `grid-template-columns` used-track serialization now match the measured fixtures. |
+| Block formatting / box model | box-model; margin-collapse | 4 | Layout used values diverge; includes parent margins and height accounting |
+| Float/clear | clear; float-clear | 6 | Float exclusion and clear placement/containing block calculations differ from Blink |
+| Grid layout | grid-areas | 3 | Grid row/area placement remains incomplete; explicit column-track serialization now matches the measured fixture |
+| Positioning | absolute; relative | 6 | Absolute stretch and relative offsets are not fully applied to used geometry |
+| Inline formatting/text | text-align; vertical-align; white-space | 8 | Line box metrics, vertical alignment and preserved whitespace differ from Blink |
+
+## Priority for implementation
+
+1. Keep the computed/used boundary explicit. The elliptical `border-radius`, explicit grid-track, and inline-baseline paths are implemented and covered by unit and corpus tests; the next priority is block formatting geometry.
+2. Fix parent box heights and margin accounting in the block formatting contract. The `display:none` and inline dimension cases now match the corpus; the remaining block gaps are isolated in box-model and margin-collapse fixtures.
+3. Repair float/clear and margin-collapse used values, then position relative/absolute geometry.
+4. Expand inline formatting and text metrics (`white-space`, `vertical-align`, `text-align`) after the box tree contracts are stable.
+
+## Blink architecture rule applied
+
+Blink separates rule matching, cascade/defaulting, computed value construction and layout used values. Therefore the RTS should not solve all differences by changing parser strings: computed serialization belongs in the style layer, while pixel positions/heights belong in the layout/used-value layer. Each fix must have one CSS fixture and one unit regression.

--- a/docs/ui/blink-parity-2026-08-27.md
+++ b/docs/ui/blink-parity-2026-08-27.md
@@ -4,24 +4,24 @@ Measurement date: 2026-08-27. Harness: `examples/claude-css-runner.ts`, expected
 
 ## Baseline
 
-The corpus contains 49 HTML fixtures. The initial RTS result was **36/49 fixtures passing**, with **38 deviations** in 13 fixtures. After the elliptical `border-radius`, resolved-grid-track, and inline-baseline cuts, the current result is **39/49 fixtures passing**, with **27 deviations** in 10 fixtures. The `rts-dom` unit suite remains green at 709 passed, 0 failed and 5 ignored.
+The corpus contains 49 HTML fixtures. The initial RTS result was **36/49 fixtures passing**, with **38 deviations** in 13 fixtures. After the elliptical `border-radius`, resolved-grid-track, inline-baseline, and parent/child margin-collapse cuts, the current result is **41/49 fixtures passing**, with **23 deviations** in 8 fixtures. The `rts-dom` unit suite remains green at 713 passed, 0 failed and 1 ignored.
 
 ## Deviations grouped by mechanism
 
 | Area | Fixtures | Deviations | Initial diagnosis |
 |---|---:|---:|---|
 | CSS computed-value serialization | — | 0 | Elliptical `border-radius` and explicit `grid-template-columns` used-track serialization now match the measured fixtures. |
-| Block formatting / box model | box-model; margin-collapse | 4 | Layout used values diverge; includes parent margins and height accounting |
-| Float/clear | clear; float-clear | 6 | Float exclusion and clear placement/containing block calculations differ from Blink |
+| Block formatting / box model | box-model; margin-collapse | 0 | Parent/child margin escape, BFC barriers, and content-box height accounting now match the measured fixtures. |
+| Float/clear | clear; float-clear | 6 | Float exclusion and clear placement/containing block calculations differ from Blink; this is the next layout priority. |
 | Grid layout | grid-areas | 3 | Grid row/area placement remains incomplete; explicit column-track serialization now matches the measured fixture |
 | Positioning | absolute; relative | 6 | Absolute stretch and relative offsets are not fully applied to used geometry |
 | Inline formatting/text | text-align; vertical-align; white-space | 8 | Line box metrics, vertical alignment and preserved whitespace differ from Blink |
 
 ## Priority for implementation
 
-1. Keep the computed/used boundary explicit. The elliptical `border-radius`, explicit grid-track, and inline-baseline paths are implemented and covered by unit and corpus tests; the next priority is block formatting geometry.
-2. Fix parent box heights and margin accounting in the block formatting contract. The `display:none` and inline dimension cases now match the corpus; the remaining block gaps are isolated in box-model and margin-collapse fixtures.
-3. Repair float/clear and margin-collapse used values, then position relative/absolute geometry.
+1. Keep the computed/used boundary explicit. The elliptical `border-radius`, explicit grid-track, inline-baseline, and margin-collapse paths are implemented and covered by unit and corpus tests; the next priority is float/clear geometry.
+2. Repair float exclusion and clear placement/containing-block used values. The parent box-model, BFC barriers, `display:none`, and inline dimension cases now match the corpus.
+3. Continue with grid area sizing and relative/absolute geometry after float/clear semantics are stable.
 4. Expand inline formatting and text metrics (`white-space`, `vertical-align`, `text-align`) after the box tree contracts are stable.
 
 ## Blink architecture rule applied

--- a/docs/ui/blink-style-notes.md
+++ b/docs/ui/blink-style-notes.md
@@ -1,0 +1,25 @@
+# Blink style calculation notes
+
+Reference: Chromium, `third_party/blink/renderer/core/css/style-calculation.md`, consulted 2026-08-27.
+
+Blink describes style calculation in three phases: gathering/partitioning/indexing style rules; visiting each element and finding all rules that match; and combining matching rules plus other context into the final computed style.
+
+The central path is `Element::StyleForLayoutObject` -> `StyleResolver::ResolveStyle`. Rule matching is indexed through `RuleSet` and `RuleData` maps by selector keys such as class names, so irrelevant selectors are avoided. Matching is performed through `ElementRuleCollector`, `SelectorCheckingContext`, `SelectorChecker`, and recursive `MatchSelector`/`CheckOne` operations.
+
+The cascade considers user-agent, user and author origins. Author matching includes host, slotted, element-scope and pseudo-part rules. Blink keeps explicit resolution context (`ElementResolveContext`, `StyleResolverState`, `ElementRuleCollector`) during style calculation instead of reducing the input immediately to an unordered property map.
+
+Implications for RTS: preserve the ordered specified declarations and rule provenance; keep indexed candidate selection separate from selector matching; keep cascade priority separate from property parsing; and resolve the final computed style only after all matching rules, inheritance context, pseudo state, animations and other conditions are known. The current RTS already has an AST, a rule index and stateful lowering, but needs a more explicit per-element resolve context and property-level cascade records to approach this model.
+
+The current `style_resolver.cc` includes dedicated components for cascade layers (`CascadeLayerMap`, `CascadeLayered`), value conversion (`StyleBuilderConverter`), custom properties (`CSSVariableData`), animation integration (`CSSAnimations`, `ElementAnimations`) and a dedicated `StyleCascade`/`StyleResolverState`. This confirms that Blink treats layer precedence, custom-property resolution, conversion to computed values and animation overlays as separate concerns rather than one property-map merge.
+
+The next RTS cut should therefore add observable provenance/cascade records at the per-element boundary and avoid folding all author rules into a single `DeclBlock` before layer/origin/importance decisions are complete. The existing RTS rule index remains a compatible optimisation for the first matching phase; it should feed a richer cascade record rather than replace it.
+
+CSS Cascade Level 5 findings (W3C Editor's Draft, consulted 2026-08-27): the cascade/defaulting process takes declarations as input and outputs a specified value for each property on each element. Value processing is staged as declared, cascaded, specified, computed, used and actual values.
+
+An unlayered author declaration takes precedence over layered author declarations in the normal cascade, even when the layered selector has higher specificity and appears later. For important declarations, layer precedence is reversed. At-rules such as `@keyframes` defined inside layers also participate in layer ordering.
+
+`unset` acts as `inherit` for inherited properties and `initial` for non-inherited properties. `revert` rolls back to the previous cascade origin; for author origin that means ignoring author-origin rules and returning to the user/UA result. `revert-layer` rolls back declarations from the current cascade layer and can fall back to an earlier layer or origin. These are not equivalent to clearing a single field in a final style map.
+
+Implications for RTS: the current implementation has normal/important layers and `initial`/`unset`, but `revert` and `revert-layer` require retaining per-declaration provenance or applying cascade in origin/layer passes. A property-level cascade record is the next necessary abstraction before implementing those keywords correctly.
+
+Blink `CSSComputedStyleDeclaration` finding: `getPropertyValue` first obtains a property-specific CSS value from the computed style mapping. `getPropertyCSSValue` updates the style/layout tree, obtains the node's `ComputedStyle`, and passes the `LayoutObject` when needed to `ComputedStyleCSSValueMapping::get`; the final CSS text is the mapped value's `cssText()`. This is why a computed-style probe may expose resolved geometry-dependent values (for example grid track sizes) while the style object still retains computed declarations separately.

--- a/docs/ui/blink-style-notes.md
+++ b/docs/ui/blink-style-notes.md
@@ -23,3 +23,12 @@ An unlayered author declaration takes precedence over layered author declaration
 Implications for RTS: the current implementation has normal/important layers and `initial`/`unset`, but `revert` and `revert-layer` require retaining per-declaration provenance or applying cascade in origin/layer passes. A property-level cascade record is the next necessary abstraction before implementing those keywords correctly.
 
 Blink `CSSComputedStyleDeclaration` finding: `getPropertyValue` first obtains a property-specific CSS value from the computed style mapping. `getPropertyCSSValue` updates the style/layout tree, obtains the node's `ComputedStyle`, and passes the `LayoutObject` when needed to `ComputedStyleCSSValueMapping::get`; the final CSS text is the mapped value's `cssText()`. This is why a computed-style probe may expose resolved geometry-dependent values (for example grid track sizes) while the style object still retains computed declarations separately.
+
+## Margin collapsing and block formatting context
+
+MDN's CSS guidance, cross-checked against the local Chrome fixtures, confirms that a first in-flow child's top margin collapses with the parent when the parent has no top border, top padding, inline content, or clearance. The last child's bottom margin can collapse with an auto-height parent unless the parent has a defined height/min-height, bottom border, or bottom padding. A new block formatting context suppresses these parent/child collapses; `display: flow-root`, flex/grid containers, and non-`visible`/non-`clip` overflow are relevant barriers in this scope.[1] [2]
+
+The incremental RTS implementation should therefore distinguish the parent's own border-box rect from the flow cursor used to place the child. When the first child's margin escapes, the child remains at the collapsed edge while the parent's rect begins there and its content height excludes the escaped margin. The same provenance must be applied to the last child's bottom margin without changing the sibling strut outside the parent.
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Box_model/Margin_collapsing "MDN: Mastering margin collapsing"
+[2]: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Display/Block_formatting_context "MDN: Block formatting context"

--- a/docs/ui/css-ast.md
+++ b/docs/ui/css-ast.md
@@ -1,0 +1,54 @@
+# Arquitectura do AST CSS
+
+## Objectivo
+
+O motor CSS mantém agora uma separação entre a sintaxe de entrada e o IR semântico consumido pela cascade. O parser não precisa de conhecer `ComputedStyle`, layout ou o backend de renderização.
+
+```text
+CSS bruto
+  → tokenize
+  → StylesheetAst
+  → lowering semântico
+  → Stylesheet { rules, keyframes }
+  → cascade
+  → ComputedStyle
+  → layout/pintura
+```
+
+## Tokens e source spans
+
+`style::syntax::Token` preserva o `raw` original e um `SourceSpan` em bytes. O tokenizer reconhece whitespace, comentários, identificadores, at-keywords, hashes, strings, números, percentagens, dimensões, funções e delimitadores. Comentários permanecem disponíveis para tooling, mas são removidos apenas na serialização semântica utilizada pelo lowering.
+
+A entrada pode ser reconstruída com `StylesheetAst::to_css()`. Essa operação não é usada para aplicar CSS; serve para inspeção e preservação da fonte.
+
+## AST sintáctico
+
+`StylesheetAst` contém `AstItem` recursivos:
+
+- `QualifiedRule` contém um prelude e um `BlockAst`;
+- `AtRule` contém nome, prelude e bloco opcional;
+- `Invalid` preserva texto estrutural que não forma uma regra válida.
+
+`BlockAst` preserva os `ComponentValue`, sabe se o delimitador de fecho existia e, quando contém regras aninhadas, disponibiliza um `StylesheetAst` filho. Funções e blocos delimitados não são achatados prematuramente, o que permite interpretar posteriormente `calc()`, `var()`, listas e construções CSS futuras sem alterar o tokenizer.
+
+Uma `DeclarationAst` separa nome, valor, importância e span. O valor continua como uma lista de component values; a sua interpretação fica para a fase semântica. A grafia original do nome está em `name_raw`.
+
+## Lowering
+
+`stylesheet::parse_rules` baixa `QualifiedRule` para `Rule`. Os selectors usam os tipos já existentes (`ComplexSelector`, `CompoundSelector`, `SimpleSelector` e `Combinator`). As declarações especificadas são preservadas em `Rule::source_declarations` e, em paralelo, convertidas para `RuleDecls`, que continua a ser o formato da cascade.
+
+O lowering preserva a ordem das declarações. Isso é importante para shorthands que limpam longhands anteriores e para propriedades de timing que acumulam informação. A conversão para `ComputedStyle` continua a usar o parser semântico stateful existente, agora depois da análise estrutural.
+
+Os at-rules suportados entram no caminho estruturado: `@media` produz `MediaQuery`, `@supports` é avaliado, `@layer` é atravessado e `@keyframes` produz a tabela de animações. At-rules desconhecidos permanecem no AST para tooling, mas não afectam a cascade até existir uma implementação semântica.
+
+## Diagnósticos
+
+`StylesheetAst::diagnostics` e `Stylesheet::diagnostics()` reportam spans de regras inválidas, blocos sem fecho e funções/blocos sem delimitador final. Isto permite distinguir CSS não suportado de CSS malformado. Uma propriedade desconhecida continua a ser preservada no AST e pode ser observada em `Rule::source_declarations`, embora não seja aplicada ao `ComputedStyle`.
+
+## Contrato de compatibilidade
+
+A API pública de `Stylesheet::append_css` não mudou. A cascade continua a consultar `Stylesheet::rules`, portanto a migração não exige alterações no layout ou no bridge. O AST é adicional e pode ser usado gradualmente para implementar propriedades novas, sem reescrever o parser estrutural.
+
+## Limites conhecidos
+
+A representação já é recursiva e preserva a fonte, mas ainda não é um CSSOM completo. A gramática de selectors continua a ser baixada para o parser de selectors existente; propriedades CSS desconhecidas ainda não têm valores tipados; e alguns at-rules permanecem apenas como nós preservados. O próximo passo natural é introduzir parsers de valores especificados por propriedade e gerar diagnósticos semânticos sem alterar a cascade.

--- a/docs/ui/css-ast.md
+++ b/docs/ui/css-ast.md
@@ -31,13 +31,13 @@ A entrada pode ser reconstruída com `StylesheetAst::to_css()`. Essa operação 
 
 `BlockAst` preserva os `ComponentValue`, sabe se o delimitador de fecho existia e, quando contém regras aninhadas, disponibiliza um `StylesheetAst` filho. Funções e blocos delimitados não são achatados prematuramente, o que permite interpretar posteriormente `calc()`, `var()`, listas e construções CSS futuras sem alterar o tokenizer.
 
-Uma `DeclarationAst` separa nome, valor, importância e span. O valor continua como uma lista de component values; a sua interpretação fica para a fase semântica. A grafia original do nome está em `name_raw`.
+Uma `DeclarationAst` separa nome, valor, importância e span. O valor continua como uma lista de component values; a sua interpretação fica para a fase semântica. A grafia original do nome está em `name_raw`. `SpecifiedStyle` agrupa essas declarações e é exposto tanto para regras (`Rule::specified`) como para `style="..."` (`parse_inline_specified`).
 
 ## Lowering
 
 `stylesheet::parse_rules` baixa `QualifiedRule` para `Rule`. Os selectors usam os tipos já existentes (`ComplexSelector`, `CompoundSelector`, `SimpleSelector` e `Combinator`). As declarações especificadas são preservadas em `Rule::source_declarations` e, em paralelo, convertidas para `RuleDecls`, que continua a ser o formato da cascade.
 
-O lowering preserva a ordem das declarações. Isso é importante para shorthands que limpam longhands anteriores e para propriedades de timing que acumulam informação. A conversão para `ComputedStyle` continua a usar o parser semântico stateful existente, agora depois da análise estrutural.
+O lowering preserva a ordem das declarações. Isso é importante para shorthands que limpam longhands anteriores e para propriedades de timing que acumulam informação. A conversão para `ComputedStyle` continua a usar o parser semântico stateful existente, agora depois da análise estrutural. `initial` e `unset` são encaminhados como operações de defaulting: o primeiro usa os valores iniciais conhecidos e o segundo escolhe entre inicial e herança; `revert` e `revert-layer` aguardam metadados de origem e camada.
 
 Os at-rules suportados entram no caminho estruturado: `@media` produz `MediaQuery`, `@supports` é avaliado, `@layer` é atravessado e `@keyframes` produz a tabela de animações. At-rules desconhecidos permanecem no AST para tooling, mas não afectam a cascade até existir uma implementação semântica.
 

--- a/docs/ui/css-ast.md
+++ b/docs/ui/css-ast.md
@@ -47,7 +47,7 @@ Os at-rules suportados entram no caminho estruturado: `@media` produz `MediaQuer
 
 ## Contrato de compatibilidade
 
-A API pública de `Stylesheet::append_css` não mudou. A cascade continua a consultar `Stylesheet::rules`, portanto a migração não exige alterações no layout ou no bridge. O AST é adicional e pode ser usado gradualmente para implementar propriedades novas, sem reescrever o parser estrutural.
+A API pública de `Stylesheet::append_css` não mudou. A cascade continua a consultar `Stylesheet::rules`, portanto a migração não exige alterações no layout ou no bridge. O AST é adicional e pode ser usado gradualmente para implementar propriedades novas, sem reescrever o parser estrutural. `Stylesheet::insert_rule` e `Stylesheet::delete_rule` oferecem uma primeira operação CSSOM mutável sobre blocos preservados: depois da mutação, rules, keyframes, layers e índices são reconstruídos de forma transaccional. Esta API ainda trabalha ao nível de blocos anexados, não pretende ser o CSSOM completo de `CSSStyleSheet` com índices individuais de cada regra.
 
 ## Limites conhecidos
 

--- a/docs/ui/css-ast.md
+++ b/docs/ui/css-ast.md
@@ -39,7 +39,7 @@ Uma `DeclarationAst` separa nome, valor, importância e span. O valor continua c
 
 O lowering preserva a ordem das declarações. Isso é importante para shorthands que limpam longhands anteriores e para propriedades de timing que acumulam informação. A conversão para `ComputedStyle` continua a usar o parser semântico stateful existente, agora depois da análise estrutural. `initial` e `unset` são encaminhados como operações de defaulting: o primeiro usa os valores iniciais conhecidos e o segundo escolhe entre inicial e herança; `revert` e `revert-layer` aguardam metadados de origem e camada.
 
-Os at-rules suportados entram no caminho estruturado: `@media` produz `MediaQuery`, `@supports` é avaliado, `@layer` é atravessado e `@keyframes` produz a tabela de animações. At-rules desconhecidos permanecem no AST para tooling, mas não afectam a cascade até existir uma implementação semântica.
+Os at-rules suportados entram no caminho estruturado: `@media` produz `MediaQuery`, `@supports` é avaliado, `@layer` é atravessado e `@keyframes` produz a tabela de animações. As layers recebem uma ordem global persistida no `Stylesheet`: regras normais sem layer vencem as nomeadas; entre layers vence a última, enquanto em `!important` a prioridade é invertida. At-rules desconhecidos permanecem no AST para tooling, mas não afectam a cascade até existir uma implementação semântica.
 
 ## Diagnósticos
 


### PR DESCRIPTION
## Resumo

- introduz tokenizer CSS com tokens, `raw` e `SourceSpan`;
- adiciona AST recursivo para regras, blocos, declarações e at-rules;
- preserva CSS especificado e propriedades desconhecidas para tooling/lowering futuro;
- adiciona diagnósticos estruturados para blocos, regras e funções incompletos;
- integra lowering estruturado de regras, `@media`, `@supports`, `@layer` e `@keyframes`;
- preserva a ordem stateful de declarações para shorthands, longhands, transições e animações;
- mantém as correções DOM/CSS da branch `dom-css-functional`.

## Validação

- `cargo test -p rts-dom --lib --no-fail-fast`: 694 passed, 0 failed, 5 ignored;
- `cargo test -p rts-dom --no-fail-fast`: sem falhas;
- smoke da fachada DOM: `FACHADA DOM REAL OK`;
- smoke CSS: `css=rgb(255, 0, 0)`;
- smoke de contrato DOM: `documentElement=HTML` e `literal=literal`;
- `git diff --check`: limpo.

## Limites conhecidos

Este PR completa a fundação sintáctica e o pipeline de lowering, mas não pretende declarar compatibilidade integral com todo o CSS de navegadores. A próxima etapa é separar explicitamente valores specified/computed/used e migrar grupos adicionais de propriedades para parsers tipados.