### PR TITLE
feat(node:crypto): AES-GCM/CBC ciphers, X25519 and XEdDSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +582,15 @@ name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "cc"
@@ -2710,6 +2728,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4555,10 +4574,13 @@ dependencies = [
 name = "rts-node"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "aes-gcm",
  "blake2",
  "brotli",
+ "cbc",
  "chacha20poly1305",
+ "curve25519-dalek",
  "digest 0.11.2",
  "ed25519-dalek",
  "encoding_rs",

--- a/crates/rts-node/Cargo.toml
+++ b/crates/rts-node/Cargo.toml
@@ -24,6 +24,21 @@ encoding_rs = "0.8"         # §4.9 — WHATWG label set for string_decoder
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"] }
 webpki-roots = "1.0"        # §3 — the CA store; NOT rustls-native-certs, which links schannel/Security.framework
 aes-gcm = "0.10"            # §6 — AEAD
+# node:crypto symmetric ciphers — §4.2. The document pins `aes 0.9`/`cbc 0.2`;
+# these are 0.8/0.1, which is deliberate and not drift: `aes-gcm 0.10` above
+# already resolves `aes 0.8`, and taking 0.9 would link TWO copies of the AES
+# block cipher into one binary — two implementations of one primitive is the
+# duplication this workspace refuses, and the version the AEAD already pulls is
+# the one with a caller. `cbc 0.1` is what pairs with `cipher 0.4`, which
+# `aes 0.8` speaks; the `alloc` feature is what exposes PKCS#7 padding as
+# `encrypt_padded_vec_mut` rather than leaving every caller to write the pad.
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+# node:crypto XEdDSA — Signal's signature over an X25519 identity key. Not a new
+# curve: `ed25519-dalek` below already resolves this exact version, and XEdDSA
+# needs the point/scalar layer (`EdwardsPoint`, `MontgomeryPoint::to_edwards`)
+# that the signature crate does not re-export.
+curve25519-dalek = "4.1"
 chacha20poly1305 = "0.10"   # §6 — AEAD
 x25519-dalek = { version = "2", features = ["static_secrets"] }  # §6 — key exchange.
                             # The feature is not optional: without it every constructor that

--- a/crates/rts-node/src/crypto/cipher/algo.rs
+++ b/crates/rts-node/src/crypto/cipher/algo.rs
@@ -1,0 +1,259 @@
+//! The block-cipher work itself — no JavaScript value crosses this file.
+//!
+//! # Why this is a separate file from `cipher/mod.rs`
+//!
+//! Everything here is a function from bytes to bytes, so it is testable without
+//! a `Context` and reviewable without knowing this engine at all. `mod.rs` above
+//! it is the opposite: it knows about prototypes, hidden ids and `Buffer`, and
+//! nothing about AES. Mixing the two is how a padding bug ends up needing a
+//! running interpreter to reproduce.
+//!
+//! # What answers this already, and what does not
+//!
+//! `tls/provider/aead.rs` also encrypts with AES-GCM, and it is NOT reused
+//! here: it implements rustls's `MessageEncrypter`, whose unit is a TLS record
+//! with its own sequence number and header as associated data. `createCipheriv`
+//! has neither. What both call is the same `aes_gcm` crate, which is the level
+//! at which the primitive is genuinely shared — one implementation of AES-GCM is
+//! linked, and this file adds a second CALLER of it, not a second copy.
+
+use aes::cipher::block_padding::Pkcs7;
+use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce};
+
+type Aes256CbcEnc = cbc::Encryptor<aes::Aes256>;
+type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
+type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
+
+/// The algorithms `createCipheriv` accepts here — exactly the ones this file
+/// can genuinely compute. A name outside this list is refused at
+/// `createCipheriv`, never approximated: `getCiphers()` answering a list and a
+/// constructor accepting a name outside it would be two different claims about
+/// the same set.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum CipherAlgo {
+    Aes256Gcm,
+    Aes128Gcm,
+    Aes256Cbc,
+    Aes128Cbc,
+}
+
+impl CipherAlgo {
+    /// The names [`CipherAlgo::parse`] accepts, for `getCiphers()`.
+    pub(crate) const NAMES: &'static [&'static str] =
+        &["aes-128-cbc", "aes-128-gcm", "aes-256-cbc", "aes-256-gcm"];
+
+    /// Node matches cipher names case-insensitively, so this does too.
+    pub(super) fn parse(name: &str) -> Option<CipherAlgo> {
+        match name.to_ascii_lowercase().as_str() {
+            "aes-256-gcm" => Some(CipherAlgo::Aes256Gcm),
+            "aes-128-gcm" => Some(CipherAlgo::Aes128Gcm),
+            "aes-256-cbc" => Some(CipherAlgo::Aes256Cbc),
+            "aes-128-cbc" => Some(CipherAlgo::Aes128Cbc),
+            _ => None,
+        }
+    }
+
+    pub(super) fn is_gcm(self) -> bool {
+        matches!(self, CipherAlgo::Aes256Gcm | CipherAlgo::Aes128Gcm)
+    }
+
+    /// The key length in bytes the name itself promises. Checked at
+    /// construction rather than left to the crate's own error, because
+    /// `new_from_slice` reports "invalid length" without saying which of key or
+    /// IV was wrong, and a 16-byte key handed to `aes-256-gcm` is the single
+    /// most common way to write this call wrongly.
+    pub(super) fn key_len(self) -> usize {
+        match self {
+            CipherAlgo::Aes256Gcm | CipherAlgo::Aes256Cbc => 32,
+            CipherAlgo::Aes128Gcm | CipherAlgo::Aes128Cbc => 16,
+        }
+    }
+
+    /// The IV length in bytes. GCM's 12 is not a limit invented here —
+    /// `aes-gcm` as configured accepts exactly 12 — and a 16-byte IV (the CBC
+    /// habit) quietly being a different nonce is the failure worth naming at
+    /// the call rather than inside the crate.
+    pub(super) fn iv_len(self) -> usize {
+        if self.is_gcm() { 12 } else { 16 }
+    }
+}
+
+/// AES-GCM encryption, answering `(ciphertext, 16-byte tag)` separately the way
+/// Node's `final()`/`getAuthTag()` pair does. `aes_gcm` appends the tag to the
+/// ciphertext, so the split here undoes that rather than computing anything.
+pub(super) fn gcm_encrypt(
+    algo: CipherAlgo,
+    key: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    plaintext: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let nonce = Nonce::from_slice(iv);
+    let payload = Payload { msg: plaintext, aad };
+    let mut out = match algo {
+        CipherAlgo::Aes256Gcm => Aes256Gcm::new_from_slice(key)
+            .map_err(|e| e.to_string())?
+            .encrypt(nonce, payload)
+            .map_err(|e| e.to_string())?,
+        CipherAlgo::Aes128Gcm => Aes128Gcm::new_from_slice(key)
+            .map_err(|e| e.to_string())?
+            .encrypt(nonce, payload)
+            .map_err(|e| e.to_string())?,
+        _ => return Err("not a GCM algorithm".to_owned()),
+    };
+    let tag = out.split_off(out.len().saturating_sub(16));
+    Ok((out, tag))
+}
+
+/// AES-GCM decryption WITH tag verification — the two are one operation and
+/// this file will not offer them apart. Node's shape (`setAuthTag`, then
+/// `final()`) suggests otherwise, and a "decrypt now, check later" split is how
+/// unauthenticated plaintext escapes: the caller in `mod.rs` therefore holds the
+/// tag until `final()` and calls this once.
+///
+/// The error text is Node's own for this case, because a program matching on it
+/// is matching on a string Node prints.
+pub(super) fn gcm_decrypt(
+    algo: CipherAlgo,
+    key: &[u8],
+    iv: &[u8],
+    aad: &[u8],
+    ciphertext: &[u8],
+    tag: &[u8],
+) -> Result<Vec<u8>, String> {
+    let nonce = Nonce::from_slice(iv);
+    let mut combined = ciphertext.to_vec();
+    combined.extend_from_slice(tag);
+    let payload = Payload { msg: &combined, aad };
+    let failed = || "Unsupported state or unable to authenticate data".to_owned();
+    match algo {
+        CipherAlgo::Aes256Gcm => Aes256Gcm::new_from_slice(key)
+            .map_err(|e| e.to_string())?
+            .decrypt(nonce, payload)
+            .map_err(|_| failed()),
+        CipherAlgo::Aes128Gcm => Aes128Gcm::new_from_slice(key)
+            .map_err(|e| e.to_string())?
+            .decrypt(nonce, payload)
+            .map_err(|_| failed()),
+        _ => Err("not a GCM algorithm".to_owned()),
+    }
+}
+
+/// AES-CBC with PKCS#7 padding, which is Node's default — `setAutoPadding(false)`
+/// is not offered, and `mod.rs`'s "Not implemented" note says so by name.
+pub(super) fn cbc_encrypt(
+    algo: CipherAlgo,
+    key: &[u8],
+    iv: &[u8],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, String> {
+    match algo {
+        CipherAlgo::Aes256Cbc => Ok(Aes256CbcEnc::new_from_slices(key, iv)
+            .map_err(|e| e.to_string())?
+            .encrypt_padded_vec_mut::<Pkcs7>(plaintext)),
+        CipherAlgo::Aes128Cbc => Ok(Aes128CbcEnc::new_from_slices(key, iv)
+            .map_err(|e| e.to_string())?
+            .encrypt_padded_vec_mut::<Pkcs7>(plaintext)),
+        _ => Err("not a CBC algorithm".to_owned()),
+    }
+}
+
+/// AES-CBC decryption, unpadding included. Bad padding is an error and not a
+/// truncated answer, and `Pkcs7`'s own unpad is what decides rather than a
+/// hand-written length check — that check is the half of CBC that is easy to
+/// write and easy to write wrongly.
+pub(super) fn cbc_decrypt(
+    algo: CipherAlgo,
+    key: &[u8],
+    iv: &[u8],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, String> {
+    let bad = |_| "error:1C800064:Provider routines::bad decrypt".to_owned();
+    match algo {
+        CipherAlgo::Aes256Cbc => Aes256CbcDec::new_from_slices(key, iv)
+            .map_err(|e| e.to_string())?
+            .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+            .map_err(bad),
+        CipherAlgo::Aes128Cbc => Aes128CbcDec::new_from_slices(key, iv)
+            .map_err(|e| e.to_string())?
+            .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+            .map_err(bad),
+        _ => Err("not a CBC algorithm".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// NIST SP 800-38D test case 13 — the all-zero 256-bit key and 96-bit IV
+    /// over an empty message. A round-trip alone cannot tell AES-GCM from any
+    /// other reversible transform; a published vector can.
+    #[test]
+    fn gcm_matches_the_published_vector() {
+        let (ct, tag) = gcm_encrypt(CipherAlgo::Aes256Gcm, &[0u8; 32], &[0u8; 12], &[], &[]).unwrap();
+        assert!(ct.is_empty());
+        assert_eq!(
+            tag,
+            [
+                0x53, 0x0f, 0x8a, 0xfb, 0xc7, 0x45, 0x36, 0xb9, 0xa9, 0x63, 0xb4, 0xf1, 0xc4, 0xcb,
+                0x73, 0x8b
+            ]
+        );
+    }
+
+    #[test]
+    fn a_changed_tag_fails_to_authenticate() {
+        let (ct, mut tag) =
+            gcm_encrypt(CipherAlgo::Aes256Gcm, &[7u8; 32], &[3u8; 12], &[], b"payload").unwrap();
+        tag[0] ^= 1;
+        assert!(gcm_decrypt(CipherAlgo::Aes256Gcm, &[7u8; 32], &[3u8; 12], &[], &ct, &tag).is_err());
+    }
+
+    /// Associated data is authenticated but not encrypted, so decrypting under
+    /// different AAD must fail even though the ciphertext is untouched.
+    #[test]
+    fn associated_data_is_authenticated() {
+        let (ct, tag) =
+            gcm_encrypt(CipherAlgo::Aes128Gcm, &[1u8; 16], &[2u8; 12], b"header", b"body").unwrap();
+        assert!(gcm_decrypt(CipherAlgo::Aes128Gcm, &[1u8; 16], &[2u8; 12], b"header", &ct, &tag).is_ok());
+        assert!(gcm_decrypt(CipherAlgo::Aes128Gcm, &[1u8; 16], &[2u8; 12], b"other!", &ct, &tag).is_err());
+    }
+
+    /// NIST SP 800-38A F.2.5 — the first block of the AES-256-CBC vector. The
+    /// assertion is on the PREFIX because this file always pads, so a 16-byte
+    /// plaintext comes back as 32 bytes of ciphertext.
+    #[test]
+    fn cbc_matches_the_published_vector() {
+        let key = [
+            0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d,
+            0x77, 0x81, 0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3,
+            0x09, 0x14, 0xdf, 0xf4,
+        ];
+        let iv: Vec<u8> = (0x00u8..=0x0f).collect();
+        let plain = [
+            0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93,
+            0x17, 0x2a,
+        ];
+        let out = cbc_encrypt(CipherAlgo::Aes256Cbc, &key, &iv, &plain).unwrap();
+        assert_eq!(
+            out[..16],
+            [
+                0xf5, 0x8c, 0x4c, 0x04, 0xd6, 0xe5, 0xf1, 0xba, 0x77, 0x9e, 0xab, 0xfb, 0x5f, 0x7b,
+                0xfb, 0xd6
+            ]
+        );
+    }
+
+    #[test]
+    fn cbc_rejects_corrupted_padding() {
+        let mut ct =
+            cbc_encrypt(CipherAlgo::Aes128Cbc, &[9u8; 16], &[4u8; 16], b"twelve bytes").unwrap();
+        let last = ct.len() - 1;
+        ct[last] ^= 0xff;
+        assert!(cbc_decrypt(CipherAlgo::Aes128Cbc, &[9u8; 16], &[4u8; 16], &ct).is_err());
+    }
+}

--- a/crates/rts-node/src/crypto/cipher/mod.rs
+++ b/crates/rts-node/src/crypto/cipher/mod.rs
@@ -1,0 +1,361 @@
+//! `Cipheriv`/`Decipheriv` — `createCipheriv`/`createDecipheriv` over
+//! AES-128/256 in GCM and CBC.
+//!
+//! # Where the cipher state lives, and why that is not a new decision
+//!
+//! Exactly where `hash.rs` puts a digest mid-update: an instance carries one
+//! hidden `__cipherId` number, and [`TABLE`] holds the bytes. A key, an IV and
+//! an accumulated message are native state no value in this engine's
+//! shape-and-property system can hold, which is the same sentence `fs/fd.rs`
+//! writes about an open file. Nothing here mints a number from anything but its
+//! own counter, and nothing here holds a JS value across a collection — the
+//! table is bytes only, so it is not a root that could be missing from a list
+//! (`docs/engine/lost-roots.md` is the class this stays out of by construction).
+//!
+//! # `update()` accumulates and answers nothing; `final()` does the work
+//!
+//! This is the divergence from Node worth reading before writing against it.
+//! Real Node streams: `update()` answers the ciphertext of what it could
+//! process, `final()` answers the remainder. Here `update()` appends to a buffer
+//! and answers an EMPTY `Buffer`, and `final()` answers the whole result.
+//!
+//! `Buffer.concat([c.update(x), c.final()])` — which is how the call is written
+//! in practice, and how Baileys and every libsignal port write it — is correct
+//! under both models, which is what makes the divergence affordable. What is NOT
+//! correct here is streaming a message larger than memory, and what is not
+//! offered at all is per-call output.
+//!
+//! The reason is GCM and not convenience: an authenticated cipher cannot answer
+//! plaintext for a prefix of a message whose tag it has not checked yet. Node
+//! answers it anyway — its `Decipheriv.update()` hands back unauthenticated
+//! bytes, and the caller is expected to discard them if `final()` throws. That
+//! is a real footgun in Node, and reproducing it faithfully would mean this
+//! module handing out plaintext it has not authenticated. CBC could stream
+//! honestly, but then `update()` would mean one thing for CBC and another for
+//! GCM, and a caller reading the doc would have to hold two models. One model,
+//! stated, was judged the better of the two honest options.
+//!
+//! # Not implemented, by name
+//!
+//! - **`setAutoPadding(false)`** — CBC here always uses PKCS#7. A no-padding
+//!   mode that silently padded anyway is the hollow surface CLAUDE.md's `sync`
+//!   note refuses; an absent method fails at the call.
+//! - **Every algorithm outside [`algo::CipherAlgo::NAMES`]** — CTR, ECB,
+//!   ChaCha20-Poly1305, the `-wrap` family. Adding one is a line in
+//!   `CipherAlgo` and a crate in the manifest, not a change of shape here.
+//! - **`authTagLength`** and the options object generally — GCM's tag is 16
+//!   bytes, which is the only length `aes-gcm` as configured produces.
+//! - **The stream interface** (`Cipheriv` as a `Transform`) — `node:stream` is
+//!   a separate surface and piping into a cipher is a `node:stream` question.
+
+pub(super) mod algo;
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rts_core::entry::{self, Context, Provided};
+
+use self::algo::CipherAlgo;
+use super::util;
+
+/// One cipher in progress. Bytes only — see this module's doc for why that
+/// matters beyond tidiness.
+struct CipherState {
+    algo: CipherAlgo,
+    key: Vec<u8>,
+    iv: Vec<u8>,
+    /// `setAAD` data, authenticated but not encrypted. Empty when never set,
+    /// which is the same input GCM sees for a call that never mentions it.
+    aad: Vec<u8>,
+    /// What `update()` has accumulated so far.
+    input: Vec<u8>,
+    /// Decrypt only: the tag `setAuthTag` was given, consumed by `final()`.
+    expected_tag: Vec<u8>,
+    /// Encrypt only: the tag `final()` produced, for `getAuthTag()`.
+    produced_tag: Option<Vec<u8>>,
+    decrypting: bool,
+}
+
+static TABLE: Mutex<Option<HashMap<u64, CipherState>>> = Mutex::new(None);
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+fn with_table<T>(body: impl FnOnce(&mut HashMap<u64, CipherState>) -> T) -> T {
+    let mut guard = TABLE.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    let table = guard.get_or_insert_with(HashMap::new);
+    body(table)
+}
+
+const METHODS: &[(&str, Provided)] = &[
+    ("update", update),
+    ("final", finalize),
+    ("setAAD", set_aad),
+    ("setAuthTag", set_auth_tag),
+    ("getAuthTag", get_auth_tag),
+];
+
+/// `crypto.createCipheriv(algorithm, key, iv)`.
+pub(crate) extern "C" fn create_cipheriv(
+    _e: u64,
+    _this: u64,
+    algorithm: u64,
+    key: u64,
+    iv: u64,
+    _a3: u64,
+) -> u64 {
+    create(algorithm, key, iv, false)
+}
+
+/// `crypto.createDecipheriv(algorithm, key, iv)`.
+pub(crate) extern "C" fn create_decipheriv(
+    _e: u64,
+    _this: u64,
+    algorithm: u64,
+    key: u64,
+    iv: u64,
+    _a3: u64,
+) -> u64 {
+    create(algorithm, key, iv, true)
+}
+
+/// `crypto.getCiphers()` — [`algo::CipherAlgo::NAMES`], which is what
+/// [`algo::CipherAlgo::parse`] accepts and nothing more. This used to answer
+/// `[]` because nothing backed a name; the list and the parser are one table now
+/// so that they cannot disagree.
+pub(crate) extern "C" fn get_ciphers(_e: u64, _this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    entry::with_runtime(|context| {
+        let values = CipherAlgo::NAMES
+            .iter()
+            .map(|name| entry::make_string(context, name))
+            .collect();
+        entry::make_array_in(context, values)
+    })
+}
+
+/// The shared half of both constructors. Every argument is validated HERE — an
+/// unknown algorithm, a key of the wrong length, an IV of the wrong length —
+/// rather than at `final()`, because a program that mistyped `aes-256-gcm`
+/// should learn it at the line that names it, not several calls later inside a
+/// function that never mentions the algorithm.
+fn create(algorithm: u64, key: u64, iv: u64, decrypting: bool) -> u64 {
+    enum Refusal {
+        Algorithm,
+        KeyLength(usize, usize),
+        IvLength(usize, usize),
+    }
+    let outcome = entry::with_runtime(|context| {
+        let name = util::text(context, algorithm).unwrap_or_default();
+        let Some(algo) = CipherAlgo::parse(&name) else {
+            return Err(Refusal::Algorithm);
+        };
+        let key = util::binary_bytes(context, key);
+        let iv = util::binary_bytes(context, iv);
+        if key.len() != algo.key_len() {
+            return Err(Refusal::KeyLength(algo.key_len(), key.len()));
+        }
+        if iv.len() != algo.iv_len() {
+            return Err(Refusal::IvLength(algo.iv_len(), iv.len()));
+        }
+        Ok(build(
+            context,
+            CipherState {
+                algo,
+                key,
+                iv,
+                aad: Vec::new(),
+                input: Vec::new(),
+                expected_tag: Vec::new(),
+                produced_tag: None,
+                decrypting,
+            },
+        ))
+    });
+    match outcome {
+        Ok(instance) => instance,
+        Err(refusal) => {
+            let message = match refusal {
+                Refusal::Algorithm => "Unknown cipher".to_owned(),
+                Refusal::KeyLength(want, got) => {
+                    format!("Invalid key length: expected {want} bytes, got {got}")
+                }
+                Refusal::IvLength(want, got) => {
+                    format!("Invalid initialization vector: expected {want} bytes, got {got}")
+                }
+            };
+            entry::throw_type_error(&message);
+            entry::undefined_value()
+        }
+    }
+}
+
+fn build(context: &mut Context, state: CipherState) -> u64 {
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let name = if state.decrypting { "Decipheriv" } else { "Cipheriv" };
+    with_table(|table| {
+        table.insert(id, state);
+    });
+    let prototype = entry::make_prototype(context, name, METHODS);
+    let instance = entry::make_instance(context, prototype);
+    util::put_hidden_number(context, instance, "__cipherId", id);
+    instance
+}
+
+/// `cipher.update(data, inputEncoding?)` — accumulates, answers an empty
+/// `Buffer`. See this module's doc for why the answer is empty rather than the
+/// ciphertext of `data`.
+///
+/// An empty `Buffer` and not `this`: `Buffer.concat([c.update(x), c.final()])`
+/// is the call this has to stay correct under, and `concat` of a non-buffer
+/// throws. Chaining (`c.update(a).update(b)`) is what that costs, and Node does
+/// not chain here either — its `update` answers bytes too.
+extern "C" fn update(_e: u64, this: u64, data: u64, input_encoding: u64, _a2: u64, _a3: u64) -> u64 {
+    entry::with_runtime(|context| {
+        let Some(id) = util::hidden_number(context, this, "__cipherId") else {
+            return entry::undefined_in(context);
+        };
+        let encoding = util::text(context, input_encoding);
+        let bytes = util::binary_bytes_encoded(context, data, encoding.as_deref());
+        with_table(|table| {
+            if let Some(state) = table.get_mut(&id) {
+                state.input.extend_from_slice(&bytes);
+            }
+        });
+        entry::make_buffer(context, &[])
+    })
+}
+
+/// `cipher.setAAD(data)` — additional authenticated data, GCM only. Chainable
+/// (answers `this`), which is what Node does and what makes
+/// `createCipheriv(...).setAAD(h)` read.
+///
+/// Called on a CBC instance it throws rather than being ignored: AAD that is
+/// accepted and never authenticated is a caller believing a message is bound to
+/// a header when it is not.
+extern "C" fn set_aad(_e: u64, this: u64, data: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let ok = entry::with_runtime(|context| {
+        let Some(id) = util::hidden_number(context, this, "__cipherId") else {
+            return true;
+        };
+        let bytes = util::binary_bytes(context, data);
+        with_table(|table| match table.get_mut(&id) {
+            Some(state) if state.algo.is_gcm() => {
+                state.aad = bytes;
+                true
+            }
+            Some(_) => false,
+            None => true,
+        })
+    });
+    if !ok {
+        entry::throw_type_error("setAAD is only supported for authenticated ciphers");
+        return entry::undefined_value();
+    }
+    this
+}
+
+/// `decipher.setAuthTag(tag)` — held until `final()`, which is the only place
+/// it can be checked. Chainable.
+extern "C" fn set_auth_tag(_e: u64, this: u64, tag: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let ok = entry::with_runtime(|context| {
+        let Some(id) = util::hidden_number(context, this, "__cipherId") else {
+            return true;
+        };
+        let bytes = util::binary_bytes(context, tag);
+        with_table(|table| match table.get_mut(&id) {
+            Some(state) if state.decrypting && state.algo.is_gcm() => {
+                state.expected_tag = bytes;
+                true
+            }
+            Some(_) => false,
+            None => true,
+        })
+    });
+    if !ok {
+        entry::throw_type_error("setAuthTag is only supported for decryption with an authenticated cipher");
+        return entry::undefined_value();
+    }
+    this
+}
+
+/// `cipher.getAuthTag()` — the 16-byte GCM tag, valid only after `final()`.
+/// Before `final()` there is no tag to answer, and this throws rather than
+/// answering 16 zero bytes: a zero tag is a value a caller would happily
+/// transmit.
+extern "C" fn get_auth_tag(_e: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let tag = entry::with_runtime(|context| {
+        let id = util::hidden_number(context, this, "__cipherId")?;
+        with_table(|table| table.get(&id).and_then(|state| state.produced_tag.clone()))
+    });
+    match tag {
+        Some(bytes) => entry::with_runtime(|context| entry::make_buffer(context, &bytes)),
+        None => {
+            entry::throw_type_error("Attempt to get auth tag in unsupported state");
+            entry::undefined_value()
+        }
+    }
+}
+
+/// `cipher.final(outputEncoding?)` — the whole ciphertext or plaintext.
+///
+/// The state is CONSUMED: the entry leaves the table, and a second `final()`
+/// throws rather than answering the same bytes again. `hash.rs` answers
+/// `undefined` on its second `digest()` and this does not follow it — there the
+/// wrong answer is a missing digest, here it would be a caller encrypting a
+/// message twice under one nonce and not being told, which is the failure that
+/// destroys GCM outright.
+extern "C" fn finalize(_e: u64, this: u64, output_encoding: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let taken = entry::with_runtime(|context| {
+        let id = util::hidden_number(context, this, "__cipherId")?;
+        with_table(|table| table.remove(&id)).map(|state| (id, state))
+    });
+    let Some((id, state)) = taken else {
+        entry::throw_type_error("Cipher job is already finalized");
+        return entry::undefined_value();
+    };
+    let outcome = match (state.decrypting, state.algo.is_gcm()) {
+        (false, true) => algo::gcm_encrypt(state.algo, &state.key, &state.iv, &state.aad, &state.input)
+            .map(|(ciphertext, tag)| (ciphertext, Some(tag))),
+        (true, true) => algo::gcm_decrypt(
+            state.algo,
+            &state.key,
+            &state.iv,
+            &state.aad,
+            &state.input,
+            &state.expected_tag,
+        )
+        .map(|plaintext| (plaintext, None)),
+        (false, false) => algo::cbc_encrypt(state.algo, &state.key, &state.iv, &state.input)
+            .map(|ciphertext| (ciphertext, None)),
+        (true, false) => algo::cbc_decrypt(state.algo, &state.key, &state.iv, &state.input)
+            .map(|plaintext| (plaintext, None)),
+    };
+    match outcome {
+        Ok((bytes, tag)) => entry::with_runtime(|context| {
+            // The tag outlives the state the rest of the entry held, and only
+            // the tag: a re-inserted entry carrying key and input would make a
+            // second `final()` possible, which the doc above says it is not.
+            if let Some(tag) = tag {
+                with_table(|table| {
+                    table.insert(
+                        id,
+                        CipherState {
+                            produced_tag: Some(tag),
+                            key: Vec::new(),
+                            iv: Vec::new(),
+                            aad: Vec::new(),
+                            input: Vec::new(),
+                            expected_tag: Vec::new(),
+                            ..state
+                        },
+                    )
+                });
+            }
+            let encoding = util::text(context, output_encoding);
+            util::digest_output(context, &bytes, encoding.as_deref())
+        }),
+        Err(message) => {
+            entry::throw_type_error(&message);
+            entry::undefined_value()
+        }
+    }
+}

--- a/crates/rts-node/src/crypto/curve/mod.rs
+++ b/crates/rts-node/src/crypto/curve/mod.rs
@@ -1,0 +1,170 @@
+//! X25519 key agreement and XEdDSA signatures, as `node:crypto` members.
+//!
+//! # These names are not Node's, and that is deliberate
+//!
+//! Node spells key agreement `generateKeyPairSync('x25519')` →
+//! `diffieHellman({ privateKey, publicKey })`, over `KeyObject` values that
+//! carry a DER/PEM encoding and an algorithm identifier. This crate has no
+//! `KeyObject` — that is the entry `mod.rs` lists under "Asymmetric keys and
+//! X.509", and it needs the encoding infrastructure that entry names.
+//!
+//! So these are `generateX25519KeyPair`, `x25519PublicKey`,
+//! `x25519DiffieHellman`, `xeddsaSign` and `xeddsaVerify`: raw 32-byte keys in,
+//! raw bytes out. A non-standard name that does exactly what it says is the
+//! honest half of the trade — the alternative was `generateKeyPairSync`
+//! answering something shaped like a `KeyObject` and missing `export()`,
+//! `asymmetricKeyType` and everything else a caller reaches for next, which is
+//! the hollow surface CLAUDE.md refuses by name. When `KeyObject` arrives, these
+//! stay: they are what the standard names will be built on, not a stand-in for
+//! them.
+//!
+//! XEdDSA has no Node spelling at all — it is Signal's, not the platform's —
+//! so no name was displaced by choosing one.
+//!
+//! # Why the keypair is an object and the rest are arrays
+//!
+//! `generateX25519KeyPair()` answers `{ privateKey, publicKey }` because two
+//! values have to come back together. Everything else answers one `Buffer`.
+//! There is a known engine gap around the object form worth stating for anyone
+//! writing against it: a FIELD read off an ad-hoc shaped object is not
+//! statically proven to be array-typed, so `generateX25519KeyPair().publicKey`
+//! passed straight into another native does not always arrive as bytes.
+//! `tests/claude-crypto-aes-x25519.test.ts` works around it by deriving the
+//! public key with [`x25519_public_key`] instead, and the gap is the emitter's
+//! rather than this module's.
+
+mod xeddsa;
+
+use rts_core::entry::{self, Provided};
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use super::random;
+use super::util;
+
+/// Every member this module contributes to `node:crypto`, so `mod.rs` chains
+/// one list rather than five lines that can each be forgotten separately — the
+/// same reason `kdf::MEMBERS` exists.
+pub(super) const MEMBERS: &[(&str, Provided)] = &[
+    ("generateX25519KeyPair", generate_key_pair),
+    ("x25519PublicKey", x25519_public_key),
+    ("x25519DiffieHellman", x25519_diffie_hellman),
+    ("xeddsaSign", xeddsa_sign),
+    ("xeddsaVerify", xeddsa_verify),
+];
+
+/// A 32-byte argument, or `None` when it is any other length. Every key and
+/// public value on this curve is exactly 32 bytes, and a shorter one silently
+/// zero-extended would agree on a shared secret with nobody while looking like
+/// it worked.
+fn key_bytes(context: &rts_core::entry::Context, value: u64) -> Option<[u8; 32]> {
+    util::binary_bytes(context, value).try_into().ok()
+}
+
+/// `crypto.generateX25519KeyPair()` — `{ privateKey, publicKey }`, both 32-byte
+/// `Buffer`s.
+///
+/// The secret comes from the OS CSPRNG through `random::os_bytes`, the same
+/// draw `randomBytes` makes. Not `x25519_dalek`'s own `StaticSecret::random`:
+/// that would bind this crate to a `rand_core` version as a second source of
+/// randomness, and one CSPRNG per process is the point of having one.
+extern "C" fn generate_key_pair(_e: u64, _this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&random::os_bytes(32));
+    let secret = StaticSecret::from(seed);
+    let public = PublicKey::from(&secret);
+    entry::with_runtime(|context| {
+        let pair = entry::make_object(context);
+        let private_value = entry::make_buffer(context, &secret.to_bytes());
+        entry::put_member(context, pair, "privateKey", private_value);
+        let public_value = entry::make_buffer(context, public.as_bytes());
+        entry::put_member(context, pair, "publicKey", public_value);
+        pair
+    })
+}
+
+/// `crypto.x25519PublicKey(privateKey)` — the 32-byte public key for a private
+/// one. Deterministic, which is what makes it usable to recover a public key
+/// from stored credentials rather than storing both.
+extern "C" fn x25519_public_key(_e: u64, _this: u64, private: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    let bytes = entry::with_runtime(|context| key_bytes(context, private));
+    let Some(bytes) = bytes else {
+        entry::throw_type_error("privateKey must be 32 bytes");
+        return entry::undefined_value();
+    };
+    let public = PublicKey::from(&StaticSecret::from(bytes));
+    entry::with_runtime(|context| entry::make_buffer(context, public.as_bytes()))
+}
+
+/// `crypto.x25519DiffieHellman(privateKey, publicKey)` — the 32-byte shared
+/// secret. This is the X3DH primitive; a Signal-style handshake calls it four
+/// times and feeds the concatenation to HKDF, which `kdf` already provides.
+///
+/// An all-zero result (a low-order public key) is answered rather than refused,
+/// which is what `x25519-dalek` without its `reject-low-order` behaviour does
+/// and what every other X25519 implementation on the wire does. A protocol that
+/// must reject it checks the output, and this is stated rather than silently
+/// chosen.
+extern "C" fn x25519_diffie_hellman(
+    _e: u64,
+    _this: u64,
+    private: u64,
+    public: u64,
+    _a2: u64,
+    _a3: u64,
+) -> u64 {
+    let pair = entry::with_runtime(|context| {
+        let private = key_bytes(context, private)?;
+        let public = key_bytes(context, public)?;
+        Some((private, public))
+    });
+    let Some((private, public)) = pair else {
+        entry::throw_type_error("privateKey and publicKey must each be 32 bytes");
+        return entry::undefined_value();
+    };
+    let shared = StaticSecret::from(private).diffie_hellman(&PublicKey::from(public));
+    entry::with_runtime(|context| entry::make_buffer(context, shared.as_bytes()))
+}
+
+/// `crypto.xeddsaSign(privateKey, message)` — a 64-byte XEdDSA signature under
+/// the X25519 private key, per Signal's specification.
+///
+/// The 64 random bytes the scheme calls `Z` are drawn HERE, not taken as an
+/// argument: a caller supplying them is a caller who can supply the same ones
+/// twice, and a repeated `Z` under one key leaks the private key. `xeddsa.rs`
+/// takes them as a parameter so its tests can pin a vector; that parameter is
+/// not exposed to JavaScript, and this line is why.
+extern "C" fn xeddsa_sign(_e: u64, _this: u64, private: u64, message: u64, _a2: u64, _a3: u64) -> u64 {
+    let input = entry::with_runtime(|context| {
+        let private = key_bytes(context, private)?;
+        Some((private, util::binary_bytes(context, message)))
+    });
+    let Some((private, message)) = input else {
+        entry::throw_type_error("privateKey must be 32 bytes");
+        return entry::undefined_value();
+    };
+    let mut nonce = [0u8; 64];
+    nonce.copy_from_slice(&random::os_bytes(64));
+    let signature = xeddsa::sign(&private, &message, &nonce);
+    entry::with_runtime(|context| entry::make_buffer(context, &signature))
+}
+
+/// `crypto.xeddsaVerify(publicKey, message, signature)` — `true` or `false`.
+///
+/// A malformed argument answers `false` rather than throwing, which is the one
+/// place in this module where a bad input is not an error: every caller is
+/// verifying something that arrived over a network, so "this did not verify" is
+/// the answer for a 63-byte signature just as much as for a wrong one. Throwing
+/// would push every call site into a `try` whose catch block means the same
+/// thing as `false`.
+extern "C" fn xeddsa_verify(_e: u64, _this: u64, public: u64, message: u64, signature: u64, _a3: u64) -> u64 {
+    let ok = entry::with_runtime(|context| {
+        (|| {
+            let public = key_bytes(context, public)?;
+            let signature: [u8; 64] = util::binary_bytes(context, signature).try_into().ok()?;
+            let message = util::binary_bytes(context, message);
+            Some(xeddsa::verify(&public, &message, &signature))
+        })()
+        .unwrap_or(false)
+    });
+    entry::boolean_value(ok)
+}

--- a/crates/rts-node/src/crypto/curve/xeddsa.rs
+++ b/crates/rts-node/src/crypto/curve/xeddsa.rs
@@ -1,0 +1,280 @@
+//! XEdDSA over Curve25519 — signing with an X25519 key, per Signal's
+//! specification (<https://signal.org/docs/specifications/xeddsa/>, §2 and
+//! §3.2).
+//!
+//! # Why this exists when `ed25519-dalek` is already linked
+//!
+//! They are not the same signature. Ed25519 has its own keypair, derived by
+//! hashing a seed; XEdDSA signs with the Montgomery (X25519) private key a
+//! program ALREADY has for key agreement, converting it to an Edwards keypair
+//! on the fly. Signal's protocol has exactly one identity key per party and it
+//! is an X25519 key, so `signedPreKey` and the account signature are XEdDSA —
+//! an Ed25519 signature over the same bytes is a different signature, and the
+//! server rejects it.
+//!
+//! That is why this file is arithmetic and not a call: `ed25519_dalek` exposes
+//! `SigningKey::from_bytes`, which treats its input as an Ed25519 SEED and
+//! hashes it. Handing an X25519 private key to it produces a valid signature
+//! under the wrong key. The conversion has to happen at the point/scalar level,
+//! which is `curve25519_dalek`.
+//!
+//! # The one place this is easy to get wrong
+//!
+//! The sign bit. `kB` lands on either of two Edwards points whose Montgomery
+//! `u` is the same, so XEdDSA fixes the convention: the public key always has
+//! sign bit 0, and the SCALAR is negated when the derived point had sign bit 1.
+//! Skipping that negation still produces a signature — it simply never
+//! verifies, half the time, against keys generated the other half. [`sign`]
+//! does it in `key_pair`, and the round-trip tests below run enough keys to
+//! reach both branches.
+
+use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
+use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
+use curve25519_dalek::montgomery::MontgomeryPoint;
+use curve25519_dalek::scalar::Scalar;
+use sha2::{Digest, Sha512};
+
+/// Signal's `hash_1` domain separator: `2^b - 1 - i` for `b = 256`, `i = 1`,
+/// little-endian. It exists so that the nonce hash can never collide with a
+/// plain SHA-512 of the same message — every other hash in the scheme is
+/// undomained, and a scalar that is both is a private key recovery.
+const HASH1_PREFIX: [u8; 32] = [
+    0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+];
+
+/// The X25519 clamping every Curve25519 private key is used under. Applied here
+/// rather than assumed of the input: `x25519_dalek::StaticSecret::to_bytes`
+/// answers the bytes it was GIVEN, so a key that made a round trip through
+/// JavaScript is not necessarily clamped, and an unclamped scalar signs under a
+/// key that is not the one `x25519PublicKey` derives.
+fn clamp(private: &[u8; 32]) -> Scalar {
+    let mut bytes = *private;
+    bytes[0] &= 248;
+    bytes[31] &= 127;
+    bytes[31] |= 64;
+    Scalar::from_bytes_mod_order(bytes)
+}
+
+/// `calculate_key_pair` of the specification: the Edwards public key with sign
+/// bit forced to 0, and the scalar that signs under it.
+fn key_pair(k: &Scalar) -> (CompressedEdwardsY, Scalar) {
+    let point = ED25519_BASEPOINT_TABLE * k;
+    let mut encoded = point.compress().to_bytes();
+    let negative = encoded[31] >> 7;
+    encoded[31] &= 0x7f;
+    let scalar = if negative == 1 { -k } else { *k };
+    (CompressedEdwardsY(encoded), scalar)
+}
+
+fn wide_reduce(hash: Sha512) -> Scalar {
+    let digest = hash.finalize();
+    let mut wide = [0u8; 64];
+    wide.copy_from_slice(&digest);
+    Scalar::from_bytes_mod_order_wide(&wide)
+}
+
+/// Sign `message` with the 32-byte X25519 private key `private`, answering the
+/// 64-byte signature `R || s`.
+///
+/// `nonce` is the specification's `Z`: 64 bytes of randomness the caller
+/// supplies. It is a parameter rather than drawn here for one reason — a test
+/// can then FIX it, and a signature over a fixed `Z` is reproducible. XEdDSA is
+/// randomized by design (`r` mixes `Z` in), so two signatures over one key and
+/// one message differ, and nothing about a run could be compared to anything
+/// otherwise. The JavaScript surface does not expose it, and `curve/mod.rs`
+/// says why not.
+pub(super) fn sign(private: &[u8; 32], message: &[u8], nonce: &[u8; 64]) -> [u8; 64] {
+    let k = clamp(private);
+    let (public, a) = key_pair(&k);
+
+    let mut hash = Sha512::new();
+    hash.update(HASH1_PREFIX);
+    hash.update(a.as_bytes());
+    hash.update(message);
+    hash.update(nonce);
+    let r = wide_reduce(hash);
+
+    let big_r = (ED25519_BASEPOINT_TABLE * &r).compress();
+
+    let mut hash = Sha512::new();
+    hash.update(big_r.as_bytes());
+    hash.update(public.as_bytes());
+    hash.update(message);
+    let h = wide_reduce(hash);
+
+    let s = r + h * a;
+
+    let mut signature = [0u8; 64];
+    signature[..32].copy_from_slice(big_r.as_bytes());
+    signature[32..].copy_from_slice(s.as_bytes());
+    signature
+}
+
+/// Verify a 64-byte XEdDSA signature against the 32-byte X25519 PUBLIC key
+/// `public` (a Montgomery `u`, which is what the wire carries).
+///
+/// Every failure answers `false` — a malformed point, a non-canonical scalar, a
+/// wrong signature are one outcome to a caller, and distinguishing them in the
+/// return would let a caller branch on which part of an attacker's input was
+/// malformed.
+pub(super) fn verify(public: &[u8; 32], message: &[u8], signature: &[u8; 64]) -> bool {
+    // The specification's own bounds check: the top bit of `s` must be clear.
+    // `from_canonical_bytes` rejects more than that, and rejecting early keeps
+    // the two checks from looking like one.
+    if signature[63] & 0x80 != 0 {
+        return false;
+    }
+    let Some(point) = MontgomeryPoint(*public).to_edwards(0) else {
+        return false;
+    };
+    let encoded_a = point.compress();
+
+    let mut big_r = [0u8; 32];
+    big_r.copy_from_slice(&signature[..32]);
+    let big_r = CompressedEdwardsY(big_r);
+
+    let mut s_bytes = [0u8; 32];
+    s_bytes.copy_from_slice(&signature[32..]);
+    let s: Option<Scalar> = Scalar::from_canonical_bytes(s_bytes).into();
+    let Some(s) = s else {
+        return false;
+    };
+
+    let mut hash = Sha512::new();
+    hash.update(big_r.as_bytes());
+    hash.update(encoded_a.as_bytes());
+    hash.update(message);
+    let h = wide_reduce(hash);
+
+    // sB - hA, which reconstructs R when the signature is genuine.
+    let recovered = EdwardsPoint::vartime_double_scalar_mul_basepoint(&(-h), &point, &s);
+    recovered.compress() == big_r
+}
+
+/// The Montgomery public key `x25519PublicKey` would derive, computed the way
+/// [`sign`] derives it internally.
+///
+/// Its only caller is a test, and it is here rather than there because the
+/// property it pins is about THIS file: the Edwards key XEdDSA signs under and
+/// the Montgomery key X25519 agrees under are the same key seen two ways. A
+/// helper in the test module could drift from `key_pair` without anything
+/// noticing.
+#[cfg(test)]
+fn montgomery_public(private: &[u8; 32]) -> [u8; 32] {
+    (ED25519_BASEPOINT_TABLE * &clamp(private)).to_montgomery().to_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The claim this file makes, checked by something that is not this file.
+    ///
+    /// An XEdDSA signature IS an Ed25519 signature — over the Edwards public key
+    /// the Montgomery key converts to, with sign bit 0. So `ed25519-dalek`,
+    /// already linked for `node:tls` and written by neither this repository nor
+    /// against this convention, must accept what [`sign`] produces. That is a
+    /// real cross-check where a self-generated vector is only a record of what
+    /// this code did once: if the sign-bit negation in `key_pair` were dropped,
+    /// every test above would still pass for the keys that happen to land on the
+    /// positive branch, and THIS one fails for the other half.
+    ///
+    /// `verify_strict` and not `verify`: it rejects small-order public keys and
+    /// pins the cofactorless equation, which is the stricter of the two readings
+    /// and the one Signal's verifier uses.
+    #[test]
+    fn ed25519_dalek_accepts_what_this_signs() {
+        for seed in 0u8..16 {
+            let private = [seed.wrapping_mul(53).wrapping_add(11); 32];
+            let edwards = MontgomeryPoint(montgomery_public(&private))
+                .to_edwards(0)
+                .expect("a public key derived on this curve converts back");
+            let verifying = ed25519_dalek::VerifyingKey::from_bytes(&edwards.compress().to_bytes())
+                .expect("the converted point is a valid Ed25519 public key");
+            let signature = sign(&private, b"cross-checked", &[seed ^ 0x5a; 64]);
+            verifying
+                .verify_strict(b"cross-checked", &ed25519_dalek::Signature::from_bytes(&signature))
+                .unwrap_or_else(|error| panic!("seed {seed}: {error}"));
+        }
+    }
+
+    /// The same signature under a message ed25519-dalek was not given must fail
+    /// there too — without this, the test above would pass against a verifier
+    /// that accepted everything.
+    #[test]
+    fn ed25519_dalek_rejects_a_different_message() {
+        let private = [0x21u8; 32];
+        let edwards = MontgomeryPoint(montgomery_public(&private)).to_edwards(0).unwrap();
+        let verifying =
+            ed25519_dalek::VerifyingKey::from_bytes(&edwards.compress().to_bytes()).unwrap();
+        let signature = sign(&private, b"signed", &[0x33u8; 64]);
+        assert!(
+            verifying
+                .verify_strict(b"not signed", &ed25519_dalek::Signature::from_bytes(&signature))
+                .is_err()
+        );
+    }
+
+
+    /// Both branches of the sign-bit convention, which is the failure this
+    /// scheme hides best: sixteen distinct keys is far past the point where all
+    /// sixteen land on one branch by chance.
+    #[test]
+    fn signatures_verify_across_many_keys() {
+        for seed in 0u8..16 {
+            let private = [seed.wrapping_mul(37).wrapping_add(3); 32];
+            let public = montgomery_public(&private);
+            let signature = sign(&private, b"message under test", &[seed; 64]);
+            assert!(verify(&public, b"message under test", &signature), "seed {seed}");
+        }
+    }
+
+    #[test]
+    fn a_changed_message_does_not_verify() {
+        let private = [0x42u8; 32];
+        let public = montgomery_public(&private);
+        let signature = sign(&private, b"original", &[0x99u8; 64]);
+        assert!(verify(&public, b"original", &signature));
+        assert!(!verify(&public, b"modified", &signature));
+    }
+
+    #[test]
+    fn a_changed_signature_does_not_verify() {
+        let private = [0x42u8; 32];
+        let public = montgomery_public(&private);
+        let mut signature = sign(&private, b"payload", &[0x5au8; 64]);
+        signature[0] ^= 1;
+        assert!(!verify(&public, b"payload", &signature));
+    }
+
+    #[test]
+    fn another_key_does_not_verify() {
+        let signature = sign(&[0x01u8; 32], b"payload", &[0x02u8; 64]);
+        assert!(!verify(&montgomery_public(&[0x03u8; 32]), b"payload", &signature));
+    }
+
+    /// An unclamped private key must sign under the same public key a clamped
+    /// one does — this is what [`clamp`]'s doc says the risk is, stated as a
+    /// test rather than as a comment alone.
+    #[test]
+    fn clamping_is_applied_to_the_input() {
+        let mut unclamped = [0x42u8; 32];
+        unclamped[0] |= 7;
+        unclamped[31] |= 0x80;
+        let public = montgomery_public(&[0x42u8; 32]);
+        let signature = sign(&unclamped, b"payload", &[0x07u8; 64]);
+        assert!(verify(&public, b"payload", &signature));
+    }
+
+    /// A scalar `s` with the top bit set is refused before any point
+    /// arithmetic happens.
+    #[test]
+    fn a_non_canonical_scalar_is_refused() {
+        let private = [0x42u8; 32];
+        let public = montgomery_public(&private);
+        let mut signature = sign(&private, b"payload", &[0x11u8; 64]);
+        signature[63] |= 0x80;
+        assert!(!verify(&public, b"payload", &signature));
+    }
+}

--- a/crates/rts-node/src/crypto/mod.rs
+++ b/crates/rts-node/src/crypto/mod.rs
@@ -32,11 +32,14 @@
 //!
 //! Everything in §2 this module does not cover, and the mechanism each
 //! waits on:
-//! - **Symmetric ciphers** (`Cipheriv`/`Decipheriv`, `createCipheriv`/
-//!   `createDecipheriv`, `getCipherInfo`) — out of the task's scope; the
-//!   vetted crates (`aes`/`cbc`/`ctr`/`aes-gcm`/`chacha20poly1305`, crates.md
-//!   §4.2) are not pulled in by this change. `getCiphers()` answers `[]`
-//!   rather than a name list nothing here backs.
+//! - **Symmetric ciphers beyond AES-128/256 in GCM and CBC** — CTR, ECB,
+//!   ChaCha20-Poly1305 and the `-wrap` family. `createCipheriv`/
+//!   `createDecipheriv` and `getCipherInfo`'s companion `getCiphers()` now
+//!   answer over the four names `cipher/algo.rs` genuinely computes, and that
+//!   file's `CipherAlgo::NAMES` is the one list both the parser and
+//!   `getCiphers()` read — a name accepted by one and refused by the other was
+//!   the shape this used to have (`getCiphers()` answered `[]` while nothing
+//!   backed any name at all). `getCipherInfo` itself is still absent.
 //! - **Asymmetric keys and X.509** (`KeyObject`, `Sign`/`Verify`,
 //!   `DiffieHellman`/`DiffieHellmanGroup`/`ECDH`, `X509Certificate`,
 //!   `generateKeyPair(Sync)`, `createPrivateKey`/`createPublicKey`/
@@ -46,6 +49,15 @@
 //!   variable-shape-return API the reference's §5.2 already flags as needing
 //!   more than the four-argument/scalar-return ceiling this module works
 //!   under for a single change.
+//!
+//!   Curve25519 is the one exception, and it is deliberately spelled OUTSIDE
+//!   Node's names rather than approximating them: [`curve`] carries
+//!   `generateX25519KeyPair`, `x25519PublicKey`, `x25519DiffieHellman`,
+//!   `xeddsaSign` and `xeddsaVerify` over raw 32-byte keys. Its module doc has
+//!   the reasoning; the short form is that a `generateKeyPairSync` answering
+//!   something shaped like a `KeyObject` and missing `export()` is the hollow
+//!   surface this repository refuses, and a non-standard name that does exactly
+//!   what it says is not.
 //! - **Every `SubtleCrypto` method except `digest`**, and `CryptoKey` with them.
 //!   This entry said the whole of WebCrypto was blocked because "every
 //!   `SubtleCrypto` method is Promise-mandatory and this module has no
@@ -77,6 +89,8 @@
 //!   so that Node's deprecated flattened `constants` module can spread THIS
 //!   list rather than keep a second copy of the same eight numbers.
 
+mod cipher;
+mod curve;
 mod digest_algo;
 mod hash;
 mod hmac;
@@ -100,12 +114,19 @@ pub fn namespace(context: &mut Context) -> u64 {
         ("randomUUID", random::random_uuid),
         ("getRandomValues", random::get_random_values),
         ("timingSafeEqual", random::timing_safe_equal),
-        ("getCiphers", get_ciphers),
+        ("createCipheriv", cipher::create_cipheriv),
+        ("createDecipheriv", cipher::create_decipheriv),
+        ("getCiphers", cipher::get_ciphers),
     ];
     // The six KDF members come from [`kdf::MEMBERS`] rather than being listed
     // here. `pbkdf2`/`pbkdf2Sync` are two spellings of one agreement, and this
     // list is where a fix could land in one spelling and not the other.
-    let all: Vec<(&str, Provided)> = members.iter().chain(kdf::MEMBERS.iter()).copied().collect();
+    let all: Vec<(&str, Provided)> = members
+        .iter()
+        .chain(kdf::MEMBERS.iter())
+        .chain(curve::MEMBERS.iter())
+        .copied()
+        .collect();
     let namespace = entry::make_namespace(context, &all);
     let constants = constants(context);
     entry::put_member(context, namespace, "constants", constants);
@@ -164,9 +185,3 @@ pub(crate) static CONSTANTS: &[(&str, f64)] = &[
     ("RSA_PSS_SALTLEN_AUTO", -2.0),
 ];
 
-/// `crypto.getCiphers()` — always `[]`; see this module's "Not implemented"
-/// note. Answering an empty list rather than `undefined` matches Node's own
-/// return type (`string[]`) on a build with no ciphers compiled in.
-extern "C" fn get_ciphers(_e: u64, _this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
-    entry::with_runtime(|context| entry::make_array_in(context, Vec::new()))
-}

--- a/crates/rts-node/src/crypto/random.rs
+++ b/crates/rts-node/src/crypto/random.rs
@@ -18,7 +18,7 @@ use rts_core::entry;
 
 use super::util;
 
-fn os_bytes(len: usize) -> Vec<u8> {
+pub(super) fn os_bytes(len: usize) -> Vec<u8> {
     let mut out = vec![0u8; len];
     // `getrandom` 0.4 — vetted in `docs/reference/node/crates.md` §4.1:
     // "getrandom | 0.4 | MIT/Apache | randomBytes/randomFillSync/

--- a/tests/claude-crypto-aes-x25519.test.ts
+++ b/tests/claude-crypto-aes-x25519.test.ts
@@ -14,10 +14,12 @@ const gcmDecipher = createDecipheriv("aes-256-gcm", gcmKey, gcmIv);
 gcmDecipher.setAuthTag(gcmTag);
 gcmDecipher.update(gcmCt);
 const gcmPt = gcmDecipher.final();
-// Buffer.from(numberArray).toString() has a pre-existing, unrelated gap (does
-// not decode bytes as UTF-8 text) — compare hex instead, which works.
-const gcmRoundTripHex = Buffer.from(gcmPt).toString("hex");
-const gcmPlainHex = Buffer.from(gcmPlain).toString("hex");
+// This used to compare hex, working around a gap where
+// `Buffer.from(numberArray).toString()` did not decode bytes as UTF-8 text.
+// That gap is gone — `tests/claude-buffer-from-array-tostring.test.ts` pins it —
+// so the comparison is on the text itself, which is what the assertion means.
+const gcmRoundTrip = Buffer.from(gcmPt).toString();
+const gcmPlainText = "hello baileys";
 
 // AES-256-GCM wrong tag → throws.
 const badKey = randomBytes(32);
@@ -45,8 +47,8 @@ const cbcCt = cbcCipher.final();
 const cbcDecipher = createDecipheriv("aes-256-cbc", cbcKey, cbcIv);
 cbcDecipher.update(cbcCt);
 const cbcPt = cbcDecipher.final();
-const cbcRoundTripHex = Buffer.from(cbcPt).toString("hex");
-const cbcPlainHex = Buffer.from(cbcPlain).toString("hex");
+const cbcRoundTrip = Buffer.from(cbcPt).toString();
+const cbcPlainText = "whatsapp binary node payload";
 
 // X25519 shared secret. `x25519PublicKey`/`x25519DiffieHellman` take/return
 // arrays directly (proven array-typed by their own ts_signature); a FIELD
@@ -76,7 +78,7 @@ const derivedAgainHex = Buffer.from(derivedAgain).toString("hex");
 
 describe("node:crypto AES-GCM/CBC + X25519", () => {
   test("AES-256-GCM round-trips", () => {
-    expect(gcmRoundTripHex).toBe(gcmPlainHex);
+    expect(gcmRoundTrip).toBe(gcmPlainText);
   });
 
   test("AES-256-GCM wrong tag throws", () => {
@@ -84,7 +86,7 @@ describe("node:crypto AES-GCM/CBC + X25519", () => {
   });
 
   test("AES-256-CBC round-trips", () => {
-    expect(cbcRoundTripHex).toBe(cbcPlainHex);
+    expect(cbcRoundTrip).toBe(cbcPlainText);
   });
 
   test("X25519 shared secret matches both directions", () => {

--- a/tests/claude-crypto-xeddsa.test.ts
+++ b/tests/claude-crypto-xeddsa.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect } from "rts:test";
+import {
+  generateX25519KeyPair,
+  x25519PublicKey,
+  xeddsaSign,
+  xeddsaVerify,
+  createCipheriv,
+  createDecipheriv,
+  getCiphers,
+  randomBytes,
+} from "node:crypto";
+
+// XEdDSA — Signal's signature over an X25519 identity key. The private key is
+// read straight off the pair and the PUBLIC key is derived with
+// `x25519PublicKey` rather than read off the same object: a field read off an
+// ad-hoc shaped object is not statically proven array-typed by this engine,
+// which is a separate emitter gap `crypto/curve/mod.rs` names.
+const identity = generateX25519KeyPair();
+const identityPriv = identity.privateKey;
+const identityPub = x25519PublicKey(identityPriv);
+
+const message = Buffer.from("signedPreKey payload");
+const signature = xeddsaSign(identityPriv, message);
+const signatureLength = Buffer.from(signature).length;
+const verified = xeddsaVerify(identityPub, message, signature);
+
+// A different message under the same signature must not verify.
+const otherMessage = Buffer.from("signedPreKey payloae");
+const verifiedOther = xeddsaVerify(identityPub, otherMessage, signature);
+
+// A different key must not verify either.
+const stranger = generateX25519KeyPair();
+const strangerPub = x25519PublicKey(stranger.privateKey);
+const verifiedStranger = xeddsaVerify(strangerPub, message, signature);
+
+// A corrupted signature must not verify. `signature` is a Buffer, so a copy
+// through an array is how one byte gets flipped without mutating the original.
+const tampered = Buffer.from(signature);
+tampered[0] = tampered[0] ^ 1;
+const verifiedTampered = xeddsaVerify(identityPub, message, tampered);
+
+// Malformed input answers false rather than throwing — every caller is checking
+// something that arrived over a network.
+const verifiedShort = xeddsaVerify(identityPub, message, randomBytes(63));
+
+// The signature is randomized (the scheme mixes 64 random bytes into the
+// nonce), so two signatures over one key and one message differ — and both
+// verify. A deterministic answer here would mean the randomness was dropped.
+const again = xeddsaSign(identityPriv, message);
+const signaturesDiffer =
+  Buffer.from(again).toString("hex") !== Buffer.from(signature).toString("hex");
+const verifiedAgain = xeddsaVerify(identityPub, message, again);
+
+// getCiphers() names exactly what createCipheriv accepts. This used to answer
+// an empty list because nothing backed any name.
+const ciphers = getCiphers();
+const cipherCount = ciphers.length;
+const namesAes256Gcm = ciphers.indexOf("aes-256-gcm") >= 0;
+
+// setAAD binds a header to a message: the same ciphertext and tag must fail to
+// authenticate under different associated data.
+const aadKey = randomBytes(32);
+const aadIv = randomBytes(12);
+const aadCipher = createCipheriv("aes-256-gcm", aadKey, aadIv);
+aadCipher.setAAD(Buffer.from("header-v1"));
+aadCipher.update(Buffer.from("body"));
+const aadCt = aadCipher.final();
+const aadTag = aadCipher.getAuthTag();
+
+const aadGood = createDecipheriv("aes-256-gcm", aadKey, aadIv);
+aadGood.setAAD(Buffer.from("header-v1"));
+aadGood.setAuthTag(aadTag);
+aadGood.update(aadCt);
+const aadPlain = Buffer.from(aadGood.final()).toString("hex");
+const aadExpected = Buffer.from("body").toString("hex");
+
+let aadMismatchThrew = false;
+try {
+  const aadBad = createDecipheriv("aes-256-gcm", aadKey, aadIv);
+  aadBad.setAAD(Buffer.from("header-v2"));
+  aadBad.setAuthTag(aadTag);
+  aadBad.update(aadCt);
+  aadBad.final();
+} catch (e) {
+  aadMismatchThrew = true;
+}
+
+// A key of the wrong length is refused at createCipheriv, not several calls
+// later inside a function that never mentions the algorithm.
+let shortKeyThrew = false;
+try {
+  createCipheriv("aes-256-gcm", randomBytes(16), randomBytes(12));
+} catch (e) {
+  shortKeyThrew = true;
+}
+
+let unknownAlgoThrew = false;
+try {
+  createCipheriv("aes-256-ctr", randomBytes(32), randomBytes(16));
+} catch (e) {
+  unknownAlgoThrew = true;
+}
+
+// Buffer.concat([update(), final()]) is the call this module has to stay
+// correct under — update() answers an empty Buffer here rather than partial
+// ciphertext, and the concatenation is the same bytes either way.
+const concatKey = randomBytes(32);
+const concatIv = randomBytes(16);
+const concatCipher = createCipheriv("aes-256-cbc", concatKey, concatIv);
+const concatCt = Buffer.concat([
+  concatCipher.update(Buffer.from("streamed in one go")),
+  concatCipher.final(),
+]);
+const concatDecipher = createDecipheriv("aes-256-cbc", concatKey, concatIv);
+const concatPt = Buffer.concat([concatDecipher.update(concatCt), concatDecipher.final()]);
+const concatHex = Buffer.from(concatPt).toString("hex");
+const concatExpected = Buffer.from("streamed in one go").toString("hex");
+
+describe("node:crypto XEdDSA", () => {
+  test("a signature is 64 bytes", () => {
+    expect(signatureLength).toBe(64);
+  });
+
+  test("a signature verifies under its own key and message", () => {
+    expect(verified).toBe(true);
+  });
+
+  test("a different message does not verify", () => {
+    expect(verifiedOther).toBe(false);
+  });
+
+  test("a different key does not verify", () => {
+    expect(verifiedStranger).toBe(false);
+  });
+
+  test("a tampered signature does not verify", () => {
+    expect(verifiedTampered).toBe(false);
+  });
+
+  test("a malformed signature answers false rather than throwing", () => {
+    expect(verifiedShort).toBe(false);
+  });
+
+  test("signing twice gives two different signatures, both valid", () => {
+    expect(signaturesDiffer).toBe(true);
+    expect(verifiedAgain).toBe(true);
+  });
+});
+
+describe("node:crypto cipher surface", () => {
+  test("getCiphers names what createCipheriv accepts", () => {
+    expect(cipherCount).toBe(4);
+    expect(namesAes256Gcm).toBe(true);
+  });
+
+  test("setAAD authenticates the associated data", () => {
+    expect(aadPlain).toBe(aadExpected);
+    expect(aadMismatchThrew).toBe(true);
+  });
+
+  test("a wrong key length is refused at construction", () => {
+    expect(shortKeyThrew).toBe(true);
+  });
+
+  test("an unsupported algorithm is refused by name", () => {
+    expect(unknownAlgoThrew).toBe(true);
+  });
+
+  test("Buffer.concat of update and final round-trips", () => {
+    expect(concatHex).toBe(concatExpected);
+  });
+});


### PR DESCRIPTION
Fills the two halves of `node:crypto` a Signal-protocol client needs: symmetric ciphers, and signing with the X25519 identity key.

## The ciphers existed once, and were lost in the engine rewrite

PR #1965 (`84ac10c9`, July) implemented `createCipheriv`/`createDecipheriv` and the X25519 trio — against the **old** engine's schema (`rts-codegen-new/front/run/registryclass.rs`, `crypto/symbols.rs`, `crypto/state.rs`). When `crypto/` was rewritten onto `rts_core::entry`, `cipher.rs` and `dh.rs` did not come with it. What survived in `main` was the fixture: `tests/claude-crypto-aes-x25519.test.ts` has been failing ever since, against a namespace with no `createCipheriv` in it.

It passes again here.

## XEdDSA is new (Oniwalib#4)

Signal's `signedPreKey` and account signature are XEdDSA over the X25519 identity key, **not** Ed25519 — an Ed25519 signature over the same bytes is a different signature and the server rejects it. `ed25519-dalek` cannot be called for this: `SigningKey::from_bytes` treats its input as an Ed25519 *seed* and hashes it, so handing it an X25519 key signs under the wrong key. The conversion happens at the point/scalar level in `curve/xeddsa.rs`.

## How it is verified

I wrote a self-generated XEdDSA test vector, then deleted it: it records what the code did once, and cannot catch the failure this scheme hides best — dropping the sign-bit negation still round-trips for every key that lands on the positive branch.

What replaced it cross-checks against **`ed25519-dalek`'s `verify_strict`** over 16 keys. An XEdDSA signature *is* an Ed25519 signature over the converted Edwards key, so a crate written by neither this repository nor against this convention must accept it. That is the independent verification the libsignal vectors would have bought.

The AES side carries two published vectors: NIST SP 800-38D case 13 (GCM) and SP 800-38A F.2.5 (CBC).

## The divergence a caller has to know

`update()` accumulates and answers an empty `Buffer`; `final()` answers the whole result. Node streams.

`Buffer.concat([c.update(x), c.final()])` — how the call is actually written — is correct under both models. A message larger than memory is not. The reason is GCM: an authenticated cipher cannot honestly answer plaintext for a prefix whose tag it has not checked. Node answers it anyway and expects the caller to discard it if `final()` throws. CBC alone could stream, and then `update()` would mean two different things depending on the algorithm.

## Rejected, and why

- **Node's own names for the curve** (`generateKeyPairSync('x25519')`, `createSign`/`createVerify`). They need `KeyObject`, which needs DER/PEM/PKCS8 encoding this change does not add. Something `KeyObject`-shaped with no `export()` is the hollow surface CLAUDE.md refuses by name; a non-standard name that does exactly what it says is not.
- **Exposing the scheme's `Z`.** `xeddsa.rs` takes it so tests can fix it; the JS surface draws it from the OS CSPRNG. A repeated `Z` under one key leaks the private key.
- **`aes 0.9`/`cbc 0.2`**, which `crates.md` §4.2 pins — `aes-gcm 0.10` already resolves `aes 0.8`, and 0.9 would link two copies of the block cipher.
- **Reusing `tls/provider/aead.rs`.** It implements rustls's `MessageEncrypter`, whose unit is a TLS record with its own sequence number and header as AAD. What is shared is the `aes_gcm` crate itself.

`getCiphers()` answered `[]` because nothing backed any name. It and the parser are now one table (`CipherAlgo::NAMES`), so they cannot disagree.

## Measured

Per file against a binary of `a3de2a3f` kept before the first edit:

| | files | assertions |
|---|---|---|
| baseline | 785 passed / 839 | 3342 / 3401 |
| this branch | **787 passed / 839** | 3359 / 3416 |

**LOST list empty.** The two gained are the two crypto fixtures. `cargo test --profile fast --no-fail-fast -p rts-node`: 103 passed, 0 failed.

Cross-runtime was **not** measured locally — `bun` is not installed on this machine, and CI is what runs that ruler. The two fixtures of 1516 that mention `crypto` (`subtle.digest`, `getRandomValues`) were run against both binaries and are byte-identical.

Refs kaizeve/Oniwalib#13, kaizeve/Oniwalib#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa
