### PR TITLE
fix(node): construct SlowBuffer and preserve vm buffers

### DIFF
--- a/crates/rts-node/src/buffer/mod.rs
+++ b/crates/rts-node/src/buffer/mod.rs
@@ -79,7 +79,6 @@ pub fn namespace(context: &mut Context) -> u64 {
         ("transcode", transcode),
         ("isAscii", is_ascii),
         ("isUtf8", is_utf8),
-        ("SlowBuffer", slow_buffer_native),
         ("resolveObjectURL", resolve_object_url),
     ];
     let namespace = entry::make_namespace(context, members);
@@ -91,6 +90,18 @@ pub fn namespace(context: &mut Context) -> u64 {
 
     let buffer = entry::buffer_class(context);
     entry::put_member(context, namespace, "Buffer", buffer);
+
+    // `SlowBuffer` is a callable legacy factory that also accepts `new`. A
+    // generic namespace callable has no `.prototype`, so the construction path
+    // cannot make its temporary receiver. Its returned value remains the real
+    // `Buffer` from `allocUnsafe`, while this separate prototype matches Node's
+    // public `SlowBuffer.prototype` identity.
+    let slow_buffer_prototype = entry::make_prototype(context, "SlowBuffer", &[]);
+    let slow_buffer = entry::make_callable(context, slow_buffer_native);
+    entry::put_member(context, slow_buffer, "prototype", slow_buffer_prototype);
+    entry::declare_host_class(context, slow_buffer, slow_buffer_prototype, "SlowBuffer", 1);
+    entry::put_member(context, namespace, "SlowBuffer", slow_buffer);
+
     blob::install(context, namespace);
 
     let constants = entry::make_object(context);

--- a/crates/rts-node/src/vm.rs
+++ b/crates/rts-node/src/vm.rs
@@ -22,18 +22,15 @@
 //! region can cross — a number, a boolean, a singleton — and `evaluate`
 //! answers `None` for anything else (an object, including a function),
 //! **and also** for a source that failed to compile. The two are one
-//! answer on purpose (see `evaluate`'s own doc) and this module inherits
-//! that: **a returned `undefined` here can mean "the source legitimately
-//! produced `undefined`", "the source produced an object that cannot
-//! cross", or "the source did not compile"** — this module cannot and does
-//! not tell those apart, and no member of it claims to.
+//! answer on purpose (see `evaluate`'s own doc) and the `run` helper below
+//! inherits that limitation.
 //!
-//! That is close to `vm.runInNewContext`'s contract (a fresh global scope,
-//! no access to the caller's locals) and is why the members below are named
-//! after it. `runInContext` and `runInThisContext` are exposed as well, but
-//! retain this engine's honest limitation: each call still evaluates in a
-//! fresh program rather than sharing live objects with a caller-supplied or
-//! ambient context.
+//! The context-aware VM methods use `evaluate_in_scope_with_receiver`
+//! instead. They compile a fresh program against an environment in the
+//! running region, so completion objects such as an `ArrayBuffer` remain
+//! usable by the caller. This still does not create a separate intrinsic
+//! realm: the scope is isolated by its environment object, not by a second
+//! heap or global implementation.
 //!
 //! # `Context` objects: a scope with explicit limits
 //!
@@ -178,15 +175,18 @@ fn run(code: u64) -> u64 {
     }
 }
 
-/// Evaluates against a caller-supplied context, falling back to a fresh program
-/// when the optional context was omitted.
+/// Evaluates against a caller-supplied context, creating an empty one when the
+/// optional context was omitted. The empty object keeps completion values in the
+/// running region, which is required for a returned `ArrayBuffer` to remain a
+/// usable `BufferSource` even though this engine has no separate intrinsic realm.
 fn run_with_context(code: u64, context_obj: u64) -> u64 {
     let absent = entry::undefined_value();
-    if context_obj == absent {
-        run(code)
+    let environment = if context_obj == absent {
+        entry::with_runtime(|context| entry::make_object(context))
     } else {
-        run_in_context_object(code, context_obj)
-    }
+        context_obj
+    };
+    run_in_context_object(code, environment)
 }
 
 /// Evaluates source text against an object that acts as the environment.


### PR DESCRIPTION
## Summary

Make the legacy `buffer.SlowBuffer` callable constructible and preserve `ArrayBuffer` completion values from `vm.runInNewContext` when no context object is supplied.

`SlowBuffer(10)` already returned the native Buffer, but `new SlowBuffer(10)` returned `undefined` because the generic namespace callable had no own `prototype` for the existing construction path to allocate against. The module now gives it a separate `SlowBuffer.prototype`, constructor metadata, and the existing native factory remains callable without `new`; the returned object is still the real Buffer.

`vm.runInNewContext(code)` now follows the same scoped evaluator used when a context object is supplied, with a fresh empty environment for the omitted-context overload. This matches the Node contract and keeps returned `ArrayBuffer` objects in the active runtime region instead of collapsing them to `undefined`. The standalone evaluator remains unchanged where object crossing is intentionally unsupported.

## Validation

Compared against the exact release baseline built from the post-#2600 `main` commit:

- Module: `buffer`
- Files: 61 vs 61
- Baseline OK: 47
- Branch OK: 49
- GAINED: 2
  - `test-buffer-bytelength`
  - `test-buffer-zero-fill-cli`
- LOST: 0
- `CARGO_BUILD_JOBS=1 cargo test --profile fast --no-fail-fast -p rts-node`: passed
- `git diff --check`: passed

The two gains are connected: both exercise `new SlowBuffer(…)`; `test-buffer-bytelength` additionally verifies an `ArrayBuffer` returned from `vm.runInNewContext`.
