### PR TITLE
fix(codegen): um helper declarado duas vezes no mesmo corpo corria o corpo errado (#2617)

### DIFF
--- a/crates/rts-codegen/README.md
+++ b/crates/rts-codegen/README.md
@@ -149,6 +149,27 @@ What the extension may substitute, and why each refusal exists, is on
 pins all of it and passes on the binary before the change as well as after,
 which is what a semantics test has to do.
 
+**The second failure of (1) came back on 2026-09-03, in the pass that was
+built to avoid the map.** "A name declared twice was admitted" is the
+sentence above; `omit::omittable` then reasoned that it did not need
+`declarations_of` at all, because proving every call is inside this body
+makes the name unambiguous *here*. That is true of other functions and false
+of this one: `helper_bindings` descends into sibling blocks, so one body can
+declare `nm` twice with a different function under each, and a map keyed by
+name keeps the last. Every call in the body then ran the last body — issue
+#2617, a protobuf decoder answering a field's number where its value
+belonged, with no error raised.
+
+Two things about it are worth keeping. **The first guard written for it
+counted the wrong thing**: the entries `helper_bindings` returned, which is
+a filtered list, so a body with two `nm`s of which one is not collectable
+counted ONE and the guard stayed quiet — the half of the defect the issue
+actually reported. Counting declarations in the tree is the question, and
+`declarations_of` already asked it one door over. **And (4) was answered
+without a benchmark**: the IR emitted for all nine files in `bench/` is
+byte-identical before and after, which is a stronger statement than two
+close numbers — the generated code did not change, so the clock cannot have.
+
 ---
 
 ## Working on this crate

--- a/crates/rts-codegen/src/emit/omit.rs
+++ b/crates/rts-codegen/src/emit/omit.rs
@@ -100,6 +100,55 @@ pub(super) fn omittable(
 
     let mut answer = Omission::default();
     for (name, function) in named {
+        // DECLARED EXACTLY ONCE IN THIS BODY.
+        //
+        // The candidate clause below used to carry the sentence "the two
+        // clauses above proved that every call to this name is inside this
+        // body, so the declaration in hand is the one every call reaches".
+        // The first half is true and the second does not follow from it:
+        // not being read as a value and not being captured say WHERE the
+        // calls are, never how many declarations they choose between.
+        // `helper_bindings` descends into sibling blocks, so one body can
+        // offer the same spelling twice with a DIFFERENT function under
+        // each, and `answer.local` is keyed by name — the second insert
+        // overwrote the first, and every call in the body, including the
+        // ones written inside the earlier block, reached the last one.
+        //
+        // # Why this counts declarations and not candidates
+        //
+        // Counting the entries `helper_bindings` returned is the version of
+        // this guard that was written first, and it is WRONG in the exact
+        // case the issue reports. That function filters as it collects (a
+        // rest parameter, a defaulted one), so a body holding two `nm`s of
+        // which only one is collectable counts ONE — the guard stays quiet
+        // and the survivor takes over every call site, which is the whole
+        // defect. `declarations_of` counts the name in the tree, which is
+        // the question actually being asked, and it is already the refusal
+        // `candidates` uses one door over for a map of the same shape.
+        //
+        // Refused rather than resolved per block: substituting the right
+        // one needs each call site attributed to the declaration whose
+        // block encloses it, and this analysis runs ONCE for the whole
+        // body, before any of it is emitted and before there is a block to
+        // ask about. A per-block answer is a different pass, not a stricter
+        // version of this one.
+        //
+        // The cost is the substitution of a helper whose spelling the same
+        // body spends twice — which `bench/analytic.ts` does not do (its
+        // four `c`s are four separate function bodies, which
+        // `local_candidate` already covers) and which the whole-program map
+        // refused anyway before this pass existed.
+        //
+        // It stood because it was a wrong ANSWER and not a crash: issue
+        // #2617 is a ~950-line protobuf decoder in which a field NUMBER
+        // came out where that field VALUE belonged, no error raised at all.
+        // Where the two declarations close over different names it surfaces
+        // as a `ReferenceError` instead — the other body emitted into this
+        // block environment, which does not hold what that body reads.
+        // `tests/claude-helper-declarado-duas-vezes.test.ts` pins both.
+        if super::inline::declarations_of(body, name) != 1 {
+            continue;
+        }
         // NEVER READ AS A VALUE. `g(f)`, `f.name`, `const h = f`, `[f]`,
         // `typeof f` and `f?.()` are all reads and all refuse; only the callee
         // of a direct call is not one, because a call is the single use a

--- a/tests/claude-helper-declarado-duas-vezes.test.ts
+++ b/tests/claude-helper-declarado-duas-vezes.test.ts
@@ -1,0 +1,244 @@
+// Um nome de helper declarado MAIS DO QUE UMA VEZ no mesmo corpo, em blocos
+// irmaos — cada declaracao com o seu proprio corpo.
+//
+// PORQUE ESTE FICHEIRO EXISTE
+//
+// `emit/omit.rs` decide, uma vez por corpo e antes de o emitir, quais dos
+// helpers desse corpo podem ser substituidos no sitio da chamada em vez de
+// construidos como closure. Recolhe as declaracoes com `helper_bindings`, que
+// desce a blocos irmaos, e guarda-as num mapa por NOME — onde a segunda
+// declaracao sobrescreve a primeira. Todas as chamadas do corpo passavam
+// entao a executar o corpo da ULTIMA declaracao.
+//
+// O comentario que autorizava isso dizia: "as duas clausulas acima provaram
+// que toda chamada a este nome esta dentro deste corpo, portanto a declaracao
+// em mao e a que toda chamada alcanca". As duas clausulas provam que o nome
+// nunca e lido como valor e que nunca e capturado. Nenhuma delas prova que ha
+// UMA declaracao.
+//
+// Reportado como issue #2617 sobre um descodificador de protobuf de ~950
+// linhas, onde o efeito era um numero de campo a sair como se fosse o valor do
+// campo — sem erro nenhum, so bytes errados. O relator nao conseguiu reduzir o
+// caso, e a razao e que o minimo precisa de DOIS corpos DIFERENTES sob um nome
+// so: com corpos identicos a colisao existe e nao se nota.
+//
+// A regra 11 do `crates/rts-codegen/README.md` manda que uma fixture destas
+// afirme VALORES e nunca que uma substituicao aconteceu — uma que afirmasse a
+// substituicao passaria a verde no dia em que o pass fosse desligado por
+// engano, que e precisamente a falha que essa regra descreve.
+
+import { describe, test, expect } from "rts:test";
+
+// --- o minimo: dois corpos, um nome ---------------------------------------
+
+function doisCorpos(): { a: number; b: number } {
+  const out: { a: number; b: number } = { a: 0, b: 0 };
+  {
+    const nm = (k: number) => k + 1;
+    out.a = nm(10);
+  }
+  {
+    const nm = (k: number) => k * 3;
+    out.b = nm(10);
+  }
+  return out;
+}
+
+// --- tres, para provar que nao e "a primeira ou a ultima" ------------------
+
+function tresCorpos(): { a: number; b: number; c: number } {
+  const out: { a: number; b: number; c: number } = { a: 0, b: 0, c: 0 };
+  {
+    const nm = (k: number) => k + 1;
+    out.a = nm(10);
+  }
+  {
+    const nm = (k: number) => k * 3;
+    out.b = nm(10);
+  }
+  {
+    const nm = (k: number) => k - 4;
+    out.c = nm(10);
+  }
+  return out;
+}
+
+// --- o caso da issue: um le uma estrutura pela CHAVE, o outro devolve o
+//     ARGUMENTO. E o par que torna o sintoma legivel — quando a chamada se
+//     liga ao segundo, `numOf(3)` responde 3, que e a chave e nao o valor.
+
+function chaveContraValor(): { a: number | undefined; b: number | undefined } {
+  const out: { a: number | undefined; b: number | undefined } = {
+    a: undefined,
+    b: undefined,
+  };
+  {
+    const sf = new Map<number, Array<number>>([
+      [2, [7]],
+      [3, [9]],
+    ]);
+    const numOf = (k: number) =>
+      typeof sf.get(k)?.[0] === "number" ? (sf.get(k)![0] as number) : undefined;
+    out.a = numOf(2);
+    out.b = numOf(3);
+  }
+  {
+    const numOf = (x: number | undefined) => (typeof x === "number" ? x : undefined);
+    // A chamada existe para que esta declaracao seja um candidato a serio.
+    // O valor nao interessa; o que interessa e o efeito dela sobre o bloco
+    // acima, que e onde a asserção esta.
+    if (numOf(42) !== 42) throw new Error("o segundo helper esta errado");
+  }
+  return out;
+}
+
+// --- ordem invertida: o que devolve o argumento vem PRIMEIRO ---------------
+
+function ordemInvertida(): { a: number | undefined; b: number | undefined } {
+  const out: { a: number | undefined; b: number | undefined } = {
+    a: undefined,
+    b: undefined,
+  };
+  {
+    const numOf = (x: number | undefined) => (typeof x === "number" ? x : undefined);
+    if (numOf(42) !== 42) throw new Error("o primeiro helper esta errado");
+  }
+  {
+    const sf = new Map<number, Array<number>>([
+      [2, [7]],
+      [3, [9]],
+    ]);
+    const numOf = (k: number) =>
+      typeof sf.get(k)?.[0] === "number" ? (sf.get(k)![0] as number) : undefined;
+    out.a = numOf(2);
+    out.b = numOf(3);
+  }
+  return out;
+}
+
+// --- cada declaracao captura uma variavel DIFERENTE ------------------------
+//
+// Aqui o sintoma nao e um valor errado mas um `ReferenceError`: o corpo da
+// outra declaracao e emitido no ambiente deste bloco, onde o nome que ele
+// captura nao existe. Um `try` prende-o como valor em vez de deixar a excecao
+// levar o processo, para que o ficheiro continue mensuravel se voltar a
+// partir-se.
+
+function capturasDiferentes(): { a: number | string; b: number | string } {
+  const out: { a: number | string; b: number | string } = { a: 0, b: 0 };
+  {
+    const p = 100;
+    const nm = (k: number) => k + p;
+    try {
+      out.a = nm(1);
+    } catch (e) {
+      out.a = `lancou: ${e}`;
+    }
+  }
+  {
+    const q = 200;
+    const nm = (k: number) => k * q;
+    try {
+      out.b = nm(2);
+    } catch (e) {
+      out.b = `lancou: ${e}`;
+    }
+  }
+  return out;
+}
+
+// --- `let` responde como `const` -------------------------------------------
+
+function comLet(): { a: number; b: number } {
+  const out: { a: number; b: number } = { a: 0, b: 0 };
+  {
+    let nm = (k: number) => k + 1;
+    out.a = nm(10);
+  }
+  {
+    let nm = (k: number) => k * 3;
+    out.b = nm(10);
+  }
+  return out;
+}
+
+// --- o controlo: nomes distintos. Tem de continuar certo depois da correcao,
+//     senao a guarda desligou mais do que devia.
+
+function nomesDistintos(): { a: number; b: number } {
+  const out: { a: number; b: number } = { a: 0, b: 0 };
+  {
+    const n1 = (k: number) => k + 1;
+    out.a = n1(10);
+  }
+  {
+    const n2 = (k: number) => k * 3;
+    out.b = n2(10);
+  }
+  return out;
+}
+
+// --- e o outro controlo: UMA so declaracao, chamada muitas vezes. E a forma
+//     que a substituicao existe para acelerar, e tem de continuar a responder
+//     bem.
+
+function umaSoDeclaracao(): number {
+  const nm = (k: number) => k * 2 + 1;
+  let total = 0;
+  for (let i = 0; i < 5; i++) total += nm(i);
+  return total;
+}
+
+const dois = doisCorpos();
+const tres = tresCorpos();
+const chave = chaveContraValor();
+const invertida = ordemInvertida();
+const capturas = capturasDiferentes();
+const let2 = comLet();
+const distintos = nomesDistintos();
+const uma = umaSoDeclaracao();
+
+describe("helper com o mesmo nome declarado duas vezes no mesmo corpo (#2617)", () => {
+  test("cada bloco corre o SEU corpo, nao o do outro", () => {
+    expect(dois.a).toBe(11);
+    expect(dois.b).toBe(30);
+  });
+
+  test("com tres declaracoes, cada uma responde a sua", () => {
+    expect(tres.a).toBe(11);
+    expect(tres.b).toBe(30);
+    expect(tres.c).toBe(6);
+  });
+
+  test("o helper que le pela chave nao passa a devolver a chave", () => {
+    expect(chave.a).toBe(7);
+    expect(chave.b).toBe(9);
+  });
+
+  test("o mesmo com a ordem das declaracoes trocada", () => {
+    expect(invertida.a).toBe(7);
+    expect(invertida.b).toBe(9);
+  });
+
+  test("cada corpo ve a variavel que ELE captura", () => {
+    expect(capturas.a).toBe(101);
+    expect(capturas.b).toBe(400);
+  });
+
+  test("`let` responde como `const`", () => {
+    expect(let2.a).toBe(11);
+    expect(let2.b).toBe(30);
+  });
+});
+
+describe("helper com o mesmo nome — os controlos", () => {
+  test("nomes distintos continuam certos", () => {
+    expect(distintos.a).toBe(11);
+    expect(distintos.b).toBe(30);
+  });
+
+  test("uma so declaracao, chamada em ciclo, continua certa", () => {
+    // 1 + 3 + 5 + 7 + 9
+    expect(uma).toBe(25);
+  });
+});


### PR DESCRIPTION
Fecha #2617.

Dois blocos irmãos que declarem `const nm = …`, cada um com a sua função — todas
as chamadas do corpo corriam a **última** declaração, incluindo as escritas
dentro do bloco anterior.

Sem erro nenhum. O relator apanhou-o num descodificador de protobuf de ~950
linhas onde o **número** de um campo saía onde devia estar o **valor**: um
`numOf` que procurava por chave num `Map`, e outro num bloco a seguir que
devolvia o argumento. A chamada ligava-se ao segundo, e `numOf(3)` respondia 3.

```ts
{ const nm = (k: number) => k + 1; a = nm(10); }   // dava 30
{ const nm = (k: number) => k * 3; b = nm(10); }   // dava 30
```

Quando as duas fecham sobre nomes diferentes o sintoma muda para
`ReferenceError` — o corpo de uma é emitido no ambiente da outra.

## A afirmação que estava errada

`emit/omit.rs` autorizava-se com esta frase:

> as duas cláusulas acima provaram que toda chamada a este nome está dentro
> deste corpo, portanto a declaração em mão é a que toda chamada alcança

A primeira metade é verdade e a segunda não se segue dela: não ser lido como
valor e não ser capturado dizem **onde** as chamadas estão, nunca entre quantas
declarações escolhem. `helper_bindings` desce a blocos irmãos, e `answer.local`
é indexado por nome — o segundo `insert` apagava o primeiro.

## A primeira guarda contou a coisa errada

Contei as entradas que `helper_bindings` devolveu — uma lista **já filtrada**.
Um corpo com dois `nm` dos quais só um é recolhível conta UM, a guarda cala-se,
e o sobrevivente fica com todas as chamadas: precisamente a metade do defeito
que a issue reporta. Os casos aritméticos ficaram verdes e os do `Map`
continuaram vermelhos, que foi o único motivo de eu dar por isso.

A pergunta certa é quantas vezes o nome é **declarado**, e a régua já existia
uma porta ao lado: `inline::declarations_of`.

## Os quatro gates da regra 11

| gate | resultado |
|---|---|
| 1. Fixture escrita **antes**, a afirmar valores | 6 de 8 falhavam → **8 de 8**; os 2 controlos passavam antes e depois |
| 2. `rts test` comparado por ficheiro | **837 de 882, lista de perdidos vazia** |
| 3. `cargo test` nos 4 crates de motor | **1 310 passam, 0 falham** |
| 4. **O relógio** | IR **idêntico** para os nove ficheiros de `bench/` |

O gate 4 merece a nota: em vez de dois números próximos, o IR emitido é
byte-a-byte igual antes e depois (24 970 linhas só no `analytic.ts`) — o código
gerado não mudou, logo o tempo não pode ter mudado. `analytic.ts` era o risco
real, por ser o ficheiro que o README cita como medidor de custo de closure; os
quatro `c` dele estão em quatro corpos diferentes, que `local_candidate` já
cobre.

E o ficheiro da issue, com a forma que reproduzia em vez do workaround:
**58 de 58**, contra 57 de 58 antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa