### PR TITLE
fix: execute node vm code in context

### DIFF
--- a/crates/rts-core/src/entry/eval_scope.rs
+++ b/crates/rts-core/src/entry/eval_scope.rs
@@ -65,9 +65,41 @@ use crate::value::Value;
 /// reason is in [`eval_direct`].
 pub type EvalCompiler = fn(&str, u64) -> Option<u64>;
 
+/// The host callback shape for evaluating source with an explicit receiver.
+pub type EvalCompilerWithReceiver = fn(&str, u64, u64) -> Option<u64>;
+
 /// Installs the host's evaluator for `eval`. See [`EvalCompiler`].
 pub fn declare_eval_compiler(context: &mut Context, compiler: EvalCompiler) {
     context.eval_compiler = Some(compiler);
+}
+
+/// Installs the host callback used by APIs that supply an explicit receiver.
+pub fn declare_eval_compiler_with_receiver(
+    context: &mut Context,
+    compiler: EvalCompilerWithReceiver,
+) {
+    context.eval_compiler_with_receiver = Some(compiler);
+}
+
+/// Evaluates source against an existing environment object.
+///
+/// This is the public counterpart of the direct-`eval` path for host-backed
+/// facilities such as `node:vm`. The compiler is still owned by `rts-host`; this
+/// function only forwards the source and environment through the installed seam,
+/// so the runtime does not duplicate compilation or placement policy.
+pub fn evaluate_in_scope(source: &str, environment: u64) -> Option<u64> {
+    let compiler = with_current(|context| context.eval_compiler)?;
+    compiler(source, environment)
+}
+
+/// Evaluates source against an environment and an explicit JavaScript receiver.
+pub fn evaluate_in_scope_with_receiver(
+    source: &str,
+    environment: u64,
+    receiver: u64,
+) -> Option<u64> {
+    let compiler = with_current(|context| context.eval_compiler_with_receiver)?;
+    compiler(source, environment, receiver)
 }
 
 /// The global `eval` VALUE — which is to say, an INDIRECT `eval`.

--- a/crates/rts-core/src/entry/mod.rs
+++ b/crates/rts-core/src/entry/mod.rs
@@ -129,7 +129,9 @@ pub use eval::{
     declare_function_compiler, declare_source_parser,
 };
 pub use eval_scope::{
-    EvalCompiler, declare_eval_compiler, environment_names, eval_direct,
+    EvalCompiler, EvalCompilerWithReceiver, declare_eval_compiler,
+    declare_eval_compiler_with_receiver, environment_names, eval_direct, evaluate_in_scope,
+    evaluate_in_scope_with_receiver,
 };
 pub use generator::{FrameShape, declare_frames, delegate_step, generator_new, generator_yield};
 pub use global::{global_get, global_get_unbound, global_object, global_set, sloppy_this};
@@ -1003,6 +1005,8 @@ pub struct Context {
     /// `eval` needs, direct or indirect. See [`eval_scope::EvalCompiler`] for why the
     /// function compiler beside it cannot answer the same question.
     pub eval_compiler: Option<eval_scope::EvalCompiler>,
+    /// How a host evaluates source with an explicit JavaScript receiver.
+    pub eval_compiler_with_receiver: Option<eval_scope::EvalCompilerWithReceiver>,
     /// What still has work to do after the program.s last statement.
     ///
     /// Registered by whoever owns a background thread, never by the host — see
@@ -1178,6 +1182,7 @@ impl Context {
             function_compiler: None,
             source_parser: None,
             eval_compiler: None,
+            eval_compiler_with_receiver: None,
             loop_sources: Vec::new(),
             rest: None,
             templates: Vec::new(),

--- a/crates/rts-host/src/live.rs
+++ b/crates/rts-host/src/live.rs
@@ -101,8 +101,9 @@ pub(crate) fn compile_function(parameters: &[String], body: &str) -> Option<u64>
         "return function anonymous({}) {{\n{body}\n}};",
         parameters.join(", ")
     );
-    let nothing = rts_core::entry::undefined_value();
-    place_and_enter(&source, None, nothing)
+            let nothing = rts_core::entry::undefined_value();
+        place_and_enter(&source, None, nothing, nothing)
+
 }
 
 /// Runs `eval` source in the scope the running program handed over.
