### PR TITLE
perf(dom): um `:nth-child` na folha deixa de esquecer o estilo da página inteira a cada mutação (lote K)

### DIFF
--- a/crates/rts-dom/PLAN.md
+++ b/crates/rts-dom/PLAN.md
@@ -32,7 +32,7 @@ linha aqui não existe.
 | H | o escopo de página não vê o Node | 2 | ☑ integrado; fixture verde; `eval` indirecto ainda vê `process` (§4.H) | `feat/dom-escopo-pagina-sem-node` → `8e30fcc1` | fixture `claude-dom-page-nao-ve-process` |
 | I | folha de UA em CSS real | 2 | ☐ | — | `<th>` negrito/centro; `scrollbar.rs` apagado |
 | J | `DeclarationRecord` e `revert` | 2 | ☐ | — | fixture `revert`/`revert-layer` medida no Chrome |
-| K | invalidação escopada para `:nth-child` | 2 | ◐ implementado (subárvore do pai em vez de `touch()` global); testes de escopo; tempo NÃO medido | `feat/dom-lote-k-invalidacao-escopada` | `dom_metrics`: cascades por `appendChild` |
+| K | invalidação escopada para `:nth-child` | 2 | ☑ subárvore do pai em vez de `touch()` global; testes de escopo; corpus 49/49 e suite 858/887 sem perdidos; TEMPO por medir (`dom_metrics`) | `feat/dom-lote-k-invalidacao-escopada` (2026-09-04) | `dom_metrics`: cascades por `appendChild` |
 | L | cache de fragmentos em flex/grid/tabela | 2 | ☐ | — | `dom_metrics`: subárvores reusadas numa app flex |
 | M | ciclo de vida do nó | 2 | ☐ | — | teste: arena não cresce ao remover/inserir N vezes |
 | N | réguas no CI | 2 | ◐ jobs `dom-rulers` (corpus, vermelho se uma fixture cair) e `dom-tests` em `build-artifacts.yml`; a escrita automática do número no README e a régua de pintura ficam por fazer | `main` (2026-09-04) | resumo do job + check vermelho |

--- a/crates/rts-dom/PLAN.md
+++ b/crates/rts-dom/PLAN.md
@@ -32,7 +32,7 @@ linha aqui não existe.
 | H | o escopo de página não vê o Node | 2 | ☑ integrado; fixture verde; `eval` indirecto ainda vê `process` (§4.H) | `feat/dom-escopo-pagina-sem-node` → `8e30fcc1` | fixture `claude-dom-page-nao-ve-process` |
 | I | folha de UA em CSS real | 2 | ☐ | — | `<th>` negrito/centro; `scrollbar.rs` apagado |
 | J | `DeclarationRecord` e `revert` | 2 | ☐ | — | fixture `revert`/`revert-layer` medida no Chrome |
-| K | invalidação escopada para `:nth-child` | 2 | ☐ | — | `dom_metrics`: cascades por `appendChild` |
+| K | invalidação escopada para `:nth-child` | 2 | ◐ implementado (subárvore do pai em vez de `touch()` global); testes de escopo; tempo NÃO medido | `feat/dom-lote-k-invalidacao-escopada` | `dom_metrics`: cascades por `appendChild` |
 | L | cache de fragmentos em flex/grid/tabela | 2 | ☐ | — | `dom_metrics`: subárvores reusadas numa app flex |
 | M | ciclo de vida do nó | 2 | ☐ | — | teste: arena não cresce ao remover/inserir N vezes |
 | N | réguas no CI | 2 | ◐ jobs `dom-rulers` (corpus, vermelho se uma fixture cair) e `dom-tests` em `build-artifacts.yml`; a escrita automática do número no README e a régua de pintura ficam por fazer | `main` (2026-09-04) | resumo do job + check vermelho |

