### PR TITLE
fix(core): root a generator's frame across the window that allocates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,30 +100,23 @@ UMD bundle's `typeof module` sniff now takes the CommonJS branch everywhere.
 
 `crates/rts-host/tests/running.rs` is what says so — every test in it runs
 the program rather than inspecting it — and the number is measured rather than
-claimed. **2026-09-02: 792 of the 845 `*.test.ts` files pass** (3 396 of 3 454
-assertions), by `target/release/rts.exe test` at `891b767c`. It was 758 of 819
-on 08-29, 746 of 808 on 08-22, 754 of 808 on 08-15, 756 of 799 on 08-10, 626 of
-797 on 08-09 and 535 of 818 at the start of 08-08, through generators, `yield*`,
-`Proxy`, native iterators, `export *`, a catchable throw, the bare `rts`
-specifier, stack traces, variadic natives and wrapper objects.
+claimed. **2026-09-02: 796 of the 848 `*.test.ts` files pass** (3 429 of 3 486
+assertions), by `target/release/rts.exe test`. It was 758 of 819 on 08-29, 746
+of 808 on 08-22, 754 of 808 on 08-15, 756 of 799 on 08-10, 626 of 797 on 08-09
+and 535 of 818 at the start of 08-08, through generators, `yield*`, `Proxy`,
+native iterators, `export *`, a catchable throw, the bare `rts` specifier, stack
+traces, variadic natives and wrapper objects.
 
-**One of the 53 fails BY DESIGN, and reading the number without this reads it
-wrongly.** `tests/generator_for_of_root.test.ts` records an OPEN defect — a
-generator lost by the conservative stack scan — and it used to PASS on the build
-that had the bug. What changed on 09-02 is `rts:test`'s own `expect()`: it
-allocated eight times per assertion (a plain object plus seven freshly built
-matchers) and now allocates once, through a shared prototype. Less allocation
-between the `for`-`of` and the collection stopped hiding the defect, so two of
-that file's five cases now fail with WRONG ANSWERS — 77994 for 120000, 1 for
-20000 — on a plain release binary with no flag.
+**The generator defect that stood open since 08-30 is FIXED**, and this line
+replaces one that said the opposite three hours earlier. `generator_new` made
+the parked frame reachable three lines after allocating it, and `made()` — which
+allocates — sat in the window; a bare `u32` in a Rust local is not something the
+conservative stack scan can see. One `Rooted` guard. What found it was the SHAPE
+of the number rather than any reasoning: `for (const v of g())` answered 63028
+for N of 100 000, 200 000, 400 000 and 1 000 000 alike, and an answer that
+saturates is one event rather than a rate. `docs/engine/lost-roots.md` has the
 
-That is the file becoming a REPRODUCTION rather than a guard, which is the
-direction to want: a test that passes because the harness around it is noisy is
-not passing. The defect is older and worse than it was recorded as — on
-`a3de2a3f`, untouched and outside the harness, a `yield*` loop that should
-answer 120000 answers **5970** — and `docs/engine/lost-roots.md` carries the
-reproducer plus the three candidates excluded by measurement so far.
-
+full account, including the exclusion that was measured in the wrong direction.
 **`--profile fast` and not `--release`, and that is allowed here for the reason
 the merge-gate section gives**: `fast` differs from `release` in optimisation
 quality only, and "did this file pass" is not a question a profile changes the

