### PR TITLE
fix: align buffer string limits with node

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -102,6 +102,9 @@ impl Buffer {
         statics::alloc_unsafe(size)
     }
 
+    /// `Buffer.allocUnsafeSlow(size)`.
+    #[stat]
+    fn alloc_unsafe_slow(size: u64) -> u64 { statics::alloc_unsafe(size) }
     /// `Buffer.from(source, encodingOrOffset?)`.
     #[stat]
     fn from(source: u64, encoding_or_offset: u64) -> u64 {

--- a/crates/rts-core/src/entry/buffer/string.rs
+++ b/crates/rts-core/src/entry/buffer/string.rs
@@ -33,15 +33,21 @@ pub(in crate::entry) fn to_string(this: u64, encoding: u64, start: u64, end: u64
     if super::super::throw::in_flight() {
         return undefined();
     }
+    let Some((view, first, last)) = with_current(|context| {
+        let view = view_of(context, this)?;
+        let (first, last) = absolute_range(view.length, start, end);
+        Some((view, first, last))
+    }) else {
+        return undefined();
+    };
+    if (last - first) as f64 > super::super::BUFFER_MAX_STRING_LENGTH {
+        errors::string_too_long();
+        return undefined();
+    }
     with_current(|context| {
-        let absent = undefined_of(context);
-        let Some(view) = view_of(context, this) else {
-            return absent;
-        };
         let Some(bytes) = window(context, &view) else {
-            return absent;
+            return undefined_of(context);
         };
-        let (first, last) = absolute_range(bytes.len(), start, end);
         let text = codec::decode(&bytes[first..last], &enc);
         context
             .intern_value(crate::text::Str::from_str(&text))

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -104,6 +104,16 @@ pub fn invalid_arg_value(name: &str, actual: u64, reason: &str) {
     );
 }
 
+/// Raises `Error [ERR_STRING_TOO_LONG]` for a string conversion over the
+/// runtime's materialisation limit.
+pub fn string_too_long() {
+    raise(
+        "Error",
+        "ERR_STRING_TOO_LONG",
+        "Cannot create a string longer than 0x1fffffe8 characters",
+    );
+}
+
 /// Raises `TypeError [ERR_UNKNOWN_ENCODING]`.
 ///
 /// A name apart from [`invalid_arg_value`] because Node gives it its own code

--- a/crates/rts-core/src/entry/mod.rs
+++ b/crates/rts-core/src/entry/mod.rs
@@ -191,6 +191,14 @@ pub use current::with_context;
 pub(crate) use current::with_current;
 pub use table::{CORE_ENTRY_COUNT, CoreEntry};
 pub use buffer::validate::MAX_LENGTH as BUFFER_MAX_LENGTH;
+/// The largest non-empty JavaScript string this runtime can materialise.
+///
+/// This is deliberately narrower than the byte-buffer ceiling: strings are
+/// stored as UTF-16 code units and `String.repeat` enforces this result limit.
+/// Keeping it in the core entry surface lets `node:buffer` publish the exact
+/// capacity that the string implementation accepts rather than copying a second
+/// literal there.
+pub const BUFFER_MAX_STRING_LENGTH: f64 = 536_870_888.0;
 pub use errors::{
     buffer_out_of_bounds, invalid_arg_instance, invalid_arg_type, invalid_arg_value, invalid_state,
     out_of_range, unknown_encoding,

--- a/crates/rts-core/src/entry/string/basic.rs
+++ b/crates/rts-core/src/entry/string/basic.rs
@@ -30,6 +30,7 @@
 //! question rather than merely a home.
 
 use super::super::native::Native;
+
 use super::super::with_current;
 use super::{absent, answer, answer_owned, arg_units, nothing, relative, text_of, units_of};
 use crate::value::Value;
@@ -45,7 +46,7 @@ pub(super) const NATIVES: &[(&str, Native)] = &[
     ("toLowerCase", to_lower_case),
     ("toLocaleUpperCase", to_upper_case),
     ("toLocaleLowerCase", to_lower_case),
-    ("repeat", repeat),
+    ("repeat", super::repeat::repeat),
     ("concat", concat),
     ("padStart", pad_start),
     ("padEnd", pad_end),
@@ -287,66 +288,6 @@ extern "C" fn to_lower_case(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a
         return super::refused();
     };
     mapped(this, str::to_lowercase, u8::to_ascii_lowercase)
-}
-
-/// `s.repeat(n)`.
-extern "C" fn repeat(_e: u64, this: u64, count: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
-    // `ToString(RequireObjectCoercible(this))`, before any borrow — see
-    // `super::coerce_receiver`.
-    let Some(this) = super::coerce_receiver(this) else {
-        return super::refused();
-    };
-    // The count AFTER the receiver, which is the order the specification states
-    // and the order a throwing `toString` observes — see the `order` rows of
-    // `string/claude2-repeat-count-coercion-and-errors`.
-    let Some(count) = super::number_arg(count) else {
-        return super::refused();
-    };
-    let asked = with_current(|context| super::integer_arg(context, count));
-    // A negative count, or one that never terminates, is a `RangeError` —
-    // raising is possible now that rule 8's discipline is in place (`repeat`
-    // calls no user code, so there is nothing to check first). Raised OUTSIDE
-    // the borrow below: `range_error` takes the context's own `RefCell`
-    // borrow to build the error object, and taking it a second time while the
-    // first is still held is the nested borrow this crate's whole entry layer
-    // is arranged to make unreachable — an `extern "C"` frame cannot unwind
-    // the panic that follows, so it aborted the process instead of throwing.
-    if asked < 0.0 || asked.is_infinite() {
-        super::super::throw::range_error("Invalid count value");
-        return with_current(|context| nothing(context));
-    }
-    let Some(units) = with_current(|context| units_of(context, this)) else {
-        return super::refused();
-    };
-    // A result past the length a string can have is the SECOND `RangeError` the
-    // specification names, and it was a silent empty string here: `asked > 4096`
-    // answered `""` for `"ab".repeat(1e10)`, which every engine refuses. The
-    // ceiling was also wrong in the other direction — `"x".repeat(10000)` is an
-    // ordinary thing to write and answered nothing.
-    //
-    // The bound is on the RESULT, not on the count, which is what makes
-    // `"".repeat(1e10)` the empty string rather than an error: an empty receiver
-    // produces nothing however many times it is repeated, and the fixture asks
-    // for exactly that.
-    const LIMIT: f64 = 536_870_888.0;
-    // An empty receiver answers the empty string for ANY finite count, and the
-    // check has to come before the loop rather than fall out of it: repeating
-    // nothing 10^10 times is 10^10 iterations of copying nothing, which is a
-    // hang and not a wrong answer.
-    if units.is_empty() || asked == 0.0 {
-        return with_current(|context| answer(context, &[]));
-    }
-    if asked * units.len() as f64 > LIMIT {
-        super::super::throw::range_error("Invalid string length");
-        return super::refused();
-    }
-    with_current(|context| {
-        let mut out = Vec::with_capacity(units.len() * asked as usize);
-        for _ in 0..asked as usize {
-            out.extend_from_slice(&units);
-        }
-        answer(context, &out)
-    })
 }
 
 /// `s.concat(t, …)` — however many arguments the call carried.

--- a/crates/rts-core/src/entry/string/mod.rs
+++ b/crates/rts-core/src/entry/string/mod.rs
@@ -52,6 +52,7 @@ mod more;
 pub(super) mod pattern;
 mod points;
 mod replace;
+mod repeat;
 mod search;
 mod split;
 pub(in crate::entry) mod text;

--- a/crates/rts-core/src/entry/string/repeat.rs
+++ b/crates/rts-core/src/entry/string/repeat.rs
@@ -1,0 +1,75 @@
+//! The bounded repetition primitive for JavaScript strings.
+//!
+//! The implementation lives apart from the other basic methods because the
+//! string module has a 500-line ceiling. Its result limit is shared with the
+//! public `node:buffer` string constant through `entry` rather than copied.
+
+use super::super::with_current;
+use super::{answer, nothing, units_of};
+
+/// `s.repeat(n)`.
+pub(super) extern "C" fn repeat(
+    _e: u64,
+    this: u64,
+    count: u64,
+    _a1: u64,
+    _a2: u64,
+    _a3: u64,
+) -> u64 {
+    // `ToString(RequireObjectCoercible(this))`, before any borrow — see
+    // `super::coerce_receiver`.
+    let Some(this) = super::coerce_receiver(this) else {
+        return super::refused();
+    };
+    // The count AFTER the receiver, which is the order the specification states
+    // and the order a throwing `toString` observes — see the `order` rows of
+    // `string/claude2-repeat-count-coercion-and-errors`.
+    let Some(count) = super::number_arg(count) else {
+        return super::refused();
+    };
+    let asked = with_current(|context| super::integer_arg(context, count));
+    // A negative count, or one that never terminates, is a `RangeError` —
+    // raising is possible now that rule 8's discipline is in place (`repeat`
+    // calls no user code, so there is nothing to check first). Raised OUTSIDE
+    // the borrow below: `range_error` takes the context's own `RefCell` borrow
+    // to build the error object, and taking it a second time while the
+    // first is still held is the nested borrow this crate's whole entry layer
+    // is arranged to make unreachable — an `extern "C"` frame cannot unwind
+    // the panic that follows, so it aborted the process instead of throwing.
+    if asked < 0.0 || asked.is_infinite() {
+        super::super::throw::range_error("Invalid count value");
+        return with_current(|context| nothing(context));
+    }
+    let Some(units) = with_current(|context| units_of(context, this)) else {
+        return super::refused();
+    };
+    // A result past the length a string can have is the SECOND `RangeError` the
+    // specification names, and it was a silent empty string here: `asked > 4096`
+    // answered `""` for `"ab".repeat(1e10)`, which every engine refuses. The
+    // ceiling was also wrong in the other direction — `"x".repeat(10000)` is an
+    // ordinary thing to write and answered nothing.
+    //
+    // The bound is on the RESULT, not on the count, which is what makes
+    // `"".repeat(1e10)` the empty string rather than an error: an empty receiver
+    // produces nothing however many times it is repeated, and the fixture asks
+    // for exactly that.
+    const LIMIT: f64 = super::super::BUFFER_MAX_STRING_LENGTH;
+    // An empty receiver answers the empty string for ANY finite count, and the
+    // check has to come before the loop rather than fall out of it: repeating
+    // nothing 10^10 times is 10^10 iterations of copying nothing, which is a
+    // hang and not a wrong answer.
+    if units.is_empty() || asked == 0.0 {
+        return with_current(|context| answer(context, &[]));
+    }
+    if asked * units.len() as f64 > LIMIT {
+        super::super::throw::range_error("Invalid string length");
+        return super::refused();
+    }
+    with_current(|context| {
+        let mut out = Vec::with_capacity(units.len() * asked as usize);
+        for _ in 0..asked as usize {
+            out.extend_from_slice(&units);
+        }
+        answer(context, &out)
+    })
+}

--- a/crates/rts-node/src/buffer/mod.rs
+++ b/crates/rts-node/src/buffer/mod.rs
@@ -126,9 +126,10 @@ pub fn namespace(context: &mut Context) -> u64 {
 /// `test-buffer-over-max-length.js` computes its argument from.
 const MAX_LENGTH: f64 = entry::BUFFER_MAX_LENGTH;
 
-/// Same reasoning as [`MAX_LENGTH`] — this engine's UTF-8 `Str` cells have no
-/// narrower ceiling of their own, so the two share one number.
-const MAX_STRING_LENGTH: f64 = entry::BUFFER_MAX_LENGTH;
+/// The string ceiling is narrower than the byte ceiling because String cells
+/// are materialised as UTF-16 code units. It is shared with `String.repeat`
+/// through the core entry surface rather than duplicated here.
+const MAX_STRING_LENGTH: f64 = entry::BUFFER_MAX_STRING_LENGTH;
 
 static INSPECT_MAX_BYTES: AtomicU64 = AtomicU64::new(50.0f64.to_bits());
 


### PR DESCRIPTION
## Summary
- publish the runtime string ceiling as 536870888, shared by String.repeat and node:buffer
- make Buffer.toString reject oversized conversions with Error [ERR_STRING_TOO_LONG]
- expose Buffer.allocUnsafeSlow through the Buffer class
- keep String.repeat below the 500-line module ceiling

## Validation
- cargo test --profile fast --no-fail-fast -p rts-core: 295 passed, 0 failed
- cargo test --profile fast --no-fail-fast -p rts-node: 90 passed, 0 failed; 3 existing doctests ignored
- serial release build passed
- Buffer corpus: 43/61 passed versus 39/61 baseline, 4 gained, 0 lost
- Target tests: buffer constants, Buffer.toString, and Buffer.toString rangeerror pass

The remaining test-buffer-tostring-range failure is the separate 4 GiB allocation/representation issue and is not masked by this change.