### PR TITLE
fix(regex): a sintaxe que o motor do Rust le e o JavaScript nao escreve (#2612)

### DIFF
--- a/crates/rts-core/src/entry/regex/compile.rs
+++ b/crates/rts-core/src/entry/regex/compile.rs
@@ -48,10 +48,16 @@ impl Engine {
     /// `SyntaxError` there; see [`super::regex_new`] for why this answers rather
     /// than throws.
     pub(super) fn compile(pattern: &str, flags: Flags) -> Option<Engine> {
-        // The three rewrites that are EXACT — see [`super::translate`] for why
-        // the list stops at three.
-        use super::translate::{empty_classes, unescape_solidus, wide_dot};
-        let pattern = empty_classes(&unescape_solidus(pattern));
+        // The four rewrites that are EXACT — see [`super::translate`] for why
+        // each one is there and what is deliberately left alone.
+        use super::translate::{class_operators, empty_classes, identity_escapes, unescape_solidus, wide_dot};
+        // `class_operators` runs on what the PROGRAM wrote, before the rewrites
+        // below inject Rust syntax of their own — `empty_classes` answers
+        // `[^\s\S]` and `wide_dot` a bracketed set, and neither should be read
+        // back as if a program had typed it.
+        let pattern = identity_escapes(&unescape_solidus(pattern), flags.unicode);
+        let pattern = class_operators(&pattern);
+        let pattern = empty_classes(&pattern);
         let pattern = match flags.dot_all {
             true => pattern,
             // With `s` the builder below already says the whole set is allowed.
@@ -177,6 +183,12 @@ pub(in crate::entry) struct Flags {
     /// beside `global` and `sticky` rather than beside the three the builder
     /// reads.
     pub(super) has_indices: bool,
+    /// The Unicode-mode grammar.
+    ///
+    /// Kept, and read in exactly one place: `translate::identity_escapes`
+    /// asks it because a property escape is one WITH the flag and two
+    /// ordinary letters without it, while Rust read the property either way.
+    pub(super) unicode: bool,
 }
 
 impl Flags {
@@ -186,8 +198,8 @@ impl Flags {
     /// `SyntaxError` in JavaScript, and silently accepting it would make a typo
     /// into a regular expression that quietly means something else.
     ///
-    /// `u` and `v` are **accepted and not acted on**. That is a stated
-    /// divergence rather than an oversight: `u` changes what a `.` is when the
+    /// The two Unicode flags are **acted on in one place only**, which is
+    /// [`Flags::unicode`]. The rest is a stated divergence: the flag also
     /// subject has astral characters. Refusing them would refuse programs this
     /// engine otherwise runs correctly for every input they actually have.
     ///
@@ -215,7 +227,7 @@ impl Flags {
                 'g' => flags.global = true,
                 'y' => flags.sticky = true,
                 'd' => flags.has_indices = true,
-                'u' | 'v' => {}
+                'u' | 'v' => flags.unicode = true,
                 _ => return None,
             }
         }

--- a/crates/rts-core/src/entry/regex/translate.rs
+++ b/crates/rts-core/src/entry/regex/translate.rs
@@ -144,6 +144,192 @@ pub(super) fn wide_dot(pattern: &str) -> String {
     out
 }
 
+
+/// The class operators Rust's engine has and JavaScript does not.
+///
+/// Inside `[...]`, JavaScript gives `[`, `&` and `~` no meaning at all: each is
+/// an ordinary member of the set, needing no escape. Rust's `regex` reads the
+/// first as a NESTED class and the other two, doubled, as set operators —
+/// `&&` intersection and `~~` symmetric difference. So the same three
+/// characters spell two different sets in the two languages, and `\\[`, `\\&`
+/// and `\\~` are how Rust writes what JavaScript meant.
+///
+/// # Why this belongs here and is not a refusal
+///
+/// The bar this file sets is that the JavaScript construct has exactly ONE
+/// meaning and Rust can spell it. A bracket inside a class is that, with no
+/// ambiguity to lose: outside the `v` flag — which this engine does not
+/// implement, and whose whole point is to GIVE these characters meaning — the
+/// specification says a `ClassAtom` may be any `SourceCharacter` but `]`,
+/// `\\` and `-`. Escaping cannot change which set is matched; it only stops
+/// Rust from reading an operator that was never written.
+///
+/// # The two failures this closes, and only one of them was visible
+///
+/// `/[a[b]/` was REFUSED — a `SyntaxError` at compile, reported as issue
+/// #2612 because `get-intrinsic` (a transitive dependency of hundreds of npm
+/// packages) carries `/[^%.[\\]]+|.../` and threw on load.
+///
+/// `/[a&&b]/` was worse and nobody had reported it: it COMPILED, as the
+/// intersection of `{a}` and `{b}`, which is empty — so `/[a&&b]/.test("a")`
+/// answered `false` where every other engine answers `true`. A wrong answer
+/// with no error is the failure this crate's own doc calls the one worth
+/// paying attention to, and it was reachable from a pattern nobody would
+/// think twice about writing.
+///
+/// # What is NOT translated, and why each is left
+///
+/// `-` is not escaped. It is a range in both languages, so escaping every one
+/// of them would destroy `[a-z]`, and the only divergence is the DOUBLED
+/// `[a--b]`: Rust reads set difference where JavaScript reads the range `a` to
+/// `-` and rejects it as out of order. That is a pattern JavaScript refuses,
+/// so nothing correct depends on it — this engine accepting it is a laxity,
+/// not a wrong answer, and narrowing it would need the range parser this file
+/// deliberately does not have.
+///
+/// A backslash and what follows it pass through untouched, so a pattern that
+/// already escaped one of the three is not escaped twice.
+pub(super) fn class_operators(pattern: &str) -> String {
+    // The six escapes that stand for a SET rather than a character. A dash
+    // beside one of them cannot be a range — a range needs two single
+    // characters — so JavaScript reads it as the dash itself, while Rust
+    // refuses the pattern outright: `/[\w-\d]/` was a SyntaxError here and
+    // matches a dash, a word character or a digit in Node.
+    const CLASS_ESCAPE: &str = "dDwWsS";
+    let mut out = String::with_capacity(pattern.len());
+    let mut inside = false;
+    // Whether the atom just emitted was one of the six above, which is what
+    // makes a following dash a literal instead of the start of a range.
+    let mut after_class_escape = false;
+    let mut characters = pattern.chars();
+    while let Some(character) = characters.next() {
+        if character == '\\' {
+            out.push(character);
+            if let Some(next) = characters.next() {
+                out.push(next);
+                after_class_escape = inside && CLASS_ESCAPE.contains(next);
+                continue;
+            }
+            continue;
+        }
+        match character {
+            // The bracket that OPENS a class, and the one that closes it. A
+            // class cannot nest in JavaScript, so the first `[` is the opener
+            // and every later one is a member.
+            '[' if !inside => inside = true,
+            ']' if inside => inside = false,
+            '[' | '&' | '~' if inside => {
+                out.push('\\');
+            }
+            // A dash with a set on either side. Looking ahead as well as
+            // behind, because `[\d-z]` and `[a-\d]` are both refused by Rust
+            // and both ordinary in JavaScript.
+            '-' if inside && (after_class_escape || next_is_class_escape(&characters, CLASS_ESCAPE)) => {
+                out.push('\\');
+            }
+            _ => {}
+        }
+        after_class_escape = false;
+        out.push(character);
+    }
+    out
+}
+
+/// Whether what follows is one of the set escapes, without consuming it.
+///
+/// Split out so [`class_operators`] reads as one rule per line; a peekable
+/// iterator would have to be threaded through every arm of that match for
+/// the sake of this one lookahead.
+fn next_is_class_escape(rest: &std::str::Chars<'_>, set: &str) -> bool {
+    let mut ahead = rest.clone();
+    ahead.next() == Some('\\') && ahead.next().is_some_and(|letter| set.contains(letter))
+}
+
+
+/// The letters JavaScript spells with a backslash and Rust reads as syntax.
+///
+/// Outside the `u` flag, JavaScript's `IdentityEscape` says a backslash before
+/// a character it does not recognise IS that character: `/\A/` matches the
+/// letter `A`, `/\z/` the letter `z`, `/\q/` the letter `q`. Measured against
+/// Node v20 rather than read off the grammar — all 32 of the letters below
+/// answer `true` to `new RegExp("\\" + letter).test(letter)`, and NONE of them
+/// answers anything else.
+///
+/// Rust's engine spends several of them: `\A` is start-of-text, `\z` and `\Z`
+/// end-of-text, `\q{...}` a literal string, `\p{...}` a Unicode property. So
+/// the same two characters are a letter in one language and an anchor in the
+/// other, and the backslash has to go.
+///
+/// # What each of the three groups was doing before
+///
+/// `\A`, `\z`: COMPILED, as anchors, so `/\A/.test("a")` answered `true`
+/// where Node answers `false` — a wrong answer with no error, the same shape
+/// as `[a&&b]` one function up.
+///
+/// `\Z`, `\q{ab}`, `\k<n>` with no named group: REFUSED, a `SyntaxError` on a
+/// pattern every other engine accepts.
+///
+/// `\p{L}` and `\P{L}` are the pair that DEPENDS on the flag, which is why
+/// this function takes it. With `u` they are Unicode property escapes in both
+/// languages and are left alone; without it JavaScript reads `p` and `{L}`
+/// separately — `/[\p{L}]/.test("a")` is `false` in Node, because the class
+/// holds `p`, `{`, `L`, `}` — while Rust reads the property either way and
+/// answered `true`.
+///
+/// # What is NOT translated here
+///
+/// `\cX` keeps the refusal [`unescape_solidus`]'s doc already names: it is a
+/// control escape in JavaScript with no Rust spelling that is exact for every
+/// `X`, and guessing is the thing this file exists not to do.
+///
+/// A digit escape is left for the same reason from the other side: `\1` is a
+/// backreference in both, and `\0` is NUL in JavaScript but not something
+/// Rust's parser takes inside a class. Both are named in the module doc rather
+/// than rewritten, because a backreference renumbered by a rewrite is a silent
+/// wrong answer of exactly the kind this function was written to remove.
+pub(super) fn identity_escapes(pattern: &str, unicode: bool) -> String {
+    // The 32 letters measured against Node: every one is itself, and none of
+    // them means anything else. Written out rather than computed as "not in
+    // the recognised set", so that adding a recognised escape later cannot
+    // silently start rewriting it.
+    const LITERAL: &str = "ACEFGHIJKLMNOQRTUVXYZaeghijlmoqyz";
+    // A named backreference is only a backreference when the pattern declares
+    // a named group; without one, Annex B reads `\k` as the letter.
+    let named_groups = pattern.contains("(?<")
+        && !pattern.contains("(?<=")
+        && !pattern.contains("(?<!")
+        || pattern.contains("(?<") && pattern.matches("(?<").count() > pattern.matches("(?<=").count() + pattern.matches("(?<!").count();
+    let mut out = String::with_capacity(pattern.len());
+    let mut characters = pattern.chars();
+    while let Some(character) = characters.next() {
+        if character != '\\' {
+            out.push(character);
+            continue;
+        }
+        match characters.next() {
+            Some(next) if LITERAL.contains(next) => out.push(next),
+            // The flag decides these two, and only these two.
+            Some(next @ ('p' | 'P')) if !unicode => out.push(next),
+            Some('k') if !named_groups => out.push('k'),
+            // `\0` is NUL in JavaScript. Rust's parser takes it outside a class
+            // and REFUSES it inside one, so `/[\0]/` was a SyntaxError on a
+            // pattern Node compiles. `\x00` is the same character, spelled the
+            // way both parsers read, and it is only substituted when no digit
+            // follows: `\0` then `1` is a legacy octal escape, which this file
+            // refuses rather than guesses at.
+            Some('0') if !characters.clone().next().is_some_and(|d| d.is_ascii_digit()) => {
+                out.push_str("\\x00");
+            }
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +361,129 @@ mod tests {
         // Every other escape is the engine's to read, backslash included.
         assert_eq!(unescape_solidus(r"a\wb"), r"a\wb");
     }
+
+    #[test]
+    fn a_bracket_inside_a_class_is_an_ordinary_member() {
+        // Issue #2612: refused before this rewrite existed.
+        assert_eq!(class_operators("[a[b]"), r"[a\[b]");
+        assert_eq!(class_operators("[^a[b]"), r"[^a\[b]");
+        assert_eq!(class_operators("[[]"), r"[\[]");
+        // The pattern from `get-intrinsic`, which is what made this reachable
+        // from hundreds of npm packages.
+        assert_eq!(class_operators(r"[^%.[\]]+"), r"[^%.\[\]]+");
+    }
+
+    #[test]
+    fn the_set_operators_rust_has_and_javascript_does_not() {
+        // `&&` compiled as INTERSECTION and answered the empty set, so
+        // `/[a&&b]/.test("a")` was `false` where every other engine says true.
+        assert_eq!(class_operators("[a&&b]"), r"[a\&\&b]");
+        assert_eq!(class_operators("[a~~b]"), r"[a\~\~b]");
+        // Single ones are literals in both, and escaping them is still right:
+        // it costs nothing and keeps one rule instead of two.
+        assert_eq!(class_operators("[a&b]"), r"[a\&b]");
+        assert_eq!(class_operators("[a~b]"), r"[a\~b]");
+    }
+
+    #[test]
+    fn outside_a_class_none_of_the_three_is_touched() {
+        assert_eq!(class_operators("a&&b"), "a&&b");
+        assert_eq!(class_operators("a~b"), "a~b");
+        // A bracket outside a class OPENS one; it is not a member.
+        assert_eq!(class_operators("a[b]c"), "a[b]c");
+        assert_eq!(class_operators("(a|b)"), "(a|b)");
+    }
+
+    #[test]
+    fn an_already_escaped_member_is_not_escaped_twice() {
+        assert_eq!(class_operators(r"[a\[b]"), r"[a\[b]");
+        assert_eq!(class_operators(r"[a\&b]"), r"[a\&b]");
+        // `\]` does not close the class, so what follows is still inside it.
+        assert_eq!(class_operators(r"[a\]&b]"), r"[a\]\&b]");
+        // A trailing backslash is passed through rather than read past the end.
+        assert_eq!(class_operators(r"[a\"), r"[a\");
+    }
+
+    #[test]
+    fn a_range_is_left_alone_because_the_dash_means_the_same_thing() {
+        assert_eq!(class_operators("[a-z]"), "[a-z]");
+        assert_eq!(class_operators("[a-z0-9_]"), "[a-z0-9_]");
+        // The doubled dash is the one divergence deliberately left: JavaScript
+        // rejects it, so nothing correct depends on either reading.
+        assert_eq!(class_operators("[a--b]"), "[a--b]");
+    }
+
+    #[test]
+    fn a_backslash_before_a_letter_rust_spends_is_that_letter() {
+        // Compiled as ANCHORS before this existed, so `/\A/.test("a")` was true.
+        assert_eq!(identity_escapes(r"\A", false), "A");
+        assert_eq!(identity_escapes(r"\z", false), "z");
+        // Refused before this existed.
+        assert_eq!(identity_escapes(r"\Z", false), "Z");
+        assert_eq!(identity_escapes(r"\q{ab}", false), "q{ab}");
+        assert_eq!(identity_escapes(r"[\q{ab}]", false), "[q{ab}]");
+    }
+
+    #[test]
+    fn the_escapes_javascript_does_recognise_are_left_alone() {
+        for kept in [r"\d", r"\D", r"\w", r"\W", r"\s", r"\S", r"\b", r"\B", r"\n", r"\r", r"\t", r"\v", r"\f"] {
+            assert_eq!(identity_escapes(kept, false), kept, "{kept} must not be rewritten");
+        }
+        // A backreference keeps its number: renumbering one would be exactly
+        // the silent wrong answer this function exists to remove.
+        assert_eq!(identity_escapes(r"(a)\1", false), r"(a)\1");
+        // And an escaped metacharacter stays escaped.
+        assert_eq!(identity_escapes(r"\.\*\[\]\\", false), r"\.\*\[\]\\");
+        // `\cX` keeps its existing refusal rather than being guessed at.
+        assert_eq!(identity_escapes(r"\cA", false), r"\cA");
+    }
+
+    #[test]
+    fn the_property_escape_is_the_one_the_flag_decides() {
+        // Without `u`, Node reads `p` `{` `L` `}` — `/[\p{L}]/.test("a")` is false.
+        assert_eq!(identity_escapes(r"[\p{L}]", false), "[p{L}]");
+        assert_eq!(identity_escapes(r"\P{L}", false), "P{L}");
+        // With `u` it is a property escape in both languages.
+        assert_eq!(identity_escapes(r"[\p{L}]", true), r"[\p{L}]");
+        assert_eq!(identity_escapes(r"\p{Script=Greek}", true), r"\p{Script=Greek}");
+    }
+
+    #[test]
+    fn a_named_backreference_survives_only_when_a_named_group_exists() {
+        assert_eq!(identity_escapes(r"(?<n>a)\k<n>", false), r"(?<n>a)\k<n>");
+        // No named group: Annex B reads the letter, and Rust refused the pattern.
+        assert_eq!(identity_escapes(r"\k<n>", false), "k<n>");
+        // A lookbehind is not a named group, and it opens with the same three
+        // characters — the reason this asks more than `contains("(?<")`.
+        assert_eq!(identity_escapes(r"(?<=a)\k<n>", false), "(?<=a)k<n>");
+        assert_eq!(identity_escapes(r"(?<!a)\k<n>", false), "(?<!a)k<n>");
+    }
+
+    #[test]
+    fn a_dash_beside_a_set_escape_is_a_literal_dash() {
+        // Refused by Rust, ordinary in JavaScript: a range needs two single
+        // characters, so a dash next to `\d` can only be itself.
+        assert_eq!(class_operators(r"[\w-\d]"), r"[\w\-\d]");
+        assert_eq!(class_operators(r"[\d-z]"), r"[\d\-z]");
+        assert_eq!(class_operators(r"[a-\d]"), r"[a\-\d]");
+        // A real range keeps its dash, which is the whole reason this asks
+        // what is on either side instead of escaping every dash.
+        assert_eq!(class_operators("[a-z]"), "[a-z]");
+        assert_eq!(class_operators("[a-z0-9]"), "[a-z0-9]");
+        // And outside a class a dash was never anything but itself.
+        assert_eq!(class_operators(r"a-\d"), r"a-\d");
+    }
+
+    #[test]
+    fn the_nul_escape_is_spelled_the_way_both_parsers_read() {
+        // `/[\0]/` was a SyntaxError; Node matches the NUL character.
+        assert_eq!(identity_escapes(r"[\0]", false), r"[\x00]");
+        assert_eq!(identity_escapes(r"\0", false), r"\x00");
+        // A digit after it is a legacy octal escape, which is refused rather
+        // than guessed at — so it is left exactly as written.
+        assert_eq!(identity_escapes(r"\01", false), r"\01");
+    }
+
+
 }
 

--- a/tests/claude-regex-classe-de-caracteres.test.ts
+++ b/tests/claude-regex-classe-de-caracteres.test.ts
@@ -1,0 +1,190 @@
+// A sintaxe de uma classe de caracteres, onde o JavaScript e o motor `regex`
+// do Rust discordam.
+//
+// PORQUE ESTE FICHEIRO EXISTE
+//
+// Dentro de `[...]`, o JavaScript nao da significado nenhum a `[`, `&` nem `~`:
+// cada um e um membro vulgar do conjunto e nao precisa de escape. O `regex` do
+// Rust le o primeiro como uma classe ANINHADA e os outros dois, dobrados, como
+// operadores de conjunto (`&&` intersecao, `~~` diferenca simetrica). Os mesmos
+// tres caracteres escrevem conjuntos diferentes nas duas linguagens.
+//
+// Isso dava duas falhas, e so uma era visivel:
+//
+//  - `/[a[b]/` era RECUSADO com `SyntaxError` — issue #2612, encontrada porque
+//    o `get-intrinsic` (dependencia transitiva de centenas de pacotes npm)
+//    traz `/[^%.[\]]+|.../` e rebentava ao carregar.
+//  - `/[a&&b]/` COMPILAVA, como a intersecao de `{a}` com `{b}`, que e vazia —
+//    e `/[a&&b]/.test("a")` respondia `false` onde todo o outro motor responde
+//    `true`. Ninguem tinha reportado, porque uma resposta errada sem erro nao
+//    se ve.
+//
+// Todas as afirmacoes aqui foram confirmadas contra o Node v20.19.5 desta
+// maquina. Onde o RTS diverge de proposito, o teste afirma o que o RTS faz e o
+// comentario diz porque.
+
+import { describe, test, expect } from "rts:test";
+
+// Um `new RegExp` que rebenta leva o processo, entao a construcao e sempre
+// embrulhada: um padrao recusado le-se como `null` e o teste falha a dizer o
+// que devia ter compilado, em vez de matar o ficheiro e levar os outros.
+function re(pattern: string, flags?: string): RegExp | null {
+  try {
+    return flags === undefined ? new RegExp(pattern) : new RegExp(pattern, flags);
+  } catch (e) {
+    return null;
+  }
+}
+
+function testa(pattern: string, subject: string): boolean | string {
+  const r = re(pattern);
+  if (r === null) return "RECUSADO";
+  return r.test(subject);
+}
+
+describe("classe de caracteres — o colchete aberto (#2612)", () => {
+  test("um `[` dentro da classe e um membro vulgar", () => {
+    expect(testa("[a[b]", "a")).toBe(true);
+    expect(testa("[a[b]", "[")).toBe(true);
+    expect(testa("[a[b]", "b")).toBe(true);
+    expect(testa("[a[b]", "z")).toBe(false);
+  });
+
+  test("o mesmo numa classe negada", () => {
+    expect(testa("[^a[b]", "a")).toBe(false);
+    expect(testa("[^a[b]", "[")).toBe(false);
+    expect(testa("[^a[b]", "z")).toBe(true);
+  });
+
+  test("uma classe que so tem o colchete", () => {
+    expect(testa("[[]", "[")).toBe(true);
+    expect(testa("[[]", "a")).toBe(false);
+  });
+
+  test("escapado continua a funcionar, e nao e escapado duas vezes", () => {
+    expect(testa("[a\\[b]", "[")).toBe(true);
+    expect(testa("[a\\[b]", "a")).toBe(true);
+    expect(testa("[a\\[b]", "z")).toBe(false);
+  });
+
+  test("misturado com um intervalo", () => {
+    expect(testa("[a-z[]", "m")).toBe(true);
+    expect(testa("[a-z[]", "[")).toBe(true);
+    expect(testa("[a-z[]", "0")).toBe(false);
+  });
+
+  test("o padrao do `get-intrinsic`, que foi como isto apareceu", () => {
+    const r = re("[^%.[\\]]+|\\[(?:(-?\\d+(?:\\.\\d+)?)|([\"'])((?:(?!\\2)[^\\\\]|\\\\.)*?)\\2)\\]", "g");
+    expect(r !== null).toBe(true);
+    // E funciona: parte `a.b[0]` nos pedacos que a biblioteca espera.
+    const achados = "a.b[0]".match(/[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]/g);
+    expect(achados !== null).toBe(true);
+    expect(achados === null ? -1 : achados.length).toBe(3);
+  });
+});
+
+describe("classe de caracteres — os operadores de conjunto do Rust", () => {
+  // Estes tres compilavam e respondiam o conjunto ERRADO. Sao a metade que
+  // ninguem tinha reportado.
+  test("`&&` e dois membros literais, nao uma intersecao", () => {
+    expect(testa("[a&&b]", "a")).toBe(true);
+    expect(testa("[a&&b]", "&")).toBe(true);
+    expect(testa("[a&&b]", "b")).toBe(true);
+    expect(testa("[a&&b]", "z")).toBe(false);
+  });
+
+  test("`~~` e dois membros literais, nao uma diferenca simetrica", () => {
+    expect(testa("[a~~b]", "a")).toBe(true);
+    expect(testa("[a~~b]", "~")).toBe(true);
+    expect(testa("[a~~b]", "b")).toBe(true);
+    expect(testa("[a~~b]", "z")).toBe(false);
+  });
+
+  test("um `&` ou `~` sozinho tambem e literal", () => {
+    expect(testa("[a&b]", "&")).toBe(true);
+    expect(testa("[a~b]", "~")).toBe(true);
+  });
+
+  test("um intervalo ao lado de um operador continua a ser um intervalo", () => {
+    expect(testa("[a-z&&0-9]", "m")).toBe(true);
+    expect(testa("[a-z&&0-9]", "5")).toBe(true);
+    expect(testa("[a-z&&0-9]", "&")).toBe(true);
+    expect(testa("[a-z&&0-9]", "_")).toBe(false);
+  });
+});
+
+describe("classe de caracteres — o que NAO mudou", () => {
+  test("fora de uma classe os tres caracteres sao o que sempre foram", () => {
+    // `[` fora de uma classe ABRE uma classe.
+    expect(testa("a[bc]d", "abd")).toBe(true);
+    expect(testa("a&&b", "a&&b")).toBe(true);
+    expect(testa("a~b", "a~b")).toBe(true);
+  });
+
+  test("um intervalo vulgar", () => {
+    expect(testa("[a-z]", "m")).toBe(true);
+    expect(testa("[a-z]", "5")).toBe(false);
+    expect(testa("[0-9a-fA-F]", "e")).toBe(true);
+  });
+
+  test("as duas classes vazias que este motor ja traduzia", () => {
+    // `[]` nao casa nada e `[^]` casa tudo — legais em JavaScript, recusadas
+    // pelo motor do Rust, traduzidas ha muito.
+    expect(testa("[]", "a")).toBe(false);
+    expect(testa("[^]", "a")).toBe(true);
+    expect(testa("[^]", "\n")).toBe(true);
+  });
+
+  test("um `]` escapado nao fecha a classe", () => {
+    expect(testa("[a\\]b]", "]")).toBe(true);
+    expect(testa("[a\\]b]", "b")).toBe(true);
+    expect(testa("[a\\]b]", "z")).toBe(false);
+  });
+
+  test("as classes com nome continuam a responder", () => {
+    expect(testa("[\\d]", "5")).toBe(true);
+    expect(testa("[\\w]", "_")).toBe(true);
+    expect(testa("[\\s]", " ")).toBe(true);
+    expect(testa("[^\\d]", "a")).toBe(true);
+  });
+
+  test("o ponto dentro de uma classe e um ponto", () => {
+    expect(testa("[.]", ".")).toBe(true);
+    expect(testa("[.]", "a")).toBe(false);
+  });
+});
+
+describe("classe de caracteres — com flags", () => {
+  test("`i` sobre uma classe que tem um colchete", () => {
+    const r = re("[a[b]", "i");
+    expect(r !== null).toBe(true);
+    expect(r === null ? false : r.test("A")).toBe(true);
+    expect(r === null ? false : r.test("[")).toBe(true);
+  });
+
+  test("`g` conta todas as ocorrencias", () => {
+    const achados = "a[b[c".match(/[a[]/g);
+    expect(achados === null ? -1 : achados.length).toBe(3);
+  });
+
+  test("`s` nao muda o que uma classe significa", () => {
+    const r = re("[a&&b]", "s");
+    expect(r !== null).toBe(true);
+    expect(r === null ? false : r.test("&")).toBe(true);
+  });
+});
+
+describe("classe de caracteres — a divergencia deixada de proposito", () => {
+  // O `-` NAO e escapado: e um intervalo nas duas linguagens, e escapar todos
+  // destruiria `[a-z]`. So o `--` dobrado diverge — o Rust le diferenca de
+  // conjuntos, o JavaScript le o intervalo `a` ate `-` e recusa-o por estar
+  // fora de ordem. E um padrao que o JavaScript rejeita, portanto nada de
+  // correto depende de nenhuma das duas leituras: o RTS aceitar e uma frouxidao
+  // e nao uma resposta errada.
+  //
+  // Este teste afirma o que o RTS FAZ, com a divergencia dita, para que uma
+  // mudanca futura apareca em vez de passar despercebida.
+  test("`[a--b]` e aceite aqui e recusado pelo Node", () => {
+    expect(re("[a--b]") !== null).toBe(true);
+  });
+});

--- a/tests/claude-regex-escapes-de-identidade.test.ts
+++ b/tests/claude-regex-escapes-de-identidade.test.ts
@@ -1,0 +1,215 @@
+// Os escapes que o motor `regex` do Rust gasta e o JavaScript le como uma
+// letra vulgar.
+//
+// PORQUE ESTE FICHEIRO EXISTE
+//
+// Fora da flag `u`, o `IdentityEscape` do JavaScript diz que uma barra antes de
+// um caracter que ele nao reconhece E esse caracter. Medido contra o Node
+// v20.19.5 desta maquina, e nao lido da gramatica: as 32 letras que o RTS passou
+// a tratar assim respondem todas `true` a `new RegExp(barra + letra).test(letra)`
+// e nenhuma responde outra coisa.
+//
+// O Rust gasta varias: `\A` e inicio-de-texto, `\z` e `\Z` sao fim-de-texto,
+// `\q{...}` e uma cadeia literal, `\p{...}` uma propriedade Unicode. Os mesmos
+// dois caracteres eram uma letra numa linguagem e uma ancora na outra.
+//
+// Isso dava falhas dos dois tipos, e so um era visivel:
+//
+//  - `\A` e `\z` COMPILAVAM, como ancoras, entao `/\A/.test("a")` respondia
+//    `true` onde o Node responde `false` — errado, sem erro nenhum.
+//  - `\Z`, `\q{ab}` e `\k<n>` sem grupo nomeado eram RECUSADOS, com
+//    `SyntaxError` sobre um padrao que todo o outro motor aceita.
+//
+// Companheiro de `claude-regex-classe-de-caracteres.test.ts`, que prende a
+// sintaxe DENTRO de `[...]` (a issue #2612 e os operadores de conjunto).
+
+import { describe, test, expect } from "rts:test";
+
+// Um `new RegExp` que rebenta leva o processo, entao a construcao e sempre
+// embrulhada: um padrao recusado le-se como `null` e o teste falha a dizer o
+// que devia ter compilado, em vez de matar o ficheiro e levar os outros.
+function re(pattern: string, flags?: string): RegExp | null {
+  try {
+    return flags === undefined ? new RegExp(pattern) : new RegExp(pattern, flags);
+  } catch (e) {
+    return null;
+  }
+}
+
+function testa(pattern: string, subject: string): boolean | string {
+  const r = re(pattern);
+  if (r === null) return "RECUSADO";
+  return r.test(subject);
+}
+
+describe("uma barra antes de uma letra que o Rust gasta", () => {
+  test("`\\A` e `\\z` sao letras, nao ancoras", () => {
+    expect(testa("\\A", "A")).toBe(true);
+    expect(testa("\\A", "a")).toBe(false);
+    expect(testa("\\z", "z")).toBe(true);
+    expect(testa("\\z", "a")).toBe(false);
+  });
+
+  test("`\\Z` e `\\q` eram recusados", () => {
+    expect(testa("\\Z", "Z")).toBe(true);
+    expect(testa("\\Z", "a")).toBe(false);
+    expect(testa("[\\q{ab}]", "q")).toBe(true);
+    expect(testa("[\\q{ab}]", "{")).toBe(true);
+  });
+
+  test("uma letra qualquer do conjunto responde por si", () => {
+    expect(testa("\\e", "e")).toBe(true);
+    expect(testa("\\h", "h")).toBe(true);
+    expect(testa("\\R", "R")).toBe(true);
+    expect(testa("\\X", "X")).toBe(true);
+    expect(testa("\\N", "N")).toBe(true);
+    expect(testa("\\K", "K")).toBe(true);
+  });
+});
+
+describe("o que a reescrita NAO pode tocar", () => {
+  test("os escapes que o JavaScript reconhece ficam como estao", () => {
+    expect(testa("\\d", "5")).toBe(true);
+    expect(testa("\\d", "a")).toBe(false);
+    expect(testa("\\w", "_")).toBe(true);
+    expect(testa("\\s", " ")).toBe(true);
+    expect(testa("\\S", "a")).toBe(true);
+    expect(testa("\\n", "\n")).toBe(true);
+    expect(testa("\\t", "\t")).toBe(true);
+  });
+
+  test("um metacaracter escapado continua escapado", () => {
+    expect(testa("\\.", ".")).toBe(true);
+    expect(testa("\\.", "a")).toBe(false);
+    expect(testa("\\*", "*")).toBe(true);
+    expect(testa("\\[", "[")).toBe(true);
+    expect(testa("\\$", "$")).toBe(true);
+  });
+
+  test("uma retro-referencia mantem o numero", () => {
+    // Renumerar uma seria exatamente a resposta errada em silencio que esta
+    // reescrita existe para remover.
+    expect(testa("(a)\\1", "aa")).toBe(true);
+    expect(testa("(a)\\1", "ab")).toBe(false);
+    expect(testa("(a)(b)\\2", "abb")).toBe(true);
+  });
+
+  test("as fronteiras de palavra continuam a ser fronteiras", () => {
+    expect(testa("a\\b", "a b")).toBe(true);
+    expect(testa("a\\Bb", "ab")).toBe(true);
+  });
+});
+
+describe("`\\k<n>` so e retro-referencia quando existe grupo com nome", () => {
+  test("com grupo nomeado, e uma retro-referencia", () => {
+    expect(testa("(?<n>a)\\k<n>", "aa")).toBe(true);
+    expect(testa("(?<n>a)\\k<n>", "ab")).toBe(false);
+  });
+
+  test("sem grupo nomeado era recusado, e o Annex B le a letra", () => {
+    expect(re("\\k<n>") !== null).toBe(true);
+    expect(testa("\\k<n>", "k")).toBe(false);
+    expect(testa("\\k<n>", "k<n>")).toBe(true);
+  });
+
+  test("um lookbehind nao e um grupo nomeado, e abre com os mesmos caracteres", () => {
+    // A razao de a verificacao perguntar mais do que "contem `(?<`".
+    expect(testa("(?<=a)b", "ab")).toBe(true);
+    expect(testa("(?<!a)b", "cb")).toBe(true);
+    expect(testa("(?<!a)b", "ab")).toBe(false);
+    expect(re("(?<=a)\\k<n>") !== null).toBe(true);
+  });
+});
+
+describe("o escape de propriedade, e a flag que o decide", () => {
+  test("sem `u`, sao letras soltas", () => {
+    // Respondia `true` porque o Rust lia a propriedade nos dois casos; o Node
+    // sem `u` le a classe com `p`, `{`, `L`, `}` la dentro.
+    expect(testa("[\\p{L}]", "a")).toBe(false);
+    expect(testa("[\\p{L}]", "p")).toBe(true);
+    expect(testa("[\\p{L}]", "{")).toBe(true);
+    expect(testa("[\\p{L}]", "L")).toBe(true);
+  });
+
+  test("com `u` e uma propriedade nas duas linguagens", () => {
+    const r = re("\\p{L}", "u");
+    expect(r !== null).toBe(true);
+    expect(r === null ? false : r.test("a")).toBe(true);
+    expect(r === null ? false : r.test("1")).toBe(false);
+  });
+
+  test("a negada, tambem", () => {
+    const r = re("\\P{L}", "u");
+    expect(r !== null).toBe(true);
+    expect(r === null ? false : r.test("1")).toBe(true);
+  });
+});
+
+describe("o traco ao lado de um escape de conjunto", () => {
+  // Um intervalo precisa de dois caracteres unicos, entao um traco encostado a
+  // `\d` so pode ser ele proprio. O Rust recusava o padrao inteiro.
+  test("`[\\w-\\d]` era recusado, e casa as tres coisas", () => {
+    expect(testa("[\\w-\\d]", "-")).toBe(true);
+    expect(testa("[\\w-\\d]", "a")).toBe(true);
+    expect(testa("[\\w-\\d]", "5")).toBe(true);
+  });
+
+  test("de qualquer um dos lados do traco", () => {
+    expect(testa("[\\d-z]", "-")).toBe(true);
+    expect(testa("[\\d-z]", "5")).toBe(true);
+    expect(testa("[a-\\d]", "-")).toBe(true);
+    expect(testa("[a-\\d]", "a")).toBe(true);
+  });
+
+  test("um intervalo a serio continua a ser um intervalo", () => {
+    expect(testa("[a-z]", "m")).toBe(true);
+    expect(testa("[a-z]", "5")).toBe(false);
+    expect(testa("[a-z0-9]", "7")).toBe(true);
+    expect(testa("[a-z0-9]", "_")).toBe(false);
+  });
+
+  test("um traco no fim ou no principio ja era literal", () => {
+    expect(testa("[-a]", "-")).toBe(true);
+    expect(testa("[a-]", "-")).toBe(true);
+    expect(testa("[a-z-]", "-")).toBe(true);
+    expect(testa("[a-z-]", "m")).toBe(true);
+  });
+});
+
+describe("o NUL, que o Rust recusava dentro de uma classe", () => {
+  // O padrao e montado por concatenacao de proposito: um `\0` escrito a letra
+  // na fonte e um escape octal legado, que o parser recusa em strict mode. O
+  // que este teste prende e a regex, nao como o TypeScript soletra uma barra.
+  const BARRA = String.fromCharCode(92);
+  const padraoNul = "[" + BARRA + "0]";
+  const soltoNul = BARRA + "0";
+
+  test("uma classe com o escape NUL compila e casa o caracter", () => {
+    expect(re(padraoNul) !== null).toBe(true);
+    expect(testa(padraoNul, String.fromCharCode(0))).toBe(true);
+    expect(testa(padraoNul, "0")).toBe(false);
+  });
+
+  test("e fora de uma classe tambem", () => {
+    expect(re(soltoNul) !== null).toBe(true);
+    expect(testa(soltoNul, String.fromCharCode(0))).toBe(true);
+  });
+});
+
+describe("as divergencias que ficam, ditas por nome", () => {
+  // Nenhuma e uma resposta errada em codigo correto: uma e a recusa deliberada
+  // que o modulo ja documentava, e as outras duas sao frouxidoes sobre padroes
+  // que o proprio JavaScript rejeita. Estao presas por um teste para que uma
+  // mudanca futura apareca em vez de passar despercebida.
+  test("`\\cX` continua recusado — a recusa que o modulo ja nomeava", () => {
+    expect(re("[\\cA]")).toBe(null);
+  });
+
+  test("`a**` e aceite aqui e recusado pelo Node", () => {
+    expect(re("a**") !== null).toBe(true);
+  });
+
+  test("`a{,3}` e um quantificador aqui e texto literal no Node", () => {
+    expect(testa("a{,3}", "a{,3}")).toBe(true);
+  });
+});


### PR DESCRIPTION
Fecha #2612 — e mais oito divergências da mesma família que ninguém tinha
reportado, porque só uma delas era visível.

## O que a issue dizia, e o que estava por baixo

`/[a[b]/` era recusado com `SyntaxError`: dentro de `[...]` o JavaScript não dá
significado ao `[`, o Rust lê uma classe **aninhada**. Impacto real — o
`get-intrinsic`, dependência transitiva de centenas de pacotes npm, traz
`/[^%.[\]]+|.../` e qualquer bundle que o puxasse rebentava ao carregar.

**Ao lado havia um pior, e sem relatório possível: `/[a&&b]/` compilava**, como
a interseção de `{a}` com `{b}` — vazia. `/[a&&b]/.test("a")` respondia `false`
onde todo o outro motor responde `true`. Um erro visível tem quem o reporte;
uma resposta errada em silêncio não tem.

## A segunda família

Fora da flag `u`, uma barra antes de um caractere que o JavaScript não reconhece
**é** esse caractere. Medido contra o Node v20, não lido da gramática: as 32
letras respondem todas `true` a `new RegExp(barra + letra).test(letra)`. O Rust
gasta várias:

| padrão | era | é |
|---|---|---|
| `\A`, `\z` | compilava como **âncora** → `/\A/.test("a")` = `true` | a letra |
| `\Z`, `\q{ab}`, `\k<n>` sem grupo | **recusado** | a letra |
| `\p{L}` sem `u` | a propriedade | as letras `p{L}` |
| `[\w-\d]`, `[\d-z]` | **recusado** | traço literal |
| `[\0]` | **recusado** | o caractere NUL |

## Como foram encontrados

Não por leitura: **90 padrões corridos lado a lado no RTS e no Node**, com a
resposta de `test()` sobre vários sujeitos comparada linha a linha. A issue dava
um caso; a varredura deu doze, dos quais **nove eram silenciosos ou recusas que
ninguém tinha topado**. São 3 agora, todas presas por um teste que afirma o que
o RTS faz, com a divergência dita: `\cX` (recusa deliberada já documentada),
`a**` e `a{,3}` (o JavaScript rejeita ambos — laxidão, não resposta errada).

## Gates

- **42 asserts novos** em dois ficheiros, confirmados contra o Node v20.19.5
- **14 testes unitários** em `translate.rs`, com os controlos: um intervalo a
  sério não é tocado, uma retro-referência mantém o número, um escape já
  escapado não é escapado duas vezes
- **Suite: 839 de 884**, comparada por ficheiro — **lista de perdidos vazia**
- `cargo test -p rts-core -p rts-codegen`: **601 passam, 0 falham**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnrif3mpJGd2Cg39tvUQLa