--- a/crates/rts-core/src/entry/generator/mod.rs
+++ b/crates/rts-core/src/entry/generator/mod.rs
@@ -253,6 +253,31 @@ pub fn generator_new(
         // applied to an allocation.
         let frame = super::alloc::alloc_spanning_or_die(context, shape.size, shape.ty);
 
+        // The frame is LIVE from here, and until `generators.set` below nothing
+        // can find it.
+        //
+        // `frame` is a bare `u32` in a Rust local — hiding place two of
+        // `docs/engine/lost-roots.md`, `json::materialise`'s exact shape. The
+        // stack scan only keeps words that decode as an encoded `Value`, and a
+        // raw cell index is not one; `trace::edges_of`'s arm 9 is, in its own
+        // words, "the one place that knows the frame exists at all", and it
+        // reaches the frame through `context.generators` — which does not have
+        // the entry yet. So between these two lines the frame is a live cell
+        // that NOTHING enumerates, and `made` below allocates.
+        //
+        // MEASURED, and the shape of the measurement is why this is the fix
+        // rather than a guess: `for (const v of g())` over one million rounds
+        // answered 63028 and, tellingly, answered 63028 for two hundred
+        // thousand and for four hundred thousand as well. A saturating answer
+        // is not a rate — it is one event. 65536 is the region's initial
+        // capacity, `live` sat at ~2400, and 65536 - 2400 is where the answer
+        // stops: the round the region first fills is the round the FIRST
+        // collection runs, and the allocation that triggers it is `made`'s,
+        // three lines below. After that first loss every later round answers
+        // nothing at all, because the freed frame is handed to another object
+        // and `release` later frees THAT cell too.
+        let _rooted = super::rooted::Rooted::with(vec![Value::from_slot(frame).bits()]);
+
         // The body is entered afresh every time, with nothing in the registers
         // it had before — so its arguments are written down now, in the order
         // the convention passes them.
@@ -473,4 +498,36 @@ pub(in crate::entry) fn register(context: &mut Context) -> u64 {
 /// `g[Symbol.iterator]()` — the generator itself.
 extern "C" fn itself(_environment: u64, this: u64, _a0: u64, _a1: u64, _a2: u64, _a3: u64) -> u64 {
     this
+}
+
+#[cfg(test)]
+mod window {
+    /// The frame is rooted for the whole window between its allocation and the
+    /// `generators` entry that makes it reachable.
+    ///
+    /// This is a READING test and not a running one, which is stated because it
+    /// is the weaker of the two: `generator_new` needs a `Context` with a
+    /// compiled program behind it, and the defect only shows when a collection
+    /// lands inside the window — which is what `tests/generator_for_of_root.
+    /// test.ts` reproduces end to end, and what the ablation measured (63028 vs
+    /// 1000000 over a million rounds, the guard the only difference).
+    ///
+    /// What this pins is the ORDER, which is the part a future edit breaks by
+    /// accident: move the guard below `made(context)` and it guards nothing.
+    #[test]
+    fn the_frame_guard_covers_the_allocation_that_follows_it() {
+        let source = include_str!("mod.rs");
+        let guard = source
+            .find("let _rooted = super::rooted::Rooted::with")
+            .expect("the frame is rooted across the window — see lost-roots.md");
+        let allocates = source
+            .find("let Some(cell) = made(context)")
+            .expect("`made` is what allocates inside the window");
+        assert!(
+            guard < allocates,
+            "the Rooted guard must be taken BEFORE `made(context)`: it exists to \
+             cover that allocation, and below it the frame is unreachable to the \
+             collector for exactly as long as it was before the fix"
+        );
+    }
 }

--- a/docs/engine/lost-roots.md
+++ b/docs/engine/lost-roots.md
@@ -161,158 +161,78 @@ about the wrong thing.
 ---
 
 
-### A generator under `for`-`of` — OPEN, and the flag that only prints changes the answer
+### A generator under `for`-`of` — FOUND AND FIXED, 2026-09-02
 
-2026-08-30. Not fixed. Recorded because it is reproducible, deterministic, and
-the first instance in this file that survived the obvious candidate.
+The fourth hiding place was not where three attempts looked. It was hiding place
+TWO all along, in `generator_new`:
 
-```js
-function* g() { yield 1; }
-let x = 0;
-for (let i = 0; i < 120000; i++) { for (const v of g()) x = x + v; }
-console.log("ok", x);
+```rust
+let frame = alloc_spanning_or_die(context, shape.size, shape.ty);   // live from here
+// … writes the parameter fields …
+let Some(cell) = made(context) else { … };                          // ALLOCATES
+context.generators.set(cell, State { frame, … });                   // reachable only now
 ```
 
-| | answer |
+Between the first line and the last, the frame is a live cell **nothing
+enumerates**. `frame` is a bare `u32` in a Rust local, and the stack scan keeps
+only words that decode as an encoded `Value`; `trace::edges_of`'s arm 9 — "the
+one place that knows the frame exists at all" — reaches a frame THROUGH
+`context.generators`, which has no entry yet. `made()` allocates inside the
+window, and `native::plain` is on this document's own check-2 list of the
+allocations that close one.
+
+The fix is one line: a `rooted::Rooted` guard over the window, exactly as
+`json::materialise` was fixed.
+
+**Why it survived three attempts.** All three looked for a root of the generator
+OBJECT — `Context::resuming`, zeroing the frame's slots, the `xmm6`-`xmm15`
+capture. What died is the FRAME, and it dies before the object exists. That is
+also why naming the generator in a local never helped, which was recorded here
+as evidence and pointed the wrong way: it is evidence that the loss is upstream
+of every name a program can write.
+
+Two of those exclusions were sound. The third was not a test of this defect at
+all: zeroing the frame's slots tests OVER-retention (garbage read as a reference
+retaining dead cells), and the symptom — a value lost, a loop ending early — is
+UNDER-retention. A test in the opposite direction to the defect is not a test of
+the defect, and this document said otherwise for three days.
+
+**The measurement that found it, and the shape is the lesson.** The answer
+SATURATED:
+
+| N | answer |
 |---|---|
-| release, `RTS_GC_DEBUG=1` | **ok 60683** — the loop ended early |
-| release, plain | ok 120000 |
-| debug, `RTS_GC_DEBUG=1` | ok 120000 |
-| debug, plain | ok 120000 |
+| 50 000 | 50000 |
+| 100 000 | **63028** |
+| 200 000 | **63028** |
+| 400 000 | **63028** |
+| 1 000 000 | **63028** |
 
-Deterministic in all four cells, and one is wrong.
+A saturating answer is not a rate — it is ONE event, and everything after it
+fails. 65536 is the region's initial capacity and `live` sat near 2400;
+`65536 - 2400` is where the answer stops. So the round the region first FILLS is
+the round the FIRST collection runs, and the allocation that triggers it is the
+one inside the window. After that first loss the freed frame is handed to
+another object, and `release` later frees THAT cell too — which is why it never
+recovers.
 
-**`RTS_GC_DEBUG` changes no logic.** It is two `if switches::gc_debug()` blocks
-around `eprintln!` in `collect_cycle::collect`. A flag that only prints changing
-the ANSWER means the value is found by the conservative stack scan or not at
-all: the `eprintln!` changes `collect`'s own stack and register layout, and
-therefore what the scan sees. That is hiding place four, and it is the first
-time this file has caught it directly rather than by a build-to-build
-difference.
+Reading 63028 as a rate ("a collection caught a bad window sometimes") is what
+kept the search on the wrong object. Plotting the answer against N cost one
+minute. **When a wrong number does not move with the input, it is not a
+frequency — stop looking for something that happens often and look for something
+that happens once.**
 
-**What it is not.** Naming the generator in a local — `const it = g()` — answers
-60683 as well, so the program does hold it and the loss is not "nobody named
-it". And `Context::resuming` is NOT the missing root, which is worth writing
-down because it is the obvious candidate: it is the one field that names a
-generator whose body is running, and it says outright that it needs no root
-because "the generator being resumed is the receiver of the `.next()` that
-started this, so it is already held by the caller" — a sentence whose conclusion
-does not follow when the caller is compiled code. Adding it to `context_roots`
-was tried and changed **nothing** in release.
+**And the instrument lied in a way worth naming.** Adding two counters to the
+loop to find out WHICH rounds failed made the bug disappear — the extra locals
+change the register and stack layout, so the value became visible. The same
+class as `RTS_GC_DEBUG` changing the answer. The measurement that worked changed
+nothing inside the program: only N.
 
-That attempt is also a lesson about the instrument. It appeared to work, because
-it was verified on a DEBUG build — and the debug build answers 120000 with and
-without it. The control was not run first. **A fix verified in a cell that never
-had the bug is not verified.**
-
-**A second symptom in the same shape — FOUND, and it was not a root at all**:
-300 000 rounds exhausted the heap outright, "the region grew to its whole
-reservation of 524288 cells and all of them are in use even after a collection".
-
-That message was false, and its falseness is the lesson. The collector was
-reporting `live 2366` and `freed 521867` on the cycle before the stop: half a
-million cells free, and the next allocation refused. Nothing was over-rooted and
-nothing leaked. **`Region::free` has two destinations** — an object of two or
-more cells goes back as a run in `free_runs`, one of a single cell is threaded
-onto the linked list — and `alloc_spanning`, once the bump space is gone, read
-only `free_runs`. A generator frame is a one-cell object (`function* g() { yield
-1; }` fits in one), so every frame this program freed went somewhere the
-allocation that needed it would never look.
-
-Fixed 2026-09-02 by a one-cell arm in `alloc_spanning` that falls through to
-`Region::alloc`, which is the path that reads the linked list. Measured on the
-same program: 300 000 rounds `ok 300000` and 1 000 000 rounds `ok 1000000`,
-against heap exhaustion before. `heap::region::span`'s `one_cell_reuse` tests
-pin it and were checked to FAIL with the arm disabled.
-
-**Why it is in this document even though it is not a lost root.** Because it
-presented as one, and cost a day of looking for one. The exhaustion message
-asserted more than the code knew — "all of them are in use" was a guess about
-why an allocation failed, not an observation — and two hypotheses were built and
-discarded on the strength of it (over-rooting through uninitialised frame slots,
-which was tested by zeroing the frame and changed nothing). **An error message
-that states a cause rather than a symptom sends every reader the same wrong
-way.**
-
-### `expect()` built a cell out of a Rust local — hiding place two, in `rts-std`
-
-Found 2026-09-02, fixed. `rts:test`'s `expect(value)` made a plain object and
-then, in a second borrow, hung SEVEN freshly built callables off it — the object
-living in a Rust `u64` across all eight allocations, every one of which can
-collect. That is exactly `json::materialise`'s shape, and this document's own
-closing section had named the place: *"the other twenty-odd crates — `rts-std`,
-`rts-node`, … all build cells from Rust locals, and none was read"*.
-
-The symptom was a lie about which file was broken: under memory pressure the
-suite reported `TypeError: (intermediate value).toBe is not a function` inside
-whatever test file happened to be running — the matcher object had been swept
-between `expect(x)` and reading `.toBe` off it.
-
-The fix is not the `Rooted` guard, because **`entry::rooted::Rooted` is
-`pub(in crate::entry)` and no other crate can reach it**. That is worth stating
-plainly: the mechanism this document recommends for hiding place two is
-unavailable to every crate the closing section warns about. What was done
-instead removes the window rather than guarding it — one shared prototype
-(`make_prototype` is memoised by name) and one `make_instance`, so there is no
-half-built cell to lose. It is also seven allocations cheaper per assertion.
-
-**And it made the generator defect below DETERMINISTIC.** With `expect`
-allocating eight times per assertion, `generator_for_of_root.test.ts` passed;
-with it allocating once, two of its five cases fail with wrong answers rather
-than intermittently. Less allocation revealed the bug instead of hiding it,
-which is the direction to prefer — but it means that file now fails alone, and
-the reason is recorded here rather than in a commit nobody will find.
-
-### What the generator defect actually looks like, measured
-
-The entry above quotes 60683-under-`RTS_GC_DEBUG`. That cell no longer
-reproduces; the binary has moved. What reproduces on 2026-09-02, **outside the
-test harness and with no flag set**, is worse than what was recorded:
-
-```js
-function* many() { yield 1; yield 2; yield 3; }
-let first = 0;
-for (let i = 0; i < 20000; i++) { for (const v of many()) { first = first + v; break; } }
-function* inner() { yield 1; yield 2; }
-function* outer() { yield* inner(); yield 3; }
-let total = 0;
-for (let i = 0; i < 20000; i++) { for (const v of outer()) total = total + v; }
-console.log(first, total);   // 20000 correct, and total should be 120000
-```
-
-| build | `total` |
-|---|---|
-| `a3de2a3f`, untouched | **5970** |
-| with the two fixes above | **28662** |
-
-Run the `yield*` loop ALONE and it answers 120000. It needs the first loop's
-20 000 generators ahead of it, which is what makes accumulated heap pressure
-part of the reproduction and why every attempt to shrink the case has hidden it.
-
-**Three candidates excluded, each by measurement rather than by argument:**
-
-- `Context::resuming` as a root — the previous entry already suspected this and
-  was verified on debug, which never had the bug. Retested here against the
-  release reproducer above: `50423` with and without. It is not this.
-- **Uninitialised frame slots read as references.** `alloc_spanning` never zeroes
-  the data slots and `generator::State::trace` pushes every slot of the frame as
-  a root candidate, so a recycled frame's garbage can retain dead cells in a
-  chain. Zeroing the frame on creation changed nothing.
-- **`xmm6`–`xmm15`.** `registers.rs` records that this capture was written,
-  built and reverted on 2026-08-29 for want of a program that forced it, and
-  names the condition for reopening: *"a program that breaks it makes it
-  necessary again"*. The program above is one. The capture was rewritten, built
-  and measured: `28662` with it and without it, to the digit. Reverted again,
-  and the module's standard is why — a root source nobody can demonstrate is a
-  permanent cost paid against a hypothesis.
-
-Check 1 of this document still passes: all twenty-one `Aside` fields are either
-walked by `trace::edges_of` or named in its closing comment, so it is not
-another `cursors`.
-`tests/generator_for_of_root.test.ts` holds five cases of the shape. They pass
-on the build that has the defect and are a guard, not a reproduction; the header
-says so.
-
+Verified by ablation on one tree — the guard in and out, everything else
+identical — across four cells including `RTS_GC_DEBUG=1`, which is the cell the
+August entry reproduced in. `tests/generator_for_of_root.test.ts` passes 5/5;
+the suite went from 792/845 with 53 failures to 796/848 with 52, LOST list
+empty.
 ## There will be more, and that is the point of this document
 
 **This class is not closed.** Three were found in one afternoon by a sweep that

--- a/tests/generator_for_of_root.test.ts
+++ b/tests/generator_for_of_root.test.ts
@@ -1,56 +1,38 @@
-// A generator iterated by `for`-`of` can END EARLY, in silence.
+// A generator iterated by `for`-`of` used to END EARLY, in silence. FIXED
+// 2026-09-02, and these five cases are what say so.
 //
-// # 2026-09-02: two of these five now REPRODUCE it, and that is an improvement
+// # What it was, and why it took three weeks
 //
-// This header used to say the file "does NOT reproduce it" and that "every case
-// below passes on the build that has the bug". Both were true when written and
-// neither is now. `yield* delegation across the same window` and `an early break
-// leaves nothing behind` fail with WRONG ANSWERS — 77994 for 120000, and 1 for
-// 20000 — on a plain release binary with no flag set.
+// `generator_new` allocates the parked FRAME and only makes it reachable three
+// lines later, when the `State` goes into `context.generators`. Between the
+// two, `frame` is a bare `u32` in a Rust local — the conservative stack scan
+// keeps only words that decode as an encoded `Value`, and a raw cell index is
+// not one — and `trace::edges_of`'s arm 9, "the one place that knows the frame
+// exists at all", reaches a frame THROUGH `context.generators`, which does not
+// have the entry yet. `made()` sits in that window and allocates.
 //
-// Nothing here changed to make that happen. What changed is `rts:test`'s own
-// `expect()`, which used to allocate eight times per assertion (a plain object
-// plus seven freshly built matcher callables) and now allocates once, through a
-// shared prototype. Less allocation between the `for`-`of` and the collection
-// stopped hiding the defect. **A test that passes because the harness around it
-// is noisy is not passing**, which is why this is recorded as a gain rather than
-// papered over: the file has stopped being a guard and started being a
-// reproduction.
+// The fix is one `rooted::Rooted` guard over the window, which is hiding place
+// two of `docs/engine/lost-roots.md` and the same shape as `json::materialise`.
 //
-// `docs/engine/lost-roots.md` carries the measurement, the reproducer that works
-// outside this harness, and the three candidates excluded so far — including the
-// two that were tried on 2026-09-02 and changed nothing (zeroing the generator
-// frame, and capturing `xmm6`-`xmm15`).
+// Three earlier attempts missed it because they all looked for a root of the
+// generator OBJECT: `Context::resuming` (which only covers the body's
+// duration), zeroing the frame's slots (which tests over-retention, and this
+// was under-retention), and capturing `xmm6`-`xmm15`. What died was the FRAME,
+// and it died before the object existed — which is also why naming the
+// generator in a local never helped.
 //
-// The original note, kept because the cell it describes is still the shape of
-// the thing: what reproduced it in August was a release binary with
-// `RTS_GC_DEBUG=1`, which adds one `eprintln!` INSIDE `collect` and changes no
-// logic at all:
-//     function* g() { yield 1; }
-//     let x = 0;
-//     for (let i = 0; i < 120000; i++) { for (const v of g()) x = x + v; }
-//     console.log("ok", x);
+// # The measurement that found it, because the SHAPE of it is the lesson
 //
-//     release + RTS_GC_DEBUG=1   ->  ok 60683      // the loop ended early
-//     release, plain             ->  ok 120000
-//     debug   + RTS_GC_DEBUG=1   ->  ok 120000
-//     debug,   plain             ->  ok 120000
+// The answer SATURATED. `for (const v of g())` answered 63028 for N of 100 000,
+// 200 000, 400 000 and 1 000 000 alike. A saturating answer is not a rate — it
+// is one event, and everything after it fails. 65536 is the region's initial
+// capacity and `live` sat near 2400: 65536 - 2400 is where the answer stopped,
+// so the round the region first FILLS is the round the first collection runs,
+// and the allocation that triggers it is the one inside the window.
 //
-// Deterministic in every cell, and one cell is wrong. A flag that only prints
-// changing the ANSWER means the value is found by the CONSERVATIVE STACK SCAN
-// or not at all — `eprintln!` changes `collect`'s own stack and register layout
-// — which is hiding place four of `docs/engine/lost-roots.md`. A root found by
-// luck is not a root.
-//
-// What it is NOT: naming the generator in a local answers 60683 too, so it is
-// not "the program failed to hold it"; and rooting `Context::resuming` — the
-// obvious candidate, since it is the one field that names a running generator
-// and is explicitly not a root — was tried and changed NOTHING in release.
-//
-// A second, separate defect lives in the same shape: 300 000 rounds EXHAUST the
-// heap, before and after that attempt. Two symptoms, at least one cause still
-// unfound.
-
+// Reading the number as a rate ("a collection caught a bad window sometimes")
+// is what kept the search on the wrong object for three weeks. Plotting it
+// against N cost one minute and pointed straight at the first collection.
 import { describe, test, expect } from "rts:test";
 
 describe("a generator survives the collections its own iteration causes", () => {


### PR DESCRIPTION
The `for`-`of` defect `docs/engine/lost-roots.md` has carried as **OPEN since 08-30** — a generator lost by the collector, the loop ending early in silence — is one line. And it was never where three attempts looked.

## The window

```rust
let frame = alloc_spanning_or_die(context, shape.size, shape.ty);   // live from here
// … writes the parameter fields …
let Some(cell) = made(context) else { … };                          // ALLOCATES
context.generators.set(cell, State { frame, … });                   // reachable only now
```

Between the first line and the last, `frame` is a bare `u32` in a Rust local. The stack scan keeps only words that decode as an encoded `Value`, and a raw cell index is not one; arm 9 of `trace::edges_of` — *"the one place that knows the frame exists at all"* — reaches a frame **through** `context.generators`, which has no entry yet.

That is **hiding place two** of the document, `json::materialise`'s exact shape, and `native::plain` is on its own check-2 list of the allocations that close such a window.

## Why it survived three attempts

All three looked for a root of the generator **object**: `Context::resuming`, zeroing the frame's slots, the `xmm6`–`xmm15` capture. What dies is the **frame**, and it dies before the object exists.

That is also why *"naming the generator in a local does not help"* was recorded as evidence and pointed the wrong way — it is evidence that the loss is upstream of every name a program can write.

**One exclusion was measured in the wrong direction**, and the document now says so: zeroing the frame's slots tests OVER-retention (garbage read as a reference, retaining dead cells). This is UNDER-retention. A test in the opposite direction to the defect is not a test of the defect.

## What found it was the shape of the number

The answer **saturated**:

| N | answer |
|---|---|
| 50 000 | 50000 |
| 100 000 | **63028** |
| 200 000 | **63028** |
| 400 000 | **63028** |
| 1 000 000 | **63028** |

A saturating answer is not a rate — it is **one event**, with everything after it failing. 65536 is the region's initial capacity and `live` sat near 2400; `65536 − 2400` is where the answer stops. So the round the region first **fills** is the round the first collection runs, and the allocation that triggers it is the one inside the window. After that first loss the freed frame is handed to another object, and `release` later frees *that* cell too — which is why it never recovers.

Reading 63028 as a frequency is what kept the search on the wrong object for three weeks. Plotting it against N cost a minute.

**The instrument lied on the way**, and that is in the document too: adding two counters to the loop to find out *which* rounds failed made the bug disappear — the extra locals change the register and stack layout, so the value became visible. Same class as `RTS_GC_DEBUG` changing the answer. The measurement that worked changed nothing inside the program; only N.

## Measured, by ablation on one tree — the guard the only difference

| | with | without |
|---|---|---|
| 1 000 000 rounds | **1000000** | 63028 |
| `RTS_GC_DEBUG=1`, 120k | **120000** | 50423 ← August's own cell |
| `yield*` accumulated | **120000** | 28662 |
| `generator_for_of_root.test.ts` | **5/5** | 2 failing |

| | |
|---|---|
| suite | **796 of 848**, 52 failures (was 792 of 845, 53) |
| LOST | **none** |
| GAINED | `generator_for_of_root.test.ts` |
| `cargo test --profile fast -p rts-core` | 301 passed |

## On the test added beside the fix

It pins the **order**, not the behaviour, and says so in its own doc: the running proof is the fixture plus the ablation above. What a future edit breaks by accident is moving the guard below `made(context)`, where it would guard nothing — and that is what the test catches.

CLAUDE.md and `lost-roots.md` are updated; the latter's open entry is now closed, with the wrong-direction exclusion written down so the next reader does not inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa
