### PR TITLE
fix(text): align atob and btoa semantics

### DIFF
--- a/crates/rts-core/src/entry/mod.rs
+++ b/crates/rts-core/src/entry/mod.rs
@@ -162,6 +162,7 @@ pub use operators::{
     remainder, subtract,
 };
 pub use primitives::{add, number_to_string, same_value, strict_equals, to_boolean, to_boolean_in};
+pub use primitive::string_for_host;
 pub use bigint_class::{bigint_new, negate};
 pub use bigints::{bigint_from_words, bigint_i64, bigint_u64, bigint_words};
 pub use buffers::detach::{buffer_detached, detach_buffer};

--- a/crates/rts-core/src/entry/primitive.rs
+++ b/crates/rts-core/src/entry/primitive.rs
@@ -152,8 +152,24 @@ pub(super) fn to_primitive(value: u64, hint: Hint) -> u64 {
     value
 }
 
-/// Both operands of a binary operator, converted in the order the operator
-/// specifies.
+/// ToString for a host entry point, preserving a throw raised by user code.
+///
+/// `Ok(Some(text))` is a materialised string, `Ok(None)` is a primitive that
+/// cannot be represented as Rust text (notably Symbol), and `Err(())` means a
+/// user conversion already left a throw in flight. The three outcomes are kept
+/// distinct so a host can raise its own specification error without replacing a
+/// callback's exception.
+pub fn string_for_host(value: u64) -> Result<Option<String>, ()> {
+    let primitive = to_primitive(value, Hint::String);
+    if super::throw::in_flight() {
+        return Err(());
+    }
+    Ok(with_current(|context| {
+        super::text::to_text(context, Value(primitive)).and_then(|text| text.to_rust())
+    }))
+}
+
+/// Both operands of a binary operator, converted in the order the operator specifies.
 ///
 /// The order is the part that is easy to get wrong and invisible until an
 /// operand has a side-effecting `valueOf`, which is why it comes from

--- a/crates/rts-node/src/buffer/mod.rs
+++ b/crates/rts-node/src/buffer/mod.rs
@@ -76,8 +76,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// The namespace `node:buffer` is.
 pub fn namespace(context: &mut Context) -> u64 {
     let members: &[(&str, Provided)] = &[
-        ("atob", atob),
-        ("btoa", btoa),
         ("transcode", transcode),
         ("isAscii", is_ascii),
         ("isUtf8", is_utf8),
@@ -85,6 +83,11 @@ pub fn namespace(context: &mut Context) -> u64 {
         ("resolveObjectURL", resolve_object_url),
     ];
     let namespace = entry::make_namespace(context, members);
+    let global = entry::global_object(context);
+    let atob_global = entry::get_member(context, global, "atob");
+    let btoa_global = entry::get_member(context, global, "btoa");
+    entry::put_member(context, namespace, "atob", atob_global);
+    entry::put_member(context, namespace, "btoa", btoa_global);
 
     let buffer = entry::buffer_class(context);
     entry::put_member(context, namespace, "Buffer", buffer);
@@ -132,25 +135,6 @@ const MAX_LENGTH: f64 = entry::BUFFER_MAX_LENGTH;
 const MAX_STRING_LENGTH: f64 = entry::BUFFER_MAX_STRING_LENGTH;
 
 static INSPECT_MAX_BYTES: AtomicU64 = AtomicU64::new(50.0f64.to_bits());
-
-/// `buffer.atob(data)` — base64 to a binary string, one code unit per byte.
-/// Invalid base64 answers `""` (no-throw stand-in); real Node throws a
-/// `DOMException` this engine has no primordial for (reference §7).
-extern "C" fn atob(_e: u64, _this: u64, data: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    let text = entry::text_of(data).unwrap_or_default();
-    let bytes = entry::decode_base64(&text);
-    let binary: String = bytes.iter().map(|&byte| byte as char).collect();
-    entry::with_runtime(|context| entry::make_string(context, &binary))
-}
-
-/// `buffer.btoa(data)` — a binary string (`U+0000`-`U+00FF`) to base64. A
-/// char above `U+00FF` truncates to its low byte — same no-throw stand-in.
-extern "C" fn btoa(_e: u64, _this: u64, data: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    let text = entry::text_of(data).unwrap_or_default();
-    let bytes: Vec<u8> = text.chars().map(|ch| ch as u32 as u8).collect();
-    let encoded = entry::encode_base64(&bytes, true);
-    entry::with_runtime(|context| entry::make_string(context, &encoded))
-}
 
 /// `buffer.transcode(source, fromEnc, toEnc)`. Decodes to a `String`
 /// intermediate with `fromEnc`'s codec, then re-encodes with `toEnc`'s —

--- a/crates/rts-std/src/globals/text/mod.rs
+++ b/crates/rts-std/src/globals/text/mod.rs
@@ -53,20 +53,15 @@
 //! would answer `["encoding"]`. `TextDecoder`'s three vary per instance, so
 //! they are own properties and `Object.keys` does diverge there — named below.
 //!
-//! # Why there is no throw anywhere in this file
+//! # Why most failures still do not throw in this file
 //!
-//! `rts_core::entry::throw` ends the program rather than unwinding to a
-//! handler; its own module doc says so, and the machine has no exception table
-//! yet. Every failure the specification defines as a throw therefore answers
-//! `undefined` here — an answer a program can test — rather than a fabricated
-//! value or a silent no-op.
+//! `rts_core::entry::throw` can now preserve a throw for compiled code to catch,
+//! but older decoder paths still answer `undefined` where their specification
+//! raises. The distinction is kept per operation rather than turning every
+//! refusal into a process-visible throw without a measured contract.
 //!
 //! # Not implemented, by name
 //!
-//! - **`atob`/`btoa` throwing `InvalidCharacterError`.** Invalid input answers
-//!   `undefined`. This differs from `node:buffer`'s `atob`, which answers `""`;
-//!   `undefined` is the one a program can distinguish from a successful decode
-//!   of an empty string, and `""` is the answer that looks like it worked.
 //! - **`new TextDecoder(label)` throwing `RangeError` for a label this engine
 //!   cannot decode.** It answers an INERT decoder instead — one carrying no
 //!   `encoding`, whose `decode` answers `undefined`. The reference document is
@@ -224,14 +219,14 @@ fn fitting_prefix(text: &str, room: usize) -> (usize, &[u8]) {
 
 /// `atob(data)` — base64 to a binary string, one code unit per byte.
 ///
-/// `undefined` for input that is not valid forgiving-base64, where Node throws
-/// `InvalidCharacterError`.
-extern "C" fn atob(_e: u64, _this: u64, data: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    let Some(text) = text_argument(data) else {
+/// Invalid input raises `InvalidCharacterError`, as required by the WHATWG
+/// forgiving-base64 API.
+extern "C" fn atob(_e: u64, _this: u64, data: u64, b: u64, c: u64, d: u64) -> u64 {
+    let Some(text) = base64_argument([data, b, c, d]) else {
         return entry::undefined_value();
     };
     if !is_forgiving_base64(&text) {
-        return entry::undefined_value();
+        return invalid_character();
     }
     let bytes = entry::decode_base64(&text);
     let binary = entry::decode_bytes(&bytes, "latin1");
@@ -240,16 +235,15 @@ extern "C" fn atob(_e: u64, _this: u64, data: u64, _b: u64, _c: u64, _d: u64) ->
 
 /// `btoa(data)` — a binary string to base64.
 ///
-/// `undefined` for a code point above `U+00FF`, where Node throws
-/// `InvalidCharacterError`. Checked BEFORE encoding, because `latin1` encoding
-/// truncates such a character to its low byte — which would answer base64 of
-/// something the caller never wrote.
-extern "C" fn btoa(_e: u64, _this: u64, data: u64, _b: u64, _c: u64, _d: u64) -> u64 {
-    let Some(text) = text_argument(data) else {
+/// A code point above `U+00FF` raises `InvalidCharacterError` BEFORE encoding,
+/// because `latin1` would otherwise truncate it to a byte the caller did not
+/// provide.
+extern "C" fn btoa(_e: u64, _this: u64, data: u64, b: u64, c: u64, d: u64) -> u64 {
+    let Some(text) = base64_argument([data, b, c, d]) else {
         return entry::undefined_value();
     };
     if text.chars().any(|character| character as u32 > 0xFF) {
-        return entry::undefined_value();
+        return invalid_character();
     }
     let Some(bytes) = entry::encode_text(&text, "latin1") else {
         return entry::undefined_value();
@@ -295,20 +289,42 @@ fn is_forgiving_base64(text: &str) -> bool {
 
 // ----------------------------------------------------------------- the shared
 
-/// An argument as text, `None` for an absent one.
+/// A base64 argument as text, `None` after raising or preserving its error.
 ///
-/// `text_of` is `ToString`, which is what a `DOMString` parameter takes — so
-/// `btoa(123)` encodes `"123"`, as it does in Node. It answers nothing for an
-/// object, whose `toString` is user code no entry point may call, and for a
-/// string holding a lone surrogate.
-///
-/// Ambient, so every caller of this is outside a borrow.
+/// `string_for_host` runs the existing ToPrimitive protocol, including
+/// `Symbol.toPrimitive`, wrappers and user-defined `toString`/`valueOf`. An
+/// absent argument and a Symbol are TypeErrors; a callback that throws is left
+/// untouched so the compiled caller can propagate its original value.
+fn base64_argument(slots: [u64; 4]) -> Option<String> {
+    let given = entry::with_runtime(|context| entry::arguments_at(context, 0, slots));
+    let Some(value) = given.first().copied() else {
+        entry::throw_type_error("The first argument must be specified");
+        return None;
+    };
+    match entry::string_for_host(value) {
+        Err(()) => None,
+        Ok(Some(text)) => Some(text),
+        Ok(None) => {
+            entry::throw_type_error("Cannot convert a Symbol value to a string");
+            None
+        }
+    }
+}
+
+/// An argument as already-materialised text for the older decoder paths.
 fn text_argument(value: u64) -> Option<String> {
     let absent = entry::undefined_value();
     match value == absent {
         true => None,
         false => entry::text_of(value),
     }
+}
+
+/// Raises the DOM error used by WHATWG base64 for malformed input.
+fn invalid_character() -> u64 {
+    let error = super::dom_exception::make("Invalid character", "InvalidCharacterError");
+    entry::throw_value(error);
+    entry::undefined_value()
 }
 
 /// One member of an options bag, `undefined` when there is no bag.


### PR DESCRIPTION
## Summary

Align global and `node:buffer` `atob`/`btoa` with Node.

- share the same callable cells so global and namespace identity checks pass;
- reuse the core ToPrimitive protocol for host text conversion;
- distinguish missing arguments from explicit `undefined`;
- preserve callback-thrown values;
- raise the existing `InvalidCharacterError` DOMException for malformed base64 and non-Latin1 `btoa` input.

## Validation

- `btoa` corpus: 1/1 passing versus 0/1 on the exact runtime baseline; 1 GAINED, 0 LOST, 0 CHANGED.
- Buffer corpus: 47/61 passing on both baseline and branch; 0 GAINED, 0 LOST, 0 CHANGED.
- `cargo test --profile fast --no-fail-fast -p rts-core`: 297 passed, 0 failed.
- `cargo test --profile fast --no-fail-fast -p rts-std`: 0 passed, 0 failed.
- `cargo test --profile fast --no-fail-fast -p rts-node`: 90 passed, 0 failed; 3 existing doctests ignored.
- `CARGO_BUILD_JOBS=1 cargo build --release -j 1`: passed.
- `git diff --check`: passed.

The runtime baseline was captured from clean `main` at `be1e3550`; the later rebase contains only automatic documentation updates on `main`. No `.node-suite` artifacts are included.