@@ -120,7 +121,22 @@ pub(crate) fn compile_function(parameters: &[String], body: &str) -> Option<u64>
 /// `SyntaxError`.
 pub(crate) fn evaluate_in_scope(source: &str, environment: u64) -> Option<u64> {
     let enclosing = rts_core::entry::environment_names(environment);
-    place_and_enter(source, Some(&enclosing), environment)
+    let nothing = rts_core::entry::undefined_value();
+    place_and_enter(source, Some(&enclosing), environment, nothing)
+}
+
+/// Runs source in an existing scope with an explicit JavaScript receiver.
+///
+/// VM contexts use the same environment for name lookup and `this`. Keeping
+/// this as a separate callback preserves direct `eval`'s existing receiver
+/// behavior while reusing the same placement and agreement checks.
+pub(crate) fn evaluate_in_scope_with_receiver(
+    source: &str,
+    environment: u64,
+    receiver: u64,
+) -> Option<u64> {
+    let enclosing = rts_core::entry::environment_names(environment);
+    place_and_enter(source, Some(&enclosing), environment, receiver)
 }
 
 /// Compiles one source text into the running region and enters it, answering
@@ -134,6 +150,7 @@ fn place_and_enter(
     source: &str,
     enclosing: Option<&[(String, u32)]>,
     environment: u64,
+    receiver: u64,
 ) -> Option<u64> {
     let agreement = rts_core::entry::agreement();
     // See the module documentation: a second compilation under single-region
@@ -216,9 +233,9 @@ fn place_and_enter(
     // emitted the reads at hop counts measured from exactly this object. A
     // `Function` body is handed `undefined`, which closes over nothing.
     //
-    // No receiver and no arguments either way. The context is the caller's and
-    // is already installed: this is reached from inside a native, which runs
-    // with one and holds no borrow.
+    // The receiver is explicit for VM contexts and `undefined` for direct eval
+    // and Function-built code. The context is already installed: this is reached
+    // from inside a native, which runs with no outstanding context borrow.
     let nothing = rts_core::entry::undefined_value();
-    Some(entry(environment, nothing, nothing, nothing, nothing, nothing))
+    Some(entry(environment, receiver, nothing, nothing, nothing, nothing))
 }

--- a/crates/rts-host/src/run.rs
+++ b/crates/rts-host/src/run.rs
@@ -380,6 +380,10 @@ fn run_region(
     rts_core::entry::declare_function_compiler(&mut context, crate::live::compile_function);
     rts_core::entry::declare_source_parser(&mut context, crate::live::check_source);
     rts_core::entry::declare_eval_compiler(&mut context, crate::live::evaluate_in_scope);
+    rts_core::entry::declare_eval_compiler_with_receiver(
+        &mut context,
+        crate::live::evaluate_in_scope_with_receiver,
+    );
     // The other capability that has to come down rather than up: letting time
     // pass. `rts-core`'s membership rule is availability and
     // `std::thread::sleep` is not on every target, so the runtime holds a hook

--- a/crates/rts-node/src/vm.rs
+++ b/crates/rts-node/src/vm.rs
@@ -30,33 +30,26 @@
 //!
 //! That is close to `vm.runInNewContext`'s contract (a fresh global scope,
 //! no access to the caller's locals) and is why the members below are named
-//! after it. It is **not** `vm.runInThisContext`'s contract — nothing here
-//! runs against "this" context, because there is no ambient context to run
-//! against: every call gets its own fresh one. `runInThisContext` is
-//! refused rather than mislabeled.
+//! after it. `runInContext` and `runInThisContext` are exposed as well, but
+//! retain this engine's honest limitation: each call still evaluates in a
+//! fresh program rather than sharing live objects with a caller-supplied or
+//! ambient context.
 //!
-//! # `Context` objects: a marker, not a scope
+//! # `Context` objects: a scope with explicit limits
 //!
-//! `vm.createContext(obj)` in real Node makes `obj`'s own properties act as
-//! additional globals for code run against it — a genuine scope
-//! substitution. `entry::evaluate` has no such mechanism (see
-//! `modules.rs`'s doc on why an ambient re-entry cannot share a region), so
-//! [`create_context`] does not attempt it: it stamps `obj` with a hidden
-//! marker property so [`is_context`] can answer honestly, and nothing
-//! evaluated against it ever sees `obj`'s properties as globals. This is
-//! stated in the object's own doc rather than left for a caller to
-//! discover by testing it.
+//! `vm.createContext(obj)` marks and returns `obj`. Code run through
+//! `runInContext` or `Script.runInContext` uses that same object for free-name
+//! lookup and as `this`, so property reads and writes stay in the running
+//! region. The evaluator does not implement every V8 context feature: it does
+//! not create a separate intrinsic realm, and completion values that require
+//! unsupported syntax still follow the host's normal failure path.
 //!
 //! # Not implemented, by name
 //!
-//! - **`vm.runInThisContext`** and **`vm.runInContext`** — both require
-//!   running against an ambient/caller-supplied context that already holds
-//!   live objects. `entry::evaluate` cannot do this: it always builds a
-//!   fresh region, so "run against a shared context" is not a smaller
-//!   version of what this module offers, it is a different capability this
-//!   crate has no seam for. Both are absent from the namespace rather than
-//!   aliased onto `runInNewContext`, which would silently answer a
-//!   different question than the one asked.
+//! - **Separate V8 realms for `vm.runInThisContext` and `vm.runInContext`** —
+//!   these methods use the active runtime region and preserve object identity,
+//!   but they do not create a separate intrinsic realm. V8-only realm controls
+//!   remain outside the scope of this implementation.
 //! - **`vm.Module` / `vm.SourceTextModule` / `vm.SyntheticModule`** — the
 //!   whole family needs a *dynamic*, user-linked module record; this
 //!   engine resolves imports statically at compile time
@@ -74,19 +67,25 @@
 //! - **`vm.constants.USE_MAIN_CONTEXT_DEFAULT_LOADER` / `importModuleDynamically`**
 //!   — dynamic `import()` inside evaluated source has nothing to resolve
 //!   against; not offered.
-//! - **`vm.constants.DONT_CONTEXTIFY`** — since [`create_context`] never
-//!   really contextifies (see above), the distinction this constant draws
-//!   does not exist here; both members are omitted from `vm.constants`.
+//! - **`vm.constants.DONT_CONTEXTIFY`** — this implementation always uses the
+//!   ordinary marked context object, so the V8 distinction this constant draws
+//!   is omitted from `vm.constants`.
 
 use rts_core::entry::{self, Context, Provided};
 
 /// The instance methods `Script` carries.
-const SCRIPT_METHODS: &[(&str, Provided)] = &[("runInNewContext", script_run), ("runInContext", script_run)];
+const SCRIPT_METHODS: &[(&str, Provided)] = &[
+    ("runInNewContext", script_run_new_context),
+    ("runInContext", script_run_context),
+    ("runInThisContext", script_run_this_context),
+];
 
 /// The namespace `node:vm` is.
 pub fn namespace(context: &mut Context) -> u64 {
     let members: &[(&str, Provided)] = &[
         ("runInNewContext", run_in_new_context),
+        ("runInContext", run_in_context),
+        ("runInThisContext", run_in_this_context),
         ("createContext", create_context),
         ("isContext", is_context),
         ("compileFunction", compile_function),
@@ -101,11 +100,30 @@ pub fn namespace(context: &mut Context) -> u64 {
 
 /// `vm.runInNewContext(code[, contextObject[, options]])`.
 ///
-/// `contextObject`/`options` are read for arity but not acted on — see the
-/// module doc's "`Context` objects" section: nothing evaluated here can see
-/// a caller-supplied object as its globals.
-extern "C" fn run_in_new_context(_e: u64, _this: u64, code: u64, _context_obj: u64, _options: u64, _d: u64) -> u64 {
-    run(code)
+/// When a context object is supplied, its properties are used as the evaluated
+/// program's environment and as its `this` value. Options remain accepted but
+/// unsupported execution controls are ignored, as documented above.
+extern "C" fn run_in_new_context(_e: u64, _this: u64, code: u64, context_obj: u64, _options: u64, _d: u64) -> u64 {
+    run_with_context(code, context_obj)
+}
+
+/// `vm.runInContext(code, contextifiedObject[, options])`.
+///
+/// The context object supplies both the evaluated program's environment and
+/// its `this` value; unsupported V8 realm features remain outside the scope of
+/// this implementation.
+extern "C" fn run_in_context(_e: u64, _this: u64, code: u64, context_obj: u64, _options: u64, _d: u64) -> u64 {
+    run_with_context(code, context_obj)
+}
+
+/// `vm.runInThisContext(code[, options])`.
+///
+/// The current global object supplies both the evaluated program's environment
+/// and its `this` value. It is still compiled through the host's live evaluator,
+/// rather than through V8's separate realm machinery.
+extern "C" fn run_in_this_context(_e: u64, _this: u64, code: u64, _options: u64, _c: u64, _d: u64) -> u64 {
+    let global = entry::with_runtime(|context| entry::global_object(context));
+    run_in_context_object(code, global)
 }
 
 /// `new vm.Script(code[, options])`.
@@ -129,20 +147,23 @@ extern "C" fn script_ctor(_e: u64, this: u64, code: u64, _options: u64, _c: u64,
     })
 }
 
-/// `script.runInNewContext([contextObject[, options]])` /
-/// `script.runInContext(contextifiedObject[, options])`.
-///
-/// One implementation for both members: `entry::evaluate` cannot
-/// distinguish "a fresh context" from "an existing one" because it never
-/// runs against either — every call is already fresh. `runInContext`
-/// against an object holding live objects (Node's actual use case for it,
-/// vs. `runInNewContext`) is exactly what this module cannot honor; giving
-/// it the same body as `runInNewContext` here would be silently wrong, so
-/// it is registered only under the `runInNewContext`-shaped contract this
-/// module doc already states, never claimed to be the general form.
-extern "C" fn script_run(_e: u64, this: u64, _context_obj: u64, _options: u64, _c: u64, _d: u64) -> u64 {
+/// `script.runInNewContext([contextObject[, options]])`.
+extern "C" fn script_run_new_context(_e: u64, this: u64, context_obj: u64, _options: u64, _c: u64, _d: u64) -> u64 {
     let code = entry::with_runtime(|context| entry::get_member(context, this, "__code__"));
-    run(code)
+    run_with_context(code, context_obj)
+}
+
+/// `script.runInContext(contextifiedObject[, options])`.
+extern "C" fn script_run_context(_e: u64, this: u64, context_obj: u64, _options: u64, _c: u64, _d: u64) -> u64 {
+    let code = entry::with_runtime(|context| entry::get_member(context, this, "__code__"));
+    run_in_context_object(code, context_obj)
+}
+
+/// `script.runInThisContext([options])`.
+extern "C" fn script_run_this_context(_e: u64, this: u64, _options: u64, _c: u64, _d: u64, _e2: u64) -> u64 {
+    let code = entry::with_runtime(|context| entry::get_member(context, this, "__code__"));
+    let global = entry::with_runtime(|context| entry::global_object(context));
+    run_in_context_object(code, global)
 }
 
 /// Compiles and runs `code`, answering `entry::evaluate`'s value or
@@ -152,6 +173,28 @@ fn run(code: u64) -> u64 {
         return entry::undefined_value();
     };
     match entry::evaluate(&source) {
+        Some(value) => value,
+        None => entry::undefined_value(),
+    }
+}
+
+/// Evaluates against a caller-supplied context, falling back to a fresh program
+/// when the optional context was omitted.
+fn run_with_context(code: u64, context_obj: u64) -> u64 {
+    let absent = entry::undefined_value();
+    if context_obj == absent {
+        run(code)
+    } else {
+        run_in_context_object(code, context_obj)
+    }
+}
+
+/// Evaluates source text against an object that acts as the environment.
+fn run_in_context_object(code: u64, environment: u64) -> u64 {
+    let Some(source) = entry::text_of(code) else {
+        return entry::undefined_value();
+    };
+    match entry::evaluate_in_scope_with_receiver(&source, environment, environment) {
         Some(value) => value,
         None => entry::undefined_value(),
     }


### PR DESCRIPTION
Adds an explicit evaluator callback with a JavaScript receiver so node:vm can execute code against the active context region.

Validation:
- 20 VM files gained status
- 0 VM files lost status
- cargo check -p rts-core -p rts-host -p rts-node passed
- Rust fast gate: 312 passed; 3 pre-existing host integration targets failed outside this change

No API or file renames included.