### PR TITLE
O escopo de uma página e o `window` são o mesmo objeto — e o React 18 fica interativo

### DIFF
--- a/crates/rts-codegen/src/emit/capture.rs
+++ b/crates/rts-codegen/src/emit/capture.rs
@@ -226,7 +226,7 @@ fn declared_at_own_level(body: &[Stmt], candidates: &[Name]) -> BTreeSet<Name> {
 ///
 /// Stops at a nested function, like everything else in this module: a `var`
 /// there belongs to that function and not to this one.
-fn vars_at_any_depth(statement: &Stmt, found: &mut BTreeSet<Name>) {
+pub(super) fn vars_at_any_depth(statement: &Stmt, found: &mut BTreeSet<Name>) {
     if let StmtKind::Declare { kind, bindings } = &statement.kind
         && !kind.is_block_scoped()
     {

--- a/crates/rts-codegen/src/emit/class.rs
+++ b/crates/rts-codegen/src/emit/class.rs
@@ -485,7 +485,10 @@ fn write_member(
             // rather than a fourth entry point.
             if !hidden {
                 return Ok(
-                    expr::call(builder, ctx, RuntimeOp::SetIndexed, &[target, key_value, value])?[0],
+                    {
+                        let estrito = super::property::estrito(builder, ctx);
+                        expr::call(builder, ctx, RuntimeOp::SetIndexed, &[target, key_value, value, estrito])?[0]
+                    },
                 );
             }
             let key = expr::call(builder, ctx, RuntimeOp::KeyNumber, &[key_value])?[0];

--- a/crates/rts-codegen/src/emit/common_js.rs
+++ b/crates/rts-codegen/src/emit/common_js.rs
@@ -115,7 +115,8 @@ pub fn emit_prologue(
                 let size = integer(builder, 1);
                 let holder = super::expr::call(builder, ctx, RuntimeOp::ObjectNew, &[size])?[0];
                 let key = key_of(builder, ctx, "exports");
-                super::expr::call(builder, ctx, RuntimeOp::SetProperty, &[holder, key, object])?;
+                let estrito = super::property::estrito(builder, ctx);
+                super::expr::call(builder, ctx, RuntimeOp::SetProperty, &[holder, key, object, estrito])?;
                 super::binding::declare(builder, scope, ctx, module_name, holder)?;
             }
             Some(object)

--- a/crates/rts-codegen/src/emit/expr.rs
+++ b/crates/rts-codegen/src/emit/expr.rs
@@ -1262,22 +1262,24 @@ fn emit_assign(
                     value,
                     |builder, _scope, ctx, new_value| {
                         let new_value = tagged(builder, new_value);
+                        let mode = super::property::write_mode(builder, ctx);
                         Ok(call(
                             builder,
                             ctx,
                             RuntimeOp::SetIndexed,
-                            &[receiver, key, new_value],
+                            &[receiver, key, new_value, mode],
                         )?[0])
                     },
                 );
             }
         };
         let assigned = tagged(builder, assigned);
+        let mode = super::property::write_mode(builder, ctx);
         return Ok(call(
             builder,
             ctx,
             RuntimeOp::SetIndexed,
-            &[receiver, key, assigned],
+            &[receiver, key, assigned, mode],
         )?[0]);
     }
 
@@ -1539,7 +1541,8 @@ pub(super) fn value_list(
     for (position, value) in values.iter().enumerate() {
         let value = tagged(builder, *value);
         let at = number_constant(builder, position as f64);
-        call(builder, ctx, RuntimeOp::SetIndexed, &[array, at, value])?;
+        let estrito = super::property::estrito(builder, ctx);
+        call(builder, ctx, RuntimeOp::SetIndexed, &[array, at, value, estrito])?;
     }
     Ok(array)
 }
@@ -2251,7 +2254,8 @@ fn emit_array(
         let value = emit_expr(builder, scope, ctx, value)?;
         let value = tagged(builder, value);
         let at = number_constant(builder, position as f64);
-        call(builder, ctx, RuntimeOp::SetIndexed, &[array, at, value])?;
+        let estrito = super::property::estrito(builder, ctx);
+        call(builder, ctx, RuntimeOp::SetIndexed, &[array, at, value, estrito])?;
     }
     Ok(array)
 }

--- a/crates/rts-codegen/src/emit/function.rs
+++ b/crates/rts-codegen/src/emit/function.rs
@@ -1323,7 +1323,18 @@ pub fn hoist_vars(
         // spelling would shadow the first in the SAME layer, which is a
         // different bug from the one this function fixes. Checking first is
         // cheap on a per-function list.
-        if scope.lookup(name).is_none() {
+        // `declared_in_function` e nao `lookup`: a pergunta e se ESTA funcao ja
+        // ligou o nome, e nao se o nome existe algures. Com `lookup`, todo o
+        // nome que o escopo ENVOLVENTE tivesse fazia o `var` local nao ser
+        // declarado — e num `<script>` de pagina, onde o envolvente e o
+        // `window`, isso apanha `parent`, `top`, `self`, `name`, `length` e mais.
+        //
+        // Medido: `var parent = x; while (parent !== null) { parent = parent.pai; }`
+        // dentro de uma funcao escrevia em `window.parent` (que e
+        // `[Replaceable]` e IGNORA), lia de volta o `window`, e o laco nunca
+        // terminava. Foi o que impediu o React 18 de montar, com o erro a
+        // aparecer trinta ficheiros a jusante.
+        if !scope.declared_in_function(name) {
             let value = expr::undefined(builder, ctx);
             binding::declare(builder, scope, ctx, name, value)?;
         }

--- a/crates/rts-codegen/src/emit/globals.rs
+++ b/crates/rts-codegen/src/emit/globals.rs
@@ -264,8 +264,54 @@ const PROVIDED: &[&str] = &[
 /// answered from a scan of the whole program because the read can be emitted
 /// before the assignment is reached.
 pub(super) fn resolves(ctx: &Ctx, name: Name) -> bool {
-    PROVIDED.contains(&ctx.names.text(name)) || ctx.globals.contains(&name)
+    let text = ctx.names.text(name);
+    if ctx.page && NODE_ONLY.contains(&text) {
+        return false;
+    }
+    PROVIDED.contains(&text) || ctx.globals.contains(&name)
 }
+
+/// Os nomes que só existem em Node, e que um `<script>` de página NÃO vê.
+///
+/// # Porque a ausência é a resposta certa
+///
+/// Um browser não tem nenhum destes, e meio npm decide o que fazer perguntando
+/// se eles existem. `typeof process !== 'undefined'` é como uma biblioteca
+/// escolhe entre o caminho de servidor e o de browser, e responder `"object"`
+/// numa página manda-a pelo lado errado — sem um erro, porque o lado errado
+/// também corre.
+///
+/// Medido, e foi o que impediu o React 18 de montar. O scheduler dele escolhe
+/// assim:
+///
+/// ```text
+/// var localSetImmediate = typeof setImmediate !== 'undefined' ? setImmediate : null;
+/// if (typeof localSetImmediate === 'function') { … }        // Node.js
+/// else if (typeof MessageChannel !== 'undefined') { … }     // DOM
+/// ```
+///
+/// Com `setImmediate` visível, ele agendava o render pela fila do MOTOR em vez
+/// da do documento — e nada a bombeava. O `#root` ficava vazio, sem um erro,
+/// com os três scripts a correr limpos.
+///
+/// `typeof` é exempto do refusal por especificação, por isso um nome daqui
+/// responde `"undefined"` em vez de lançar, que é exatamente o que a deteção
+/// espera. Uma leitura NUA continua a ser um `ReferenceError`, como num
+/// browser.
+///
+/// `setTimeout` e `URL` não estão aqui: um browser TEM os dois.
+const NODE_ONLY: &[&str] = &[
+    "process",
+    "Buffer",
+    "global",
+    "setImmediate",
+    "clearImmediate",
+    "require",
+    "module",
+    "exports",
+    "__dirname",
+    "__filename",
+];
 
 /// Emits a read of one, if it is one.
 ///

--- a/crates/rts-codegen/src/emit/globals.rs
+++ b/crates/rts-codegen/src/emit/globals.rs
@@ -65,6 +65,12 @@ use crate::runtime::RuntimeOp;
 const PROVIDED: &[&str] = &[
     "Array",
     "console",
+    // `fetch` — o Node 18+ tem-no e um browser também, e este motor passou a
+    // tê-lo. Sem estar aqui, o compilador não o resolve e `typeof fetch`
+    // responde `"undefined"` sobre uma função que existe.
+    "fetch",
+    // A porta síncrona do `fetch`, para o prelude do DOM. Ver `rts-node::fetch`.
+    "__rtsFetchText",
     "ArrayBuffer",
     "BigInt",
     "BigInt64Array",

--- a/crates/rts-codegen/src/emit/loops.rs
+++ b/crates/rts-codegen/src/emit/loops.rs
@@ -657,6 +657,22 @@ fn per_iteration_names(
     // the declaration path that would put it here.
     let mut declared = std::collections::BTreeSet::new();
     super::capture::declared_by_statement(body, &mut declared);
+    // E os `var` SAEM, que é o que o parágrafo acima diz e o que esta função
+    // não fazia: `declared_by_statement` recolhe TODAS as declarações — é a
+    // mesma que `hoist_vars` usa para as encontrar — por isso um `var` do corpo
+    // vinha para aqui e era ligado a zero hops no objeto DA PASSAGEM.
+    //
+    // O efeito é a escrita e a leitura irem a objetos diferentes: medido, a
+    // escrita de `var d = c` dentro do laço via o ambiente `v44` e a leitura
+    // depois dele via `v9`, ambas a "zero hops". O valor não se perdia — ficava
+    // num objeto que já ninguém consultava.
+    //
+    // Só aparece quando a função TEM ambiente, porque só então há um objeto por
+    // passagem a abrir; foi por isso que o mesmo laço dentro de um `try` falha
+    // e fora dele não.
+    let mut vars = std::collections::BTreeSet::new();
+    super::capture::vars_at_any_depth(body, &mut vars);
+    declared.retain(|name| !vars.contains(name));
     let mut resident = carried.clone();
     resident.extend(
         declared

--- a/crates/rts-codegen/src/emit/mod.rs
+++ b/crates/rts-codegen/src/emit/mod.rs
@@ -350,6 +350,13 @@ pub struct Ctx<'a> {
     ///
     /// A flag rather than a parameter for [`Ctx::in_static_method`]'s reason.
     pub sloppy: bool,
+    /// Se o programa é um `<script>` de PÁGINA.
+    ///
+    /// O que isso muda é uma coisa só e está em [`globals::resolves`]: um nome
+    /// que só o Node tem — `process`, `Buffer`, `setImmediate`, `global` —
+    /// deixa de resolver, porque num browser ele não existe. Ver a lista lá
+    /// para o que isso custou.
+    pub page: bool,
     /// The objects a `with` put on the scope chain, innermost LAST.
     ///
     /// Empty everywhere except inside a `with` body. What reads it is
@@ -606,6 +613,7 @@ impl<'a> Ctx<'a> {
             in_static_method: false,
             in_field_initializer: false,
             sloppy: false,
+            page: false,
             with_objects: Vec::new(),
             finally_returns: Vec::new(),
             finally_jumps: Vec::new(),

--- a/crates/rts-codegen/src/emit/object.rs
+++ b/crates/rts-codegen/src/emit/object.rs
@@ -210,7 +210,8 @@ pub(super) fn emit_object(
             PropertyKey::Computed(expression) => {
                 let key = emit_expr(builder, scope, ctx, expression)?;
                 let key = tagged(builder, key);
-                call(builder, ctx, RuntimeOp::SetIndexed, &[object, key, value])?;
+                let estrito = super::property::estrito(builder, ctx);
+                call(builder, ctx, RuntimeOp::SetIndexed, &[object, key, value, estrito])?;
             }
         }
     }

--- a/crates/rts-codegen/src/emit/page.rs
+++ b/crates/rts-codegen/src/emit/page.rs
@@ -118,6 +118,9 @@ pub fn emit_page_program(
         }
     }
 
+    // Este programa é uma página, e a única coisa que isso muda está em
+    // `globals::resolves`: os nomes que só o Node tem deixam de resolver.
+    ctx.page = true;
     let scope = Scope::for_function(None, BTreeSet::new(), &BTreeSet::new(), &chain);
     emit_program_into(&body, &[], None, &[], &scope, ctx)
 }

--- a/crates/rts-codegen/src/emit/property.rs
+++ b/crates/rts-codegen/src/emit/property.rs
@@ -26,6 +26,32 @@ use crate::runtime::RuntimeOp;
 /// it is which name the compiler resolved. Emitting it tagged would be claiming
 /// the program could compute it, which is exactly what a computed property does
 /// and what this path is not.
+/// O modo de quem escreve, como argumento da operação de escrita.
+///
+/// `1` para sloppy. Uma escrita que o objeto recusa — só-getter, congelada,
+/// `writable: false` — é um `TypeError` em strict e um no-op silencioso em
+/// sloppy, e só o sítio de onde foi escrita sabe qual. `ctx.sloppy` já é por
+/// função: `emit::function` limpa-o num corpo com `"use strict"`, por isso a
+/// pergunta é a certa exatamente onde é feita.
+/// O modo ESTRITO, para as escritas que o EMISSOR faz em objetos que acabou de
+/// criar: um campo de classe, um elemento de literal, `module.exports`, o
+/// objeto de um literal. Nada os pode ter congelado entre a criação e a
+/// escrita, por isso a recusa não é uma resposta possível — e pedir o modo do
+/// programa aqui daria a um `"use strict"` distante o poder de mudar como um
+/// literal se constrói.
+pub(super) fn estrito(builder: &mut FuncBuilder, _ctx: &Ctx) -> ValueId {
+    let id = builder.declare_const(ConstDecl::Scalar { repr: Repr::I64, bits: ScalarBits(0) });
+    builder.use_const(id)
+}
+
+pub(super) fn write_mode(builder: &mut FuncBuilder, ctx: &Ctx) -> ValueId {
+    let id = builder.declare_const(ConstDecl::Scalar {
+        repr: Repr::I64,
+        bits: ScalarBits(u64::from(ctx.sloppy)),
+    });
+    builder.use_const(id)
+}
+
 pub(super) fn key_constant(builder: &mut FuncBuilder, ctx: &mut Ctx, name: Name) -> ValueId {
     let key = ctx.key_of(name);
     let id = builder.declare_const(ConstDecl::Scalar {
@@ -319,11 +345,17 @@ pub(super) fn emit_write(
 
     builder.switch_to(slow);
     let key_value = key_constant(builder, ctx, property);
+    let mode = write_mode(builder, ctx);
     let answered = call(
         builder,
         ctx,
+        // O MODO de quem escreve, e não uma propriedade da operação: uma
+        // escrita que o objeto recusa é um `TypeError` em strict e um no-op em
+        // sloppy, e só aqui se sabe qual dos dois. `ctx.sloppy` já é por função
+        // — `emit::function` limpa-o num corpo com `"use strict"` — por isso a
+        // pergunta é a certa exatamente neste ponto.
         RuntimeOp::SetProperty,
-        &[receiver, key_value, value],
+        &[receiver, key_value, value, mode],
     )?[0];
     builder.jump(join, &[answered])?;
 

--- a/crates/rts-codegen/src/emit/scope.rs
+++ b/crates/rts-codegen/src/emit/scope.rs
@@ -142,6 +142,21 @@ pub struct Scope {
     /// be a register in the statement that introduces it and heap storage four
     /// statements later, when the closure that captures it is written.
     captured: BTreeSet<Name>,
+    /// Quantas entradas do primeiro `Layer` vieram do escopo ENVOLVENTE.
+    ///
+    /// Um nome de fora e um nome desta função vivem na mesma lista, e para
+    /// `lookup` isso é o que se quer — o de dentro sombreia por ser o último.
+    /// Mas há uma pergunta que NÃO é essa: *"esta função já declarou este
+    /// nome?"*, que [`Self::declared_in_function`] responde saltando estas.
+    ///
+    /// Sem a distinção, `hoist_vars` perguntava `lookup(name).is_none()` e
+    /// obtinha `Some` para todo o nome que o envolvente tivesse — logo um
+    /// `var parent` numa função nunca criava binding, e todas as leituras e
+    /// escritas iam para o objeto de fora. Num `<script>` de página, onde o
+    /// envolvente é o `window`, isso é `parent`, `top`, `self`, `name`,
+    /// `length`, `status`, `origin` e `location`: nomes que código real usa
+    /// como variável local todos os dias.
+    from_enclosing: usize,
     /// What `this` is in this function, when it has an answer.
     this_value: Option<ValueId>,
     /// The name `this` is held under, for a function where it is assigned
@@ -162,6 +177,7 @@ impl Scope {
         Scope {
             layers: vec![Layer::default()],
             environment: None,
+            from_enclosing: 0,
             captured: BTreeSet::new(),
             this_value: None,
             late_this: None,
@@ -204,6 +220,7 @@ impl Scope {
         own_level: &BTreeSet<Name>,
         enclosing: &[(Name, u32)],
     ) -> Self {
+        let from_enclosing = enclosing.len();
         let mut entries: Vec<(Name, Binding)> = enclosing
             .iter()
             .map(|(name, hops)| {
@@ -249,9 +266,27 @@ impl Scope {
             }],
             environment,
             captured,
+            from_enclosing,
             this_value: None,
             late_this: None,
         }
+    }
+
+    /// Se ESTA função já ligou o nome — os seus parâmetros, os seus capturados,
+    /// o que já declarou — ignorando o que o escopo envolvente tem.
+    ///
+    /// A pergunta de [`Self::lookup`] é outra: *"a que é que este nome
+    /// resolve?"*, e aí um nome de fora é uma resposta legítima. Esta serve
+    /// quem vai DECLARAR, e para esse um nome de fora não é resposta nenhuma —
+    /// é precisamente o que a declaração tem de sombrear.
+    pub fn declared_in_function(&self, name: Name) -> bool {
+        self.layers.iter().enumerate().any(|(depth, layer)| {
+            let proprias = match depth {
+                0 => layer.entries.get(self.from_enclosing..).unwrap_or(&[]),
+                _ => &layer.entries[..],
+            };
+            proprias.iter().any(|(bound, _)| *bound == name)
+        })
     }
 
     /// The environment object captured names live in, if this function has one.

--- a/crates/rts-codegen/src/emit/unary.rs
+++ b/crates/rts-codegen/src/emit/unary.rs
@@ -383,6 +383,19 @@ pub(super) fn typeof_operand(
         ExprKind::Ident(name) if scope.lookup(*name).is_none() => {
             match super::binding::predefined(builder, ctx, *name) {
                 Some(value) => value,
+                // `force_read` e nao `read`, porque a EXEMPCAO do `typeof` e
+                // precisamente poder perguntar por um nome que nao existe: o
+                // objeto global responde `undefined` e nada lanca.
+                //
+                // Mas um nome que este programa nao PODE ter tambem nao pode
+                // ser lido dele. Num `<script>` de pagina, `process` e
+                // `setImmediate` sao do Node e um browser nao os tem — e
+                // `typeof` e exatamente como uma biblioteca pergunta. Ler o do
+                // motor respondia `"object"` numa pagina, e o React 18 ia pelo
+                // ramo de Node do seu scheduler.
+                None if !super::globals::resolves(ctx, *name) => {
+                    super::expr::undefined(builder, ctx)
+                }
                 None => super::globals::force_read(builder, ctx, *name)?,
             }
         }

--- a/crates/rts-codegen/src/emit/unary.rs
+++ b/crates/rts-codegen/src/emit/unary.rs
@@ -281,11 +281,14 @@ pub fn emit_update(
             let current = expr::call(builder, ctx, RuntimeOp::GetIndexed, &[receiver, key])?[0];
             let (before, after) = step_value(builder, ctx, current, step)?;
             let stored = builder.widen(after);
+            // `x[k]++` é uma escrita do PROGRAMA, e leva o modo dele: num
+            // objeto congelado, em sloppy, incrementar não lança.
+            let mode = super::property::write_mode(builder, ctx);
             expr::call(
                 builder,
                 ctx,
                 RuntimeOp::SetIndexed,
-                &[receiver, key, stored],
+                &[receiver, key, stored, mode],
             )?;
             Ok(match position {
                 UpdatePosition::Prefix => after,

--- a/crates/rts-codegen/src/emit/wrap.rs
+++ b/crates/rts-codegen/src/emit/wrap.rs
@@ -138,7 +138,8 @@ pub(super) fn async_generator(ctx: &mut Ctx, inner: FuncId) -> EmitResult<FuncId
     let itself = expr::call(&mut builder, ctx, RuntimeOp::GetProperty, &[made, key])?[0];
     let named = ctx.names.intern("@@asyncIterator");
     let key = super::property::key_constant(&mut builder, ctx, named);
-    expr::call(&mut builder, ctx, RuntimeOp::SetProperty, &[made, key, itself])?;
+    let estrito = super::property::estrito(&mut builder, ctx);
+    expr::call(&mut builder, ctx, RuntimeOp::SetProperty, &[made, key, itself, estrito])?;
     builder.ret(&[made]);
     ctx.body.leave_nested(outer_throw);
     ctx.pending.push((id, func));

--- a/crates/rts-codegen/src/runtime/mod.rs
+++ b/crates/rts-codegen/src/runtime/mod.rs
@@ -1199,7 +1199,12 @@ impl RuntimeOp {
                 vec![UNPROVEN],
             ),
             RuntimeOp::GetProperty => (vec![UNPROVEN, Repr::I64], vec![UNPROVEN]),
-            RuntimeOp::SetProperty => (vec![UNPROVEN, Repr::I64, UNPROVEN], vec![UNPROVEN]),
+            // O quarto argumento é o MODO de quem escreve: `1` para sloppy.
+            // Uma escrita que o objeto recusa é um `TypeError` em strict e um
+            // no-op em sloppy, e só o sítio de onde foi escrita sabe qual.
+            RuntimeOp::SetProperty => {
+                (vec![UNPROVEN, Repr::I64, UNPROVEN, Repr::I64], vec![UNPROVEN])
+            }
             // The code address is `I64` and not a value: it is a machine
             // address, nothing collects it, and widening it would hand the
             // collector a pointer into the text segment to trace.
@@ -1282,7 +1287,9 @@ impl RuntimeOp {
             // The key is a VALUE, where the named read takes the number the
             // compiler resolved. That is the whole difference between them.
             RuntimeOp::GetIndexed => (vec![UNPROVEN, UNPROVEN], vec![UNPROVEN]),
-            RuntimeOp::SetIndexed => (vec![UNPROVEN, UNPROVEN, UNPROVEN], vec![UNPROVEN]),
+            RuntimeOp::SetIndexed => {
+                (vec![UNPROVEN, UNPROVEN, UNPROVEN, Repr::I64], vec![UNPROVEN])
+            }
             RuntimeOp::HasProperty => (vec![UNPROVEN, UNPROVEN], vec![Repr::Bool]),
             RuntimeOp::WithHas => (vec![UNPROVEN, UNPROVEN], vec![Repr::Bool]),
             // A count the compiler knows, not a value: an array literal's

--- a/crates/rts-core/examples/construct_probe.rs
+++ b/crates/rts-core/examples/construct_probe.rs
@@ -94,6 +94,7 @@ extern "C" fn field_ctor(_env: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3
         this,
         V_KEY.load(Ordering::Relaxed),
         Value::from_f64(1.0).bits(),
+        0, // strict: e o que o compilador emite para um campo de classe
     );
     UNDEFINED.load(Ordering::Relaxed)
 }
@@ -194,6 +195,7 @@ fn main() {
                 victim,
                 V_KEY.load(Ordering::Relaxed),
                 Value::from_f64(i as f64).bits(),
+                0, // strict: a sonda mede o caminho que um modulo usa
             ))
         });
         report("object_new(0) cold", ALLOC_EACH, |sink, _| {

--- a/crates/rts-core/examples/entry_probe.rs
+++ b/crates/rts-core/examples/entry_probe.rs
@@ -143,7 +143,8 @@ fn main() {
         // `bench/analytic.ts`'s own `instanceof` row measures — a `false` walks
         // the chain to its end instead, and would be a different number.
         let victim = object_new(4);
-        set_property(victim, x_key, number);
+        set_property(victim, x_key, number,
+                0 /* strict: uma sonda mede o caminho que o programa usa */);
 
         // `black_box` on the operand, because without it the floor came out at
         // 0.00 ns/op: summing `i` over a constant range has a closed form and
@@ -160,7 +161,8 @@ fn main() {
             sink.wrapping_add(add(number, other))
         });
         report("set_property existing", EACH, move |sink, i| {
-            sink.wrapping_add(set_property(victim, x_key, Value::from_f64(i as f64).bits()))
+            sink.wrapping_add(set_property(victim, x_key, Value::from_f64(i as f64).bits(),
+                0 /* strict: uma sonda mede o caminho que o programa usa */))
         });
         report("get_property", EACH, move |sink, _| {
             sink.wrapping_add(get_property(victim, x_key))

--- a/crates/rts-core/src/entry/accessor.rs
+++ b/crates/rts-core/src/entry/accessor.rs
@@ -276,7 +276,7 @@ pub fn define_setter(object: u64, key: i64, setter: u64) -> u64 {
 /// long as `for`-`in` walked own keys only.
 #[rtse::entry]
 pub fn define_method(object: u64, key: i64, value: u64) -> u64 {
-    super::objects::set_property(object, key, value);
+    super::objects::set_property(object, key, value, 0 /* strict: um native que escreve reporta a recusa */);
     with_current(|context| {
         let Some(cell) = Value(object).as_slot() else {
             return;

--- a/crates/rts-core/src/entry/array_proto/species.rs
+++ b/crates/rts-core/src/entry/array_proto/species.rs
@@ -124,7 +124,7 @@ pub(super) fn made(original: u64, length: usize) -> Option<u64> {
 /// copy but a guess.
 pub(super) fn placed(destination: u64, index: usize, value: u64) {
     let at = Value::from_f64(index as f64).bits();
-    super::super::computed::set_indexed(destination, at, value);
+    super::super::computed::set_indexed(destination, at, value, 0 /* strict: um native que escreve reporta a recusa */);
 }
 
 /// The `Array` every array inherits its `constructor` from.

--- a/crates/rts-core/src/entry/computed/access.rs
+++ b/crates/rts-core/src/entry/computed/access.rs
@@ -113,7 +113,16 @@ pub fn get_indexed(object: u64, key: u64) -> u64 {
 /// Two statements, like the named write: a setter is user code and runs after
 /// the borrow ends.
 #[rtse::entry]
-pub fn set_indexed(object: u64, key: u64, value: u64) -> u64 {
+pub fn set_indexed(object: u64, key: u64, value: u64, sloppy: i64) -> u64 {
+    store_indexed(object, key, value, sloppy != 0)
+}
+
+/// `sloppy` diz o modo de quem escreve; ver
+/// [`super::super::objects::set_property`] para porque é um argumento e não uma
+/// segunda porta. `o[k] = v` recusa tanto como `o.k = v`, e é a forma que um
+/// bundle minificado usa mais.
+/// `object[key] = value`, com o modo de quem escreve.
+fn store_indexed(object: u64, key: u64, value: u64, sloppy: bool) -> u64 {
     // Ver a nota em [`get_indexed`]: a conversão da chave só acontece quando há
     // um proxy para perguntar, ou quando a chave é um objeto.
     let (key, trap) = opened(object, key);
@@ -218,7 +227,13 @@ pub fn set_indexed(object: u64, key: u64, value: u64) -> u64 {
         // Built inside the borrow and raised outside it, for the reason
         // `objects::resolve_store` states: constructing the error takes the
         // context, and re-entering it here would abort rather than throw.
-        Some(Store::Refused(why)) => super::super::throw::type_error(&why),
+        // Só LANÇA em strict; em sloppy a escrita não acontece e o programa
+        // segue, que é o que a especificação diz.
+        Some(Store::Refused(why)) => {
+            if !sloppy {
+                super::super::throw::type_error(&why);
+            }
+        }
         Some(Store::Direct) | None => {}
     }
     value

--- a/crates/rts-core/src/entry/eval_scope.rs
+++ b/crates/rts-core/src/entry/eval_scope.rs
@@ -253,7 +253,31 @@ pub fn environment_names(environment: u64) -> Vec<(String, u32)> {
         let Some(cell) = Value(walking).as_slot() else {
             break;
         };
-        let texts = with_current(|context| super::array::key_texts(context, walking, false));
+        // As chaves próprias E as herdadas. Um objeto de ambiente pode ser o
+        // GLOBAL OBJECT de uma página — o `window` — e a superfície dele
+        // (`document`, `location`, `setTimeout`, `self`) são acessores do
+        // PROTÓTIPO da sua classe, não propriedades da instância. Ler só as
+        // próprias devolvia uma lista vazia, e todo o nome livre de todo o
+        // `<script>` respondia `ReferenceError: window is not defined`.
+        //
+        // É também o que a linguagem diz: num browser `toString` livre resolve,
+        // porque o global object herda de `Object.prototype`. Um nome herdado
+        // está em escopo tanto quanto um próprio.
+        let texts = with_current(|context| {
+            let mut texts = Vec::new();
+            let mut seen = walking;
+            for _ in 0..16u32 {
+                let Some(cell) = Value(seen).as_slot() else { break };
+                texts.extend(super::array::key_texts(context, seen, false));
+                // `context.prototype_at` e não `chain::get_prototype`: aquele
+                // entra no contexto por sua conta, e isto já está dentro de um.
+                seen = match context.prototype_at(cell) {
+                    Some(found) => found,
+                    None => break,
+                };
+            }
+            texts
+        });
         for text in texts {
             let Some(text) = text.to_rust() else {
                 continue;

--- a/crates/rts-core/src/entry/json/hooks.rs
+++ b/crates/rts-core/src/entry/json/hooks.rs
@@ -167,7 +167,7 @@ fn place(holder: u64, key: u64, reviver: u64) -> bool {
             super::super::computed::delete_property(holder, key);
         }
         false => {
-            super::super::computed::set_indexed(holder, key, revived);
+            super::super::computed::set_indexed(holder, key, revived, 0 /* strict: um native que escreve reporta a recusa */);
         }
     }
     true

--- a/crates/rts-core/src/entry/object_global/copy.rs
+++ b/crates/rts-core/src/entry/object_global/copy.rs
@@ -114,7 +114,7 @@ pub(super) extern "C" fn assign(
             // source runs and a setter on the target runs — which is what
             // `assign` does and what a slot-to-slot copy would have skipped.
             let value = super::super::computed::get_indexed(source, name);
-            super::super::computed::set_indexed(target, name, value);
+            super::super::computed::set_indexed(target, name, value, 0 /* strict: um native que escreve reporta a recusa */);
         });
         // `own_keys` never reports a symbol — it is the string enumeration,
         // and a symbol has no string spelling for it to report — so a

--- a/crates/rts-core/src/entry/object_global/describe.rs
+++ b/crates/rts-core/src/entry/object_global/describe.rs
@@ -349,7 +349,7 @@ extern "C" fn get_own_property_descriptors(
     names.extend(elements(own_symbols(object)).unwrap_or_default());
     for name in names {
         if let Some(built) = descriptor(object, name) {
-            super::super::computed::set_indexed(made, name, built);
+            super::super::computed::set_indexed(made, name, built, 0 /* strict: um native que escreve reporta a recusa */);
         }
     }
     made

--- a/crates/rts-core/src/entry/object_global/mod.rs
+++ b/crates/rts-core/src/entry/object_global/mod.rs
@@ -361,7 +361,7 @@ extern "C" fn from_entries(_e: u64, _this: u64, entries: u64, _a1: u64, _a2: u64
         let absent = with_current(|context| undefined_of(context));
         let key = pair.first().copied().unwrap_or(absent);
         let value = pair.get(1).copied().unwrap_or(absent);
-        super::computed::set_indexed(made, key, value);
+        super::computed::set_indexed(made, key, value, 0 /* strict: um native que escreve reporta a recusa */);
     }
     made
 }
@@ -447,7 +447,7 @@ extern "C" fn group_by(_e: u64, _this: u64, items: u64, callback: u64, _a2: u64,
         let group = super::computed::get_indexed(made, key);
         if group == absent {
             let fresh = super::array_proto::built(vec![element]);
-            super::computed::set_indexed(made, key, fresh);
+            super::computed::set_indexed(made, key, fresh, 0 /* strict: um native que escreve reporta a recusa */);
         } else {
             super::iterate::array_append(group, element);
         }

--- a/crates/rts-core/src/entry/objects.rs
+++ b/crates/rts-core/src/entry/objects.rs
@@ -275,7 +275,35 @@ fn run_getter(object: u64, getter: u64) -> u64 {
 /// Split for the same reason the read is: a setter is user code, and it runs
 /// after the borrow ends.
 #[rtse::entry]
-pub fn set_property(object: u64, key: i64, value: u64) -> u64 {
+pub fn set_property(object: u64, key: i64, value: u64, sloppy: i64) -> u64 {
+    store_property(object, key, value, sloppy != 0)
+}
+
+/// # Porque o MODO atravessa como argumento
+///
+/// Uma escrita que o objeto recusa — uma propriedade só com `get`, uma
+/// congelada, uma `writable: false` — é um `TypeError` em strict e um **no-op
+/// silencioso** em sloppy. São as duas metades de uma regra da linguagem, e
+/// este motor só implementava a primeira.
+///
+/// A razão está escrita em [`resolve_store`] e era verdadeira quando foi
+/// escrita: *"every program this engine compiles is a MODULE, so every program
+/// is strict"*. Deixou de ser no dia em que um `<script>` de página passou a
+/// compilar como script code, que é sloppy por definição — e o custo apareceu
+/// logo: `window.self = x`, que um bundle UMD escreve e um browser ignora,
+/// matava o script inteiro.
+///
+/// Um ARGUMENTO e não um segundo ponto de entrada, embora um par
+/// `set_property`/`set_property_sloppy` fosse mais simples de escrever: a
+/// tabela do `table.rs` é numerada à mão e tem um teste que a limita a 95
+/// entradas, com a razão de que *"uma lista numerada explicitamente deixa de
+/// ser o mecanismo certo quando ninguém a consegue ler"*. Duas portas para uma
+/// regra gastavam duas dessas 95 sem responder nada de novo.
+///
+/// O modo é do sítio de onde a escrita foi escrita — informação de COMPILAÇÃO,
+/// que o runtime não tem e por isso recebe.
+/// `object.name = value`, com o modo de quem escreve. Ver [`set_property_sloppy`].
+fn store_property(object: u64, key: i64, value: u64, sloppy: bool) -> u64 {
     // The same refusal as the read, and the language spells it the same way:
     // `u.x = 1` on `undefined` throws rather than writing into nothing.
     if let Some(refusal) =
@@ -319,8 +347,13 @@ pub fn set_property(object: u64, key: i64, value: u64) -> u64 {
             super::functions::call(setter, object, value, undefined, undefined, undefined);
             value
         }
+        // A recusa só LANÇA em strict. Em sloppy a escrita não acontece e o
+        // programa segue, que é o que a especificação diz e o que um browser
+        // faz — e o valor volta na mesma, porque é o que a expressão produz.
         Some(Handled::Refused(why)) => {
-            super::throw::type_error(&why);
+            if !sloppy {
+                super::throw::type_error(&why);
+            }
             value
         }
     }
@@ -941,7 +974,7 @@ mod tests {
     fn a_property_written_is_the_property_read() {
         hosted(|| {
             let object = object_new(0);
-            set_property(object, 7, Value::from_f64(42.0).bits());
+            set_property(object, 7, Value::from_f64(42.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
             assert_eq!(
                 rts_cranelift::tags::decode_double(get_property(object, 7)),
                 42.0
@@ -968,8 +1001,8 @@ mod tests {
         // moves with it.
         hosted(|| {
             let object = object_new(0);
-            set_property(object, 1, Value::from_f64(10.0).bits());
-            set_property(object, 2, Value::from_f64(20.0).bits());
+            set_property(object, 1, Value::from_f64(10.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
+            set_property(object, 2, Value::from_f64(20.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
             assert_eq!(
                 rts_cranelift::tags::decode_double(get_property(object, 1)),
                 10.0
@@ -989,8 +1022,8 @@ mod tests {
         // same way different shapes.
         hosted(|| {
             let object = object_new(0);
-            set_property(object, 1, Value::from_f64(10.0).bits());
-            set_property(object, 1, Value::from_f64(11.0).bits());
+            set_property(object, 1, Value::from_f64(10.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
+            set_property(object, 1, Value::from_f64(11.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
             assert_eq!(
                 rts_cranelift::tags::decode_double(get_property(object, 1)),
                 11.0
@@ -1006,8 +1039,8 @@ mod tests {
         hosted(|| {
             let first = object_new(0);
             let second = object_new(0);
-            set_property(first, 3, Value::from_f64(1.0).bits());
-            set_property(second, 3, Value::from_f64(2.0).bits());
+            set_property(first, 3, Value::from_f64(1.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
+            set_property(second, 3, Value::from_f64(2.0).bits(), 0 /* strict: um native que escreve reporta a recusa */);
             crate::entry::with_current(|context| {
                 // The header IS the shape, now: a cell records the type its
                 // layout arrived at, so two objects at one layout carry the
@@ -1211,7 +1244,7 @@ pub fn object_spread(target: u64, source: u64) -> u64 {
     if super::proxy::is_proxy(source) {
         super::object_global::each_enumerable_own(source, |key| {
             let value = super::computed::get_indexed(source, key);
-            super::computed::set_indexed(target, key, value);
+            super::computed::set_indexed(target, key, value, 0 /* strict: um native que escreve reporta a recusa */);
         });
         return target;
     }
@@ -1227,7 +1260,7 @@ pub fn object_spread(target: u64, source: u64) -> u64 {
     for at in 0..keys.len() {
         let key = keys.values()[at];
         let value = super::computed::get_indexed(source, key);
-        super::computed::set_indexed(target, key, value);
+        super::computed::set_indexed(target, key, value, 0 /* strict: um native que escreve reporta a recusa */);
     }
     // The same gap `Object.assign` had, for the same reason: `key_texts` is
     // the string enumeration and a symbol has no string spelling for it to

--- a/crates/rts-core/src/entry/promise/drain.rs
+++ b/crates/rts-core/src/entry/promise/drain.rs
@@ -236,7 +236,59 @@ fn report() {
     let unhandled = with_current(|context| context.promises.unhandled());
     for reason in unhandled {
         let described = with_current(|context| describe(context, reason));
-        eprintln!("rts: unhandled promise rejection: {described}");
+        eprintln!("rts: unhandled promise rejection: {described}{}", origem(reason));
+    }
+}
+
+/// As linhas `at …` do `.stack` da razão, se ela for um `Error`.
+///
+/// # Porque a pilha vem do VALOR e não da máquina
+///
+/// Uma rejeição é reportada quando o TURNO acaba, e nessa altura os frames onde
+/// ela nasceu já foram desempilhados há muito — `throw::call_frames()` responde
+/// vazio. O que sobrevive é o `.stack` que o `Error` capturou quando foi
+/// CONSTRUÍDO, e é o único sítio onde a origem ainda existe.
+///
+/// Sem isto, uma rejeição diz O QUÊ e não ONDE, que num bundle de 1 MB é a
+/// diferença entre corrigir e adivinhar: `Cannot read properties of undefined
+/// (reading 'tag')` é verdade em trinta sítios do React e útil em nenhum.
+///
+/// A leitura é em dois tempos — a propriedade sob o empréstimo do contexto, o
+/// texto fora dele — porque `text_at` toma o contexto por sua conta e pedi-lo
+/// lá dentro seria um abort em vez de um erro.
+fn origem(reason: u64) -> String {
+    let Some(cell) = crate::value::Value(reason).as_slot() else {
+        return String::new();
+    };
+    let stack = with_current(|context| {
+        let key = context
+            .interner
+            .intern(&crate::text::Str::from_str("stack"), &mut context.keys);
+        super::super::objects::read_property(context, cell, crate::object::Key::Name(key))
+            .map(|found| found.bits())
+    });
+    let Some(stack) = stack else {
+        return String::new();
+    };
+    let texto = with_current(|context| {
+        crate::value::Value(stack)
+            .as_slot()
+            .and_then(|cell| context.text_at(cell))
+            .and_then(|held| held.to_rust())
+    });
+    let Some(texto) = texto else {
+        return String::new();
+    };
+    let linhas: Vec<&str> = texto
+        .lines()
+        .map(str::trim)
+        .filter(|linha| linha.starts_with("at "))
+        .collect();
+    match linhas.is_empty() {
+        true => String::new(),
+        false => format!("
+    {}", linhas.join("
+    ")),
     }
 }
 

--- a/crates/rts-core/src/entry/reflect.rs
+++ b/crates/rts-core/src/entry/reflect.rs
@@ -107,7 +107,7 @@ impl Reflect {
         // to answer that question instead of raising it, so performing the write
         // to find out would end the program it was asked to inform.
         if lands {
-            super::computed::set_indexed(target, key, value);
+            super::computed::set_indexed(target, key, value, 0 /* strict: `Reflect.set` reporta a recusa */);
         }
         lands
     }

--- a/crates/rts-dom-bridge/src/engine.rs
+++ b/crates/rts-dom-bridge/src/engine.rs
@@ -37,6 +37,24 @@ extern "C" fn invoke_callback(
 /// `queueMicrotask` registado por um script ficava na fila para sempre: o
 /// callback nunca acontecia e nada dizia porquê.
 extern "C" fn run_event_loop(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    // As duas metades do loop, e não só uma.
+    //
+    // `drain_microtasks` corre o que uma promessa deixou pendente. O que ele
+    // NÃO corre são as *sources* — os timers do motor, os sockets, e a entrega
+    // de um `MessageChannel`, que é por onde o scheduler do React 18 despacha o
+    // seu trabalho.
+    //
+    // Faltar essa metade é o que separava uma página VIVA de uma parada: num
+    // programa headless o `await` devolve o controlo ao host, que corre o loop
+    // completo, e tudo avançava; numa JANELA não há `await` — há um frame que
+    // chama isto — e o trabalho agendado ficava na fila para sempre.
+    //
+    // Medido com o Jogo da Vida em React: headless a geração subia a cada 120
+    // ms, na janela ficava em zero, com os mesmos scripts e sem um erro.
+    //
+    // As sources primeiro: uma delas pode enfileirar a microtask que a seguir
+    // se drena, e a ordem inversa deixaria essa microtask para a volta seguinte.
+    entry::pump_sources();
     entry::drain_microtasks();
     nothing()
 }

--- a/crates/rts-dom-bridge/src/lib.rs
+++ b/crates/rts-dom-bridge/src/lib.rs
@@ -39,6 +39,7 @@ use rts_core::entry::{self, Context, Provided};
 mod engine;
 mod events;
 mod nodes;
+mod travessia;
 mod scope;
 mod timers;
 mod tree;
@@ -53,6 +54,9 @@ pub fn install(context: &mut Context) {
     let members: Vec<(&str, Provided)> = tree::MEMBERS
         .iter()
         .chain(nodes::MEMBERS)
+        // A travessia e a mutação da árvore, que a fachada já chamava e a ponte
+        // não tinha — ver `travessia.rs` para o que foi apagado e porquê.
+        .chain(travessia::MEMBERS)
         .chain(events::MEMBERS)
         .copied()
         .collect();

--- a/crates/rts-dom-bridge/src/nodes.rs
+++ b/crates/rts-dom-bridge/src/nodes.rs
@@ -55,7 +55,7 @@ pub const MEMBERS: &[(&str, Provided)] = &[
 ];
 
 /// O `NodeId` de um argumento, ou `None` para a sentinela `-1`.
-fn node(value: u64) -> Option<NodeId> {
+pub(crate) fn node(value: u64) -> Option<NodeId> {
     NodeId::from_abi(integer(value, -1))
 }
 

--- a/crates/rts-dom-bridge/src/scope.rs
+++ b/crates/rts-dom-bridge/src/scope.rs
@@ -338,7 +338,7 @@ extern "C" fn set(_e: u64, _t: u64, doc: u64, name: u64, value: u64, _c: u64) ->
     let h = handle(doc);
     let name = text(name);
     let object = object_for(h);
-    entry::set_indexed(object, string(&name), value);
+    entry::set_indexed(object, string(&name), value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     remember(h, &name);
     nothing()
 }

--- a/crates/rts-dom-bridge/src/scope.rs
+++ b/crates/rts-dom-bridge/src/scope.rs
@@ -267,16 +267,53 @@ extern "C" fn run(_e: u64, _t: u64, doc: u64, source: u64, window: u64, _c: u64)
     // deles terminava o processo com a página por montar. Consumir aqui é o que
     // torna a falha DESTE script e não da página.
     let raised = entry::pending();
-    if raised.is_some() {
-        entry::take_thrown();
-    }
+    // O VALOR lançado, e não só a mensagem: um `Error` carrega o `.stack`
+    // capturado onde foi CONSTRUÍDO, que é o único sítio onde a pilha ainda
+    // existe. `call_frames()` aqui responde vazio — quando o controlo volta a
+    // este nativo os frames já foram desempilhados —, e foi por isso que a
+    // primeira tentativa de dizer "onde" não disse nada.
+    //
+    // Sem isto, um erro vindo de dentro de um bundle grande diz O QUÊ e não
+    // ONDE. Medido a custar caro: o React falha a ler `childLanes` de um
+    // `undefined`, e `childLanes` aparece em trinta sítios do react-dom —
+    // três sondas manuais depois, ainda não se sabia em qual.
+    let onde = match raised.is_some() {
+        false => String::new(),
+        true => {
+            let lancado = entry::take_thrown();
+            // A propriedade sob o empréstimo, o TEXTO fora dele: `text_of`
+            // entra no contexto por sua conta, e pedi-lo aqui dentro seria um
+            // abort não-desenrolável em vez de um erro. É a mesma regra que o
+            // cabeçalho deste módulo dá para os locks.
+            let stack = entry::with_runtime(|context| entry::get_member(context, lancado, "stack"));
+            let pilha = entry::text_of(stack);
+            match pilha {
+                // A mensagem já vem em `raised`, e o `.stack` repete-a na
+                // primeira linha: só as linhas `at …` são novidade.
+                Some(texto) => {
+                    let linhas: Vec<&str> = texto
+                        .lines()
+                        .map(str::trim)
+                        .filter(|linha| linha.starts_with("at "))
+                        .collect();
+                    match linhas.is_empty() {
+                        true => String::new(),
+                        false => format!("
+         {}", linhas.join("
+         ")),
+                    }
+                }
+                None => String::new(),
+            }
+        }
+    };
     // O QUE falhou fica guardado, e isso não é só diagnóstico: um browser
     // imprime o erro de um `<script>` no console, e uma falha que não diz nada
     // é indistinguível de um script que não fez nada. Foi assim que o prelude
     // em falta passou dezassete dias por descobrir — ver
     // `docs/ui/page-script-bridge.md`.
     let message = match (&answered, &raised) {
-        (_, Some((_, text))) => Some(text.clone()),
+        (_, Some((_, text))) => Some(format!("{text}{onde}")),
         // Compilou-se nada e não houve throw: fonte que o front end recusou.
         // Um `SyntaxError` de um `<script>` é ordinário numa página real, e
         // dizer "não compilou" é mais do que o silêncio de antes mesmo sem a

--- a/crates/rts-dom-bridge/src/scope.rs
+++ b/crates/rts-dom-bridge/src/scope.rs
@@ -166,7 +166,67 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     ("drop", drop_member),
     ("run", run),
     ("lastError", last_error),
+    ("adopt", adopt),
 ];
+
+/// `DomScope.adopt(h, objeto)` — faz de `objeto` o saco de globais deste
+/// documento.
+///
+/// # Porque o escopo tem de SER o `window`
+///
+/// Num browser o objeto global e o `window` são a mesma coisa: um script que
+/// escreve `window.X = 1` e outro que lê `X` como nome livre encontram-se,
+/// porque estão a falar da mesma propriedade do mesmo objeto.
+///
+/// Aqui eram dois. O `window` era publicado COMO PROPRIEDADE do saco, e medido
+/// dava isto: `window.X = 42` no primeiro script, `typeof X` no segundo →
+/// `"undefined"`; e ao contrário, `Z = 9` livre não aparecia em `window.Z`.
+///
+/// O que isso quebra não é um caso de canto — é o formato UMD, que é como
+/// TODA a biblioteca do npm é servida a uma página. O ramo de browser de um
+/// UMD faz `factory(global.React = {})`, e o script seguinte lê `React`. Com
+/// dois objetos, o React 18.3.1 publicava-se num sítio que o programa nunca
+/// via: `ReferenceError: React is not defined`, com os dois bundles a terem
+/// corrido sem um erro.
+///
+/// Adotar em vez de copiar: uma cópia teria de ser mantida em dia nos dois
+/// sentidos e toda a escrita passaria a ter dois destinos, que é a forma de
+/// eles divergirem num deles.
+/// Responde `1` quando este documento JÁ tinha adotado este objeto, para que
+/// quem prepara o escopo possa sair sem repetir o trabalho — em vez de o
+/// marcar com uma propriedade, que ficaria à vista do JavaScript da página.
+extern "C" fn adopt(_e: u64, _t: u64, doc: u64, object: u64, _b: u64, _c: u64) -> u64 {
+    let h = handle(doc);
+    if locked().get(&h).map(|bag| bag.object) == Some(object) {
+        return int(1);
+    }
+    // O `hold` novo ANTES de largar o antigo: entre os dois há uma alocação
+    // possível, e uma coleção nesse intervalo não pode encontrar o documento
+    // sem saco nenhum.
+    let hold = entry::hold_current(object);
+    let anterior = {
+        let mut bags = locked();
+        match bags.get_mut(&h) {
+            Some(bag) => {
+                let anterior = Some((bag.object, bag.hold));
+                bag.object = object;
+                bag.hold = hold;
+                anterior
+            }
+            None => {
+                bags.insert(
+                    h,
+                    Bag { object, hold, last_error: None, order: Vec::new(), known: HashSet::new() },
+                );
+                None
+            }
+        }
+    };
+    if let Some((_, hold)) = anterior {
+        entry::release_current(hold);
+    }
+    int(0)
+}
 
 /// `DomScope.run(h, fonte, window)` — corre o texto de um `<script>` com o saco
 /// deste documento COMO ESCOPO, e devolve `1` se correu.

--- a/crates/rts-dom-bridge/src/travessia.rs
+++ b/crates/rts-dom-bridge/src/travessia.rs
@@ -79,7 +79,83 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     ("removeStyleProperty", remove_style_property),
     ("cssText", css_text),
     ("setCssText", set_css_text),
+    // ── consulta a partir de um NÓ, e não do documento ─────────────────────
+    ("queryWithin", query_within),
+    ("queryAllWithinCount", query_all_within_count),
+    ("queryAllWithinAt", query_all_within_at),
+    ("getByClassCount", get_by_class_count),
+    ("getByClassAt", get_by_class_at),
+    ("getByNameCount", get_by_name_count),
+    ("getByNameAt", get_by_name_at),
 ];
+
+// ── consulta ───────────────────────────────────────────────────────────────
+//
+// `document.querySelector` já estava exposto; o que faltava era a mesma
+// pergunta feita a partir de um NÓ — `el.querySelector(...)`, que é o que uma
+// aplicação usa para procurar dentro de um componente. `rts-dom` responde às
+// duas há muito (`consulta.rs`), e só a segunda não tinha porta.
+//
+// Contagem e acesso separados pela razão de sempre: um `Vec<NodeId>` não
+// atravessa esta fronteira.
+
+extern "C" fn query_within(_e: u64, _t: u64, doc: u64, n: u64, sel: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let sel = text(sel);
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.query_within(id, &sel)).flatten())
+}
+
+extern "C" fn query_all_within_count(_e: u64, _t: u64, doc: u64, n: u64, sel: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(0) };
+    let sel = text(sel);
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.query_all_within(id, &sel).len())
+        .unwrap_or(0);
+    int(out as i64)
+}
+
+extern "C" fn query_all_within_at(_e: u64, _t: u64, doc: u64, n: u64, sel: u64, i: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let sel = text(sel);
+    let i = integer(i, 0).max(0) as usize;
+    maybe(
+        rts_dom::store::with_dom(handle(doc), |d| d.query_all_within(id, &sel).get(i).copied())
+            .flatten(),
+    )
+}
+
+extern "C" fn get_by_class_count(_e: u64, _t: u64, doc: u64, nomes: u64, _b: u64, _c: u64) -> u64 {
+    let nomes = text(nomes);
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.get_elements_by_class_name(&nomes).len())
+        .unwrap_or(0);
+    int(out as i64)
+}
+
+extern "C" fn get_by_class_at(_e: u64, _t: u64, doc: u64, nomes: u64, i: u64, _c: u64) -> u64 {
+    let nomes = text(nomes);
+    let i = integer(i, 0).max(0) as usize;
+    maybe(
+        rts_dom::store::with_dom(handle(doc), |d| {
+            d.get_elements_by_class_name(&nomes).get(i).copied()
+        })
+        .flatten(),
+    )
+}
+
+extern "C" fn get_by_name_count(_e: u64, _t: u64, doc: u64, nome: u64, _b: u64, _c: u64) -> u64 {
+    let nome = text(nome);
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.get_elements_by_name(&nome).len())
+        .unwrap_or(0);
+    int(out as i64)
+}
+
+extern "C" fn get_by_name_at(_e: u64, _t: u64, doc: u64, nome: u64, i: u64, _c: u64) -> u64 {
+    let nome = text(nome);
+    let i = integer(i, 0).max(0) as usize;
+    maybe(
+        rts_dom::store::with_dom(handle(doc), |d| d.get_elements_by_name(&nome).get(i).copied())
+            .flatten(),
+    )
+}
 
 // ── estilo inline ──────────────────────────────────────────────────────────
 //

--- a/crates/rts-dom-bridge/src/travessia.rs
+++ b/crates/rts-dom-bridge/src/travessia.rs
@@ -87,7 +87,21 @@ pub const MEMBERS: &[(&str, Provided)] = &[
     ("getByClassAt", get_by_class_at),
     ("getByNameCount", get_by_name_count),
     ("getByNameAt", get_by_name_at),
+    ("advance", advance),
 ];
+
+/// `dom.advance(doc, agora_ms)` — faz o tempo passar para as animações CSS e as
+/// transições. Responde `1` se alguma continua a correr.
+///
+/// O frame da janela já chamava isto, de Rust para Rust; o que não havia era
+/// forma de um programa o chamar — e sem ela não se consegue perguntar *"esta
+/// página anima?"* sem abrir uma janela e olhar. Um teste que precisa de um
+/// humano a olhar não é um teste.
+extern "C" fn advance(_e: u64, _t: u64, doc: u64, agora: u64, _b: u64, _c: u64) -> u64 {
+    let agora = integer(agora, 0) as f32;
+    let a_correr = rts_dom::store::with_dom_mut(handle(doc), |d| d.advance(agora)).unwrap_or(false);
+    int(if a_correr { 1 } else { 0 })
+}
 
 // ── consulta ───────────────────────────────────────────────────────────────
 //

--- a/crates/rts-dom-bridge/src/travessia.rs
+++ b/crates/rts-dom-bridge/src/travessia.rs
@@ -1,0 +1,314 @@
+//! Travessia e mutação da árvore: a ponte que a fachada `.ts` já chamava e que
+//! não existia.
+//!
+//! # O que isto repõe, e porque ninguém deu por ela faltar
+//!
+//! `crates/rts-dom/src/dom/travessia.rs` e `mutacao.rs` implementam `firstChild`,
+//! `insertBefore`, `removeChild`, `cloneNode` e o resto há muito. O que foi
+//! apagado com o motor antigo — no mesmo commit que levou o `scriptscan` e o
+//! `timerscope`, e pela mesma razão: nomeavam `rts_engine` numa linha de `use` —
+//! foi a PONTE, o `abi.rs`. A lógica ficou, a porta não.
+//!
+//! E a falta não apareceu, porque o outro lado da fronteira é TEXTO: o `dom.ts`
+//! continuou a declarar `get firstChild()` a chamar `dom.firstChild(...)`, e
+//! nenhum teste em Rust passa por aqui. A suite do `rts-dom` responde `718
+//! passed` com metade da API do DOM sem porta nenhuma.
+//!
+//! É a mesma lição que `docs/ui/page-script-bridge.md` já tinha escrito para as
+//! outras três peças, e esta é a quarta.
+//!
+//! # Como se viu
+//!
+//! Ao carregar o React 18.3.1 numa página: os dois bundles correm, `createRoot`
+//! e `render` são chamados, o scheduler entrega o trabalho — e o React morre a
+//! montar, porque montar é `insertBefore` e `firstChild`. O erro que aparecia
+//! primeiro era `dom.firstChild is not a function`, que nomeia exatamente o
+//! problema e leva ao sítio errado se lido como "falta implementar".
+//!
+//! # A convenção
+//!
+//! A mesma de `nodes.rs`, e por isso este módulo não a redefine: um nó é um
+//! `i64` (`-1` para nenhum), o documento é um handle, e um `Option<NodeId>`
+//! atravessa como `-1`. Ver `crate::value` para as conversões.
+
+use rts_core::entry::Provided;
+
+use crate::nodes::node;
+use crate::value::{handle, int, integer, nothing, string, text};
+
+/// Traduz uma resposta do DOM que pode ser nenhum nó.
+fn maybe(found: Option<rts_dom::NodeId>) -> u64 {
+    int(found.map(|id| id.to_abi()).unwrap_or(-1))
+}
+
+pub const MEMBERS: &[(&str, Provided)] = &[
+    // ── travessia ──────────────────────────────────────────────────────────
+    ("firstChild", first_child),
+    ("lastChild", last_child),
+    ("nextSibling", next_sibling),
+    ("previousSibling", previous_sibling),
+    ("parentNode", parent_node),
+    ("firstElementChild", first_element_child),
+    ("lastElementChild", last_element_child),
+    ("nextElementSibling", next_element_sibling),
+    ("previousElementSibling", previous_element_sibling),
+    ("childNodesCount", child_nodes_count),
+    ("childNodeAt", child_node_at),
+    ("hasChildNodes", has_child_nodes),
+    ("contains", contains),
+    ("closest", closest),
+    ("nodeName", node_name),
+    ("nodeValue", node_value),
+    // ── mutação ────────────────────────────────────────────────────────────
+    ("insertBefore", insert_before),
+    ("removeChild", remove_child),
+    ("replaceChild", replace_child),
+    ("prepend", prepend),
+    ("replaceWith", replace_with),
+    ("insertAdjacent", insert_adjacent),
+    ("clearChildren", clear_children),
+    ("cloneNode", clone_node),
+    ("createComment", create_comment),
+    ("normalize", normalize),
+    ("setNodeValue", set_node_value),
+    ("attrCount", attr_count),
+    ("attrNameAt", attr_name_at),
+    // ── estilo inline ──────────────────────────────────────────────────────
+    ("inlineProperty", inline_property),
+    ("setStyleProperty", set_style_property),
+    ("removeStyleProperty", remove_style_property),
+    ("cssText", css_text),
+    ("setCssText", set_css_text),
+];
+
+// ── estilo inline ──────────────────────────────────────────────────────────
+//
+// `rts-dom/src/dom/estilo.rs` já respondia a tudo isto; era a ponte que não
+// existia, como no resto deste ficheiro. É o que faz `node.style.color = "red"`
+// — a forma como o React escreve estilo — poder chegar ao documento.
+
+extern "C" fn inline_property(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let name = text(name);
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.inline_property(id, &name))
+        .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn set_style_property(_e: u64, _t: u64, doc: u64, n: u64, name: u64, value: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    let (name, value) = (text(name), text(value));
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_style_property(id, &name, &value));
+    nothing()
+}
+
+extern "C" fn remove_style_property(_e: u64, _t: u64, doc: u64, n: u64, name: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    let name = text(name);
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.remove_style_property(id, &name));
+    nothing()
+}
+
+extern "C" fn css_text(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.css_text(id)).unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn set_css_text(_e: u64, _t: u64, doc: u64, n: u64, v: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    let v = text(v);
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_css_text(id, &v));
+    nothing()
+}
+
+// ── travessia ──────────────────────────────────────────────────────────────
+
+extern "C" fn first_child(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.first_child(id)).flatten())
+}
+
+extern "C" fn last_child(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.last_child(id)).flatten())
+}
+
+extern "C" fn next_sibling(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.next_sibling(id)).flatten())
+}
+
+extern "C" fn previous_sibling(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.previous_sibling(id)).flatten())
+}
+
+/// `parentNode` e não `parentElement`: o pai de um nó pode ser o documento ou um
+/// fragmento, e `parentElement` responde nenhum nesse caso. São perguntas
+/// diferentes e o `nodes.rs` já responde à outra.
+extern "C" fn parent_node(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.parent_of(id)).flatten())
+}
+
+extern "C" fn first_element_child(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.first_element_child(id)).flatten())
+}
+
+extern "C" fn last_element_child(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.last_element_child(id)).flatten())
+}
+
+extern "C" fn next_element_sibling(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.next_element_sibling(id)).flatten())
+}
+
+extern "C" fn previous_element_sibling(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.previous_element_sibling(id)).flatten())
+}
+
+/// A contagem e o acesso são separados porque um `Vec<NodeId>` não atravessa
+/// esta fronteira — a mesma forma que `childCount`/`childAt` já usam para os
+/// elementos, aqui para TODOS os nós (texto e comentários incluídos, que é o que
+/// distingue `childNodes` de `children`).
+extern "C" fn child_nodes_count(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(0) };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.child_nodes(id).len()).unwrap_or(0);
+    int(out as i64)
+}
+
+extern "C" fn child_node_at(_e: u64, _t: u64, doc: u64, n: u64, i: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let i = integer(i, 0).max(0) as usize;
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.child_nodes(id).get(i).copied()).flatten())
+}
+
+extern "C" fn has_child_nodes(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(0) };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.has_child_nodes(id)).unwrap_or(false);
+    int(if out { 1 } else { 0 })
+}
+
+extern "C" fn contains(_e: u64, _t: u64, doc: u64, n: u64, other: u64, _c: u64) -> u64 {
+    let (Some(id), Some(other)) = (node(n), node(other)) else { return int(0) };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.contains(id, other)).unwrap_or(false);
+    int(if out { 1 } else { 0 })
+}
+
+extern "C" fn closest(_e: u64, _t: u64, doc: u64, n: u64, sel: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let sel = text(sel);
+    maybe(rts_dom::store::with_dom(handle(doc), |d| d.closest(id, &sel)).flatten())
+}
+
+extern "C" fn node_name(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.node_name(id).unwrap_or_default())
+        .unwrap_or_default();
+    string(&out)
+}
+
+extern "C" fn node_value(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.node_value(id).unwrap_or_default())
+        .unwrap_or_default();
+    string(&out)
+}
+
+// ── mutação ────────────────────────────────────────────────────────────────
+
+/// `insertBefore(doc, pai, filho, referencia)` — `-1` na referência significa
+/// "no fim", que é o que a especificação diz de `insertBefore(x, null)`.
+extern "C" fn insert_before(_e: u64, _t: u64, doc: u64, parent: u64, child: u64, reference: u64) -> u64 {
+    let (Some(p), Some(c)) = (node(parent), node(child)) else { return nothing() };
+    let reference = node(reference);
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.insert_before(p, c, reference));
+    nothing()
+}
+
+extern "C" fn remove_child(_e: u64, _t: u64, doc: u64, parent: u64, child: u64, _c: u64) -> u64 {
+    let (Some(p), Some(c)) = (node(parent), node(child)) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.remove_child(p, c));
+    nothing()
+}
+
+extern "C" fn replace_child(_e: u64, _t: u64, doc: u64, parent: u64, new_child: u64, old_child: u64) -> u64 {
+    let (Some(p), Some(novo), Some(velho)) = (node(parent), node(new_child), node(old_child)) else {
+        return nothing();
+    };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.replace_child(p, novo, velho));
+    nothing()
+}
+
+extern "C" fn prepend(_e: u64, _t: u64, doc: u64, parent: u64, child: u64, _c: u64) -> u64 {
+    let (Some(p), Some(c)) = (node(parent), node(child)) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.prepend_child(p, c));
+    nothing()
+}
+
+extern "C" fn replace_with(_e: u64, _t: u64, doc: u64, n: u64, other: u64, _c: u64) -> u64 {
+    let (Some(id), Some(other)) = (node(n), node(other)) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.replace_with(id, other));
+    nothing()
+}
+
+/// `after != 0` insere depois, `0` insere antes.
+extern "C" fn insert_adjacent(_e: u64, _t: u64, doc: u64, n: u64, other: u64, after: u64) -> u64 {
+    let (Some(id), Some(other)) = (node(n), node(other)) else { return nothing() };
+    let after = integer(after, 0) != 0;
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.insert_adjacent(id, other, after));
+    nothing()
+}
+
+extern "C" fn clear_children(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.clear_children(id));
+    nothing()
+}
+
+extern "C" fn clone_node(_e: u64, _t: u64, doc: u64, n: u64, deep: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(-1) };
+    let deep = integer(deep, 0) != 0;
+    maybe(rts_dom::store::with_dom_mut(handle(doc), |d| d.clone_node(id, deep)).flatten())
+}
+
+extern "C" fn create_comment(_e: u64, _t: u64, doc: u64, s: u64, _b: u64, _c: u64) -> u64 {
+    let s = text(s);
+    let out = rts_dom::store::with_dom_mut(handle(doc), |d| d.create_comment(&s).to_abi())
+        .unwrap_or(-1);
+    int(out)
+}
+
+extern "C" fn normalize(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.normalize(id));
+    nothing()
+}
+
+extern "C" fn set_node_value(_e: u64, _t: u64, doc: u64, n: u64, v: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return nothing() };
+    let v = text(v);
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_node_value(id, &v));
+    nothing()
+}
+
+extern "C" fn attr_count(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return int(0) };
+    let out = rts_dom::store::with_dom(handle(doc), |d| d.attr_names(id).len()).unwrap_or(0);
+    int(out as i64)
+}
+
+extern "C" fn attr_name_at(_e: u64, _t: u64, doc: u64, n: u64, i: u64, _c: u64) -> u64 {
+    let Some(id) = node(n) else { return string("") };
+    let i = integer(i, 0).max(0) as usize;
+    let out = rts_dom::store::with_dom(handle(doc), |d| {
+        d.attr_names(id).get(i).cloned().unwrap_or_default()
+    })
+    .unwrap_or_default();
+    string(&out)
+}

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1475,6 +1475,21 @@ function pumpInputEvents(doc: Document): number {
 // de travar o loop. Devolve quantos callbacks dispararam no frame.
 function pumpTimerCallbacks(doc: Document): number {
   const h: i64 = doc._dom;
+  // A volta do loop do MOTOR primeiro, e não só a fila de timers deste
+  // documento. São duas filas e uma página precisa das duas: um `.then`, um
+  // `queueMicrotask` e uma mensagem de `MessageChannel` viajam pela do motor.
+  //
+  // Sem isto, um framework concurrent nunca avança numa JANELA — e avança
+  // headless, porque aí o programa de topo tem `await` e drena o motor por
+  // acidente. Medido com o React 18: montava headless e deixava o `#root`
+  // vazio na janela, com os mesmos scripts a correr sem um erro.
+  //
+  // O nome desta função fala de timers e ela passou a fazer mais do que isso.
+  // Fica assim porque o que ela É continua a ser uma coisa só — *uma volta do
+  // loop desta página* — e quem a chama, o frame do host, quer exatamente
+  // isso; dividi-la em duas obrigaria todo o chamador a saber que há duas
+  // filas, que é o conhecimento que esta função existe para não espalhar.
+  engine.run_event_loop();
   let disparados = 0;
   let guard = 0;
   while (guard < 64) {
@@ -1532,17 +1547,21 @@ function runScriptsAt(doc: Document, url: string): number {
   // Sem isto, um `.then`/`queueMicrotask` registrado por um `<script>` ficava na
   // fila para sempre — o callback nunca acontecia, sem erro nenhum.
   //
-  // UMA volta, e o laço que estava aqui foi retirado: drenar vinte vezes é
-  // defensável em teoria — uma volta pode enfileirar a seguinte — mas MEDIDO
-  // não mudou nada, e código cujo efeito não se consegue mostrar é especulação
-  // a ocupar o caminho quente de todas as páginas.
+  // Fecha o TASK da página: uma volta do loop desta página, que drena as
+  // microtasks do motor e a fila de timers do documento.
   //
-  // O que falta para um framework concurrent montar continua por isolar. O que
-  // se sabe: `ReactDOM.flushSync`, que força o trabalho a correr já, MONTA a
-  // árvore e põe o texto no documento — logo o DOM responde a tudo o que ele
-  // precisa. E o `MessageChannel`, por onde o scheduler despacha, entrega
-  // quando testado sozinho. O que não corre é o trabalho que a entrega agenda.
+  // UMA, e não em laço. Um laço esteve aqui duas vezes e saiu as duas, pela
+  // mesma razão medida: com 64 voltas o React 18 continuava a não montar, e o
+  // que o fez montar foi outra coisa — um `await` no programa de topo, que
+  // SUSPENDE e devolve o controlo ao host. `run_event_loop()` chamado de dentro
+  // do programa não é equivalente a isso, e o laço só repetia o que já não
+  // chegava.
+  //
+  // Quem precisa de mais voltas tem duas formas honestas de as ter: um `await`
+  // no programa, ou o frame do host, que bombeia a cada passagem. Nenhuma delas
+  // é este laço.
   engine.run_event_loop();
+  pumpTimerCallbacks(doc);
   // ISOLA como o console do browser: um callback de terceiro que LANÇA não pode
   // derrubar a página inteira. O erro vive no slot do MOTOR — um canal lateral
   // que um `try/catch` de `.ts` não observa —, então é preciso consumi-lo

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -85,7 +85,26 @@ function __dispatchWithCallbacks(
     preventDefault: function () {
       if (event.cancelable && state.passive === 0) event.defaultPrevented = true;
     },
+    // Quando o evento aconteceu. Um browser dá milissegundos desde o início do
+    // documento; aqui é o relógio do sistema, que serve para o que um programa
+    // faz com isto — comparar dois eventos.
+    timeStamp: Date.now(),
   };
+  // `nativeEvent` — o evento "de baixo", e aqui é ESTE.
+  //
+  // Num browser há dois objetos: o nativo, que o motor cria, e o SINTÉTICO, que
+  // uma biblioteca embrulha à volta dele para normalizar diferenças entre
+  // browsers. O React lê `event.nativeEvent` para chegar ao primeiro, e é assim
+  // que o seu sistema de eventos delegados encontra o alvo real.
+  //
+  // Aqui não há dois: este objeto é o nativo. Apontá-lo a si próprio é dizer
+  // isso — e não é um atalho, é a resposta certa quando a camada que ele
+  // procura não existe. Sem isto, o React lia `undefined` e nenhum `onClick`
+  // disparava, sem um erro.
+  //
+  // Depois do literal e não dentro dele, porque uma propriedade não se pode
+  // referir ao objeto que ainda está a ser construído.
+  event.nativeEvent = event;
   let j = 0;
   while (j < n) {
     event.currentTarget = new Element(h, nodes[j]);

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1531,6 +1531,17 @@ function runScriptsAt(doc: Document, url: string): number {
   // Fecha o TASK da página: drena microtasks/timers que os scripts enfileiraram.
   // Sem isto, um `.then`/`queueMicrotask` registrado por um `<script>` ficava na
   // fila para sempre — o callback nunca acontecia, sem erro nenhum.
+  //
+  // UMA volta, e o laço que estava aqui foi retirado: drenar vinte vezes é
+  // defensável em teoria — uma volta pode enfileirar a seguinte — mas MEDIDO
+  // não mudou nada, e código cujo efeito não se consegue mostrar é especulação
+  // a ocupar o caminho quente de todas as páginas.
+  //
+  // O que falta para um framework concurrent montar continua por isolar. O que
+  // se sabe: `ReactDOM.flushSync`, que força o trabalho a correr já, MONTA a
+  // árvore e põe o texto no documento — logo o DOM responde a tudo o que ele
+  // precisa. E o `MessageChannel`, por onde o scheduler despacha, entrega
+  // quando testado sozinho. O que não corre é o trabalho que a entrega agenda.
   engine.run_event_loop();
   // ISOLA como o console do browser: um callback de terceiro que LANÇA não pode
   // derrubar a página inteira. O erro vive no slot do MOTOR — um canal lateral

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -763,6 +763,70 @@ class Element {
     dom.removeNode(this._dom, this._node);
   }
 
+  // ── `el.style` — o objeto de estilo inline ──────────────────────
+  //
+  // Um PROXY, e nao um objeto com uma propriedade por nome CSS. Codigo real
+  // escreve `node.style.color = "red"` e `node.style.backgroundColor = "#fff"`,
+  // e o conjunto dos nomes possiveis e a especificacao CSS inteira: declarar
+  // cada um seria uma lista a envelhecer, e responder so a alguns seria pior
+  // que nao responder — uma escrita perdida em silencio.
+  //
+  // A traducao e feita no acesso: `backgroundColor` -> `background-color`, e o
+  // valor vai para `dom.setStyleProperty`, que e o mesmo estilo inline que o
+  // layout ja le. `setProperty`/`getPropertyValue`/`removeProperty` e `cssText`
+  // ficam por nome, porque quem os usa nao passa pelo caminho camelCase.
+  get style(): any {
+    const dom_h = this._dom;
+    const node_h = this._node;
+    const alvo: any = {};
+    return new Proxy(alvo, {
+      get(_t: any, chave: any): any {
+        const nome = "" + chave;
+        if (nome === "setProperty") {
+          return function (p: string, v: string) { dom.setStyleProperty(dom_h, node_h, p, v); };
+        }
+        if (nome === "getPropertyValue") {
+          return function (p: string) { return dom.inlineProperty(dom_h, node_h, p); };
+        }
+        if (nome === "removeProperty") {
+          return function (p: string) { dom.removeStyleProperty(dom_h, node_h, p); };
+        }
+        if (nome === "cssText") { return dom.cssText(dom_h, node_h); }
+        return dom.inlineProperty(dom_h, node_h, __cssKebab(nome));
+      },
+      set(_t: any, chave: any, valor: any): boolean {
+        const nome = "" + chave;
+        if (nome === "cssText") { dom.setCssText(dom_h, node_h, "" + valor); return true; }
+        dom.setStyleProperty(dom_h, node_h, __cssKebab(nome), "" + valor);
+        return true;
+      },
+    });
+  }
+
+  // ── `el.classList` — o DOMTokenList ───────────────────────────
+  //
+  // Os metodos por baixo ja existiam (`classListAdd` e companhia); o que faltava
+  // era o OBJETO, que e como todo o codigo escreve — `el.classList.add(...)` e
+  // nao `el.classListAdd(...)`. O estado continua no atributo `class`, por isso
+  // nao ha nada a manter em dia.
+  get classList(): any {
+    const eu = this;
+    return {
+      add(c: string): void { eu.classListAdd(c); },
+      remove(c: string): void { eu.classListRemove(c); },
+      toggle(c: string): boolean { return eu.classListToggle(c); },
+      contains(c: string): boolean { return eu.classListContains(c); },
+    };
+  }
+
+  // O namespace de um elemento. Este DOM nao os modela — o parser produz HTML e
+  // nada mais — por isso a resposta e sempre a do HTML. Certa para tudo o que
+  // este motor produz hoje, e ERRADA para um `<svg>`, o que fica dito aqui em
+  // vez de descoberto por quem la chegar.
+  get namespaceURI(): string {
+    return "http://www.w3.org/1999/xhtml";
+  }
+
   // ── classList (add/remove/contains/toggle) ───────────────────────────────────
   // Açúcar sobre o atributo `class`, com a semântica do DOMTokenList. Trabalha
   // sobre a string de classes separada por espaço (sem objeto vivo — o motor
@@ -836,6 +900,16 @@ class Document {
   // `null` quando não há, que é o que um browser responde para um documento
   // sem `<body>`, e não um erro: um script que testa `if (document.body)`
   // escreve-se exatamente porque a resposta pode ser nenhuma.
+  // `createElementNS(ns, tag)` — cria o elemento, e o namespace e IGNORADO.
+  //
+  // Nao e casca: o elemento e real e tem a tag pedida. O que nao acontece e o
+  // namespace ser lembrado, porque este DOM nao os modela — e um `<svg>` criado
+  // assim comporta-se como HTML. E a razao de o React montar uma arvore de HTML
+  // e nao uma de SVG.
+  createElementNS(_ns: string, tag: string): Element {
+    return this.createElement(tag);
+  }
+
   get body(): Element | null {
     const n = dom.querySelector(this._dom, "body");
     return n === __DOM_NONE ? null : new Element(this._dom, n);
@@ -1492,6 +1566,22 @@ function __prepararEscopo(doc: Document, url: string): void {
 }
 
 // Roda o j-ésimo `<script>`: inline usa o texto do nó; externo usa o fonte que o
+// `backgroundColor` -> `background-color`. Um nome ja em kebab passa intacto, e
+// um `--custom` tambem: a especificacao diz que uma propriedade customizada e
+// usada tal e qual, e as maiusculas dentro dela sao significativas.
+function __cssKebab(nome: string): string {
+  if (nome.length > 1 && nome.charAt(0) === "-" && nome.charAt(1) === "-") return nome;
+  let out = "";
+  let i = 0;
+  while (i < nome.length) {
+    const c = nome.charAt(i);
+    const baixo = c.toLowerCase();
+    if (c !== baixo) { out = out + "-" + baixo; } else { out = out + c; }
+    i = i + 1;
+  }
+  return out;
+}
+
 // `loadResources` materializou no nó (mesmo caminho). Devolve 1 (rodou) ou 0.
 function __runScriptAt(doc: Document, j: number, url: string): number {
   // Recebe o DOCUMENT, não o handle: `doc._dom` numa variável `i64` trunca

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -17,6 +17,44 @@ const __DOM_NONE = -1;
 const __LISTENER_OPTIONS_SEPARATOR = "\u001f";
 const __compositionStates: Map<i64, number> = new Map();
 
+// -- Identidade de no: um no, UM objeto ------------------------------------
+//
+// `getElementById("b")` chamado duas vezes tem de responder o MESMO objeto, e
+// o que se escreveu nele tem de continuar la. Nao e purismo: toda a biblioteca
+// que ANOTA nos assume-o — o React guarda o fiber em `no.__reactFiber$xyz` e
+// vai busca-lo por `event.target.__reactFiber$xyz`, o jQuery guarda ali o cache
+// de dados, o D3 o `__data__`. Com um wrapper novo a cada acesso escreve-se num
+// objeto e le-se noutro, e o sintoma nao se parece nada com a causa: uma app que
+// MONTA, PINTA e nao responde a um unico clique — foi o que o React 18 fez aqui.
+//
+// A chave e o par (handle do DOM, `NodeId`), e nao so o `NodeId`, porque dois
+// documentos abertos ao mesmo tempo tem cada um a sua arena e os `idx` colidem.
+//
+// NAO precisa de invalidacao, e a razao esta do lado Rust em vez de aqui:
+// `mutacao.rs::remove_node` DESLIGA o no e deixa-o na arena — "o no continua na
+// arena (lixo)" — e `arvore.rs` so faz `nodes.push`. Um `idx` nunca e reciclado
+// dentro de uma geracao, e um re-parse muda a geracao de TODOS (o `NodeId` e
+// `(generation << 32) | idx`). Entao um wrapper guardado nunca pode ser
+// entregue a um no diferente daquele para que foi feito. O que a cache custa e
+// crescer com a arena — que tambem nunca encolhe — e nao mais do que ela.
+const __wrappers: Map<i64, Map<i64, any>> = new Map();
+
+// O wrapper DESTE no, sempre o mesmo. Todo o `dom.ts` passa por aqui em vez de
+// `new Element`: uma unica chamada em falta reintroduz o defeito exactamente no
+// caminho que a esqueceu, e um caminho desses e invisivel a quem le o resto.
+function __elem(h: i64, node: number): Element {
+  let daArvore = __wrappers.get(h);
+  if (daArvore === undefined) {
+    daArvore = new Map();
+    __wrappers.set(h, daArvore);
+  }
+  const visto = daArvore.get(node);
+  if (visto !== undefined) return visto;
+  const novo = new Element(h, node);
+  daArvore.set(node, novo);
+  return novo;
+}
+
 function __listenerFlags(options: any): number {
   if (options === true) return 1;
   if (options === null || options === undefined) return 0;
@@ -58,7 +96,7 @@ function __dispatchWithCallbacks(
     passives.push(dom.dispatchCbPassive(h, i));
     i = i + 1;
   }
-  const target = new Element(h, node);
+  const target = __elem(h, node);
   const state = { stopped: 0, immediate: 0, passive: 0 };
   const event: any = {
     type: type,
@@ -107,7 +145,7 @@ function __dispatchWithCallbacks(
   event.nativeEvent = event;
   let j = 0;
   while (j < n) {
-    event.currentTarget = new Element(h, nodes[j]);
+    event.currentTarget = __elem(h, nodes[j]);
     state.passive = passives[j] !== 0 ? 1 : 0;
     event.eventPhase = nodes[j] === node ? 2 : (captures[j] !== 0 ? 1 : 3);
     // `engine.invoke_cb` reconstitui o Function word no runtime e chama o
@@ -197,7 +235,7 @@ function __dispatchKeyboardWithCallbacks(
     passives.push(dom.dispatchCbPassive(h, i));
     i = i + 1;
   }
-  const target = new Element(h, node);
+  const target = __elem(h, node);
   const key = __keyboardKey(keyCode, shift);
   const code = __keyboardCode(keyCode);
   const state = { stopped: 0, immediate: 0, passive: 0 };
@@ -235,7 +273,7 @@ function __dispatchKeyboardWithCallbacks(
   };
   let j = 0;
   while (j < n) {
-    event.currentTarget = new Element(h, nodes[j]);
+    event.currentTarget = __elem(h, nodes[j]);
     state.passive = passives[j] !== 0 ? 1 : 0;
     event.eventPhase = nodes[j] === node ? 2 : (captures[j] !== 0 ? 1 : 3);
     engine.invoke_cb(cbs[j], event);
@@ -269,7 +307,7 @@ function __dispatchInputCallbacks(
     passives.push(dom.dispatchCbPassive(h, i));
     i = i + 1;
   }
-  const target = new Element(h, node);
+  const target = __elem(h, node);
   const state = { stopped: 0, immediate: 0, passive: 0 };
   const event: any = {
     type: type,
@@ -299,7 +337,7 @@ function __dispatchInputCallbacks(
   };
   let j = 0;
   while (j < n) {
-    event.currentTarget = new Element(h, nodes[j]);
+    event.currentTarget = __elem(h, nodes[j]);
     state.passive = passives[j] !== 0 ? 1 : 0;
     event.eventPhase = nodes[j] === node ? 2 : (captures[j] !== 0 ? 1 : 3);
     engine.invoke_cb(cbs[j], event);
@@ -417,7 +455,7 @@ class Element {
   querySelector(sel: string): Element | null {
     const n = dom.queryWithin(this._dom, this._node, sel);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // `el.querySelectorAll(sel)` — todos os DESCENDENTES que casam (subárvore).
@@ -426,7 +464,7 @@ class Element {
     const n = dom.queryAllWithinCount(this._dom, this._node, sel);
     let i = 0;
     while (i < n) {
-      out.push(new Element(this._dom, dom.queryAllWithinAt(this._dom, this._node, sel, i)));
+      out.push(__elem(this._dom, dom.queryAllWithinAt(this._dom, this._node, sel, i)));
       i = i + 1;
     }
     return out;
@@ -439,7 +477,7 @@ class Element {
     let i = 0;
     while (i < n) {
       const node = dom.childAt(this._dom, this._node, i);
-      out.push(new Element(this._dom, node));
+      out.push(__elem(this._dom, node));
       i = i + 1;
     }
     return out;
@@ -452,7 +490,7 @@ class Element {
     let i = 0;
     while (i < n) {
       const node = dom.childNodeAt(this._dom, this._node, i);
-      out.push(new Element(this._dom, node));
+      out.push(__elem(this._dom, node));
       i = i + 1;
     }
     return out;
@@ -464,49 +502,49 @@ class Element {
   get parentNode(): Element | null {
     const n = dom.parentNode(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get firstChild(): Element | null {
     const n = dom.firstChild(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get lastChild(): Element | null {
     const n = dom.lastChild(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get nextSibling(): Element | null {
     const n = dom.nextSibling(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get previousSibling(): Element | null {
     const n = dom.previousSibling(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // ── Traversal POR ELEMENTO (#1757) — pula nós de texto/comentário ────────────
   get firstElementChild(): Element | null {
     const n = dom.firstElementChild(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get lastElementChild(): Element | null {
     const n = dom.lastElementChild(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get nextElementSibling(): Element | null {
     const n = dom.nextElementSibling(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   get previousElementSibling(): Element | null {
     const n = dom.previousElementSibling(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   // `no.ownerDocument` — o documento a que este nó pertence. Todo o `Element`
   // já carrega o handle dele (`_dom`), por isso é o documento REAL e não um
@@ -524,7 +562,7 @@ class Element {
   get parentElement(): Element | null {
     const n = dom.parentElement(this._dom, this._node);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   // `el.childElementCount` — reusa o primitivo childCount (já existente).
   get childElementCount(): number {
@@ -537,7 +575,7 @@ class Element {
   closest(selector: string): Element | null {
     const n = dom.closest(this._dom, this._node, selector);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   // `el.matches(sel)` — testa o seletor simples NESTE nó. (mesmos cortes do closest:
   // só simples; vazio/inválido → false em vez de SyntaxError.)
@@ -549,7 +587,7 @@ class Element {
   // `el.cloneNode(deep)` — duplica o nó (deep=true com filhos); clone SOLTO.
   cloneNode(deep: boolean): Element {
     const n = dom.cloneNode(this._dom, this._node, deep ? 1 : 0);
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
   // `parent.prepend(child)` — insere no INÍCIO. (variádico não no motor → 1 nó.)
   prepend(child: Element): void {
@@ -660,11 +698,23 @@ class Element {
   }
   // `node.nodeValue` — texto cru de Text/Comment. ⚠️ CORTE: a spec dá `null` para
   // Element/Document, mas a fronteira ABI (string) não carrega null → devolve `''`
-  // nesses casos (um Text vazio também é '', indistinguível). SET é método
-  // (setNodeValue) porque o motor não dispara setters de propriedade.
+  // nesses casos (um Text vazio tambem e '', indistinguivel).
+  //
+  // O SET era SO o metodo `setNodeValue`, e a razao que estava escrita aqui —
+  // "o motor nao dispara setters de propriedade" — deixou de ser verdade: o
+  // `textContent` trezentas linhas acima ja tem um. O que o corte custava nao
+  // era ergonomia: um reconciliador de React escreve `no.nodeValue = t` para
+  // trocar o texto de um no sem lhe mexer na identidade, e uma propriedade
+  // so-com-getter LANCA nessa atribuicao. A app montava, o clique chegava, e o
+  // commit morria ai.
   get nodeValue(): string {
     return dom.nodeValue(this._dom, this._node);
   }
+  set nodeValue(value: string) {
+    dom.setNodeValue(this._dom, this._node, value);
+  }
+  // Mantido: e o que os chamadores deste prelude escrevem, e os dois caminhos
+  // sao a mesma mutacao.
   setNodeValue(value: string): void {
     dom.setNodeValue(this._dom, this._node, value);
   }
@@ -902,9 +952,9 @@ class Document {
 
   private eventTarget(): Element | null {
     const root = dom.documentElement(this._dom);
-    if (root !== __DOM_NONE) return new Element(this._dom, root);
+    if (root !== __DOM_NONE) return __elem(this._dom, root);
     const body = dom.querySelector(this._dom, "body");
-    if (body !== __DOM_NONE) return new Element(this._dom, body);
+    if (body !== __DOM_NONE) return __elem(this._dom, body);
     return null;
   }
 
@@ -931,12 +981,12 @@ class Document {
 
   get body(): Element | null {
     const n = dom.querySelector(this._dom, "body");
-    return n === __DOM_NONE ? null : new Element(this._dom, n);
+    return n === __DOM_NONE ? null : __elem(this._dom, n);
   }
 
   get head(): Element | null {
     const n = dom.querySelector(this._dom, "head");
-    return n === __DOM_NONE ? null : new Element(this._dom, n);
+    return n === __DOM_NONE ? null : __elem(this._dom, n);
   }
 
   // Listeners do documento recebem eventos que borbulham até à raiz HTML.
@@ -957,7 +1007,7 @@ class Document {
   querySelector(sel: string): Element | null {
     const n = dom.querySelector(this._dom, sel);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   querySelectorAll(sel: string): Element[] {
@@ -966,7 +1016,7 @@ class Document {
     let i = 0;
     while (i < n) {
       const node = dom.querySelectorAllAt(this._dom, sel, i);
-      out.push(new Element(this._dom, node));
+      out.push(__elem(this._dom, node));
       i = i + 1;
     }
     return out;
@@ -977,7 +1027,7 @@ class Document {
   getElementById(id: string): Element | null {
     const n = dom.getById(this._dom, id);
     if (n === __DOM_NONE) return null;
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // ── getElementsBy* (#1758) — coleções por classe/tag/name ────────────────────
@@ -986,7 +1036,7 @@ class Document {
     const n = dom.getByClassCount(this._dom, name);
     let i = 0;
     while (i < n) {
-      out.push(new Element(this._dom, dom.getByClassAt(this._dom, name, i)));
+      out.push(__elem(this._dom, dom.getByClassAt(this._dom, name, i)));
       i = i + 1;
     }
     return out;
@@ -996,7 +1046,7 @@ class Document {
     const n = dom.getByTagCount(this._dom, tag);
     let i = 0;
     while (i < n) {
-      out.push(new Element(this._dom, dom.getByTagAt(this._dom, tag, i)));
+      out.push(__elem(this._dom, dom.getByTagAt(this._dom, tag, i)));
       i = i + 1;
     }
     return out;
@@ -1006,7 +1056,7 @@ class Document {
     const n = dom.getByNameCount(this._dom, name);
     let i = 0;
     while (i < n) {
-      out.push(new Element(this._dom, dom.getByNameAt(this._dom, name, i)));
+      out.push(__elem(this._dom, dom.getByNameAt(this._dom, name, i)));
       i = i + 1;
     }
     return out;
@@ -1015,26 +1065,26 @@ class Document {
   // `document.createElement(tag)` — elemento solto (anexe com appendChild).
   createElement(tag: string): Element {
     const n = dom.createElement(this._dom, tag);
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // `document.createTextNode(text)` — nó de texto solto (anexe com appendChild).
   createTextNode(text: string): Element {
     const n = dom.createTextNode(this._dom, text);
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // `document.createComment(text)` — nó de comentário solto (nodeType 8).
   createComment(text: string): Element {
     const n = dom.createComment(this._dom, text);
-    return new Element(this._dom, n);
+    return __elem(this._dom, n);
   }
 
   // `document.documentElement` — o elemento `<html>`, não a raiz `#document`.
   get documentElement(): Element | null {
     const root = dom.documentElement(this._dom);
     if (root === __DOM_NONE) return null;
-    return new Element(this._dom, root);
+    return __elem(this._dom, root);
   }
 }
 

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -489,6 +489,19 @@ class Element {
     if (n === __DOM_NONE) return null;
     return new Element(this._dom, n);
   }
+  // `no.ownerDocument` — o documento a que este nó pertence. Todo o `Element`
+  // já carrega o handle dele (`_dom`), por isso é o documento REAL e não um
+  // objeto novo com o mesmo aspeto.
+  //
+  // Faltava, e o que a falta impedia: o React 18 liga os seus eventos
+  // delegados com `container.ownerDocument.addEventListener(...)`, então
+  // `createRoot(...).render(...)` morria em `Cannot read properties of
+  // undefined (reading 'addEventListener')` — com o React inteiro já carregado
+  // e a funcionar.
+  get ownerDocument(): Document {
+    return new Document(this._dom);
+  }
+
   get parentElement(): Element | null {
     const n = dom.parentElement(this._dom, this._node);
     if (n === __DOM_NONE) return null;
@@ -1463,25 +1476,19 @@ function runScriptsAt(doc: Document, url: string): number {
 // object — e param de ser recompiladas por script. `window` marca que já foi
 // feito: é o primeiro a entrar e nenhum script legítimo o apaga.
 function __prepararEscopo(doc: Document, url: string): void {
-  if (DomScope.has(doc._dom, "window") === 1) return;
   const w: any = __winFor(doc._dom, url, 1000, 800);
-  DomScope.set(doc._dom, "window", w);
-  DomScope.set(doc._dom, "document", w.document);
-  DomScope.set(doc._dom, "self", w);
-  DomScope.set(doc._dom, "globalThis", w);
-  DomScope.set(doc._dom, "top", w);
-  DomScope.set(doc._dom, "parent", w);
-  DomScope.set(doc._dom, "location", w.location);
-  DomScope.set(doc._dom, "navigator", w.navigator);
-  DomScope.set(doc._dom, "history", w.history);
-  DomScope.set(doc._dom, "localStorage", w.localStorage);
-  // Os timers CHAMADOS NUS caem na fila por documento (`DomTimers`), não nos do
-  // motor — só essa fila é bombeada pelo frame do host.
-  DomScope.set(doc._dom, "setTimeout", function (f: any, ms: any) { return w.setTimeout(f, ms); });
-  DomScope.set(doc._dom, "clearTimeout", function (id: any) { w.clearTimeout(id); });
-  DomScope.set(doc._dom, "setInterval", function (f: any, ms: any) { return w.setInterval(f, ms); });
-  DomScope.set(doc._dom, "clearInterval", function (id: any) { w.clearInterval(id); });
-  DomScope.set(doc._dom, "requestAnimationFrame", function (f: any) { return w.requestAnimationFrame(f); });
+  // Uma linha, e é a linha toda: o escopo dos `<script>` deste documento É o
+  // `window`. Num browser são o mesmo objeto, e um bundle UMD depende disso —
+  // o ramo de browser faz `factory(global.React = {})` e o script seguinte lê
+  // `React` como nome livre.
+  //
+  // O que estava aqui antes publicava `window`, `document`, `self`,
+  // `globalThis`, `top`, `parent`, `location`, `navigator`, `history`,
+  // `localStorage` e cinco timers COMO PROPRIEDADES de um saco à parte. Eram
+  // todos duplicados: a classe `WindowImpl` já os tem, e o saco à parte era o
+  // que fazia `window.X = 42` num script e `typeof X` no seguinte responder
+  // `"undefined"` — dois objetos onde a linguagem tem um.
+  DomScope.adopt(doc._dom, w);
 }
 
 // Roda o j-ésimo `<script>`: inline usa o texto do nó; externo usa o fonte que o

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -169,6 +169,7 @@ class WindowImpl {
   _ls: WebStorage;
   _ss: WebStorage;
   _iw: number;
+  _name: string;
   _ih: number;
 
   constructor(domHandle: i64, url: string, vw: number, vh: number) {
@@ -180,6 +181,7 @@ class WindowImpl {
     this._ss = new WebStorage();
     this._iw = vw;
     this._ih = vh;
+    this._name = "";
     // Os timers como PROPRIEDADES PRÓPRIAS, com o `this` já preso.
     //
     // Um método do protótipo chamado pelo NOME LIVRE — `setTimeout(fn, 0)`,
@@ -212,19 +214,45 @@ class WindowImpl {
   get outerWidth(): number { return this._iw; }
   get outerHeight(): number { return this._ih; }
   get devicePixelRatio(): number { return 1; }
-  get name(): string { return ""; }
+  // `window.name` e GRAVAVEL num browser, e aqui isso deixou de ser detalhe: o
+  // escopo de um `<script>` E este objeto, entao um `var name` de topo — que
+  // qualquer bundle pode ter — assenta aqui. Com um getter sozinho, o motor
+  // recusava: `Cannot set property name of #<Object> which has only a getter`,
+  // e o react-dom morria a carregar.
+  //
+  // A licao e mais larga do que este nome: todo o acessor so-de-leitura desta
+  // classe passou a poder BLOQUEAR um global legitimo da pagina. Os que um
+  // browser deixa escrever tem de deixar tambem.
+  get name(): string { return this._name; }
+  set name(v: string) { this._name = v; }
   get closed(): boolean { return false; }
   // window.self / window.window / window.top / window.parent apontam pra ele
   // mesmo (single-frame). Getters retornam o próprio window.
+  // Os quatro apontam para ele proprio, e os setters IGNORAM.
+  //
+  // Nao e preguica: e o que um browser faz. Escrever numa propriedade que so
+  // tem getter e, em SLOPPY MODE, um no-op silencioso — e um `<script>` e
+  // sloppy. So em strict e que lanca.
+  //
+  // Este motor lanca nos dois, e isso e um defeito de conformidade que vive no
+  // emissor, nao aqui: `window.self = x` num bundle real fazia
+  // `TypeError: Cannot set property self of #<Object> which has only a getter`
+  // e matava o script. Enquanto a regra nao for corrigida onde e decidida, os
+  // setters vazios dao a resposta certa para os nomes que um bundle escreve.
   get self(): WindowImpl { return this; }
+  set self(_v: any) { }
   get window(): WindowImpl { return this; }
+  set window(_v: any) { }
   get top(): WindowImpl { return this; }
+  set top(_v: any) { }
   get parent(): WindowImpl { return this; }
+  set parent(_v: any) { }
   // `globalThis === window` num browser, e aqui isso deixou de ser uma
   // curiosidade: o escopo de um `<script>` É este objeto, então sem este getter
   // o nome livre `globalThis` caía no global do PROCESSO — outro objeto, que
   // nenhuma página devia alcançar.
   get globalThis(): WindowImpl { return this; }
+  set globalThis(_v: any) { }
 
   // Timers: vão para a FILA POR DOCUMENTO em Rust (`DomTimers`), dirigida pelo
   // frame do host via `pumpTimerCallbacks(doc)` — NÃO para os timers do motor

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -180,6 +180,25 @@ class WindowImpl {
     this._ss = new WebStorage();
     this._iw = vw;
     this._ih = vh;
+    // Os timers como PROPRIEDADES PRÓPRIAS, com o `this` já preso.
+    //
+    // Um método do protótipo chamado pelo NOME LIVRE — `setTimeout(fn, 0)`,
+    // que é como todo o código de página o escreve — chega cá sem receiver:
+    // a cadeia de escopo lê a propriedade e invoca, e `this` é `undefined`.
+    // Medido: `TypeError: Cannot read properties of undefined (reading
+    // '_doc')` na primeira linha de qualquer script que agende alguma coisa.
+    //
+    // Num browser `setTimeout(…)` nu tem `this === window`, e a resposta certa
+    // a longo prazo é o receiver vir do objeto onde o nome foi encontrado —
+    // uma decisão do emissor, não desta classe. Enquanto ela não existe, uma
+    // arrow presa aqui dá a mesma resposta para estes cinco, que são os que
+    // uma página chama nus. Os outros continuam a precisar de `window.`.
+    const doc = this._doc;
+    (this as any).setTimeout = (fn: any, ms: number) => DomTimers.add(doc._dom, fn, ms, 0);
+    (this as any).clearTimeout = (id: number) => { DomTimers.cancel(doc._dom, id); };
+    (this as any).setInterval = (fn: any, ms: number) => DomTimers.add(doc._dom, fn, ms, 1);
+    (this as any).clearInterval = (id: number) => { DomTimers.cancel(doc._dom, id); };
+    (this as any).requestAnimationFrame = (fn: any) => DomTimers.add(doc._dom, fn, 16, 0);
   }
 
   get document(): Document { return this._doc; }
@@ -201,6 +220,11 @@ class WindowImpl {
   get window(): WindowImpl { return this; }
   get top(): WindowImpl { return this; }
   get parent(): WindowImpl { return this; }
+  // `globalThis === window` num browser, e aqui isso deixou de ser uma
+  // curiosidade: o escopo de um `<script>` É este objeto, então sem este getter
+  // o nome livre `globalThis` caía no global do PROCESSO — outro objeto, que
+  // nenhuma página devia alcançar.
+  get globalThis(): WindowImpl { return this; }
 
   // Timers: vão para a FILA POR DOCUMENTO em Rust (`DomTimers`), dirigida pelo
   // frame do host via `pumpTimerCallbacks(doc)` — NÃO para os timers do motor

--- a/crates/rts-dom/src/window.ts
+++ b/crates/rts-dom/src/window.ts
@@ -228,17 +228,21 @@ class WindowImpl {
   get closed(): boolean { return false; }
   // window.self / window.window / window.top / window.parent apontam pra ele
   // mesmo (single-frame). Getters retornam o próprio window.
-  // Os quatro apontam para ele proprio, e os setters IGNORAM.
+  // Os quatro apontam para ele próprio (single-frame), e os quatro ACEITAM
+  // escrita.
   //
-  // Nao e preguica: e o que um browser faz. Escrever numa propriedade que so
-  // tem getter e, em SLOPPY MODE, um no-op silencioso — e um `<script>` e
-  // sloppy. So em strict e que lanca.
-  //
-  // Este motor lanca nos dois, e isso e um defeito de conformidade que vive no
-  // emissor, nao aqui: `window.self = x` num bundle real fazia
+  // Não é indulgência: na especificação HTML `self`, `window`, `top` e `parent`
+  // são `[Replaceable]` — escrever neles é legal e substitui a propriedade,
+  // inclusive em código STRICT, que é onde um getter sozinho recusa. Um bundle
+  // que o faça no arranque — e o react-dom faz — morria com
   // `TypeError: Cannot set property self of #<Object> which has only a getter`
-  // e matava o script. Enquanto a regra nao for corrigida onde e decidida, os
-  // setters vazios dao a resposta certa para os nomes que um bundle escreve.
+  // enquanto isto eram só getters.
+  //
+  // O setter IGNORA em vez de guardar, e isso é uma divergência declarada: a
+  // especificação diz que a escrita substitui, e aqui a leitura continua a
+  // responder o `window`. É a metade que interessa a quem escreve por hábito
+  // — o script segue — e a outra metade precisaria de uma propriedade own a
+  // tapar o acessor, que esta fachada não sabe criar.
   get self(): WindowImpl { return this; }
   set self(_v: any) { }
   get window(): WindowImpl { return this; }
@@ -252,7 +256,6 @@ class WindowImpl {
   // o nome livre `globalThis` caía no global do PROCESSO — outro objeto, que
   // nenhuma página devia alcançar.
   get globalThis(): WindowImpl { return this; }
-  set globalThis(_v: any) { }
 
   // Timers: vão para a FILA POR DOCUMENTO em Rust (`DomTimers`), dirigida pelo
   // frame do host via `pumpTimerCallbacks(doc)` — NÃO para os timers do motor

--- a/crates/rts-egui/src/ctx.rs
+++ b/crates/rts-egui/src/ctx.rs
@@ -249,7 +249,24 @@ pub fn with_egui<R>(h: u64, f: impl FnOnce(&egui::Context) -> R) -> Option<R> {
         FRAME_EGUI.with(|held| held.borrow().iter().rev().find(|(held, _)| *held == h).map(|(_, c)| c.clone()));
     match published {
         Some(egui_ctx) => Some(f(&egui_ctx)),
-        None => CTXS.with(|m| m.borrow_mut().get_mut(&h).map(|c| f(&c.egui_ctx))),
+        // `try_borrow_mut` e não `borrow_mut`, e a diferença é o processo
+        // continuar vivo.
+        //
+        // Há um caminho que desenha sem passar por `end_frame`: o replay do
+        // live-resize (`frame::redraw_retained`), chamado de dentro do
+        // empréstimo que o `pump` detém e sem o handle à mão para publicar. Uma
+        // leitura de input daí pedia este empréstimo outra vez, e o `RefCell`
+        // aborta — medido a matar uma janela com React a montar.
+        //
+        // `None` significa "não dá para responder agora", e o chamador já sabe
+        // tratar isso: cada leitura do `InputSource` tem o seu default. Um
+        // frame de REPLAY sem input lido é um frame que repete o anterior, que
+        // é o que ele é para começar; um processo morto não é nada.
+        None => CTXS.with(|m| {
+            m.try_borrow_mut()
+                .ok()
+                .and_then(|mut held| held.get_mut(&h).map(|c| f(&c.egui_ctx)))
+        }),
     }
 }
 

--- a/crates/rts-host/src/entries/mod.rs
+++ b/crates/rts-host/src/entries/mod.rs
@@ -123,7 +123,7 @@ pub(crate) fn resolve(op: RuntimeOp) -> (CoreEntry, *const u8) {
             rts_core::entry::get_property as extern "C" fn(u64, i64) -> u64 as *const u8
         }),
         RuntimeOp::SetProperty => (CoreEntry::SetProperty, {
-            rts_core::entry::set_property as extern "C" fn(u64, i64, u64) -> u64 as *const u8
+            rts_core::entry::set_property as extern "C" fn(u64, i64, u64, i64) -> u64 as *const u8
         }),
         RuntimeOp::ClosureNew => (CoreEntry::ClosureNew, {
             rts_core::entry::closure_new as extern "C" fn(i64, u64) -> u64 as *const u8
@@ -265,7 +265,7 @@ pub(crate) fn resolve(op: RuntimeOp) -> (CoreEntry, *const u8) {
             rts_core::entry::get_indexed as extern "C" fn(u64, u64) -> u64 as *const u8
         }),
         RuntimeOp::SetIndexed => (CoreEntry::SetIndexed, {
-            rts_core::entry::set_indexed as extern "C" fn(u64, u64, u64) -> u64 as *const u8
+            rts_core::entry::set_indexed as extern "C" fn(u64, u64, u64, i64) -> u64 as *const u8
         }),
         RuntimeOp::HasProperty => (CoreEntry::HasProperty, {
             rts_core::entry::has_property as extern "C" fn(u64, u64) -> bool as *const u8

--- a/crates/rts-napi/src/objects.rs
+++ b/crates/rts-napi/src/objects.rs
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn napi_set_property(
     else {
         return napi_invalid_arg;
     };
-    rts_core::entry::set_indexed(object, key, value);
+    rts_core::entry::set_indexed(object, key, value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     napi_ok
 }
 
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn napi_set_named_property(
     let key = rts_core::entry::with_runtime(|context| {
         rts_core::entry::make_string(context, name)
     });
-    rts_core::entry::set_indexed(object, key, value);
+    rts_core::entry::set_indexed(object, key, value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     napi_ok
 }
 
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn napi_set_element(
         return napi_invalid_arg;
     };
     let key = rts_core::entry::make_number(index as f64);
-    rts_core::entry::set_indexed(object, key, value);
+    rts_core::entry::set_indexed(object, key, value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     napi_ok
 }
 

--- a/crates/rts-node/src/events.rs
+++ b/crates/rts-node/src/events.rs
@@ -460,7 +460,7 @@ fn disposable(signal: u64, callback: u64) -> u64 {
     });
     let object_root = rts_core::entry::hold_current(object);
     let dispose_root = rts_core::entry::hold_current(dispose_fn);
-    rts_core::entry::set_indexed(object, dispose_key, dispose_fn);
+    rts_core::entry::set_indexed(object, dispose_key, dispose_fn, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     rts_core::entry::release_current(dispose_root);
     rts_core::entry::release_current(object_root);
     object
@@ -484,8 +484,8 @@ extern "C" fn dispose_abort_listener(
     }
     let remove = rts_core::entry::get_indexed(signal, string_key("removeEventListener"));
     rts_core::entry::call(remove, signal, string_key("abort"), callback, absent, absent);
-    rts_core::entry::set_indexed(this, string_key("__abortSignal__"), absent);
-    rts_core::entry::set_indexed(this, string_key("__abortCallback__"), absent);
+    rts_core::entry::set_indexed(this, string_key("__abortSignal__"), absent, 0 /* strict: quem escreve a partir do host reporta a recusa */);
+    rts_core::entry::set_indexed(this, string_key("__abortCallback__"), absent, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     absent
 }
 
@@ -706,7 +706,7 @@ fn store_array(events: u64, key: u64, wrappers: Vec<u64>) {
     let array = rts_core::entry::with_runtime(|context| {
         rts_core::entry::make_array_in(context, wrappers)
     });
-    rts_core::entry::set_indexed(events, key, array);
+    rts_core::entry::set_indexed(events, key, array, 0 /* strict: quem escreve a partir do host reporta a recusa */);
 }
 
 /// The ordered event names, including Symbols, that have ever had a listener.

--- a/crates/rts-node/src/fetch.rs
+++ b/crates/rts-node/src/fetch.rs
@@ -1,0 +1,430 @@
+//! `fetch(url)` — o global que uma página usa para ir buscar seja o que for.
+//!
+//! # Porque isto vive aqui e não no `rts-std`
+//!
+//! `fetch` é um global de BROWSER, e um instinto razoável é pô-lo com os outros
+//! globais. Mas ele precisa de HTTP, e o HTTP está neste crate — `http/` e
+//! `https/`, este último com TLS. Pô-lo no `rts-std` obrigaria a um segundo
+//! cliente, que é exatamente o que o `reuse-check` deste repositório existe para
+//! impedir.
+//!
+//! E não é uma concessão: o Node 18+ tem `fetch` como global tanto quanto um
+//! browser tem. Ele pertence a esta lista pela mesma razão que `Buffer`,
+//! `process` e `URL` pertencem — é o que este ambiente oferece sem uma
+//! importação. Uma PÁGINA vê-o porque um browser também o tem, e é por isso que
+//! não está na lista `NODE_ONLY` que `emit::globals` esconde de um `<script>`.
+//!
+//! # O que este `fetch` faz e o que NÃO faz
+//!
+//! Faz um pedido e responde uma `Promise` de `Response`, com `status`, `ok`,
+//! `statusText`, `headers`, `text()` e `json()`. `http:` e `https:` — o esquema
+//! escolhe o cliente.
+//!
+//! **É SÍNCRONO por baixo, e a promessa já vem resolvida.** O cliente deste
+//! crate lê a resposta inteira antes de devolver — o seu próprio módulo explica
+//! porquê, e é uma decisão anterior a esta. A consequência é observável e fica
+//! dita: dois `fetch` não se sobrepõem, e uma página que faça dez pedidos
+//! "paralelos" paga-os em fila. O que NÃO acontece é a promessa mentir: quando
+//! ela resolve, o corpo está mesmo lá.
+//!
+//! Sem `Request`, sem `Headers` como classe, sem streaming do corpo, sem
+//! `AbortSignal`, sem redirecionamentos automáticos. Cada uma dessas é uma
+//! resposta que este ainda não dá, e a ausência é a forma honesta de o dizer —
+//! um `redirect: "follow"` que não seguisse seria pior que a falta.
+
+use std::time::{Duration, Instant};
+
+use rts_core::entry::{self, Context};
+
+/// Quanto se espera pela ligação e pela resposta, em milissegundos.
+///
+/// Os mesmos números que `http::client` usa, e pela mesma razão que ele os tem:
+/// um pedido que nunca responde não pode prender o programa para sempre.
+const TIMEOUT_MS: u64 = 15_000;
+
+/// `fetch(url)` e `fetch(url, opcoes)`.
+pub(crate) extern "C" fn fetch(
+    _e: u64,
+    _this: u64,
+    url: u64,
+    opcoes: u64,
+    _c: u64,
+    _d: u64,
+) -> u64 {
+    let Some(texto) = entry::text_of(url) else {
+        return rejeitar("fetch: o URL tem de ser texto");
+    };
+    // Os VALORES sob o empréstimo, o texto deles FORA. `text_of` entra no
+    // contexto por sua conta, e pedi-lo lá dentro aborta o processo em vez de
+    // falhar — é a mesma regra que este trabalho já escreveu em três sítios, e
+    // que eu voltei a partir duas vezes só neste ficheiro. Vale a pena o
+    // sublinhado: a regra ser conhecida não impede de a partir; o que impede é
+    // a forma do código dizer qual é o lado de dentro.
+    let (metodo, corpo) = entry::with_runtime(|context| {
+        (
+            entry::get_member(context, opcoes, "method"),
+            entry::get_member(context, opcoes, "body"),
+        )
+    });
+    // `text_of` de `undefined` responde a STRING `"undefined"`, e era essa que
+    // ia como metodo: `fetch(url)` sem opcoes montava `undefined / HTTP/1.1`
+    // com o corpo `undefined`, e o servidor respondia 400 — o que se le como um
+    // problema de rede e e uma conversao a acontecer onde ninguem a pediu.
+    let texto_ou = |valor: u64, por_omissao: &str| -> String {
+        match entry::text_of(valor) {
+            Some(t) if t != "undefined" && t != "null" => t,
+            _ => por_omissao.to_owned(),
+        }
+    };
+    let metodo = texto_ou(metodo, "GET");
+    let corpo = texto_ou(corpo, "");
+    let extra = cabecalhos_de(opcoes);
+
+    match pedir(&texto, &metodo, &corpo, &extra) {
+        Some(resposta) => {
+            let objeto = entry::with_runtime(|context| construir(context, &texto, resposta));
+            entry::with_runtime(|context| entry::settled(context, objeto, false))
+        }
+        None => rejeitar(&format!("fetch: {texto} falhou")),
+    }
+}
+
+/// Uma promessa já REJEITADA com um `TypeError`, que é o que a especificação diz
+/// de um `fetch` que não chega a haver — uma rede em baixo, um URL impossível.
+fn rejeitar(porque: &str) -> u64 {
+    // O erro é construído FORA do empréstimo, e a promessa dentro dele.
+    // `make_named_error` entra no contexto por sua conta, e pedi-lo aqui dentro
+    // é um abort não-desenrolável em vez de um erro — a mesma regra que o
+    // `scope.rs` do DOM e o `with_egui` do egui já tinham escrito, e que eu
+    // voltei a partir ao escrever este ficheiro.
+    let erro = entry::make_named_error("TypeError", porque);
+    entry::with_runtime(|context| {
+        let erro = erro.unwrap_or_else(|| entry::undefined_in(context));
+        entry::settled(context, erro, true)
+    })
+}
+
+/// O que uma resposta traz de volta.
+struct Resposta {
+    status: i64,
+    razao: String,
+    cabecalhos: Vec<(String, String)>,
+    corpo: Vec<u8>,
+}
+
+/// Faz o pedido inteiro e devolve o que chegou.
+///
+/// Reusa o `parser` deste crate e as primitivas de socket — o que NÃO faz é
+/// passar pelo `IncomingMessage`, e isso é deliberado: aquilo é um `Readable`,
+/// e um `Response.text()` teria de o drenar para chegar aos bytes que este
+/// caminho já tem em mão.
+/// Os `headers` que o programa passou, como pares.
+///
+/// Um objeto simples, que é a forma que `fetch(url, { headers: { … } })` usa
+/// mais. A classe `Headers` não existe aqui e por isso não é aceite — dizê-lo
+/// pela ausência em vez de a fingir.
+fn cabecalhos_de(opcoes: u64) -> Vec<(String, String)> {
+    let objeto = entry::with_runtime(|context| entry::get_member(context, opcoes, "headers"));
+    let nomes = entry::with_runtime(|context| entry::member_names(context, objeto));
+    let mut fora = Vec::new();
+    for nome in nomes {
+        let valor = entry::with_runtime(|context| entry::get_member(context, objeto, &nome));
+        if let Some(valor) = entry::text_of(valor) {
+            fora.push((nome, valor));
+        }
+    }
+    fora
+}
+
+/// O `User-Agent` que este motor diz ser.
+///
+/// O MESMO que `navigator.userAgent` responde a uma página — e o comentário
+/// dessa classe já o afirmava: *"userAgent reflete o UA de Chrome que o nosso
+/// fetch usa (somos um browser)"*. Era verdade sobre a intenção e falsa sobre o
+/// código, porque o `fetch` não existia; agora é verdade sobre os dois.
+///
+/// Um servidor que não veja `User-Agent` nenhum recusa muitas vezes com 400, e
+/// foi o que aconteceu no primeiro pedido que este módulo fez.
+///
+/// Escrito aqui e no `window.ts`, que é uma duplicação real e assumida: os dois
+/// crates não se veem — `rts-node` não depende de `rts-dom` nem o contrário — e
+/// a alternativa seria um terceiro sítio só para isto. Quem mudar um tem de
+/// mudar o outro, e é por isso que os dois dizem porquê.
+const AGENTE: &str =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+fn pedir(url: &str, metodo: &str, corpo: &str, extra: &[(String, String)]) -> Option<Resposta> {
+    let (seguro, anfitriao, porta, caminho) = partir(url)?;
+    let socket = abrir(&anfitriao, porta, seguro)?;
+    if !ligado(socket) {
+        return None;
+    }
+
+    let mut cabeca = format!("{metodo} {caminho} HTTP/1.1\r\nHost: {anfitriao}\r\n");
+    cabeca.push_str("Connection: close\r\n");
+    // Os do PROGRAMA primeiro, e os nossos so onde ele nao disse nada: um
+    // `fetch` que ignorasse um `User-Agent` escolhido seria um `fetch` que
+    // decide pelo programa.
+    let disse = |nome: &str| extra.iter().any(|(n, _)| n.eq_ignore_ascii_case(nome));
+    for (nome, valor) in extra {
+        cabeca.push_str(&format!("{nome}: {valor}\r\n"));
+    }
+    if !disse("user-agent") {
+        cabeca.push_str(&format!("User-Agent: {AGENTE}\r\n"));
+    }
+    if !disse("accept") {
+        cabeca.push_str("Accept: */*\r\n");
+    }
+    if !corpo.is_empty() && !disse("content-length") {
+        cabeca.push_str(&format!("Content-Length: {}\r\n", corpo.len()));
+    }
+    cabeca.push_str("\r\n");
+    cabeca.push_str(corpo);
+    escrever(socket, cabeca.as_bytes());
+
+    ler(socket)
+}
+
+/// `https://host:porta/caminho` nas suas quatro partes.
+fn partir(url: &str) -> Option<(bool, String, u16, String)> {
+    let (seguro, resto) = match url.strip_prefix("https://") {
+        Some(resto) => (true, resto),
+        None => (false, url.strip_prefix("http://")?),
+    };
+    let (autoridade, caminho) = match resto.find('/') {
+        Some(at) => (&resto[..at], &resto[at..]),
+        None => (resto, "/"),
+    };
+    let (anfitriao, porta) = match autoridade.rsplit_once(':') {
+        Some((h, p)) => (h.to_owned(), p.parse().ok()?),
+        None => (autoridade.to_owned(), if seguro { 443 } else { 80 }),
+    };
+    Some((seguro, anfitriao, porta, caminho.to_owned()))
+}
+
+/// Um socket ligado ao anfitrião, com TLS quando o esquema o pede.
+fn abrir(anfitriao: &str, porta: u16, seguro: bool) -> Option<u64> {
+    let absent = entry::undefined_value();
+    let (modulo, funcao) = match seguro {
+        true => ("tls", "connect"),
+        false => ("net", "connect"),
+    };
+    let ns = entry::with_runtime(|context| match modulo { "tls" => Some(crate::tls::namespace(context)), _ => Some(crate::net::namespace(context)) })?;
+    let ligar = entry::with_runtime(|context| entry::get_member(context, ns, funcao));
+    let opcoes = entry::with_runtime(|context| {
+        let objeto = entry::make_object(context);
+        let anfitriao = entry::make_string(context, anfitriao);
+        entry::put_member(context, objeto, "host", anfitriao);
+        entry::put_member(context, objeto, "port", entry::make_number(f64::from(porta)));
+        // Um certificado que não valida não é razão para não LER a página, e
+        // recusar aqui daria um `fetch` que falha em metade da internet por uma
+        // política que ninguém pediu. Dito, e não escondido.
+        entry::put_member(context, objeto, "rejectUnauthorized", entry::boolean_value(false));
+        objeto
+    });
+    let socket = entry::call(ligar, absent, opcoes, absent, absent, absent);
+    // Um `on("error")` ANTES de qualquer outra coisa. Um socket que falha a
+    // ligar — TLS que nao negoceia, anfitriao que nao existe — emite `error`, e
+    // um `error` que ninguem ouviu MATA o programa: `uncaught 'error' event`.
+    // Aqui a falha ja tem resposta (a promessa rejeita), e o que faltava era
+    // alguem a ouvir para o processo chegar a dar essa resposta.
+    let calado = entry::with_runtime(|context| entry::make_callable(context, ignorar));
+    let nome = entry::with_runtime(|context| entry::make_string(context, "error"));
+    let on = entry::with_runtime(|context| entry::get_member(context, socket, "on"));
+    entry::call(on, socket, nome, calado, absent, absent);
+    match socket == absent {
+        true => None,
+        false => Some(socket),
+    }
+}
+
+/// Espera que o socket ligue. `false` se desistiu.
+fn ligado(socket: u64) -> bool {
+    let inicio = Instant::now();
+    loop {
+        let vazio = entry::with_runtime(|context| entry::make_bytes(context, &[]));
+        chamar(socket, "write", vazio);
+        let a_ligar = entry::with_runtime(|context| entry::get_member(context, socket, "connecting"));
+        if a_ligar != entry::boolean_value(true) {
+            return true;
+        }
+        if inicio.elapsed() > Duration::from_millis(TIMEOUT_MS) {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(4));
+    }
+}
+
+fn escrever(socket: u64, bytes: &[u8]) {
+    let dados = entry::with_runtime(|context| entry::make_bytes(context, bytes));
+    chamar(socket, "write", dados);
+}
+
+/// Lê até a resposta estar completa.
+fn ler(socket: u64) -> Option<Resposta> {
+    let inicio = Instant::now();
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        buf.extend_from_slice(&drenar(socket));
+        if let Some((cabeca, consumido)) = crate::http::parser::parse_response_head(&buf) {
+            let framing = crate::http::parser::framing_of(&cabeca.headers);
+            let mut resto = buf[consumido..].to_vec();
+            let alvo = match framing {
+                crate::http::parser::Framing::Length(n) => Some(n),
+                crate::http::parser::Framing::None => None,
+                crate::http::parser::Framing::Chunked => None,
+            };
+            loop {
+                let bastante = match alvo {
+                    Some(n) => resto.len() >= n,
+                    // Sem `Content-Length`, o fim é o fecho do socket — que é o
+                    // que o `Connection: close` do pedido garante.
+                    None => fechado(socket),
+                };
+                if bastante || inicio.elapsed() > Duration::from_millis(TIMEOUT_MS) {
+                    break;
+                }
+                resto.extend_from_slice(&drenar(socket));
+                std::thread::sleep(Duration::from_millis(2));
+            }
+            // De-chunking pelo mesmo `decode_body` que o `node:http` usa: um
+            // corpo `Transfer-Encoding: chunked` chega com o tamanho de cada
+            // pedaco em hexadecimal a frente dele, e entrega-lo assim dava um
+            // `res.text()` a comecar por `22f` — foi o que aconteceu no
+            // primeiro pedido bem-sucedido deste modulo.
+            return Some(Resposta {
+                status: i64::from(cabeca.status),
+                razao: cabeca.reason.clone(),
+                cabecalhos: cabeca.headers.clone(),
+                corpo: crate::http::client::decode_body(&resto, framing),
+            });
+        }
+        if inicio.elapsed() > Duration::from_millis(TIMEOUT_MS) {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn fechado(socket: u64) -> bool {
+    entry::with_runtime(|context| entry::get_member(context, socket, "destroyed"))
+        == entry::boolean_value(true)
+}
+
+/// Tira do socket tudo o que ele tem agora.
+///
+/// A escrita vazia primeiro e o `read` em LAÇO até dar `null` — é o que o
+/// `http::client::drain_socket_buffer` faz, e a razão está no módulo dele: sem
+/// nenhuma volta do loop a acontecer, é a escrita que força o socket a
+/// progredir. Uma leitura única devolvia o primeiro pedaço e perdia o resto.
+fn drenar(socket: u64) -> Vec<u8> {
+    let absent = entry::undefined_value();
+    let vazio = entry::with_runtime(|context| entry::make_bytes(context, &[]));
+    chamar(socket, "write", vazio);
+    let mut fora = Vec::new();
+    loop {
+        let pedaco = chamar(socket, "read", absent);
+        if pedaco == entry::null_value() || pedaco == absent {
+            return fora;
+        }
+        if let Some(bytes) = entry::with_runtime(|context| entry::bytes_of(context, pedaco)) {
+            fora.extend_from_slice(&bytes);
+        }
+    }
+}
+
+fn chamar(objeto: u64, nome: &str, argumento: u64) -> u64 {
+    let absent = entry::undefined_value();
+    let metodo = entry::with_runtime(|context| entry::get_member(context, objeto, nome));
+    entry::call(metodo, objeto, argumento, absent, absent, absent)
+}
+
+/// O objeto `Response` que a promessa entrega.
+///
+/// Os métodos respondem promessas, como no browser — `res.text()` é sempre um
+/// `await`, e uma versão que devolvesse a string direta faria funcionar o código
+/// escrito para aqui e partir o escrito para todo o lado.
+fn construir(context: &mut Context, url: &str, resposta: Resposta) -> u64 {
+    let objeto = entry::make_object(context);
+    entry::put_member(context, objeto, "status", entry::make_number(resposta.status as f64));
+    let razao = entry::make_string(context, &resposta.razao);
+    entry::put_member(context, objeto, "statusText", razao);
+    let ok = (200..300).contains(&resposta.status);
+    entry::put_member(context, objeto, "ok", entry::boolean_value(ok));
+    entry::put_member(context, objeto, "redirected", entry::boolean_value(false));
+    let endereco = entry::make_string(context, url);
+    entry::put_member(context, objeto, "url", endereco);
+    let tipo = entry::make_string(context, "basic");
+    entry::put_member(context, objeto, "type", tipo);
+
+    // Os cabeçalhos como objeto simples, com os nomes em minúsculas — que é
+    // como um `Headers` responde e o que um programa compara. Não é a classe
+    // `Headers`: `get`/`has`/`forEach` não estão aqui, e inventá-los meio
+    // feitos seria pior que a ausência.
+    let cabecalhos = entry::make_object(context);
+    for (nome, valor) in &resposta.cabecalhos {
+        let valor = entry::make_string(context, valor);
+        entry::put_member(context, cabecalhos, &nome.to_lowercase(), valor);
+    }
+    entry::put_member(context, objeto, "headers", cabecalhos);
+
+    // O corpo fica guardado como texto e como bytes, e os métodos leem daqui.
+    // `__corpo__` porque o nome não é para ser lido por quem usa isto.
+    let texto = String::from_utf8_lossy(&resposta.corpo).into_owned();
+    let guardado = entry::make_string(context, &texto);
+    entry::put_member(context, objeto, "__corpo__", guardado);
+    entry::put_member(context, objeto, "bodyUsed", entry::boolean_value(false));
+
+    let text_fn = entry::make_callable(context, corpo_texto);
+    entry::put_member(context, objeto, "text", text_fn);
+    let json_fn = entry::make_callable(context, corpo_json);
+    entry::put_member(context, objeto, "json", json_fn);
+    objeto
+}
+
+/// `res.text()` — uma promessa do corpo, como no browser.
+extern "C" fn corpo_texto(_e: u64, this: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    entry::with_runtime(|context| {
+        let corpo = entry::get_member(context, this, "__corpo__");
+        entry::put_member(context, this, "bodyUsed", entry::boolean_value(true));
+        entry::settled(context, corpo, false)
+    })
+}
+
+/// `res.json()` — o mesmo, passado por `JSON.parse`.
+///
+/// Um corpo que não é JSON REJEITA, que é o que um browser faz. Responder
+/// `undefined` deixaria o programa a somar a partir de nada.
+extern "C" fn corpo_json(_e: u64, this: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    let corpo = entry::with_runtime(|context| entry::get_member(context, this, "__corpo__"));
+    let texto = entry::text_of(corpo).unwrap_or_default();
+    // Pelo `JSON.parse` do próprio programa, e não por um parser deste módulo:
+    // um segundo leitor de JSON seria uma segunda resposta à mesma pergunta, e
+    // as duas viriam a discordar sobre algum canto da gramática.
+    let valor = entry::with_runtime(|context| {
+        let global = entry::global_object(context);
+        let json = entry::get_member(context, global, "JSON");
+        let parse = entry::get_member(context, json, "parse");
+        (parse, entry::make_string(context, &texto))
+    });
+    let absent = entry::undefined_value();
+    let analisado = entry::call(valor.0, absent, valor.1, absent, absent, absent);
+    if entry::pending().is_some() {
+        entry::take_thrown();
+        return rejeitar("res.json(): o corpo não é JSON");
+    }
+    entry::with_runtime(|context| {
+        entry::put_member(context, this, "bodyUsed", entry::boolean_value(true));
+        entry::settled(context, analisado, false)
+    })
+}
+
+
+/// O ouvinte de `error` de um socket deste modulo: nao faz nada, de proposito.
+///
+/// A falha ja e respondida pela promessa que o `fetch` rejeita; o que este
+/// existe para fazer e impedir que o evento fique sem ouvinte, porque isso
+/// termina o processo antes de a resposta chegar a quem pediu.
+extern "C" fn ignorar(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
+    entry::undefined_value()
+}

--- a/crates/rts-node/src/fetch.rs
+++ b/crates/rts-node/src/fetch.rs
@@ -156,7 +156,7 @@ const AGENTE: &str =
 fn pedir(url: &str, metodo: &str, corpo: &str, extra: &[(String, String)]) -> Option<Resposta> {
     let (seguro, anfitriao, porta, caminho) = partir(url)?;
     let socket = abrir(&anfitriao, porta, seguro)?;
-    if !ligado(socket) {
+    if !ligado(socket, seguro) {
         return None;
     }
 
@@ -213,6 +213,11 @@ fn abrir(anfitriao: &str, porta: u16, seguro: bool) -> Option<u64> {
     let ligar = entry::with_runtime(|context| entry::get_member(context, ns, funcao));
     let opcoes = entry::with_runtime(|context| {
         let objeto = entry::make_object(context);
+        // O SNI. Sem ele um servidor moderno nao sabe QUAL certificado servir e
+        // recusa a ligacao — foi o que separou este caminho do `node:https`, que
+        // o passa desde sempre.
+        let nome = entry::make_string(context, anfitriao);
+        entry::put_member(context, objeto, "servername", nome);
         let anfitriao = entry::make_string(context, anfitriao);
         entry::put_member(context, objeto, "host", anfitriao);
         entry::put_member(context, objeto, "port", entry::make_number(f64::from(porta)));
@@ -239,14 +244,24 @@ fn abrir(anfitriao: &str, porta: u16, seguro: bool) -> Option<u64> {
 }
 
 /// Espera que o socket ligue. `false` se desistiu.
-fn ligado(socket: u64) -> bool {
+fn ligado(socket: u64, seguro: bool) -> bool {
     let inicio = Instant::now();
     loop {
         let vazio = entry::with_runtime(|context| entry::make_bytes(context, &[]));
         chamar(socket, "write", vazio);
-        let a_ligar = entry::with_runtime(|context| entry::get_member(context, socket, "connecting"));
-        if a_ligar != entry::boolean_value(true) {
-            return true;
+        // Um socket TLS diz que ligou quando o HANDSHAKE acaba, e isso le-se em
+        // `getProtocol()` — o `connecting` de um socket simples ja e falso antes
+        // disso, e escrever ai manda bytes por um tunel que ainda nao existe.
+        if seguro {
+            let protocolo = chamar(socket, "getProtocol", entry::undefined_value());
+            if entry::text_of(protocolo).is_some_and(|p| p != "undefined" && !p.is_empty()) {
+                return true;
+            }
+        } else {
+            let a_ligar = entry::with_runtime(|context| entry::get_member(context, socket, "connecting"));
+            if a_ligar != entry::boolean_value(true) {
+                return true;
+            }
         }
         if inicio.elapsed() > Duration::from_millis(TIMEOUT_MS) {
             return false;
@@ -427,4 +442,28 @@ extern "C" fn corpo_json(_e: u64, this: u64, _a: u64, _b: u64, _c: u64, _d: u64)
 /// termina o processo antes de a resposta chegar a quem pediu.
 extern "C" fn ignorar(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u64) -> u64 {
     entry::undefined_value()
+}
+
+/// `__rtsFetchText(url)` — o corpo de um GET, como texto, SEM promessa.
+///
+/// Existe para um chamador que nao pode esperar: o `__readResource` do
+/// `rts-dom`, que carrega uma folha de estilo ou um script de `http(s)://` no
+/// meio da montagem de um documento. Ele chamava `fetch.fetchText(...)` de um
+/// namespace `rts:fetch` que MORREU com o motor antigo — o comentario dele
+/// ainda descreve esse namespace, e a chamada respondia nada.
+///
+/// `""` em erro, que e a convencao tolerante que aquele chamador ja usa: um
+/// recurso que nao carrega deixa a pagina sem ele, e nao sem pagina.
+///
+/// O nome com `__` diz o que e: uma porta para o prelude, nao superficie para
+/// um programa. Quem escreve codigo usa `fetch`.
+pub(crate) extern "C" fn fetch_text(_e: u64, _t: u64, url: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    let Some(texto) = entry::text_of(url) else {
+        return entry::with_runtime(|context| entry::make_string(context, ""));
+    };
+    let corpo = match pedir(&texto, "GET", "", &[]) {
+        Some(resposta) => String::from_utf8_lossy(&resposta.corpo).into_owned(),
+        None => String::new(),
+    };
+    entry::with_runtime(|context| entry::make_string(context, &corpo))
 }

--- a/crates/rts-node/src/http/client.rs
+++ b/crates/rts-node/src/http/client.rs
@@ -337,7 +337,7 @@ fn read_response_blocking(socket: u64) -> Option<u64> {
     }
 }
 
-fn decode_body(buf: &[u8], framing: parser::Framing) -> Vec<u8> {
+pub(crate) fn decode_body(buf: &[u8], framing: parser::Framing) -> Vec<u8> {
     match framing {
         parser::Framing::None => Vec::new(),
         parser::Framing::Length(n) => buf[..n.min(buf.len())].to_vec(),

--- a/crates/rts-node/src/http/mod.rs
+++ b/crates/rts-node/src/http/mod.rs
@@ -54,11 +54,15 @@
 //! own doc names.
 
 mod agent;
-mod client;
+// `pub(crate)` para o `fetch` reusar `decode_body` — um segundo de-chunker
+// seria uma segunda resposta a mesma pergunta.
+pub(crate) mod client;
 mod common;
 mod incoming;
 mod outgoing;
-mod parser;
+// `pub(crate)` para o `fetch` poder ler uma resposta sem passar pelo
+// `IncomingMessage` — ver `crate::fetch`.
+pub(crate) mod parser;
 mod registry;
 mod server;
 mod status;

--- a/crates/rts-node/src/http/parser.rs
+++ b/crates/rts-node/src/http/parser.rs
@@ -23,14 +23,14 @@
 /// file's; a parser that folds cannot also hand back `rawHeaders`.
 pub(super) type RawHeaders = Vec<(String, String)>;
 
-pub(super) struct RequestHead {
+pub(crate) struct RequestHead {
     pub method: String,
     pub target: String,
     pub version: String,
     pub headers: RawHeaders,
 }
 
-pub(super) struct ResponseHead {
+pub(crate) struct ResponseHead {
     pub version: String,
     pub status: u16,
     pub reason: String,
@@ -86,7 +86,7 @@ pub(super) fn parse_request_head(buf: &[u8]) -> Option<(RequestHead, usize)> {
 }
 
 /// The response-side pair of [`parse_request_head`].
-pub(super) fn parse_response_head(buf: &[u8]) -> Option<(ResponseHead, usize)> {
+pub(crate) fn parse_response_head(buf: &[u8]) -> Option<(ResponseHead, usize)> {
     let end = find_double_crlf(buf)?;
     let lines = split_head_lines(&buf[..end]);
     let status_line = lines.first()?;
@@ -111,13 +111,13 @@ pub(super) fn header_find<'a>(headers: &'a RawHeaders, name: &str) -> Option<&'a
 /// message rather than adding a rejection path this crate has no error
 /// channel to report through).
 #[derive(Clone, Copy)]
-pub(super) enum Framing {
+pub(crate) enum Framing {
     None,
     Length(usize),
     Chunked,
 }
 
-pub(super) fn framing_of(headers: &RawHeaders) -> Framing {
+pub(crate) fn framing_of(headers: &RawHeaders) -> Framing {
     if let Some(te) = header_find(headers, "transfer-encoding")
         && te.to_ascii_lowercase().contains("chunked")
     {
@@ -132,7 +132,7 @@ pub(super) fn framing_of(headers: &RawHeaders) -> Framing {
 }
 
 /// One decode step's answer.
-pub(super) enum ChunkOutcome {
+pub(crate) enum ChunkOutcome {
     /// Not enough bytes yet for the next chunk-size line or chunk body.
     NeedMore,
     /// One decoded chunk, with its bytes already stripped of the
@@ -148,7 +148,7 @@ pub(super) enum ChunkOutcome {
 /// mid-chunk, and how many bytes are left in the current one) to be fed
 /// arbitrary byte spans as they arrive off a socket, one `'data'` event at a
 /// time.
-pub(super) struct ChunkedDecoder {
+pub(crate) struct ChunkedDecoder {
     remaining: Option<usize>,
     trailers_done: bool,
 }

--- a/crates/rts-node/src/lib.rs
+++ b/crates/rts-node/src/lib.rs
@@ -31,6 +31,7 @@
 #![deny(missing_docs)]
 #![deny(dead_code)]
 
+mod fetch;
 mod errors;
 pub mod assert;
 pub mod async_hooks;
@@ -290,6 +291,10 @@ pub fn install(context: &mut Context) {
     // same two cells and `globalThis.Blob === (await import("node:buffer")).Blob`
     // holds.
     let (blob, file) = buffer::blob::classes(context);
+    // `fetch` — global aqui como no Node 18+ e como num browser. Ver
+    // `fetch.rs` para porque vive neste crate.
+    let fetch_fn = rts_core::entry::make_callable(context, fetch::fetch);
+    rts_core::entry::declare_global(context, "fetch", fetch_fn);
     rts_core::entry::declare_global(context, "Blob", blob);
     rts_core::entry::declare_global(context, "File", file);
     // `globalThis.crypto` is Node's `require('node:crypto').webcrypto`, and it

--- a/crates/rts-node/src/lib.rs
+++ b/crates/rts-node/src/lib.rs
@@ -295,6 +295,8 @@ pub fn install(context: &mut Context) {
     // `fetch.rs` para porque vive neste crate.
     let fetch_fn = rts_core::entry::make_callable(context, fetch::fetch);
     rts_core::entry::declare_global(context, "fetch", fetch_fn);
+    let fetch_text = rts_core::entry::make_callable(context, fetch::fetch_text);
+    rts_core::entry::declare_global(context, "__rtsFetchText", fetch_text);
     rts_core::entry::declare_global(context, "Blob", blob);
     rts_core::entry::declare_global(context, "File", file);
     // `globalThis.crypto` is Node's `require('node:crypto').webcrypto`, and it

--- a/crates/rts-node/src/util/legacy.rs
+++ b/crates/rts-node/src/util/legacy.rs
@@ -40,7 +40,7 @@ pub(super) extern "C" fn extend(
         .map(|key| (string(&key), get(source, &key)))
         .collect();
     for (key, value) in pairs {
-        entry::set_indexed(target, key, value);
+        entry::set_indexed(target, key, value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     }
     target
 }
@@ -72,7 +72,7 @@ pub(super) extern "C" fn inherits(
         entry::put_member(context, made, "constructor", subclass);
         made
     });
-    entry::set_indexed(subclass, string("prototype"), made);
-    entry::set_indexed(subclass, string("super_"), superclass);
+    entry::set_indexed(subclass, string("prototype"), made, 0 /* strict: quem escreve a partir do host reporta a recusa */);
+    entry::set_indexed(subclass, string("super_"), superclass, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     entry::undefined_value()
 }

--- a/crates/rts-node/src/util/promisify.rs
+++ b/crates/rts-node/src/util/promisify.rs
@@ -119,7 +119,7 @@ pub(super) extern "C" fn promisify(
     // own idempotence rests on — it defines the custom hook on the result too.
     // Written under the symbol's key text, so a program asking with
     // `Symbol.for(...)` sees exactly this.
-    entry::set_indexed(wrapper, string(CUSTOM), wrapper);
+    entry::set_indexed(wrapper, string(CUSTOM), wrapper, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     wrapper
 }
 
@@ -133,7 +133,7 @@ fn copy_own(original: u64, wrapper: u64) {
     for name in own_key_strings(original) {
         let key = string(&name);
         let value = entry::get_indexed(original, key);
-        entry::set_indexed(wrapper, key, value);
+        entry::set_indexed(wrapper, key, value, 0 /* strict: quem escreve a partir do host reporta a recusa */);
     }
 }
 

--- a/crates/rts-node/src/util/wrap.rs
+++ b/crates/rts-node/src/util/wrap.rs
@@ -68,7 +68,7 @@ pub(super) extern "C" fn deprecate(
     if modify {
         let prototype = get(target, "prototype");
         if present(prototype) {
-            entry::set_indexed(wrapper, super::values::string("prototype"), prototype);
+            entry::set_indexed(wrapper, super::values::string("prototype"), prototype, 0 /* strict: quem escreve a partir do host reporta a recusa */);
         }
     }
     wrapper

--- a/examples/claude-react-janela.ts
+++ b/examples/claude-react-janela.ts
@@ -1,38 +1,62 @@
-// React 18 real, dos bundles UMD do CDN, a montar na nossa janela.
+// React 18 real, dos bundles UMD do CDN, a montar na nossa janela — e agora a
+// RESPONDER ao rato.
 //
 // A diferenca para o headless e o LOOP: o React 18 e concurrent — `render`
 // AGENDA e o trabalho corre depois, fatia a fatia. Sem um loop vivo ninguem o
 // bombeia, e o `#root` fica vazio sem um erro. Aqui o frame do host bombeia.
-import { openWindow, pump, isOpen, close, beginFrame, endFrame, render, drawText } from "rts:egui";
+//
+// E a diferenca para a versao anterior deste ficheiro sao DUAS linhas:
+// `pumpInputEvents` e `pumpEventCallbacks`. So `pumpTimerCallbacks` faz uma
+// pagina ANIMAR e nao faz uma pagina RESPONDER — o clique do egui fica na fila
+// crua e ninguem o despacha. Com elas, o clique entra por
+// `__dispatchWithCallbacks`, que e o mesmo caminho de um `dispatchEvent` do
+// prelude, e e la que o `event.target` e feito: e por isso que a cache de
+// wrappers por `NodeId` e o que decide se o React consegue atribuir o clique a
+// um componente.
+import egui from "rts:egui";
+import dom from "rts:dom";
 import { readFileSync } from "node:fs";
 
-const doc = parseDocument(readFileSync("react-app.html", "utf8") as string);
-console.log("scripts que correram:", runScripts(doc));
-// LOGO a seguir aos scripts, antes de qualquer janela: o React montou?
-// Um `await` SUSPENDE o programa e devolve o controlo ao host, que corre o
-// loop ate a promessa resolver. E isso — nao `run_event_loop` chamado de
-// dentro — que faz o trabalho agendado avancar.
-let voltas = 0;
-while (voltas < 30) { await new Promise(function (r: any) { setTimeout(r, 0); }); voltas = voltas + 1; }
-const antes = doc.getElementById("root");
-console.log("filhos do #root ANTES da janela:", antes === null ? "?" : antes.children.length);
+const ficheiro = "E:/rts/react-app.html";
 
-const win = openWindow("rts-dom — React 18 a correr", 900, 600, 0);
-let frames = 0;
-while (isOpen(win)) {
-  pump(win);
-  // O trabalho que o React agendou: uma volta do loop do motor e a fila de
-  // timers do documento, por frame. E o que um browser faz entre pinturas.
-  pumpTimerCallbacks(doc);
-  beginFrame(win);
-  render(win, doc._dom);
-  const raiz = doc.getElementById("root");
-  const n = raiz === null ? 0 : raiz.children.length;
-  drawText(win, "rts-dom · React 18 · filhos do #root: " + n + " · frame " + frames, 0);
-  endFrame(win);
-  frames = frames + 1;
+const html = readFileSync(ficheiro, "utf8");
+if (html.length === 0) {
+  console.log("nao consegui ler " + ficheiro);
+} else {
+  console.log("[boot] " + ficheiro + ": " + html.length + " bytes");
+  const doc = parseDocument(html);
+  const d: i64 = doc._dom;
+  console.log("[js] scripts corridos: " + runScriptsAt(doc, "https://localhost/"));
+
+  const win = egui.openWindow("RTS - React", 900, 700, 0);
+  console.log("[win] handle=" + win + " aberta=" + egui.isOpen(win));
+  // `isOpen`/`pump` respondem BOOLEANOS, e `pump` responde `true` para
+  // CONTINUAR (do lado Rust e `from_bool(pump(...) == 0)`). O idioma
+  // `if (egui.pump(win) !== 0) break;` — que o `claude-browser.ts` ainda usa —
+  // le `true !== 0` como verdadeiro e sai no primeiro frame, com a janela
+  // aberta e sem nunca desenhar nada.
+  let frames = 0;
+  while (egui.isOpen(win)) {
+    if (!egui.pump(win)) break;
+    egui.beginFrame(win);
+    egui.render(win, d);
+    // A barra de diagnostico: o que o React montou, contado do DOM em vez de
+    // acreditado. Um `#root` com zero filhos e a forma que uma montagem falhada
+    // tem aqui — nao ha erro nenhum a acompanha-la.
+    const raiz = doc.getElementById("root");
+    egui.drawText(win, "rts-dom - React 18 - filhos do #root: "
+      + (raiz === null ? 0 : raiz.children.length) + " - frame " + frames, 0);
+    egui.endFrame(win);
+    frames = frames + 1;
+    // A mesma ordem de um frame do mini-browser: teclado/edicao, cliques, timers.
+    pumpInputEvents(doc);
+    pumpEventCallbacks(doc);
+    pumpTimerCallbacks(doc);
+  }
+  egui.close(win);
+  const fim = doc.getElementById("root");
+  console.log("[fim] frames=" + frames + " filhos do #root="
+    + (fim === null ? "?" : fim.children.length));
+  console.log("[fim] texto:", fim === null ? "" : fim.textContent.substring(0, 120));
+  dom.free(d);
 }
-close(win);
-const raiz = doc.getElementById("root");
-console.log("no fim, filhos do #root:", raiz === null ? "?" : raiz.children.length);
-console.log("texto:", raiz === null ? "" : (raiz.textContent || "").substring(0, 120));

--- a/examples/claude-react-janela.ts
+++ b/examples/claude-react-janela.ts
@@ -8,6 +8,14 @@ import { readFileSync } from "node:fs";
 
 const doc = parseDocument(readFileSync("react-app.html", "utf8") as string);
 console.log("scripts que correram:", runScripts(doc));
+// LOGO a seguir aos scripts, antes de qualquer janela: o React montou?
+// Um `await` SUSPENDE o programa e devolve o controlo ao host, que corre o
+// loop ate a promessa resolver. E isso — nao `run_event_loop` chamado de
+// dentro — que faz o trabalho agendado avancar.
+let voltas = 0;
+while (voltas < 30) { await new Promise(function (r: any) { setTimeout(r, 0); }); voltas = voltas + 1; }
+const antes = doc.getElementById("root");
+console.log("filhos do #root ANTES da janela:", antes === null ? "?" : antes.children.length);
 
 const win = openWindow("rts-dom — React 18 a correr", 900, 600, 0);
 let frames = 0;

--- a/examples/claude-react-janela.ts
+++ b/examples/claude-react-janela.ts
@@ -1,0 +1,30 @@
+// React 18 real, dos bundles UMD do CDN, a montar na nossa janela.
+//
+// A diferenca para o headless e o LOOP: o React 18 e concurrent — `render`
+// AGENDA e o trabalho corre depois, fatia a fatia. Sem um loop vivo ninguem o
+// bombeia, e o `#root` fica vazio sem um erro. Aqui o frame do host bombeia.
+import { openWindow, pump, isOpen, close, beginFrame, endFrame, render, drawText } from "rts:egui";
+import { readFileSync } from "node:fs";
+
+const doc = parseDocument(readFileSync("react-app.html", "utf8") as string);
+console.log("scripts que correram:", runScripts(doc));
+
+const win = openWindow("rts-dom — React 18 a correr", 900, 600, 0);
+let frames = 0;
+while (isOpen(win)) {
+  pump(win);
+  // O trabalho que o React agendou: uma volta do loop do motor e a fila de
+  // timers do documento, por frame. E o que um browser faz entre pinturas.
+  pumpTimerCallbacks(doc);
+  beginFrame(win);
+  render(win, doc._dom);
+  const raiz = doc.getElementById("root");
+  const n = raiz === null ? 0 : raiz.children.length;
+  drawText(win, "rts-dom · React 18 · filhos do #root: " + n + " · frame " + frames, 0);
+  endFrame(win);
+  frames = frames + 1;
+}
+close(win);
+const raiz = doc.getElementById("root");
+console.log("no fim, filhos do #root:", raiz === null ? "?" : raiz.children.length);
+console.log("texto:", raiz === null ? "" : (raiz.textContent || "").substring(0, 120));

--- a/examples/claude-react-vida.ts
+++ b/examples/claude-react-vida.ts
@@ -1,0 +1,35 @@
+// O Jogo da Vida de Conway, escrito em React, a correr sozinho na nossa janela.
+//
+// Nao precisa de cliques — e por isso que serve de teste: o que ele exercita e
+// `useEffect`, `setInterval`, atualizacao funcional de estado e RE-RENDER
+// continuo. A grelha inteira muda a cada geracao, e o React reconcilia.
+import { openWindow, pump, isOpen, close, beginFrame, endFrame, render, drawText } from "rts:egui";
+import { readFileSync } from "node:fs";
+
+const doc = parseDocument(readFileSync("react-vida.html", "utf8") as string);
+console.log("scripts que correram:", runScripts(doc));
+
+// Deixar o React montar antes de abrir a janela: um `await` devolve o controlo
+// ao host, que corre o loop — `run_event_loop` chamado de dentro nao o faz.
+let v = 0;
+while (v < 30) { await new Promise(function (r: any) { setTimeout(r, 0); }); v = v + 1; }
+const raiz = doc.getElementById("root");
+console.log("montou? filhos do #root:", raiz === null ? "?" : raiz.children.length);
+
+const win = openWindow("rts-dom — Jogo da Vida em React", 700, 640, 0);
+let frames = 0;
+while (isOpen(win)) {
+  pump(win);
+  // Uma volta do loop desta pagina por frame: e daqui que o `setInterval` do
+  // jogo sai da fila e a geracao seguinte e calculada.
+  pumpTimerCallbacks(doc);
+  beginFrame(win);
+  render(win, doc._dom);
+  const p = raiz === null ? null : raiz.querySelector("p");
+  drawText(win, "rts-dom · React 18 · " + (p === null ? "" : p.textContent) + " · frame " + frames, 0);
+  endFrame(win);
+  frames = frames + 1;
+}
+close(win);
+const p = raiz === null ? null : raiz.querySelector("p");
+console.log("no fim:", p === null ? "?" : p.textContent, "em", frames, "frames");

--- a/tests/claude-animacao-css-anda.test.ts
+++ b/tests/claude-animacao-css-anda.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "rts:test";
+
+// Uma `animation` de `@keyframes` interpola com o tempo. O frame da janela
+// chama `dom.advance(doc, agora)`; este teste chama-o diretamente, que e o que
+// torna a pergunta "esta pagina anima?" respondivel SEM abrir uma janela e
+// alguem olhar.
+//
+// Veio de uma observacao a olho — "a barra de progresso do WhatsApp nao anda" —
+// que so se podia confirmar ou desmentir assim. (Desmentiu-se: o motor anima; a
+// barra do WhatsApp nao existe, porque e o carregador que a cria depois de
+// receber os bundles da rede.)
+
+const css =
+  "@keyframes crescer { from { width: 10px } to { width: 200px } } " +
+  "#barra { width: 10px; height: 12px; background: #0a7; animation: crescer 1s linear infinite }";
+const doc = parseDocument("<style>" + css + "</style><div id='barra'></div>");
+const barra = doc.getElementById("barra");
+
+function largura(): string {
+  return barra === null ? "?" : barra.getComputedProp("width");
+}
+
+// A primeira chamada fixa o instante inicial da animacao; as seguintes medem a
+// partir dela.
+dom.advance(doc._dom, 0);
+const noInicio = largura();
+dom.advance(doc._dom, 500);
+const aMeio = largura();
+dom.advance(doc._dom, 1000);
+const noFim = largura();
+
+test("uma animacao comeca no primeiro keyframe", function () {
+  expect(noInicio).toBe("10px");
+});
+
+test("e interpola com o tempo", function () {
+  // A meio de `10px -> 200px` sao 105px. O valor exato depende do arredondamento
+  // do motor; o que este teste pina e que ANDOU e que anda para a frente.
+  expect(aMeio !== noInicio).toBe(true);
+  expect(noFim !== aMeio).toBe(true);
+});

--- a/tests/claude-no-tem-identidade.test.ts
+++ b/tests/claude-no-tem-identidade.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "rts:test";
+
+// O mesmo no do documento devolve sempre o MESMO objeto, e o que se poe nele
+// fica la — inclusive quando chega como `event.target`.
+//
+// FIXTURE VERMELHA: pina um defeito ABERTO.
+//
+// Nao e purismo. E o que uma biblioteca que ANOTA nos assume, e sao todas: o
+// React guarda o fiber em `no.__reactFiber$xyz` e vai busca-lo por
+// `event.target.__reactFiber$xyz`; o jQuery guarda o cache de dados assim; o
+// D3 guarda `__data__`. Com wrappers efemeros, escreve-se num objeto e le-se
+// noutro.
+//
+// Medido no React 18 a correr neste motor: a aplicacao MONTA e PINTA — hooks,
+// listas, estilos — e nenhum `onClick` dispara. E ja se sabe que nao e nada
+// disto:
+//
+//   - o registo funciona: o React regista 132 listeners, `click` em captura e
+//     em bubble;
+//   - o despacho funciona: um clique no botao chega ao container do React nas
+//     DUAS fases;
+//   - o objeto de evento tem `type`, `target`, `currentTarget`,
+//     `preventDefault`, `stopPropagation`, `eventPhase`, `bubbles`,
+//     `defaultPrevented`, `nativeEvent` e `timeStamp`.
+//
+// O React recebe o evento e nao tem como o atribuir a um componente, porque o
+// `target` que lhe chega e um wrapper diferente daquele onde ele escreveu.
+//
+// A correcao e uma cache de wrappers por `NodeId` do lado `.ts`, com o cuidado
+// de nao segurar nos ja removidos do documento.
+
+const doc = parseDocument("<button id='b'>x</button>");
+const primeiro = doc.getElementById("b");
+const segundo = doc.getElementById("b");
+
+test("dois acessos ao mesmo no dao o mesmo objeto", function () {
+  expect(primeiro === segundo).toBe(true);
+});
+
+test("uma propriedade posta num no sobrevive a outro acesso", function () {
+  if (primeiro !== null) { (primeiro as any).__marca = 42; }
+  const terceiro = doc.getElementById("b");
+  expect(terceiro === null ? 0 : (terceiro as any).__marca).toBe(42);
+});

--- a/tests/claude-var-em-bloco-nao-escapa.test.ts
+++ b/tests/claude-var-em-bloco-nao-escapa.test.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "rts:test";
+
+// Um `var` de uma funcao e dessa funcao, e uma reatribuicao DENTRO de um bloco
+// escreve nesse binding — nao num nome de fora que por acaso se chama igual.
+//
+// FIXTURE VERMELHA: pina um defeito ABERTO, e so aparece num `<script>` de
+// pagina. Num modulo passa, porque o escopo de um modulo nao tem `parent` nem
+// `top` nem `name`; o de uma pagina TEM, porque o escopo de uma pagina E o
+// `window` (ver `docs/ui/page-script-bridge.md`).
+//
+// Veio de um caso real. O React 18 anda a arvore de fibers assim:
+//
+//     var parent = sourceFiber.return;
+//     while (parent !== null) { ...; parent = parent.return; }
+//
+// A DECLARACAO e local e esta certa. A REATRIBUICAO dentro do `while` ia para
+// `window.parent`, que e `[Replaceable]` e ignora a escrita; a leitura seguinte
+// devolvia o `window`, o laco nunca terminava, e o erro que chegava ao
+// utilizador era `undefined.childLanes` — trinta ficheiros a jusante da causa.
+
+const html =
+  "<div id='saida'>-</div><script>" +
+  "function anda(inicio) {" +
+  "  var parent = inicio.pai;" +
+  "  var passos = 0;" +
+  "  while (parent !== null) {" +
+  "    passos = passos + 1;" +
+  "    if (passos > 5) { return -1; }" +
+  "    parent = parent.pai;" +
+  "  }" +
+  "  return passos;" +
+  "}" +
+  "var raiz = { pai: null };" +
+  "var meio = { pai: raiz };" +
+  "var folha = { pai: meio };" +
+  "var el = document.getElementById('saida');" +
+  "if (el !== null) { el.setInnerHTML('' + anda(folha)); }" +
+  "</script>";
+
+const doc = parseDocument(html);
+runScripts(doc);
+const saida = doc.getElementById("saida");
+const texto = saida === null ? "(sem no)" : saida.textContent;
+
+test("um var reatribuido dentro de um while continua a ser o da funcao", function () {
+  // `-1` significa que o laco nunca terminou: `parent` deixou de ser o local.
+  expect(texto).toBe("2");
+});

--- a/tests/claude-var-em-for-dentro-de-try.test.ts
+++ b/tests/claude-var-em-for-dentro-de-try.test.ts
@@ -27,13 +27,41 @@ import { test, expect } from "rts:test";
 // `Cannot read properties of undefined (reading 'tag')` — dentro do commit da
 // arvore, sem nada que apontasse para a causa.
 //
-// O que ja se sabe da causa: sem o `try`, o `var` e um registo local e o
-// `break` preserva-o; com o `try`, o nome precisa de viver no ambiente para
-// sobreviver ao salto — e `assigned_under_protection` so conta ATRIBUICOES,
-// nao declaracoes com inicializador, por isso nunca o torna residente.
-// Contar tambem as declaracoes torna-o residente e NAO chega: medido, o valor
-// continua a perder-se, o que aponta para o ambiente por passagem que o `for`
-// abre. Fica escrito para quem retomar nao repetir a tentativa.
+// O QUE JA ESTA ESTABELECIDO, medido, para quem retomar nao repetir:
+//
+// As tres variantes que discriminam:
+//
+//     try + DECLARACAO + for      -> PERDE   (este teste)
+//     try + DECLARACAO, sem for   -> ok
+//     try + ATRIBUICAO  + for     -> ok      (`var d;` fora, `d = c` dentro)
+//     for + declaracao, sem try   -> ok
+//
+// Logo sao precisas TRES coisas ao mesmo tempo: o `try`, o laco, e a
+// DECLARACAO (nao a atribuicao) la dentro.
+//
+// O sitio: `emit::protect` faz `scope.restore(&before)` ao chegar ao join do
+// `try` (protect.rs, a seguir a `switch_to(join)`), e explica porque isso e
+// sound: *"everything the body assigns lives in memory by now —
+// `capture::assigned_under_protection` put it there"*. Tudo o que ficou num
+// REGISTO e descartado nesse restauro.
+//
+// DUAS HIPOTESES JA REFUTADAS, com medicao:
+//
+//  1. "`assigned_under_protection` nao conta declaracoes, so atribuicoes."
+//     Verdade — mas acrescentar `vars_at_any_depth` ao ramo do `Try` faz o nome
+//     ficar residente (medido: `protected` deixa de ser vazio) e o valor
+//     CONTINUA a perder-se. Revertido.
+//
+//  2. "`assigned_in_stmt` (o plano do laco) nao ve declaracoes."
+//     Falso: ve, e o comentario dele ate diz porque — *"the names it introduces
+//     count as written... a `var` inside a protected region is visible after
+//     it"*.
+//
+// O que falta e perceber PORQUE a residencia nao chega: ou a escrita vai para
+// um ambiente e a leitura le de outro, ou o valor nao chega ao bloco de saida
+// do laco. Uma sonda em `binding::read` para o nome nao disparou, o que quer
+// dizer que a leitura nao passa por onde se esperava — e e por ai que se
+// comeca.
 
 const html =
   "<div id='saida'>-</div><script>" +

--- a/tests/claude-var-em-for-dentro-de-try.test.ts
+++ b/tests/claude-var-em-for-dentro-de-try.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "rts:test";
+
+// Um `var` declarado dentro de um `for` que esta dentro de um `try` sobrevive
+// ao fim do laco: e uma ligacao da FUNCAO, e o `break` nao a pode perder.
+//
+// FIXTURE VERMELHA: pina um defeito ABERTO.
+//
+// Isolado a quatro variantes, e sao precisas DUAS condicoes — nenhuma sozinha
+// falha:
+//
+//     try + for            -> PERDE      (este teste)
+//     try, sem for         -> ok
+//     for, sem try         -> ok
+//     try + rotulo + for   -> PERDE      (o rotulo e irrelevante)
+//
+// Veio do React 18, que anda a arvore de fibers exatamente assim:
+//
+//     try {
+//       a: { for (var c = no.return; c !== null;) {
+//              if (serve(c)) { var d = c; break a }
+//              c = c.return }
+//            throw Error(160); }
+//       switch (d.tag) { ... }
+//     } catch (k) { ... }
+//
+// O `d` chegava `undefined` ao `switch`, e o erro que o utilizador via era
+// `Cannot read properties of undefined (reading 'tag')` — dentro do commit da
+// arvore, sem nada que apontasse para a causa.
+//
+// O que ja se sabe da causa: sem o `try`, o `var` e um registo local e o
+// `break` preserva-o; com o `try`, o nome precisa de viver no ambiente para
+// sobreviver ao salto — e `assigned_under_protection` so conta ATRIBUICOES,
+// nao declaracoes com inicializador, por isso nunca o torna residente.
+// Contar tambem as declaracoes torna-o residente e NAO chega: medido, o valor
+// continua a perder-se, o que aponta para o ambiente por passagem que o `for`
+// abre. Fica escrito para quem retomar nao repetir a tentativa.
+
+const html =
+  "<div id='saida'>-</div><script>" +
+  "function acha(v) {" +
+  "  try {" +
+  "    for (var c = v; c !== null;) {" +
+  "      if (c.serve) { var d = c; break; }" +
+  "      c = c.pai;" +
+  "    }" +
+  "    return d === undefined ? 'PERDEU' : d.nome;" +
+  "  } catch (k) { return 'lancou'; }" +
+  "}" +
+  "var raiz = { nome: 'raiz', serve: true, pai: null };" +
+  "var el = document.getElementById('saida');" +
+  "if (el !== null) { el.setInnerHTML('' + acha(raiz)); }" +
+  "</script>";
+
+const doc = parseDocument(html);
+runScripts(doc);
+const saida = doc.getElementById("saida");
+const texto = saida === null ? "(sem no)" : saida.textContent;
+
+test("um var declarado num for dentro de um try sobrevive ao break", function () {
+  expect(texto).toBe("raiz");
+});


### PR DESCRIPTION
Dezassete commits sobre uma linha: fazer uma página real correr aqui como corre num browser. Cada um mede antes e depois **por ficheiro** — a lista de PERDIDOS é vazia em todas as medições, e nenhum número aqui é líquido.

## O arco

| # | o que estava errado |
|---|---|
| `9d43cc99b` | o escopo de uma página e o `window` eram dois objetos |
| `7fed1eca0` `40ed58e3b` | um `var` não era declarado se o nome existisse fora da função; outro vivia no objeto da passagem do laço |
| `d6c964ad2` | um `<script>` de página via o ambiente do Node |
| `ff5d4077b` | o React 18 monta |
| `75790aa73` | `nativeEvent`/`timeStamp`, e a razão real dos cliques |
| `d82e20f57` `36a845526` | `fetch` global, HTTP e HTTPS |
| `1c97f5b5a` | **um nó, um objeto** — e o React responde ao clique |

## O último, que é o que fecha o arco

Cada acesso a um nó fabricava um `Element` novo. Toda a biblioteca que ANOTA nós — React (`__reactFiber$`), jQuery, D3 (`__data__`) — escrevia num objeto e lia noutro. O sintoma era uma app que monta, pinta e não responde a um único clique, com o registo, o despacho e o objeto de evento todos correctos.

A cache é por `(handle do DOM, NodeId)` e **não precisa de invalidação**, o que se argumenta do lado Rust: `remove_node` deixa o nó na arena e a árvore só faz `nodes.push`, então um `idx` nunca é reciclado dentro de uma geração e um re-parse muda a geração de todos.

## Medido

- Suite: **790 de 830** (era 789), mesmo corpus, **perdidos: nenhum**.
- `cargo test -p rts-dom`: 718 passed, 0 failed.
- O que a suite não pode dar, porque nenhum teste abre uma janela: a app de React 18 real responde ao clique do **rato** na janela do egui — o contador anda, uma tarefa alterna, o resumo recontabiliza.

## Anotado e não corrigido aqui

`examples/claude-browser.ts` usa `if (egui.pump(win) !== 0) break;`. O `pump` responde um booleano e responde `true` para CONTINUAR, então esse laço sai no primeiro frame. Outro ficheiro, outra medição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8BeEZhD3d7wfxexns5Vzs