### PR TITLE
ci(dom): as réguas do rts-dom passam a correr no CI — corpus CSS e testes do crate (lote N)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -221,6 +221,80 @@ jobs:
       # The program this used to compile was also wrong for the new engine —
       # `import { io } from "rts"` and `io.print` are surface it does not have.
 
+  # As réguas do rts-dom, que até 2026-09-04 não corriam em lado nenhum do CI
+  # (lente 6 da auditoria estrutural, docs/ui/html-engine/analises/): o corpus
+  # CSS medido no Chrome (tests/css) sobre o binário Linux que `build` já fez,
+  # e os testes Rust do crate e do bridge. Não bloqueia, como os outros três —
+  # o CLAUDE.md diz porquê — mas uma fixture que deixe de passar fica VERMELHA
+  # aqui em vez de só no terminal de quem se lembrar de correr o corredor.
+  dom-rulers:
+    needs: [version, build]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download rts binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rts-${{ needs.version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+          path: dl
+
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p target/release
+          f=$(find dl -type f | head -1)
+          cp "$f" target/release/rts
+          chmod +x target/release/rts
+
+      # O binário Linux carrega libasound.so.2 (cpal). Sem ela o processo nem
+      # arranca, e um corredor que não arranca reportaria 0/49 — foi assim que
+      # a badge cross-runtime deu 0% uma vez (ver cross-runtime.yml). Retry
+      # porque o apt do runner flakeia, e um passo-guarda a seguir.
+      - name: Install ALSA runtime
+        run: |
+          for i in 1 2 3; do sudo apt-get update && sudo apt-get install -y libasound2-dev && break || sleep 5; done
+
+      - name: Guard — the binary runs at all
+        shell: bash
+        run: test "$(target/release/rts -e 'console.log(41)')" = "41"
+
+      - name: CSS corpus against Chrome (tests/css)
+        shell: bash
+        run: |
+          set -o pipefail
+          target/release/rts run examples/claude-css-runner.ts 2>&1 | tee corpus.txt
+          resumo=$(grep -E '^passam: ' corpus.txt)
+          { echo "### Corpus CSS (Chrome 1280x800, 1 px)"; echo; echo '```'; cat corpus.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          # A regra do corpus é por FICHEIRO: qualquer fixture a falhar é vermelho.
+          # O denominador é o do corredor (conta os .html que existem), não daqui.
+          falham=$(echo "$resumo" | sed -E 's/.*falham: ([0-9]+).*/\1/')
+          echo "$resumo"
+          test "$falham" = "0"
+
+  # Os testes Rust do rts-dom (sem dependências: segundos) e do rts-dom-bridge
+  # (o teste de contrato que cruza o que a fachada chama com o que o bridge
+  # regista — o que teria apanhado getBoundingClientRect morto). Perfil dev de
+  # propósito: são dois crates, não os 41 binários que fazem o `--profile fast`
+  # do CLAUDE.md valer a pena.
+  dom-tests:
+    needs: version
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: rts-dom and rts-dom-bridge tests
+        run: cargo test -p rts-dom -p rts-dom-bridge --no-fail-fast
+
   # Reuses the Linux binary from `build` (no recompile). Runs as part of this
   # workflow so it keeps the PR/push context its badge/issue/comment steps need.
   cross-runtime:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ not background reading, and the rules in it are binding for changes inside it.
 | `crates/rts-core/` | its `README.md` (10 rules) + `PLAN.md` |
 | `crates/rts-host/` | its `README.md` (6 rules) + `PLAN.md` |
 | `crates/rts-egui/`, DOM, render, input | `docs/ui/html-engine/` + `docs/ui/egui-crate.md`; for the NEW engine's side of it, `docs/ui/new-engine-port.md` |
+| `crates/rts-dom/`, `crates/rts-dom-bridge/` | the row above, PLUS `crates/rts-dom/PLAN.md` — §0 is the state (which lot is in flight, on which branch, measured how) and §1–§2 are the rules and the three rulers — and the verdict in `docs/ui/html-engine/analises/2026-09-04-auditoria-estrutural/README.md`, which is the current picture of the engine where the roadmap of June is the picture from before |
 | anything else | this file, and `docs/README.md` for where things live |
 
 If a change requires breaking a rule, **change the rule first, with the reason,

--- a/crates/rts-dom/PLAN.md
+++ b/crates/rts-dom/PLAN.md
@@ -35,7 +35,7 @@ linha aqui não existe.
 | K | invalidação escopada para `:nth-child` | 2 | ☐ | — | `dom_metrics`: cascades por `appendChild` |
 | L | cache de fragmentos em flex/grid/tabela | 2 | ☐ | — | `dom_metrics`: subárvores reusadas numa app flex |
 | M | ciclo de vida do nó | 2 | ☐ | — | teste: arena não cresce ao remover/inserir N vezes |
-| N | réguas no CI | 2 | ☐ | — | job verde a escrever o número no `tests/css/README.md` |
+| N | réguas no CI | 2 | ◐ jobs `dom-rulers` (corpus, vermelho se uma fixture cair) e `dom-tests` em `build-artifacts.yml`; a escrita automática do número no README e a régua de pintura ficam por fazer | `main` (2026-09-04) | resumo do job + check vermelho |
 | O–U | CSS como área | 3 | ☐ | — | §5 |
 | V–Y | a superfície DOM que as bibliotecas pedem | 4 | ☐ | — | §6 |
 


### PR DESCRIPTION
Lote N do `crates/rts-dom/PLAN.md`: jobs `dom-rulers` (corpus CSS sobre o binário de `build`, com passo-guarda e vermelho se uma fixture cair) e `dom-tests` (`cargo test -p rts-dom -p rts-dom-bridge`), ambos `continue-on-error` como os outros. Ensaiado localmente (`passam: 49 | falham: 0`); YAML validado; a primeira corrida real é este merge. Também a linha do `rts-dom` na RULE 0 do CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQz8qV3D3nVYu6KLh4djTs