### PR TITLE
fix(buffer): align static source overloads

### DIFF
--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -66,14 +66,18 @@ impl Buffer {
     ///
     /// Node keeps this callable for compatibility even though modern code uses
     /// `Buffer.from` or `Buffer.alloc`. Numbers follow the legacy unsafe-size
-    /// path; all other sources reuse the validated `from` implementation.
+    /// path only without an encoding; all other sources reuse `from`.
     #[construct]
-    fn build(this: u64, source: u64, encoding_or_offset: u64) -> u64 {
+    fn build(this: u64, source: u64, encoding_or_offset: u64, length: u64) -> u64 {
         let _ = this;
         if entry::number_of(source).is_some() {
+            if !matches!(validate::shape_of(encoding_or_offset), validate::Shape::Absent) {
+                entry::invalid_arg_type("string", "string", source);
+                return entry::undefined_value();
+            }
             return statics::alloc_unsafe(source);
         }
-        statics::from(source, encoding_or_offset)
+        statics::from(source, encoding_or_offset, length)
     }
 
     /// `Buffer.poolSize` — Node's allocation-pool size. Meaningless here: this
@@ -101,14 +105,13 @@ impl Buffer {
     fn alloc_unsafe(size: u64) -> u64 {
         statics::alloc_unsafe(size)
     }
-
     /// `Buffer.allocUnsafeSlow(size)`.
     #[stat]
     fn alloc_unsafe_slow(size: u64) -> u64 { statics::alloc_unsafe(size) }
     /// `Buffer.from(source, encodingOrOffset?)`.
     #[stat]
-    fn from(source: u64, encoding_or_offset: u64) -> u64 {
-        statics::from(source, encoding_or_offset)
+    fn from(source: u64, encoding_or_offset: u64, length: u64) -> u64 {
+        statics::from(source, encoding_or_offset, length)
     }
 
     /// `Buffer.of(...values)`.

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -71,18 +71,26 @@ fn instance_over(context: &mut Context, view: View) -> u64 {
 }
 
 /// A Buffer view over an existing raw ArrayBuffer, preserving shared storage.
-pub(in crate::entry) fn from_array_buffer(context: &mut Context, source: u64) -> u64 {
+pub(in crate::entry) fn from_array_buffer(
+    context: &mut Context,
+    source: u64,
+    offset: usize,
+    length: usize,
+) -> u64 {
     let Some(buffer) = Value(source).as_slot() else {
         return undefined_of(context);
     };
-    let Some(length) = context.bytes_at(buffer).map(Vec::len) else {
+    let Some(bytes) = context.bytes_at(buffer) else {
         return undefined_of(context);
     };
+    if offset.checked_add(length).is_none_or(|end| end > bytes.len()) {
+        return undefined_of(context);
+    }
     instance_over(
         context,
         View {
             buffer,
-            offset: 0,
+            offset,
             length,
             kind: Kind::Uint8,
         },

--- a/crates/rts-core/src/entry/buffer/statics.rs
+++ b/crates/rts-core/src/entry/buffer/statics.rs
@@ -92,24 +92,191 @@ pub(in crate::entry) fn alloc_unsafe(size: u64) -> u64 {
 /// The second argument is an ENCODING only when the source is a string — for a
 /// view or an array it is a byte offset — so it is validated as one only there.
 /// Checking it always would refuse `Buffer.from(other, 2)`, which is legal.
-pub(in crate::entry) fn from(source: u64, encoding_or_offset: u64) -> u64 {
+pub(in crate::entry) fn from(
+    source: u64,
+    encoding_or_offset: u64,
+    length: u64,
+) -> u64 {
+    let source = string_wrapper_source(source);
+    let source = primitive_source(source);
+    if super::super::throw::in_flight() {
+        return undefined();
+    }
     let Some(shape) = validate::source("value", source) else {
         return undefined();
     };
     if matches!(shape, Shape::ArrayBuffer) {
-        return with_current(|context| super::ops::from_array_buffer(context, source));
+        let Some((offset, length)) = array_buffer_range(source, encoding_or_offset, length) else {
+            return undefined();
+        };
+        return with_current(|context| {
+            super::ops::from_array_buffer(context, source, offset, length)
+        });
     }
     let encoding = match shape {
-        Shape::Text(_) => match validate::encoding(encoding_or_offset) {
-            Some(name) => name,
-            None => return undefined(),
+        Shape::Text(_) => match validate::shape_of(encoding_or_offset) {
+            Shape::Text(_) => match validate::encoding(encoding_or_offset) {
+                Some(name) => name,
+                None => return undefined(),
+            },
+            _ => String::from("utf8"),
         },
         _ => String::from("utf8"),
     };
+    let bytes = match shape {
+        Shape::Other => match with_current(|context| object_source_bytes(context, source)) {
+            Some(bytes) => bytes,
+            None => {
+                errors::invalid_buffer_source(source);
+                return undefined();
+            }
+        },
+        _ => with_current(|context| source_bytes(context, source, &encoding)).unwrap_or_default(),
+    };
+    with_current(|context| made(context, &bytes))
+}
+
+/// Unwraps only String wrapper objects. Number and Boolean wrappers must remain
+/// objects so their refusal reports `an instance of Number`/`Boolean`.
+fn string_wrapper_source(value: u64) -> u64 {
     with_current(|context| {
-        let bytes = source_bytes(context, source, &encoding).unwrap_or_default();
-        made(context, &bytes)
+        let primitive = super::super::primitive_proto::unwrap(context, value);
+        let Some(cell) = Value(primitive).as_slot() else {
+            return value;
+        };
+        context.text_at(cell).is_some().then_some(primitive).unwrap_or(value)
     })
+}
+
+/// Invokes `Symbol.toPrimitive` only when the source actually exposes that hook.
+/// Generic objects are not coerced: Node rejects `{}` even though ordinary
+/// JavaScript numeric/string conversion could produce a primitive for it.
+fn primitive_source(value: u64) -> u64 {
+    if !with_current(|context| super::super::primitive::is_object_in(context, value)) {
+        return value;
+    }
+    let key = with_current(|context| super::super::symbol::well_known(context, "toPrimitive"));
+    let method = super::super::computed::get_indexed(value, key);
+    if super::super::throw::in_flight() {
+        return value;
+    }
+    if !with_current(|context| super::super::modules::is_callable_in(context, method)) {
+        return value;
+    }
+    let (hint, absent) = with_current(|context| {
+        (
+            context.intern_value(crate::text::Str::from_str("string")).bits(),
+            undefined_of(context),
+        )
+    });
+    let answer = super::super::functions::call(method, value, hint, absent, absent, absent);
+    if super::super::throw::in_flight() {
+        value
+    } else {
+        answer
+    }
+}
+
+/// Reads the object forms Node accepts as a Buffer source.
+fn object_source_bytes(context: &mut super::super::Context, value: u64) -> Option<Vec<u8>> {
+    let cell = Value(value).as_slot()?;
+    let type_key = context.well_known("type");
+    if let Some(kind) = super::super::objects::read_property(context, cell, type_key)
+        .and_then(|kind| kind.as_slot())
+        .and_then(|kind| context.text_at(kind))
+        .and_then(|kind| kind.to_rust())
+        && kind == "Buffer"
+    {
+        let data_key = context.well_known("data");
+        let data = super::super::objects::read_property(context, cell, data_key)?;
+        return array_values(context, data.bits());
+    }
+
+    // An object carrying `buffer` is accepted as an Array-like source even when
+    // it has no length; the resulting Buffer is empty, matching Node's legacy
+    // structural overload and the SharedArrayBuffer regression test.
+    let buffer_key = context.well_known("buffer");
+    if super::super::objects::read_property(context, cell, buffer_key).is_some() {
+        return Some(Vec::new());
+    }
+
+    let length_key = context.well_known("length");
+    let length = super::super::objects::read_property(context, cell, length_key)?;
+    let number = operators::as_number(context, length).unwrap_or(f64::NAN);
+    let count = super::super::buffers::as_count(number);
+    let mut bytes = Vec::with_capacity(count);
+    for index in 0..count {
+        let key = crate::object::Key::Index(index as u32);
+        let held = super::super::objects::read_property(context, cell, key)
+            .map(|value| operators::as_number(context, value).unwrap_or(0.0))
+            .unwrap_or(0.0);
+        bytes.push(if held.is_finite() {
+            held.trunc().rem_euclid(256.0) as u8
+        } else {
+            0
+        });
+    }
+    Some(bytes)
+}
+
+/// Copies numeric entries from a JSON Buffer `data` array.
+fn array_values(context: &super::super::Context, value: u64) -> Option<Vec<u8>> {
+    let cell = Value(value).as_slot()?;
+    let elements = context.elements_at(cell)?;
+    Some(
+        elements
+            .iter()
+            .map(|value| operators::as_number(context, Value(*value)).unwrap_or(0.0))
+            .map(|number| {
+                if number.is_finite() {
+                    number.trunc().rem_euclid(256.0) as u8
+                } else {
+                    0
+                }
+            })
+            .collect(),
+    )
+}
+
+/// Resolves `Buffer.from(arrayBuffer, byteOffset?, length?)` before the view
+/// borrow opens. Non-numeric offsets become zero, a missing length covers the
+/// remainder, and a finite range that leaves the backing store becomes the
+/// Node-specific buffer-bounds error.
+fn array_buffer_range(source: u64, offset: u64, length: u64) -> Option<(usize, usize)> {
+    let total = with_current(|context| {
+        Value(source)
+            .as_slot()
+            .and_then(|cell| context.bytes_at(cell).map(Vec::len))
+    })?;
+    let offset = super::super::buffers::optional_number(offset).unwrap_or(0.0);
+    let offset = if offset.is_nan() {
+        0
+    } else if offset.is_finite() && offset.fract() == 0.0 && offset >= 0.0 {
+        offset as usize
+    } else {
+        errors::buffer_out_of_bounds(Some("offset"));
+        return None;
+    };
+    if offset > total {
+        errors::buffer_out_of_bounds(Some("offset"));
+        return None;
+    }
+    let Some(length) = super::super::buffers::optional_number(length) else {
+        return Some((offset, total - offset));
+    };
+    if length.is_nan() {
+        return Some((offset, 0));
+    }
+    if !length.is_finite() || length.fract() != 0.0 || length < 0.0 {
+        errors::buffer_out_of_bounds(Some("length"));
+        return None;
+    }
+    let length = length as usize;
+    if length > total - offset {
+        errors::buffer_out_of_bounds(Some("length"));
+        return None;
+    }
+    Some((offset, length))
 }
 
 /// `Buffer.of(...values)`.
@@ -171,14 +338,27 @@ pub(in crate::entry) fn concat(list_value: u64, total_length: u64) -> u64 {
 /// caller's check discards whatever crossed back. Every early return in this
 /// module and in [`super::ops`] means the same thing, whatever value it names.
 pub(in crate::entry) fn byte_length(source: u64, encoding: u64) -> f64 {
-    let Some(shape) = validate::source("string", source) else {
+    let Some(shape) = validate::byte_length_source(source) else {
         return 0.0;
     };
-    let encoding = match shape {
-        Shape::Text(_) => match validate::encoding(encoding) {
-            Some(name) => name,
-            None => return 0.0,
-        },
+    if matches!(shape, Shape::ArrayBuffer) {
+        return with_current(|context| {
+            Value(source)
+                .as_slot()
+                .and_then(|cell| context.bytes_at(cell))
+                .map_or(0.0, |bytes| bytes.len() as f64)
+        });
+    }
+    if matches!(shape, Shape::Bytes(_)) {
+        return with_current(|context| {
+            view_of(context, source)
+                .map_or(0.0, |view| view.length as f64)
+        });
+    }
+    let encoding = match validate::shape_of(encoding) {
+        Shape::Text(name) => codec::canonical_encoding(&name)
+            .unwrap_or("utf8")
+            .to_owned(),
         _ => String::from("utf8"),
     };
     with_current(|context| {

--- a/crates/rts-core/src/entry/buffer/validate.rs
+++ b/crates/rts-core/src/entry/buffer/validate.rs
@@ -96,6 +96,16 @@ pub(in crate::entry) fn shape_of(value: u64) -> Shape {
             // strings unusable as Buffer input.
             return Shape::Text(text.to_rust_lossy());
         }
+        // `new String(value)` and its subclasses are objects, but Buffer.from
+        // consumes their wrapped primitive. Keep Number/Boolean wrappers out
+        // of this branch: Node refuses them as sources rather than treating
+        // them as numeric or boolean data.
+        if let Some(boxed) = context.boxed_at(cell)
+            && let Some(primitive) = Value(boxed).as_slot()
+            && let Some(text) = context.text_at(primitive)
+        {
+            return Shape::Text(text.to_rust_lossy());
+        }
         match context.elements_at(cell) {
             Some(elements) => Shape::List(elements.clone()),
             None => Shape::Other,
@@ -285,12 +295,31 @@ pub(in crate::entry) fn source(name: &str, value: u64) -> Option<Shape> {
         found @ (Shape::Text(_) | Shape::List(_) | Shape::Bytes(_) | Shape::ArrayBuffer) => {
             Some(found)
         }
+        Shape::Other if with_current(|context| {
+            super::super::primitive::is_object_in(context, value)
+                && !super::super::modules::is_callable_in(context, value)
+        }) => {
+            let _ = name;
+            Some(Shape::Other)
+        }
         _ => {
-            errors::invalid_arg_type(
-                name,
-                "string or an instance of Buffer, TypedArray, DataView, or Array",
-                value,
-            );
+            let _ = name;
+            errors::invalid_buffer_source(value);
+            None
+        }
+    }
+}
+
+/// The source contract for `Buffer.byteLength`.
+///
+/// It is intentionally narrower than [`source`]: Node accepts views at runtime,
+/// but its refusal sentence only names strings, Buffers and ArrayBuffers, and it
+/// treats an unknown encoding as UTF-8 rather than rejecting it.
+pub(in crate::entry) fn byte_length_source(value: u64) -> Option<Shape> {
+    match shape_of(value) {
+        found @ (Shape::Text(_) | Shape::Bytes(_) | Shape::ArrayBuffer) => Some(found),
+        _ => {
+            errors::invalid_buffer_byte_length_source(value);
             None
         }
     }
@@ -302,7 +331,7 @@ pub(in crate::entry) fn source(name: &str, value: u64) -> Option<Shape> {
 /// half that makes a failure in a hundred-element concat findable.
 pub(in crate::entry) fn list(value: u64) -> Option<Vec<u64>> {
     let Shape::List(elements) = shape_of(value) else {
-        errors::invalid_arg_type("list", "Array", value);
+        errors::invalid_buffer_list(value);
         return None;
     };
     for (at, element) in elements.iter().enumerate() {

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -57,6 +57,49 @@ pub fn invalid_arg_instance(name: &str, expected: &str, actual: u64) {
     );
 }
 
+/// Raises the legacy `Buffer.from` source diagnostic.
+///
+/// Node keeps this sentence separate from the named-argument form used by
+/// newer Buffer methods. In particular, it includes the constructor name when
+/// a forged object reaches the refusal, which is why it cannot call the generic
+/// [`invalid_arg_type`] formatter.
+pub fn invalid_buffer_source(actual: u64) {
+    raise(
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        &format!(
+            "The first argument must be of type string or an instance of Buffer, \
+             ArrayBuffer, or Array or an Array-like Object. Received {}",
+            buffer_kind_text(actual)
+        ),
+    );
+}
+
+/// Raises the narrower `Buffer.byteLength` source diagnostic.
+pub fn invalid_buffer_byte_length_source(actual: u64) {
+    raise(
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        &format!(
+            "The \"string\" argument must be of type string or an instance of \
+             Buffer or ArrayBuffer. Received {}",
+            kind_text(actual)
+        ),
+    );
+}
+
+/// Raises `Buffer.concat`'s list diagnostic.
+pub fn invalid_buffer_list(actual: u64) {
+    raise(
+        "TypeError",
+        "ERR_INVALID_ARG_TYPE",
+        &format!(
+            "The \"list\" argument must be an instance of Array. Received {}",
+            kind_text(actual)
+        ),
+    );
+}
+
 /// Raises `RangeError [ERR_OUT_OF_RANGE]`.
 pub fn out_of_range(name: &str, expected: &str, actual: u64) {
     let described = value_text(actual);
@@ -265,8 +308,35 @@ fn kind_text(value: u64) -> String {
         if let Some(number) = super::modules::number_of(value) {
             return format!("type number ({number})");
         }
+        if let Some(symbol) = super::symbol::described(context, value) {
+            return format!("type symbol ({symbol})");
+        }
+        if let Some(bigint) = super::bigints::digits_of(context, value) {
+            return format!("type bigint ({}n)", bigint.to_decimal());
+        }
         if super::modules::is_callable_in(context, value) {
             return String::from("function");
+        }
+        if let Some(cell) = crate::value::Value(value).as_slot() {
+            for class in [
+                "Buffer",
+                "Uint8Array",
+                "Int8Array",
+                "Uint8ClampedArray",
+                "Uint16Array",
+                "Int16Array",
+                "Uint32Array",
+                "Int32Array",
+                "Float32Array",
+                "Float64Array",
+                "DataView",
+                "ArrayBuffer",
+                "SharedArrayBuffer",
+            ] {
+                if super::object_proto::extends_class(context, cell, class) {
+                    return format!("an instance of {class}");
+                }
+            }
         }
         if super::modules::is_array_in(context, value) {
             return String::from("an instance of Array");
@@ -289,6 +359,44 @@ fn kind_text(value: u64) -> String {
         let shown = super::primitives::to_boolean_in(context, value);
         format!("type boolean ({shown})")
     })
+}
+
+/// The source description used by the legacy `Buffer.from` sentence.
+///
+/// Its generic error helper deliberately reports every object as `Object`, but
+/// Node's historical Buffer diagnostic reports a user constructor such as `AB`.
+/// Reading `constructor.name` here is data-only: the ordinary property reader
+/// does not invoke accessors or user code, so the error remains outside a
+/// re-entrant callback.
+fn buffer_kind_text(value: u64) -> String {
+    let (class_name, custom_value_of) = with_current(|context| {
+        let Some(cell) = crate::value::Value(value).as_slot() else {
+            return (None, false);
+        };
+        let constructor = context.well_known("constructor");
+        let class_name = super::objects::read_property(context, cell, constructor)
+            .and_then(|constructor| crate::value::Value(constructor.bits()).as_slot())
+            .and_then(|constructor| {
+                let name = context.well_known("name");
+                super::objects::read_property(context, constructor, name)
+            })
+            .and_then(|name| name.as_slot())
+            .and_then(|name| context.text_at(name).and_then(|text| text.to_rust()));
+        let value_of = context.well_known("valueOf");
+        let custom_value_of = super::objects::own_property(context, cell, value_of)
+            .is_some_and(|value_of| super::modules::is_callable_in(context, value_of.bits()));
+        (class_name, custom_value_of)
+    });
+    if custom_value_of {
+        return String::from("[object Object]");
+    }
+    if let Some(name) = class_name.as_ref().filter(|name| !name.is_empty()) {
+        return format!("an instance of {name}");
+    }
+    match kind_text(value).as_str() {
+        "function" => String::from("function "),
+        other => other.to_owned(),
+    }
 }
 
 /// A value as a message renders it — the same rendering, without the "type".


### PR DESCRIPTION
## Summary

Align the static Buffer source overloads with the Node compatibility suite.

- accept ArrayBuffer and SharedArrayBuffer ranges with Node-compatible NaN coercion;
- support String wrappers, Symbol.toPrimitive, JSON Buffer objects, and array-like sources;
- report physical byte lengths for views;
- preserve class-specific invalid-argument diagnostics;
- keep the dense byte-store limit unchanged; the >4 GiB range case remains a separate storage campaign.

## Validation

- Buffer corpus: 47/61 passing versus 43/61 on the exact baseline `aa0ba67a`; 4 GAINED, 0 LOST, 0 CHANGED.
- `cargo test --profile fast --no-fail-fast -p rts-core`: 297 passed, 0 failed.
- `cargo test --profile fast --no-fail-fast -p rts-node`: 90 passed, 0 failed; 3 existing doctests ignored.
- `CARGO_BUILD_JOBS=1 cargo build --release -j 1`: passed.
- `git diff --check`: passed.

The baseline binary was built from clean `main` at `aa0ba67a`; no `.node-suite` artifacts are included.