### PR TITLE
fix(domexception): preserve options cause

### DIFF
--- a/crates/rts-std/src/globals/dom_exception.rs
+++ b/crates/rts-std/src/globals/dom_exception.rs
@@ -168,9 +168,26 @@ pub(super) fn class(context: &mut Context) -> u64 {
 /// cannot unwind — it aborts the process.
 extern "C" fn construct(_e: u64, _this: u64, message: u64, name: u64, _c: u64, _d: u64) -> u64 {
     let message_text = text_argument(message).unwrap_or_default();
+    // The second parameter is either the legacy name string or an options
+    // object. Read the object before making the error, but check `cause` with
+    // `in` semantics so an explicitly supplied `undefined` is not lost.
+    let absent = entry::undefined_value();
+    let legacy_name = name == absent || entry::text_of(name).is_some();
+    let options = !legacy_name && entry::with_runtime(|context| entry::is_object(context, name));
+    let (name_value, cause_value) = if options {
+        let name_value = entry::with_runtime(|context| entry::get_member(context, name, "name"));
+        let cause_key = entry::with_runtime(|context| entry::make_string(context, "cause"));
+        let has_cause = entry::has_property(cause_key, name);
+        let cause_value = has_cause.then(|| {
+            entry::with_runtime(|context| entry::get_member(context, name, "cause"))
+        });
+        (name_value, cause_value)
+    } else {
+        (name, None)
+    };
     // `"Error"`, not the empty string: that is what a `DOMException` built with
     // no name reports, in Node and in every browser.
-    let name_text = text_argument(name).unwrap_or_else(|| "Error".to_owned());
+    let name_text = text_argument(name_value).unwrap_or_else(|| "Error".to_owned());
     let Some(error) = entry::make_named_error("Error", &message_text) else {
         return entry::undefined_value();
     };
@@ -187,6 +204,9 @@ extern "C" fn construct(_e: u64, _this: u64, message: u64, name: u64, _c: u64, _
         entry::put_member(context, error, "name", held);
         let code = entry::make_number(code_of(&name_text));
         entry::put_member(context, error, "code", code);
+        if let Some(cause_value) = cause_value {
+            entry::put_member(context, error, "cause", cause_value);
+        }
         error
     })
 }


### PR DESCRIPTION
## Summary

Implement the Node DOMException options form used by `test-domexception-cause.js`.

- treat a non-text object second argument as options;
- read its `name` and derive the legacy numeric `code`;
- create an own `cause` property when the options object contains `cause`, including `cause: undefined`;
- keep primitive string and `undefined` second arguments on the legacy name path.

## Validation

- `domexception` corpus: 1/1 passing versus 0/1 on the exact baseline; 1 GAINED, 0 LOST, 0 CHANGED.
- `cargo test --profile fast --no-fail-fast -p rts-core`: 297 passed, 0 failed.
- `cargo test --profile fast --no-fail-fast -p rts-std`: 0 passed, 0 failed.
- `cargo test --profile fast --no-fail-fast -p rts-node`: 90 passed, 0 failed; 3 existing doctests ignored.
- `CARGO_BUILD_JOBS=1 cargo build --release -j 1`: passed.
- `git diff --check`: passed.

The runtime baseline was captured from clean `main` at `a1980883`; the branch was subsequently rebased over one automatic documentation-only update at `2d3feec7`. No `.node-suite` artifacts are included.