### PR TITLE
fix: align Buffer.toString ranges and errors

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -49,6 +49,7 @@ pub(in crate::entry) mod bigint;
 pub(in crate::entry) mod codec;
 pub(in crate::entry) mod ops;
 pub(in crate::entry) mod statics;
+pub(in crate::entry) mod string;
 pub(in crate::entry) mod swap;
 pub(in crate::entry) mod validate;
 
@@ -146,7 +147,7 @@ impl Buffer {
 
     /// `buf.toString(encoding?, start?, end?)`.
     fn to_string(this: u64, encoding: u64, start: u64, end: u64) -> u64 {
-        ops::to_string(this, encoding, start, end)
+        string::to_string(this, encoding, start, end)
     }
 
     /// `buf.write(string, offset?, length?, encoding?)`.

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -156,26 +156,6 @@ pub(in crate::entry) fn pattern_of(context: &Context, value: u64, encoding: &str
 // Instance methods
 // ---------------------------------------------------------------------------
 
-/// `buf.toString(encoding?, start?, end?)`.
-pub(in crate::entry) fn to_string(this: u64, encoding: u64, start: u64, end: u64) -> u64 {
-    // The encoding is the only argument Node refuses here: `start` and `end` are
-    // defined to clamp, so `buf.toString('utf8', 0, 99)` is an answer and not a
-    // mistake. `buf.toString('nope')` is `ERR_UNKNOWN_ENCODING`.
-    let Some(enc) = validate::encoding(encoding) else {
-        return undefined();
-    };
-    let start = optional_number(start);
-    let end = optional_number(end);
-    with_current(|context| {
-        let absent = undefined_of(context);
-        let Some(view) = view_of(context, this) else { return absent };
-        let Some(bytes) = window(context, &view) else { return absent };
-        let (first, last) = range(bytes.len(), start, end);
-        let text = codec::decode(&bytes[first..last], &enc);
-        context.intern_value(crate::text::Str::from_str(&text)).bits()
-    })
-}
-
 /// `buf.write(string, offset?, length?, encoding?)`.
 ///
 /// # The two-argument form, and why a string `offset` is not always one

--- a/crates/rts-core/src/entry/buffer/string.rs
+++ b/crates/rts-core/src/entry/buffer/string.rs
@@ -1,0 +1,118 @@
+//! The string-facing half of `Buffer`.
+//!
+//! `Buffer.toString` looks like another range operation, but its bounds are not
+//! the bounds of `slice`: negative values clamp to zero instead of counting from
+//! the end. Reusing [`super::super::buffers::range`] therefore makes a negative
+//! start select the final bytes, which is a different API contract. The helper
+//! below keeps that deliberate distinction local rather than weakening the
+//! shared slice/subarray rule.
+//!
+//! Its encoding argument also has a separate contract. Node converts a supplied
+//! value with the string hint before looking up a codec, so an object can provide
+//! `toString()`, while `Buffer.from` and allocation APIs continue to use the
+//! strict validator in [`super::validate`].
+
+use super::super::buffers::{optional_number, undefined, view_of, window};
+use super::super::errors;
+use super::super::objects::undefined_of;
+use super::super::with_current;
+use super::codec;
+use crate::coerce::Hint;
+use crate::value::Value;
+
+/// `buf.toString(encoding?, start?, end?)`.
+pub(in crate::entry) fn to_string(this: u64, encoding: u64, start: u64, end: u64) -> u64 {
+    let Some(enc) = encoding_arg(encoding) else {
+        return undefined();
+    };
+    let start = optional_number(start);
+    if super::super::throw::in_flight() {
+        return undefined();
+    }
+    let end = optional_number(end);
+    if super::super::throw::in_flight() {
+        return undefined();
+    }
+    with_current(|context| {
+        let absent = undefined_of(context);
+        let Some(view) = view_of(context, this) else {
+            return absent;
+        };
+        let Some(bytes) = window(context, &view) else {
+            return absent;
+        };
+        let (first, last) = absolute_range(bytes.len(), start, end);
+        let text = codec::decode(&bytes[first..last], &enc);
+        context
+            .intern_value(crate::text::Str::from_str(&text))
+            .bits()
+    })
+}
+
+/// A `toString` encoding, with Node's string-hint coercion and error split.
+fn encoding_arg(value: u64) -> Option<String> {
+    let raw = if value == undefined() {
+        return Some("utf8".to_owned());
+    } else {
+        value
+    };
+    let primitive = super::super::primitive::to_primitive(raw, Hint::String);
+    if super::super::throw::in_flight() {
+        return None;
+    }
+    let name = with_current(|context| {
+        super::super::text::to_text(context, Value(primitive)).and_then(|text| text.to_rust())
+    });
+    let Some(name) = name else {
+        super::super::throw::type_error("Cannot convert a Symbol value to a string");
+        return None;
+    };
+    match codec::canonical_encoding(&name) {
+        Some(canonical) => Some(canonical.to_owned()),
+        None => {
+            errors::unknown_encoding(&name);
+            None
+        }
+    }
+}
+
+/// Clamp `start` and `end` as absolute byte positions.
+fn absolute_range(count: usize, start: Option<f64>, end: Option<f64>) -> (usize, usize) {
+    let first = absolute_index(start.unwrap_or(0.0), count);
+    let last = match end {
+        Some(value) => absolute_index(value, count),
+        None => count,
+    };
+    if last < first {
+        (first, first)
+    } else {
+        (first, last)
+    }
+}
+
+/// `ToIntegerOrInfinity`, followed by an absolute clamp into the view.
+fn absolute_index(value: f64, count: usize) -> usize {
+    if value.is_nan() || value == f64::NEG_INFINITY {
+        return 0;
+    }
+    if value == f64::INFINITY {
+        return count;
+    }
+    value.trunc().max(0.0).min(count as f64) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::absolute_range;
+
+    #[test]
+    fn to_string_bounds_are_absolute_and_empty_when_end_precedes_start() {
+        assert_eq!(absolute_range(3, Some(-1.0), Some(3.0)), (0, 3));
+        assert_eq!(absolute_range(3, Some(1.0), Some(-1.2)), (1, 1));
+        assert_eq!(
+            absolute_range(3, Some(f64::NAN), Some(f64::INFINITY)),
+            (0, 3)
+        );
+        assert_eq!(absolute_range(3, Some(f64::INFINITY), None), (3, 3));
+    }
+}

--- a/crates/rts-core/src/entry/error.rs
+++ b/crates/rts-core/src/entry/error.rs
@@ -252,6 +252,10 @@ fn written(this: u64, message: u64, class: &'static str) -> u64 {
             let value = context.intern_value(text).bits();
             let key = context.well_known("message");
             super::objects::put(context, cell, key, value);
+            // Node exposes `message` as an own property, but not as an enumerable
+            // one. Keeping the data property and changing only its attributes
+            // preserves ordinary reads while making `Object.keys(error)` agree.
+            super::native::hidden(context, cell, key);
         }
 
         // `.stack`, captured HERE — where the error is CONSTRUCTED, not where it
@@ -270,6 +274,7 @@ fn written(this: u64, message: u64, class: &'static str) -> u64 {
         let value = context.intern_value(crate::text::Str::from_str(&stack)).bits();
         let key = context.well_known("stack");
         super::objects::put(context, cell, key, value);
+        super::native::hidden(context, cell, key);
 
         Value::from_slot(cell).bits()
     })


### PR DESCRIPTION
## Summary

- Move `Buffer.toString` into a focused module with absolute start/end clamping. Negative starts now clamp to zero instead of counting from the end.
- Coerce supplied encodings with the string hint before codec canonicalization, while preserving strict validation for other Buffer APIs.
- Mark Error `message` and `stack` own properties non-enumerable, matching Node error descriptors and `common.expectsError`.

## Validation

- `CARGO_BUILD_JOBS=1 cargo test --profile fast --no-fail-fast -p rts-core`: 295 passed, 0 failed.
- `CARGO_BUILD_JOBS=1 cargo build --release -j 1`: passed.
- Buffer corpus: baseline 35/58 ok; new 36/58 ok. Per-file comparison: 1 gained, 0 lost. Gained: `test-buffer-tostring.js`.
- `test-buffer-tostring-range.js` basic assertions pass; the full file reaches the existing 4 GiB allocation limitation.
- `test-buffer-includes.js` and `test-buffer-slice.js` pass unchanged. `test-buffer-write.js` remains a pre-existing message-format failure.

## Scope note

The large-buffer allocation/string-length contract is intentionally not masked with a smaller public constant. The current dense byte store needs a separate representation design for the 4 GiB range and `ERR_STRING_TOO_LONG` tests.