### PR TITLE
fix: expose text codecs and detached buffer state

### DIFF
--- a/crates/rts-core/src/entry/clone.rs
+++ b/crates/rts-core/src/entry/clone.rs
@@ -133,7 +133,7 @@ extern "C" fn structured_clone(_e: u64, _t: u64, value: u64, options: u64, _a2: 
     result
 }
 
-/// Zeroes every `ArrayBuffer` named in `options.transfer`, if any.
+/// Detaches every `ArrayBuffer` named in `options.transfer`, if any.
 ///
 /// Read and applied AFTER the clone is fully materialised: a buffer transfers
 /// itself (`transfer: [buffer]` cloning `buffer`), and detaching it first would
@@ -154,11 +154,10 @@ fn detach_transferred(options: u64) {
             let Some(cell) = Value(held).as_slot() else {
                 continue;
             };
-            if let Some(bytes) = context.bytes_at_mut(cell) {
-                bytes.clear();
-            }
-            let key = context.well_known("byteLength");
-            super::objects::put(context, cell, key, Value::from_f64(0.0).bits());
+            // Use the canonical detach operation so the mark, byteLength and
+            // detached state stay in sync for every consumer, including
+            // `buffer.isAscii`/`isUtf8` and N-API's detached query.
+            context.detach_buffer(cell);
         }
     });
 }

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -69,6 +69,11 @@ pub fn out_of_range(name: &str, expected: &str, actual: u64) {
     );
 }
 
