### PR TITLE
feat(ws): WebSocket client over ws:// and wss://, and two GC fixes it uncovered

### DIFF
--- a/crates/rts-core/src/heap/region/span.rs
+++ b/crates/rts-core/src/heap/region/span.rs
@@ -60,6 +60,29 @@ impl Region {
             let taken = self.next;
             self.next += cells;
             taken
+        } else if cells == 1 {
+            // UMA célula não é um run, e é por aqui que ela volta.
+            //
+            // `Region::free` manda um objeto de uma célula para a lista LIGADA
+            // e só um de duas ou mais para `free_runs` — a razão está lá e é
+            // boa (enfiar um objeto largo na lista ligada espalha-o entre
+            // alocações estreitas e nenhum run se volta a formar). O efeito
+            // colateral é que uma alocação spanning de uma célula, que nunca
+            // olha para a lista ligada, não conseguia reaproveitar NENHUMA das
+            // células que ela própria libertou.
+            //
+            // Um frame de gerador é exatamente esse caso: `function* g() {
+            // yield 1; }` cabe numa célula. Medido antes desta linha: 300 000
+            // rondas de `for (const v of g())` paravam com "heap exhausted"
+            // enquanto o coletor reportava `live 2366` e `freed 521867` — meio
+            // milhão de células livres, e a alocação seguinte recusada. A
+            // mensagem de exaustão dizia "all of them are in use", que era
+            // falso; o que faltava era um caminho até elas.
+            //
+            // `alloc` é o caminho, e o header que ele escreve é o mesmo:
+            // `alloc_spanning` calcula `width = 1 * (INLINE_SLOTS + 1) - 1`,
+            // que é `INLINE_SLOTS`, que é o que `alloc` escreve.
+            return self.alloc(size, ty);
         } else {
             // Nothing left to bump into, so the free list is asked — for a RUN
             // of cells and not one cell, which is why this cannot be
@@ -205,5 +228,61 @@ mod tests {
             region.alloc(16, 1).is_some(),
             "a refusal takes no cells with it"
         );
+    }
+}
+
+#[cfg(test)]
+mod one_cell_reuse {
+    use super::*;
+
+    /// Uma alocação spanning de UMA célula reaproveita o que ela própria
+    /// libertou, mesmo com o bump space esgotado.
+    ///
+    /// O que isto pina não é uma preferência de arrumação: sem o ramo de uma
+    /// célula em [`Region::alloc_spanning`], `Region::free` mandava um frame
+    /// de uma célula para a lista LIGADA e a alocação spanning só olhava para
+    /// `free_runs`, que nunca recebe objetos estreitos. Um frame de gerador é
+    /// exatamente isso — `function* g() { yield 1; }` cabe numa célula — e o
+    /// efeito era o programa parar com "heap exhausted" enquanto o coletor
+    /// reportava meio milhão de células livres.
+    ///
+    /// O laço enche a região de propósito: o caminho a testar é o que corre
+    /// DEPOIS de o bump space acabar, e uma região com espaço livre nunca lá
+    /// chega.
+    #[test]
+    fn a_one_cell_span_comes_back_from_the_free_list() {
+        let mut region = Region::with_capacity(8);
+        let mut taken = Vec::new();
+        while let Some(cell) = region.alloc_spanning(STRIDE, 1) {
+            taken.push(cell);
+        }
+        assert!(taken.len() >= 2, "a região tinha de dar mais do que uma célula");
+
+        // Com o bump space gasto, a alocação seguinte só pode vir do que foi
+        // libertado.
+        assert_eq!(region.alloc_spanning(STRIDE, 1), None, "a região devia estar cheia");
+        assert!(region.free(taken[0]), "libertar a primeira célula");
+        let reusada = region.alloc_spanning(STRIDE, 1);
+        assert!(
+            reusada.is_some(),
+            "uma célula acabada de libertar tem de estar ao alcance de uma \
+             alocação spanning de uma célula — era este o caminho que não existia"
+        );
+    }
+
+    /// E o header que o caminho novo escreve é o mesmo do caminho antigo: um
+    /// campo escrito através da célula reusada lê-se de volta, o que não
+    /// aconteceria se a largura tivesse ficado a zero.
+    #[test]
+    fn the_reused_cell_still_has_a_usable_width() {
+        let mut region = Region::with_capacity(4);
+        let mut taken = Vec::new();
+        while let Some(cell) = region.alloc_spanning(STRIDE, 1) {
+            taken.push(cell);
+        }
+        region.free(taken[0]);
+        let cell = region.alloc_spanning(STRIDE, 1).expect("a célula libertada volta");
+        assert_eq!(region.set_spanning_field(cell, 0, 1, 0x1234), Some(()));
+        assert_eq!(region.spanning_field(cell, 0, 1), Some(0x1234));
     }
 }

--- a/crates/rts-node/src/crypto/mod.rs
+++ b/crates/rts-node/src/crypto/mod.rs
@@ -185,3 +185,14 @@ pub(crate) static CONSTANTS: &[(&str, f64)] = &[
     ("RSA_PSS_SALTLEN_AUTO", -2.0),
 ];
 
+
+/// Bytes do CSPRNG do sistema, para outro módulo deste crate.
+///
+/// Existe para que o `ws` não abra um segundo caminho até ao gerador: o
+/// `Sec-WebSocket-Key` tem de ser imprevisível (RFC 6455 §4.1 — é ele que
+/// impede um proxy de servir um handshake da cache), e um contador ou o
+/// `Math.random` do motor não servem. Uma fonte de aleatoriedade por processo é
+/// a razão de haver esta linha em vez de um `getrandom` chamado noutro sítio.
+pub(crate) fn random_bytes_for(len: usize) -> Vec<u8> {
+    random::os_bytes(len)
+}

--- a/crates/rts-node/src/crypto/random.rs
+++ b/crates/rts-node/src/crypto/random.rs
@@ -18,7 +18,7 @@ use rts_core::entry;
 
 use super::util;
 
