### PR TITLE
fix: complete legacy Buffer construction and search

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -52,10 +52,25 @@ pub(in crate::entry) mod validate;
 
 use super::buffers::element::Kind;
 use super::buffers::uint8_array;
+use crate::entry;
 
 /// `Buffer`.
 #[rtse::class("Buffer", extends = uint8_array)]
 impl Buffer {
+    /// `Buffer(size)` / `new Buffer(size)` and the legacy source overloads.
+    ///
+    /// Node keeps this callable for compatibility even though modern code uses
+    /// `Buffer.from` or `Buffer.alloc`. Numbers follow the legacy unsafe-size
+    /// path; all other sources reuse the validated `from` implementation.
+    #[construct]
+    fn build(this: u64, source: u64, encoding_or_offset: u64) -> u64 {
+        let _ = this;
+        if entry::number_of(source).is_some() {
+            return statics::alloc_unsafe(source);
+        }
+        statics::from(source, encoding_or_offset)
+    }
+
     /// `Buffer.poolSize` — Node's allocation-pool size. Meaningless here: this
     /// engine's `allocUnsafe` zero-fills fresh memory rather than drawing from a
     /// shared pool (see `rts-node`'s former module doc), so the property

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -30,6 +30,7 @@ use super::super::errors;
 use super::super::objects::undefined_of;
 use super::super::{Context, native, with_current};
 use super::codec;
+use crate::entry;
 use super::validate::{self, Shape};
 use crate::value::Value;
 
@@ -60,8 +61,33 @@ fn instance_over(context: &mut Context, view: View) -> u64 {
     if let Some(prototype) = super::super::class_support::prototype(context, "Buffer") {
         context.set_prototype(cell, prototype);
     }
+    let parent = Value::from_slot(view.buffer).bits();
     super::super::buffers::attach(context, cell, view);
+    // Node exposes the backing ArrayBuffer through the legacy `parent` alias;
+    // keep it identical to `buffer` so zero-length and shared views retain the
+    // same identity as the source storage.
+    let parent_key = context.well_known("parent");
+    super::super::objects::put(context, cell, parent_key, parent);
     Value::from_slot(cell).bits()
+}
+
+/// A Buffer view over an existing raw ArrayBuffer, preserving shared storage.
+pub(in crate::entry) fn from_array_buffer(context: &mut Context, source: u64) -> u64 {
+    let Some(buffer) = Value(source).as_slot() else {
+        return undefined_of(context);
+    };
+    let Some(length) = context.bytes_at(buffer).map(Vec::len) else {
+        return undefined_of(context);
+    };
+    instance_over(
+        context,
+        View {
+            buffer,
+            offset: 0,
+            length,
+            kind: Kind::Uint8,
+        },
+    )
 }
 
 /// The bytes a value carries as source data: a `Uint8Array`/`Buffer`'s window,
@@ -111,7 +137,18 @@ pub(in crate::entry) fn pattern_of(context: &Context, value: u64, encoding: &str
             }
             Vec::new()
         }
-        None => vec![super::super::operators::as_number(context, Value(value)).unwrap_or(0.0) as u8],
+        None => {
+            let number = super::super::operators::as_number(context, Value(value)).unwrap_or(0.0);
+            // ToUint8 is modulo 256, while Rust's float-to-u8 cast saturates
+            // negative values to zero. Buffer searches/fills rely on the JS
+            // conversion, e.g. -140 becomes 116 (`'t'`).
+            let byte = if number.is_finite() {
+                number.trunc().rem_euclid(256.0) as u8
+            } else {
+                0
+            };
+            vec![byte]
+        },
     }
 }
 