+/// Raises `TypeError [ERR_INVALID_STATE]` for an operation on detached state.
+pub fn invalid_state(message: &str) {
+    raise("TypeError", "ERR_INVALID_STATE", message);
+}
+
 /// Raises `TypeError [ERR_INVALID_ARG_VALUE]`.
 pub fn invalid_arg_value(name: &str, actual: u64, reason: &str) {
     let described = value_text(actual);

--- a/crates/rts-core/src/entry/mod.rs
+++ b/crates/rts-core/src/entry/mod.rs
@@ -192,8 +192,8 @@ pub(crate) use current::with_current;
 pub use table::{CORE_ENTRY_COUNT, CoreEntry};
 pub use buffer::validate::MAX_LENGTH as BUFFER_MAX_LENGTH;
 pub use errors::{
-    buffer_out_of_bounds, invalid_arg_instance, invalid_arg_type, invalid_arg_value, out_of_range,
-    unknown_encoding,
+    buffer_out_of_bounds, invalid_arg_instance, invalid_arg_type, invalid_arg_value, invalid_state,
+    out_of_range, unknown_encoding,
 };
 pub use throw::{
     call_frames, declare_function_names, make_named_error, pending, take_thrown, throw, throw_type_error,

--- a/crates/rts-node/src/buffer/mod.rs
+++ b/crates/rts-node/src/buffer/mod.rs
@@ -46,10 +46,9 @@
 //!   view over one: a `Buffer`, a typed array or a `DataView`, all of which
 //!   work). [`entry::bytes_of`] reads bytes through a view, and an
 //!   `ArrayBuffer` has none — so such a part contributes **zero bytes** and is
-//!   named here rather than silently changing `blob.size`. The same limit
-//!   makes [`is_ascii`]/[`is_utf8`] answer `undefined` for an `ArrayBuffer`
-//!   argument instead of guessing. The missing host capability is "bytes of an
-//!   `ArrayBuffer` cell".
+//!   named here rather than silently changing `blob.size`. The missing host
+//!   capability is "bytes of an `ArrayBuffer` cell"; `isAscii`/`isUtf8` raise
+//!   `ERR_INVALID_ARG_TYPE` for inputs without a readable view.
 //! - **`resolveObjectURL(id)`** answers `undefined` for every `id`, and that is
 //!   a correct total answer rather than a stub: the ids it resolves are minted
 //!   only by `URL.createObjectURL`, which `node:url` refuses by name for want
@@ -189,24 +188,32 @@ fn transcode_encoding(name: &str) -> Option<&'static str> {
 
 /// `buffer.isAscii(input)` — every byte `<= 0x7F`.
 ///
-/// `undefined`, not `false`, for an argument whose bytes cannot be read: Node
-/// throws `ERR_INVALID_ARG_TYPE` there, and `false` would be a wrong answer
-/// that runs — indistinguishable from a real buffer containing a high byte.
+/// Inputs without a readable byte view raise `ERR_INVALID_ARG_TYPE`, matching
+/// Node's contract instead of returning an ambiguous boolean or `undefined`.
 extern "C" fn is_ascii(_e: u64, _this: u64, input: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    match bytes_argument(input) {
-        Some(bytes) => entry::boolean_value(bytes.iter().all(|byte| byte.is_ascii())),
-        None => entry::undefined_value(),
-    }
+    let Some(bytes) = bytes_argument(input) else {
+        if entry::buffer_detached(input) {
+            entry::invalid_state("Cannot use a detached ArrayBuffer");
+        } else {
+            entry::invalid_arg_instance("input", "Buffer, TypedArray, or DataView", input);
+        }
+        return entry::undefined_value();
+    };
+    entry::boolean_value(bytes.iter().all(|byte| byte.is_ascii()))
+}
+/// `buffer.isUtf8(input)` — the bytes decode as UTF-8.
+extern "C" fn is_utf8(_e: u64, _this: u64, input: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    let Some(bytes) = bytes_argument(input) else {
+        if entry::buffer_detached(input) {
+            entry::invalid_state("Cannot use a detached ArrayBuffer");
+        } else {
+            entry::invalid_arg_instance("input", "Buffer, TypedArray, or DataView", input);
+        }
+        return entry::undefined_value();
+    };
+    entry::boolean_value(std::str::from_utf8(&bytes).is_ok())
 }
 
-/// `buffer.isUtf8(input)` — the bytes decode as UTF-8. Same `undefined`-for-
-/// unreadable rule as [`is_ascii`].
-extern "C" fn is_utf8(_e: u64, _this: u64, input: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    match bytes_argument(input) {
-        Some(bytes) => entry::boolean_value(std::str::from_utf8(&bytes).is_ok()),
-        None => entry::undefined_value(),
-    }
-}
 
 /// The bytes of a `Buffer`/typed array/`DataView` argument. `None` for
 /// anything else — including a raw `ArrayBuffer`, refused by name in the

--- a/crates/rts-node/src/util/mod.rs
+++ b/crates/rts-node/src/util/mod.rs
@@ -28,7 +28,8 @@
 //! here; `crate::fs::options_and_listener` is the overload shifter and no
 //! function in `node:util` has an optional-middle-argument overload, so it is
 //! not used. `TextEncoder`/`TextDecoder` live in `rts-std`'s globals and are
-//! refused here — see below for why re-exporting them is not possible yet.
+//! re-exported here by reading those same global constructors, so `node:util`
+//! does not mint a second class or prototype.
 //!
 //! # The rule this module tree is written around
 //!
@@ -72,14 +73,10 @@
 //!
 //! ## Needs something this engine does not have
 //!
-//! - **`TextEncoder` / `TextDecoder`.** They exist — `rts-std`'s
-//!   `globals/text.rs` implements both and declares them as globals — and this
-//!   module still cannot name them: a host module has no way to READ a global
-//!   by name (`entry::global_get` takes an interned key number nothing here can
-//!   mint), and `entry::make_prototype` is idempotent BY NAME, so asking it for
-//!   `"TextEncoder"` would mint an empty prototype and win the name from the
-//!   real class. Re-exporting them needs one host accessor, not code here.
-//!   A program reaching the ambient globals directly gets the real classes.
+//! - **`TextEncoder` / `TextDecoder`.** They are implemented by `rts-std`'s
+//!   `globals/text` and installed as globals; `namespace` reads those existing
+//!   constructors and attaches the same values to `node:util`, preserving class
+//!   identity instead of minting a second prototype.
 //! - **`getCallSites`.** No stack walk, and no `scriptId` concept to synthesize
 //!   one from.
 //! - **`getSystemErrorName` / `getSystemErrorMap` / `getSystemErrorMessage`.**
@@ -210,6 +207,17 @@ pub fn namespace(context: &mut Context) -> u64 {
         .chain(call_site::MEMBERS.iter().copied())
         .collect();
     let namespace = entry::make_namespace(context, &members);
+    // `TextEncoder` and `TextDecoder` are owned by `rts-std`'s global text
+    // implementation. Reuse those exact constructors so `new util.TextEncoder`
+    // has the same prototype and identity as the ambient class.
+    let undefined = entry::undefined_in(context);
+    let global = entry::global_object(context);
+    for name in ["TextEncoder", "TextDecoder"] {
+        let constructor = entry::get_member(context, global, name);
+        if constructor != undefined {
+            entry::put_member(context, namespace, name, constructor);
+        }
+    }
     // `inspect` is built apart from the list because it carries members of its
     // own, and `make_namespace` installs plain callables.
     let inspector = entry::make_callable(context, inspect::inspect);


### PR DESCRIPTION
Reuses the existing rts-std TextEncoder/TextDecoder constructors from node:util, reports ERR_INVALID_ARG_TYPE/ERR_INVALID_STATE from buffer.isAscii/isUtf8, and makes structuredClone transfer use the canonical detached-buffer marker.

Validation:
- test-buffer-isascii.js: ok
- test-buffer-isutf8.js: ok
- rts-core library fast tests: 294 passed
- release build passed

No API or file renames included.