### PR TITLE
fix(linker): o AOT no macOS liga o SystemConfiguration que o hickory-resolver exige; e o dom-rulers corre sem a matriz inteira

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -229,6 +229,12 @@ jobs:
   # aqui em vez de só no terminal de quem se lembrar de correr o corredor.
   dom-rulers:
     needs: [version, build]
+    # `needs: build` é a MATRIZ inteira, e o macOS está vermelho no smoke de
+    # AOT desde 471bbbd2 (2026-09-03, anterior a este job): sem isto, este job
+    # era SALTADO em todos os runs e a régua nunca corria — o primeiro run
+    # provou-o. Corre sempre que o run não foi cancelado; o binário que lhe
+    # interessa é o Linux, e se esse não existir o download falha por si.
+    if: ${{ !cancelled() && needs.version.result == 'success' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/crates/rts-linker/src/system_linker.rs
+++ b/crates/rts-linker/src/system_linker.rs
@@ -568,6 +568,14 @@ fn macos_frameworks() -> &'static [&'static str] {
         // glutin/glow GL fallback (egui glow backend): CGL context creation
         // (_CGLErrorString/_CGLSetParameter/_CGLChoosePixelFormat/…).
         "OpenGL",
+        // `system-configuration`, via `hickory-resolver` (o DNS do rts-node,
+        // 471bbbd2): `SCDynamicStoreCreateWithOptions` e companhia. O `cargo
+        // build` do próprio `rts` liga-o porque o crate emite
+        // `cargo:rustc-link-lib=framework=…`; o AOT liga o archive com ESTA
+        // lista, e sem esta linha o smoke de macOS falhou em todos os runs de
+        // main desde 2026-09-03 (issue #2632). A lista continua escrita à mão —
+        // é o que a issue diz que devia mudar.
+        "SystemConfiguration",
     ]
 }
 


### PR DESCRIPTION
Refs #2632. Uma linha em `macos_frameworks()` (não verificada num macOS — o próximo run de main é a medição) e o `dom-rulers` com `if: !cancelled()` para não ser saltado enquanto a matriz tiver um leg vermelho (o primeiro run provou que era).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQz8qV3D3nVYu6KLh4djTs