### PR TITLE
fix: implement Buffer byte swaps

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -48,6 +48,7 @@
 pub(in crate::entry) mod codec;
 pub(in crate::entry) mod ops;
 pub(in crate::entry) mod statics;
+pub(in crate::entry) mod swap;
 pub(in crate::entry) mod validate;
 
 use super::buffers::element::Kind;
@@ -184,6 +185,24 @@ impl Buffer {
     /// `buf.includes(value, byteOffset?, encoding?)`.
     fn includes(this: u64, value: u64, byte_offset: u64, encoding: u64) -> bool {
         ops::includes(this, value, byte_offset, encoding)
+    }
+
+    /// `buf.swap16()` — reverse each 16-bit word in place.
+    #[js("swap16")]
+    fn swap_16(this: u64) -> u64 {
+        swap::swap(this, 2)
+    }
+
+    /// `buf.swap32()` — reverse each 32-bit word in place.
+    #[js("swap32")]
+    fn swap_32(this: u64) -> u64 {
+        swap::swap(this, 4)
+    }
+
+    /// `buf.swap64()` — reverse each 64-bit word in place.
+    #[js("swap64")]
+    fn swap_64(this: u64) -> u64 {
+        swap::swap(this, 8)
     }
 
     /// `buf.toJSON()`.

--- a/crates/rts-core/src/entry/buffer/swap.rs
+++ b/crates/rts-core/src/entry/buffer/swap.rs
@@ -1,0 +1,27 @@
+//! In-place byte-order swaps for `Buffer` views.
+
+use super::super::buffers::{view_of, window_mut};
+use super::super::errors;
+use super::super::with_current;
+use super::validate;
+
+/// Reverse each fixed-width word in the current Buffer view, in place.
+pub(in crate::entry) fn swap(this: u64, width: usize) -> u64 {
+    let Some(count) = validate::bytes("buffer", this) else {
+        return this;
+    };
+    if count % width != 0 {
+        errors::invalid_buffer_size(width * 8);
+        return this;
+    }
+    with_current(|context| {
+        if let Some(view) = view_of(context, this)
+            && let Some(bytes) = window_mut(context, &view)
+        {
+            for word in bytes.chunks_exact_mut(width) {
+                word.reverse();
+            }
+        }
+        this
+    })
+}

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -152,6 +152,15 @@ pub fn buffer_out_of_bounds(name: Option<&str>) {
     raise("RangeError", "ERR_BUFFER_OUT_OF_BOUNDS", &message);
 }
 
+/// Raises `RangeError [ERR_INVALID_BUFFER_SIZE]` for a byte-swap width mismatch.
+pub fn invalid_buffer_size(bits: usize) {
+    raise(
+        "RangeError",
+        "ERR_INVALID_BUFFER_SIZE",
+        &format!("Buffer size must be a multiple of {bits}-bits"),
+    );
+}
+
 /// Builds an error of `class`, stamps `code` on it, and raises it.
 ///
 /// # Why the class name crosses as text


### PR DESCRIPTION
## Summary

This change adds `Buffer.prototype.swap16`, `swap32`, and `swap64`. Each method reverses fixed-width words in place over the current Buffer view, returns the same Buffer, and therefore works for slices and non-aligned views without touching bytes outside the view. Invalid view lengths raise Node's `ERR_INVALID_BUFFER_SIZE` diagnostic.

The implementation lives in a focused `buffer/swap.rs` module so the existing Buffer operations file remains within the repository's 500-line limit.

## Validation

The release binary passed `test-buffer-swap.js`, including in-place mutation, shared slices, 16/32/64-bit size checks, large buffers, and unaligned views. The serial fast gate passed for `rts-core`: 294 passed, 0 failed; doctests: 0 passed, 3 existing doctests ignored.

The official `buffer` corpus was measured with `JOBS=2` and `TIMEOUT=10` over 58 counted files plus 3 skipped internal-Node files:

| measurement | ok | fail | error | timeout | skipped | denominator |
|---|---:|---:|---:|---:|---:|---:|
| baseline `target/baseline-buffer-swap.exe` | 28 | 19 | 11 | 0 | 3 | 58 |
| this branch `target/release/rts` | 29 | 19 | 10 | 0 | 3 | 58 |

The per-file comparison is **1 gained, 0 lost**: `test-buffer-swap` changed from `error` to `ok`.

No tests were disabled, renamed, reduced, or special-cased.
