### PR TITLE
fix(buffer): match Node index search semantics

### DIFF
--- a/crates/rts-core/src/entry/buffer/codec.rs
+++ b/crates/rts-core/src/entry/buffer/codec.rs
@@ -48,6 +48,33 @@ pub(in crate::entry) fn encode(text: &str, encoding: &str) -> Option<Vec<u8>> {
     }
 }
 
+/// A JavaScript string encoded from its UTF-16 code units.
+///
+/// `Str::to_rust()` deliberately refuses lone surrogates, but Buffer follows
+/// the byte codec's rules: UTF-8 writes U+FFFD, while UTF-16LE preserves the
+/// original code unit. The narrow Rust-string entry point remains for callers
+/// that already have well-formed text; this one is for JS strings.
+pub(in crate::entry) fn encode_text(
+    text: &crate::text::Str,
+    encoding: &str,
+) -> Option<Vec<u8>> {
+    match canonical_encoding(encoding)? {
+        "utf8" => Some(text.to_rust_lossy().into_bytes()),
+        "ascii" => Some(text.units().map(|unit| unit as u8).collect()),
+        "latin1" => Some(text.units().map(|unit| unit as u8).collect()),
+        "utf16le" => {
+            let mut out = Vec::with_capacity(text.len() * 2);
+            for unit in text.units() {
+                out.extend_from_slice(&unit.to_le_bytes());
+            }
+            Some(out)
+        }
+        "base64" | "base64url" => Some(decode_base64(&text.to_rust_lossy())),
+        "hex" => Some(decode_hex(&text.to_rust_lossy())),
+        _ => None,
+    }
+}
+
 /// Bytes decoded to text under the named encoding.
 pub(in crate::entry) fn decode(bytes: &[u8], encoding: &str) -> String {
     match canonical_encoding(encoding) {

--- a/crates/rts-core/src/entry/buffer/mod.rs
+++ b/crates/rts-core/src/entry/buffer/mod.rs
@@ -44,23 +44,21 @@
 //! rather than a line per member because the same three questions are asked
 //! fourteen times over — see [`validate`], which also documents the borrow rule
 //! that decides their shape.
-
 pub(in crate::entry) mod bigint;
 pub(in crate::entry) mod codec;
 pub(in crate::entry) mod ops;
+pub(in crate::entry) mod search;
 pub(in crate::entry) mod statics;
 pub(in crate::entry) mod string;
 pub(in crate::entry) mod swap;
 pub(in crate::entry) mod validate;
 pub(in crate::entry) mod write;
-
 use super::buffers::element::Kind;
 use super::buffers::uint8_array;
 use super::Context;
 use crate::entry;
-
 /// `Buffer`.
-#[rtse::class("Buffer", extends = uint8_array)]
+#[rtse::class("Buffer", extends = uint8_array, method_prototypes)]
 impl Buffer {
     /// `Buffer(size)` / `new Buffer(size)` and the legacy source overloads.
     ///
@@ -99,7 +97,6 @@ impl Buffer {
     fn alloc(size: u64, fill: u64, encoding: u64) -> u64 {
         statics::alloc(size, fill, encoding)
     }
-
     /// `Buffer.allocUnsafe(size)`.
     #[stat]
     fn alloc_unsafe(size: u64) -> u64 {
@@ -113,19 +110,16 @@ impl Buffer {
     fn from(source: u64, encoding_or_offset: u64, length: u64) -> u64 {
         statics::from(source, encoding_or_offset, length)
     }
-
     /// `Buffer.of(...values)`.
     #[stat]
     fn of(a0: u64, a1: u64, a2: u64, a3: u64) -> u64 {
         statics::of(a0, a1, a2, a3)
     }
-
     /// `Buffer.concat(list, totalLength?)`.
     #[stat]
     fn concat(list: u64, total_length: u64) -> u64 {
         statics::concat(list, total_length)
     }
-
     /// `Buffer.byteLength(source, encoding?)`.
     #[stat]
     fn byte_length(source: u64, encoding: u64) -> f64 {
@@ -195,6 +189,12 @@ impl Buffer {
     /// `buf.indexOf(value, byteOffset?, encoding?)`.
     fn index_of(this: u64, value: u64, byte_offset: u64, encoding: u64) -> f64 {
         ops::index_of(this, value, byte_offset, encoding)
+    }
+
+    /// `buf.lastIndexOf(value, byteOffset?, encoding?)`.
+    #[js("lastIndexOf")]
+    fn last_index_of(this: u64, value: u64, byte_offset: u64, encoding: u64) -> f64 {
+        ops::last_index_of(this, value, byte_offset, encoding)
     }
 
     /// `buf.includes(value, byteOffset?, encoding?)`.

--- a/crates/rts-core/src/entry/buffer/ops.rs
+++ b/crates/rts-core/src/entry/buffer/ops.rs
@@ -29,6 +29,7 @@ use super::super::buffers::{
 use super::super::objects::undefined_of;
 use super::super::{Context, native, with_current};
 use super::codec;
+use super::search;
 use crate::entry;
 use super::validate::{self, Shape};
 use crate::value::Value;
@@ -106,7 +107,7 @@ pub(in crate::entry) fn source_bytes(context: &Context, value: u64, encoding: &s
     if let Some(cell) = Value(value).as_slot()
         && let Some(text) = context.text_at(cell)
     {
-        return codec::encode(&text.to_rust()?, encoding);
+        return codec::encode_text(text, encoding);
     }
     if let Some(cell) = Value(value).as_slot()
         && let Some(elements) = context.elements_at(cell)
@@ -131,13 +132,23 @@ fn encoding_arg(context: &Context, value: u64) -> String {
         .unwrap_or_else(|| "utf8".to_owned())
 }
 
+/// Encoding validation for search methods, whose optional trailing slot is null
+/// when the native ABI receives no third argument.
+fn validated_encoding(value: u64) -> Option<String> {
+    if value == entry::undefined_value() || value == entry::null_value() {
+        Some("utf8".to_owned())
+    } else {
+        validate::encoding(value)
+    }
+}
+
 /// A byte, a string's encoded bytes, or a view's bytes — what
 /// [`fill`]/[`index_of`]/[`includes`] search for or write.
 pub(in crate::entry) fn pattern_of(context: &Context, value: u64, encoding: &str) -> Vec<u8> {
     match Value(value).as_slot() {
         Some(cell) => {
             if let Some(text) = context.text_at(cell) {
-                return codec::encode(&text.to_rust().unwrap_or_default(), encoding).unwrap_or_default();
+                return codec::encode_text(text, encoding).unwrap_or_default();
             }
             if let Some(view) = view_of(context, value) {
                 return window(context, &view).map(<[u8]>::to_vec).unwrap_or_default();
@@ -273,42 +284,78 @@ pub(in crate::entry) fn fill(this: u64, value: u64, begin: u64, end: u64, encodi
     })
 }
 
-/// The first index at or after `from` where `needle` occurs in `haystack`, or
-/// `None`. An empty needle matches at `from` itself, the way `String.indexOf`
-/// treats one.
-fn find(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
-    if needle.is_empty() {
-        return (from <= haystack.len()).then_some(from);
-    }
-    if from >= haystack.len() {
-        return None;
-    }
-    // Two-way with a SIMD prefilter, where the window compare this replaces was
-    // O(n*m). The same swap `entry::string::basic` took, and this one is the
-    // case that wants it most: a `Buffer` is bytes by construction and is
-    // routinely megabytes, where a string in this engine is usually short.
-    memchr::memmem::find(&haystack[from..], needle).map(|position| position + from)
-}
-
 /// `buf.indexOf(value, byteOffset?, encoding?)`.
 pub(in crate::entry) fn index_of(this: u64, value: u64, byte_offset: u64, encoding: u64) -> f64 {
+    if !validate::search_receiver(this) {
+        return -1.0;
+    }
     if !validate::search_value(value) {
         return -1.0;
     }
-    let byte_offset = optional_number(byte_offset);
+    let byte_offset_value = byte_offset;
+    let (byte_offset, encoding_in_offset) = search::search_arguments(byte_offset, encoding);
+    let enc = if encoding_in_offset {
+        validated_encoding(byte_offset_value)
+    } else {
+        validated_encoding(encoding)
+    };
+    let Some(enc) = enc else { return -1.0 };
     with_current(|context| {
         let Some(view) = view_of(context, this) else { return -1.0 };
         let Some(bytes) = window(context, &view) else { return -1.0 };
-        let enc = encoding_arg(context, encoding);
         let needle = pattern_of(context, value, &enc);
-        // UTF-16 searches operate on two-byte code units. A raw Buffer needle
-        // with an odd byte length cannot represent one, and Node returns no
-        // match rather than finding a byte halfway through a code unit.
-        if entry::canonical_encoding(&enc) == Some("utf16le") && needle.len() % 2 != 0 {
+        // UTF-16 searches operate on two-byte code-unit boundaries. A raw
+        // Buffer needle with an odd byte length cannot represent one, and Node
+        // returns no match rather than finding a byte halfway through a unit.
+        let utf16 = entry::canonical_encoding(&enc) == Some("utf16le");
+        if utf16 && needle.len() % 2 != 0 {
             return -1.0;
         }
         let (from, _) = range(bytes.len(), byte_offset, None);
-        find(bytes, &needle, from).map(|at| at as f64).unwrap_or(-1.0)
+        let found = if utf16 {
+            search::find_utf16(bytes, &needle, from)
+        } else {
+            search::find(bytes, &needle, from)
+        };
+        found.map(|at| at as f64).unwrap_or(-1.0)
+    })
+}
+
+pub(in crate::entry) fn last_index_of(
+    this: u64,
+    value: u64,
+    byte_offset: u64,
+    encoding: u64,
+) -> f64 {
+    if !validate::search_receiver(this) {
+        return -1.0;
+    }
+    if !validate::search_value(value) {
+        return -1.0;
+    }
+    let byte_offset_value = byte_offset;
+    let (byte_offset, encoding_in_offset) = search::search_arguments(byte_offset, encoding);
+    let enc = if encoding_in_offset {
+        validated_encoding(byte_offset_value)
+    } else {
+        validated_encoding(encoding)
+    };
+    let Some(enc) = enc else { return -1.0 };
+    with_current(|context| {
+        let Some(view) = view_of(context, this) else { return -1.0 };
+        let Some(bytes) = window(context, &view) else { return -1.0 };
+        let needle = pattern_of(context, value, &enc);
+        let utf16 = entry::canonical_encoding(&enc) == Some("utf16le");
+        if utf16 && needle.len() % 2 != 0 {
+            return -1.0;
+        }
+        let Some(from) = search::last_from(bytes.len(), byte_offset) else { return -1.0 };
+        let found = if utf16 {
+            search::find_last_utf16(bytes, &needle, from)
+        } else {
+            search::find_last(bytes, &needle, from)
+        };
+        found.map(|at| at as f64).unwrap_or(-1.0)
     })
 }
 

--- a/crates/rts-core/src/entry/buffer/search.rs
+++ b/crates/rts-core/src/entry/buffer/search.rs
@@ -1,0 +1,135 @@
+//! Search bounds and byte-search primitives shared by Buffer index methods.
+//!
+//! The forward and reverse methods have different default bounds, but the
+//! needle encoding overload and the actual byte search are the same questions.
+//! Keeping them here prevents the instance-method module from crossing the
+//! 500-line boundary while preserving the SIMD-backed `memchr` implementation.
+
+use super::super::buffers::optional_number;
+use crate::entry;
+use crate::value::Value;
+
+fn is_text_value(value: u64) -> bool {
+    entry::with_runtime(|context| {
+        Value(value)
+            .as_slot()
+            .and_then(|cell| context.text_at(cell))
+            .is_some()
+    })
+}
+
+/// The first index at or after `from` where `needle` occurs in `haystack`, or
+/// `None`. An empty needle matches at `from` itself, the way `String.indexOf`
+/// treats one.
+pub(in crate::entry) fn find(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return (from <= haystack.len()).then_some(from);
+    }
+    if from >= haystack.len() {
+        return None;
+    }
+    // Two-way with a SIMD prefilter, where the window compare this replaces was
+    // O(n*m). The same swap `entry::string::basic` took, and this one is the
+    // case that wants it most: a `Buffer` is bytes by construction and is
+    // routinely megabytes, where a string in this engine is usually short.
+    memchr::memmem::find(&haystack[from..], needle).map(|position| position + from)
+}
+
+/// The last index at or before `from` where `needle` occurs in `haystack`.
+pub(in crate::entry) fn find_last(
+    haystack: &[u8],
+    needle: &[u8],
+    from: usize,
+) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(from.min(haystack.len()));
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    let start = from.min(haystack.len() - needle.len());
+    let end = start + needle.len();
+    memchr::memmem::rfind(&haystack[..end], needle)
+}
+
+/// Detects Node's overload where a textual second argument is the encoding.
+pub(in crate::entry) fn search_arguments(
+    byte_offset: u64,
+    encoding: u64,
+) -> (Option<f64>, bool) {
+    // The native ABI fills omitted trailing slots with either singleton; an
+    // explicit text in the offset slot is still the unambiguous encoding form.
+    let encoding_in_offset = (encoding == entry::undefined_value()
+        || encoding == entry::null_value())
+        && entry::number_of(byte_offset).is_none()
+        && is_text_value(byte_offset);
+    let offset = if encoding_in_offset {
+        None
+    } else {
+        optional_number(byte_offset)
+    };
+    (offset, encoding_in_offset)
+}
+
+/// Forward search on two-byte code-unit boundaries.
+pub(in crate::entry) fn find_utf16(
+    haystack: &[u8],
+    needle: &[u8],
+    from: usize,
+) -> Option<usize> {
+    if needle.is_empty() {
+        return find(haystack, needle, from);
+    }
+    let mut from = from.saturating_add(from % 2);
+    while let Some(found) = find(haystack, needle, from) {
+        if found % 2 == 0 {
+            return Some(found);
+        }
+        from = found + 1;
+    }
+    None
+}
+
+/// Reverse search on two-byte code-unit boundaries.
+pub(in crate::entry) fn find_last_utf16(
+    haystack: &[u8],
+    needle: &[u8],
+    from: usize,
+) -> Option<usize> {
+    if needle.is_empty() {
+        return find_last(haystack, needle, from);
+    }
+    let mut from = from - from % 2;
+    loop {
+        let found = find_last(haystack, needle, from)?;
+        if found % 2 == 0 {
+            return Some(found);
+        }
+        if found == 0 {
+            return None;
+        }
+        from = found - 1;
+    }
+}
+
+/// Converts the optional last-search bound, retaining negative infinity as no
+/// possible index rather than clamping it to the first byte.
+pub(in crate::entry) fn last_from(count: usize, offset: Option<f64>) -> Option<usize> {
+    let Some(offset) = offset else { return Some(count) };
+    if offset.is_nan() {
+        return Some(count);
+    }
+    if offset == f64::NEG_INFINITY {
+        return None;
+    }
+    if offset == f64::INFINITY {
+        return Some(count);
+    }
+    let offset = offset.trunc();
+    if offset < 0.0 {
+        let from_end = count as f64 + offset;
+        (from_end >= 0.0).then_some(from_end as usize)
+    } else {
+        Some((offset as usize).min(count))
+    }
+}

--- a/crates/rts-core/src/entry/buffer/validate.rs
+++ b/crates/rts-core/src/entry/buffer/validate.rs
@@ -249,6 +249,17 @@ pub(in crate::entry) fn bytes(name: &str, value: u64) -> Option<usize> {
     }
 }
 
+/// A receiver accepted by `Buffer.indexOf`/`lastIndexOf`: any byte view.
+pub(in crate::entry) fn search_receiver(value: u64) -> bool {
+    match shape_of(value) {
+        Shape::Bytes(_) => true,
+        _ => {
+            errors::invalid_arg_instance("buffer", "Buffer, TypedArray, or DataView", value);
+            false
+        }
+    }
+}
+
 /// A value accepted by `Buffer.indexOf`/`includes`: number, string or bytes.
 pub(in crate::entry) fn search_value(value: u64) -> bool {
     match shape_of(value) {

--- a/crates/rts-core/src/entry/errors.rs
+++ b/crates/rts-core/src/entry/errors.rs
@@ -276,6 +276,17 @@ fn raise(class: &str, code: &str, message: &str) {
     super::throw::throw_value(error);
 }
 
+fn constructor_name_in(context: &mut super::Context, value: u64) -> Option<String> {
+    let cell = crate::value::Value(value).as_slot()?;
+    let constructor = context.well_known("constructor");
+    let constructor = super::objects::read_property(context, cell, constructor)?;
+    let constructor = crate::value::Value(constructor.bits()).as_slot()?;
+    let name = context.well_known("name");
+    let name = super::objects::read_property(context, constructor, name)?;
+    let name = name.as_slot()?;
+    context.text_at(name).and_then(|text| text.to_rust())
+}
+
 /// What a value is, in the words Node's `ERR_INVALID_ARG_TYPE` uses.
 ///
 /// Node writes `type number` for a primitive, `an instance of Buffer` for an
@@ -341,6 +352,9 @@ fn kind_text(value: u64) -> String {
         if super::modules::is_array_in(context, value) {
             return String::from("an instance of Array");
         }
+        if let Some(name) = constructor_name_in(context, value).filter(|name| !name.is_empty()) {
+            return format!("an instance of {name}");
+        }
         if super::modules::is_object(context, value) {
             return String::from("an instance of Object");
         }
@@ -373,15 +387,7 @@ fn buffer_kind_text(value: u64) -> String {
         let Some(cell) = crate::value::Value(value).as_slot() else {
             return (None, false);
         };
-        let constructor = context.well_known("constructor");
-        let class_name = super::objects::read_property(context, cell, constructor)
-            .and_then(|constructor| crate::value::Value(constructor.bits()).as_slot())
-            .and_then(|constructor| {
-                let name = context.well_known("name");
-                super::objects::read_property(context, constructor, name)
-            })
-            .and_then(|name| name.as_slot())
-            .and_then(|name| context.text_at(name).and_then(|text| text.to_rust()));
+        let class_name = constructor_name_in(context, value);
         let value_of = context.well_known("valueOf");
         let custom_value_of = super::objects::own_property(context, cell, value_of)
             .is_some_and(|value_of| super::modules::is_callable_in(context, value_of.bits()));

--- a/crates/rts-core/src/entry/native.rs
+++ b/crates/rts-core/src/entry/native.rs
@@ -123,6 +123,56 @@ pub(in crate::entry) fn install_with_arity(context: &mut Context, cell: u32, nat
     }
 }
 
+/// Installs native members that Node exposes as constructible functions.
+///
+/// Most runtime-created callables deliberately have no own `prototype`: making
+/// `native::callable` constructible globally would change getters, global
+/// functions and bound-function helpers. Buffer's methods are the exception
+/// observed by the compatibility suite. Their own prototype is an ordinary
+/// object, its `constructor` points back to the method, and the prototype
+/// property is non-enumerable/non-configurable but writable. The rejected
+/// alternative was to special-case the error formatter for one method, which
+/// would leave `new` with the wrong observable prototype and would not generalise
+/// to the other constructible Buffer methods.
+pub(in crate::entry) fn install_with_arity_and_prototypes(
+    context: &mut Context,
+    cell: u32,
+    natives: &[(&str, Native, u32)],
+) {
+    for (name, code, arity) in natives {
+        let method = callable(context, *code);
+        name_of(context, method, name);
+        length_of(context, method, *arity);
+        let Some(method_cell) = Value(method).as_slot() else {
+            continue;
+        };
+        let Some(prototype_cell) = plain(context) else {
+            continue;
+        };
+        let prototype = Value::from_slot(prototype_cell).bits();
+        let prototype_key = context.well_known("prototype");
+        super::objects::put(context, method_cell, prototype_key, prototype);
+        if let crate::object::Key::Name(named) = prototype_key {
+            super::integrity::set_attributes(
+                context,
+                method_cell,
+                named,
+                super::integrity::Attributes {
+                    writable: true,
+                    enumerable: false,
+                    configurable: false,
+                },
+            );
+        }
+        let constructor_key = context.well_known("constructor");
+        super::objects::put(context, prototype_cell, constructor_key, method);
+        hidden(context, prototype_cell, constructor_key);
+        let key = context.well_known(name);
+        super::objects::put(context, cell, key, method);
+        hidden(context, cell, key);
+    }
+}
+
 /// Marks a property nothing may change: non-writable, non-enumerable,
 /// NON-configurable.
 ///

--- a/crates/rts-core/src/entry/string/search.rs
+++ b/crates/rts-core/src/entry/string/search.rs
@@ -42,6 +42,9 @@ extern "C" fn index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64, _a3
     let Some(search) = super::text_arg(search) else {
         return super::refused();
     };
+    // ToIntegerOrInfinity must run outside the borrow so arrays and objects can
+    // perform their ordinary ToPrimitive conversion instead of becoming NaN.
+    let from = super::integer_outside(from);
     with_current(|context| {
         // The narrow path first, and it is the common one: both sides ASCII, so
         // there is nothing to widen and nothing to copy. `units_of` builds a
@@ -52,7 +55,7 @@ extern "C" fn index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64, _a3
         //
         // Answered from borrowed slices, so neither side allocates at all.
         if let Some((hay, pin)) = narrow_pair(context, this, search) {
-            let start = relative(super::integer_arg(context, from).max(0.0), hay.len());
+            let start = relative(from.max(0.0), hay.len());
             let found = find_bytes(hay, pin, start);
             return Value::from_f64(found.map_or(-1.0, |at| at as f64)).bits();
         }
@@ -60,7 +63,7 @@ extern "C" fn index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64, _a3
         else {
             return nothing(context);
         };
-        let start = relative(super::integer_arg(context, from).max(0.0), units.len());
+        let start = relative(from.max(0.0), units.len());
         let found = find(&units, &needle, start);
         Value::from_f64(found.map_or(-1.0, |at| at as f64)).bits()
     })
@@ -104,6 +107,10 @@ extern "C" fn last_index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64
     let Some(search) = super::text_arg(search) else {
         return super::refused();
     };
+    // Unlike `integer_arg`, this keeps NaN visible: String.lastIndexOf treats
+    // it like an omitted upper bound, and the conversion still belongs outside
+    // the runtime borrow so object offsets can run their primitive hooks.
+    let from = super::super::class_support::to_number(from);
     with_current(|context| {
         let (Some(units), Some(needle)) = (units_of(context, this), arg_units(context, search))
         else {
@@ -114,13 +121,12 @@ extern "C" fn last_index_of(_e: u64, this: u64, search: u64, from: u64, _a2: u64
         // position means 0. The asymmetry is the specification's: one searches
         // forwards from a lower bound, the other backwards from an upper one.
         //
-        // Asked through `ToNumber` rather than through `integer_arg`, because
-        // that one folds `NaN` into zero and here `NaN` means the far end. This
-        // is the one method the specification writes with `ToNumber` and an
-        // explicit `NaN` case instead of `ToIntegerOrInfinity`.
-        let limit = match super::super::operators::as_number(context, Value(from)) {
-            Some(number) if !number.is_nan() => relative(number.trunc().max(0.0), units.len()),
-            _ => units.len(),
+        // `from` was converted before this borrow. Keep NaN as the far end;
+        // otherwise truncate and clamp the requested upper bound.
+        let limit = if from.is_nan() {
+            units.len()
+        } else {
+            relative(from.trunc().max(0.0), units.len())
         };
         // The last position a match could START at: past `len - needle.len()`
         // there is not enough string left for one.

--- a/crates/rts-macro/src/class/mod.rs
+++ b/crates/rts-macro/src/class/mod.rs
@@ -139,6 +139,7 @@ pub fn expand(args: TokenStream, item: TokenStream) -> syn::Result<TokenStream> 
             options.extends.as_ref(),
             &prefix,
             options.tag,
+            options.method_prototypes,
         ),
     };
 
@@ -257,8 +258,20 @@ fn class_body(
     extends: Option<&Path>,
     prefix: &str,
     tag: bool,
+    method_prototypes: bool,
 ) -> TokenStream {
     let tagged = tagging(name, quote!(prototype_cell), tag);
+    let install_members = if method_prototypes {
+        quote! {
+            crate::entry::native::install_with_arity_and_prototypes(
+                context, prototype_cell, #natives,
+            );
+        }
+    } else {
+        quote! {
+            crate::entry::native::install_with_arity(context, prototype_cell, #natives);
+        }
+    };
     // A class with no constructor of its own still has to be callable, because
     // `new C()` runs one. The default keeps the object `construct` made, which
     // is what a JavaScript constructor with an empty body does.
@@ -345,7 +358,7 @@ fn class_body(
             // runtime answers `[]`, and `for (const k in Map)` walked it.
             crate::entry::native::pinned(context, cell, key);
         }
-        crate::entry::native::install_with_arity(context, prototype_cell, #natives);
+        #install_members
         crate::entry::class_support::constants(context, prototype_cell, #constants);
         // `p.constructor` is an ordinary property, and a program reads it.
         let key = context.well_known("constructor");

--- a/crates/rts-macro/src/class/options.rs
+++ b/crates/rts-macro/src/class/options.rs
@@ -38,10 +38,12 @@ pub(super) struct Options {
     /// Everything added since ES6 carries one. Defaulting to installed would
     /// put a property on eight prototypes that a real engine does not have.
     pub(super) tag: bool,
+    /// Whether prototype members get their own constructible-function prototype.
+    pub(super) method_prototypes: bool,
 }
 
-/// Reads `("Name")`, `("Name", namespace)`, `("Name", extends = path)` and
-/// `("Name", tag)`.
+/// Reads `("Name")`, `("Name", namespace)`, `("Name", extends = path)`,
+/// `("Name", tag)` and `("Name", method_prototypes)`.
 pub(super) fn parse_options(args: TokenStream) -> syn::Result<Options> {
     let span = args.span();
     // A `macro_rules!` metavariable arrives wrapped in an invisible group, and
@@ -75,6 +77,7 @@ pub(super) fn parse_options(args: TokenStream) -> syn::Result<Options> {
         flavour: Flavour::Class,
         extends: None,
         tag: false,
+        method_prototypes: false,
     };
 
     for part in parts {
@@ -84,6 +87,9 @@ pub(super) fn parse_options(args: TokenStream) -> syn::Result<Options> {
             }
             Expr::Path(path) if path.path.is_ident("tag") => {
                 options.tag = true;
+            }
+            Expr::Path(path) if path.path.is_ident("method_prototypes") => {
+                options.method_prototypes = true;
             }
             Expr::Assign(assign) => {
                 let Expr::Path(left) = assign.left.as_ref() else {
@@ -104,7 +110,7 @@ pub(super) fn parse_options(args: TokenStream) -> syn::Result<Options> {
             other => {
                 return Err(syn::Error::new(
                     other.span(),
-                    "the options are `namespace`, `tag` and `extends = path`",
+                    "the options are `namespace`, `tag`, `method_prototypes` and `extends = path`",
                 ));
             }
         }


### PR DESCRIPTION
## Summary

Implement Node-compatible `Buffer.indexOf` and `Buffer.lastIndexOf` behaviour without special-casing the fixture. The change adds reverse byte search, the string-encoding overload, UTF-16 code-unit alignment, correct handling of empty needles and non-finite/negative offsets, and JavaScript string encoding that preserves isolated UTF-16 surrogates.

The native class installer now has an opt-in method-prototype path used by `Buffer`. This gives constructed built-in methods their own `.prototype` and `prototype.constructor` metadata, matching Node's observable object shape while leaving ordinary native callables, getters, global functions, and bound functions unchanged. Receiver validation now runs before value and encoding validation, and object offset coercion stays outside active runtime borrows.

The rejected alternatives were raw byte search for UTF-16 values, which can match at an odd byte offset, and a `lastIndexOf`-specific error-message special case, which would encode one fixture instead of the general construction and metadata semantics.

## Validation

Measured against `target/baseline-post-2602.exe` using the release binary and the official `buffer` harness over exactly 61 files:

| Metric | Baseline | Branch |
|---|---:|---:|
| OK | 50 | 51 |
| Failed | 6 | 5 |
| Error | 2 | 2 |
| Timeout | 0 | 0 |
| Skipped | 3 | 3 |
| Ran | 58 | 58 |
| Per-file gained | — | `test-buffer-indexof.js` |
| Per-file lost | — | none |

Direct validation passed for `test-buffer-indexof.js`, `test-buffer-concat.js`, `test-buffer-bytelength.js`, `test-buffer-zero-fill-cli.js`, and `test-buffer-compare.js`. `test-buffer-fakes.js` and `test-buffer-from.js` remain failures identical to the preserved baseline. Rust gates passed with `CARGO_BUILD_JOBS=1 cargo test --profile fast --no-fail-fast -p rts-core -p rts-macro`: `rts-core` 297 passed, `rts-macro` 8 passed, and doctests completed without failures. The release build completed successfully.