--- a/crates/rts-dom/src/dom/invalidacao.rs
+++ b/crates/rts-dom/src/dom/invalidacao.rs
@@ -147,8 +147,10 @@ impl Dom {
     /// estilo de nenhum outro: basta invalidar a subárvore que entrou/saiu e os
     /// ancestrais (que podem mudar de tamanho), que é o que `touch_subtrees`
     /// faz. Com `:nth-child`/`:first-child`/`:empty`/`+`/`~`, os irmãos mudam
-    /// de verdade e o global é a resposta certa — a guarda está em
-    /// [`Stylesheet::position_sensitive`](crate::style::Stylesheet::position_sensitive).
+    /// de verdade — e SÓ eles, com o pai e os descendentes: a guarda está em
+    /// [`Stylesheet::position_sensitive`](crate::style::Stylesheet::position_sensitive)
+    /// e a resposta é a subárvore do pai, não o documento (era o global até
+    /// 2026-09-04; o comentário no corpo diz porque a subárvore chega).
     /// `moved` é o nó que entrou/saiu (a subárvore dele é o que muda de estilo);
     /// `former_parent` é o pai anterior, quando houve um, para os epochs de
     /// layout dele subirem também.
@@ -160,10 +162,6 @@ impl Dom {
     /// varrer a subárvore do PAI por nó removido é quadrático, e é o pai que tem
     /// 2000 filhos, não o nó que saiu.
     pub(in crate::dom) fn touch_structural(&mut self, moved: NodeIdx, former_parent: Option<NodeIdx>) {
-        if self.stylesheet.position_sensitive() {
-            self.touch();
-            return;
-        }
         self.revision = self.revision.wrapping_add(1);
         crate::bump!(touch_subtree_calls);
         // CONSTRUÇÃO PURA (montar a árvore antes de ler qualquer estilo): não há
@@ -180,6 +178,35 @@ impl Dom {
             && self.layout_measure_cache.borrow().is_empty()
             && self.intrinsic_width_cache.borrow().is_empty()
         {
+            return;
+        }
+        // Com um seletor sensível a POSIÇÃO na folha, quem muda de estilo são
+        // os IRMÃOS de `moved` (`:nth-child`, `:first-child`, `+`, `~`) e o
+        // PAI (`:empty`) — nunca um nó fora da subárvore do pai: um seletor
+        // casa a partir do ALVO, e só um alvo dentro dessa subárvore lê a
+        // ordem ou a contagem dos filhos do pai. Isto era um `touch()`
+        // global, e o custo era ser global: com UM `tr:nth-child(odd)` em
+        // qualquer ponto da folha, cada `appendChild` em qualquer ponto da
+        // página esquecia o estilo de TODOS os nós (auditoria de 2026-09-04,
+        // lente de estilo, finding 3). A subárvore do pai é o conjunto de
+        // invalidação mínimo que esta conta permite; `:has()` é o único
+        // seletor que a quebraria, não existe, e quando existir é aqui que
+        // a quebra se escreve. Num `move`, o pai anterior entra pela mesma
+        // razão: os irmãos que ficaram lá também mudaram de posição.
+        if self.stylesheet.position_sensitive() {
+            let mut roots: Vec<NodeIdx> = Vec::with_capacity(2);
+            for pai in [self.nodes[moved].parent, former_parent].into_iter().flatten() {
+                if !roots.contains(&pai) {
+                    roots.push(pai);
+                }
+            }
+            if roots.is_empty() {
+                // `moved` é a própria raiz: não há pai cuja subárvore delimite
+                // o efeito, e o global é a única resposta certa.
+                self.touch();
+            } else {
+                self.touch_subtrees(roots);
+            }
             return;
         }
         let mut computed = self.computed_memo.borrow_mut();

--- a/crates/rts-dom/src/dom/tests/invalidacao.rs
+++ b/crates/rts-dom/src/dom/tests/invalidacao.rs
@@ -246,3 +246,59 @@
             "o irmão precisa reagir ao hover do anterior"
         );
     }
+
+    /// Com um seletor sensível a posição na folha, inserir um irmão muda a
+    /// paridade dos outros — e SÓ deles: um nó fora da subárvore do pai mutado
+    /// mantém o memo. Antes de 2026-09-04 isto era um `touch()` global, e um
+    /// `tr:nth-child(odd)` em qualquer ponto da folha fazia cada `appendChild`
+    /// esquecer o estilo da página inteira.
+    #[test]
+    fn nth_child_na_folha_invalida_os_irmaos_e_nao_o_documento() {
+        let mut dom = parse_html_to_dom(
+            "<style>li:nth-child(odd) { color:#ff0000 }</style><ul id='lista'><li id='l1'>a</li><li id='l2'>b</li></ul><div id='outro'><p id='p'>x</p></div>",
+        );
+        let lista = dom.query("#lista").unwrap();
+        let l1 = dom.query("#l1").unwrap();
+        let l2 = dom.query("#l2").unwrap();
+        let p = dom.query("#p").unwrap();
+        let (l1_idx, l2_idx, p_idx) = (idx(&dom, l1), idx(&dom, l2), idx(&dom, p));
+        assert_eq!(dom.computed_style(l1).unwrap().color, Some(0xFF0000FF));
+        assert_eq!(dom.computed_style(l2).unwrap().color, None);
+        let _ = dom.computed_style(p);
+        assert!(memoizado(&dom, l1_idx) && memoizado(&dom, l2_idx) && memoizado(&dom, p_idx));
+
+        let novo = dom.create_element("li");
+        dom.insert_before(lista, novo, Some(l1));
+
+        // Os irmãos esquecem; quem está fora da subárvore do pai não.
+        assert!(!memoizado(&dom, l1_idx), "l1 mudou de paridade e tem de ser recalculado");
+        assert!(!memoizado(&dom, l2_idx), "l2 mudou de paridade e tem de ser recalculado");
+        assert!(memoizado(&dom, p_idx), "#p está fora da subárvore do pai mutado");
+
+        // E a resposta recalculada é a certa: novo=1.º (ímpar), l1=2.º, l2=3.º.
+        assert_eq!(dom.computed_style(novo).unwrap().color, Some(0xFF0000FF));
+        assert_eq!(dom.computed_style(l1).unwrap().color, None);
+        assert_eq!(dom.computed_style(l2).unwrap().color, Some(0xFF0000FF));
+    }
+
+
+    /// Remover um irmão (o `former_parent` é o único pai envolvido) segue a
+    /// mesma regra: a lista é recalculada, o resto do documento não.
+    #[test]
+    fn remover_irmao_com_nth_child_invalida_so_a_lista() {
+        let mut dom = parse_html_to_dom(
+            "<style>li:first-child { color:#00ff00 }</style><ul id='lista'><li id='l1'>a</li><li id='l2'>b</li></ul><div id='outro'><p id='p'>x</p></div>",
+        );
+        let l1 = dom.query("#l1").unwrap();
+        let l2 = dom.query("#l2").unwrap();
+        let p = dom.query("#p").unwrap();
+        let (l2_idx, p_idx) = (idx(&dom, l2), idx(&dom, p));
+        assert_eq!(dom.computed_style(l2).unwrap().color, None);
+        let _ = dom.computed_style(p);
+
+        dom.remove_node(l1);
+        assert!(!memoizado(&dom, l2_idx), "l2 passou a ser o primeiro");
+        assert!(memoizado(&dom, p_idx), "#p está fora da lista");
+        assert_eq!(dom.computed_style(l2).unwrap().color, Some(0x00FF00FF));
+    }
+


### PR DESCRIPTION
Lote K do `crates/rts-dom/PLAN.md`: com um seletor sensível a posição na folha, `touch_structural` invalida a subárvore do pai (e do pai anterior) em vez de fazer `touch()` global. Dois testes pinam o ESCOPO (um nó fora da lista mantém o memo; a paridade recalculada é a certa). O tempo não foi medido — o que se afirma é o conjunto invalidado.

Medido: corpus CSS 49/49; suite por ficheiro 858/887, perdidos: nenhum; `cargo test -p rts-dom` 758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQz8qV3D3nVYu6KLh4djTs