### PR TITLE
chore: split three files back under their ceilings, and re-measure the suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,12 +100,29 @@ UMD bundle's `typeof module` sniff now takes the CommonJS branch everywhere.
 
 `crates/rts-host/tests/running.rs` is what says so — every test in it runs
 the program rather than inspecting it — and the number is measured rather than
-claimed. **2026-08-29: 758 of the 819 `*.test.ts` files pass** (3 059 of 3 123
-assertions), by `target/fast/rts.exe test` at `d58bd54a`. It was 746 of 808 on
-08-22, 754 of 808 on 08-15, 756 of 799 on 08-10, 626 of 797 on 08-09 and 535 of
-818 at the start of 08-08, through generators, `yield*`, `Proxy`, native
-iterators, `export *`, a catchable throw, the bare `rts` specifier, stack traces,
-variadic natives and wrapper objects.
+claimed. **2026-09-02: 792 of the 845 `*.test.ts` files pass** (3 396 of 3 454
+assertions), by `target/release/rts.exe test` at `891b767c`. It was 758 of 819
+on 08-29, 746 of 808 on 08-22, 754 of 808 on 08-15, 756 of 799 on 08-10, 626 of
+797 on 08-09 and 535 of 818 at the start of 08-08, through generators, `yield*`,
+`Proxy`, native iterators, `export *`, a catchable throw, the bare `rts`
+specifier, stack traces, variadic natives and wrapper objects.
+
+**One of the 53 fails BY DESIGN, and reading the number without this reads it
+wrongly.** `tests/generator_for_of_root.test.ts` records an OPEN defect — a
+generator lost by the conservative stack scan — and it used to PASS on the build
+that had the bug. What changed on 09-02 is `rts:test`'s own `expect()`: it
+allocated eight times per assertion (a plain object plus seven freshly built
+matchers) and now allocates once, through a shared prototype. Less allocation
+between the `for`-`of` and the collection stopped hiding the defect, so two of
+that file's five cases now fail with WRONG ANSWERS — 77994 for 120000, 1 for
+20000 — on a plain release binary with no flag.
+
+That is the file becoming a REPRODUCTION rather than a guard, which is the
+direction to want: a test that passes because the harness around it is noisy is
+not passing. The defect is older and worse than it was recorded as — on
+`a3de2a3f`, untouched and outside the harness, a `yield*` loop that should
+answer 120000 answers **5970** — and `docs/engine/lost-roots.md` carries the
+reproducer plus the three candidates excluded by measurement so far.
 
 **`--profile fast` and not `--release`, and that is allowed here for the reason
 the merge-gate section gives**: `fast` differs from `release` in optimisation

--- a/crates/rts-codegen/src/parse/item.rs
+++ b/crates/rts-codegen/src/parse/item.rs
@@ -1,16 +1,14 @@
 //! Statements, functions, classes and modules.
 
-use swc_common::Spanned;
 use swc_ecma_ast as swc;
 
 use super::expr::{expr, property_key};
-use super::pat::{binding, binding_element, target};
+use super::pat::{binding, binding_element};
+use super::stmt::{decl, stmt, stmts};
 use super::{Cx, Result, position, unsupported};
 use crate::syntax::{
-    Binding, BindingKind, Catch, Claim, Class, ClassElement, ClassKey, Directive, Export,
-    ExportDefault, ExportKind, ExportSpecifier, Field, ForEachSource, ForEachTarget, ForInit,
-    Function, FunctionBody, Goal, Import, ImportAttribute, ImportBinding, Method, MethodKind,
-    ModuleItem, Parameter, Pattern, Program, Stmt, StmtKind, SwitchClause,
+    Binding, BindingKind, Claim, Class, ClassElement, ClassKey, Directive, Field, Function,
+    FunctionBody, Goal, Method, MethodKind, Parameter, Pattern, Program, Stmt, StmtKind,
 };
 use crate::syntax::{AssignOp, AssignTarget, Expr, ExprKind, Literal, LogicalOp, Spreadable};
 
@@ -32,7 +30,7 @@ pub(crate) fn program(cx: &mut Cx, parsed: &swc::Program, goal: Goal) -> Result<
                 }
                 in_prologue = false;
                 // `None` where TypeScript erases the statement — see `import_decl`.
-                if let Some(built) = module_item(cx, item)? {
+                if let Some(built) = super::module::module_item(cx, item)? {
                     items.push(built);
                 }
             }
@@ -45,7 +43,7 @@ pub(crate) fn program(cx: &mut Cx, parsed: &swc::Program, goal: Goal) -> Result<
                     continue;
                 }
                 in_prologue = false;
-                items.push(ModuleItem::Stmt(stmt(cx, statement)?));
+                items.push(crate::syntax::ModuleItem::Stmt(super::stmt::stmt(cx, statement)?));
             }
         }
     }
@@ -76,467 +74,8 @@ fn as_directive(statement: &swc::Stmt) -> Option<Directive> {
     })
 }
 
-/// One item, or `None` for one TypeScript erases entirely — today that is a
-/// type-only import, and [`import_decl`] says what the language does with it.
-fn module_item(cx: &mut Cx, item: &swc::ModuleItem) -> Result<Option<ModuleItem>> {
-    Ok(match item {
-        swc::ModuleItem::Stmt(statement) => Some(ModuleItem::Stmt(stmt(cx, statement)?)),
-        swc::ModuleItem::ModuleDecl(declaration) => match declaration {
-            swc::ModuleDecl::Import(import) => import_decl(cx, import)?.map(ModuleItem::Import),
-            other => Some(ModuleItem::Export(export_decl(cx, other)?)),
-        },
-    })
-}
-
-/// One `import`, or `None` when TypeScript erases the whole statement.
-///
-/// # Import elision, and why it is the parser's job
-///
-/// `import type { Foo } from "./x"` names nothing that exists at run time, and
-/// the language says so: the statement is ERASED, and no module is loaded. That
-/// is what lets `tsc` compile a file without reading the files it imports types
-/// from, and a program that relies on it is not doing anything unusual — it is
-/// the ordinary way a `.d.ts`-shaped module is consumed.
-///
-/// Keeping the import made a type-only module a run-time request for a module
-/// with no namespace, because `entry::module_publish` creates the namespace on
-/// the first export and a module of only interfaces has none. That runtime
-/// decision is right — *"a module that exports nothing has no namespace to speak
-/// of"*, as it says — and it is not what changes here. What changes is that the
-/// erased import stops reaching it.
-///
-/// This is done at the bridge rather than in a later pass because it is not a
-/// lowering decision: the statement is not in the program at all, and every
-/// pass after this one would otherwise have to know that some imports are not
-/// imports. `relative_imports` in the host still walks the file, which costs one
-/// parse of a module that is then compiled to nothing — the alternative is a
-/// second place that decides what a type-only import is, and two answers to that
-/// question is what this crate's rule 3 refuses.
-///
-/// Two spellings are erased, and they are the two TypeScript erases:
-/// - `import type { … } from "x"` — the whole statement.
-/// - `import { type A, type B } from "x"` — each marked specifier, and then the
-///   statement too if nothing is left. NOT if the statement had no specifiers to
-///   begin with: `import "x"` is a side-effect import and means the module RUNS,
-///   which is the one case where an empty binding list is the point.
-fn import_decl(cx: &mut Cx, import: &swc::ImportDecl) -> Result<Option<Import>> {
-    if import.type_only {
-        return Ok(None);
-    }
-    let had_specifiers = !import.specifiers.is_empty();
-    let bindings = import
-        .specifiers
-        .iter()
-        .filter(|specifier| match specifier {
-            // `import { type A, B }` — only the marked one goes.
-            swc::ImportSpecifier::Named(named) => !named.is_type_only,
-            swc::ImportSpecifier::Default(_) | swc::ImportSpecifier::Namespace(_) => true,
-        })
-        .map(|specifier| {
-            Ok(match specifier {
-                swc::ImportSpecifier::Default(default) => {
-                    ImportBinding::Default(cx.name(&default.local.sym))
-                }
-                swc::ImportSpecifier::Namespace(namespace) => {
-                    ImportBinding::Namespace(cx.name(&namespace.local.sym))
-                }
-                swc::ImportSpecifier::Named(named) => ImportBinding::Named {
-                    exported: match &named.imported {
-                        Some(swc::ModuleExportName::Ident(ident)) => ident.sym.to_string(),
-                        Some(swc::ModuleExportName::Str(string)) => {
-                            string.value.to_string_lossy().to_string()
-                        }
-                        None => named.local.sym.to_string(),
-                    },
-                    local: cx.name(&named.local.sym),
-                },
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    // Every binding was type-only: the statement erases with them. The guard is
-    // on what was WRITTEN, so `import "./x"` still runs the module.
-    if had_specifiers && bindings.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(Import {
-        bindings,
-        source: import.src.value.to_string_lossy().to_string(),
-        attributes: attributes(import.with.as_deref()),
-        at: position(import.span),
-    }))
-}
-/// `with { type: "json" }`.
-fn attributes(with: Option<&swc::ObjectLit>) -> Vec<ImportAttribute> {
-    let Some(object) = with else {
-        return Vec::new();
-    };
-    object
-        .props
-        .iter()
-        .filter_map(|property| {
-            let swc::PropOrSpread::Prop(prop) = property else {
-                return None;
-            };
-            let swc::Prop::KeyValue(pair) = &**prop else {
-                return None;
-            };
-            let key = match &pair.key {
-                swc::PropName::Ident(ident) => ident.sym.to_string(),
-                swc::PropName::Str(string) => string.value.to_string_lossy().to_string(),
-                _ => return None,
-            };
-            let swc::Expr::Lit(swc::Lit::Str(value)) = &*pair.value else {
-                return None;
-            };
-            Some(ImportAttribute {
-                key,
-                value: value.value.to_string_lossy().to_string(),
-            })
-        })
-        .collect()
-}
-
-fn export_decl(cx: &mut Cx, declaration: &swc::ModuleDecl) -> Result<Export> {
-    let at = position(declaration.span());
-    let kind = match declaration {
-        swc::ModuleDecl::ExportDecl(export) => {
-            ExportKind::Declaration(Box::new(decl(cx, &export.decl)?))
-        }
-
-        swc::ModuleDecl::ExportNamed(named) => ExportKind::Named {
-            specifiers: named
-                .specifiers
-                .iter()
-                .map(|specifier| match specifier {
-                    swc::ExportSpecifier::Named(entry) => Ok(ExportSpecifier {
-                        local: export_name(&entry.orig),
-                        exported: entry
-                            .exported
-                            .as_ref()
-                            .map(export_name)
-                            .unwrap_or_else(|| export_name(&entry.orig)),
-                    }),
-                    swc::ExportSpecifier::Default(entry) => Ok(ExportSpecifier {
-                        local: entry.exported.sym.to_string(),
-                        exported: "default".to_owned(),
-                    }),
-                    swc::ExportSpecifier::Namespace(entry) => Ok(ExportSpecifier {
-                        local: "*".to_owned(),
-                        exported: export_name(&entry.name),
-                    }),
-                })
-                .collect::<Result<_>>()?,
-            source: named
-                .src
-                .as_ref()
-                .map(|s| s.value.to_string_lossy().to_string()),
-            attributes: attributes(named.with.as_deref()),
-        },
-
-        swc::ModuleDecl::ExportDefaultDecl(default) => {
-            ExportKind::Default(ExportDefault::Declaration(Box::new(match &default.decl {
-                swc::DefaultDecl::Fn(function) => Stmt::new(
-                    StmtKind::Function(Box::new(function_expr(cx, function)?)),
-                    at,
-                ),
-                swc::DefaultDecl::Class(class) => {
-                    Stmt::new(StmtKind::Class(Box::new(class_expr(cx, class)?)), at)
-                }
-                swc::DefaultDecl::TsInterfaceDecl(interface) => {
-                    return unsupported("an exported interface", position(interface.span));
-                }
-            })))
-        }
-
-        swc::ModuleDecl::ExportDefaultExpr(default) => {
-            ExportKind::Default(ExportDefault::Expr(expr(cx, &default.expr)?))
-        }
-
-        swc::ModuleDecl::ExportAll(all) => ExportKind::All {
-            source: all.src.value.to_string_lossy().to_string(),
-            alias: None,
-            attributes: attributes(all.with.as_deref()),
-        },
-
-        swc::ModuleDecl::Import(_) => return unsupported("an import reached as an export", at),
-        swc::ModuleDecl::TsImportEquals(_)
-        | swc::ModuleDecl::TsExportAssignment(_)
-        | swc::ModuleDecl::TsNamespaceExport(_) => {
-            return unsupported("a TypeScript-only module declaration", at);
-        }
-    };
-
-    Ok(Export { kind, at })
-}
-
-fn export_name(name: &swc::ModuleExportName) -> String {
-    match name {
-        swc::ModuleExportName::Ident(ident) => ident.sym.to_string(),
-        swc::ModuleExportName::Str(string) => string.value.to_string_lossy().to_string(),
-    }
-}
-
-/// One statement.
-pub(crate) fn stmt(cx: &mut Cx, statement: &swc::Stmt) -> Result<Stmt> {
-    let at = position(statement.span());
-    let kind = match statement {
-        swc::Stmt::Expr(expression) => StmtKind::Expr(expr(cx, &expression.expr)?),
-        swc::Stmt::Empty(_) => StmtKind::Empty,
-        swc::Stmt::Debugger(_) => StmtKind::Debugger,
-
-        swc::Stmt::Block(block) => StmtKind::Block(stmts(cx, &block.stmts)?),
-
-        swc::Stmt::If(if_) => StmtKind::If {
-            condition: expr(cx, &if_.test)?,
-            then_branch: Box::new(stmt(cx, &if_.cons)?),
-            else_branch: match &if_.alt {
-                Some(alt) => Some(Box::new(stmt(cx, alt)?)),
-                None => None,
-            },
-        },
-
-        swc::Stmt::While(while_) => StmtKind::While {
-            condition: expr(cx, &while_.test)?,
-            body: Box::new(stmt(cx, &while_.body)?),
-        },
-
-        swc::Stmt::DoWhile(do_while) => StmtKind::DoWhile {
-            body: Box::new(stmt(cx, &do_while.body)?),
-            condition: expr(cx, &do_while.test)?,
-        },
-
-        swc::Stmt::For(for_) => StmtKind::For {
-            init: match &for_.init {
-                Some(swc::VarDeclOrExpr::VarDecl(declaration)) => Some(ForInit::Declare {
-                    kind: binding_kind(declaration.kind),
-                    bindings: declarators(cx, &declaration.decls)?,
-                }),
-                Some(swc::VarDeclOrExpr::Expr(expression)) => {
-                    Some(ForInit::Expr(expr(cx, expression)?))
-                }
-                None => None,
-            },
-            test: match &for_.test {
-                Some(test) => Some(expr(cx, test)?),
-                None => None,
-            },
-            update: match &for_.update {
-                Some(update) => Some(expr(cx, update)?),
-                None => None,
-            },
-            body: Box::new(stmt(cx, &for_.body)?),
-        },
-
-        swc::Stmt::ForIn(for_in) => StmtKind::ForEach {
-            source: ForEachSource::In,
-            target: for_head(cx, &for_in.left)?,
-            subject: expr(cx, &for_in.right)?,
-            body: Box::new(stmt(cx, &for_in.body)?),
-        },
-
-        swc::Stmt::ForOf(for_of) => StmtKind::ForEach {
-            source: if for_of.is_await {
-                ForEachSource::AwaitOf
-            } else {
-                ForEachSource::Of
-            },
-            target: for_head(cx, &for_of.left)?,
-            subject: expr(cx, &for_of.right)?,
-            body: Box::new(stmt(cx, &for_of.body)?),
-        },
-
-        swc::Stmt::Return(return_) => StmtKind::Return(match &return_.arg {
-            Some(value) => Some(expr(cx, value)?),
-            None => None,
-        }),
-
-        swc::Stmt::Break(break_) => StmtKind::Break(break_.label.as_ref().map(|l| cx.name(&l.sym))),
-        swc::Stmt::Continue(continue_) => {
-            StmtKind::Continue(continue_.label.as_ref().map(|l| cx.name(&l.sym)))
-        }
-
-        swc::Stmt::Labeled(labeled) => StmtKind::Labelled {
-            label: cx.name(&labeled.label.sym),
-            body: Box::new(stmt(cx, &labeled.body)?),
-        },
-
-        swc::Stmt::Switch(switch) => StmtKind::Switch {
-            discriminant: expr(cx, &switch.discriminant)?,
-            clauses: switch
-                .cases
-                .iter()
-                .map(|case| {
-                    Ok(SwitchClause {
-                        test: match &case.test {
-                            Some(test) => Some(expr(cx, test)?),
-                            None => None,
-                        },
-                        body: stmts(cx, &case.cons)?,
-                    })
-                })
-                .collect::<Result<_>>()?,
-        },
-
-        swc::Stmt::Throw(throw) => StmtKind::Throw(expr(cx, &throw.arg)?),
-
-        swc::Stmt::Try(try_) => StmtKind::Try {
-            body: stmts(cx, &try_.block.stmts)?,
-            catch: match &try_.handler {
-                Some(handler) => Some(Catch {
-                    binding: match &handler.param {
-                        Some(parameter) => Some(binding(cx, parameter)?),
-                        None => None,
-                    },
-                    body: stmts(cx, &handler.body.stmts)?,
-                }),
-                None => None,
-            },
-            finally: match &try_.finalizer {
-                Some(block) => Some(stmts(cx, &block.stmts)?),
-                None => None,
-            },
-        },
-
-        swc::Stmt::With(with) => StmtKind::With {
-            object: expr(cx, &with.obj)?,
-            body: Box::new(stmt(cx, &with.body)?),
-        },
-
-        swc::Stmt::Decl(declaration) => return decl(cx, declaration),
-    };
-
-    Ok(Stmt::new(kind, at))
-}
-
-fn stmts(cx: &mut Cx, list: &[swc::Stmt]) -> Result<Vec<Stmt>> {
-    list.iter().map(|s| stmt(cx, s)).collect()
-}
-
-fn for_head(cx: &mut Cx, head: &swc::ForHead) -> Result<ForEachTarget> {
-    Ok(match head {
-        swc::ForHead::VarDecl(declaration) => {
-            let Some(first) = declaration.decls.first() else {
-                return unsupported(
-                    "a for-head that declares nothing",
-                    position(declaration.span),
-                );
-            };
-            ForEachTarget::Declare {
-                kind: binding_kind(declaration.kind),
-                target: binding(cx, &first.name)?,
-            }
-        }
-        // `target`, not `binding`: a for-head with no declaration assigns to
-        // places that already exist, so `for ([a, obj.b] of xs)` is as legal as
-        // `[a, obj.b] = xs`. Reading it in the binding role refused every member
-        // target in a for-head — the same shape read in the wrong one of the two
-        // roles this module exists to keep apart.
-        swc::ForHead::Pat(pattern) => ForEachTarget::Assign(target(cx, pattern)?),
-        // Read rather than refused. The bridge had nowhere to put it, which
-        // made a construct SWC reads perfectly well look like one the front end
-        // could not parse — and moved the gap away from where it is. Where it
-        // is, is disposal: emission refuses it by name.
-        swc::ForHead::UsingDecl(using) => {
-            let Some(first) = using.decls.first() else {
-                return unsupported(
-                    "a `using` for-head that declares nothing",
-                    position(using.span),
-                );
-            };
-            let swc::Pat::Ident(ident) = &first.name else {
-                return unsupported("a `using` for-head with a pattern", position(using.span));
-            };
-            ForEachTarget::Dispose {
-                target: cx.name(&ident.id.sym),
-                is_async: using.is_await,
-            }
-        }
-    })
-}
-
-/// A declaration, which is a statement here.
-fn decl(cx: &mut Cx, declaration: &swc::Decl) -> Result<Stmt> {
-    let at = position(declaration.span());
-    let kind = match declaration {
-        // `declare const x: T` states that something EXISTS elsewhere; it
-        // introduces no binding and emits nothing, which is the whole meaning of
-        // the keyword. Lowering it as an ordinary declaration bound `x` to
-        // `undefined` in the enclosing scope — and since the thing being
-        // declared is almost always a global, the binding SHADOWED the very
-        // value it was announcing.
-        //
-        // The failure reads as the global not existing: `declare const print`
-        // followed by `print(x)` died with "print is not a function", while the
-        // same call one line above the declaration worked. `declare function f`
-        // was never affected, because a function with no body is already
-        // nothing to emit — which is why this looked like a global that only
-        // sometimes existed.
-        swc::Decl::Var(variables) if variables.declare => StmtKind::Empty,
-        swc::Decl::Var(variables) => StmtKind::Declare {
-            kind: binding_kind(variables.kind),
-            bindings: declarators(cx, &variables.decls)?,
-        },
-        swc::Decl::Fn(function) => StmtKind::Function(Box::new(Function {
-            name: Some(cx.name(&function.ident.sym)),
-            ..function_parts(cx, &function.function)?
-        })),
-        swc::Decl::Class(class) if class.class.decorators.is_empty() => {
-            StmtKind::Class(Box::new(Class {
-                name: Some(cx.name(&class.ident.sym)),
-                ..class_parts(cx, &class.class)?
-            }))
-        }
-        swc::Decl::Class(class) => return decorated_class_declaration(cx, class, at),
-        swc::Decl::Using(using) => StmtKind::Using {
-            bindings: declarators(cx, &using.decls)?,
-            is_async: using.is_await,
-        },
-        swc::Decl::TsInterface(_)
-        | swc::Decl::TsTypeAlias(_)
-        | swc::Decl::TsEnum(_)
-        | swc::Decl::TsModule(_) => {
-            // Types are erased, so an interface or an alias contributes nothing
-            // to what runs. An enum and a namespace DO, and refusing them is
-            // honest until they are lowered.
-            match declaration {
-                swc::Decl::TsInterface(_) | swc::Decl::TsTypeAlias(_) => StmtKind::Empty,
-                swc::Decl::TsEnum(held) => return enum_declaration(cx, held),
-                swc::Decl::TsModule(module) => return namespace_declaration(cx, module, at),
-                _ => unreachable!("all `Decl` variants are matched above"),
-            }
-        }
-    };
-    Ok(Stmt::new(kind, at))
-}
-
-fn declarators(cx: &mut Cx, declarators: &[swc::VarDeclarator]) -> Result<Vec<Binding>> {
-    declarators
-        .iter()
-        .map(|declarator| {
-            Ok(Binding {
-                claim: type_of(cx, &declarator.name),
-                target: binding(cx, &declarator.name)?,
-                value: match &declarator.init {
-                    Some(value) => Some(expr(cx, value)?),
-                    None => None,
-                },
-            })
-        })
-        .collect()
-}
-
-fn binding_kind(kind: swc::VarDeclKind) -> BindingKind {
-    match kind {
-        swc::VarDeclKind::Var => BindingKind::Var,
-        swc::VarDeclKind::Let => BindingKind::Let,
-        swc::VarDeclKind::Const => BindingKind::Const,
-    }
-}
-
 /// A function declaration or expression.
-pub(crate) fn function_expr(cx: &mut Cx, function: &swc::FnExpr) -> Result<Function> {
+pub(super) fn function_expr(cx: &mut Cx, function: &swc::FnExpr) -> Result<Function> {
     Ok(Function {
         name: function.ident.as_ref().map(|i| cx.name(&i.sym)),
         ..function_parts(cx, &function.function)?
@@ -548,7 +87,7 @@ pub(crate) fn function(cx: &mut Cx, function: &swc::Function) -> Result<Function
     function_parts(cx, function)
 }
 
-fn function_parts(cx: &mut Cx, function: &swc::Function) -> Result<Function> {
+pub(super) fn function_parts(cx: &mut Cx, function: &swc::Function) -> Result<Function> {
     let (parameters, rest_parameter) = parameters(cx, function.params.iter().map(|p| &p.pat))?;
     let (directives, body) = block_body(cx, function.body.as_ref())?;
 
@@ -684,7 +223,7 @@ fn is_receiver_annotation(parameter: &swc::Pat) -> bool {
 }
 
 /// What a pattern's annotation claimed, if it carried one.
-fn type_of(cx: &mut Cx, pattern: &swc::Pat) -> Option<Claim> {
+pub(super) fn type_of(cx: &mut Cx, pattern: &swc::Pat) -> Option<Claim> {
     let annotation = match pattern {
         swc::Pat::Ident(ident) => ident.type_ann.as_deref(),
         swc::Pat::Array(array) => array.type_ann.as_deref(),
@@ -732,7 +271,7 @@ pub(crate) fn class_expr(cx: &mut Cx, class: &swc::ClassExpr) -> Result<Class> {
     })
 }
 
-fn class_parts(cx: &mut Cx, class: &swc::Class) -> Result<Class> {
+pub(super) fn class_parts(cx: &mut Cx, class: &swc::Class) -> Result<Class> {
     cx.enter_class(private_names_of(class));
     let parts = class_members(cx, class);
     cx.leave_class();
@@ -980,7 +519,7 @@ fn parameter_of(cx: &mut Cx, pattern: &swc::Pat) -> Result<Parameter> {
 /// be right for the forward direction and wrong for the reverse one, which
 /// needs the VALUE to index by. A member that is right in one direction and
 /// missing in the other is the shape a program finds out about late.
-fn enum_declaration(cx: &mut Cx, declaration: &swc::TsEnumDecl) -> Result<Stmt> {
+pub(super) fn enum_declaration(cx: &mut Cx, declaration: &swc::TsEnumDecl) -> Result<Stmt> {
     let at = position(declaration.span);
     let name = cx.names.intern(declaration.id.sym.as_ref());
     let mut properties: Vec<crate::syntax::Property> = Vec::new();
@@ -1098,7 +637,7 @@ fn enum_declaration(cx: &mut Cx, declaration: &swc::TsEnumDecl) -> Result<Stmt> 
 /// identifier (`@register`) has no such call to be "the whole decoration", so
 /// it is invoked directly on the class, which is the one case that still
 /// matches full legacy semantics exactly.
-fn decorated_class_declaration(
+pub(super) fn decorated_class_declaration(
     cx: &mut Cx,
     class: &swc::ClassDecl,
     at: rts_cranelift::fault::Position,
@@ -1194,7 +733,7 @@ fn decorated_class_declaration(
 /// wrong in general. Fixing it means rewriting internal references to the
 /// object parameter, which is `scope/`'s job (absent — see this crate's
 /// README) and not attempted here as a workaround.
-fn namespace_declaration(
+pub(super) fn namespace_declaration(
     cx: &mut Cx,
     module: &swc::TsModuleDecl,
     at: rts_cranelift::fault::Position,

--- a/crates/rts-codegen/src/parse/mod.rs
+++ b/crates/rts-codegen/src/parse/mod.rs
@@ -38,7 +38,9 @@
 mod expr;
 mod item;
 mod members;
+mod module;
 mod pat;
+mod stmt;
 
 use std::fmt;
 

--- a/crates/rts-codegen/src/parse/module.rs
+++ b/crates/rts-codegen/src/parse/module.rs
@@ -1,0 +1,220 @@
+//! `import` and `export` — the module half of what a file's items can be.
+//!
+//! Split out of `item.rs` because that file was 1395 lines against this crate's
+//! 1000-line ceiling (rule 8), and because import and export are one subject:
+//! they are the two sides of the same table, and TypeScript's erasure rules
+//! apply to both. `item.rs` keeps statements, functions and classes.
+
+use swc_common::Spanned;
+use swc_ecma_ast as swc;
+
+use super::expr::expr;
+use super::item::{class_expr, function_expr};
+use super::stmt::{decl, stmt};
+use super::{Cx, Result, position, unsupported};
+use crate::syntax::{
+    Stmt, StmtKind,
+    Export, ExportDefault, ExportKind, ExportSpecifier, Import, ImportAttribute, ImportBinding,
+    ModuleItem,
+};
+
+pub(super) fn module_item(cx: &mut Cx, item: &swc::ModuleItem) -> Result<Option<ModuleItem>> {
+    Ok(match item {
+        swc::ModuleItem::Stmt(statement) => Some(ModuleItem::Stmt(stmt(cx, statement)?)),
+        swc::ModuleItem::ModuleDecl(declaration) => match declaration {
+            swc::ModuleDecl::Import(import) => import_decl(cx, import)?.map(ModuleItem::Import),
+            other => Some(ModuleItem::Export(export_decl(cx, other)?)),
+        },
+    })
+}
+
+/// One `import`, or `None` when TypeScript erases the whole statement.
+///
+/// # Import elision, and why it is the parser's job
+///
+/// `import type { Foo } from "./x"` names nothing that exists at run time, and
+/// the language says so: the statement is ERASED, and no module is loaded. That
+/// is what lets `tsc` compile a file without reading the files it imports types
+/// from, and a program that relies on it is not doing anything unusual — it is
+/// the ordinary way a `.d.ts`-shaped module is consumed.
+///
+/// Keeping the import made a type-only module a run-time request for a module
+/// with no namespace, because `entry::module_publish` creates the namespace on
+/// the first export and a module of only interfaces has none. That runtime
+/// decision is right — *"a module that exports nothing has no namespace to speak
+/// of"*, as it says — and it is not what changes here. What changes is that the
+/// erased import stops reaching it.
+///
+/// This is done at the bridge rather than in a later pass because it is not a
+/// lowering decision: the statement is not in the program at all, and every
+/// pass after this one would otherwise have to know that some imports are not
+/// imports. `relative_imports` in the host still walks the file, which costs one
+/// parse of a module that is then compiled to nothing — the alternative is a
+/// second place that decides what a type-only import is, and two answers to that
+/// question is what this crate's rule 3 refuses.
+///
+/// Two spellings are erased, and they are the two TypeScript erases:
+/// - `import type { … } from "x"` — the whole statement.
+/// - `import { type A, type B } from "x"` — each marked specifier, and then the
+///   statement too if nothing is left. NOT if the statement had no specifiers to
+///   begin with: `import "x"` is a side-effect import and means the module RUNS,
+///   which is the one case where an empty binding list is the point.
+fn import_decl(cx: &mut Cx, import: &swc::ImportDecl) -> Result<Option<Import>> {
+    if import.type_only {
+        return Ok(None);
+    }
+    let had_specifiers = !import.specifiers.is_empty();
+    let bindings = import
+        .specifiers
+        .iter()
+        .filter(|specifier| match specifier {
+            // `import { type A, B }` — only the marked one goes.
+            swc::ImportSpecifier::Named(named) => !named.is_type_only,
+            swc::ImportSpecifier::Default(_) | swc::ImportSpecifier::Namespace(_) => true,
+        })
+        .map(|specifier| {
+            Ok(match specifier {
+                swc::ImportSpecifier::Default(default) => {
+                    ImportBinding::Default(cx.name(&default.local.sym))
+                }
+                swc::ImportSpecifier::Namespace(namespace) => {
+                    ImportBinding::Namespace(cx.name(&namespace.local.sym))
+                }
+                swc::ImportSpecifier::Named(named) => ImportBinding::Named {
+                    exported: match &named.imported {
+                        Some(swc::ModuleExportName::Ident(ident)) => ident.sym.to_string(),
+                        Some(swc::ModuleExportName::Str(string)) => {
+                            string.value.to_string_lossy().to_string()
+                        }
+                        None => named.local.sym.to_string(),
+                    },
+                    local: cx.name(&named.local.sym),
+                },
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Every binding was type-only: the statement erases with them. The guard is
+    // on what was WRITTEN, so `import "./x"` still runs the module.
+    if had_specifiers && bindings.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(Import {
+        bindings,
+        source: import.src.value.to_string_lossy().to_string(),
+        attributes: attributes(import.with.as_deref()),
+        at: position(import.span),
+    }))
+}
+/// `with { type: "json" }`.
+fn attributes(with: Option<&swc::ObjectLit>) -> Vec<ImportAttribute> {
+    let Some(object) = with else {
+        return Vec::new();
+    };
+    object
+        .props
+        .iter()
+        .filter_map(|property| {
+            let swc::PropOrSpread::Prop(prop) = property else {
+                return None;
+            };
+            let swc::Prop::KeyValue(pair) = &**prop else {
+                return None;
+            };
+            let key = match &pair.key {
+                swc::PropName::Ident(ident) => ident.sym.to_string(),
+                swc::PropName::Str(string) => string.value.to_string_lossy().to_string(),
+                _ => return None,
+            };
+            let swc::Expr::Lit(swc::Lit::Str(value)) = &*pair.value else {
+                return None;
+            };
+            Some(ImportAttribute {
+                key,
+                value: value.value.to_string_lossy().to_string(),
+            })
+        })
+        .collect()
+}
+
+pub(super) fn export_decl(cx: &mut Cx, declaration: &swc::ModuleDecl) -> Result<Export> {
+    let at = position(declaration.span());
+    let kind = match declaration {
+        swc::ModuleDecl::ExportDecl(export) => {
+            ExportKind::Declaration(Box::new(decl(cx, &export.decl)?))
+        }
+
+        swc::ModuleDecl::ExportNamed(named) => ExportKind::Named {
+            specifiers: named
+                .specifiers
+                .iter()
+                .map(|specifier| match specifier {
+                    swc::ExportSpecifier::Named(entry) => Ok(ExportSpecifier {
+                        local: export_name(&entry.orig),
+                        exported: entry
+                            .exported
+                            .as_ref()
+                            .map(export_name)
+                            .unwrap_or_else(|| export_name(&entry.orig)),
+                    }),
+                    swc::ExportSpecifier::Default(entry) => Ok(ExportSpecifier {
+                        local: entry.exported.sym.to_string(),
+                        exported: "default".to_owned(),
+                    }),
+                    swc::ExportSpecifier::Namespace(entry) => Ok(ExportSpecifier {
+                        local: "*".to_owned(),
+                        exported: export_name(&entry.name),
+                    }),
+                })
+                .collect::<Result<_>>()?,
+            source: named
+                .src
+                .as_ref()
+                .map(|s| s.value.to_string_lossy().to_string()),
+            attributes: attributes(named.with.as_deref()),
+        },
+
+        swc::ModuleDecl::ExportDefaultDecl(default) => {
+            ExportKind::Default(ExportDefault::Declaration(Box::new(match &default.decl {
+                swc::DefaultDecl::Fn(function) => Stmt::new(
+                    StmtKind::Function(Box::new(function_expr(cx, function)?)),
+                    at,
+                ),
+                swc::DefaultDecl::Class(class) => {
+                    Stmt::new(StmtKind::Class(Box::new(class_expr(cx, class)?)), at)
+                }
+                swc::DefaultDecl::TsInterfaceDecl(interface) => {
+                    return unsupported("an exported interface", position(interface.span));
+                }
+            })))
+        }
+
+        swc::ModuleDecl::ExportDefaultExpr(default) => {
+            ExportKind::Default(ExportDefault::Expr(expr(cx, &default.expr)?))
+        }
+
+        swc::ModuleDecl::ExportAll(all) => ExportKind::All {
+            source: all.src.value.to_string_lossy().to_string(),
+            alias: None,
+            attributes: attributes(all.with.as_deref()),
+        },
+
+        swc::ModuleDecl::Import(_) => return unsupported("an import reached as an export", at),
+        swc::ModuleDecl::TsImportEquals(_)
+        | swc::ModuleDecl::TsExportAssignment(_)
+        | swc::ModuleDecl::TsNamespaceExport(_) => {
+            return unsupported("a TypeScript-only module declaration", at);
+        }
+    };
+
+    Ok(Export { kind, at })
+}
+
+fn export_name(name: &swc::ModuleExportName) -> String {
+    match name {
+        swc::ModuleExportName::Ident(ident) => ident.sym.to_string(),
+        swc::ModuleExportName::Str(string) => string.value.to_string_lossy().to_string(),
+    }
+}
+

--- a/crates/rts-codegen/src/parse/stmt.rs
+++ b/crates/rts-codegen/src/parse/stmt.rs
@@ -1,0 +1,280 @@
+//! Statements and declarations.
+//!
+//! Split out of `item.rs` for this crate's 1000-line ceiling (rule 8), which
+//! that file was 395 lines past. The cut is where the subject changes: this is
+//! what a statement can BE, and `item.rs` keeps what a function and a class
+//! are — the two things a statement can declare but not the same question.
+
+use swc_common::Spanned;
+use swc_ecma_ast as swc;
+
+use super::expr::expr;
+use super::item::{
+    class_parts, decorated_class_declaration, enum_declaration, function_parts,
+    namespace_declaration, type_of,
+};
+use super::pat::{binding, target};
+use super::{Cx, Result, position, unsupported};
+use crate::syntax::{
+    Class, Function,
+    Binding, BindingKind, Catch, ForEachSource, ForEachTarget, ForInit, Stmt, StmtKind,
+    SwitchClause,
+};
+/// One statement.
+
+pub(crate) fn stmt(cx: &mut Cx, statement: &swc::Stmt) -> Result<Stmt> {
+    let at = position(statement.span());
+    let kind = match statement {
+        swc::Stmt::Expr(expression) => StmtKind::Expr(expr(cx, &expression.expr)?),
+        swc::Stmt::Empty(_) => StmtKind::Empty,
+        swc::Stmt::Debugger(_) => StmtKind::Debugger,
+
+        swc::Stmt::Block(block) => StmtKind::Block(stmts(cx, &block.stmts)?),
+
+        swc::Stmt::If(if_) => StmtKind::If {
+            condition: expr(cx, &if_.test)?,
+            then_branch: Box::new(stmt(cx, &if_.cons)?),
+            else_branch: match &if_.alt {
+                Some(alt) => Some(Box::new(stmt(cx, alt)?)),
+                None => None,
+            },
+        },
+
+        swc::Stmt::While(while_) => StmtKind::While {
+            condition: expr(cx, &while_.test)?,
+            body: Box::new(stmt(cx, &while_.body)?),
+        },
+
+        swc::Stmt::DoWhile(do_while) => StmtKind::DoWhile {
+            body: Box::new(stmt(cx, &do_while.body)?),
+            condition: expr(cx, &do_while.test)?,
+        },
+
+        swc::Stmt::For(for_) => StmtKind::For {
+            init: match &for_.init {
+                Some(swc::VarDeclOrExpr::VarDecl(declaration)) => Some(ForInit::Declare {
+                    kind: binding_kind(declaration.kind),
+                    bindings: declarators(cx, &declaration.decls)?,
+                }),
+                Some(swc::VarDeclOrExpr::Expr(expression)) => {
+                    Some(ForInit::Expr(expr(cx, expression)?))
+                }
+                None => None,
+            },
+            test: match &for_.test {
+                Some(test) => Some(expr(cx, test)?),
+                None => None,
+            },
+            update: match &for_.update {
+                Some(update) => Some(expr(cx, update)?),
+                None => None,
+            },
+            body: Box::new(stmt(cx, &for_.body)?),
+        },
+
+        swc::Stmt::ForIn(for_in) => StmtKind::ForEach {
+            source: ForEachSource::In,
+            target: for_head(cx, &for_in.left)?,
+            subject: expr(cx, &for_in.right)?,
+            body: Box::new(stmt(cx, &for_in.body)?),
+        },
+
+        swc::Stmt::ForOf(for_of) => StmtKind::ForEach {
+            source: if for_of.is_await {
+                ForEachSource::AwaitOf
+            } else {
+                ForEachSource::Of
+            },
+            target: for_head(cx, &for_of.left)?,
+            subject: expr(cx, &for_of.right)?,
+            body: Box::new(stmt(cx, &for_of.body)?),
+        },
+
+        swc::Stmt::Return(return_) => StmtKind::Return(match &return_.arg {
+            Some(value) => Some(expr(cx, value)?),
+            None => None,
+        }),
+
+        swc::Stmt::Break(break_) => StmtKind::Break(break_.label.as_ref().map(|l| cx.name(&l.sym))),
+        swc::Stmt::Continue(continue_) => {
+            StmtKind::Continue(continue_.label.as_ref().map(|l| cx.name(&l.sym)))
+        }
+
+        swc::Stmt::Labeled(labeled) => StmtKind::Labelled {
+            label: cx.name(&labeled.label.sym),
+            body: Box::new(stmt(cx, &labeled.body)?),
+        },
+
+        swc::Stmt::Switch(switch) => StmtKind::Switch {
+            discriminant: expr(cx, &switch.discriminant)?,
+            clauses: switch
+                .cases
+                .iter()
+                .map(|case| {
+                    Ok(SwitchClause {
+                        test: match &case.test {
+                            Some(test) => Some(expr(cx, test)?),
+                            None => None,
+                        },
+                        body: stmts(cx, &case.cons)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+        },
+
+        swc::Stmt::Throw(throw) => StmtKind::Throw(expr(cx, &throw.arg)?),
+
+        swc::Stmt::Try(try_) => StmtKind::Try {
+            body: stmts(cx, &try_.block.stmts)?,
+            catch: match &try_.handler {
+                Some(handler) => Some(Catch {
+                    binding: match &handler.param {
+                        Some(parameter) => Some(binding(cx, parameter)?),
+                        None => None,
+                    },
+                    body: stmts(cx, &handler.body.stmts)?,
+                }),
+                None => None,
+            },
+            finally: match &try_.finalizer {
+                Some(block) => Some(stmts(cx, &block.stmts)?),
+                None => None,
+            },
+        },
+
+        swc::Stmt::With(with) => StmtKind::With {
+            object: expr(cx, &with.obj)?,
+            body: Box::new(stmt(cx, &with.body)?),
+        },
+
+        swc::Stmt::Decl(declaration) => return decl(cx, declaration),
+    };
+
+    Ok(Stmt::new(kind, at))
+}
+
+pub(super) fn stmts(cx: &mut Cx, list: &[swc::Stmt]) -> Result<Vec<Stmt>> {
+    list.iter().map(|s| stmt(cx, s)).collect()
+}
+
+fn for_head(cx: &mut Cx, head: &swc::ForHead) -> Result<ForEachTarget> {
+    Ok(match head {
+        swc::ForHead::VarDecl(declaration) => {
+            let Some(first) = declaration.decls.first() else {
+                return unsupported(
+                    "a for-head that declares nothing",
+                    position(declaration.span),
+                );
+            };
+            ForEachTarget::Declare {
+                kind: binding_kind(declaration.kind),
+                target: binding(cx, &first.name)?,
+            }
+        }
+        // `target`, not `binding`: a for-head with no declaration assigns to
+        // places that already exist, so `for ([a, obj.b] of xs)` is as legal as
+        // `[a, obj.b] = xs`. Reading it in the binding role refused every member
+        // target in a for-head — the same shape read in the wrong one of the two
+        // roles this module exists to keep apart.
+        swc::ForHead::Pat(pattern) => ForEachTarget::Assign(target(cx, pattern)?),
+        // Read rather than refused. The bridge had nowhere to put it, which
+        // made a construct SWC reads perfectly well look like one the front end
+        // could not parse — and moved the gap away from where it is. Where it
+        // is, is disposal: emission refuses it by name.
+        swc::ForHead::UsingDecl(using) => {
+            let Some(first) = using.decls.first() else {
+                return unsupported(
+                    "a `using` for-head that declares nothing",
+                    position(using.span),
+                );
+            };
+            let swc::Pat::Ident(ident) = &first.name else {
+                return unsupported("a `using` for-head with a pattern", position(using.span));
+            };
+            ForEachTarget::Dispose {
+                target: cx.name(&ident.id.sym),
+                is_async: using.is_await,
+            }
+        }
+    })
+}
+
+/// A declaration, which is a statement here.
+pub(super) fn decl(cx: &mut Cx, declaration: &swc::Decl) -> Result<Stmt> {
+    let at = position(declaration.span());
+    let kind = match declaration {
+        // `declare const x: T` states that something EXISTS elsewhere; it
+        // introduces no binding and emits nothing, which is the whole meaning of
+        // the keyword. Lowering it as an ordinary declaration bound `x` to
+        // `undefined` in the enclosing scope — and since the thing being
+        // declared is almost always a global, the binding SHADOWED the very
+        // value it was announcing.
+        //
+        // The failure reads as the global not existing: `declare const print`
+        // followed by `print(x)` died with "print is not a function", while the
+        // same call one line above the declaration worked. `declare function f`
+        // was never affected, because a function with no body is already
+        // nothing to emit — which is why this looked like a global that only
+        // sometimes existed.
+        swc::Decl::Var(variables) if variables.declare => StmtKind::Empty,
+        swc::Decl::Var(variables) => StmtKind::Declare {
+            kind: binding_kind(variables.kind),
+            bindings: declarators(cx, &variables.decls)?,
+        },
+        swc::Decl::Fn(function) => StmtKind::Function(Box::new(Function {
+            name: Some(cx.name(&function.ident.sym)),
+            ..function_parts(cx, &function.function)?
+        })),
+        swc::Decl::Class(class) if class.class.decorators.is_empty() => {
+            StmtKind::Class(Box::new(Class {
+                name: Some(cx.name(&class.ident.sym)),
+                ..class_parts(cx, &class.class)?
+            }))
+        }
+        swc::Decl::Class(class) => return decorated_class_declaration(cx, class, at),
+        swc::Decl::Using(using) => StmtKind::Using {
+            bindings: declarators(cx, &using.decls)?,
+            is_async: using.is_await,
+        },
+        swc::Decl::TsInterface(_)
+        | swc::Decl::TsTypeAlias(_)
+        | swc::Decl::TsEnum(_)
+        | swc::Decl::TsModule(_) => {
+            // Types are erased, so an interface or an alias contributes nothing
+            // to what runs. An enum and a namespace DO, and refusing them is
+            // honest until they are lowered.
+            match declaration {
+                swc::Decl::TsInterface(_) | swc::Decl::TsTypeAlias(_) => StmtKind::Empty,
+                swc::Decl::TsEnum(held) => return enum_declaration(cx, held),
+                swc::Decl::TsModule(module) => return namespace_declaration(cx, module, at),
+                _ => unreachable!("all `Decl` variants are matched above"),
+            }
+        }
+    };
+    Ok(Stmt::new(kind, at))
+}
+
+fn declarators(cx: &mut Cx, declarators: &[swc::VarDeclarator]) -> Result<Vec<Binding>> {
+    declarators
+        .iter()
+        .map(|declarator| {
+            Ok(Binding {
+                claim: type_of(cx, &declarator.name),
+                target: binding(cx, &declarator.name)?,
+                value: match &declarator.init {
+                    Some(value) => Some(expr(cx, value)?),
+                    None => None,
+                },
+            })
+        })
+        .collect()
+}
+
+fn binding_kind(kind: swc::VarDeclKind) -> BindingKind {
+    match kind {
+        swc::VarDeclKind::Var => BindingKind::Var,
+        swc::VarDeclKind::Let => BindingKind::Let,
+        swc::VarDeclKind::Const => BindingKind::Const,
+    }
+}
+

--- a/crates/rts-node/src/ws/client/mod.rs
+++ b/crates/rts-node/src/ws/client/mod.rs
@@ -48,99 +48,21 @@ use std::time::Duration;
 
 use super::transport::Transport;
 
-/// Para onde o cliente vai.
-#[cfg_attr(test, derive(Debug))]
-pub(super) struct Target {
-    pub(super) host: String,
-    pub(super) port: u16,
-    /// O caminho e a query, já com a barra inicial — o que vai na linha do
-    /// pedido.
-    pub(super) resource: String,
-    pub(super) secure: bool,
-}
+mod url;
+
+pub(in crate::ws) use self::url::{Target, parse};
+use self::url::request;
+
 
 /// O que um programa pode acrescentar ao pedido.
 #[derive(Default)]
-pub(super) struct Options {
-    pub(super) origin: Option<String>,
+pub(in crate::ws) struct Options {
+    pub(in crate::ws) origin: Option<String>,
     /// Pares nome/valor, na ordem em que o programa os deu. Um `Vec` e não um
     /// mapa: o HTTP permite repetir um cabeçalho, a ordem é observável do outro
     /// lado, e um mapa perderia as duas coisas para não ganhar nada.
-    pub(super) headers: Vec<(String, String)>,
-    pub(super) protocols: Vec<String>,
-}
-
-/// Os cabeçalhos que este ficheiro escreve e um programa não pode substituir —
-/// ver a nota do módulo. Comparados sem distinguir maiúsculas, que é como o
-/// HTTP os compara.
-const RESERVED: &[&str] = &[
-    "host",
-    "upgrade",
-    "connection",
-    "sec-websocket-key",
-    "sec-websocket-version",
-    "sec-websocket-protocol",
-    "content-length",
-];
-
-/// Parte um `ws://`/`wss://` no que o pedido precisa.
-///
-/// Escrito à mão em vez de pela crate `url`, que este crate já tem: o que aqui
-/// interessa é um esquema de dois valores, um autoridade e o resto textual, e a
-/// `Url` normaliza o caminho de formas que um servidor WebSocket nota — um
-/// `?a=1&a=2` reordenado é outra query. O `node:url` continua a ser quem
-/// responde por URLs em geral; isto é o recorte do handshake.
-pub(super) fn parse(url: &str) -> Result<Target, String> {
-    let (secure, rest) = if let Some(rest) = url.strip_prefix("wss://") {
-        (true, rest)
-    } else if let Some(rest) = url.strip_prefix("ws://") {
-        (false, rest)
-    } else if url.starts_with("http://") || url.starts_with("https://") {
-        // Recusado por nome: um `http://` que "funcionasse" abriria um
-        // WebSocket sobre um endereço que nenhum outro cliente aceitaria, e o
-        // programa só descobria no servidor.
-        return Err("WebSocket URL must use the ws: or wss: scheme".to_owned());
-    } else {
-        return Err("WebSocket URL must start with ws:// or wss://".to_owned());
-    };
-
-    let (authority, resource) = match rest.find(['/', '?', '#']) {
-        Some(cut) => (&rest[..cut], &rest[cut..]),
-        None => (rest, ""),
-    };
-    // O fragmento nunca vai para a rede — é do cliente, e o RFC 3986 diz o
-    // mesmo para qualquer pedido.
-    let resource = resource.split('#').next().unwrap_or("");
-    let resource = if resource.is_empty() { "/".to_owned() } else { resource.to_owned() };
-
-    // As credenciais de `user:pass@host` são descartadas em vez de viradas em
-    // `Authorization`: o `ws` do npm também não as usa, e inventar aqui um
-    // cabeçalho de autenticação mandaria uma senha que ninguém escreveu.
-    let authority = authority.rsplit('@').next().unwrap_or(authority);
-
-    let (host, port) = split_port(authority, secure)?;
-    Ok(Target { host, port, resource, secure })
-}
-
-fn split_port(authority: &str, secure: bool) -> Result<(String, u16), String> {
-    let padrao = if secure { 443 } else { 80 };
-    // `[::1]:8080` — o IPv6 traz dois-pontos que não separam a porta.
-    if let Some(fim) = authority.strip_prefix('[').and_then(|_| authority.find(']')) {
-        let host = authority[1..fim].to_owned();
-        let resto = &authority[fim + 1..];
-        let port = match resto.strip_prefix(':') {
-            Some(texto) => texto.parse().map_err(|_| format!("invalid port: {texto}"))?,
-            None => padrao,
-        };
-        return Ok((host, port));
-    }
-    match authority.rsplit_once(':') {
-        Some((host, texto)) => {
-            let port = texto.parse().map_err(|_| format!("invalid port: {texto}"))?;
-            Ok((host.to_owned(), port))
-        }
-        None => Ok((authority.to_owned(), padrao)),
-    }
+    pub(in crate::ws) headers: Vec<(String, String)>,
+    pub(in crate::ws) protocols: Vec<String>,
 }
 
 /// Abre, aperta a mão e devolve o transporte pronto a falar frames.
@@ -262,42 +184,6 @@ fn nonce() -> String {
     rts_core::entry::encode_base64(&bytes, true)
 }
 
-/// O pedido, literalmente.
-fn request(target: &Target, options: &Options, key: &str) -> String {
-    // A porta só entra no `Host` quando não é a do esquema, que é o que um
-    // servidor com virtual hosts compara.
-    let padrao = if target.secure { 443 } else { 80 };
-    let host = if target.port == padrao {
-        target.host.clone()
-    } else {
-        format!("{}:{}", target.host, target.port)
-    };
-    let mut pedido = format!(
-        "GET {} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\
-         Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n",
-        target.resource
-    );
-    if !options.protocols.is_empty() {
-        pedido.push_str(&format!("Sec-WebSocket-Protocol: {}\r\n", options.protocols.join(", ")));
-    }
-    if let Some(origin) = &options.origin {
-        pedido.push_str(&format!("Origin: {origin}\r\n"));
-    }
-    for (nome, valor) in &options.headers {
-        if RESERVED.contains(&nome.to_ascii_lowercase().as_str()) {
-            continue;
-        }
-        // Um `\r` ou `\n` num valor injecta um cabeçalho — ou um pedido
-        // inteiro. Recortado no primeiro, e não recusado: um valor que o
-        // programa compôs de dados alheios é o caso normal, e rebentar aqui
-        // transformaria uma sanitização numa falha de conexão.
-        let valor = valor.split(['\r', '\n']).next().unwrap_or("");
-        pedido.push_str(&format!("{nome}: {valor}\r\n"));
-    }
-    pedido.push_str("\r\n");
-    pedido
-}
-
 /// Lê o `101` e confirma que quem respondeu leu a nossa chave.
 fn read_response(transport: &mut Transport, key: &str) -> Result<Vec<u8>, String> {
     let (cabecalho, resto) = read_headers(transport)?;
@@ -392,109 +278,6 @@ pub(super) const TIMEOUT: Duration = Duration::from_secs(30);
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_the_parts_of_a_url() {
-        let alvo = parse("wss://gateway.example.com/socket?v=2").unwrap();
-        assert_eq!(alvo.host, "gateway.example.com");
-        assert_eq!(alvo.port, 443);
-        assert_eq!(alvo.resource, "/socket?v=2");
-        assert!(alvo.secure);
-    }
-
-    #[test]
-    fn a_missing_path_becomes_a_slash() {
-        let alvo = parse("ws://localhost:8080").unwrap();
-        assert_eq!(alvo.port, 8080);
-        assert_eq!(alvo.resource, "/");
-        assert!(!alvo.secure);
-    }
-
-    #[test]
-    fn the_default_port_follows_the_scheme() {
-        assert_eq!(parse("ws://a.example").unwrap().port, 80);
-        assert_eq!(parse("wss://a.example").unwrap().port, 443);
-    }
-
-    /// Os dois-pontos de um IPv6 não separam a porta.
-    #[test]
-    fn an_ipv6_authority_keeps_its_colons() {
-        let alvo = parse("ws://[::1]:9001/x").unwrap();
-        assert_eq!(alvo.host, "::1");
-        assert_eq!(alvo.port, 9001);
-        assert_eq!(alvo.resource, "/x");
-    }
-
-    #[test]
-    fn a_fragment_never_reaches_the_wire() {
-        assert_eq!(parse("ws://a.example/p?q=1#top").unwrap().resource, "/p?q=1");
-    }
-
-    #[test]
-    fn http_is_refused_by_name() {
-        assert!(parse("https://a.example").unwrap_err().contains("ws: or wss:"));
-        assert!(parse("a.example").is_err());
-    }
-
-    /// O `Host` leva a porta só quando ela não é a do esquema — é o que um
-    /// servidor com virtual hosts compara.
-    #[test]
-    fn the_host_header_omits_a_default_port() {
-        let alvo = parse("wss://a.example/x").unwrap();
-        let pedido = request(&alvo, &Options::default(), "chave");
-        assert!(pedido.contains("Host: a.example\r\n"), "{pedido}");
-
-        let alvo = parse("ws://a.example:8080/x").unwrap();
-        let pedido = request(&alvo, &Options::default(), "chave");
-        assert!(pedido.contains("Host: a.example:8080\r\n"), "{pedido}");
-    }
-
-    #[test]
-    fn custom_headers_and_origin_reach_the_request() {
-        let alvo = parse("wss://a.example/x").unwrap();
-        let opcoes = Options {
-            origin: Some("https://a.example".to_owned()),
-            headers: vec![("User-Agent".to_owned(), "Oniwalib/1".to_owned())],
-            protocols: vec!["chat".to_owned()],
-        };
-        let pedido = request(&alvo, &opcoes, "chave");
-        assert!(pedido.contains("Origin: https://a.example\r\n"), "{pedido}");
-        assert!(pedido.contains("User-Agent: Oniwalib/1\r\n"), "{pedido}");
-        assert!(pedido.contains("Sec-WebSocket-Protocol: chat\r\n"), "{pedido}");
-    }
-
-    /// Um cabeçalho do protocolo não se deixa substituir — ver a nota do
-    /// módulo. Aqui o programa tenta trocar `Connection`, e o pedido continua a
-    /// pedir o upgrade.
-    #[test]
-    fn a_reserved_header_is_ignored() {
-        let alvo = parse("ws://a.example/x").unwrap();
-        let opcoes = Options {
-            headers: vec![
-                ("Connection".to_owned(), "close".to_owned()),
-                ("sec-websocket-key".to_owned(), "outra".to_owned()),
-            ],
-            ..Options::default()
-        };
-        let pedido = request(&alvo, &opcoes, "chave");
-        assert!(pedido.contains("Connection: Upgrade\r\n"), "{pedido}");
-        assert!(!pedido.contains("close"), "{pedido}");
-        assert_eq!(pedido.matches("Sec-WebSocket-Key").count(), 1, "{pedido}");
-    }
-
-    /// Um `\r\n` num valor injectaria um cabeçalho inteiro. É cortado, e o que
-    /// vinha depois não aparece em lado nenhum.
-    #[test]
-    fn a_newline_in_a_header_value_is_cut() {
-        let alvo = parse("ws://a.example/x").unwrap();
-        let opcoes = Options {
-            headers: vec![("X-Test".to_owned(), "ok\r\nX-Injected: yes".to_owned())],
-            ..Options::default()
-        };
-        let pedido = request(&alvo, &opcoes, "chave");
-        assert!(pedido.contains("X-Test: ok\r\n"), "{pedido}");
-        assert!(!pedido.contains("X-Injected"), "{pedido}");
-    }
 
     #[test]
     fn the_header_end_is_found_and_not_overshot() {

--- a/crates/rts-node/src/ws/client/url.rs
+++ b/crates/rts-node/src/ws/client/url.rs
@@ -1,0 +1,237 @@
+//! O que um `ws://`/`wss://` diz, e o pedido que se escreve a partir dele.
+//!
+//! Separado de `client/mod.rs` para o teto de 500 linhas deste crate, e o corte
+//! é onde o assunto muda: aqui não há socket nenhum — texto a entrar, texto a
+//! sair — e é por isso que os testes desta metade correm sem rede.
+
+use super::Options;
+
+/// Para onde o cliente vai.
+#[cfg_attr(test, derive(Debug))]
+pub(in crate::ws) struct Target {
+    pub(in crate::ws) host: String,
+    pub(in crate::ws) port: u16,
+    /// O caminho e a query, já com a barra inicial — o que vai na linha do
+    /// pedido.
+    pub(in crate::ws) resource: String,
+    pub(in crate::ws) secure: bool,
+}
+
+/// Os cabeçalhos que este ficheiro escreve e um programa não pode substituir —
+/// ver a nota do módulo. Comparados sem distinguir maiúsculas, que é como o
+/// HTTP os compara.
+const RESERVED: &[&str] = &[
+    "host",
+    "upgrade",
+    "connection",
+    "sec-websocket-key",
+    "sec-websocket-version",
+    "sec-websocket-protocol",
+    "content-length",
+];
+
+/// Parte um `ws://`/`wss://` no que o pedido precisa.
+///
+/// Escrito à mão em vez de pela crate `url`, que este crate já tem: o que aqui
+/// interessa é um esquema de dois valores, um autoridade e o resto textual, e a
+/// `Url` normaliza o caminho de formas que um servidor WebSocket nota — um
+/// `?a=1&a=2` reordenado é outra query. O `node:url` continua a ser quem
+/// responde por URLs em geral; isto é o recorte do handshake.
+pub(in crate::ws) fn parse(url: &str) -> Result<Target, String> {
+    let (secure, rest) = if let Some(rest) = url.strip_prefix("wss://") {
+        (true, rest)
+    } else if let Some(rest) = url.strip_prefix("ws://") {
+        (false, rest)
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        // Recusado por nome: um `http://` que "funcionasse" abriria um
+        // WebSocket sobre um endereço que nenhum outro cliente aceitaria, e o
+        // programa só descobria no servidor.
+        return Err("WebSocket URL must use the ws: or wss: scheme".to_owned());
+    } else {
+        return Err("WebSocket URL must start with ws:// or wss://".to_owned());
+    };
+
+    let (authority, resource) = match rest.find(['/', '?', '#']) {
+        Some(cut) => (&rest[..cut], &rest[cut..]),
+        None => (rest, ""),
+    };
+    // O fragmento nunca vai para a rede — é do cliente, e o RFC 3986 diz o
+    // mesmo para qualquer pedido.
+    let resource = resource.split('#').next().unwrap_or("");
+    let resource = if resource.is_empty() { "/".to_owned() } else { resource.to_owned() };
+
+    // As credenciais de `user:pass@host` são descartadas em vez de viradas em
+    // `Authorization`: o `ws` do npm também não as usa, e inventar aqui um
+    // cabeçalho de autenticação mandaria uma senha que ninguém escreveu.
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+
+    let (host, port) = split_port(authority, secure)?;
+    Ok(Target { host, port, resource, secure })
+}
+
+fn split_port(authority: &str, secure: bool) -> Result<(String, u16), String> {
+    let padrao = if secure { 443 } else { 80 };
+    // `[::1]:8080` — o IPv6 traz dois-pontos que não separam a porta.
+    if let Some(fim) = authority.strip_prefix('[').and_then(|_| authority.find(']')) {
+        let host = authority[1..fim].to_owned();
+        let resto = &authority[fim + 1..];
+        let port = match resto.strip_prefix(':') {
+            Some(texto) => texto.parse().map_err(|_| format!("invalid port: {texto}"))?,
+            None => padrao,
+        };
+        return Ok((host, port));
+    }
+    match authority.rsplit_once(':') {
+        Some((host, texto)) => {
+            let port = texto.parse().map_err(|_| format!("invalid port: {texto}"))?;
+            Ok((host.to_owned(), port))
+        }
+        None => Ok((authority.to_owned(), padrao)),
+    }
+}
+
+
+/// O pedido, literalmente.
+pub(super) fn request(target: &Target, options: &Options, key: &str) -> String {
+    // A porta só entra no `Host` quando não é a do esquema, que é o que um
+    // servidor com virtual hosts compara.
+    let padrao = if target.secure { 443 } else { 80 };
+    let host = if target.port == padrao {
+        target.host.clone()
+    } else {
+        format!("{}:{}", target.host, target.port)
+    };
+    let mut pedido = format!(
+        "GET {} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\
+         Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n",
+        target.resource
+    );
+    if !options.protocols.is_empty() {
+        pedido.push_str(&format!("Sec-WebSocket-Protocol: {}\r\n", options.protocols.join(", ")));
+    }
+    if let Some(origin) = &options.origin {
+        pedido.push_str(&format!("Origin: {origin}\r\n"));
+    }
+    for (nome, valor) in &options.headers {
+        if RESERVED.contains(&nome.to_ascii_lowercase().as_str()) {
+            continue;
+        }
+        // Um `\r` ou `\n` num valor injecta um cabeçalho — ou um pedido
+        // inteiro. Recortado no primeiro, e não recusado: um valor que o
+        // programa compôs de dados alheios é o caso normal, e rebentar aqui
+        // transformaria uma sanitização numa falha de conexão.
+        let valor = valor.split(['\r', '\n']).next().unwrap_or("");
+        pedido.push_str(&format!("{nome}: {valor}\r\n"));
+    }
+    pedido.push_str("\r\n");
+    pedido
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_the_parts_of_a_url() {
+        let alvo = parse("wss://gateway.example.com/socket?v=2").unwrap();
+        assert_eq!(alvo.host, "gateway.example.com");
+        assert_eq!(alvo.port, 443);
+        assert_eq!(alvo.resource, "/socket?v=2");
+        assert!(alvo.secure);
+    }
+
+    #[test]
+    fn a_missing_path_becomes_a_slash() {
+        let alvo = parse("ws://localhost:8080").unwrap();
+        assert_eq!(alvo.port, 8080);
+        assert_eq!(alvo.resource, "/");
+        assert!(!alvo.secure);
+    }
+
+    #[test]
+    fn the_default_port_follows_the_scheme() {
+        assert_eq!(parse("ws://a.example").unwrap().port, 80);
+        assert_eq!(parse("wss://a.example").unwrap().port, 443);
+    }
+
+    /// Os dois-pontos de um IPv6 não separam a porta.
+    #[test]
+    fn an_ipv6_authority_keeps_its_colons() {
+        let alvo = parse("ws://[::1]:9001/x").unwrap();
+        assert_eq!(alvo.host, "::1");
+        assert_eq!(alvo.port, 9001);
+        assert_eq!(alvo.resource, "/x");
+    }
+
+    #[test]
+    fn a_fragment_never_reaches_the_wire() {
+        assert_eq!(parse("ws://a.example/p?q=1#top").unwrap().resource, "/p?q=1");
+    }
+
+    #[test]
+    fn http_is_refused_by_name() {
+        assert!(parse("https://a.example").unwrap_err().contains("ws: or wss:"));
+        assert!(parse("a.example").is_err());
+    }
+
+    /// O `Host` leva a porta só quando ela não é a do esquema — é o que um
+    /// servidor com virtual hosts compara.
+    #[test]
+    fn the_host_header_omits_a_default_port() {
+        let alvo = parse("wss://a.example/x").unwrap();
+        let pedido = request(&alvo, &Options::default(), "chave");
+        assert!(pedido.contains("Host: a.example\r\n"), "{pedido}");
+
+        let alvo = parse("ws://a.example:8080/x").unwrap();
+        let pedido = request(&alvo, &Options::default(), "chave");
+        assert!(pedido.contains("Host: a.example:8080\r\n"), "{pedido}");
+    }
+
+    #[test]
+    fn custom_headers_and_origin_reach_the_request() {
+        let alvo = parse("wss://a.example/x").unwrap();
+        let opcoes = Options {
+            origin: Some("https://a.example".to_owned()),
+            headers: vec![("User-Agent".to_owned(), "Oniwalib/1".to_owned())],
+            protocols: vec!["chat".to_owned()],
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("Origin: https://a.example\r\n"), "{pedido}");
+        assert!(pedido.contains("User-Agent: Oniwalib/1\r\n"), "{pedido}");
+        assert!(pedido.contains("Sec-WebSocket-Protocol: chat\r\n"), "{pedido}");
+    }
+
+    /// Um cabeçalho do protocolo não se deixa substituir — ver a nota do
+    /// módulo. Aqui o programa tenta trocar `Connection`, e o pedido continua a
+    /// pedir o upgrade.
+    #[test]
+    fn a_reserved_header_is_ignored() {
+        let alvo = parse("ws://a.example/x").unwrap();
+        let opcoes = Options {
+            headers: vec![
+                ("Connection".to_owned(), "close".to_owned()),
+                ("sec-websocket-key".to_owned(), "outra".to_owned()),
+            ],
+            ..Options::default()
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("Connection: Upgrade\r\n"), "{pedido}");
+        assert!(!pedido.contains("close"), "{pedido}");
+        assert_eq!(pedido.matches("Sec-WebSocket-Key").count(), 1, "{pedido}");
+    }
+
+    /// Um `\r\n` num valor injectaria um cabeçalho inteiro. É cortado, e o que
+    /// vinha depois não aparece em lado nenhum.
+    #[test]
+    fn a_newline_in_a_header_value_is_cut() {
+        let alvo = parse("ws://a.example/x").unwrap();
+        let opcoes = Options {
+            headers: vec![("X-Test".to_owned(), "ok\r\nX-Injected: yes".to_owned())],
+            ..Options::default()
+        };
+        let pedido = request(&alvo, &opcoes, "chave");
+        assert!(pedido.contains("X-Test: ok\r\n"), "{pedido}");
+        assert!(!pedido.contains("X-Injected"), "{pedido}");
+    }
+
+}

--- a/crates/rts-node/src/ws/conn/mod.rs
+++ b/crates/rts-node/src/ws/conn/mod.rs
@@ -34,7 +34,7 @@ use super::handshake;
 use super::transport::{Chunk, Transport};
 
 /// O que aconteceu numa conexão. Dados nativos apenas — nada aqui toca JS.
-pub(super) enum Event {
+pub(in crate::ws) enum Event {
     Open,
     Message(Message),
     Close { code: u16, reason: String },
@@ -82,7 +82,7 @@ fn servers() -> &'static Mutex<HashMap<u64, Server>> {
 
 /// Os ids. Um contador só para conexões e servidores porque nenhum dos dois é
 /// procurado pelo número do outro, e um espaço só torna impossível confundi-los.
-fn next_id() -> u64 {
+pub(super) fn next_id() -> u64 {
     static NEXT: AtomicU64 = AtomicU64::new(1);
     NEXT.fetch_add(1, Ordering::Relaxed)
 }
@@ -275,111 +275,12 @@ pub(super) fn fail(id: u64, motivo: String) {
         }
     });
 }
-/// O laço de leitura de uma conexão. Roda numa thread de fundo e NUNCA chama JS.
-///
-/// `inicial` é semeado no acumulador e processado ANTES da primeira leitura da
-/// rede — se um frame inteiro veio colado à resposta do handshake, ele já está
-/// completo aqui, e bloquear à espera de mais bytes antes de o olhar entregaria
-/// a primeira mensagem só quando chegasse a segunda.
-fn ler_ate_fechar(id: u64, mut fluxo: Transport, masks: bool, inicial: Vec<u8>) {
-    let mut acumulado: Vec<u8> = inicial;
-    let mut montador = Assembler::default();
-    loop {
-        // Processar primeiro, ler depois. Na primeira volta isto consome o que
-        // veio com o handshake; nas seguintes o acumulado está vazio e o laço
-        // interno sai de imediato.
-        loop {
-            match frame::read_frame(&acumulado) {
-                Read::Incomplete => break,
-                Read::Invalid(motivo) => {
-                    push(id, Event::Error(motivo.to_owned()));
-                    encerrar(id);
-                    return;
-                }
-                Read::Got(quadro, usados) => {
-                    acumulado.drain(..usados);
-                    match montador.accept(quadro) {
-                        Delivered::Message(mensagem) => push(id, Event::Message(mensagem)),
-                        Delivered::Ping(dados) => {
-                            // Responder PONG é obrigação do RFC §5.5.2, e é o
-                            // que mantém viva uma conexão atrás de um proxy que
-                            // derruba o que fica quieto.
-                            let pong = frame::write_frame(frame::OP_PONG, &dados, mascara(masks));
-                            let _ = fluxo.write_all(&pong);
-                        }
-                        Delivered::Pong | Delivered::Partial => {}
-                        Delivered::Close(fim) => {
-                            let veio_com_codigo = fim.is_some();
-                            let (code, reason) = fim.unwrap_or((1005, String::new()));
-                            // O eco leva o MESMO código de volta, que é o que o
-                            // RFC §5.5.1 manda ("SHOULD echo the status code").
-                            // Ecoar vazio dava um `'close'` com 1005 — "sem
-                            // código" — a quem tinha acabado de mandar 1000, e
-                            // um lado a dizer "encerramento normal" e o outro a
-                            // ouvir "não disse nada" é uma discordância sobre se
-                            // a despedida foi ordeira.
-                            //
-                            // 1005 é o que o RFC proíbe de aparecer NA REDE: é o
-                            // valor que uma API mostra quando não veio código, e
-                            // não um código que se envie. Por isso o eco vazio
-                            // se mantém nesse caso.
-                            let carga = if veio_com_codigo {
-                                code.to_be_bytes().to_vec()
-                            } else {
-                                Vec::new()
-                            };
-                            let eco = frame::write_frame(frame::OP_CLOSE, &carga, mascara(masks));
-                            let _ = fluxo.write_all(&eco);
-                            push(id, Event::Close { code, reason });
-                            encerrar(id);
-                            return;
-                        }
-                        Delivered::Invalid(motivo) => {
-                            push(id, Event::Error(motivo.to_owned()));
-                            encerrar(id);
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-        let bytes = match fluxo.read_plaintext() {
-            Ok(Chunk::Eof) => break,
-            // Um pedaço VAZIO não é fim: um registo TLS de controlo consome
-            // bytes da rede e não produz plaintext nenhum. Tratar isso como fim
-            // fechava a conexão a meio de uma troca de chaves.
-            Ok(Chunk::Data(bytes)) => bytes,
-            Err(erro) => {
-                push(id, Event::Error(erro.to_string()));
-                break;
-            }
-        };
-        acumulado.extend_from_slice(&bytes);
-    }
-    // 1006 é o código que o RFC reserva para "fechou sem frame de close" — é o
-    // que um cabo puxado produz, e mentir 1000 aqui faria uma queda parecer uma
-    // despedida.
-    push(id, Event::Close { code: 1006, reason: String::new() });
-    encerrar(id);
-}
 
-/// A chave de máscara de um lado que mascara.
-///
-/// `None` no servidor: mascarar do servidor para o cliente é violação do RFC
-/// §5.1, e um cliente conforme fecha a conexão ao receber.
-fn mascara(masks: bool) -> Option<[u8; 4]> {
-    if !masks {
-        return None;
-    }
-    let mut chave = [0u8; 4];
-    // Não precisa ser imprevisível para segurança de conteúdo — a máscara existe
-    // contra envenenamento de cache em proxies, e o que ela exige é que varie.
-    let semente = next_id().wrapping_mul(0x9E37_79B9_7F4A_7C15);
-    chave.copy_from_slice(&semente.to_ne_bytes()[..4]);
-    Some(chave)
-}
+mod reader;
 
-fn push(id: u64, event: Event) {
+use self::reader::{ler_ate_fechar, mascara};
+
+pub(super) fn push(id: u64, event: Event) {
     with_conns(|table| {
         if let Some(conn) = table.get_mut(&id) {
             conn.queue.push_back(event);
@@ -405,7 +306,7 @@ fn push_server(id: u64, event: ServerEvent) {
 ///
 /// Do lado do servidor isto passou despercebido porque nada fechava: um teste
 /// que aceita uma ligação e acaba nunca chega a este caminho.
-fn encerrar(id: u64) {
+pub(super) fn encerrar(id: u64) {
     with_conns(|table| {
         if let Some(conn) = table.get_mut(&id) {
             conn.stream = None;

--- a/crates/rts-node/src/ws/conn/reader.rs
+++ b/crates/rts-node/src/ws/conn/reader.rs
@@ -1,0 +1,114 @@
+//! O laço que lê uma conexão, e a máscara que decide de que lado ele está.
+//!
+//! Separado de `conn/mod.rs` para o teto de 500 linhas deste crate, e o corte é
+//! onde a thread muda: tudo aqui corre numa thread de FUNDO e nunca toca em
+//! JavaScript, onde `mod.rs` é a tabela que a thread do JS consulta. As duas
+//! metades já se falavam só através de `push`, e o ficheiro agora diz isso.
+
+use super::{Event, encerrar, next_id, push};
+use crate::ws::frame::{self, Assembler, Delivered, Read};
+use crate::ws::transport::{Chunk, Transport};
+
+/// O laço de leitura de uma conexão. Roda numa thread de fundo e NUNCA chama JS.
+///
+/// `inicial` é semeado no acumulador e processado ANTES da primeira leitura da
+/// rede — se um frame inteiro veio colado à resposta do handshake, ele já está
+/// completo aqui, e bloquear à espera de mais bytes antes de o olhar entregaria
+/// a primeira mensagem só quando chegasse a segunda.
+pub(super) fn ler_ate_fechar(id: u64, mut fluxo: Transport, masks: bool, inicial: Vec<u8>) {
+    let mut acumulado: Vec<u8> = inicial;
+    let mut montador = Assembler::default();
+    loop {
+        // Processar primeiro, ler depois. Na primeira volta isto consome o que
+        // veio com o handshake; nas seguintes o acumulado está vazio e o laço
+        // interno sai de imediato.
+        loop {
+            match frame::read_frame(&acumulado) {
+                Read::Incomplete => break,
+                Read::Invalid(motivo) => {
+                    push(id, Event::Error(motivo.to_owned()));
+                    encerrar(id);
+                    return;
+                }
+                Read::Got(quadro, usados) => {
+                    acumulado.drain(..usados);
+                    match montador.accept(quadro) {
+                        Delivered::Message(mensagem) => push(id, Event::Message(mensagem)),
+                        Delivered::Ping(dados) => {
+                            // Responder PONG é obrigação do RFC §5.5.2, e é o
+                            // que mantém viva uma conexão atrás de um proxy que
+                            // derruba o que fica quieto.
+                            let pong = frame::write_frame(frame::OP_PONG, &dados, mascara(masks));
+                            let _ = fluxo.write_all(&pong);
+                        }
+                        Delivered::Pong | Delivered::Partial => {}
+                        Delivered::Close(fim) => {
+                            let veio_com_codigo = fim.is_some();
+                            let (code, reason) = fim.unwrap_or((1005, String::new()));
+                            // O eco leva o MESMO código de volta, que é o que o
+                            // RFC §5.5.1 manda ("SHOULD echo the status code").
+                            // Ecoar vazio dava um `'close'` com 1005 — "sem
+                            // código" — a quem tinha acabado de mandar 1000, e
+                            // um lado a dizer "encerramento normal" e o outro a
+                            // ouvir "não disse nada" é uma discordância sobre se
+                            // a despedida foi ordeira.
+                            //
+                            // 1005 é o que o RFC proíbe de aparecer NA REDE: é o
+                            // valor que uma API mostra quando não veio código, e
+                            // não um código que se envie. Por isso o eco vazio
+                            // se mantém nesse caso.
+                            let carga = if veio_com_codigo {
+                                code.to_be_bytes().to_vec()
+                            } else {
+                                Vec::new()
+                            };
+                            let eco = frame::write_frame(frame::OP_CLOSE, &carga, mascara(masks));
+                            let _ = fluxo.write_all(&eco);
+                            push(id, Event::Close { code, reason });
+                            encerrar(id);
+                            return;
+                        }
+                        Delivered::Invalid(motivo) => {
+                            push(id, Event::Error(motivo.to_owned()));
+                            encerrar(id);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        let bytes = match fluxo.read_plaintext() {
+            Ok(Chunk::Eof) => break,
+            // Um pedaço VAZIO não é fim: um registo TLS de controlo consome
+            // bytes da rede e não produz plaintext nenhum. Tratar isso como fim
+            // fechava a conexão a meio de uma troca de chaves.
+            Ok(Chunk::Data(bytes)) => bytes,
+            Err(erro) => {
+                push(id, Event::Error(erro.to_string()));
+                break;
+            }
+        };
+        acumulado.extend_from_slice(&bytes);
+    }
+    // 1006 é o código que o RFC reserva para "fechou sem frame de close" — é o
+    // que um cabo puxado produz, e mentir 1000 aqui faria uma queda parecer uma
+    // despedida.
+    push(id, Event::Close { code: 1006, reason: String::new() });
+    encerrar(id);
+}
+
+/// A chave de máscara de um lado que mascara.
+///
+/// `None` no servidor: mascarar do servidor para o cliente é violação do RFC
+/// §5.1, e um cliente conforme fecha a conexão ao receber.
+pub(super) fn mascara(masks: bool) -> Option<[u8; 4]> {
+    if !masks {
+        return None;
+    }
+    let mut chave = [0u8; 4];
+    // Não precisa ser imprevisível para segurança de conteúdo — a máscara existe
+    // contra envenenamento de cache em proxies, e o que ela exige é que varie.
+    let semente = next_id().wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    chave.copy_from_slice(&semente.to_ne_bytes()[..4]);
+    Some(chave)
+}


### PR DESCRIPTION
CLAUDE.md's ceilings are binding — the two engine crates at 1000 lines, the rest at 500 — and the work of the last three PRs broke them in three places. **All three are mine**, and the worst is the third, because the rule names that case exactly: *"new code lands in a small focused module, never appended to something already oversized"*.

| file | was | now |
|---|---|---|
| `parse/item.rs` | 1345 → **1395** (already 345 over, and I added to it) | **934** |
| `ws/client.rs` | new → **504** | `client/mod.rs` 286 + `client/url.rs` 241 |
| `ws/conn.rs` | 436 → **563** | `conn/mod.rs` 463 + `conn/reader.rs` 115 |

## The cuts are where the subject changes, not wherever 500 fell

- **`parse/module.rs`** is `import` and `export` — one subject, since they are two sides of the same table and TypeScript's erasure applies to both. **`parse/stmt.rs`** is what a statement can BE, where `item.rs` keeps what a function and a class ARE. The folder already had `expr.rs`, `members.rs` and `pat.rs`; these two were the ones missing.
- **`ws/client/url.rs`** has no socket in it at all — text in, text out — which is why its ten tests run with no network. `client/mod.rs` is everything that touches one.
- **`ws/conn/reader.rs`** is everything that runs on the BACKGROUND thread and may never touch JavaScript, where `conn/mod.rs` is the table the JS thread reads. The two halves already spoke only through `push`; the file says so now.

**What is not done:** `rts-core` and `rts-codegen` still hold eight files over 1000 (`functions.rs`, `capture.rs`, `objects.rs`, …). Those predate this work and are untouched — splitting unrelated code to tidy a number is the scope creep the ceiling rule is not asking for.

## The number in CLAUDE.md was stale

`rts-codegen`'s rule 7 names this: *"a number quoted from memory is worse than no number"*. It said 758 of 819 for 08-29.

Re-measured: **792 of 845**, by `target/release/rts.exe test` at `891b767c`, 2026-09-02.

The paragraph added beside it matters more than the count: **one of the 53 failures is there by design**. `generator_for_of_root.test.ts` records an open defect and used to pass on the build that had it; `expect()` going from eight allocations per assertion to one stopped hiding it. Anyone reading 792/845 without that reads it wrongly, and the honesty floor is why it belongs in the file rather than in a commit message nobody will find.

## Gates

- `cargo test --profile fast -p rts-node -p rts-codegen -p rts-core` — all green, identical counts
- suite at **792/845** with an **empty lost list** against the measurement before the split

No behaviour changes: this moves code and adjusts visibility, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa
