### PR TITLE
fix: align Buffer write and copy semantics

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -52,6 +52,7 @@ pub(in crate::entry) mod statics;
 pub(in crate::entry) mod string;
 pub(in crate::entry) mod swap;
 pub(in crate::entry) mod validate;
+pub(in crate::entry) mod write;
 
 use super::buffers::element::Kind;
 use super::buffers::uint8_array;
@@ -488,5 +489,6 @@ pub(in crate::entry) fn register_buffer_with_aliases(context: &mut Context) -> u
             super::modules::put_member(context, prototype, lower, value);
         }
     }
+    write::install_aliases(context, prototype);
     constructor
 }

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -24,9 +24,8 @@
 
 use super::super::buffers::element::Kind;
 use super::super::buffers::{
-    View, as_count, optional_number, range, undefined, view_of, window, window_mut,
+    View, as_count, optional_number, range, view_of, window, window_mut,
 };
-use super::super::errors;
 use super::super::objects::undefined_of;
 use super::super::{Context, native, with_current};
 use super::codec;
@@ -157,53 +156,8 @@ pub(in crate::entry) fn pattern_of(context: &Context, value: u64, encoding: &str
 // ---------------------------------------------------------------------------
 
 /// `buf.write(string, offset?, length?, encoding?)`.
-///
-/// # The two-argument form, and why a string `offset` is not always one
-///
-/// `buf.write(string, encoding)` is legal — Node reads a string second argument
-/// as the encoding. What it does NOT allow is that shorthand with anything after
-/// it: `buf.write('o', '1', 'ascii')` and `buf.write('test', 'utf8', 0)` are both
-/// `ERR_INVALID_ARG_TYPE`, because the caller has now given an encoding twice or
-/// a length after an offset that is not one. Both are in `test-buffer-alloc.js`,
-/// and both used to be accepted here — the string coerced to an offset of 0 and
-/// the write silently landed at the start of the buffer.
 pub(in crate::entry) fn write(this: u64, string: u64, offset: u64, length: u64, encoding: u64) -> f64 {
-    let Some(count) = validate::bytes("source", this) else { return 0.0 };
-    let Shape::Text(text) = validate::shape_of(string) else {
-        errors::invalid_arg_type("string", "string", string);
-        return 0.0;
-    };
-    let shorthand = matches!(validate::shape_of(offset), Shape::Text(_));
-    let (offset, encoding) = match shorthand {
-        true => {
-            let trailing = !matches!(validate::shape_of(length), Shape::Absent)
-                || !matches!(validate::shape_of(encoding), Shape::Absent);
-            if trailing {
-                errors::invalid_arg_type("offset", "number", offset);
-                return 0.0;
-            }
-            (undefined(), offset)
-        }
-        false => (offset, encoding),
-    };
-    let Some(enc) = validate::encoding(encoding) else { return 0.0 };
-    let Some(start) = validate::offset("offset", offset, count) else { return 0.0 };
-    let cap = match validate::shape_of(length) {
-        Shape::Absent => count - start,
-        _ => match validate::offset("length", length, count - start) {
-            Some(length) => length,
-            None => return 0.0,
-        },
-    };
-    with_current(|context| {
-        let Some(view) = view_of(context, this) else { return 0.0 };
-        let bytes = codec::encode(&text, &enc).unwrap_or_default();
-        let count = bytes.len().min(cap).min(view.count() - start);
-        if let Some(destination) = window_mut(context, &view) {
-            destination[start..start + count].copy_from_slice(&bytes[..count]);
-        }
-        count as f64
-    })
+    super::write::write(this, string, offset, length, encoding)
 }
 
 /// `buf.slice(begin?, end?)` / `buf.subarray(begin?, end?)` — a Buffer
@@ -260,15 +214,15 @@ pub(in crate::entry) fn copy(this: u64, target: u64, target_start: u64, source_s
     // not ask about first.
     let Some(source_len) = validate::bytes("source", this) else { return 0.0 };
     let Some(target_len) = validate::bytes("target", target) else { return 0.0 };
-    let Some(target_at) = validate::offset("targetStart", target_start, target_len) else {
+    let Some(target_at) = validate::copy_target(target_start, target_len) else {
         return 0.0;
     };
-    let Some(source_at) = validate::offset("sourceStart", source_start, source_len) else {
+    let Some(source_at) = validate::copy_source_start(source_start, source_len) else {
         return 0.0;
     };
     let source_to = match validate::shape_of(source_end) {
         Shape::Absent => source_len,
-        _ => match validate::offset("sourceEnd", source_end, source_len) {
+        _ => match validate::copy_source_end(source_end, source_len) {
             Some(at) => at,
             None => return 0.0,
         },

--- a/crates/rts-core/src/entry/buffer/validate.rs
+++ b/crates/rts-core/src/entry/buffer/validate.rs
@@ -149,23 +149,79 @@ fn integer_offset(name: &str, value: u64) -> Option<f64> {
     Some(number)
 }
 
-/// A position inside a buffer: every `read*`/`write*` offset, and `buf.write`'s.
+/// A `Buffer.write` offset or length, whose public message uses `&&`.
 ///
-/// `limit` is the largest offset that is still inside — the caller subtracts the
-/// width of what it is about to read, because "offset 3 of a 4-byte buffer" is
-/// fine for a `UInt8` and out of range for a `UInt16`, and only the caller knows
-/// which.
-///
-/// An absent offset is `0`, which is what Node documents and what
-/// `test-buffer-readuint.js` asserts explicitly for both `undefined` and no
-/// argument at all.
-pub(in crate::entry) fn offset(name: &str, value: u64, limit: usize) -> Option<usize> {
+/// The generic offset validator cannot change spelling: `copy` and the legacy
+/// numeric readers expose the older `and` wording, and their tests match it.
+/// Keeping this one operation-specific avoids making a shared validator answer
+/// two observable contracts.
+pub(in crate::entry) fn write_offset(name: &str, value: u64, limit: usize) -> Option<usize> {
     let number = integer_offset(name, value)?;
     if !number.is_finite() || number < 0.0 || number > limit as f64 {
-        errors::out_of_range(name, &format!(">= 0 and <= {limit}"), value);
+        errors::out_of_range(name, &format!(">= 0 && <= {limit}"), value);
         return None;
     }
     Some(number as usize)
+}
+
+/// A bound for the legacy `asciiWrite`/`latin1Write`/`utf8Write` methods.
+///
+/// These methods predate `Buffer.write` and report a bounds error for an
+/// invalid offset rather than the newer numeric range diagnostic. Their length
+/// still clamps at the remaining capacity, which is why the two cases stay
+/// separate below.
+pub(in crate::entry) fn legacy_offset(name: &str, value: u64, limit: usize) -> Option<usize> {
+    let number = integer_offset(name, value)?;
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
+        errors::buffer_out_of_bounds(Some(name));
+        return None;
+    }
+    Some(number as usize)
+}
+
+pub(in crate::entry) fn legacy_length(value: u64, limit: usize) -> Option<usize> {
+    let number = integer_offset("length", value)?;
+    if !number.is_finite() || number < 0.0 {
+        errors::buffer_out_of_bounds(Some("length"));
+        return None;
+    }
+    Some((number as usize).min(limit))
+}
+
+/// `Buffer.copy` uses JavaScript number coercion for its range arguments.
+fn copy_integer(value: u64) -> Option<f64> {
+    let number = super::super::class_support::to_number(value);
+    if super::super::throw::in_flight() {
+        return None;
+    }
+    Some(if number.is_nan() { 0.0 } else { number.trunc() })
+}
+
+pub(in crate::entry) fn copy_target(value: u64, limit: usize) -> Option<usize> {
+    let number = copy_integer(value)?;
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
+        errors::out_of_range("targetStart", ">= 0", value);
+        return None;
+    }
+    Some(number as usize)
+}
+
+pub(in crate::entry) fn copy_source_start(value: u64, limit: usize) -> Option<usize> {
+    let number = copy_integer(value)?;
+    if !number.is_finite() || number < 0.0 || number > limit as f64 {
+        errors::out_of_range("sourceStart", &format!(">= 0 && <= {limit}"), value);
+        return None;
+    }
+    Some(number as usize)
+}
+
+pub(in crate::entry) fn copy_source_end(value: u64, limit: usize) -> Option<usize> {
+    let number = copy_integer(value)?;
+    if !number.is_finite() || number < 0.0 {
+        errors::out_of_range("sourceEnd", ">= 0", value);
+        return None;
+    }
+    Some((number as usize).min(limit))
 }
 
 /// An argument that must be a `Buffer` or a `Uint8Array` — `compare`'s target,
@@ -226,7 +282,9 @@ pub(in crate::entry) fn element_offset(
 /// classification is a second borrow, which is what the module doc forbids.
 pub(in crate::entry) fn source(name: &str, value: u64) -> Option<Shape> {
     match shape_of(value) {
-        found @ (Shape::Text(_) | Shape::List(_) | Shape::Bytes(_) | Shape::ArrayBuffer) => Some(found),
+        found @ (Shape::Text(_) | Shape::List(_) | Shape::Bytes(_) | Shape::ArrayBuffer) => {
+            Some(found)
+        }
         _ => {
             errors::invalid_arg_type(
                 name,
@@ -331,7 +389,10 @@ pub(in crate::entry) fn variable_offset(value: u64, count: usize, width: usize) 
 pub(in crate::entry) fn variable_fits(value: f64, width: usize, signed: bool) -> bool {
     let bits = (width * 8) as u32;
     let (low, high) = if signed {
-        (-(2f64.powi(bits as i32 - 1)), 2f64.powi(bits as i32 - 1) - 1.0)
+        (
+            -(2f64.powi(bits as i32 - 1)),
+            2f64.powi(bits as i32 - 1) - 1.0,
+        )
     } else {
         (0.0, 2f64.powi(bits as i32) - 1.0)
     };
@@ -363,7 +424,10 @@ pub(in crate::entry) fn fits(kind: Kind, value: f64) -> bool {
         return true;
     };
     let (low, high) = match signed {
-        true => (-(2f64.powi(bits as i32 - 1)), 2f64.powi(bits as i32 - 1) - 1.0),
+        true => (
+            -(2f64.powi(bits as i32 - 1)),
+            2f64.powi(bits as i32 - 1) - 1.0,
+        ),
         false => (0.0, 2f64.powi(bits as i32) - 1.0),
     };
     if value >= low && value <= high {
@@ -371,6 +435,10 @@ pub(in crate::entry) fn fits(kind: Kind, value: f64) -> bool {
     }
     // The raw bits back, so the message renders the number the program passed
     // rather than a re-parse of it.
-    errors::out_of_range("value", &format!(">= {low} and <= {high}"), Value::from_f64(value).bits());
+    errors::out_of_range(
+        "value",
+        &format!(">= {low} and <= {high}"),
+        Value::from_f64(value).bits(),
+    );
     false
 }

--- a/crates/rts-core/src/entry/buffer/write.rs
+++ b/crates/rts-core/src/entry/buffer/write.rs
@@ -1,0 +1,157 @@
+//! Buffer string writes, including the three legacy encoding-specific methods.
+//!
+//! The modern `write` overload and the legacy `asciiWrite`/`latin1Write`/
+//! `utf8Write` methods share the final byte-copy step. Their argument rules stay
+//! separate because the modern method reports numeric range errors while the
+//! legacy methods report buffer-bounds errors and clamp an oversized length.
+
+use super::super::buffers::{undefined, view_of, window_mut};
+use super::super::errors;
+use super::super::{Context, native, with_current};
+use super::codec;
+use super::validate::{self, Shape};
+use crate::value::Value;
+
+/// Install the legacy encoding-specific methods on `Buffer.prototype`.
+pub(in crate::entry) fn install_aliases(context: &mut Context, prototype: u64) {
+    let Some(cell) = Value(prototype).as_slot() else {
+        return;
+    };
+    native::install_with_arity(
+        context,
+        cell,
+        &[
+            ("asciiWrite", ascii_write, 1),
+            ("latin1Write", latin1_write, 1),
+            ("utf8Write", utf8_write, 1),
+        ],
+    );
+}
+
+/// `buf.write(string, offset?, length?, encoding?)`.
+pub(in crate::entry) fn write(
+    this: u64,
+    string: u64,
+    offset: u64,
+    length: u64,
+    encoding: u64,
+) -> f64 {
+    let Some(count) = validate::bytes("source", this) else {
+        return 0.0;
+    };
+    let Shape::Text(text) = validate::shape_of(string) else {
+        errors::invalid_arg_type("string", "string", string);
+        return 0.0;
+    };
+    let shorthand = matches!(validate::shape_of(offset), Shape::Text(_));
+    let (offset, length, encoding) = match shorthand {
+        true => {
+            let trailing = !matches!(validate::shape_of(length), Shape::Absent)
+                || !matches!(validate::shape_of(encoding), Shape::Absent);
+            if trailing {
+                errors::invalid_arg_type("offset", "number", offset);
+                return 0.0;
+            }
+            (undefined(), length, offset)
+        }
+        false
+            if matches!(validate::shape_of(length), Shape::Text(_))
+                && matches!(validate::shape_of(encoding), Shape::Absent) =>
+        {
+            (offset, undefined(), length)
+        }
+        false => (offset, length, encoding),
+    };
+    let Some(enc) = validate::encoding(encoding) else {
+        return 0.0;
+    };
+    let Some(start) = validate::write_offset("offset", offset, count) else {
+        return 0.0;
+    };
+    let cap = match validate::shape_of(length) {
+        Shape::Absent => count - start,
+        _ => match validate::write_offset("length", length, count - start) {
+            Some(length) => length,
+            None => return 0.0,
+        },
+    };
+    write_bytes(this, &text, start, cap, &enc)
+}
+
+/// The ABI entry point for `Buffer.prototype.asciiWrite`.
+pub(in crate::entry) extern "C" fn ascii_write(
+    _e: u64,
+    this: u64,
+    string: u64,
+    offset: u64,
+    length: u64,
+    _a3: u64,
+) -> u64 {
+    legacy_write(this, string, offset, length, "ascii").to_bits()
+}
+
+/// The ABI entry point for `Buffer.prototype.latin1Write`.
+pub(in crate::entry) extern "C" fn latin1_write(
+    _e: u64,
+    this: u64,
+    string: u64,
+    offset: u64,
+    length: u64,
+    _a3: u64,
+) -> u64 {
+    legacy_write(this, string, offset, length, "latin1").to_bits()
+}
+
+/// The ABI entry point for `Buffer.prototype.utf8Write`.
+pub(in crate::entry) extern "C" fn utf8_write(
+    _e: u64,
+    this: u64,
+    string: u64,
+    offset: u64,
+    length: u64,
+    _a3: u64,
+) -> u64 {
+    legacy_write(this, string, offset, length, "utf8").to_bits()
+}
+
+fn legacy_write(this: u64, string: u64, offset: u64, length: u64, encoding: &str) -> f64 {
+    let Some(count) = validate::bytes("source", this) else {
+        return 0.0;
+    };
+    let Shape::Text(text) = validate::shape_of(string) else {
+        errors::invalid_arg_type("string", "string", string);
+        return 0.0;
+    };
+    let start = match validate::shape_of(offset) {
+        Shape::Absent => 0,
+        _ => match validate::legacy_offset("offset", offset, count) {
+            Some(start) => start,
+            None => return 0.0,
+        },
+    };
+    let cap = match validate::shape_of(length) {
+        Shape::Absent => count - start,
+        _ => match validate::legacy_length(length, count - start) {
+            Some(length) => length,
+            None => return 0.0,
+        },
+    };
+    write_bytes(this, &text, start, cap, encoding)
+}
+
+fn write_bytes(this: u64, text: &str, start: usize, cap: usize, encoding: &str) -> f64 {
+    with_current(|context| {
+        let Some(view) = view_of(context, this) else {
+            return 0.0;
+        };
+        let bytes = codec::encode(text, encoding).unwrap_or_default();
+        let mut count = bytes.len().min(cap).min(view.count() - start);
+        if encoding == "utf16le" {
+            count -= count % 2;
+        }
+        if let Some(destination) = window_mut(context, &view) {
+            destination[start..start + count].copy_from_slice(&bytes[..count]);
+        }
+        count as f64
+    })
+}


### PR DESCRIPTION
## Summary

- Add the legacy `asciiWrite`, `latin1Write`, and `utf8Write` prototype methods with Node-compatible bounds errors and arity.
- Share the byte-copy implementation with `Buffer.write`, including UTF-16 code-unit alignment and the supported `write(string, encoding)` overload.
- Coerce `Buffer.copy` range arguments through JavaScript number conversion, preserving its per-argument range diagnostics and clamping behavior.

## Validation

- `CARGO_BUILD_JOBS=1 cargo test --profile fast --no-fail-fast -p rts-core`: 295 passed, 0 failed.
- `CARGO_BUILD_JOBS=1 cargo build --release -j 1`: passed.
- Buffer corpus: baseline 36/58 ok; new 39/58 ok. Per-file comparison: 3 gained, 0 lost. Gained: `test-buffer-write.js`, `test-buffer-copy.js`, `test-buffer-badhex.js`.
- Release target tests pass: write, copy, readuint, tostring, includes, and slice.
- `test-buffer-tostring-range.js` and `test-buffer-tostring-rangeerror.js` still expose the separate dense 4 GiB/string-length limitation; no smaller constant or test masking was introduced.