### PR TITLE
fix: support SlowBuffer and Buffer inspection

### DIFF
--- a/crates/rts-node/src/buffer/mod.rs
+++ b/crates/rts-node/src/buffer/mod.rs
@@ -80,6 +80,7 @@ pub fn namespace(context: &mut Context) -> u64 {
         ("transcode", transcode),
         ("isAscii", is_ascii),
         ("isUtf8", is_utf8),
+        ("SlowBuffer", slow_buffer_native),
         ("resolveObjectURL", resolve_object_url),
     ];
     let namespace = entry::make_namespace(context, members);
@@ -220,6 +221,23 @@ extern "C" fn is_utf8(_e: u64, _this: u64, input: u64, _b: u64, _c: u64, _d: u64
 /// module doc.
 fn bytes_argument(input: u64) -> Option<Vec<u8>> {
     entry::with_runtime(|context| entry::bytes_of(context, input))
+}
+
+/// The legacy `buffer.SlowBuffer(size)` factory.
+extern "C" fn slow_buffer_native(
+    _e: u64,
+    _this: u64,
+    size: u64,
+    _a1: u64,
+    _a2: u64,
+    _a3: u64,
+) -> u64 {
+    let buffer = entry::with_runtime(|context| entry::buffer_class(context));
+    let alloc_unsafe = entry::with_runtime(|context| {
+        entry::get_member(context, buffer, "allocUnsafe")
+    });
+    let absent = entry::undefined_value();
+    entry::call(alloc_unsafe, buffer, size, absent, absent, absent)
 }
 
 /// `buffer.resolveObjectURL(id)` — always `undefined`, and totally correct

--- a/crates/rts-node/src/util/inspect.rs
+++ b/crates/rts-node/src/util/inspect.rs
@@ -59,7 +59,7 @@ impl Default for Options {
 
 impl Options {
     /// The same options one level deeper in.
-    fn inner(self) -> Self {
+    pub(super) fn inner(self) -> Self {
         Self { depth: self.depth.saturating_sub(1), ..self }
     }
 }
@@ -128,6 +128,9 @@ pub(super) fn format_value(value: u64, options: Options, seen: &mut Vec<u64>) ->
     }
     if value == entry::null_value() {
         return "null".to_owned();
+    }
+    if let Some(rendered) = super::inspect_buffer::format(value, options, seen) {
+        return rendered;
     }
     match kind_of(value).as_str() {
         "string" => quoted(&string_of(value).unwrap_or_default()),
@@ -223,7 +226,7 @@ fn format_members(value: u64, options: Options, seen: &mut Vec<u64>) -> String {
 /// A property name as Node writes it: bare when it is an identifier, quoted
 /// otherwise, so `{ "a b": 1 }` does not print as something that would not
 /// parse back.
-fn key_text(key: &str) -> String {
+pub(super) fn key_text(key: &str) -> String {
     let identifier = !key.is_empty()
         && !key.starts_with(|c: char| c.is_ascii_digit())
         && key.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$');
@@ -234,7 +237,7 @@ fn key_text(key: &str) -> String {
 }
 
 /// Entries between their brackets, with Node's inner spacing.
-fn wrapped(open: char, close: char, parts: &[String]) -> String {
+pub(super) fn wrapped(open: char, close: char, parts: &[String]) -> String {
     match parts.is_empty() {
         true => format!("{open}{close}"),
         false => format!("{open} {} {close}", parts.join(", ")),

--- a/crates/rts-node/src/util/inspect_buffer.rs
+++ b/crates/rts-node/src/util/inspect_buffer.rs
@@ -1,0 +1,75 @@
+//! Byte-view formatting for `util.inspect`.
+
+use rts_core::entry;
+
+use super::inspect::{self, Options};
+use super::values::{get, number_of, own_key_strings, string_of};
+
+/// Format a Buffer or Uint8Array, or leave other objects to the structural walk.
+pub(super) fn format(value: u64, options: Options, seen: &mut Vec<u64>) -> Option<String> {
+    let name = constructor_name(value)?;
+    match name.as_str() {
+        "Buffer" => format_buffer(value, options, seen),
+        "Uint8Array" => format_uint8_array(value),
+        _ => None,
+    }
+}
+
+/// Node's `<Buffer …>` representation, including user-defined properties.
+fn format_buffer(value: u64, options: Options, seen: &mut Vec<u64>) -> Option<String> {
+    let bytes = entry::with_runtime(|context| entry::bytes_of(context, value))?;
+    if seen.contains(&value) {
+        return Some("[Circular]".to_owned());
+    }
+    seen.push(value);
+    let limit = inspect_max_bytes();
+    let shown = bytes.len().min(limit);
+    let mut parts: Vec<String> = bytes[..shown]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    if bytes.len() > shown {
+        parts.push(format!("... {} more bytes", bytes.len() - shown));
+    }
+    let mut rendered = format!("<Buffer {}", parts.join(" "));
+    let extras = own_key_strings(value)
+        .into_iter()
+        .filter(|key| !internal_key(key) && key.parse::<usize>().is_err())
+        .map(|key| format!("{}: {}", inspect::key_text(&key), inspect::format_value(get(value, &key), options.inner(), seen)))
+        .collect::<Vec<_>>();
+    if !extras.is_empty() {
+        if !parts.is_empty() {
+            rendered.push_str(", ");
+        }
+        rendered.push_str(&extras.join(", "));
+    }
+    rendered.push('>');
+    seen.pop();
+    Some(rendered)
+}
+
+/// Node's typed-array spelling for the Uint8Array values used as Buffer extras.
+fn format_uint8_array(value: u64) -> Option<String> {
+    let bytes = entry::with_runtime(|context| entry::bytes_of(context, value))?;
+    let parts = bytes.iter().map(|byte| byte.to_string()).collect::<Vec<_>>();
+    Some(format!("Uint8Array({}) {}", bytes.len(), inspect::wrapped('[', ']', &parts)))
+}
+
+/// Read the mutable limit exposed by `node:buffer`.
+fn inspect_max_bytes() -> usize {
+    let namespace = entry::with_runtime(|context| entry::module_at_name(context, "node:buffer"));
+    match number_of(get(namespace, "INSPECT_MAX_BYTES")) {
+        Some(value) if value.is_infinite() && value.is_sign_positive() => usize::MAX,
+        Some(value) if value.is_finite() && value >= 0.0 => value as usize,
+        _ => 50,
+    }
+}
+
+/// Metadata installed on every Buffer view, not user-defined properties.
+fn internal_key(key: &str) -> bool {
+    matches!(key, "byteLength" | "byteOffset" | "length" | "buffer" | "parent")
+}
+
+fn constructor_name(value: u64) -> Option<String> {
+    string_of(get(get(value, "constructor"), "name"))
+}

--- a/crates/rts-node/src/util/inspect_buffer.rs
+++ b/crates/rts-node/src/util/inspect_buffer.rs
@@ -35,7 +35,13 @@ fn format_buffer(value: u64, options: Options, seen: &mut Vec<u64>) -> Option<St
     let extras = own_key_strings(value)
         .into_iter()
         .filter(|key| !internal_key(key) && key.parse::<usize>().is_err())
-        .map(|key| format!("{}: {}", inspect::key_text(&key), inspect::format_value(get(value, &key), options.inner(), seen)))
+        .map(|key| {
+            format!(
+                "{}: {}",
+                inspect::key_text(&key),
+                inspect::format_value(get(value, &key), options.inner(), seen)
+            )
+        })
         .collect::<Vec<_>>();
     if !extras.is_empty() {
         if !parts.is_empty() {
@@ -51,8 +57,15 @@ fn format_buffer(value: u64, options: Options, seen: &mut Vec<u64>) -> Option<St
 /// Node's typed-array spelling for the Uint8Array values used as Buffer extras.
 fn format_uint8_array(value: u64) -> Option<String> {
     let bytes = entry::with_runtime(|context| entry::bytes_of(context, value))?;
-    let parts = bytes.iter().map(|byte| byte.to_string()).collect::<Vec<_>>();
-    Some(format!("Uint8Array({}) {}", bytes.len(), inspect::wrapped('[', ']', &parts)))
+    let parts = bytes
+        .iter()
+        .map(|byte| byte.to_string())
+        .collect::<Vec<_>>();
+    Some(format!(
+        "Uint8Array({}) {}",
+        bytes.len(),
+        inspect::wrapped('[', ']', &parts)
+    ))
 }
 
 /// Read the mutable limit exposed by `node:buffer`.
@@ -67,7 +80,10 @@ fn inspect_max_bytes() -> usize {
 
 /// Metadata installed on every Buffer view, not user-defined properties.
 fn internal_key(key: &str) -> bool {
-    matches!(key, "byteLength" | "byteOffset" | "length" | "buffer" | "parent")
+    matches!(
+        key,
+        "byteLength" | "byteOffset" | "length" | "buffer" | "parent"
+    )
 }
 
 fn constructor_name(value: u64) -> Option<String> {

--- a/crates/rts-node/src/util/mod.rs
+++ b/crates/rts-node/src/util/mod.rs
@@ -164,6 +164,7 @@ mod args;
 mod call_site;
 mod equal;
 mod inspect;
+mod inspect_buffer;
 mod legacy;
 mod promisify;
 mod signals;


### PR DESCRIPTION
## Summary

This change adds the legacy `buffer.SlowBuffer(size)` factory without creating a second Buffer class. The native factory delegates to the existing `Buffer.allocUnsafe` implementation, preserving Buffer instances and the size-validation behavior for omitted, invalid, and out-of-range sizes.

It also gives `util.inspect` the byte-view formatting that Node uses for Buffer and Uint8Array values. Buffer output reads the live `buffer.INSPECT_MAX_BYTES` value, prints hexadecimal bytes, preserves user-defined properties, and omits internal view metadata. Uint8Array values use the `Uint8Array(length) [ ... ]` form, including when nested as a custom Buffer property.

## Validation

The serial fast gate passed for `rts-node`: 90 passed, 0 failed; 3 existing ignored tests.

The release binary passed both dedicated tests:

- `test-buffer-slow.js`
- `test-buffer-inspect.js`

The official `buffer` corpus was measured with `JOBS=2` and `TIMEOUT=10` over 58 counted files plus 3 skipped internal-Node files:

| measurement | ok | fail | error | timeout | skipped | denominator |
|---|---:|---:|---:|---:|---:|---:|
| baseline `target/baseline-buffer-slow.exe` | 31 | 19 | 8 | 0 | 3 | 58 |
| this branch `target/release/rts` | 33 | 19 | 6 | 0 | 3 | 58 |

The per-file comparison is **2 gained, 0 lost**:

- `test-buffer-slow`: `error` → `ok`
- `test-buffer-inspect`: `error` → `ok`

No tests were disabled, renamed, reduced, or special-cased. The full formatter file remains below the 500-line ceiling; the new `inspect_buffer.rs` module is 91 lines.