@@ -313,12 +350,21 @@ fn find(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 
 /// `buf.indexOf(value, byteOffset?, encoding?)`.
 pub(in crate::entry) fn index_of(this: u64, value: u64, byte_offset: u64, encoding: u64) -> f64 {
+    if !validate::search_value(value) {
+        return -1.0;
+    }
     let byte_offset = optional_number(byte_offset);
     with_current(|context| {
         let Some(view) = view_of(context, this) else { return -1.0 };
         let Some(bytes) = window(context, &view) else { return -1.0 };
         let enc = encoding_arg(context, encoding);
         let needle = pattern_of(context, value, &enc);
+        // UTF-16 searches operate on two-byte code units. A raw Buffer needle
+        // with an odd byte length cannot represent one, and Node returns no
+        // match rather than finding a byte halfway through a code unit.
+        if entry::canonical_encoding(&enc) == Some("utf16le") && needle.len() % 2 != 0 {
+            return -1.0;
+        }
         let (from, _) = range(bytes.len(), byte_offset, None);
         find(bytes, &needle, from).map(|at| at as f64).unwrap_or(-1.0)
     })

--- a/crates/rts-core/src/entry/buffer/statics.rs
+++ b/crates/rts-core/src/entry/buffer/statics.rs
@@ -94,6 +94,9 @@ pub(in crate::entry) fn from(source: u64, encoding_or_offset: u64) -> u64 {
     let Some(shape) = validate::source("value", source) else {
         return undefined();
     };
+    if matches!(shape, Shape::ArrayBuffer) {
+        return with_current(|context| super::ops::from_array_buffer(context, source));
+    }
     let encoding = match shape {
         Shape::Text(_) => match validate::encoding(encoding_or_offset) {
             Some(name) => name,

--- a/crates/rts-core/src/entry/buffer/validate.rs
+++ b/crates/rts-core/src/entry/buffer/validate.rs
@@ -62,6 +62,8 @@ pub(in crate::entry) enum Shape {
     List(Vec<u64>),
     /// A `Buffer`, typed array or `DataView`, and how many bytes it is.
     Bytes(usize),
+    /// A raw `ArrayBuffer`, whose storage can be exposed through a Buffer view.
+    ArrayBuffer,
     /// Anything else: an object, a boolean, `null`, a function.
     Other,
 }
@@ -84,8 +86,15 @@ pub(in crate::entry) fn shape_of(value: u64) -> Shape {
         let Some(cell) = Value(value).as_slot() else {
             return Shape::Other;
         };
-        if let Some(text) = context.text_at(cell).and_then(|text| text.to_rust()) {
-            return Shape::Text(text);
+        if let Some(bytes) = context.bytes_at(cell) {
+            let _ = bytes;
+            return Shape::ArrayBuffer;
+        }
+        if let Some(text) = context.text_at(cell) {
+            // Buffer's UTF-8 encoder replaces lone UTF-16 surrogates with
+            // U+FFFD; refusing the whole source would make valid JavaScript
+            // strings unusable as Buffer input.
+            return Shape::Text(text.to_rust_lossy());
         }
         match context.elements_at(cell) {
             Some(elements) => Shape::List(elements.clone()),
@@ -167,6 +176,17 @@ pub(in crate::entry) fn bytes(name: &str, value: u64) -> Option<usize> {
     }
 }
 
+/// A value accepted by `Buffer.indexOf`/`includes`: number, string or bytes.
+pub(in crate::entry) fn search_value(value: u64) -> bool {
+    match shape_of(value) {
+        Shape::Number(_) | Shape::Text(_) | Shape::Bytes(_) => true,
+        _ => {
+            errors::invalid_search_value(value);
+            false
+        }
+    }
+}
+
 /// The offset of an ELEMENT `width` bytes wide inside a buffer of `count`.
 ///
 /// The two refusals differ, which is why this is not [`offset`] with the
@@ -195,7 +215,7 @@ pub(in crate::entry) fn element_offset(
 /// classification is a second borrow, which is what the module doc forbids.
 pub(in crate::entry) fn source(name: &str, value: u64) -> Option<Shape> {
     match shape_of(value) {
-        found @ (Shape::Text(_) | Shape::List(_) | Shape::Bytes(_)) => Some(found),
+        found @ (Shape::Text(_) | Shape::List(_) | Shape::Bytes(_) | Shape::ArrayBuffer) => Some(found),
         _ => {
             errors::invalid_arg_type(
                 name,

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -69,6 +69,26 @@ pub fn out_of_range(name: &str, expected: &str, actual: u64) {
     );
 }
 
+/// Raises `TypeError [ERR_INVALID_ARG_TYPE]` for Buffer search values.
+pub fn invalid_search_value(actual: u64) {
+    let described = kind_text(actual);
+    // Node's helper formats an anonymous function with a trailing space after
+    // `function`; keep that small textual distinction because the suite checks
+    // the complete error message for this overload.
+    let received = if described == "function" {
+        format!("{described} ")
+    } else {
+        described
+    };
+    raise(
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        &format!(
+            "The \"value\" argument must be one of type number or string or an instance of Buffer or Uint8Array. Received {received}"
+        ),
+    );
+}
+
 /// Raises `TypeError [ERR_INVALID_STATE]` for an operation on detached state.
 pub fn invalid_state(message: &str) {
     raise("TypeError", "ERR_INVALID_STATE", message);

--- a/crates/rts-node/src/assert/equality.rs
+++ b/crates/rts-node/src/assert/equality.rs
@@ -118,6 +118,18 @@ fn walk(actual: u64, expected: u64, mode: Mode, seen: &mut Vec<(u64, u64)>) -> b
     if mode.prototypes && entry::get_prototype(actual) != entry::get_prototype(expected) {
         return false;
     }
+    // Typed arrays and Buffer instances expose their indexed elements through
+    // internal view state rather than enumerable properties. Compare that state
+    // directly so two equal slices do not depend on the underlying ArrayBuffer
+    // identity or on the implementation-only shape fields.
+    let (actual_bytes, expected_bytes) = entry::with_runtime(|context| {
+        (entry::bytes_of(context, actual), entry::bytes_of(context, expected))
+    });
+    match (actual_bytes, expected_bytes) {
+        (Some(left), Some(right)) => return left == right,
+        (Some(_), None) | (None, Some(_)) => return false,
+        (None, None) => {}
+    }
     if identity_only(actual) || identity_only(expected) {
         return false;
     }


### PR DESCRIPTION
Completes legacy Buffer construction and search semantics, preserves ArrayBuffer-backed parent views, compares binary views by bytes, and handles WTF-16/ToUint8 cases.

Validation:
- six targeted Buffer tests pass in release: slice, includes, zero-fill, parent-property, isAscii, isUtf8
- rts-core fast tests: 294 passed
- release build passed

No API or file renames included.