### PR TITLE
fix(buffer): keep empty concat lists empty

### DIFF
--- a/crates/rts-core/src/entry/buffer/statics.rs
+++ b/crates/rts-core/src/entry/buffer/statics.rs
@@ -318,6 +318,11 @@ pub(in crate::entry) fn concat(list_value: u64, total_length: u64) -> u64 {
             None => return undefined(),
         },
     };
+    // An empty list is special: Node returns an empty Buffer regardless of the
+    // optional total length, while a non-empty list uses it as the output size.
+    if elements.is_empty() {
+        return with_current(|context| made(context, &[]));
+    }
     with_current(|context| {
         let mut joined = Vec::new();
         for element in elements {


### PR DESCRIPTION
## Summary

Match Node's special case for `Buffer.concat([], totalLength)`: an empty list returns an empty Buffer regardless of the optional total length. The existing validation of `totalLength` remains in place, and non-empty lists retain their current truncation and zero-fill behavior.

## Validation

Compared against the exact release baseline built from post-#2601 `main`:

| Metric | Result |
|---|---:|
| Common files | 61 |
| Baseline OK | 49 |
| Branch OK | 50 |
| GAINED | 1 (`test-buffer-concat`) |
| LOST | 0 |

The direct test passed, `CARGO_BUILD_JOBS=1 cargo test --profile fast --no-fail-fast -p rts-core` passed with 297 tests and 0 failures, and `git diff --check` passed. The edited file remains below the 500-line limit (418 lines).