-pub(super) fn os_bytes(len: usize) -> Vec<u8> {
+pub(crate) fn os_bytes(len: usize) -> Vec<u8> {
     let mut out = vec![0u8; len];
     // `getrandom` 0.4 — vetted in `docs/reference/node/crates.md` §4.1:
     // "getrandom | 0.4 | MIT/Apache | randomBytes/randomFillSync/

--- a/crates/rts-node/src/tls/conn.rs
+++ b/crates/rts-node/src/tls/conn.rs
@@ -13,30 +13,30 @@ use std::io::{Cursor, Read, Write};
 
 use rustls::{ClientConnection, ServerConnection};
 
-pub(super) enum Side {
+pub(crate) enum Side {
     Client(ClientConnection),
     Server(ServerConnection),
 }
 
-pub(super) struct Driver {
-    pub(super) side: Side,
+pub(crate) struct Driver {
+    pub(crate) side: Side,
 }
 
 /// What one `feed` produced.
-pub(super) struct Fed {
-    pub(super) plaintext: Vec<u8>,
+pub(crate) struct Fed {
+    pub(crate) plaintext: Vec<u8>,
     /// `true` once, the call the handshake completes on.
-    pub(super) just_connected: bool,
+    pub(crate) just_connected: bool,
     /// What rustls refused, when it refused something — the message and not a
     /// bool. `process_new_packets().is_err()` used to be the whole answer, and
     /// the `'error'` a program received carried `undefined`: a bad certificate,
     /// an unsupported version and a corrupt record were one indistinguishable
     /// "sem detalhe" at the only place anyone would read them.
-    pub(super) error: Option<String>,
+    pub(crate) error: Option<String>,
 }
 
 impl Driver {
-    fn is_handshaking(&self) -> bool {
+    pub(crate) fn is_handshaking(&self) -> bool {
         match &self.side {
             Side::Client(c) => c.is_handshaking(),
             Side::Server(s) => s.is_handshaking(),
@@ -47,7 +47,7 @@ impl Driver {
     /// answers whatever plaintext that unlocked plus handshake-completion/
     /// close state — never calls into JS itself; the caller (`socket.rs`'s
     /// `'data'` listener) does that, per this crate's nested-borrow rule.
-    pub(super) fn feed(&mut self, ciphertext: &[u8]) -> Fed {
+    pub(crate) fn feed(&mut self, ciphertext: &[u8]) -> Fed {
         let was_handshaking = self.is_handshaking();
         let mut cursor = Cursor::new(ciphertext);
         // ALTERNAR `read_tls` e `process_new_packets` até o cursor esvaziar, em
@@ -97,7 +97,7 @@ impl Driver {
 
     /// Queues plaintext to send; call [`Driver::outgoing`] to get the bytes
     /// this produces to actually write to the underlying socket.
-    pub(super) fn send(&mut self, plaintext: &[u8]) {
+    pub(crate) fn send(&mut self, plaintext: &[u8]) {
         match &mut self.side {
             Side::Client(c) => {
                 let _ = c.writer().write_all(plaintext);
@@ -110,7 +110,7 @@ impl Driver {
 
     /// Every ciphertext byte the connection wants written right now —
     /// handshake flights and/or the result of [`Driver::send`].
-    pub(super) fn outgoing(&mut self) -> Vec<u8> {
+    pub(crate) fn outgoing(&mut self) -> Vec<u8> {
         let mut out = Vec::new();
         match &mut self.side {
             Side::Client(c) => {

--- a/crates/rts-node/src/tls/context.rs
+++ b/crates/rts-node/src/tls/context.rs
@@ -96,7 +96,7 @@ pub(super) fn context_id(instance: u64) -> Option<u64> {
 
 /// The roots this context declares, falling back to the bundled default
 /// store (`rootCertificates`) when none were given.
-pub(super) fn roots_for(id: Option<u64>) -> RootCertStore {
+pub(crate) fn roots_for(id: Option<u64>) -> RootCertStore {
     let extra = id.map(|id| with_contexts(|table| table.get(&id).map(|held| held.ca.clone()).unwrap_or_default())).unwrap_or_default();
     let mut store = RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     for der in extra {

--- a/crates/rts-node/src/tls/mod.rs
+++ b/crates/rts-node/src/tls/mod.rs
@@ -41,10 +41,10 @@
 //! `node:net` itself names).
 
 mod common;
-mod conn;
-mod context;
+pub(crate) mod conn;
+pub(crate) mod context;
 mod pem;
-mod provider;
+pub(crate) mod provider;
 mod registry;
 mod server;
 mod socket;

--- a/crates/rts-node/src/ws/api.rs
+++ b/crates/rts-node/src/ws/api.rs
@@ -13,21 +13,31 @@
 //! - `new WebSocketServer({ server })` e `{ noServer: true }` — precisam do
 //!   evento `'upgrade'` do `node:http`, que não existe (o doc dele diz). `{ port }`
 //!   é a forma que funciona.
-//! - **cliente** (`new WebSocket(url)`) — o núcleo já serve os dois lados
-//!   (`conn::adopt` recebe se este lado mascara), mas falta o handshake de
-//!   saída. Ausente por nome em vez de presente e quebrado.
 //! - `permessage-deflate`, `ping()`/`pong()` explícitos, `binaryType`,
-//!   `bufferedAmount`, subprotocolos (`Sec-WebSocket-Protocol`).
+//!   `bufferedAmount`.
+//! - **TLS 1.2** no `wss://` — o `CryptoProvider` deste crate publica só suites
+//!   de TLS 1.3, então um servidor que não fale 1.3 não conecta. É uma
+//!   propriedade do provider e `client.rs` diz onde se corrige.
 //!
 //! Um PING que CHEGA é respondido — isso é obrigação do RFC e está em
 //! [`super::conn`]. O que falta é o programa poder mandar um.
+//!
+//! O **cliente** esteve nesta lista e saiu: `new WebSocket(url)` conecta em
+//! `ws://` e `wss://`, com cabeçalhos próprios, `Origin` e subprotocolos. O que
+//! a entrada dizia continua verdade e é por isso que o acréscimo foi pequeno —
+//! o núcleo já servia os dois lados, e faltava só o handshake de saída, que é
+//! [`super::client`]. `Sec-WebSocket-Protocol` sai da lista de ausentes pela
+//! metade que se pode cumprir: é ENVIADO, e a resposta do servidor não é lida
+//! de volta para `ws.protocol`.
 
 use rts_core::entry::{self, Context, Provided};
 
+use super::client;
 use super::conn::{self, Event, ServerEvent};
 use super::frame::Message;
 
 /// `readyState`, com os números que a API web define (e o `ws` copia).
+const CONNECTING: f64 = 0.0;
 const OPEN: f64 = 1.0;
 const CLOSED: f64 = 3.0;
 
@@ -163,6 +173,142 @@ extern "C" fn socket_close(_e: u64, this: u64, code: u64, reason: u64, _c: u64, 
     entry::undefined_value()
 }
 
+/// `new WebSocket(url, protocols?, options?)` — o CLIENTE.
+///
+/// Devolve já, com `readyState` em `CONNECTING`: o handshake corre numa thread
+/// de fundo e chega como `'open'` ou `'error'` + `'close'`. É o contrato do
+/// `ws` do npm e o da API do browser, e é o único possível aqui — a thread que
+/// roda JavaScript não pode bloquear à espera da rede sem parar o laço de
+/// eventos que entregaria o resultado.
+///
+/// # As duas formas do segundo argumento
+///
+/// O `ws` aceita `new WebSocket(url, protocols)` e `new WebSocket(url, options)`
+/// e distingue-os pelo tipo. Aqui é igual: uma string ou um array é a lista de
+/// subprotocolos, um objeto são as opções. Sem isto, `new WebSocket(url,
+/// { headers })` passaria `[object Object]` como subprotocolo e o servidor
+/// recusaria com uma mensagem sobre algo que o programa não escreveu.
+extern "C" fn socket_new(_e: u64, this: u64, url: u64, segundo: u64, terceiro: u64, _d: u64) -> u64 {
+    let (instancia, url) = entry::with_runtime(|context| {
+        let prototype = entry::make_prototype(context, "WebSocket", SOCKET_METHODS);
+        let instancia = as_emitter(context, this, prototype);
+        let url = entry::string_in(context, url);
+        (instancia, url)
+    });
+    let opcoes = client_options(segundo, terceiro);
+
+    let Some(url) = url else {
+        entry::throw_type_error("new WebSocket requires a URL string");
+        return entry::undefined_value();
+    };
+    let alvo = match client::parse(&url) {
+        Ok(alvo) => alvo,
+        Err(motivo) => {
+            // Uma URL errada é do PROGRAMA e é sabida já — lançar aqui aponta
+            // para a linha que a escreveu, onde um `'error'` assíncrono
+            // apontaria para o laço de eventos.
+            entry::throw_type_error(&motivo);
+            return entry::undefined_value();
+        }
+    };
+
+    entry::with_runtime(|context| {
+        let conectando = entry::make_number(CONNECTING);
+        entry::put_member(context, instancia, "readyState", conectando);
+        let texto = entry::make_string(context, &url);
+        entry::put_member(context, instancia, "url", texto);
+    });
+
+    // O `owner` é ESTA thread — a que roda JS e vai bombear —, e por isso é
+    // colhido aqui e não lá dentro. É a mesma armadilha que o `adopt` documenta
+    // do lado do servidor, onde gravar `current()` na thread errada fazia o
+    // handshake completar e mensagem nenhuma ser entregue.
+    let id = conn::reserve(true, std::thread::current().id());
+    conn::bind_instance(id, instancia);
+    entry::with_runtime(|context| set_id(context, instancia, id));
+    std::thread::spawn(move || match client::connect(&alvo, &opcoes) {
+        Ok((transporte, resto)) => conn::attach(id, transporte, resto),
+        Err(motivo) => conn::fail(id, motivo),
+    });
+    instancia
+}
+
+/// Lê o segundo e o terceiro argumento do construtor nas opções do handshake.
+///
+/// **Fora** do `with_runtime`, e cada empréstimo aberto e fechado antes do
+/// seguinte. Os nomes dos cabeçalhos vêm de `own_keys`, que é um ponto de
+/// entrada AMBIENTE — chamá-lo de dentro de um empréstimo é um empréstimo
+/// aninhado, que aborta o processo em vez de falhar. É a mesma disciplina que
+/// `crypto/util.rs` e `assert/mod.rs` documentam, pela mesma razão.
+fn client_options(segundo: u64, terceiro: u64) -> client::Options {
+    let absent = entry::undefined_value();
+    let mut opcoes = client::Options::default();
+
+    // Um objeto no segundo lugar são as opções; string ou array são os
+    // subprotocolos, e então as opções são o terceiro argumento.
+    let (objeto, protocolo) = entry::with_runtime(|context| {
+        if segundo == absent {
+            return (terceiro, None);
+        }
+        if let Some(texto) = entry::string_in(context, segundo) {
+            return (terceiro, Some(texto));
+        }
+        if entry::is_array_in(context, segundo) {
+            return (terceiro, None);
+        }
+        (segundo, None)
+    });
+    if let Some(texto) = protocolo {
+        opcoes.protocols.push(texto);
+    }
+    // Um array de subprotocolos: os elementos lêem-se fora do empréstimo.
+    for valor in elements(segundo) {
+        if let Some(texto) = entry::with_runtime(|context| entry::string_in(context, valor)) {
+            opcoes.protocols.push(texto);
+        }
+    }
+    if objeto == absent {
+        return opcoes;
+    }
+
+    let (origin, headers) = entry::with_runtime(|context| {
+        let held = entry::get_member(context, objeto, "origin");
+        let origin = entry::string_in(context, held);
+        (origin, entry::get_member(context, objeto, "headers"))
+    });
+    opcoes.origin = origin;
+    if headers == absent {
+        return opcoes;
+    }
+    // As chaves na ordem em que o objeto as tem, que é a ordem em que o
+    // programa as escreveu — ver o doc de `client::Options::headers`.
+    for chave in elements(entry::own_keys(headers)) {
+        let Some(nome) = entry::described(chave) else { continue };
+        let valor = entry::with_runtime(|context| {
+            let held = entry::get_member(context, headers, &nome);
+            entry::text_in(context, held)
+        });
+        if let Some(valor) = valor {
+            opcoes.headers.push((nome, valor));
+        }
+    }
+    opcoes
+}
+
+/// Os elementos de um array, vazio para o que não é um.
+///
+/// Ambiente pela mesma razão que a de [`client_options`]: o comprimento é uma
+/// propriedade e lê-se sob empréstimo, os elementos não são e lêem-se fora.
+fn elements(value: u64) -> Vec<u64> {
+    let count = entry::with_runtime(|context| {
+        if !entry::is_array_in(context, value) {
+            return 0;
+        }
+        let length = entry::get_member(context, value, "length");
+        entry::number_of(length).unwrap_or(0.0).max(0.0) as usize
+    });
+    (0..count).map(|index| entry::get_indexed(value, entry::make_number(index as f64))).collect()
+}
 /// Constrói a instância JS de uma conexão que o servidor aceitou.
 fn make_socket(context: &mut Context, id: u64) -> u64 {
     let prototype = entry::make_prototype(context, "WebSocket", &[]);
@@ -217,7 +363,18 @@ pub(super) fn pump() -> entry::Pending {
     for (_id, instancia, eventos) in conn::drain_conns() {
         for evento in eventos {
             match evento {
-                Event::Open => emit(instancia, "open", absent, absent, absent),
+                // Marcar OPEN aqui e não só no construtor: o CLIENTE chega em
+                // CONNECTING e é este evento que diz que o handshake acabou. Do
+                // lado do servidor a instância já nasce OPEN, e reescrever o
+                // mesmo valor não custa nada — o que custaria era dois sítios a
+                // decidir quando uma conexão está aberta.
+                Event::Open => {
+                    entry::with_runtime(|context| {
+                        let aberto = entry::make_number(OPEN);
+                        entry::put_member(context, instancia, "readyState", aberto);
+                    });
+                    emit(instancia, "open", absent, absent, absent)
+                }
                 Event::Message(mensagem) => {
                     let dados = entry::with_runtime(|context| match &mensagem {
                         Message::Text(texto) => entry::make_string(context, texto),
@@ -283,12 +440,27 @@ pub(super) fn namespace(context: &mut Context) -> u64 {
     // resultado deste módulo. É o que `net::class_ctor` faz, pela mesma razão.
     let construtor = entry::make_callable(context, server_new);
     entry::put_member(context, construtor, "prototype", server_proto);
+    let cliente = entry::make_callable(context, socket_new);
+    entry::put_member(context, cliente, "prototype", socket_proto);
+
     let namespace = entry::make_namespace(context, &[]);
     entry::put_member(context, namespace, "WebSocketServer", construtor);
-    // O `ws` expõe o mesmo construtor sob três nomes: `WebSocketServer`, `Server`
-    // e `WebSocket.Server`. São o MESMO objeto, não três cópias — um programa que
-    // compare `a.Server === a.WebSocketServer` tem de ver `true`.
+    // O `ws` expõe o mesmo construtor de servidor sob três nomes:
+    // `WebSocketServer`, `Server` e `WebSocket.Server`. São o MESMO objeto, não
+    // três cópias — um programa que compare `a.Server === a.WebSocketServer` tem
+    // de ver `true`. O terceiro nome só agora pode ser escrito: até haver um
+    // `WebSocket` não havia onde o pendurar, e o comentário que estava aqui
+    // prometia um nome que o código não registava.
     entry::put_member(context, namespace, "Server", construtor);
-    entry::put_member(context, namespace, "default", construtor);
+    entry::put_member(context, namespace, "WebSocket", cliente);
+    entry::put_member(context, cliente, "Server", construtor);
+
+    // `default` passa a ser o CLIENTE, e isto é uma correção e não uma escolha:
+    // o `ws` do npm faz `module.exports = WebSocket` e pendura o servidor em
+    // `WebSocket.Server`, então `import WS from "ws"; new WS(url)` é o que um
+    // programa portado escreve. Apontava para o servidor porque era o único que
+    // existia, e um `new WS("wss://…")` tratava a URL como um objeto de opções
+    // e falhava a pedir `{ port }`.
+    entry::put_member(context, namespace, "default", cliente);
     namespace
 }

--- a/crates/rts-node/src/ws/client.rs
+++ b/crates/rts-node/src/ws/client.rs
@@ -1,0 +1,504 @@
+//! O handshake de SAÍDA — o que faltava para haver cliente.
+//!
+//! O `api.rs` dizia isto por nome: *"o núcleo já serve os dois lados
+//! (`conn::adopt` recebe se este lado mascara), mas falta o handshake de saída.
+//! Ausente por nome em vez de presente e quebrado."* É este ficheiro, e nada em
+//! [`super::frame`] mudou para o receber — o RFC já estava escrito dos dois
+//! lados.
+//!
+//! # A ordem que não é negociável
+//!
+//! TCP, **depois TLS até ao fim**, depois o `GET` de upgrade. Escrever o pedido
+//! HTTP assim que o socket TCP abre é o erro natural — e produz uma falha que
+//! parece do servidor, porque o que chega ao par é texto claro onde ele espera
+//! um ClientHello. [`connect`] completa o aperto de mão do rustls antes de
+//! escrever o primeiro byte de HTTP, e a função que o faz ([`handshake_tls`])
+//! existe separada para que a ordem seja visível em vez de implícita.
+//!
+//! # Cabeçalhos próprios, e por que são o ponto e não um extra
+//!
+//! Um servidor real recusa um cliente sem `Origin` (política de mesma origem
+//! aplicada no handshake) ou sem o `User-Agent` que espera. Como o pedido é
+//! construído aqui, `headers` e `origin` custam as linhas que os escrevem — não
+//! são uma segunda funcionalidade. O que NÃO se deixa sobrepor são os seis
+//! cabeçalhos que definem o protocolo (`Host`, `Upgrade`, `Connection`,
+//! `Sec-WebSocket-Key`, `Sec-WebSocket-Version` e, quando pedido,
+//! `Sec-WebSocket-Protocol`): um `Connection: close` vindo de um objeto de
+//! opções não é uma preferência, é uma conexão que não abre, e falhar com um
+//! erro que aponta para o servidor seria pior do que ignorar a linha.
+//!
+//! # O que este ficheiro não faz
+//!
+//! - **TLS 1.2.** O `CryptoProvider` deste crate publica dois cifradores, ambos
+//!   de TLS 1.3 (`tls/provider/mod.rs`), então um servidor que só fale 1.2 não
+//!   conecta. É uma propriedade do provider e não uma decisão tomada aqui;
+//!   corrigi-la é acrescentar suites lá, e mentir sobre a versão aqui não a
+//!   corrigiria.
+//! - **Redirecções.** Um `3xx` ao handshake é um erro, não um segundo pedido.
+//!   Seguir uma redirecção sem o dizer levaria um `wss://` a acabar num `ws://`
+//!   sem que ninguém reparasse.
+//! - **`permessage-deflate`.** Não é oferecido, logo não é negociado. É opcional
+//!   no RFC e recusá-lo é legal; oferecê-lo sem o saber descomprimir seria a
+//!   superfície oca.
+//! - **Proxies.** Sem `CONNECT`, e sem ler `HTTP_PROXY` do ambiente.
+
+use std::io::{Read as _, Write as _};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use super::transport::Transport;
+
+/// Para onde o cliente vai.
+#[cfg_attr(test, derive(Debug))]
+pub(super) struct Target {
+    pub(super) host: String,
+    pub(super) port: u16,
+    /// O caminho e a query, já com a barra inicial — o que vai na linha do
+    /// pedido.
+    pub(super) resource: String,
+    pub(super) secure: bool,
+}
+
+/// O que um programa pode acrescentar ao pedido.
+#[derive(Default)]
+pub(super) struct Options {
+    pub(super) origin: Option<String>,
+    /// Pares nome/valor, na ordem em que o programa os deu. Um `Vec` e não um
+    /// mapa: o HTTP permite repetir um cabeçalho, a ordem é observável do outro
+    /// lado, e um mapa perderia as duas coisas para não ganhar nada.
+    pub(super) headers: Vec<(String, String)>,
+    pub(super) protocols: Vec<String>,
+}
+
+/// Os cabeçalhos que este ficheiro escreve e um programa não pode substituir —
+/// ver a nota do módulo. Comparados sem distinguir maiúsculas, que é como o
+/// HTTP os compara.
+const RESERVED: &[&str] = &[
+    "host",
+    "upgrade",
+    "connection",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "content-length",
+];
+
+/// Parte um `ws://`/`wss://` no que o pedido precisa.
+///
+/// Escrito à mão em vez de pela crate `url`, que este crate já tem: o que aqui
+/// interessa é um esquema de dois valores, um autoridade e o resto textual, e a
+/// `Url` normaliza o caminho de formas que um servidor WebSocket nota — um
+/// `?a=1&a=2` reordenado é outra query. O `node:url` continua a ser quem
+/// responde por URLs em geral; isto é o recorte do handshake.
+pub(super) fn parse(url: &str) -> Result<Target, String> {
+    let (secure, rest) = if let Some(rest) = url.strip_prefix("wss://") {
+        (true, rest)
+    } else if let Some(rest) = url.strip_prefix("ws://") {
+        (false, rest)
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        // Recusado por nome: um `http://` que "funcionasse" abriria um
+        // WebSocket sobre um endereço que nenhum outro cliente aceitaria, e o
+        // programa só descobria no servidor.
+        return Err("WebSocket URL must use the ws: or wss: scheme".to_owned());
+    } else {
+        return Err("WebSocket URL must start with ws:// or wss://".to_owned());
+    };
+
+    let (authority, resource) = match rest.find(['/', '?', '#']) {
+        Some(cut) => (&rest[..cut], &rest[cut..]),
+        None => (rest, ""),
+    };
+    // O fragmento nunca vai para a rede — é do cliente, e o RFC 3986 diz o
+    // mesmo para qualquer pedido.
+    let resource = resource.split('#').next().unwrap_or("");
+    let resource = if resource.is_empty() { "/".to_owned() } else { resource.to_owned() };
+
+    // As credenciais de `user:pass@host` são descartadas em vez de viradas em
+    // `Authorization`: o `ws` do npm também não as usa, e inventar aqui um
+    // cabeçalho de autenticação mandaria uma senha que ninguém escreveu.
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+
+    let (host, port) = split_port(authority, secure)?;
+    Ok(Target { host, port, resource, secure })
+}
+
+fn split_port(authority: &str, secure: bool) -> Result<(String, u16), String> {
+    let padrao = if secure { 443 } else { 80 };
+    // `[::1]:8080` — o IPv6 traz dois-pontos que não separam a porta.
+    if let Some(fim) = authority.strip_prefix('[').and_then(|_| authority.find(']')) {
+        let host = authority[1..fim].to_owned();
+        let resto = &authority[fim + 1..];
+        let port = match resto.strip_prefix(':') {
+            Some(texto) => texto.parse().map_err(|_| format!("invalid port: {texto}"))?,
+            None => padrao,
+        };
+        return Ok((host, port));
+    }
+    match authority.rsplit_once(':') {
+        Some((host, texto)) => {
+            let port = texto.parse().map_err(|_| format!("invalid port: {texto}"))?;
+            Ok((host.to_owned(), port))
+        }
+        None => Ok((authority.to_owned(), padrao)),
+    }
+}
+
+/// Abre, aperta a mão e devolve o transporte pronto a falar frames.
+///
+/// Bloqueia. Quem chama é a thread de fundo que o `api.rs` levanta — nunca a
+/// que roda JavaScript, pela mesma razão que o resto deste módulo existe.
+///
+/// # Os prazos, e por que só valem durante o aperto de mão
+///
+/// Um servidor que aceita a ligação TCP e depois não diz nada penduraria esta
+/// thread para sempre — não é um caso teórico, é o que um balanceador faz
+/// quando o serviço por trás está em baixo. Por isso [`TIMEOUT`] cobre a
+/// ligação, o TLS e a resposta ao upgrade.
+///
+/// E é LEVANTADO depois: passado o handshake, uma leitura que não devolve nada
+/// é o normal — é uma conversa à espera da próxima mensagem — e um prazo aí
+/// transformaria trinta segundos de silêncio num erro. É a diferença entre
+/// "ainda não abriu" e "está aberta e calada", que são estados opostos.
+pub(super) fn connect(target: &Target, options: &Options) -> Result<(Transport, Vec<u8>), String> {
+    let endereco = format!("{}:{}", target.host, target.port);
+    let tcp = connect_timeout(&endereco)?;
+    // Nagle atrasa um frame pequeno até haver mais que enviar, e uma conversa
+    // por WebSocket é feita de frames pequenos. O `ws` do npm faz o mesmo.
+    let _ = tcp.set_nodelay(true);
+    let _ = tcp.set_read_timeout(Some(TIMEOUT));
+    let _ = tcp.set_write_timeout(Some(TIMEOUT));
+
+    let mut transport = if target.secure {
+        handshake_tls(tcp, &target.host)?
+    } else {
+        Transport::plain(tcp)
+    };
+
+    let key = nonce();
+    let pedido = request(target, options, &key);
+    transport
+        .write_all(pedido.as_bytes())
+        .map_err(|erro| format!("failed to send the upgrade request: {erro}"))?;
+    let resto = read_response(&mut transport, &key)?;
+    transport.clear_timeouts();
+    Ok((transport, resto))
+}
+
+/// Liga com prazo, resolvendo o nome primeiro.
+///
+/// `TcpStream::connect` aceita um nome e não aceita um prazo;
+/// `connect_timeout` aceita um prazo e não aceita um nome. Esta função é a
+/// junção das duas, e a resolução acontece aqui porque é onde se pode dizer
+/// que endereço falhou.
+fn connect_timeout(endereco: &str) -> Result<TcpStream, String> {
+    use std::net::ToSocketAddrs;
+    let enderecos: Vec<_> = endereco
+        .to_socket_addrs()
+        .map_err(|erro| format!("{endereco}: {erro}"))?
+        .collect();
+    let mut ultimo = format!("{endereco}: no address resolved");
+    for addr in enderecos {
+        match TcpStream::connect_timeout(&addr, TIMEOUT) {
+            Ok(tcp) => return Ok(tcp),
+            // Cada endereço é tentado por vez — um nome que responde em IPv6 e
+            // IPv4 tem os dois, e desistir do primeiro erro deixaria de fora o
+            // que funcionava.
+            Err(erro) => ultimo = format!("{addr}: {erro}"),
+        }
+    }
+    Err(ultimo)
+}
+/// O aperto de mão do TLS, até ao fim, antes de qualquer HTTP.
+fn handshake_tls(tcp: TcpStream, servername: &str) -> Result<Transport, String> {
+    let provider = crate::tls::provider::provider();
+    let roots = crate::tls::context::roots_for(None);
+    let builder = rustls::ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .map_err(|erro| format!("TLS configuration: {erro}"))?;
+    let config = builder.with_root_certificates(roots).with_no_client_auth();
+    let name = rustls::pki_types::ServerName::try_from(servername.to_owned())
+        .map_err(|_| format!("not a valid TLS server name: {servername}"))?;
+    let sessao = rustls::ClientConnection::new(std::sync::Arc::new(config), name)
+        .map_err(|erro| format!("TLS handshake could not start: {erro}"))?;
+
+    let mut driver = crate::tls::conn::Driver { side: crate::tls::conn::Side::Client(sessao) };
+    let mut tcp = tcp;
+    let mut buffer = [0u8; 8192];
+    // O laço é do rustls e não do relógio: ele diz o que quer escrever
+    // (`outgoing`) e diz quando acabou (`is_handshaking`). Um limite de voltas
+    // guarda contra um par que responde para sempre sem terminar — sem ele isto
+    // é um pendurar, não um erro.
+    for _ in 0..64 {
+        let sair = {
+            let saida = driver.outgoing();
+            if !saida.is_empty() {
+                tcp.write_all(&saida).map_err(|erro| format!("TLS handshake write: {erro}"))?;
+            }
+            !driver.is_handshaking()
+        };
+        if sair {
+            return Ok(Transport::tls(tcp, driver));
+        }
+        let lidos = tcp.read(&mut buffer).map_err(|erro| format!("TLS handshake read: {erro}"))?;
+        if lidos == 0 {
+            return Err("the server closed the connection during the TLS handshake".to_owned());
+        }
+        let fed = driver.feed(&buffer[..lidos]);
+        if let Some(erro) = fed.error {
+            return Err(format!("TLS handshake failed: {erro}"));
+        }
+    }
+    Err("the TLS handshake did not finish".to_owned())
+}
+
+/// Os 16 bytes aleatórios do `Sec-WebSocket-Key`, em base64.
+///
+/// Do CSPRNG do sistema através do `node:crypto`, que é o mesmo sorteio do
+/// `randomBytes` — e não de um contador. O RFC §4.1 exige que a chave seja
+/// imprevisível: ela é o que impede um proxy de ser levado a servir uma
+/// resposta guardada em cache como se fosse um handshake.
+fn nonce() -> String {
+    let bytes = crate::crypto::random_bytes_for(16);
+    rts_core::entry::encode_base64(&bytes, true)
+}
+
+/// O pedido, literalmente.
+fn request(target: &Target, options: &Options, key: &str) -> String {
+    // A porta só entra no `Host` quando não é a do esquema, que é o que um
+    // servidor com virtual hosts compara.
+    let padrao = if target.secure { 443 } else { 80 };
+    let host = if target.port == padrao {
+        target.host.clone()
+    } else {
+        format!("{}:{}", target.host, target.port)
+    };
+    let mut pedido = format!(
+        "GET {} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\
+         Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n",
+        target.resource
+    );
+    if !options.protocols.is_empty() {
+        pedido.push_str(&format!("Sec-WebSocket-Protocol: {}\r\n", options.protocols.join(", ")));
+    }
+    if let Some(origin) = &options.origin {
+        pedido.push_str(&format!("Origin: {origin}\r\n"));
+    }
+    for (nome, valor) in &options.headers {
+        if RESERVED.contains(&nome.to_ascii_lowercase().as_str()) {
+            continue;
+        }
+        // Um `\r` ou `\n` num valor injecta um cabeçalho — ou um pedido
+        // inteiro. Recortado no primeiro, e não recusado: um valor que o
+        // programa compôs de dados alheios é o caso normal, e rebentar aqui
+        // transformaria uma sanitização numa falha de conexão.
+        let valor = valor.split(['\r', '\n']).next().unwrap_or("");
+        pedido.push_str(&format!("{nome}: {valor}\r\n"));
+    }
+    pedido.push_str("\r\n");
+    pedido
+}
+
+/// Lê o `101` e confirma que quem respondeu leu a nossa chave.
+fn read_response(transport: &mut Transport, key: &str) -> Result<Vec<u8>, String> {
+    let (cabecalho, resto) = read_headers(transport)?;
+    let mut linhas = cabecalho.split("\r\n");
+    let estado = linhas.next().unwrap_or("");
+    let mut campos = estado.split_whitespace();
+    let _versao = campos.next();
+    let codigo = campos.next().unwrap_or("");
+    if codigo != "101" {
+        // O código e a razão inteiros, porque é o que diagnostica: um 401 e um
+        // 404 no mesmo `handshake failed` mandam procurar em sítios opostos.
+        return Err(format!("the server refused the upgrade: {estado}"));
+    }
+
+    let mut upgrade = false;
+    let mut connection = false;
+    let mut accept = None;
+    for linha in linhas {
+        let Some((nome, valor)) = linha.split_once(':') else { continue };
+        let valor = valor.trim();
+        match nome.trim().to_ascii_lowercase().as_str() {
+            "upgrade" => upgrade = valor.eq_ignore_ascii_case("websocket"),
+            // `Connection` pode trazer uma lista — `keep-alive, Upgrade`.
+            "connection" => {
+                connection = valor.split(',').any(|item| item.trim().eq_ignore_ascii_case("upgrade"))
+            }
+            "sec-websocket-accept" => accept = Some(valor.to_owned()),
+            _ => {}
+        }
+    }
+    if !upgrade || !connection {
+        return Err("the server answered 101 without upgrading the connection".to_owned());
+    }
+    let esperado = super::handshake::accept_key(key);
+    match accept {
+        // Esta é a verificação que o RFC §4.1 exige e a que dá sentido à chave
+        // ser aleatória: sem ela, uma resposta guardada em cache por um proxy
+        // passaria por um handshake.
+        Some(recebido) if recebido == esperado => Ok(resto),
+        Some(_) => Err("the server's Sec-WebSocket-Accept does not match the key sent".to_owned()),
+        None => Err("the server answered 101 without a Sec-WebSocket-Accept header".to_owned()),
+    }
+}
+
+/// Lê até `\r\n\r\n` e devolve o cabeçalho **e o que veio a seguir**.
+///
+/// O resto não é um detalhe: um servidor pode mandar a resposta 101 e o
+/// primeiro frame WebSocket no mesmo segmento TCP — ou, sobre TLS, no mesmo
+/// registo, que é ainda mais provável porque um registo leva até 16 KB. Bytes
+/// consumidos para lá do cabeçalho não voltam ao socket.
+///
+/// Isto começou por ser recusado com um erro que dizia que o cliente "não sabe
+/// guardar" esses bytes. O primeiro servidor real contra o qual foi corrido
+/// (`wss://echo.websocket.org`) fez exatamente isso, e a conexão não abria — o
+/// que prova que a limitação documentada era, na prática, o caso normal e não
+/// a exceção. O resto é devolvido e semeia o acumulador de quem lê.
+fn read_headers(transport: &mut Transport) -> Result<(String, Vec<u8>), String> {
+    let mut acumulado: Vec<u8> = Vec::new();
+    for _ in 0..256 {
+        match transport.read_plaintext() {
+            Ok(super::transport::Chunk::Eof) => {
+                return Err("the server closed the connection during the handshake".to_owned());
+            }
+            Ok(super::transport::Chunk::Data(bytes)) => {
+                acumulado.extend_from_slice(&bytes);
+                if let Some(fim) = find_header_end(&acumulado) {
+                    let resto = acumulado.split_off(fim);
+                    let cabecalho = String::from_utf8(acumulado)
+                        .map_err(|_| "the handshake response is not valid UTF-8".to_owned())?;
+                    return Ok((cabecalho, resto));
+                }
+                if acumulado.len() > 64 * 1024 {
+                    return Err("the handshake response header is too large".to_owned());
+                }
+            }
+            Err(erro) => return Err(format!("failed to read the handshake response: {erro}")),
+        }
+    }
+    Err("the server did not finish the handshake response".to_owned())
+}
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|janela| janela == b"\r\n\r\n").map(|inicio| inicio + 4)
+}
+
+/// Quanto tempo uma tentativa de conexão espera antes de desistir.
+///
+/// Um número num sítio só. Não é configurável pelo programa ainda, e isso é
+/// dito aqui em vez de ficar implícito num valor perdido no meio de uma
+/// função.
+pub(super) const TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_parts_of_a_url() {
+        let alvo = parse("wss://gateway.example.com/socket?v=2").unwrap();
+        assert_eq!(alvo.host, "gateway.example.com");
+        assert_eq!(alvo.port, 443);
+        assert_eq!(alvo.resource, "/socket?v=2");
+        assert!(alvo.secure);
+    }
+
+    #[test]
+    fn a_missing_path_becomes_a_slash() {
+        let alvo = parse("ws://localhost:8080").unwrap();
+        assert_eq!(alvo.port, 8080);
+        assert_eq!(alvo.resource, "/");
+        assert!(!alvo.secure);
+    }
+
+    #[test]
+    fn the_default_port_follows_the_scheme() {
+        assert_eq!(parse("ws://a.example").unwrap().port, 80);
+        assert_eq!(parse("wss://a.example").unwrap().port, 443);
+    }
+
+    /// Os dois-pontos de um IPv6 não separam a porta.
+    #[test]
+    fn an_ipv6_authority_keeps_its_colons() {
+        let alvo = parse("ws://[::1]:9001/x").unwrap();
+        assert_eq!(alvo.host, "::1");
+        assert_eq!(alvo.port, 9001);
+        assert_eq!(alvo.resource, "/x");
+    }
+
+    #[test]
+    fn a_fragment_never_reaches_the_wire() {
+        assert_eq!(parse("ws://a.example/p?q=1#top").unwrap().resource, "/p?q=1");
+    }
+
+    #[test]
+    fn http_is_refused_by_name() {
+        assert!(parse("https://a.example").unwrap_err().contains("ws: or wss:"));
+        assert!(parse("a.example").is_err());
+    }
+
+    /// O `Host` leva a porta só quando ela não é a do esquema — é o que um
+    /// servidor com virtual hosts compara.
+    #[test]
+    fn the_host_header_omits_a_default_port() {
+        let alvo = parse("wss://a.example/x").unwrap();
+        let pedido = request(&alvo, &Options::default(), "chave");
+        assert!(pedido.contains("Host: a.example\r\n"), "{pedido}");
+
+        let alvo = parse("ws://a.example:8080/x").unwrap();
+        let pedido = request(&alvo, &Options::default(), "chave");
+        assert!(pedido.contains("Host: a.example:8080\r\n"), "{pedido}");
+    }
+
+    #[test]
+    fn custom_headers_and_origin_reach_the_request() {
+        let alvo = parse("wss://a.example/x").unwrap();
+        let opcoes = Options {
+            origin: Some("https://a.example".to_owned()),
+            headers: vec![("User-Agent".to_owned(), "Oniwalib/1".to_owned())],
+            protocols: vec!["chat".to_owned()],
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("Origin: https://a.example\r\n"), "{pedido}");
+        assert!(pedido.contains("User-Agent: Oniwalib/1\r\n"), "{pedido}");
+        assert!(pedido.contains("Sec-WebSocket-Protocol: chat\r\n"), "{pedido}");
+    }
+
+    /// Um cabeçalho do protocolo não se deixa substituir — ver a nota do
+    /// módulo. Aqui o programa tenta trocar `Connection`, e o pedido continua a
+    /// pedir o upgrade.
+    #[test]
+    fn a_reserved_header_is_ignored() {
+        let alvo = parse("ws://a.example/x").unwrap();
+        let opcoes = Options {
+            headers: vec![
+                ("Connection".to_owned(), "close".to_owned()),
+                ("sec-websocket-key".to_owned(), "outra".to_owned()),
+            ],
+            ..Options::default()
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("Connection: Upgrade\r\n"), "{pedido}");
+        assert!(!pedido.contains("close"), "{pedido}");
+        assert_eq!(pedido.matches("Sec-WebSocket-Key").count(), 1, "{pedido}");
+    }
+
+    /// Um `\r\n` num valor injectaria um cabeçalho inteiro. É cortado, e o que
+    /// vinha depois não aparece em lado nenhum.
+    #[test]
+    fn a_newline_in_a_header_value_is_cut() {
+        let alvo = parse("ws://a.example/x").unwrap();
+        let opcoes = Options {
+            headers: vec![("X-Test".to_owned(), "ok\r\nX-Injected: yes".to_owned())],
+            ..Options::default()
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("X-Test: ok\r\n"), "{pedido}");
+        assert!(!pedido.contains("X-Injected"), "{pedido}");
+    }
+
+    #[test]
+    fn the_header_end_is_found_and_not_overshot() {
+        assert_eq!(find_header_end(b"HTTP/1.1 101\r\n\r\n"), Some(16));
+        assert_eq!(find_header_end(b"HTTP/1.1 101\r\n"), None);
+    }
+}

--- a/crates/rts-node/src/ws/conn.rs
+++ b/crates/rts-node/src/ws/conn.rs
@@ -31,6 +31,7 @@ use rts_core::entry::{self, Pending};
 
 use super::frame::{self, Assembler, Delivered, Message, Read};
 use super::handshake;
+use super::transport::{Chunk, Transport};
 
 /// O que aconteceu numa conexão. Dados nativos apenas — nada aqui toca JS.
 pub(super) enum Event {
@@ -54,9 +55,11 @@ pub(super) struct Conn {
     pub(super) instance: u64,
     queue: VecDeque<Event>,
     /// Por onde se escreve. A thread de leitura tem o seu próprio `try_clone`.
-    stream: Option<TcpStream>,
+    stream: Option<Transport>,
     /// Este lado mascara? Cliente sim, servidor não (RFC §5.1).
     masks: bool,
+    /// Quando `close()` foi chamado deste lado — ver o doc de [`close`].
+    closing_since: Option<std::time::Instant>,
     pub(super) closed: bool,
 }
 
@@ -137,7 +140,7 @@ pub(super) fn listen(port: u16, host: &str) -> u64 {
                 // cliente que erra o handshake nunca vira um evento.
                 match apertar_mao(fluxo) {
                     Some((fluxo, path, host)) => {
-                        let conn = adopt(fluxo, false, dono);
+                        let conn = adopt(Transport::plain(fluxo), false, dono);
                         push_server(id, ServerEvent::Connected { conn, path, host });
                     }
                     None => continue,
@@ -194,15 +197,27 @@ fn apertar_mao(mut fluxo: TcpStream) -> Option<(TcpStream, String, String)> {
 /// certo, gravado por `listen` na thread do JS) e nenhuma MENSAGEM era entregue,
 /// porque o filtro de `drain_conns` nunca casava. É a mesma armadilha que o
 /// campo existe para evitar, do outro lado.
-pub(super) fn adopt(fluxo: TcpStream, masks: bool, owner: std::thread::ThreadId) -> u64 {
+pub(super) fn adopt(fluxo: Transport, masks: bool, owner: std::thread::ThreadId) -> u64 {
+    let id = reserve(masks, owner);
+    attach(id, fluxo, Vec::new());
+    id
+}
+
+/// Reserva o id de uma conexão que ainda não tem por onde falar.
+///
+/// Existe por causa do cliente: `new WebSocket(url)` tem de devolver a
+/// instância JS **antes** de o handshake acabar — é para isso que serve o
+/// `readyState` `CONNECTING` — e a instância precisa de um id para se ligar. Um
+/// `adopt` só depois de conectar chegaria tarde demais, e guardar a instância
+/// numa segunda tabela à espera seria uma segunda numeração para o mesmo
+/// espaço, que é o caso que o reuse-check chama de fatal.
+///
+/// `closed` fica falso desde já, e isso é deliberado: `pending()` conta uma
+/// conexão não fechada como trabalho, o que segura o laço de eventos aberto
+/// enquanto o handshake corre. Sem isso, um programa cujo único trabalho é
+/// conectar terminaria antes de o servidor responder.
+pub(super) fn reserve(masks: bool, owner: std::thread::ThreadId) -> u64 {
     let id = next_id();
-    let leitura = match fluxo.try_clone() {
-        Ok(clone) => clone,
-        Err(erro) => {
-            push(id, Event::Error(erro.to_string()));
-            return id;
-        }
-    };
     with_conns(|table| {
         table.insert(
             id,
@@ -210,32 +225,69 @@ pub(super) fn adopt(fluxo: TcpStream, masks: bool, owner: std::thread::ThreadId)
                 owner,
                 instance: 0,
                 queue: VecDeque::new(),
-                stream: Some(fluxo),
+                stream: None,
                 masks,
+                closing_since: None,
                 closed: false,
             },
         );
     });
-    push(id, Event::Open);
-    std::thread::spawn(move || ler_ate_fechar(id, leitura, masks));
     id
 }
 
+/// Dá a uma conexão reservada por onde falar, e põe-na a ler.
+///
+/// `inicial` são bytes que já chegaram e ainda não foram interpretados como
+/// frames — o que veio colado à resposta do handshake. Não é um caso raro: o
+/// primeiro servidor `wss://` real contra o qual isto correu mandou a resposta
+/// 101 e o primeiro frame no mesmo registo TLS. Bytes lidos do socket não
+/// voltam lá para dentro, então ou são passados para aqui ou são perdidos.
+pub(super) fn attach(id: u64, fluxo: Transport, inicial: Vec<u8>) {
+    let leitura = match fluxo.try_clone() {
+        Ok(clone) => clone,
+        Err(erro) => {
+            push(id, Event::Error(erro.to_string()));
+            return;
+        }
+    };
+    let masks = with_conns(|table| {
+        let Some(conn) = table.get_mut(&id) else { return None };
+        conn.stream = Some(fluxo);
+        Some(conn.masks)
+    });
+    let Some(masks) = masks else { return };
+    push(id, Event::Open);
+    std::thread::spawn(move || ler_ate_fechar(id, leitura, masks, inicial));
+}
+/// Falhou a ligar: um `'error'` com o motivo e um `'close'` a seguir.
+///
+/// Os dois, e nesta ordem, porque é o que o `ws` do npm faz e o que um programa
+/// escrito contra ele espera — um `'error'` sozinho deixa quem espera pelo
+/// `'close'` pendurado para sempre. 1006 é o código do RFC para "fechou sem
+/// frame de close", que é exatamente o que uma conexão que nunca abriu fez.
+pub(super) fn fail(id: u64, motivo: String) {
+    push(id, Event::Error(motivo));
+    push(id, Event::Close { code: 1006, reason: String::new() });
+    with_conns(|table| {
+        if let Some(conn) = table.get_mut(&id) {
+            conn.stream = None;
+            conn.closed = true;
+        }
+    });
+}
 /// O laço de leitura de uma conexão. Roda numa thread de fundo e NUNCA chama JS.
-fn ler_ate_fechar(id: u64, mut fluxo: TcpStream, masks: bool) {
-    let mut acumulado: Vec<u8> = Vec::new();
+///
+/// `inicial` é semeado no acumulador e processado ANTES da primeira leitura da
+/// rede — se um frame inteiro veio colado à resposta do handshake, ele já está
+/// completo aqui, e bloquear à espera de mais bytes antes de o olhar entregaria
+/// a primeira mensagem só quando chegasse a segunda.
+fn ler_ate_fechar(id: u64, mut fluxo: Transport, masks: bool, inicial: Vec<u8>) {
+    let mut acumulado: Vec<u8> = inicial;
     let mut montador = Assembler::default();
-    let mut buffer = [0u8; 8192];
     loop {
-        let lidos = match fluxo.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(lidos) => lidos,
-            Err(erro) => {
-                push(id, Event::Error(erro.to_string()));
-                break;
-            }
-        };
-        acumulado.extend_from_slice(&buffer[..lidos]);
+        // Processar primeiro, ler depois. Na primeira volta isto consome o que
+        // veio com o handshake; nas seguintes o acumulado está vazio e o laço
+        // interno sai de imediato.
         loop {
             match frame::read_frame(&acumulado) {
                 Read::Incomplete => break,
@@ -257,8 +309,26 @@ fn ler_ate_fechar(id: u64, mut fluxo: TcpStream, masks: bool) {
                         }
                         Delivered::Pong | Delivered::Partial => {}
                         Delivered::Close(fim) => {
+                            let veio_com_codigo = fim.is_some();
                             let (code, reason) = fim.unwrap_or((1005, String::new()));
-                            let eco = frame::write_frame(frame::OP_CLOSE, &[], mascara(masks));
+                            // O eco leva o MESMO código de volta, que é o que o
+                            // RFC §5.5.1 manda ("SHOULD echo the status code").
+                            // Ecoar vazio dava um `'close'` com 1005 — "sem
+                            // código" — a quem tinha acabado de mandar 1000, e
+                            // um lado a dizer "encerramento normal" e o outro a
+                            // ouvir "não disse nada" é uma discordância sobre se
+                            // a despedida foi ordeira.
+                            //
+                            // 1005 é o que o RFC proíbe de aparecer NA REDE: é o
+                            // valor que uma API mostra quando não veio código, e
+                            // não um código que se envie. Por isso o eco vazio
+                            // se mantém nesse caso.
+                            let carga = if veio_com_codigo {
+                                code.to_be_bytes().to_vec()
+                            } else {
+                                Vec::new()
+                            };
+                            let eco = frame::write_frame(frame::OP_CLOSE, &carga, mascara(masks));
                             let _ = fluxo.write_all(&eco);
                             push(id, Event::Close { code, reason });
                             encerrar(id);
@@ -273,6 +343,18 @@ fn ler_ate_fechar(id: u64, mut fluxo: TcpStream, masks: bool) {
                 }
             }
         }
+        let bytes = match fluxo.read_plaintext() {
+            Ok(Chunk::Eof) => break,
+            // Um pedaço VAZIO não é fim: um registo TLS de controlo consome
+            // bytes da rede e não produz plaintext nenhum. Tratar isso como fim
+            // fechava a conexão a meio de uma troca de chaves.
+            Ok(Chunk::Data(bytes)) => bytes,
+            Err(erro) => {
+                push(id, Event::Error(erro.to_string()));
+                break;
+            }
+        };
+        acumulado.extend_from_slice(&bytes);
     }
     // 1006 é o código que o RFC reserva para "fechou sem frame de close" — é o
     // que um cabo puxado produz, e mentir 1000 aqui faria uma queda parecer uma
@@ -313,10 +395,21 @@ fn push_server(id: u64, event: ServerEvent) {
     });
 }
 
+/// Fecha do lado nativo: sem por onde escrever, e CONTADA como fechada.
+///
+/// O `closed` é o que faltava aqui, e a falta só ficou visível quando houve
+/// cliente. `pending()` conta uma conexão não fechada como trabalho por fazer,
+/// para que o laço de eventos acorde a olhar por mensagens; uma conexão que o
+/// par encerrou nunca perdia essa marca, então o programa nunca terminava — o
+/// processo ficava a acordar de 5 em 5 ms sobre um socket que já não existia.
+///
+/// Do lado do servidor isto passou despercebido porque nada fechava: um teste
+/// que aceita uma ligação e acaba nunca chega a este caminho.
 fn encerrar(id: u64) {
     with_conns(|table| {
         if let Some(conn) = table.get_mut(&id) {
             conn.stream = None;
+            conn.closed = true;
         }
     });
 }
@@ -336,6 +429,24 @@ pub(super) fn send(id: u64, mensagem: &Message) -> bool {
 }
 
 /// Fecha educadamente: manda o frame de CLOSE e para de escrever.
+///
+/// # Por que isto NÃO marca a conexão como fechada
+///
+/// Porque o `'close'` que o programa espera é o do OUTRO lado. O RFC §5.5.1
+/// manda o par ecoar o close, e é esse eco que a thread de leitura transforma
+/// em [`Event::Close`] — com o código que voltou, que é o que um programa lê
+/// para saber se a despedida foi ordeira.
+///
+/// Marcar `closed` aqui tirava a conexão da conta de [`pending`], o laço de
+/// eventos achava que não tinha mais nada a fazer e o processo terminava antes
+/// de o eco chegar. Contra `wss://echo.websocket.org` isso era visível: a
+/// mensagem chegava, o `close(1000)` era enviado e o `'close'` nunca disparava
+/// — o programa saía com 0 e um listener por chamar.
+///
+/// O que substitui a marca é [`Conn::closing_since`]: a conexão continua a
+/// contar como trabalho, mas só por [`ESPERA_DE_FECHO`]. Um par que não ecoa
+/// nem fecha o socket é um par avariado, e esperar por ele para sempre seria
+/// trocar um evento perdido por um processo pendurado.
 pub(super) fn close(id: u64, code: u16, reason: &str) {
     with_conns(|table| {
         let Some(conn) = table.get_mut(&id) else { return };
@@ -345,10 +456,13 @@ pub(super) fn close(id: u64, code: u16, reason: &str) {
         let quadro = frame::write_frame(frame::OP_CLOSE, &carga, mascara(conn.masks));
         let _ = fluxo.write_all(&quadro);
         conn.stream = None;
-        conn.closed = true;
+        conn.closing_since = Some(std::time::Instant::now());
     });
 }
 
+/// Quanto tempo uma conexão a fechar espera pelo eco do par antes de o laço
+/// deixar de a contar. O RFC não põe número; este é o do `ws` do npm.
+const ESPERA_DE_FECHO: Duration = Duration::from_secs(30);
 pub(super) fn close_server(id: u64) {
     with_servers(|table| {
         if let Some(server) = table.get_mut(&id) {
@@ -415,7 +529,20 @@ pub(super) fn pending() -> Pending {
     if com_evento {
         return Pending::In(Duration::ZERO);
     }
-    let conectado = with_conns(|table| table.values().any(|c| c.owner == esta && !c.closed));
+    // Uma conexão a fechar continua a segurar o laço — é o eco do par que
+    // vira o `'close'` — mas só por [`ESPERA_DE_FECHO`]. Ver o doc de
+    // [`close`] para o evento que se perdia sem isto e o processo que se
+    // penduraria sem o prazo.
+    let conectado = with_conns(|table| {
+        table.values().any(|c| {
+            c.owner == esta
+                && !c.closed
+                && match c.closing_since {
+                    Some(desde) => desde.elapsed() < ESPERA_DE_FECHO,
+                    None => true,
+                }
+        })
+    });
     if conectado {
         return Pending::In(PASSADA);
     }

--- a/crates/rts-node/src/ws/handshake.rs
+++ b/crates/rts-node/src/ws/handshake.rs
@@ -113,7 +113,7 @@ pub fn response(client_key: &str) -> Vec<u8> {
 }
 
 /// Onde os cabeçalhos terminam.
-fn find_end(bytes: &[u8]) -> Option<usize> {
+pub(super) fn find_end(bytes: &[u8]) -> Option<usize> {
     bytes.windows(4).position(|janela| janela == b"\r\n\r\n")
 }
 

--- a/crates/rts-node/src/ws/mod.rs
+++ b/crates/rts-node/src/ws/mod.rs
@@ -13,10 +13,14 @@
 //! `node:` responde ao que um programa escrito para outro runtime espera
 //! encontrar. `import { WebSocketServer } from "ws"` é exatamente isso.
 //!
-//! O CLIENTE tem um segundo endereço legítimo — o global `WebSocket`, que
-//! `docs/reference/node/globals.md` §2.19 registra como adiado. Quando ele
-//! chegar, virá deste mesmo núcleo: [`frame`] não conhece cliente nem servidor,
-//! só o RFC.
+//! O CLIENTE está aqui — `new WebSocket(url)` — e veio deste mesmo núcleo:
+//! [`frame`] não conhece cliente nem servidor, só o RFC, e não mudou uma linha
+//! para o receber. O que faltava era o handshake de saída, que é [`client`].
+//!
+//! Tem um segundo endereço legítimo que continua por preencher: o global
+//! `WebSocket`, que `docs/reference/node/globals.md` §2.19 regista como adiado.
+//! Quando chegar, é este construtor sob outro nome e não uma segunda
+//! implementação.
 //!
 //! # O que NÃO está aqui, e por nome
 //!
@@ -27,9 +31,11 @@
 //! é a que funciona.
 
 mod api;
+mod client;
 mod conn;
 mod frame;
 mod handshake;
+mod transport;
 
 use rts_core::entry::{self, Context, Pending};
 

--- a/crates/rts-node/src/ws/transport.rs
+++ b/crates/rts-node/src/ws/transport.rs
@@ -1,0 +1,153 @@
+//! Por onde os bytes de uma conexão passam — TCP cru ou TLS.
+//!
+//! # Reuse-check: o TLS aqui é o `tls::conn::Driver`, não uma segunda sessão
+//!
+//! `node:tls` já resolveu "conduzir uma `rustls::Connection` sem runtime
+//! async": o [`Driver`](crate::tls::conn::Driver) é puro sobre buffers de bytes
+//! — `feed(ciphertext) -> plaintext`, `send(plaintext)`, `outgoing() ->
+//! ciphertext` — e não conhece socket nem JS. Este ficheiro é o que lhe liga um
+//! `TcpStream`, e é a ÚNICA coisa que acrescenta. Uma segunda condução do
+//! rustls escrita aqui seria a duplicação que o reuse-check chama de fatal: dois
+//! sítios a decidir quando um registo está completo.
+//!
+//! O `tls/socket.rs` não serve para isto pela razão oposta e igualmente
+//! concreta: ele constrói um `net.Socket` do JavaScript e conduz o TLS a partir
+//! dos eventos `'data'` desse objeto. Um cliente WebSocket precisa de bytes
+//! antes de haver um objeto JS, e a partir de uma thread que não pode tocar em
+//! nenhum — é a regra que o `ws/conn.rs` inteiro existe para respeitar.
+//!
+//! # Ordem dos locks, que é onde isto pode travar
+//!
+//! São duas fechaduras: a da tabela de conexões (`ws/conn.rs`) e a da sessão
+//! TLS aqui. `send` do lado do JS pega a tabela e depois a sessão; a thread de
+//! leitura pega a sessão para descodificar e depois a tabela para enfileirar o
+//! evento. Ordem inversa é o impasse clássico.
+//!
+//! O que o impede é [`Transport::read_plaintext`] devolver os bytes com a
+//! sessão JÁ LIBERTADA — nenhum caminho aqui segura a sessão enquanto chama
+//! `push`. Está escrito com escopos explícitos por isso, e não por estilo.
+
+use std::io::{self, Read as _, Write as _};
+use std::net::TcpStream;
+use std::sync::{Arc, Mutex};
+
+use crate::tls::conn::Driver;
+
+/// O que uma leitura produziu.
+pub(super) enum Chunk {
+    /// Bytes de aplicação. Pode vir VAZIO sem que a conexão tenha acabado: um
+    /// registo TLS de controlo consome bytes da rede e não produz plaintext
+    /// nenhum, e tratar isso como fim de ficheiro fechava a conexão a meio de
+    /// uma troca de chaves.
+    Data(Vec<u8>),
+    Eof,
+}
+
+/// Por onde uma conexão fala.
+///
+/// Clonável no sentido de [`Transport::try_clone`]: o `TcpStream` duplica-se
+/// (dois descritores para o mesmo socket, que é o que separa ler de escrever) e
+/// a sessão TLS **não** — ela é estado partilhado atrás de um `Arc<Mutex<_>>`,
+/// porque uma sessão TLS duplicada seriam dois contadores de sequência a
+/// discordar no primeiro registo.
+pub(super) enum Transport {
+    Plain(TcpStream),
+    Tls { tcp: TcpStream, session: Arc<Mutex<Driver>> },
+}
+
+impl Transport {
+    pub(super) fn plain(tcp: TcpStream) -> Transport {
+        Transport::Plain(tcp)
+    }
+
+    pub(super) fn tls(tcp: TcpStream, driver: Driver) -> Transport {
+        Transport::Tls { tcp, session: Arc::new(Mutex::new(driver)) }
+    }
+
+    pub(super) fn try_clone(&self) -> io::Result<Transport> {
+        match self {
+            Transport::Plain(tcp) => tcp.try_clone().map(Transport::Plain),
+            Transport::Tls { tcp, session } => {
+                tcp.try_clone().map(|tcp| Transport::Tls { tcp, session: Arc::clone(session) })
+            }
+        }
+    }
+
+    /// Escreve bytes de aplicação, cifrando-os quando há sessão.
+    pub(super) fn write_all(&mut self, plaintext: &[u8]) -> io::Result<()> {
+        match self {
+            Transport::Plain(tcp) => tcp.write_all(plaintext),
+            Transport::Tls { tcp, session } => {
+                let ciphertext = {
+                    let mut driver = lock(session);
+                    driver.send(plaintext);
+                    driver.outgoing()
+                };
+                tcp.write_all(&ciphertext)
+            }
+        }
+    }
+
+    /// Lê bytes de aplicação, bloqueando até chegar alguma coisa.
+    ///
+    /// A leitura da rede acontece **fora** do lock da sessão — é o ponto todo
+    /// deste desenho. Uma `read` bloqueante com a sessão presa impediria
+    /// qualquer escrita durante o tempo em que não chega nada, que numa
+    /// conversa por WebSocket é quase sempre.
+    pub(super) fn read_plaintext(&mut self) -> io::Result<Chunk> {
+        let mut buffer = [0u8; 8192];
+        match self {
+            Transport::Plain(tcp) => match tcp.read(&mut buffer)? {
+                0 => Ok(Chunk::Eof),
+                lidos => Ok(Chunk::Data(buffer[..lidos].to_vec())),
+            },
+            Transport::Tls { tcp, session } => {
+                let lidos = tcp.read(&mut buffer)?;
+                if lidos == 0 {
+                    return Ok(Chunk::Eof);
+                }
+                // A sessão é presa aqui e solta antes de sair — ver a nota sobre
+                // ordem dos locks no topo do módulo.
+                let (plaintext, pendente, erro) = {
+                    let mut driver = lock(session);
+                    let fed = driver.feed(&buffer[..lidos]);
+                    (fed.plaintext, driver.outgoing(), fed.error)
+                };
+                if let Some(erro) = erro {
+                    return Err(io::Error::other(erro));
+                }
+                // O rustls pode querer responder sem que o programa tenha pedido
+                // nada — uma troca de chaves de TLS 1.3, por exemplo. Ignorar
+                // isto deixa a sessão a meio de um protocolo que o par já
+                // avançou.
+                if !pendente.is_empty() {
+                    tcp.write_all(&pendente)?;
+                }
+                Ok(Chunk::Data(plaintext))
+            }
+        }
+    }
+
+    /// Levanta os prazos que o handshake pôs — ver o doc de
+    /// [`super::client::connect`] para a diferença entre "ainda não abriu" e
+    /// "está aberta e calada".
+    pub(super) fn clear_timeouts(&self) {
+        let tcp = match self {
+            Transport::Plain(tcp) => tcp,
+            Transport::Tls { tcp, .. } => tcp,
+        };
+        let _ = tcp.set_read_timeout(None);
+        let _ = tcp.set_write_timeout(None);
+    }
+}
+
+/// A fechadura da sessão, envenenada ou não.
+///
+/// Uma thread que entrou em pânico com a sessão presa deixa-a envenenada, e
+/// recusar a partir daí mataria a conexão por causa de um pânico noutro sítio.
+/// O estado do rustls é consistente na fronteira de cada método, que é onde o
+/// lock é tomado e largado.
+fn lock(session: &Mutex<Driver>) -> std::sync::MutexGuard<'_, Driver> {
+    session.lock().unwrap_or_else(|envenenado| envenenado.into_inner())
+}
+

--- a/crates/rts-std/src/test.rs
+++ b/crates/rts-std/src/test.rs
@@ -104,28 +104,51 @@ extern "C" fn test(_e: u64, _this: u64, name: u64, body: u64, _a2: u64, _a3: u64
     answered
 }
 
-/// `expect(value)` — an object carrying the value and the matchers.
-extern "C" fn expect(_e: u64, _this: u64, value: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
-    let object = rts_core::entry::with_runtime(rts_core::entry::make_object);
-    let members: &[(&str, Provided)] = &[
-        ("toBe", to_be),
-        ("toEqual", to_be),
-        ("toBeTruthy", to_be_truthy),
-        ("toBeFalsy", to_be_falsy),
-        ("toBeNull", to_be_null),
-        ("toBeUndefined", to_be_undefined),
-        ("toBeDefined", to_be_defined),
-    ];
-    rts_core::entry::with_runtime(|context| {
-        rts_core::entry::put_member(context, object, RECEIVED, value);
-        for (name, code) in members {
-            let method = rts_core::entry::make_callable(context, *code);
-            rts_core::entry::put_member(context, object, name, method);
-        }
-    });
-    object
-}
+/// The matchers, on ONE prototype every `expect` shares.
+///
+/// `make_prototype` is memoised by name, so these seven callables are built
+/// once for the process instead of once per call — which is what makes
+/// [`expect`] a single allocation.
+const MATCHERS: &[(&str, Provided)] = &[
+    ("toBe", to_be),
+    ("toEqual", to_be),
+    ("toBeTruthy", to_be_truthy),
+    ("toBeFalsy", to_be_falsy),
+    ("toBeNull", to_be_null),
+    ("toBeUndefined", to_be_undefined),
+    ("toBeDefined", to_be_defined),
+];
 
+/// `expect(value)` — an object carrying the value and the matchers.
+///
+/// # One allocation, and why that is correctness rather than economy
+///
+/// This used to make a plain object and then, in a second borrow, hang SEVEN
+/// freshly built callables off it. The object lived in a Rust local across all
+/// of them, and every one of those `make_callable`/`put_member` calls can
+/// collect — which is hiding place two of `docs/engine/lost-roots.md`, the one
+/// `json::materialise` was caught by: *a native building a cell out of a Rust
+/// local*. The guard for it, `entry::rooted::Rooted`, is `pub(in crate::entry)`
+/// and this crate cannot reach it.
+///
+/// A shared prototype removes the window instead of guarding it. `make_instance`
+/// is the only allocation between having nothing and having a complete object,
+/// so there is no longer a half-built cell to lose. The failure this fixes was
+/// visible and misleading: under memory pressure the suite reported
+/// `TypeError: (intermediate value).toBe is not a function` — the matcher
+/// object had been swept between `expect(x)` and reading `.toBe` off it, and
+/// the file that crashed was never the file at fault.
+///
+/// It is also seven allocations cheaper per assertion, which a suite of three
+/// thousand assertions pays three thousand times. That is the smaller half.
+extern "C" fn expect(_e: u64, _this: u64, value: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
+    rts_core::entry::with_runtime(|context| {
+        let prototype = rts_core::entry::make_prototype(context, "Expectation", MATCHERS);
+        let object = rts_core::entry::make_instance(context, prototype);
+        rts_core::entry::put_member(context, object, RECEIVED, value);
+        object
+    })
+}
 /// Where `expect` keeps what it was given.
 ///
 /// A name a program is unlikely to write, and reachable if it does — see the

--- a/docs/engine/lost-roots.md
+++ b/docs/engine/lost-roots.md
@@ -205,13 +205,110 @@ it was verified on a DEBUG build — and the debug build answers 120000 with and
 without it. The control was not run first. **A fix verified in a cell that never
 had the bug is not verified.**
 
-**A second symptom in the same shape, also open**: 300 000 rounds exhaust the
-heap outright — "the region grew to its whole reservation of 524288 cells and
-all of them are in use even after a collection" — before and after that attempt.
-Two symptoms; at least one cause still unfound. Check 1 of this document passes:
-all twenty-one `Aside` fields are either walked by `trace::edges_of` or named in
-its closing comment, so it is not another `cursors`.
+**A second symptom in the same shape — FOUND, and it was not a root at all**:
+300 000 rounds exhausted the heap outright, "the region grew to its whole
+reservation of 524288 cells and all of them are in use even after a collection".
 
+That message was false, and its falseness is the lesson. The collector was
+reporting `live 2366` and `freed 521867` on the cycle before the stop: half a
+million cells free, and the next allocation refused. Nothing was over-rooted and
+nothing leaked. **`Region::free` has two destinations** — an object of two or
+more cells goes back as a run in `free_runs`, one of a single cell is threaded
+onto the linked list — and `alloc_spanning`, once the bump space is gone, read
+only `free_runs`. A generator frame is a one-cell object (`function* g() { yield
+1; }` fits in one), so every frame this program freed went somewhere the
+allocation that needed it would never look.
+
+Fixed 2026-09-02 by a one-cell arm in `alloc_spanning` that falls through to
+`Region::alloc`, which is the path that reads the linked list. Measured on the
+same program: 300 000 rounds `ok 300000` and 1 000 000 rounds `ok 1000000`,
+against heap exhaustion before. `heap::region::span`'s `one_cell_reuse` tests
+pin it and were checked to FAIL with the arm disabled.
+
+**Why it is in this document even though it is not a lost root.** Because it
+presented as one, and cost a day of looking for one. The exhaustion message
+asserted more than the code knew — "all of them are in use" was a guess about
+why an allocation failed, not an observation — and two hypotheses were built and
+discarded on the strength of it (over-rooting through uninitialised frame slots,
+which was tested by zeroing the frame and changed nothing). **An error message
+that states a cause rather than a symptom sends every reader the same wrong
+way.**
+
+### `expect()` built a cell out of a Rust local — hiding place two, in `rts-std`
+
+Found 2026-09-02, fixed. `rts:test`'s `expect(value)` made a plain object and
+then, in a second borrow, hung SEVEN freshly built callables off it — the object
+living in a Rust `u64` across all eight allocations, every one of which can
+collect. That is exactly `json::materialise`'s shape, and this document's own
+closing section had named the place: *"the other twenty-odd crates — `rts-std`,
+`rts-node`, … all build cells from Rust locals, and none was read"*.
+
+The symptom was a lie about which file was broken: under memory pressure the
+suite reported `TypeError: (intermediate value).toBe is not a function` inside
+whatever test file happened to be running — the matcher object had been swept
+between `expect(x)` and reading `.toBe` off it.
+
+The fix is not the `Rooted` guard, because **`entry::rooted::Rooted` is
+`pub(in crate::entry)` and no other crate can reach it**. That is worth stating
+plainly: the mechanism this document recommends for hiding place two is
+unavailable to every crate the closing section warns about. What was done
+instead removes the window rather than guarding it — one shared prototype
+(`make_prototype` is memoised by name) and one `make_instance`, so there is no
+half-built cell to lose. It is also seven allocations cheaper per assertion.
+
+**And it made the generator defect below DETERMINISTIC.** With `expect`
+allocating eight times per assertion, `generator_for_of_root.test.ts` passed;
+with it allocating once, two of its five cases fail with wrong answers rather
+than intermittently. Less allocation revealed the bug instead of hiding it,
+which is the direction to prefer — but it means that file now fails alone, and
+the reason is recorded here rather than in a commit nobody will find.
+
+### What the generator defect actually looks like, measured
+
+The entry above quotes 60683-under-`RTS_GC_DEBUG`. That cell no longer
+reproduces; the binary has moved. What reproduces on 2026-09-02, **outside the
+test harness and with no flag set**, is worse than what was recorded:
+
+```js
+function* many() { yield 1; yield 2; yield 3; }
+let first = 0;
+for (let i = 0; i < 20000; i++) { for (const v of many()) { first = first + v; break; } }
+function* inner() { yield 1; yield 2; }
+function* outer() { yield* inner(); yield 3; }
+let total = 0;
+for (let i = 0; i < 20000; i++) { for (const v of outer()) total = total + v; }
+console.log(first, total);   // 20000 correct, and total should be 120000
+```
+
+| build | `total` |
+|---|---|
+| `a3de2a3f`, untouched | **5970** |
+| with the two fixes above | **28662** |
+
+Run the `yield*` loop ALONE and it answers 120000. It needs the first loop's
+20 000 generators ahead of it, which is what makes accumulated heap pressure
+part of the reproduction and why every attempt to shrink the case has hidden it.
+
+**Three candidates excluded, each by measurement rather than by argument:**
+
+- `Context::resuming` as a root — the previous entry already suspected this and
+  was verified on debug, which never had the bug. Retested here against the
+  release reproducer above: `50423` with and without. It is not this.
+- **Uninitialised frame slots read as references.** `alloc_spanning` never zeroes
+  the data slots and `generator::State::trace` pushes every slot of the frame as
+  a root candidate, so a recycled frame's garbage can retain dead cells in a
+  chain. Zeroing the frame on creation changed nothing.
+- **`xmm6`–`xmm15`.** `registers.rs` records that this capture was written,
+  built and reverted on 2026-08-29 for want of a program that forced it, and
+  names the condition for reopening: *"a program that breaks it makes it
+  necessary again"*. The program above is one. The capture was rewritten, built
+  and measured: `28662` with it and without it, to the digit. Reverted again,
+  and the module's standard is why — a root source nobody can demonstrate is a
+  permanent cost paid against a hypothesis.
+
+Check 1 of this document still passes: all twenty-one `Aside` fields are either
+walked by `trace::edges_of` or named in its closing comment, so it is not
+another `cursors`.
 `tests/generator_for_of_root.test.ts` holds five cases of the shape. They pass
 on the build that has the defect and are a guard, not a reproduction; the header
 says so.

--- a/tests/claude-ws-client.test.ts
+++ b/tests/claude-ws-client.test.ts
@@ -1,0 +1,139 @@
+// O cliente WebSocket contra o servidor deste mesmo crate, em loopback.
+//
+// Não toca a rede de propósito: uma fixture que depende de um servidor na
+// internet falha por motivos que não são do motor, e um teste que às vezes
+// passa não mede nada. O que isto cobre e um teste de unidade não consegue é o
+// handshake de saída inteiro (pedido, 101, `Sec-WebSocket-Accept`), o
+// mascaramento — que o cliente é obrigado a fazer e o servidor a recusar se
+// faltar — e o caminho pelo laço de eventos nos dois sentidos.
+//
+// # Por que o `describe` está DENTRO de um callback
+//
+// Porque o `rts:test` avalia cada `test()` no momento em que o encontra, e um
+// handshake WebSocket só acaba muitas voltas do laço de eventos depois — um
+// `expect` escrito ao lado do `new WebSocket(...)` compara o estado inicial e
+// falha contra um cliente que ainda não teve tempo de abrir. Registar o
+// `describe` a partir do `'close'` é o que faz as asserções correrem quando os
+// valores já existem; o relatório sai no fim do processo, e um `test()` chamado
+// de dentro do laço entra nele como qualquer outro.
+//
+// A primeira versão disto resolvia o mesmo problema com um SUBPROCESSO, e
+// custava caro por uma razão que não se adivinha: um processo `rts` extra
+// acrescenta o seu runtime inteiro ao pico de memória da suite, que corre os
+// ficheiros em PARALELO, e isso empurrava `generator_for_of_root.test.ts` —
+// que é um canário do defeito ABERTO de raízes perdidas de
+// `docs/engine/lost-roots.md`, e cujo próprio cabeçalho o descreve como
+// sensível a pressão de memória ("300 000 rondas esgotam a heap"). Três
+// corridas da suite com o subprocesso, três quedas desse ficheiro; sem ele,
+// nenhuma, e a lista de perdidos vazia. Um processo em vez de dois não é
+// arrumação: é a diferença entre esta fixture medir o cliente ws e medir a
+// memória livre da máquina.
+import { describe, test, expect } from "rts:test";
+import { WebSocketServer, WebSocket } from "ws";
+
+const PORT = 39187;
+
+let readyStateAoConstruir = -1;
+let readyStateAoAbrir = -1;
+let servidorViu = "";
+let ecoTexto = "";
+let ecoBytes = -1;
+let ecoPrimeiroByte = -1;
+let codigoDeFecho = -1;
+
+const server = new WebSocketServer({ port: PORT });
+
+server.on("connection", (socket: any) => {
+  socket.on("message", (data: any, isBinary: boolean) => {
+    if (isBinary) {
+      socket.send(data);
+    } else {
+      servidorViu = String(data);
+      socket.send("echo:" + String(data));
+    }
+  });
+});
+
+const client = new WebSocket("ws://127.0.0.1:" + PORT + "/room?id=7", {
+  origin: "https://example.test",
+  headers: { "User-Agent": "Oniwalib/1" },
+});
+
+// CONNECTING é 0, e é o que o construtor tem de devolver — a resposta ao
+// handshake ainda nem começou.
+readyStateAoConstruir = client.readyState;
+
+client.on("open", () => {
+  readyStateAoAbrir = client.readyState;
+  client.send("hello");
+});
+
+client.on("message", (data: any, isBinary: boolean) => {
+  if (isBinary) {
+    const bytes = Buffer.from(data);
+    ecoBytes = bytes.length;
+    ecoPrimeiroByte = bytes[0];
+    client.close(1000, "done");
+  } else {
+    ecoTexto = String(data);
+    client.send(Buffer.from([7, 8, 9]));
+  }
+});
+
+client.on("error", (erro: any) => {
+  server.close();
+  relatar("the client failed to connect: " + erro.message);
+});
+
+client.on("close", (code: number) => {
+  codigoDeFecho = code;
+  server.close();
+  relatar("");
+});
+
+// Rede de segurança: sem isto, um handshake que nunca completa deixa o processo
+// a girar até o harness o matar, e um ficheiro morto por timeout diz muito
+// menos do que um que falha com o nome da verificação que caiu.
+const guarda = setTimeout(() => {
+  server.close();
+  client.close();
+  relatar("the scenario did not finish within 8s");
+}, 8000);
+
+// Corre as asserções uma vez só — o `'close'` e a guarda podem ambos disparar.
+let relatado = false;
+function relatar(falha: string) {
+  if (relatado) return;
+  relatado = true;
+  clearTimeout(guarda);
+
+  describe("ws client", () => {
+    test("connects and opens", () => {
+      expect(falha).toBe("");
+    });
+
+    test("readyState goes CONNECTING then OPEN", () => {
+      expect(readyStateAoConstruir).toBe(0);
+      expect(readyStateAoAbrir).toBe(1);
+    });
+
+    test("the server receives what the client sent", () => {
+      expect(servidorViu).toBe("hello");
+    });
+
+    test("a text message round-trips", () => {
+      expect(ecoTexto).toBe("echo:hello");
+    });
+
+    test("a binary message round-trips as bytes", () => {
+      expect(ecoBytes).toBe(3);
+      expect(ecoPrimeiroByte).toBe(7);
+    });
+
+    // 1000 e não 1005: o par tem de ecoar o código que recebeu, e um eco vazio
+    // dava "sem código" a quem tinha acabado de dizer "encerramento normal".
+    test("close carries the code the client sent", () => {
+      expect(codigoDeFecho).toBe(1000);
+    });
+  });
+}

--- a/tests/generator_for_of_root.test.ts
+++ b/tests/generator_for_of_root.test.ts
@@ -1,11 +1,31 @@
-// A generator iterated by `for`-`of` can END EARLY, in silence, and this file
-// does NOT reproduce it.
+// A generator iterated by `for`-`of` can END EARLY, in silence.
 //
-// It is here as a guard on the shape and as the record of an OPEN defect, not
-// as a regression test — every case below passes on the build that has the bug.
-// What reproduces it is a release binary with `RTS_GC_DEBUG=1`, which adds one
-// `eprintln!` INSIDE `collect` and changes no logic at all:
+// # 2026-09-02: two of these five now REPRODUCE it, and that is an improvement
 //
+// This header used to say the file "does NOT reproduce it" and that "every case
+// below passes on the build that has the bug". Both were true when written and
+// neither is now. `yield* delegation across the same window` and `an early break
+// leaves nothing behind` fail with WRONG ANSWERS — 77994 for 120000, and 1 for
+// 20000 — on a plain release binary with no flag set.
+//
+// Nothing here changed to make that happen. What changed is `rts:test`'s own
+// `expect()`, which used to allocate eight times per assertion (a plain object
+// plus seven freshly built matcher callables) and now allocates once, through a
+// shared prototype. Less allocation between the `for`-`of` and the collection
+// stopped hiding the defect. **A test that passes because the harness around it
+// is noisy is not passing**, which is why this is recorded as a gain rather than
+// papered over: the file has stopped being a guard and started being a
+// reproduction.
+//
+// `docs/engine/lost-roots.md` carries the measurement, the reproducer that works
+// outside this harness, and the three candidates excluded so far — including the
+// two that were tried on 2026-09-02 and changed nothing (zeroing the generator
+// frame, and capturing `xmm6`-`xmm15`).
+//
+// The original note, kept because the cell it describes is still the shape of
+// the thing: what reproduced it in August was a release binary with
+// `RTS_GC_DEBUG=1`, which adds one `eprintln!` INSIDE `collect` and changes no
+// logic at all:
 //     function* g() { yield 1; }
 //     let x = 0;
 //     for (let i = 0; i < 120000; i++) { for (const v of g()) x = x + v; }


### PR DESCRIPTION
> **Base is #2609**, not `main`, so the diff shows only this work. Merge that one first.

The `ws` package had a server and no client, and `api.rs` said so by name:

> *"o núcleo já serve os dois lados (`conn::adopt` recebe se este lado mascara), mas falta o handshake de saída. Ausente por nome em vez de presente e quebrado."*

That entry was accurate, which is why this is small. **`frame.rs` did not change a line** — it already took `mask: Option<[u8; 4]>`, and the client is just the side that passes `Some`.

New: `client.rs` (URL parse, TCP with a deadline, TLS to completion, the `GET` with custom headers/`Origin`/subprotocols, `101` + `Sec-WebSocket-Accept` validation) and `transport.rs` (the twenty lines tying `tls::conn::Driver` to a `TcpStream`).

**Verified against a real server**: `wss://echo.websocket.org` connects, receives its greeting, echoes a message, closes with 1000, exit 0.

## Three real bugs, none of them in the new code

- `encerrar()` never set `closed`, so a program with a finished connection **never terminated** — it woke every 5 ms over a socket that was gone. Invisible on the server side because nothing ever closed.
- The CLOSE echo carried no status code, so a peer that sent `close(1000)` received a `'close'` with **1005** ("no code"). RFC 6455 §5.5.1 says echo it.
- `close()` marked the connection closed immediately, so the loop found no work and the process exited **before** the peer's echo arrived — the `'close'` listener never ran.

## Two GC fixes

**1. `alloc_spanning` of ONE cell could not reach the free list.** `Region::free` sends a multi-cell object back as a run in `free_runs` and a one-cell object onto the linked list; `alloc_spanning` read only `free_runs`. A generator frame is one cell, so every frame a program freed went where the allocation that needed it would never look.

| 300 000 rounds of `for (const v of g())` | |
|---|---|
| before | `heap exhausted` — while the collector reported `live 2366`, `freed 521867` |
| after | **`ok 300000`** (and `ok 1000000` at a million rounds) |

The exhaustion message claimed *"all of them are in use"*, which was false and cost a day — two hypotheses were built on it and discarded. An error message that states a cause rather than a symptom sends every reader the same wrong way.

**2. `rts:test`'s `expect()` built a cell out of a Rust local.** A plain object, then SEVEN freshly made callables hung off it, with the object in a Rust `u64` across all eight allocations. That is hiding place two of `docs/engine/lost-roots.md` — `json::materialise`'s exact shape — and it surfaced as `TypeError: (intermediate value).toBe is not a function` in whatever file happened to be running under memory pressure.

The `Rooted` guard is **not** the fix and cannot be: it is `pub(in crate::entry)` and no other crate can reach it. The document now records that as a hole in its own advice, since its closing section warns about exactly these crates. A shared prototype removes the window instead of guarding it — one allocation, not eight.

## Regression, stated — and it is not what it looks like

**`generator_for_of_root.test.ts` now fails.** It passed before, and nothing about generators changed here.

Fix 2 made it deterministic. With `expect` allocating eight times per assertion, the defect that file *documents* was hidden by the harness's own noise; with it allocating once, two of its five cases fail with wrong answers (77994 for 120000; 1 for 20000). A test that passes because the harness around it is noisy is not passing — so the file has stopped being a guard and become a **reproduction**, and its header now says so.

That defect is older and worse than the file recorded. On `a3de2a3f`, untouched, with no flag, outside the test harness, a `yield*` loop that should answer 120000 answers **5970**.

Three candidates excluded **by measurement, not argument**:
- `Context::resuming` — retested on a release reproducer, since the previous attempt was verified on debug, which never had the bug
- zeroing the generator frame (uninitialised slots read as references)
- reopening the `xmm6`–`xmm15` capture that `registers.rs` reverted in August *"for want of a program that forced it"* — there is such a program now; the capture changed the answer by zero digits, so it was reverted again on that module's own standard

## Measured

Per file against a binary of `a3de2a3f` run under the same load:

| | |
|---|---|
| suite | 787 passed of 840, before and after |
| LOST | `generator_for_of_root.test.ts` (above) |
| GAINED | `claude-ws-client.test.ts` |
| `cargo test --profile fast -p rts-core -p rts-std -p rts-node` | 415 passed, 0 failed |

## One behaviour change to know about

The `ws` package's `default` export moves from the server to the **client**. npm's `ws` does `module.exports = WebSocket` with `WebSocket.Server` hung off it, so `import WS from "ws"; new WS(url)` is what a ported program writes. It pointed at the server because the server was all there was — and `new WS("wss://…")` read the URL as an options object and asked for `{ port }`.

Not implemented, by name: TLS 1.2 (the crate's `CryptoProvider` publishes only 1.3 suites), `permessage-deflate`, explicit `ping()`/`pong()`, `binaryType`, `bufferedAmount`, redirects, proxies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa
