### PR TITLE
perf: streamline native array and template paths

### DIFF
--- a/crates/rts-core/src/entry/array.rs
+++ b/crates/rts-core/src/entry/array.rs
@@ -488,6 +488,27 @@ pub(in crate::entry) fn key_list(
         // occupies its place in the sequence, so dropping it early would move
         // everything an accessor is ranked against.
         let ranked = context.ranked_accessors(slot);
+        // Most objects have no accessor side table. In that representation there
+        // is nothing to merge or rank: filter the shape's own keys directly and
+        // let `ordered_keys` perform the only ordering required. The old merge
+        // path allocated a second vector and walked every property twice even
+        // though no accessor could enter it.
+        if ranked.is_empty() {
+            for (key, _) in context.shapes.properties(shape) {
+                if enumerable_only && !super::integrity::enumerable(context, slot, key) {
+                    continue;
+                }
+                if context
+                    .interner
+                    .text(key)
+                    .is_some_and(super::symbol::is_symbol_key)
+                {
+                    continue;
+                }
+                keys.push(crate::object::Key::Name(key));
+            }
+            return ordered_keys(context, keys);
+        }
         let mut order: Vec<rts_cranelift::shape::Key> = Vec::new();
         let mut next = 0;
         for (position, (key, _)) in context.shapes.properties(shape).into_iter().enumerate() {

--- a/crates/rts-core/src/entry/array.rs
+++ b/crates/rts-core/src/entry/array.rs
@@ -488,27 +488,6 @@ pub(in crate::entry) fn key_list(
         // occupies its place in the sequence, so dropping it early would move
         // everything an accessor is ranked against.
         let ranked = context.ranked_accessors(slot);
-        // Most objects have no accessor side table. In that representation there
-        // is nothing to merge or rank: filter the shape's own keys directly and
-        // let `ordered_keys` perform the only ordering required. The old merge
-        // path allocated a second vector and walked every property twice even
-        // though no accessor could enter it.
-        if ranked.is_empty() {
-            for (key, _) in context.shapes.properties(shape) {
-                if enumerable_only && !super::integrity::enumerable(context, slot, key) {
-                    continue;
-                }
-                if context
-                    .interner
-                    .text(key)
-                    .is_some_and(super::symbol::is_symbol_key)
-                {
-                    continue;
-                }
-                keys.push(crate::object::Key::Name(key));
-            }
-            return ordered_keys(context, keys);
-        }
         let mut order: Vec<rts_cranelift::shape::Key> = Vec::new();
         let mut next = 0;
         for (position, (key, _)) in context.shapes.properties(shape).into_iter().enumerate() {

--- a/crates/rts-core/src/entry/array.rs
+++ b/crates/rts-core/src/entry/array.rs
@@ -171,6 +171,12 @@ fn allocate_array_cell(context: &mut Context) -> u32 {
                 return super::alloc::alloc_or_die(context, crate::heap::STRIDE, ty);
             };
             let ty = context.layout_of(grown).index() as u32;
+            // The array layout is immutable, so its `length` field has one
+            // structural offset for every array, including arrays whose shape
+            // later grows or is retyped by an integrity operation. Keep the
+            // offset beside the layout rather than rediscovering it on every
+            // mutation.
+            context.array_length_slot = context.shapes.slot_of(grown, key);
             context.array_layout = Some(ty);
             ty
         }
@@ -769,34 +775,18 @@ pub(super) fn set_length(context: &mut Context, cell: u32, length: usize) {
     let key = super::computed::length_key(context);
     let value = Value::from_f64(length as f64).bits();
     // Ordinary arrays already own `length` in their current shape. Updating an
-    // existing slot cannot change the shape, so avoid the generic property path
-    // on every push/pop; first materialisation and malformed layouts keep `put`.
+    // existing slot cannot change the shape, so use the offset recorded with the
+    // immutable array layout instead of rediscovering it through the shape tree
+    // on every push/pop. The array side table is the brand check; objects that
+    // merely happen to have a `length` property stay on the generic path.
     if let crate::object::Key::Name(name) = key
-        && let Some(ty) = context.region.type_of(cell)
-        && let Some(shape) = context.shape_of(ty)
-        && let Some(slot) = context.shapes.slot_of(shape, name)
+        && let Some(slot) = context.array_length_slot
+        && context.array_elements.copied(cell).is_some()
     {
-        // `length` is born in the array layout, so the slot exists before the
-        // first call reaches this branch. Its descriptor does not: the shape
-        // stores only the value representation, while array-specific attributes
-        // live beside the cell. Initialise that side table once, then preserve
-        // any descriptor subsequently installed by `defineProperty`, freeze, or
-        // seal.
-        if !context.has_attributes(cell, name) {
-            super::integrity::set_attributes(
-                context,
-                cell,
-                name,
-                super::integrity::Attributes {
-                    writable: true,
-                    enumerable: false,
-                    configurable: false,
-                },
-            );
-        }
         // The raw slot write deliberately has no descriptor check; do it before
         // using the fast path, otherwise push/pop could change a frozen array
-        // while its `length` property stayed unchanged.
+        // while its `length` property stayed unchanged. `attributes_at` still
+        // supplies the implicit array descriptor when no explicit record exists.
         if super::integrity::refuses_key_write(context, cell, name) {
             return;
         }

--- a/crates/rts-core/src/entry/array_proto/joining.rs
+++ b/crates/rts-core/src/entry/array_proto/joining.rs
@@ -56,9 +56,9 @@ pub(super) extern "C" fn join(
         // `"a-b"` — and it answered `undefined` here for every receiver that was
         // not a real array. That is the spelling `Array.prototype.toString`
         // reaches for a non-array receiver, so the two were wrong together.
-        let (real_array, elements) = match staged(context, this) {
-            Some((_, elements)) => (true, elements),
-            None => (false, super::array_like(context, this)?),
+        let elements = match staged(context, this) {
+            Some((_, elements)) => elements,
+            None => super::array_like(context, this)?,
         };
         // O buraco vira `undefined` AQUI, dentro do mesmo empréstimo que leu os
         // elementos. Sem isto ele escapava ao conjunto `empty` de baixo — que
@@ -74,29 +74,15 @@ pub(super) extern "C" fn join(
             true => Str::from_str(","),
             false => super::super::text::to_text(context, Value(separator))?,
         };
-        let primitive_only = real_array
-            && elements
-                .iter()
-                .all(|&value| !super::super::primitive::is_object_in(context, value));
         Some((
-            primitive_only,
             between,
             elements,
             [undefined_of(context), null_of(context)],
         ))
     });
-    let Some((primitive_only, between, elements, empty)) = staged else {
+    let Some((between, elements, empty)) = staged else {
         return with_current(|context| undefined_of(context));
     };
-
-    // A real array keeps every element reachable through `this`, so a join whose
-    // elements are all already primitive can assemble under one context borrow.
-    // Objects and generic array-likes stay on the staged path below: their
-    // conversion can execute user code, and their values cannot be assumed to be
-    // rooted by the receiver. This is a proof from representation, not a cache.
-    if primitive_only {
-        return join_primitives(between, elements, empty);
-    }
 
     // Assembled as UTF-16 UNITS rather than through Rust strings, and that is a
     // correctness difference rather than a shortcut. `Str::to_rust` refuses
@@ -167,57 +153,6 @@ pub(super) extern "C" fn join(
     }
 
     with_current(|context| {
-        let result = if narrow {
-            Str::owning_latin1(bytes)
-        } else {
-            Str::from_utf16(&joined)
-        };
-        context.intern_value(result).bits()
-    })
-}
-
-/// Joins a real array whose elements are already primitive values.
-///
-/// No element can invoke user code in this branch, so the text conversion and
-/// final interning can share one context borrow. The receiver keeps string
-/// references alive while that allocation happens; generic array-like values do
-/// not receive this proof and use `join`'s staged fallback instead.
-fn join_primitives(between: Str, elements: Vec<u64>, empty: [u64; 2]) -> u64 {
-    with_current(|context| {
-        let separator_bytes = between.narrow();
-        let mut narrow = separator_bytes.is_some();
-        let mut bytes = Vec::with_capacity(elements.len() * between.len());
-        let mut joined = Vec::with_capacity(elements.len() * between.len());
-        if !narrow {
-            joined.extend(between.units());
-        }
-        for (at, held) in elements.iter().enumerate() {
-            if at > 0 {
-                if narrow {
-                    bytes.extend_from_slice(separator_bytes.expect("narrow was proved"));
-                } else {
-                    joined.extend(between.units());
-                }
-            }
-            if empty.contains(held) {
-                continue;
-            }
-            let Some(text) = super::super::text::to_text(context, Value(*held)) else {
-                continue;
-            };
-            if narrow {
-                if let Some(part) = text.narrow() {
-                    bytes.extend_from_slice(part);
-                } else {
-                    joined.extend(bytes.iter().map(|byte| u16::from(*byte)));
-                    bytes.clear();
-                    narrow = false;
-                    joined.extend(text.units());
-                }
-            } else {
-                joined.extend(text.units());
-            }
-        }
         let result = if narrow {
             Str::owning_latin1(bytes)
         } else {

--- a/crates/rts-core/src/entry/array_proto/joining.rs
+++ b/crates/rts-core/src/entry/array_proto/joining.rs
@@ -56,9 +56,9 @@ pub(super) extern "C" fn join(
         // `"a-b"` — and it answered `undefined` here for every receiver that was
         // not a real array. That is the spelling `Array.prototype.toString`
         // reaches for a non-array receiver, so the two were wrong together.
-        let elements = match staged(context, this) {
-            Some((_, elements)) => elements,
-            None => super::array_like(context, this)?,
+        let (real_array, elements) = match staged(context, this) {
+            Some((_, elements)) => (true, elements),
+            None => (false, super::array_like(context, this)?),
         };
         // O buraco vira `undefined` AQUI, dentro do mesmo empréstimo que leu os
         // elementos. Sem isto ele escapava ao conjunto `empty` de baixo — que
@@ -74,15 +74,29 @@ pub(super) extern "C" fn join(
             true => Str::from_str(","),
             false => super::super::text::to_text(context, Value(separator))?,
         };
+        let primitive_only = real_array
+            && elements
+                .iter()
+                .all(|&value| !super::super::primitive::is_object_in(context, value));
         Some((
+            primitive_only,
             between,
             elements,
             [undefined_of(context), null_of(context)],
         ))
     });
-    let Some((between, elements, empty)) = staged else {
+    let Some((primitive_only, between, elements, empty)) = staged else {
         return with_current(|context| undefined_of(context));
     };
+
+    // A real array keeps every element reachable through `this`, so a join whose
+    // elements are all already primitive can assemble under one context borrow.
+    // Objects and generic array-likes stay on the staged path below: their
+    // conversion can execute user code, and their values cannot be assumed to be
+    // rooted by the receiver. This is a proof from representation, not a cache.
+    if primitive_only {
+        return join_primitives(between, elements, empty);
+    }
 
     // Assembled as UTF-16 UNITS rather than through Rust strings, and that is a
     // correctness difference rather than a shortcut. `Str::to_rust` refuses
@@ -153,6 +167,57 @@ pub(super) extern "C" fn join(
     }
 
     with_current(|context| {
+        let result = if narrow {
+            Str::owning_latin1(bytes)
+        } else {
+            Str::from_utf16(&joined)
+        };
+        context.intern_value(result).bits()
+    })
+}
+
+/// Joins a real array whose elements are already primitive values.
+///
+/// No element can invoke user code in this branch, so the text conversion and
+/// final interning can share one context borrow. The receiver keeps string
+/// references alive while that allocation happens; generic array-like values do
+/// not receive this proof and use `join`'s staged fallback instead.
+fn join_primitives(between: Str, elements: Vec<u64>, empty: [u64; 2]) -> u64 {
+    with_current(|context| {
+        let separator_bytes = between.narrow();
+        let mut narrow = separator_bytes.is_some();
+        let mut bytes = Vec::with_capacity(elements.len() * between.len());
+        let mut joined = Vec::with_capacity(elements.len() * between.len());
+        if !narrow {
+            joined.extend(between.units());
+        }
+        for (at, held) in elements.iter().enumerate() {
+            if at > 0 {
+                if narrow {
+                    bytes.extend_from_slice(separator_bytes.expect("narrow was proved"));
+                } else {
+                    joined.extend(between.units());
+                }
+            }
+            if empty.contains(held) {
+                continue;
+            }
+            let Some(text) = super::super::text::to_text(context, Value(*held)) else {
+                continue;
+            };
+            if narrow {
+                if let Some(part) = text.narrow() {
+                    bytes.extend_from_slice(part);
+                } else {
+                    joined.extend(bytes.iter().map(|byte| u16::from(*byte)));
+                    bytes.clear();
+                    narrow = false;
+                    joined.extend(text.units());
+                }
+            } else {
+                joined.extend(text.units());
+            }
+        }
         let result = if narrow {
             Str::owning_latin1(bytes)
         } else {

--- a/crates/rts-core/src/entry/integrity.rs
+++ b/crates/rts-core/src/entry/integrity.rs
@@ -165,13 +165,6 @@ impl Context {
         }
         Attributes::default()
     }
-
-    /// Whether this cell has an explicit descriptor for this key.
-    pub(in crate::entry) fn has_attributes(&self, cell: u32, key: ShapeKey) -> bool {
-        self.attributes
-            .get(cell)
-            .is_some_and(|held| held.iter().any(|(at, _)| *at == key))
-    }
 }
 
 /// What a key permits once the OBJECT's own refusals are folded in.

--- a/crates/rts-core/src/entry/mod.rs
+++ b/crates/rts-core/src/entry/mod.rs
@@ -815,6 +815,13 @@ pub struct Context {
     /// Computed on the first array and remembered, because it is the same
     /// answer for every one of them. See `array::built_in`.
     array_layout: Option<u32>,
+    /// The field holding `length` in the array layout.
+    ///
+    /// This is layout metadata, not an inline cache: every array starts with the
+    /// same immutable `length` field, and shape transitions preserve that field's
+    /// position. It lets array mutation write the already-known field directly;
+    /// descriptor and integrity checks still run before the write when needed.
+    array_length_slot: Option<u32>,
     /// The sweep's scratch list of cells to free, kept across cycles for its
     /// capacity. See `collect_cycle::sweep`.
     doomed: Vec<u32>,
@@ -1181,6 +1188,7 @@ impl Context {
             array_buffer_prototype: None,
             resolves: 0,
             array_layout: None,
+            array_length_slot: None,
             doomed: Vec::new(),
             census: std::env::var_os("RTS_CACHE_CENSUS")
                 .map(|_| std::collections::BTreeMap::new()),

--- a/crates/rts-core/src/entry/primitive.rs
+++ b/crates/rts-core/src/entry/primitive.rs
@@ -65,6 +65,13 @@ pub(super) fn is_object_in(context: &Context, value: u64) -> bool {
 /// `toString` never run when it does — including when it answers an object,
 /// which is a `TypeError` rather than a reason to try the pair.
 pub(super) fn to_primitive(value: u64, hint: Hint) -> u64 {
+    // Only a reference can be a string or an object. Every other tag is already
+    // primitive, so it cannot consult a hook and does not need to borrow the
+    // runtime context just to answer that fact. This is the common path for
+    // numeric array joins, arithmetic and template substitutions.
+    if !matches!(Value(value).kind(), Kind::Reference(_)) {
+        return value;
+    }
     if !with_current(|context| is_object_in(context, value)) {
         return value;
     }

--- a/crates/rts-core/src/entry/string/basic.rs
+++ b/crates/rts-core/src/entry/string/basic.rs
@@ -86,8 +86,35 @@ extern "C" fn char_at(_e: u64, this: u64, index: u64, _a1: u64, _a2: u64, _a3: u
 
 /// `s.charCodeAt(i)` — the code unit as a number.
 extern "C" fn char_code_at(_e: u64, this: u64, index: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
-    // `ToString(RequireObjectCoercible(this))`, before any borrow — see
-    // `super::coerce_receiver`.
+    // A primitive index has no conversion effects, so it may be decoded before
+    // the receiver only in this branch. If the receiver is already a text cell,
+    // read both values under one borrow instead of asking `coerce_receiver` for
+    // a cell and borrowing the context again for the code unit.
+    if matches!(
+        Value(index).kind(),
+        crate::value::Kind::Float
+            | crate::value::Kind::Int
+            | crate::value::Kind::Bool
+            | crate::value::Kind::Singleton(_)
+    ) {
+        if let Some(answer) = with_current(|context| {
+            let cell = Value(this).as_slot()?;
+            let text = context.text_at(cell)?;
+            let at = super::integer_arg(context, index);
+            if at < 0.0 || at >= text.len() as f64 {
+                return Some(Value::from_f64(f64::NAN).bits());
+            }
+            Some(match text.unit_at(at as usize) {
+                Some(unit) => Value::from_f64(f64::from(unit)).bits(),
+                None => Value::from_f64(f64::NAN).bits(),
+            })
+        }) {
+            return answer;
+        }
+    }
+
+    // The fallback preserves the specified order: receiver conversion happens
+    // before an object index can run its `valueOf` hook.
     let Some(this) = super::coerce_receiver(this) else {
         return super::refused();
     };
@@ -107,10 +134,6 @@ extern "C" fn char_code_at(_e: u64, this: u64, index: u64, _a1: u64, _a2: u64, _
         };
         let at = super::integer_arg(context, index);
         if at < 0.0 || at >= text.len() as f64 {
-            // `NaN`, not `undefined`. A program comparing the result to a number
-            // gets false either way; one doing arithmetic with it gets `NaN`
-            // where `undefined` would also give `NaN` — but `typeof` tells them
-            // apart, and the language says which it is.
             return Value::from_f64(f64::NAN).bits();
         }
         match text.unit_at(at as usize) {

--- a/crates/rts-core/src/entry/string/basic.rs
+++ b/crates/rts-core/src/entry/string/basic.rs
@@ -182,6 +182,39 @@ extern "C" fn at(_e: u64, this: u64, index: u64, _a1: u64, _a2: u64, _a3: u64) -
 
 /// `s.slice(from, to)` — negative counts from the end.
 extern "C" fn slice(_e: u64, this: u64, from: u64, to: u64, _a2: u64, _a3: u64) -> u64 {
+    // A bare narrow string and primitive bounds cannot run user code. Resolve
+    // both bounds and copy the requested byte range under one borrow. Objects,
+    // wrappers, symbols, BigInts and wide strings keep the staged path below,
+    // where conversion order and UTF-16 semantics remain unchanged.
+    let primitive_bound = |value: u64| {
+        matches!(
+            Value(value).kind(),
+            crate::value::Kind::Float
+                | crate::value::Kind::Int
+                | crate::value::Kind::Bool
+                | crate::value::Kind::Singleton(_)
+        )
+    };
+    if primitive_bound(from) && primitive_bound(to) {
+        if let Some(answer) = with_current(|context| {
+            let bytes = context.text_at(Value(this).as_slot()?)?.narrow()?;
+            let start = relative(super::integer_arg(context, from), bytes.len());
+            let end = if absent(context, to) {
+                bytes.len()
+            } else {
+                relative(super::integer_arg(context, to), bytes.len())
+            };
+            let taken = if start >= end {
+                Vec::new()
+            } else {
+                bytes[start..end].to_vec()
+            };
+            Some(answer_owned(context, taken))
+        }) {
+            return answer;
+        }
+    }
+
     // `ToString(RequireObjectCoercible(this))`, before any borrow — see
     // `super::coerce_receiver`.
     let Some(this) = super::coerce_receiver(this) else {

--- a/crates/rts-core/src/entry/string/search.rs
+++ b/crates/rts-core/src/entry/string/search.rs
@@ -32,6 +32,29 @@ pub(super) const NATIVES: &[(&str, Native)] = &[
 
 /// `s.indexOf(t, from)` — where `t` first occurs, or -1.
 extern "C" fn index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64, _a3: u64) -> u64 {
+    // Bare text values and a primitive position cannot run user code. When all
+    // three are already in their machine representation, answer the common
+    // narrow case under one borrow that reads both immutable text cells.
+    // Objects, wrappers, symbols, BigInts and wide strings keep the staged path
+    // below, where the existing conversion and refusal order remains unchanged.
+    if matches!(
+        Value(from).kind(),
+        crate::value::Kind::Float
+            | crate::value::Kind::Int
+            | crate::value::Kind::Bool
+            | crate::value::Kind::Singleton(_)
+    ) {
+        if let Some(answer) = with_current(|context| {
+            let haystack = context.text_at(Value(this).as_slot()?)?.narrow()?;
+            let needle = context.text_at(Value(search).as_slot()?)?.narrow()?;
+            let start = super::relative(super::integer_arg(context, from).max(0.0), haystack.len());
+            let found = find_bytes(haystack, needle, start);
+            Some(Value::from_f64(found.map_or(-1.0, |at| at as f64)).bits())
+        }) {
+            return answer;
+        }
+    }
+
     // `ToString(RequireObjectCoercible(this))`, before any borrow — see
     // `super::coerce_receiver`.
     let Some(this) = super::coerce_receiver(this) else {

--- a/crates/rts-core/src/entry/text.rs
+++ b/crates/rts-core/src/entry/text.rs
@@ -137,36 +137,80 @@ pub fn string_of(value: u64) -> u64 {
 /// Three values because the arguments are scalars across an `extern "C"`
 /// boundary. A template with more keeps the chain of additions, which is
 /// correct rather than a gap: it pays what it always paid.
+/// A template substitution that either borrows an already-rooted text cell or
+/// owns a primitive spelling produced without allocating an intermediate cell.
+///
+/// A borrowed value is kept alive by `primitive_values` in [`template_join`]. An
+/// owned value contains no heap reference, so it needs no separate root. Keeping
+/// these two cases distinct avoids cloning an existing string and avoids
+/// interning a number only to read it back immediately.
+enum TemplateText {
+    /// A primitive string cell held in the rooted input list.
+    Borrowed(u64),
+    /// Text produced directly from a primitive value.
+    Owned(Str),
+}
+
+impl TemplateText {
+    /// The text represented by this substitution while `context` is borrowed.
+    fn as_str<'a>(&'a self, context: &'a Context) -> Option<&'a Str> {
+        match self {
+            Self::Borrowed(value) => Value(*value)
+                .as_slot()
+                .and_then(|cell| context.text_at(cell)),
+            Self::Owned(text) => Some(text),
+        }
+    }
+}
+
+/// `` `a${x}b${y}c` `` — every piece and every value joined, in ONE crossing.
+///
+/// Literal pieces are already registered at compile time. Primitive
+/// substitutions are converted with the string hint, kept rooted when they are
+/// heap strings, and assembled into one final allocation.
 #[rtse::entry]
 pub fn template_join(which: i64, count: i64, v0: u64, v1: u64, v2: u64) -> u64 {
-    // Convertidos ANTES do empréstimo, e com o hint STRING: `to_text` sozinho
-    // não corre `ToPrimitive` nenhum, então um objeto com `toString` não
-    // contribuía nada e um com `valueOf` contribuía o número. Enraizados porque
-    // cada conversão interna uma string, e internar aloca.
+    // Run `ToPrimitive` with the STRING hint before borrowing the context. An
+    // object may execute its own `toString`, and that code can re-enter the
+    // runtime. The primitive results stay rooted until the final string owns its
+    // bytes, so a hook returning a newly allocated string cannot be swept while
+    // another substitution is converted.
     let wanted = count.clamp(0, 3) as usize;
-    let mut converted = super::rooted::Rooted::new();
+    let mut primitive_values = super::rooted::Rooted::new();
     for value in [v0, v1, v2].into_iter().take(wanted) {
-        let text = string_of(value);
-        converted.values().push(text);
+        let primitive = super::primitive::to_primitive(value, crate::coerce::Hint::String);
+        if super::throw::in_flight() {
+            return with_current(|context| undefined_of(context));
+        }
+        primitive_values.values().push(primitive);
     }
-    let values = converted.take();
+
     with_current(|context| {
         let Some((pieces, _)) = context.templates.get(which as usize) else {
             return undefined_of(context);
         };
-        // Convert each already-rooted substitution once, then size the final
-        // output exactly. The old loop repeatedly allocated an intermediate
-        // `Str` for every literal/value boundary; this builds only the answer.
-        let converted: Vec<Option<Str>> = values
+        // Keep existing text cells borrowed and spell other primitives directly.
+        // The previous path called `string_of` for each value, which interned a
+        // temporary cell, then cloned that cell's `Str` here before discarding it.
+        let converted: Vec<Option<TemplateText>> = primitive_values
+            .as_slice()
             .iter()
-            .take(wanted)
-            .map(|&value| to_text(context, crate::value::Value(value)))
+            .map(|&value| {
+                if Value(value)
+                    .as_slot()
+                    .is_some_and(|cell| context.text_at(cell).is_some())
+                {
+                    Some(TemplateText::Borrowed(value))
+                } else {
+                    to_text(context, Value(value)).map(TemplateText::Owned)
+                }
+            })
             .collect();
         let mut capacity = 0usize;
         let mut narrow = true;
         for piece in pieces {
             if let Some(&literal) = context.literals.get(*piece as usize)
-                && let Some(text) = crate::value::Value(literal)
+                && let Some(text) = Value(literal)
                     .as_slot()
                     .and_then(|cell| context.text_at(cell))
             {
@@ -174,7 +218,7 @@ pub fn template_join(which: i64, count: i64, v0: u64, v1: u64, v2: u64) -> u64 {
                 narrow &= text.narrow().is_some();
             }
         }
-        for text in converted.iter().flatten() {
+        for text in converted.iter().flatten().filter_map(|text| text.as_str(context)) {
             capacity += text.len();
             narrow &= text.narrow().is_some();
         }
@@ -183,13 +227,15 @@ pub fn template_join(which: i64, count: i64, v0: u64, v1: u64, v2: u64) -> u64 {
             let mut bytes = Vec::with_capacity(capacity);
             for (at, piece) in pieces.iter().enumerate() {
                 if let Some(&literal) = context.literals.get(*piece as usize)
-                    && let Some(text) = crate::value::Value(literal)
+                    && let Some(text) = Value(literal)
                         .as_slot()
                         .and_then(|cell| context.text_at(cell))
                 {
                     bytes.extend_from_slice(text.narrow().expect("narrow was proved"));
                 }
-                if let Some(Some(text)) = converted.get(at) {
+                if let Some(Some(text)) = converted.get(at)
+                    && let Some(text) = text.as_str(context)
+                {
                     bytes.extend_from_slice(text.narrow().expect("narrow was proved"));
                 }
             }
@@ -199,13 +245,15 @@ pub fn template_join(which: i64, count: i64, v0: u64, v1: u64, v2: u64) -> u64 {
         let mut units = Vec::with_capacity(capacity);
         for (at, piece) in pieces.iter().enumerate() {
             if let Some(&literal) = context.literals.get(*piece as usize)
-                && let Some(text) = crate::value::Value(literal)
+                && let Some(text) = Value(literal)
                     .as_slot()
                     .and_then(|cell| context.text_at(cell))
             {
                 units.extend(text.units());
             }
-            if let Some(Some(text)) = converted.get(at) {
+            if let Some(Some(text)) = converted.get(at)
+                && let Some(text) = text.as_str(context)
+            {
                 units.extend(text.units());
             }
         }

--- a/crates/rts-host/tests/esparso.rs
+++ b/crates/rts-host/tests/esparso.rs
@@ -115,6 +115,19 @@ fn array_length_keeps_its_descriptor_and_blocks_mutation_when_non_writable() {
 }
 
 #[test]
+fn a_built_array_keeps_its_implicit_length_descriptor_after_mutation() {
+    assert_eq!(
+        numero(
+            "const a=[]; a.push(1); \
+             const d=Object.getOwnPropertyDescriptor(a, 'length'); \
+             const popped=a.pop(); \
+             return (popped===1 && d.writable && !d.enumerable && !d.configurable && a.length===0) ? 1 : 0;"
+        ),
+        1.0
+    );
+}
+
+#[test]
 fn um_array_denso_nao_muda_em_nada() {
     // A rede de segurança: nada acima pode ter custado o caso comum.
     assert_eq!(numero("const a=[1,2,3]; return a.length;"), 3.0);

--- a/crates/rts-host/tests/running.rs
+++ b/crates/rts-host/tests/running.rs
@@ -2564,7 +2564,7 @@ fn a_string_finds_its_methods_by_inheriting_them() {
 
 #[test]
 fn the_string_methods_count_code_units_and_not_bytes() {
-    // `"é"` is one code unit and two UTF-8 bytes. Every index in these methods
+    // `é` is one code unit and two UTF-8 bytes. Every index in these methods
     // is a position in the unit sequence, and working in bytes here would make
     // `slice` cut a character in half while `length` said otherwise.
     let length = run("return \"é\".length;");
@@ -2575,6 +2575,18 @@ fn the_string_methods_count_code_units_and_not_bytes() {
 
     let found = run("return \"éa\".indexOf(\"a\");");
     assert_eq!(tags::decode_double(found), 1.0);
+}
+
+#[test]
+fn index_of_keeps_object_conversion_order_off_the_direct_path() {
+    let produced = run(
+        "let order = ''; \
+         let receiver = { toString() { order = order + 'h'; return 'abc'; } }; \
+         let needle = { toString() { order = order + 'n'; return 'b'; } }; \
+         let found = String.prototype.indexOf.call(receiver, needle, 0); \
+         return found === 1 && order === 'hn';"
+    );
+    assert_eq!(tags::payload_of(produced), tags::BOOL_TRUE);
 }
 
 #[test]
@@ -2615,6 +2627,18 @@ fn char_code_at_keeps_utf16_units_and_nan_semantics() {
                  'abc'.charCodeAt(9) !== 'abc'.charCodeAt(9)) ? 1 : 0;"
     );
     assert_eq!(tags::decode_double(produced), 1.0);
+}
+
+#[test]
+fn char_code_at_converts_the_receiver_before_an_object_index() {
+    let produced = run(
+        "let order = ''; \
+         let receiver = { toString() { order = order + 'r'; return 'abc'; } }; \
+         let index = { valueOf() { order = order + 'i'; return 1; } }; \
+         let code = String.prototype.charCodeAt.call(receiver, index); \
+         return code === 98 && order === 'ri';"
+    );
+    assert_eq!(tags::payload_of(produced), tags::BOOL_TRUE);
 }
 
 #[test]
@@ -3035,6 +3059,19 @@ fn object_keys_and_values_agree_about_order() {
 
     let value = run("let o = { a: 1, b: 2 }; return Object.values(o)[1];");
     assert_eq!(tags::decode_double(value), 2.0);
+}
+
+#[test]
+fn object_keys_filters_hidden_and_symbol_properties_after_ordering_indices() {
+    let produced = run(
+        "let symbol = Symbol('hidden'); \
+         let o = {}; o['2'] = 2; o['1'] = 1; o.name = 3; \
+         Object.defineProperty(o, 'secret', { value: 4, enumerable: false }); \
+         o[symbol] = 5; \
+         let keys = Object.keys(o); \
+         return keys.length === 3 && keys[0] === '1' && keys[1] === '2' && keys[2] === 'name';"
+    );
+    assert_eq!(tags::payload_of(produced), tags::BOOL_TRUE);
 }
 
 #[test]

--- a/crates/rts-host/tests/running.rs
+++ b/crates/rts-host/tests/running.rs
@@ -2605,6 +2605,19 @@ fn slice_crosses_where_substring_swaps() {
 }
 
 #[test]
+fn slice_keeps_receiver_and_bound_conversion_order_off_the_direct_path() {
+    let produced = run(
+        "let order = ''; \
+         let receiver = { toString() { order = order + 'r'; return 'abcd'; } }; \
+         let from = { valueOf() { order = order + 'f'; return 1; } }; \
+         let to = { valueOf() { order = order + 't'; return 3; } }; \
+         let result = String.prototype.slice.call(receiver, from, to); \
+         return result === 'bc' && order === 'rft';"
+    );
+    assert_eq!(tags::payload_of(produced), tags::BOOL_TRUE);
+}
+
+#[test]
 fn char_at_answers_the_empty_string_where_the_index_answers_undefined() {
     // Both spellings exist because they disagree here, and an engine answering
     // the same for both makes `s.charAt(9) === ""` false.

--- a/crates/rts-host/tests/running.rs
+++ b/crates/rts-host/tests/running.rs
@@ -1168,6 +1168,29 @@ fn a_template_concatenates_rather_than_adding() {
 }
 
 #[test]
+fn a_template_uses_the_string_hint_for_object_substitutions() {
+    let produced = run(
+        "let calls = 0; \
+         let o = { valueOf: function () { return 7; }, \
+                   toString: function () { calls++; return 'T'; } }; \
+         return `${o}` === 'T' && calls === 1;",
+    );
+    assert_eq!(tags::payload_of(produced), tags::BOOL_TRUE);
+}
+
+#[test]
+fn template_join_roots_hook_returned_strings_until_the_final_string_is_built() {
+    holds(concat!(
+        "let total = 0; ",
+        "for (let i = 0; i < 2000; i++) { ",
+        "let o = { toString: function () { return 'x'.repeat(8); } }; ",
+        "total += `${o}`.length; ",
+        "} ",
+        "return total === 16000;",
+    ));
+}
+
+#[test]
 fn string_concat_preserves_arguments_layouts_and_coercion_effects() {
     holds(
         "return \"a\".concat(\"b\", \"c\", \"d\", \"e\", \"f\") === \"abcdef\";",


### PR DESCRIPTION
## Summary

This PR continues the machine-oriented optimization work in RTS. The accepted changes reduce repeated runtime crossings only when the representation and the absence of user-observable effects are proven locally. No new inline cache, benchmark special case, mock data, or semantic shortcut is introduced.

The branch is intentionally kept as one PR, with the follow-up work and safety reverts recorded in separate commits.

## Accepted implementation changes

### Stable array layout metadata

`Array.length` now keeps its structural slot alongside the immutable array layout. Array mutation no longer rediscovers that slot through the shape tree on every `push`/`pop`, while descriptor checks, explicit definitions, and integrity restrictions remain active.

### Root-safe template joining

`TemplateJoin` converts substitutions with the String hint outside active runtime borrows, keeps converted values rooted until the final string is published, and builds one final string without interning a temporary cell for every substitution. This preserves `Symbol.toPrimitive`/`toString` order and GC safety.

### Primitive conversion fast return

`ToPrimitive` returns an already-primitive value before borrowing `Context`. Only references can be strings or objects in the current NaN-boxed representation; object references still follow the full hook protocol, and string references remain distinguishable from heap objects through the context text table.

### Constant-time UTF-16 unit reads

`charCodeAt` uses `Str::unit_at` directly for a primitive string receiver and a primitive numeric-like index. The fallback still performs receiver conversion before an object index can run `valueOf`, so wrappers and observable conversions keep the generic path.

### One-borrow primitive `String.indexOf`

`String.indexOf` now has a narrow, representation-proven path for a bare string receiver, a bare string needle, and a primitive position. It reads both immutable text cells and performs the search under one `Context` borrow. Objects, wrappers, symbols, BigInts, wide strings, and other dynamic cases remain on the existing staged conversion path.

### One-borrow primitive `String.slice`

`String.slice` now uses the same proof for a bare narrow string and primitive bounds. It computes the clamped UTF-16-equivalent byte range and publishes one result under a single `Context` borrow. Dynamic receivers and bounds retain the existing receiver-first and left-to-right conversion path.

## Safety reverts

An experimental primitive-only `Array.join` path was removed after it caused intermittent heap corruption in the official benchmark (`c.run is not a function`, incomplete rows, and `undefined undefined`). The stable join implementation is restored in `cb26a584`.

A no-accessor `Object.keys` shortcut was also removed because the release benchmark did not confirm a benefit outside noise. Its semantic coverage remains in the test suite, while the implementation continues to use the established accessor-aware ordering path.

These reverts are deliberate: correctness and generalizable evidence take priority over a local nanosecond result.

## Validation

The official `bench/analytic.ts` was run in release mode against an exact `c349b26d` baseline, with three alternating pairs on a pinned CPU, after rebuilding the baseline and final binaries in independent target directories. All six executions in the final repeat completed with a checksum and no `UNAVAILABLE`, `TypeError: c.run is not a function`, or `undefined undefined` output.

The table reports median raw `ns/op` across the three final pairs. It is evidence for the measured cases, not a promise that every operation reaches two digits; parsing, allocation, regex, JSON, exception, and generator rows retain their semantic costs.

| Official row | c349 median | Final median | Delta | Interpretation |
|---|---:|---:|---:|---|
| `string indexOf 256` | 125.55 ns | 113.56 ns | -9.55% | Consistent benefit from the one-borrow narrow path. |
| `string slice 16` | 168.78 ns | 164.86 ns | -2.32% | Small benefit from the one-borrow primitive-bound path. |
| `string charCodeAt` | 72.33 ns | 71.58 ns | -1.04% | Within expected benchmark noise; no strong claim. |
| `array join 16` | 62.08 ns | 62.78 ns | +1.13% | Stable path restored; no join optimization claim. |
| `coll Object.keys 4` | 113.76 ns | 119.32 ns | +4.89% | Shortcut removed because it was not confirmed. |
| `string template literal` | 202.50 ns | 209.37 ns | +3.39% | Control variation; no new template performance claim. |

The semantic gates passed as follows:

| Gate | Result |
|---|---|
| `git diff --check` | Passed. |
| `cargo check -p rts-core -p rts-host` | Passed. |
| `cargo test --profile fast -p rts-core` | 297 passed, 0 failed. |
| Focused string, search, join, and object-key tests | Passed. |
| Full `rts-host` running suite | 326 passed, 3 known pre-existing failures. |

The three full-suite failures are unchanged known gaps: `a_construct_still_missing_is_refused_by_name_rather_than_approximated`, `an_object_operand_is_converted_by_its_own_method`, and `an_iterator_carries_the_helpers_a_program_expects`.

## Design constraints

The optimization boundary follows the runtime's machine representation and the compiler/runtime layering. A path is accepted only when it does not bypass mutable property semantics, getters/setters, proxies, `Symbol` hooks, `ToPrimitive` ordering, wrapper identity, exceptions, or GC rooting. Runtime-dependent inline caches are intentionally not added.

The approach is consistent with Cranelift's SSA-based IR and verification model, the Rust Performance Book's guidance to measure allocations and copies rather than assume them away, and conservative escape/scalar-replacement practice: representation proofs are local and explicit, and unknown calls remain optimization barriers.

## References

1. [Cranelift IR documentation](https://cranelift.dev/)
2. [Rust Performance Book — memory allocations](https://nnethercote.github.io/perf-book/heap-allocations.html)
3. [OpenJDK escape analysis and scalar replacement](https://wiki.openjdk.org/display/HotSpot/ServerCompiler)
