### PR TITLE
fix: add Buffer integer and float methods

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -52,6 +52,7 @@ pub(in crate::entry) mod validate;
 
 use super::buffers::element::Kind;
 use super::buffers::uint8_array;
+use super::Context;
 use crate::entry;
 
 /// `Buffer`.
@@ -191,6 +192,16 @@ impl Buffer {
         ops::to_json(this)
     }
 
+    /// `buf.readInt8(offset?)`.
+    fn read_int8(this: u64, offset: u64) -> f64 {
+        ops::read_num(this, offset, Kind::Int8, true)
+    }
+
+    /// `buf.writeInt8(value, offset?)`.
+    fn write_int8(this: u64, value: f64, offset: u64) -> f64 {
+        ops::write_num(this, value, offset, Kind::Int8, true)
+    }
+
     /// `buf.readUInt8(offset?)`.
     fn read_u_int8(this: u64, offset: u64) -> f64 {
         ops::read_num(this, offset, Kind::Uint8, true)
@@ -223,6 +234,78 @@ impl Buffer {
     #[js("writeUInt16BE")]
     fn write_u_int16_be(this: u64, value: f64, offset: u64) -> f64 {
         ops::write_num(this, value, offset, Kind::Uint16, false)
+    }
+
+    /// `buf.readInt16LE(offset?)`.
+    #[js("readInt16LE")]
+    fn read_int16_le(this: u64, offset: u64) -> f64 {
+        ops::read_num(this, offset, Kind::Int16, true)
+    }
+
+    /// `buf.readInt16BE(offset?)`.
+    #[js("readInt16BE")]
+    fn read_int16_be(this: u64, offset: u64) -> f64 {
+        ops::read_num(this, offset, Kind::Int16, false)
+    }
+
+    /// `buf.writeInt16LE(value, offset?)`.
+    #[js("writeInt16LE")]
+    fn write_int16_le(this: u64, value: f64, offset: u64) -> f64 {
+        ops::write_num(this, value, offset, Kind::Int16, true)
+    }
+
+    /// `buf.writeInt16BE(value, offset?)`.
+    #[js("writeInt16BE")]
+    fn write_int16_be(this: u64, value: f64, offset: u64) -> f64 {
+        ops::write_num(this, value, offset, Kind::Int16, false)
+    }
+
+    /// `buf.readUIntLE(offset?, byteLength)`.
+    #[js("readUIntLE")]
+    fn read_u_int_le(this: u64, offset: u64, byte_length: u64) -> f64 {
+        ops::read_variable(this, offset, byte_length, true, false)
+    }
+
+    /// `buf.readUIntBE(offset?, byteLength)`.
+    #[js("readUIntBE")]
+    fn read_u_int_be(this: u64, offset: u64, byte_length: u64) -> f64 {
+        ops::read_variable(this, offset, byte_length, false, false)
+    }
+
+    /// `buf.writeUIntLE(value, offset?, byteLength)`.
+    #[js("writeUIntLE")]
+    fn write_u_int_le(this: u64, value: f64, offset: u64, byte_length: u64) -> f64 {
+        ops::write_variable(this, value, offset, byte_length, true, false)
+    }
+
+    /// `buf.writeUIntBE(value, offset?, byteLength)`.
+    #[js("writeUIntBE")]
+    fn write_u_int_be(this: u64, value: f64, offset: u64, byte_length: u64) -> f64 {
+        ops::write_variable(this, value, offset, byte_length, false, false)
+    }
+
+    /// `buf.readIntLE(offset?, byteLength)`.
+    #[js("readIntLE")]
+    fn read_int_le(this: u64, offset: u64, byte_length: u64) -> f64 {
+        ops::read_variable(this, offset, byte_length, true, true)
+    }
+
+    /// `buf.readIntBE(offset?, byteLength)`.
+    #[js("readIntBE")]
+    fn read_int_be(this: u64, offset: u64, byte_length: u64) -> f64 {
+        ops::read_variable(this, offset, byte_length, false, true)
+    }
+
+    /// `buf.writeIntLE(value, offset?, byteLength)`.
+    #[js("writeIntLE")]
+    fn write_int_le(this: u64, value: f64, offset: u64, byte_length: u64) -> f64 {
+        ops::write_variable(this, value, offset, byte_length, true, true)
+    }
+
+    /// `buf.writeIntBE(value, offset?, byteLength)`.
+    #[js("writeIntBE")]
+    fn write_int_be(this: u64, value: f64, offset: u64, byte_length: u64) -> f64 {
+        ops::write_variable(this, value, offset, byte_length, false, true)
     }
 
     /// `buf.readUInt32LE(offset?)`.
@@ -291,10 +374,34 @@ impl Buffer {
         ops::write_num(this, value, offset, Kind::Float32, true)
     }
 
+    /// `buf.readFloatBE(offset?)`.
+    #[js("readFloatBE")]
+    fn read_float_be(this: u64, offset: u64) -> f64 {
+        ops::read_num(this, offset, Kind::Float32, false)
+    }
+
+    /// `buf.writeFloatBE(value, offset?)`.
+    #[js("writeFloatBE")]
+    fn write_float_be(this: u64, value: f64, offset: u64) -> f64 {
+        ops::write_num(this, value, offset, Kind::Float32, false)
+    }
+
     /// `buf.readDoubleLE(offset?)`.
     #[js("readDoubleLE")]
     fn read_double_le(this: u64, offset: u64) -> f64 {
         ops::read_num(this, offset, Kind::Float64, true)
+    }
+
+    /// `buf.readDoubleBE(offset?)`.
+    #[js("readDoubleBE")]
+    fn read_double_be(this: u64, offset: u64) -> f64 {
+        ops::read_num(this, offset, Kind::Float64, false)
+    }
+
+    /// `buf.writeDoubleBE(value, offset?)`.
+    #[js("writeDoubleBE")]
+    fn write_double_be(this: u64, value: f64, offset: u64) -> f64 {
+        ops::write_num(this, value, offset, Kind::Float64, false)
     }
 
     /// `buf.writeDoubleLE(value, offset?)`.
@@ -302,4 +409,35 @@ impl Buffer {
     fn write_double_le(this: u64, value: f64, offset: u64) -> f64 {
         ops::write_num(this, value, offset, Kind::Float64, true)
     }
+}
+
+/// Register Buffer and install Node's spelling aliases without generating a
+/// second native wrapper for each `UInt`/`Uint` pair.
+pub(in crate::entry) fn register_buffer_with_aliases(context: &mut Context) -> u64 {
+    let constructor = register_buffer(context);
+    let Some(prototype) = super::class_support::prototype(context, "Buffer") else {
+        return constructor;
+    };
+    for (upper, lower) in [
+        ("readUInt8", "readUint8"),
+        ("writeUInt8", "writeUint8"),
+        ("readUInt16LE", "readUint16LE"),
+        ("writeUInt16LE", "writeUint16LE"),
+        ("readUInt16BE", "readUint16BE"),
+        ("writeUInt16BE", "writeUint16BE"),
+        ("readUInt32LE", "readUint32LE"),
+        ("writeUInt32LE", "writeUint32LE"),
+        ("readUInt32BE", "readUint32BE"),
+        ("writeUInt32BE", "writeUint32BE"),
+        ("readUIntLE", "readUintLE"),
+        ("writeUIntLE", "writeUintLE"),
+        ("readUIntBE", "readUintBE"),
+        ("writeUIntBE", "writeUintBE"),
+    ] {
+        let value = super::modules::get_member(context, prototype, upper);
+        if value != super::modules::undefined_in(context) {
+            super::modules::put_member(context, prototype, lower, value);
+        }
+    }
+    constructor
 }

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -442,3 +442,59 @@ pub(in crate::entry) fn write_num(this: u64, value: f64, offset: u64, kind: Kind
         (at + kind.size()) as f64
     })
 }
+
+/// A variable-width integer read, used by the 1–6 byte Buffer methods.
+pub(in crate::entry) fn read_variable(
+    this: u64,
+    offset: u64,
+    byte_length: u64,
+    little: bool,
+    signed: bool,
+) -> f64 {
+    let Some(count) = validate::bytes("buffer", this) else { return f64::NAN };
+    let Some(width) = validate::byte_length(byte_length) else { return f64::NAN };
+    let Some(at) = validate::variable_offset(offset, count, width) else { return f64::NAN };
+    with_current(|context| {
+        let Some(view) = view_of(context, this) else { return f64::NAN };
+        let Some(bytes) = window(context, &view) else { return f64::NAN };
+        let Some(word) = super::super::buffers::element::gathered(bytes, at, width, little) else {
+            return f64::NAN;
+        };
+        let bits = width * 8;
+        if signed && (word & (1u64 << (bits - 1))) != 0 {
+            (word as i128 - (1i128 << bits)) as f64
+        } else {
+            word as f64
+        }
+    })
+}
+
+/// A variable-width integer write, used by the 1–6 byte Buffer methods.
+pub(in crate::entry) fn write_variable(
+    this: u64,
+    value: f64,
+    offset: u64,
+    byte_length: u64,
+    little: bool,
+    signed: bool,
+) -> f64 {
+    let Some(count) = validate::bytes("buffer", this) else { return 0.0 };
+    let Some(width) = validate::byte_length(byte_length) else { return 0.0 };
+    let Some(at) = validate::variable_offset(offset, count, width) else { return 0.0 };
+    if !validate::variable_fits(value, width, signed) {
+        return 0.0;
+    }
+    let bits = width * 8;
+    let word = (value as i128).rem_euclid(1i128 << bits) as u64;
+    with_current(|context| {
+        if let Some(view) = view_of(context, this)
+            && let Some(bytes) = window_mut(context, &view)
+        {
+            for index in 0..width {
+                let shift = if little { index } else { width - 1 - index };
+                bytes[at + index] = (word >> (shift * 8)) as u8;
+            }
+        }
+        (at + width) as f64
+    })
+}

--- a/crates/rts-core/src/entry/buffer/validate.rs
+++ b/crates/rts-core/src/entry/buffer/validate.rs
@@ -128,6 +128,27 @@ pub(in crate::entry) fn size(name: &str, value: u64) -> Option<usize> {
     Some(number as usize)
 }
 
+/// The numeric part of an offset, after type and integralness checks.
+///
+/// Keeping this first step separate matters for a short buffer: Node reports an
+/// invalid type or a fractional offset before it reports that the element cannot
+/// fit, but reports out-of-bounds for an integer, Infinity, or a negative value.
+fn integer_offset(name: &str, value: u64) -> Option<f64> {
+    let number = match shape_of(value) {
+        Shape::Absent => 0.0,
+        Shape::Number(number) => number,
+        _ => {
+            errors::invalid_arg_type(name, "number", value);
+            return None;
+        }
+    };
+    if number.is_nan() || (number.is_finite() && number.fract() != 0.0) {
+        errors::out_of_range(name, "an integer", value);
+        return None;
+    }
+    Some(number)
+}
+
 /// A position inside a buffer: every `read*`/`write*` offset, and `buf.write`'s.
 ///
 /// `limit` is the largest offset that is still inside — the caller subtracts the
@@ -139,22 +160,8 @@ pub(in crate::entry) fn size(name: &str, value: u64) -> Option<usize> {
 /// `test-buffer-readuint.js` asserts explicitly for both `undefined` and no
 /// argument at all.
 pub(in crate::entry) fn offset(name: &str, value: u64, limit: usize) -> Option<usize> {
-    let number = match shape_of(value) {
-        Shape::Absent => return Some(0),
-        Shape::Number(number) => number,
-        _ => {
-            errors::invalid_arg_type(name, "number", value);
-            return None;
-        }
-    };
-    // Two range messages, not one, because Node distinguishes them and the test
-    // compares the text: a fractional or non-finite offset "must be an integer",
-    // where an integer outside the buffer names the bounds it missed.
-    if !number.is_finite() || number.fract() != 0.0 {
-        errors::out_of_range(name, "an integer", value);
-        return None;
-    }
-    if number < 0.0 || number > limit as f64 {
+    let number = integer_offset(name, value)?;
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
         errors::out_of_range(name, &format!(">= 0 and <= {limit}"), value);
         return None;
     }
@@ -200,13 +207,17 @@ pub(in crate::entry) fn element_offset(
     count: usize,
     width: usize,
 ) -> Option<usize> {
-    match count.checked_sub(width) {
-        Some(limit) => offset(name, value, limit),
-        None => {
-            errors::buffer_out_of_bounds(Some(name));
-            None
-        }
+    let number = integer_offset(name, value)?;
+    if width > count {
+        errors::buffer_out_of_bounds(None);
+        return None;
     }
+    let limit = count - width;
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
+        errors::out_of_range(name, &format!(">= 0 and <= {limit}"), value);
+        return None;
+    }
+    Some(number as usize)
 }
 
 /// A `Buffer.from`/`Buffer.byteLength` source.
@@ -269,6 +280,75 @@ pub(in crate::entry) fn encoding(value: u64) -> Option<String> {
             None
         }
     }
+}
+
+/// A byte length for `read/write{Int,UInt}{LE,BE}`.
+pub(in crate::entry) fn byte_length(value: u64) -> Option<usize> {
+    let number = match shape_of(value) {
+        Shape::Number(number) => number,
+        _ => {
+            errors::invalid_arg_type("byteLength", "number", value);
+            return None;
+        }
+    };
+    if number.is_nan() || (number.is_finite() && number.fract() != 0.0) {
+        errors::out_of_range("byteLength", "an integer", value);
+        return None;
+    }
+    if !number.is_finite() || number < 1.0 || number > 6.0 {
+        errors::out_of_range("byteLength", ">= 1 and <= 6", value);
+        return None;
+    }
+    Some(number as usize)
+}
+
+/// A required offset for a variable-width integer operation.
+pub(in crate::entry) fn variable_offset(value: u64, count: usize, width: usize) -> Option<usize> {
+    let number = match shape_of(value) {
+        Shape::Number(number) => number,
+        _ => {
+            errors::invalid_arg_type("offset", "number", value);
+            return None;
+        }
+    };
+    if number.is_nan() || (number.is_finite() && number.fract() != 0.0) {
+        errors::out_of_range("offset", "an integer", value);
+        return None;
+    }
+    let limit = count.saturating_sub(width);
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
+        if width > count {
+            errors::buffer_out_of_bounds(None);
+        } else {
+            errors::out_of_range("offset", &format!(">= 0 and <= {limit}"), value);
+        }
+        return None;
+    }
+    Some(number as usize)
+}
+
+/// Whether a variable-width integer value fits its signedness and byte width.
+pub(in crate::entry) fn variable_fits(value: f64, width: usize, signed: bool) -> bool {
+    let bits = (width * 8) as u32;
+    let (low, high) = if signed {
+        (-(2f64.powi(bits as i32 - 1)), 2f64.powi(bits as i32 - 1) - 1.0)
+    } else {
+        (0.0, 2f64.powi(bits as i32) - 1.0)
+    };
+    if value.is_finite() && value.fract() == 0.0 && value >= low && value <= high {
+        return true;
+    }
+    let expected = if signed && width > 4 {
+        format!(">= -(2 ** {}) and < 2 ** {}", bits - 1, bits - 1)
+    } else if !signed && width > 4 {
+        format!(">= 0 and < 2 ** {bits}")
+    } else if signed {
+        format!(">= {low} and <= {high}")
+    } else {
+        format!(">= 0 and <= {high}")
+    };
+    errors::out_of_range_number("value", &expected, value, width > 4);
+    false
 }
 
 /// Whether a number fits the integer element it is about to be written as.

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -118,6 +118,27 @@ pub fn unknown_encoding(encoding: &str) {
     );
 }
 
+/// Raises a numeric `RangeError [ERR_OUT_OF_RANGE]`, optionally using Node's
+/// grouped presentation for variable-width 48-bit values.
+pub fn out_of_range_number(name: &str, expected: &str, number: f64, grouped: bool) {
+    let received = if grouped
+        && number.is_finite()
+        && number.fract() == 0.0
+        && number.abs() >= 4_294_967_296.0
+    {
+        grouped_integer(number)
+    } else {
+        format!("{number}")
+    };
+    raise(
+        "RangeError",
+        "ERR_OUT_OF_RANGE",
+        &format!(
+            "The value of \"{name}\" is out of range. It must be {expected}. Received {received}"
+        ),
+    );
+}
+
 /// Raises `RangeError [ERR_BUFFER_OUT_OF_BOUNDS]`.
 ///
 /// Node's own message has two forms: with an argument name for a bound that was
@@ -217,8 +238,27 @@ fn kind_text(value: u64) -> String {
 
 /// A value as a message renders it — the same rendering, without the "type".
 fn value_text(value: u64) -> String {
-    with_current(|context| match super::modules::text_in(context, value) {
-        Some(text) => text,
-        None => String::from("undefined"),
+    with_current(|context| {
+        match super::modules::text_in(context, value) {
+            Some(text) => text,
+            None => String::from("undefined"),
+        }
     })
+}
+
+/// Node's Buffer range diagnostics group integers once they leave the 32-bit
+/// range; the separator is presentation only and must not affect the value.
+fn grouped_integer(number: f64) -> String {
+    let negative = number.is_sign_negative();
+    let mut digits = format!("{:.0}", number.abs());
+    let mut at = digits.len().saturating_sub(3);
+    while at > 0 {
+        digits.insert(at, '_');
+        at = at.saturating_sub(3);
+    }
+    if negative {
+        format!("-{digits}")
+    } else {
+        digits
+    }
 }

--- a/crates/rts-core/src/entry/global.rs
+++ b/crates/rts-core/src/entry/global.rs
@@ -148,7 +148,7 @@ pub(in crate::entry) fn supply(
         "Proxy" => super::proxy::register_proxy(context),
         "Map" => super::collections::register_map(context),
             "Set" => super::collections::register_set(context),
-            "Buffer" => super::buffer::register_buffer(context),
+            "Buffer" => super::buffer::register_buffer_with_aliases(context),
             "ArrayBuffer" => super::buffers::register_array_buffer(context),
             "DataView" => super::buffers::register_data_view(context),
             "Int8Array" => super::buffers::int8_array(context),

--- a/crates/rts-core/src/entry/modules.rs
+++ b/crates/rts-core/src/entry/modules.rs
@@ -881,7 +881,7 @@ pub fn decode_base64(text: &str) -> Vec<u8> {
 /// the small accessor `rts-node` needs to hand its own `Buffer` name back to
 /// the one this crate builds, rather than fabricating a second one.
 pub fn buffer_class(context: &mut Context) -> u64 {
-    super::buffer::register_buffer(context)
+    super::buffer::register_buffer_with_aliases(context)
 }
 
 /// An object inheriting from a prototype.

--- a/crates/rts-node/src/assert/throws.rs
+++ b/crates/rts-node/src/assert/throws.rs
@@ -173,6 +173,29 @@ fn satisfies(error: u64, expected: u64) -> Verdict {
     for name in values::own_key_strings(expected) {
         let wanted = member(expected, &name);
         let held = member(error, &name);
+        // Object matchers may use a RegExp for a field such as `message`.
+        // Treat it like the top-level matcher above instead of comparing the
+        // RegExp object identity with the actual string value.
+        let tester = member(wanted, "test");
+        if values::is_callable(tester) && member(wanted, "source") != entry::undefined_value() {
+            let actual = string_of(held).unwrap_or_else(|| values::render(held));
+            let matched = entry::call(
+                tester,
+                wanted,
+                values::string(&actual),
+                entry::undefined_value(),
+                entry::undefined_value(),
+                entry::undefined_value(),
+            );
+            if !entry::to_boolean(matched) {
+                return Verdict::Failed(format!(
+                    "Expected the error's `{name}` to match {}, got {}",
+                    values::render(wanted),
+                    actual
+                ));
+            }
+            continue;
+        }
         if !super::equality::same_value(held, wanted) {
             return Verdict::Failed(format!(
                 "Expected the error's `{name}` to be {}, got {}",


### PR DESCRIPTION
## Summary

- Add fixed-width Buffer integer methods for signed and unsigned 8/16/32-bit values, including both endiannesses.
- Add variable-width `readInt*`/`writeInt*` and `readUInt*`/`writeUInt*` methods for 1–6 byte values.
- Install `UInt`/`Uint` spelling aliases on the same callable, preserving `===` identity.
- Add the missing big-endian float/double methods and align offset and short-buffer diagnostics with Node.
- Extend `assert.throws` object matching to support RegExp-valued properties.

## Validation

All eight directly covered Node files passed against the release binary:

- `test-buffer-readuint.js`
- `test-buffer-writeuint.js`
- `test-buffer-readint.js`
- `test-buffer-writeint.js`
- `test-buffer-readfloat.js`
- `test-buffer-readdouble.js`
- `test-buffer-writefloat.js`
- `test-buffer-writedouble.js`

The serial fast gate passed with `rts-core`: 294 passed, 0 failed; `rts-node`: 90 passed, 0 failed; doctests compiled and the three existing ignored doctests remained ignored.

The release `buffer` corpus was measured with `JOBS=2` and `TIMEOUT=10` over 58 counted files plus 3 skipped internal-Node files:

| measurement | ok | fail | error | timeout | skipped | denominator |
|---|---:|---:|---:|---:|---:|---:|
| baseline `target/baseline-buffer-methods.exe` | 19 | 19 | 20 | 0 | 3 | 58 |
| this branch `target/release/rts` | 28 | 19 | 11 | 0 | 3 | 58 |

Per-file comparison: **9 gained, 0 lost**. The rows and comparison were saved under `.node-suite/` locally for review; those generated files are ignored and are not part of this PR.

## Notes

The release build and the suite measurement were run serially where required by the repository's memory constraints. No tests were disabled, renamed, reduced, or special-cased.
