### PR TITLE
fix(lang): Uint8Array.of, and erase type-only imports

### DIFF
--- a/crates/rts-codegen/src/parse/item.rs
+++ b/crates/rts-codegen/src/parse/item.rs
@@ -31,7 +31,10 @@ pub(crate) fn program(cx: &mut Cx, parsed: &swc::Program, goal: Goal) -> Result<
                     continue;
                 }
                 in_prologue = false;
-                items.push(module_item(cx, item)?);
+                // `None` where TypeScript erases the statement — see `import_decl`.
+                if let Some(built) = module_item(cx, item)? {
+                    items.push(built);
+                }
             }
         }
         swc::Program::Script(script) => {
@@ -73,20 +76,62 @@ fn as_directive(statement: &swc::Stmt) -> Option<Directive> {
     })
 }
 
-fn module_item(cx: &mut Cx, item: &swc::ModuleItem) -> Result<ModuleItem> {
+/// One item, or `None` for one TypeScript erases entirely — today that is a
+/// type-only import, and [`import_decl`] says what the language does with it.
+fn module_item(cx: &mut Cx, item: &swc::ModuleItem) -> Result<Option<ModuleItem>> {
     Ok(match item {
-        swc::ModuleItem::Stmt(statement) => ModuleItem::Stmt(stmt(cx, statement)?),
+        swc::ModuleItem::Stmt(statement) => Some(ModuleItem::Stmt(stmt(cx, statement)?)),
         swc::ModuleItem::ModuleDecl(declaration) => match declaration {
-            swc::ModuleDecl::Import(import) => ModuleItem::Import(import_decl(cx, import)?),
-            other => ModuleItem::Export(export_decl(cx, other)?),
+            swc::ModuleDecl::Import(import) => import_decl(cx, import)?.map(ModuleItem::Import),
+            other => Some(ModuleItem::Export(export_decl(cx, other)?)),
         },
     })
 }
 
-fn import_decl(cx: &mut Cx, import: &swc::ImportDecl) -> Result<Import> {
+/// One `import`, or `None` when TypeScript erases the whole statement.
+///
+/// # Import elision, and why it is the parser's job
+///
+/// `import type { Foo } from "./x"` names nothing that exists at run time, and
+/// the language says so: the statement is ERASED, and no module is loaded. That
+/// is what lets `tsc` compile a file without reading the files it imports types
+/// from, and a program that relies on it is not doing anything unusual — it is
+/// the ordinary way a `.d.ts`-shaped module is consumed.
+///
+/// Keeping the import made a type-only module a run-time request for a module
+/// with no namespace, because `entry::module_publish` creates the namespace on
+/// the first export and a module of only interfaces has none. That runtime
+/// decision is right — *"a module that exports nothing has no namespace to speak
+/// of"*, as it says — and it is not what changes here. What changes is that the
+/// erased import stops reaching it.
+///
+/// This is done at the bridge rather than in a later pass because it is not a
+/// lowering decision: the statement is not in the program at all, and every
+/// pass after this one would otherwise have to know that some imports are not
+/// imports. `relative_imports` in the host still walks the file, which costs one
+/// parse of a module that is then compiled to nothing — the alternative is a
+/// second place that decides what a type-only import is, and two answers to that
+/// question is what this crate's rule 3 refuses.
+///
+/// Two spellings are erased, and they are the two TypeScript erases:
+/// - `import type { … } from "x"` — the whole statement.
+/// - `import { type A, type B } from "x"` — each marked specifier, and then the
+///   statement too if nothing is left. NOT if the statement had no specifiers to
+///   begin with: `import "x"` is a side-effect import and means the module RUNS,
+///   which is the one case where an empty binding list is the point.
+fn import_decl(cx: &mut Cx, import: &swc::ImportDecl) -> Result<Option<Import>> {
+    if import.type_only {
+        return Ok(None);
+    }
+    let had_specifiers = !import.specifiers.is_empty();
     let bindings = import
         .specifiers
         .iter()
+        .filter(|specifier| match specifier {
+            // `import { type A, B }` — only the marked one goes.
+            swc::ImportSpecifier::Named(named) => !named.is_type_only,
+            swc::ImportSpecifier::Default(_) | swc::ImportSpecifier::Namespace(_) => true,
+        })
         .map(|specifier| {
             Ok(match specifier {
                 swc::ImportSpecifier::Default(default) => {
@@ -107,16 +152,21 @@ fn import_decl(cx: &mut Cx, import: &swc::ImportDecl) -> Result<Import> {
                 },
             })
         })
-        .collect::<Result<_>>()?;
+        .collect::<Result<Vec<_>>>()?;
 
-    Ok(Import {
+    // Every binding was type-only: the statement erases with them. The guard is
+    // on what was WRITTEN, so `import "./x"` still runs the module.
+    if had_specifiers && bindings.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(Import {
         bindings,
         source: import.src.value.to_string_lossy().to_string(),
         attributes: attributes(import.with.as_deref()),
         at: position(import.span),
-    })
+    }))
 }
-
 /// `with { type: "json" }`.
 fn attributes(with: Option<&swc::ObjectLit>) -> Vec<ImportAttribute> {
     let Some(object) = with else {

--- a/crates/rts-core/src/entry/buffers/typed_classes.rs
+++ b/crates/rts-core/src/entry/buffers/typed_classes.rs
@@ -212,6 +212,38 @@ macro_rules! declare {
                     typed_visit::from($kind, source, mapper, receiver)
                 }
 
+                /// `T.of(...items)` — a typed array of exactly the arguments,
+                /// where [`from`](Self::from) takes one iterable.
+                ///
+                /// The second static, and it goes through `from` rather than
+                /// beside it: `of` is `from` over an array of the arguments, and
+                /// writing the element conversion twice is how the two end up
+                /// clamping differently — which is the failure this whole file
+                /// exists to prevent (see its module doc).
+                ///
+                /// `rest_arguments` is called OUTSIDE any borrow, because it is
+                /// an entry point that takes the ambient one; a nested borrow
+                /// aborts the process rather than failing.
+                ///
+                /// # The divergence, stated
+                ///
+                /// `rest_arguments` drops trailing `undefined`, which is right
+                /// for a rest parameter and wrong here by one case:
+                /// `Uint8Array.of(1, undefined)` answers a length of 1 where
+                /// Node answers 2 (`undefined` becomes `NaN` becomes 0). A
+                /// native has four argument slots and no count beside them, so
+                /// telling "two arguments, the second `undefined`" from "one
+                /// argument" needs something this boundary does not carry.
+                /// Passing an explicit `undefined` to `of` is the whole of what
+                /// is lost, and answering a length that is right for every other
+                /// call was judged better than refusing all of them.
+                #[stat]
+                fn of(a0: u64, a1: u64, a2: u64, a3: u64) -> u64 {
+                    let items = crate::entry::functions::rest_arguments(0, a0, a1, a2, a3);
+                    let absent = crate::entry::undefined_value();
+                    typed_visit::from($kind, items, absent, absent)
+                }
+
                 /// `t.forEach(callback, thisArg)`.
                 fn for_each(this: u64, callback: u64, receiver: u64) -> u64 {
                     typed_visit::for_each(this, callback, receiver)

--- a/tests/_module_types_only.ts
+++ b/tests/_module_types_only.ts
@@ -1,0 +1,8 @@
+// Um módulo SÓ de tipos: nada disto sobrevive ao type-strip.
+//
+// Existe para `claude-module-type-only.test.ts`, e o ponto é precisamente que
+// não exporta nada em tempo de execução.
+export interface Shape {
+  side: number;
+}
+export type Name = string;

--- a/tests/claude-module-type-only.test.ts
+++ b/tests/claude-module-type-only.test.ts
@@ -1,0 +1,49 @@
+// Um módulo só de tipos pode ser importado.
+//
+// O que isto pina é o que o TypeScript SIGNIFICA, e não o que esta cadeia de
+// compilação faz: `import type { … } from "./x"` é apagado — é a "import
+// elision" da especificação, e a razão pela qual o TS pode compilar ficheiro a
+// ficheiro. Nenhum runtime vê o módulo, portanto não há módulo para resolver.
+//
+// Sem isso, `tests/_module_types_only.ts` chegava a tempo de execução como um
+// `import` a sério, e o programa parava com
+// `cannot resolve module "…_module_types_only.ts" — nothing registered that
+// specifier`. O módulo é carregado e compilado; o que não existe é uma entrada
+// na tabela de specifiers, porque `module_publish` cria o namespace no primeiro
+// export e um módulo só de tipos não tem nenhum. Essa decisão do runtime está
+// certa e não é o que muda: o que estava errado era o import sobreviver.
+//
+// A forma que se contornava na oniwalib (kaizeve/Oniwalib#13) era acrescentar
+// um export de runtime ao módulo de tipos só para o tornar registável.
+import { describe, test, expect } from "rts:test";
+import type { Shape, Name } from "./_module_types_only";
+
+// Os tipos são usados como tipos — que é a única coisa que se pode fazer com
+// eles — e o programa corre.
+const quadrado: Shape = { side: 4 };
+const nome: Name = "quadrado";
+
+describe("a type-only module", () => {
+  test("can be imported with `import type` and the program runs", () => {
+    expect(quadrado.side).toBe(4);
+    expect(nome).toBe("quadrado");
+  });
+
+  test("the annotation still describes the value", () => {
+    const outro: Shape = { side: quadrado.side * 2 };
+    expect(outro.side).toBe(8);
+  });
+});
+
+// # O que continua a NÃO funcionar, e é preciso saber
+//
+// `import { Shape } from "./_module_types_only"` — sem a palavra `type` — ainda
+// falha com a mesma mensagem. O TypeScript elide-o também, mas para saber que
+// pode fazê-lo tem de ver que `Shape` só é usado como tipo em todo o ficheiro,
+// que é uma análise de uso que esta cadeia não faz. `isolatedModules` existe
+// precisamente porque essa análise não é local, e escrever `import type` é o
+// que a especificação pede a quem compila ficheiro a ficheiro.
+//
+// Não está testado aqui porque um teste que afirma uma falha fixa uma decisão
+// que se quer mudar; está escrito porque a próxima pessoa a ler isto vai tentar
+// a forma sem `type` e merece saber porquê.


### PR DESCRIPTION
Two of the three language gaps from [kaizeve/Oniwalib#13](https://github.com/kaizeve/Oniwalib/issues/13). Independent of #2609/#2610 — based on `main`.

## The third one does not reproduce, and that is stated rather than skipped

> Blocos `{}` irmãos com `const` de mesmo nome → `ReferenceError: x is not defined`

Seven shapes tried — module top level, inside a function, `if`, `for`, `switch`/`case`, `try`/`catch`, class methods, with annotations, with closures capturing the binding, three blocks in a row. Every one answers correctly. Either it was fixed since it was reported, or it needs context I did not guess; the exact case from the oniwalib would settle it.

## `Uint8Array.of`

Missing from every typed array while `T.from` was there. It goes **through** `from` rather than beside it: `of` is `from` over an array of the arguments, and writing the element conversion twice is how two variants end up clamping differently — which is what `typed_classes.rs` exists to prevent, in its own module doc's words.

Verified across `Uint8Array`, `Int32Array`, `Float64Array`, empty, and wrapping (`Uint8Array.of(300)` → 44).

**Divergence, stated in the doc rather than hidden:** `Uint8Array.of(1, undefined)` answers a length of 1 where Node answers 2. A native has four argument slots and no count beside them, and `rest_arguments` drops trailing `undefined` — telling *"two arguments, the second `undefined`"* from *"one argument"* needs something this boundary does not carry.

## Type-only imports were not erased — and the issue located this elsewhere

The report read:

> Módulo só-de-tipos (só `export interface`/`type`) não fica registrável depois do type-strip — precisa de ao menos 1 export runtime.

The module is loaded and compiled fine. What was wrong is that `import type { Foo } from "./x"` **survived to run time** and asked for a module with no namespace.

`entry::module_publish` creates the namespace on the first export, and a module of only interfaces has none. That decision is **right**, in its own words — *"a module that exports nothing has no namespace to speak of, and `import * as ns` of it answering `undefined` is the honest result of that rather than an empty object pretending"* — and it is untouched here. What changes is that the erased import stops reaching it.

The bridge did not carry the flag at all: `syntax::Import` has no `type_only`, and swc's was dropped on the floor. Erasing happens **there** rather than in a later pass because the statement is not in the program at all, and every pass after it would otherwise have to know that some imports are not imports.

Two spellings go, which are the two TypeScript erases:
- `import type { … } from "x"` — the whole statement
- `import { type A, type B } from "x"` — each marked specifier, then the statement if nothing is left — but **not** if it had no specifiers to begin with, because `import "x"` is a side-effect import and running the module is the point

**What still fails**, recorded in the fixture so it is not rediscovered: `import { Shape } from "./types"` *without* the `type` keyword. TypeScript elides that too, but only after seeing that `Shape` is used solely as a type across the whole file — a use analysis this chain does not do, and precisely why `isolatedModules` exists.

## Gates

The fixture was written **before** the change and failed with the reported error, per this crate's rule 11. Rule 6 is why it asserts what the *language* means (the specification's import elision) rather than what this lowering emits.

| | |
|---|---|
| suite | **788 passed of 841** (was 787 of 840 — the gain is the new fixture) |
| LOST | **none** |
| `cargo test --profile fast -p rts-codegen -p rts-core` | all green |

Unrelated and **not** fixed, noticed while testing and confirmed on a pre-change binary: `import "./x"` for side effect does not evaluate the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa
