### PR TITLE
fix: add Buffer BigInt accessors

### DIFF
--- a/crates/rts-core/src/entry/buffer/bigint.rs
+++ b/crates/rts-core/src/entry/buffer/bigint.rs
@@ -1,0 +1,78 @@
+//! BigInt64 and BigUint64 accessors for Buffer views.
+
+use super::super::buffers::element::{self, Kind};
+use super::super::buffers::{view_of, window, window_mut};
+use super::super::errors;
+use super::super::objects::undefined_of;
+use super::super::with_current;
+use super::validate;
+
+/// Read one 64-bit BigInt word from the current Buffer view.
+pub(in crate::entry) fn read(this: u64, offset: u64, kind: Kind, little: bool) -> u64 {
+    let Some(count) = validate::bytes("buffer", this) else {
+        return super::super::buffers::undefined();
+    };
+    let Some(at) = validate::element_offset("offset", offset, count, kind.size()) else {
+        return super::super::buffers::undefined();
+    };
+    with_current(|context| {
+        let absent = undefined_of(context);
+        let Some(view) = view_of(context, this) else {
+            return absent;
+        };
+        let Some(bytes) = window(context, &view) else {
+            return absent;
+        };
+        let Some(word) = element::word_at(bytes, at, kind, little) else {
+            return absent;
+        };
+        super::super::buffers::bigint_value(context, word, kind)
+    })
+}
+
+/// Write one 64-bit BigInt word, rejecting non-BigInt and out-of-range values.
+pub(in crate::entry) fn write(
+    this: u64,
+    value: u64,
+    offset: u64,
+    kind: Kind,
+    little: bool,
+) -> f64 {
+    let Some(count) = validate::bytes("buffer", this) else {
+        return 0.0;
+    };
+    let Some(at) = validate::element_offset("offset", offset, count, kind.size()) else {
+        return 0.0;
+    };
+    let (word, lossy) = if kind == Kind::BigInt64 {
+        let Some((word, lossy)) = super::super::bigints::bigint_i64(value) else {
+            errors::invalid_bigint_type();
+            return 0.0;
+        };
+        (word as u64, lossy)
+    } else {
+        let Some((word, lossy)) = super::super::bigints::bigint_u64(value) else {
+            errors::invalid_bigint_type();
+            return 0.0;
+        };
+        (word, lossy)
+    };
+    if lossy {
+        let expected = if kind == Kind::BigInt64 {
+            ">= -(2n ** 63n) and < 2n ** 63n"
+        } else {
+            ">= 0n and < 2n ** 64n"
+        };
+        errors::out_of_range_bigint("value", expected, value);
+        return 0.0;
+    }
+    with_current(|context| {
+        let Some(view) = view_of(context, this) else {
+            return 0.0;
+        };
+        if let Some(bytes) = window_mut(context, &view) {
+            element::write_word(bytes, at, kind, word, little);
+        }
+        (at + kind.size()) as f64
+    })
+}

--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -45,6 +45,7 @@
 //! fourteen times over — see [`validate`], which also documents the borrow rule
 //! that decides their shape.
 
+pub(in crate::entry) mod bigint;
 pub(in crate::entry) mod codec;
 pub(in crate::entry) mod ops;
 pub(in crate::entry) mod statics;
@@ -192,6 +193,24 @@ impl Buffer {
     fn includes(this: u64, value: u64, byte_offset: u64, encoding: u64) -> bool {
         ops::includes(this, value, byte_offset, encoding)
     }
+
+    // BigInt64 and BigUint64 accessors share the dedicated word codec.
+    #[js("readBigInt64LE")]
+    fn read_big_int64_le(this: u64, offset: u64) -> u64 { bigint::read(this, offset, Kind::BigInt64, true) }
+    #[js("readBigInt64BE")]
+    fn read_big_int64_be(this: u64, offset: u64) -> u64 { bigint::read(this, offset, Kind::BigInt64, false) }
+    #[js("readBigUInt64LE")]
+    fn read_big_u_int64_le(this: u64, offset: u64) -> u64 { bigint::read(this, offset, Kind::BigUint64, true) }
+    #[js("readBigUInt64BE")]
+    fn read_big_u_int64_be(this: u64, offset: u64) -> u64 { bigint::read(this, offset, Kind::BigUint64, false) }
+    #[js("writeBigInt64LE")]
+    fn write_big_int64_le(this: u64, value: u64, offset: u64) -> f64 { bigint::write(this, value, offset, Kind::BigInt64, true) }
+    #[js("writeBigInt64BE")]
+    fn write_big_int64_be(this: u64, value: u64, offset: u64) -> f64 { bigint::write(this, value, offset, Kind::BigInt64, false) }
+    #[js("writeBigUInt64LE")]
+    fn write_big_u_int64_le(this: u64, value: u64, offset: u64) -> f64 { bigint::write(this, value, offset, Kind::BigUint64, true) }
+    #[js("writeBigUInt64BE")]
+    fn write_big_u_int64_be(this: u64, value: u64, offset: u64) -> f64 { bigint::write(this, value, offset, Kind::BigUint64, false) }
 
     /// `buf.swap16()` — reverse each 16-bit word in place.
     #[js("swap16")]
@@ -458,6 +477,10 @@ pub(in crate::entry) fn register_buffer_with_aliases(context: &mut Context) -> u
         ("writeUIntLE", "writeUintLE"),
         ("readUIntBE", "readUintBE"),
         ("writeUIntBE", "writeUintBE"),
+        ("readBigUInt64LE", "readBigUint64LE"),
+        ("writeBigUInt64LE", "writeBigUint64LE"),
+        ("readBigUInt64BE", "readBigUint64BE"),
+        ("writeBigUInt64BE", "writeBigUint64BE"),
     ] {
         let value = super::modules::get_member(context, prototype, upper);
         if value != super::modules::undefined_in(context) {

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -161,6 +161,42 @@ pub fn invalid_buffer_size(bits: usize) {
     );
 }
 
+/// Raises the TypeError used when a Buffer BigInt method receives another type.
+pub fn invalid_bigint_type() {
+    super::throw::type_error("Cannot mix BigInt and other types, use explicit conversions");
+}
+
+/// Raises a BigInt `RangeError [ERR_OUT_OF_RANGE]` with Node's `n` rendering.
+pub fn out_of_range_bigint(name: &str, expected: &str, actual: u64) {
+    let received = with_current(|context| {
+        super::bigints::digits_of(context, actual)
+            .map(|value| grouped_bigint(&value.to_decimal()))
+            .unwrap_or_else(|| String::from("undefined"))
+    });
+    raise(
+        "RangeError",
+        "ERR_OUT_OF_RANGE",
+        &format!(
+            "The value of \"{name}\" is out of range. It must be {expected}. Received {received}"
+        ),
+    );
+}
+
+/// Group a decimal BigInt magnitude in the presentation used by Node errors.
+fn grouped_bigint(decimal: &str) -> String {
+    let (sign, digits) = match decimal.strip_prefix('-') {
+        Some(digits) => ("-", digits),
+        None => ("", decimal),
+    };
+    let mut grouped = digits.to_owned();
+    let mut at = grouped.len().saturating_sub(3);
+    while at > 0 {
+        grouped.insert(at, '_');
+        at = at.saturating_sub(3);
+    }
+    format!("{sign}{grouped}n")
+}
+
 /// Builds an error of `class`, stamps `code` on it, and raises it.
 ///
 /// # Why the class name crosses as text


### PR DESCRIPTION
## Summary

This change exposes Buffer's eight 64-bit BigInt accessors: `readBigInt64LE/BE`, `readBigUInt64LE/BE`, `writeBigInt64LE/BE`, and `writeBigUInt64LE/BE`. Reads and writes reuse the shared word/endianness codec. Writes require a BigInt and reject values outside the signed or unsigned 64-bit range instead of inheriting typed-array wrapping. `BigUint` aliases are installed as the same callable as the canonical `BigUInt` methods.

## Validation

The release binary passed `test-buffer-bigint64.js` and the previously green `test-buffer-writeuint.js`.

The serial fast gate passed for `rts-core`: 294 passed, 0 failed; doctests: 0 passed, 3 existing doctests ignored.

The official `buffer` corpus was measured with `JOBS=2` and `TIMEOUT=10` over 58 counted files plus 3 skipped internal-Node files:

| measurement | ok | fail | error | timeout | skipped | denominator |
|---|---:|---:|---:|---:|---:|---:|
| baseline `target/baseline-buffer-bigint.exe` | 30 | 19 | 9 | 0 | 3 | 58 |
| this branch `target/release/rts` | 31 | 19 | 8 | 0 | 3 | 58 |

The per-file comparison is **1 gained, 0 lost**: `test-buffer-bigint64` changed from `error` to `ok`.

An intermediate release measurement exposed a regression in the existing `UInt`/`Uint` identity test because the new canonical `BigUInt` methods made the previously-absent `BigUint` aliases observable. The alias list was extended to cover those four pairs; the final release measurement has no loss.

No tests were disabled, renamed, reduced, or special-cased.
