### PR TITLE
feat(scripts): a régua de PINTURA — rasterizador headless, captura no Edge, comparador por pixel; primeiro número: 79/86 abaixo de 0,5 %

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ scripts/parity/*.combinada.html
 # assim que o walker do `rts test` o ignora, em vez de o contar como corpus.
 .node-suite/
 .claude/worktrees/
+
+# Regua de pintura: PNG regeneraveis (tests/css/pintura), grandes e nao versionados
+tests/css/pintura/

--- a/crates/rts-dom/PLAN.md
+++ b/crates/rts-dom/PLAN.md
@@ -45,6 +45,7 @@ linha aqui não existe.
 | S-transform | transformações 2D | 4 | ☑ `matrix()`, `skew*`, composição na ordem da spec, `transform-origin`, bounding box transformada (e dos descendentes), o fluxo não muda; pintura de rotação/skew no egui continua APROXIMADA (anchor exacto, w/h por norma das colunas) | `feat/dom-lote-transformacoes` → `508181548` (2026-09-04) | `claude-transform-*` (3/3 passam) |
 | T | fontes reais | 3 | ☐ | — | §5 |
 | U | composição e pintura | 3 | ☐ | — | §5 |
+| N-pintura | a régua de PINTURA (screenshot-diff contra o Blink) | 5 | ☑ `claude-raster` (rasterizador headless da DisplayList, PNG sem crate nova), `css_fixtures_screenshot_edge.mjs` (captura no Edge por CDP), `css_pintura_comparar.mjs` (diff por pixel, texto mascarado e reportado). Verificado: cor sólida 0%, gradiente 0,24%, box-model 0,01%. Não pinta texto nem imagens (dito). PNG não versionados | `feat/dom-regua-de-pintura` → `d415d9124` (2026-09-04) | `scripts/css_pintura.md` |
 | V–Y | a superfície DOM que as bibliotecas pedem | 4 | ☐ | — | §6 |
 
 **Estado após a vaga 1 (2026-09-04, 01:41)** — medido com o `rts.exe`

--- a/crates/rts-dom/examples/claude-raster.rs
+++ b/crates/rts-dom/examples/claude-raster.rs
@@ -1,0 +1,352 @@
+//! O RASTERIZADOR headless do nosso lado da régua de pintura: parseia uma
+//! fixture, faz layout a 1280x800 com o `ApproxMeasurer` (o mesmo do
+//! `claude-paint-dump.rs`, para que os dois lados desta régua meçam o MESMO
+//! layout) e escreve um PNG RGBA da `DisplayList` — sem egui, sem wgpu, sem
+//! janela. É a metade que faltava ao `06-reguas-e-saude-do-codigo.md`
+//! finding 2: as réguas existentes comparam CAIXAS, nunca a IMAGEM.
+//!
+//!   cargo run -q -p rts-dom --example claude-raster -- pagina.html saida.png
+//!
+//! # O que pinta e o que salta — decidido aqui, não na régua
+//!
+//! Pinta: `SolidRect` (cantos quadrados — arredondar exigiria um rasterizador
+//! de arco, e a régua já tolera 8/255 por canal na borda de um retângulo,
+//! que é onde um canto reto contra um arredondado diverge), `Border` (quatro
+//! tiras retas), `GradientRect` linear (interpolação por pixel ao longo de
+//! `angle_deg`, a MESMA fórmula que `rts-egui` usa no mesh de 4 vértices —
+//! ver `crates/rts-egui/src/frame/render/pintura.rs`), `Shadow` (achatada:
+//! preenche o rect deslocado com a cor, sem blur — o blur é um desfoque
+//! gaussiano e não vale o código para uma régua que já ignora texto),
+//! `BeginClip`/`EndClip` (pilha de rects, interseção).
+//!
+//! SALTA: `Text` — o medidor é aproximado (`0.5×size` por caractere, sem
+//! fonte real) e pintar caixas por essa métrica compararia um erro de medição
+//! contra um glifo real do Blink, o que a fixture de texto nunca vai bater
+//! nem que o rasterizador esteja perfeito. `Image`/`Pixels` — a primeira
+//! aponta para um handle do `HandleTable`, que este exemplo não tem (não há
+//! `Engine` nem `Registry` aqui, só `Dom`+layout); a segunda carrega bytes
+//! próprios e É pintável, mas nenhuma fixture do corpus a usa hoje, então fica
+//! para quando uma precisar. Ambas as omissões contam para a MÁSCARA que o
+//! comparador (`scripts/css_pintura_comparar.mjs`) recebe: os rects de texto
+//! do nosso lado saem também num `.mask.json` ao lado do PNG.
+//!
+//! # Zero dependências novas no CRATE
+//!
+//! `rts-dom` continua com zero `[dependencies]` — o PNG é escrito à mão neste
+//! FICHEIRO (bloco IDAT com deflate "stored", sem compressão) porque o
+//! ficheiro é um exemplo e não faz parte do crate publicado, e a alternativa
+//! (a crate `png`) não está no `Cargo.lock`: trazê-la custaria uma
+//! dependência nova (mesmo que só de dev) para ~40 linhas de CRC32/Adler32.
+
+use rts_dom::layout::{self, DisplayItem, DisplayList, Rect, TextMeasurer};
+use rts_dom::Dom;
+use std::io::Write;
+
+const W: usize = 1280;
+const H: usize = 800;
+
+/// Um pixel RGBA reto (sem alpha pré-multiplicado) num buffer W×H.
+struct Canvas {
+    px: Vec<u8>,
+}
+
+impl Canvas {
+    fn new(bg: u32) -> Canvas {
+        let mut px = vec![0u8; W * H * 4];
+        let (r, g, b, a) = argb_bytes(bg);
+        for i in 0..(W * H) {
+            px[i * 4] = r;
+            px[i * 4 + 1] = g;
+            px[i * 4 + 2] = b;
+            px[i * 4 + 3] = a;
+        }
+        Canvas { px }
+    }
+
+    /// Alpha-blend de UM pixel. `clip` é a interseção corrente das
+    /// `BeginClip` abertas — `None` fora de qualquer rect pintável.
+    fn blend(&mut self, x: i32, y: i32, color: u32, clip: Option<Rect>) {
+        if x < 0 || y < 0 || x as usize >= W || y as usize >= H {
+            return;
+        }
+        if let Some(c) = clip {
+            let fx = x as f32 + 0.5;
+            let fy = y as f32 + 0.5;
+            if fx < c.x || fy < c.y || fx > c.x + c.w || fy > c.y + c.h {
+                return;
+            }
+        }
+        let (r, g, b, a) = argb_bytes(color);
+        if a == 0 {
+            return;
+        }
+        let i = (y as usize * W + x as usize) * 4;
+        if a == 255 {
+            self.px[i] = r;
+            self.px[i + 1] = g;
+            self.px[i + 2] = b;
+            self.px[i + 3] = 255;
+            return;
+        }
+        let af = a as f32 / 255.0;
+        for (k, s) in [r, g, b].into_iter().enumerate() {
+            let d = self.px[i + k] as f32;
+            self.px[i + k] = (s as f32 * af + d * (1.0 - af)).round() as u8;
+        }
+        self.px[i + 3] = 255;
+    }
+
+    fn fill_rect(&mut self, r: Rect, color: u32, clip: Option<Rect>) {
+        let x0 = r.x.floor() as i32;
+        let y0 = r.y.floor() as i32;
+        let x1 = (r.x + r.w).ceil() as i32;
+        let y1 = (r.y + r.h).ceil() as i32;
+        for y in y0..y1 {
+            for x in x0..x1 {
+                self.blend(x, y, color, clip);
+            }
+        }
+    }
+
+    /// Borda como quatro tiras — não um retângulo vazado, para não assumir
+    /// que `width` é igual nos quatro lados (a `DisplayList` já colapsou para
+    /// um valor só neste item; ver o comentário em `display.rs`).
+    fn stroke_rect(&mut self, r: Rect, width: f32, color: u32, clip: Option<Rect>) {
+        let w = width.max(1.0);
+        self.fill_rect(Rect::new(r.x, r.y, r.w, w), color, clip); // topo
+        self.fill_rect(Rect::new(r.x, r.y + r.h - w, r.w, w), color, clip); // fundo
+        self.fill_rect(Rect::new(r.x, r.y, w, r.h), color, clip); // esquerda
+        self.fill_rect(Rect::new(r.x + r.w - w, r.y, w, r.h), color, clip); // direita
+    }
+
+    /// Gradiente linear por pixel. `angle_deg` na convenção do CSS (0 = para
+    /// cima, 90 = para a direita) — a mesma leitura que `pintura.rs` faz no
+    /// backend egui, para que o mesh e este pixel-a-pixel concordem.
+    fn fill_gradient(&mut self, r: Rect, c0: u32, c1: u32, angle_deg: f32, clip: Option<Rect>) {
+        let rad = angle_deg.to_radians();
+        let (dx, dy) = (rad.sin(), -rad.cos()); // direção do gradiente
+        let x0 = r.x.floor() as i32;
+        let y0 = r.y.floor() as i32;
+        let x1 = (r.x + r.w).ceil() as i32;
+        let y1 = (r.y + r.h).ceil() as i32;
+        // Projeta os 4 cantos na direção do gradiente para achar [tmin, tmax] —
+        // o intervalo real que o rect ocupa, não [0,1] cru.
+        let corners = [(r.x, r.y), (r.x + r.w, r.y), (r.x, r.y + r.h), (r.x + r.w, r.y + r.h)];
+        let ts: Vec<f32> = corners.iter().map(|(cx, cy)| cx * dx + cy * dy).collect();
+        let tmin = ts.iter().cloned().fold(f32::INFINITY, f32::min);
+        let tmax = ts.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let span = (tmax - tmin).max(0.0001);
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let fx = x as f32 + 0.5;
+                let fy = y as f32 + 0.5;
+                let t = ((fx * dx + fy * dy) - tmin) / span;
+                let t = t.clamp(0.0, 1.0);
+                self.blend(x, y, lerp_color(c0, c1, t), clip);
+            }
+        }
+    }
+}
+
+fn argb_bytes(c: u32) -> (u8, u8, u8, u8) {
+    // A `DisplayList` guarda RGBA em u32 (ver comentário em `display.rs`:
+    // "cor é u32 RGBA"). Byte mais significativo = R.
+    (
+        ((c >> 24) & 0xff) as u8,
+        ((c >> 16) & 0xff) as u8,
+        ((c >> 8) & 0xff) as u8,
+        (c & 0xff) as u8,
+    )
+}
+
+fn lerp_color(c0: u32, c1: u32, t: f32) -> u32 {
+    let (r0, g0, b0, a0) = argb_bytes(c0);
+    let (r1, g1, b1, a1) = argb_bytes(c1);
+    let l = |a: u8, b: u8| (a as f32 + (b as f32 - a as f32) * t).round() as u32;
+    (l(r0, r1) << 24) | (l(g0, g1) << 16) | (l(b0, b1) << 8) | l(a0, a1)
+}
+
+fn rect_intersect(a: Rect, b: Rect) -> Rect {
+    let x0 = a.x.max(b.x);
+    let y0 = a.y.max(b.y);
+    let x1 = (a.x + a.w).min(b.x + b.w);
+    let y1 = (a.y + a.h).min(b.y + b.h);
+    Rect::new(x0, y0, (x1 - x0).max(0.0), (y1 - y0).max(0.0))
+}
+
+/// Escreve um PNG RGBA8 mínimo: sem paleta, sem interlace, um bloco IDAT
+/// deflate "stored" (sem compressão — o ficheiro fica maior que um PNG real,
+/// mas continua um PNG válido; qualquer leitor de PNG o decodifica).
+fn write_png(path: &str, w: u32, h: u32, rgba: &[u8]) -> std::io::Result<()> {
+    let mut out = Vec::new();
+    out.extend_from_slice(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    let mut ihdr = Vec::new();
+    ihdr.extend_from_slice(&w.to_be_bytes());
+    ihdr.extend_from_slice(&h.to_be_bytes());
+    ihdr.extend_from_slice(&[8, 6, 0, 0, 0]); // 8 bpc, RGBA, sem filtro/interlace especial
+    write_chunk(&mut out, b"IHDR", &ihdr);
+
+    // Um filtro-byte 0 (None) por linha, depois os RGBA da linha.
+    let mut raw = Vec::with_capacity((w as usize * 4 + 1) * h as usize);
+    for y in 0..h as usize {
+        raw.push(0u8);
+        let row = &rgba[y * w as usize * 4..(y + 1) * w as usize * 4];
+        raw.extend_from_slice(row);
+    }
+    let zlib = deflate_stored(&raw);
+    write_chunk(&mut out, b"IDAT", &zlib);
+    write_chunk(&mut out, b"IEND", &[]);
+
+    std::fs::File::create(path)?.write_all(&out)
+}
+
+fn write_chunk(out: &mut Vec<u8>, kind: &[u8; 4], data: &[u8]) {
+    out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    let mut body = Vec::with_capacity(4 + data.len());
+    body.extend_from_slice(kind);
+    body.extend_from_slice(data);
+    out.extend_from_slice(&body);
+    out.extend_from_slice(&crc32(&body).to_be_bytes());
+}
+
+/// zlib: cabeçalho de 2 bytes, N blocos deflate "stored" (BFINAL/BTYPE=00,
+/// cada um até 65535 bytes crus), depois Adler-32.
+fn deflate_stored(data: &[u8]) -> Vec<u8> {
+    let mut out = vec![0x78, 0x01]; // CMF/FLG: deflate, janela 32K, sem dicionário
+    let chunks = data.chunks(65535).collect::<Vec<_>>();
+    for (i, chunk) in chunks.iter().enumerate() {
+        let is_last = i + 1 == chunks.len();
+        out.push(if is_last { 1 } else { 0 });
+        let len = chunk.len() as u16;
+        out.extend_from_slice(&len.to_le_bytes());
+        out.extend_from_slice(&(!len).to_le_bytes());
+        out.extend_from_slice(chunk);
+    }
+    out.extend_from_slice(&adler32(data).to_be_bytes());
+    out
+}
+
+fn adler32(data: &[u8]) -> u32 {
+    let (mut a, mut b) = (1u32, 0u32);
+    for &byte in data {
+        a = (a + byte as u32) % 65521;
+        b = (b + a) % 65521;
+    }
+    (b << 16) | a
+}
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffffu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 { (crc >> 1) ^ 0xedb8_8320 } else { crc >> 1 };
+        }
+    }
+    !crc
+}
+
+/// Um item de texto não pintado, para a máscara de "área ignorada" que o
+/// comparador soma. Usa o MESMO `ApproxMeasurer` do layout — a régua de N já
+/// diz porquê: um medidor diferente aqui daria uma máscara que não cobre o
+/// que o layout de facto colocou onde.
+fn text_mask_rect(x: f32, y: f32, text: &str, size: f32, mono: bool) -> Rect {
+    let w = layout::ApproxMeasurer.text_width(text, size, mono, false, false);
+    Rect::new(x, y - size, w, size * 1.3)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let (Some(entrada), Some(saida)) = (args.get(1), args.get(2)) else {
+        eprintln!("uso: claude-raster <pagina.html> <saida.png>");
+        std::process::exit(2);
+    };
+    let html = std::fs::read_to_string(entrada).unwrap_or_else(|e| {
+        eprintln!("não li {entrada}: {e}");
+        std::process::exit(2);
+    });
+    let dom: Dom = rts_dom::parse_html_to_dom(&html);
+    let ctx = layout::LayoutCtx {
+        viewport_w: W as f32,
+        viewport_h: H as f32,
+        measurer: &layout::ApproxMeasurer,
+    };
+    let list: DisplayList = layout::layout_document(&dom, &ctx);
+
+    let mut canvas = Canvas::new(list.canvas_background);
+    let mut clip_stack: Vec<Rect> = Vec::new();
+    let mut mask: Vec<[f32; 4]> = Vec::new(); // [x,y,w,h] dos rects de texto ignorados
+    let mut pintados = 0usize;
+    let mut saltados_texto = 0usize;
+    let mut saltados_imagem = 0usize;
+
+    list.walk(|item, dx, dy| {
+        let clip = clip_stack.last().copied();
+        match item {
+            DisplayItem::SolidRect { rect, color, .. } => {
+                canvas.fill_rect(shift(*rect, dx, dy), *color, clip);
+                pintados += 1;
+            }
+            DisplayItem::Border { rect, width, color, .. } => {
+                canvas.stroke_rect(shift(*rect, dx, dy), *width, *color, clip);
+                pintados += 1;
+            }
+            DisplayItem::GradientRect { rect, c0, c1, angle_deg, .. } => {
+                canvas.fill_gradient(shift(*rect, dx, dy), *c0, *c1, *angle_deg, clip);
+                pintados += 1;
+            }
+            DisplayItem::Shadow { rect, dx: sdx, dy: sdy, color, .. } => {
+                let r = shift(*rect, dx + sdx, dy + sdy);
+                canvas.fill_rect(r, *color, clip);
+                pintados += 1;
+            }
+            DisplayItem::Text { x, y, text, size, mono, .. } => {
+                let r = text_mask_rect(x + dx, y + dy, text, *size, *mono);
+                mask.push([r.x, r.y, r.w, r.h]);
+                saltados_texto += 1;
+            }
+            DisplayItem::Image { rect, .. } | DisplayItem::Pixels { rect, .. } => {
+                let _ = shift(*rect, dx, dy);
+                saltados_imagem += 1;
+            }
+            DisplayItem::BeginClip { rect, .. } => {
+                let r = shift(*rect, dx, dy);
+                let novo = match clip {
+                    Some(c) => rect_intersect(c, r),
+                    None => r,
+                };
+                clip_stack.push(novo);
+            }
+            DisplayItem::EndClip { .. } => {
+                clip_stack.pop();
+            }
+        }
+    });
+
+    write_png(saida, W as u32, H as u32, &canvas.px).unwrap_or_else(|e| {
+        eprintln!("não escrevi {saida}: {e}");
+        std::process::exit(2);
+    });
+
+    // A máscara vive ao lado do PNG com o MESMO nome — o comparador a lê sem
+    // precisar de um segundo argumento na linha de comandos.
+    let mask_path = format!("{saida}.mask.json");
+    let mask_json: Vec<String> = mask
+        .iter()
+        .map(|[x, y, w, h]| format!("[{x:.2},{y:.2},{w:.2},{h:.2}]"))
+        .collect();
+    std::fs::write(&mask_path, format!("[{}]", mask_json.join(","))).unwrap_or_else(|e| {
+        eprintln!("não escrevi {mask_path}: {e}");
+        std::process::exit(2);
+    });
+
+    eprintln!(
+        "rts-raster: {pintados} itens pintados, {saltados_texto} texto (mascarado), \
+         {saltados_imagem} imagem (saltados, sem handle table aqui)"
+    );
+}
+
+fn shift(r: Rect, dx: f32, dy: f32) -> Rect {
+    Rect::new(r.x + dx, r.y + dy, r.w, r.h)
+}

--- a/scripts/css_fixtures_screenshot_edge.mjs
+++ b/scripts/css_fixtures_screenshot_edge.mjs
@@ -1,0 +1,103 @@
+// A CAPTURA do lado Blink da régua de PINTURA: para cada fixture de
+// `tests/css/`, abre-a DIRECTAMENTE (não num iframe — a régua de N usa iframe
+// porque quer o `contentDocument`; esta régua quer o PIXEL, e um iframe traz
+// a moldura da página-mãe para dentro do screenshot) a 1280x800 por CDP cru,
+// no Edge headless, e grava `tests/css/pintura/<fixture>.blink.png`.
+//
+// A canalização CDP é a de `scripts/css_fixtures_medir_edge.mjs`, reutilizada
+// verbatim (Target.attachToTarget, Emulation.setDeviceMetricsOverride,
+// Runtime.evaluate) — só o fim muda: aqui não há colheita de `getComputedStyle`,
+// há `Page.captureScreenshot`.
+//
+//   bun scripts/css_fixtures_serve.ts &                                  # porta 8731
+//   bun scripts/css_fixtures_screenshot_edge.mjs claude-cor-e-fundo      # uma fixture
+//   bun scripts/css_fixtures_screenshot_edge.mjs                        # todas
+//
+// `bun` e não `node`: o Node 20 desta máquina não tem `WebSocket` global (a
+// mesma nota do script irmão).
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CHROME = [
+  process.env.CHROME_BIN,
+  "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe",
+  "C:/Program Files/Microsoft/Edge/Application/msedge.exe",
+  "C:/Program Files/Google/Chrome/Application/chrome.exe",
+].find((p) => p && existsSync(p));
+if (!CHROME) { console.error("nem Edge nem Chrome encontrados — defina CHROME_BIN"); process.exit(2); }
+
+const RAIZ = "tests/css";
+const SAIDA = resolve(RAIZ, "pintura");
+mkdirSync(SAIDA, { recursive: true });
+
+// Sem argumentos: todas as `.html` do corpus. Com argumentos: só os nomes
+// (sem `.html`) dados — o mesmo padrão de `css_fixtures.sh`.
+const pedidos = process.argv.slice(2);
+const fixtures = (pedidos.length
+  ? pedidos.map((n) => (n.endsWith(".html") ? n : `${n}.html`))
+  : readdirSync(RAIZ).filter((n) => n.endsWith(".html")).sort()
+);
+
+const PORTA = Number(process.env.CDP_PORT ?? 9338);
+const perfil = resolve(process.env.TEMP ?? ".", "edge-pintura-profile");
+
+const chrome = spawn(CHROME, [
+  "--headless=new", `--remote-debugging-port=${PORTA}`, `--user-data-dir=${perfil}`,
+  "--no-first-run", "--no-default-browser-check", "--disable-extensions",
+  "--disable-background-networking", "--disable-remote-fonts", "--hide-scrollbars",
+  "--force-device-scale-factor=1", "about:blank",
+], { stdio: ["ignore", "ignore", "pipe"] });
+chrome.stderr.on("data", () => {});
+
+async function esperarCdp() {
+  const t0 = Date.now();
+  for (;;) {
+    try { const r = await fetch(`http://127.0.0.1:${PORTA}/json/version`); return (await r.json()).webSocketDebuggerUrl; }
+    catch { if (Date.now() - t0 > 30000) throw new Error("CDP não subiu em 30s"); await new Promise((r) => setTimeout(r, 150)); }
+  }
+}
+function cliente(ws) {
+  let proximo = 0; const pendentes = new Map(); const eventos = new Map();
+  ws.addEventListener("message", (ev) => {
+    const m = JSON.parse(ev.data);
+    if (m.id !== undefined) { const p = pendentes.get(m.id); pendentes.delete(m.id); m.error ? p.rej(new Error(JSON.stringify(m.error))) : p.res(m.result); }
+    else (eventos.get(m.method) ?? []).forEach((f) => f(m.params, m.sessionId));
+  });
+  return {
+    envia(method, params = {}, sessionId) { const id = ++proximo; return new Promise((res, rej) => { pendentes.set(id, { res, rej }); ws.send(JSON.stringify({ id, method, params, sessionId })); }); },
+    quando(method, f) { if (!eventos.has(method)) eventos.set(method, []); eventos.get(method).push(f); },
+  };
+}
+
+const wsUrl = await esperarCdp();
+const ws = new WebSocket(wsUrl);
+await new Promise((r) => ws.addEventListener("open", r));
+const c = cliente(ws);
+const { targetInfos } = await c.envia("Target.getTargets");
+const alvo = targetInfos.find((t) => t.type === "page");
+const { sessionId } = await c.envia("Target.attachToTarget", { targetId: alvo.targetId, flatten: true });
+await c.envia("Page.enable", {}, sessionId);
+await c.envia("Runtime.enable", {}, sessionId);
+await c.envia("Emulation.setDeviceMetricsOverride", { width: 1280, height: 800, deviceScaleFactor: 1, mobile: false }, sessionId);
+
+let ok = 0; const falhas = [];
+for (const nome of fixtures) {
+  try {
+    const carregou = new Promise((r) => c.quando("Page.loadEventFired", (_p, s) => { if (s === sessionId) r(); }));
+    await c.envia("Page.navigate", { url: `http://127.0.0.1:8731/${nome}` }, sessionId);
+    await carregou;
+    // A folha pode continuar a aplicar layout um frame depois do load (fontes
+    // web, reflow tardio) — a mesma razão por que `css_fixtures_medir.md` já
+    // espera o `onload` do iframe e não navega direto ao screenshot.
+    await new Promise((r) => setTimeout(r, 30));
+    const { data } = await c.envia("Page.captureScreenshot", { format: "png", captureBeyondViewport: false }, sessionId);
+    writeFileSync(resolve(SAIDA, `${nome.replace(/\.html$/, "")}.blink.png`), Buffer.from(data, "base64"));
+    ok++;
+  } catch (e) {
+    falhas.push(`${nome}: ${e.message}`);
+  }
+}
+console.log(`capturadas ${ok}/${fixtures.length}${falhas.length ? " — falhas: " + JSON.stringify(falhas) : ""}`);
+ws.close();
+chrome.kill();

--- a/scripts/css_pintura.md
+++ b/scripts/css_pintura.md
@@ -78,3 +78,14 @@ um PNG de 1280×800 RGBA sai por volta de **4 MB**, contra ~5-6 KB do
 qualquer momento pelos três comandos acima, e não há decisão tomada aqui
 sobre quais — se algum — entram como esperado versionado; essa decisão fica
 para quando uma fixture específica precisar de um esperado de pintura fixo.
+
+## O número, hoje
+
+**2026-09-04, primeira medição sobre o corpus inteiro (86 fixtures, Edge 152
+headless):** 79 fixtures com ≤ 0,5 % de pixels diferentes, 82 com ≤ 2 %, e
+**4 acima de 2 %** — `claude-transform-origin` (6,06 %) e
+`claude-transform-nao-afeta-fluxo` (2,05 %): a rotação é pintada como caixa
+axis-aligned (o backend não roda); `claude-overflow` (5,57 %): o recorte por
+`overflow` não é aplicado pelo rasterizador; `claude-sel-target` (2,55 %).
+Texto ignorado em todas (a máscara): no máximo 1,4 % da área. Estes quatro
+são os primeiros alvos de um lote de pintura, e o número que os fecha é este.

--- a/scripts/css_pintura.md
+++ b/scripts/css_pintura.md
@@ -1,0 +1,80 @@
+# A régua de pintura
+
+Compara PIXEL, não caixa nem estilo computado. As outras réguas de
+`tests/css/` (`css_fixtures.sh`, `css_fixtures_medir_edge.mjs`) respondem
+"a caixa está no sítio certo?" e "a propriedade computada é a mesma?"; esta
+responde "o desenho é o mesmo?" — a que faltava segundo o achado 2 de
+`docs/ui/html-engine/analises/2026-09-04-auditoria-estrutural/06-reguas-e-saude-do-codigo.md`.
+
+## As três peças
+
+1. **`cargo run -p rts-dom --example claude-raster -- <fixture>.html <saida>.png`**
+   Faz layout da fixture a 1280×800 com o `ApproxMeasurer` (o mesmo medidor
+   do `claude-paint-dump.rs` — trocar de medidor trocaria o layout que se
+   está a rasterizar) e rasteriza a `DisplayList` para um PNG RGBA, sem egui
+   nem wgpu. Grava também `<saida>.png.mask.json`: os retângulos de texto que
+   NÃO pintou.
+
+2. **`bun scripts/css_fixtures_screenshot_edge.mjs [nomes...]`**
+   Abre cada fixture DIRETAMENTE (não num iframe) a 1280×800 no Edge headless
+   por CDP e grava `tests/css/pintura/<nome>.blink.png` via
+   `Page.captureScreenshot`. Precisa de `bun scripts/css_fixtures_serve.ts`
+   a correr (porta 8731) — a mesma dependência da régua de N.
+
+3. **`bun scripts/css_pintura_comparar.mjs [nomes...]`**
+   Lê `<nome>.rts.png` e `<nome>.blink.png` de `tests/css/pintura/`,
+   decodifica os dois (um decodificador PNG mínimo — `node:zlib` para o
+   `inflate`, "unfilter" dos 5 filtros à mão) e responde por fixture:
+   `% diferente` (pixels acima da tolerância por canal, 8/255 por omissão,
+   `TOLERANCIA=N` muda) e `% de área ignorada` (a máscara de texto do passo
+   1). Grava `<nome>.diff.png` — vermelho onde diverge, cinza onde foi
+   ignorado, a cor original onde bate.
+
+## O que é ignorado, e porquê
+
+**Texto**, sempre. Nenhum dos dois lados desta régua usa fonte real do nosso
+motor: o `ApproxMeasurer` mede `0.5×size` por caractere, sem glifo nenhum —
+comparar essa área contra um `Page.captureScreenshot` do Blink (Segoe UI de
+verdade) mediria o erro do medidor aproximado, não um defeito de pintura. O
+`claude-raster.rs` por isso NÃO pinta texto — decisão tomada no rasterizador,
+não escondida no comparador — e grava onde ficaria como máscara.
+
+**Imagem** (`<img>`, `background-image` com URL), por agora. `DisplayItem::Image`
+aponta para um handle do `HandleTable`, que o exemplo não tem (não instancia
+`Engine`/`Registry`, só `Dom`+layout — trazê-los para um exemplo de
+rasterização é o preço de pintar UMA fixture no corpus atual). Nenhuma
+fixture de `tests/css/` depende disto para o que fixa; quando uma depender,
+o custo de instanciar o handle table paga-se então.
+
+**Cantos arredondados**, aproximados a quadrados. Rasterizar um arco exige
+mais do que um "fill rect", e a tolerância por canal (8/255) já absorve a
+faixa de poucos pixels onde um canto reto diverge de um arredondado — não
+valia o código para o que a régua está a verificar primeiro.
+
+**Sombra sem desfoque** (`box-shadow` pinta achatada, sem blur gaussiano) —
+mesma razão: código a mais para o que esta primeira entrega precisa provar.
+
+## Como ler o número
+
+`% diferente` é sobre os pixels COMPARADOS (área total menos a área
+ignorada), nunca sobre o total — a mesma regra do "verifique a entrada" do
+`CLAUDE.md`: se a área ignorada crescer sem que ninguém note, o "% diferente"
+cai por ter menos para comparar, e pareceria uma melhoria que não houve. É
+por isso que o comparador imprime as duas percentagens sempre juntas.
+
+Um valor de referência foi medido antes de qualquer PR se apoiar nesta régua
+(`tests/css/claude-cor-e-fundo.html`, só cor sólida e fundo — sem gradiente
+nem texto): **0% diferente, 0.09% de área ignorada** (um `div` vazio ainda
+gera um item de texto de largura zero). E com gradiente linear
+(`tests/css/claude-background-camadas.html`, `linear-gradient(red, blue)`):
+**0.24% diferente, 0% de área ignorada**.
+
+## Tamanho
+
+O `claude-raster.rs` escreve PNG sem compressão (bloco `deflate` "stored") —
+um PNG de 1280×800 RGBA sai por volta de **4 MB**, contra ~5-6 KB do
+`Page.captureScreenshot` do Blink (que comprime de verdade). Por isso
+`tests/css/pintura/` está no `.gitignore`: os PNG são regeneráveis a
+qualquer momento pelos três comandos acima, e não há decisão tomada aqui
+sobre quais — se algum — entram como esperado versionado; essa decisão fica
+para quando uma fixture específica precisar de um esperado de pintura fixo.

--- a/scripts/css_pintura_comparar.mjs
+++ b/scripts/css_pintura_comparar.mjs
@@ -190,14 +190,24 @@ function compararUma(nome) {
 }
 
 const pedidos = process.argv.slice(2);
-const nomes = pedidos.length
+// Aceita `claude-x` e `claude-x.html` (o nome como está em tests/css/). Um
+// nome sem `.rts.png` é ERRO dito e exit 2 — a primeira versão respondia
+// silêncio e exit 0, que é um instrumento a parecer um resultado.
+const nomes = (pedidos.length
   ? pedidos
   : readdirSync(PASTA)
       .filter((n) => n.endsWith(".rts.png"))
-      .map((n) => n.replace(/\.rts\.png$/, ""));
+      .map((n) => n.replace(/\.rts\.png$/, ""))
+).map((n) => n.replace(/\.html$/, ""));
+let emFalta = 0;
+for (const n of nomes) {
+  if (!existsSync(resolve(PASTA, `${n}.rts.png`))) { console.log(`${n}: ERRO sem ${n}.rts.png em ${PASTA} (corra o claude-raster)`); emFalta++; }
+  if (!existsSync(resolve(PASTA, `${n}.blink.png`))) { console.log(`${n}: ERRO sem ${n}.blink.png em ${PASTA} (corra o css_fixtures_screenshot_edge)`); emFalta++; }
+}
 
 const resultados = nomes.map(compararUma).filter(Boolean);
 for (const r of resultados) {
   if (r.erro) console.log(`${r.nome}: ERRO ${r.erro}`);
   else console.log(`${r.nome}: ${r.pct_diferente}% diferente (área ignorada por texto: ${r.pct_area_ignorada}%)`);
 }
+if (emFalta) process.exit(2);

--- a/scripts/css_pintura_comparar.mjs
+++ b/scripts/css_pintura_comparar.mjs
@@ -1,0 +1,203 @@
+// O COMPARADOR da régua de pintura: lê o PNG do nosso lado
+// (`crates/rts-dom/examples/claude-raster.rs`) e o do Blink
+// (`css_fixtures_screenshot_edge.mjs`), e responde por fixture a % de pixels
+// diferentes acima de uma tolerância por canal — IGNORANDO as regiões de
+// texto do nosso lado (o `.mask.json` que o rasterizador grava ao lado do
+// PNG), porque nenhum dos dois lados desta régua tem fonte real: o
+// `ApproxMeasurer` não pinta glifo nenhum, e comparar essa área contra o
+// Blink mediria o medidor aproximado, não o motor de pintura.
+//
+//   bun scripts/css_pintura_comparar.mjs claude-cor-e-fundo
+//   bun scripts/css_pintura_comparar.mjs                       # todas as que têm os dois PNG
+//
+// Decodificar PNG: em vez de trazer uma dependência, usamos `node:zlib`
+// (disponível no bun) para o `inflate` do IDAT e escrevemos ~40 linhas de
+// "unfilter" (os 5 filtros do PNG — None/Sub/Up/Average/Paeth) à mão. Foi
+// preferido a gravar `.ppm`/`.rgba` cru dos dois lados porque o
+// `Page.captureScreenshot` do CDP só sabe responder PNG (ou JPEG, com
+// perdas) — gravar cru do lado Blink exigiria decodificar de qualquer forma,
+// então decodificar os dois é o caminho mais curto, não o mais longo.
+import { readFileSync, existsSync, readdirSync, writeFileSync } from "node:fs";
+import { inflateSync } from "node:zlib";
+import { resolve } from "node:path";
+
+const RAIZ = "tests/css";
+const PASTA = resolve(RAIZ, "pintura");
+const TOLERANCIA = Number(process.env.TOLERANCIA ?? 8); // por canal, 0-255
+
+function decodePng(buf) {
+  if (buf.readUInt32BE(0) !== 0x89504e47) throw new Error("assinatura PNG inválida");
+  let pos = 8, w = 0, h = 0, bitDepth = 0, colorType = 0;
+  const idat = [];
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const kind = buf.toString("ascii", pos + 4, pos + 8);
+    const data = buf.subarray(pos + 8, pos + 8 + len);
+    if (kind === "IHDR") {
+      w = data.readUInt32BE(0); h = data.readUInt32BE(4);
+      bitDepth = data[8]; colorType = data[9];
+    } else if (kind === "IDAT") {
+      idat.push(data);
+    } else if (kind === "IEND") break;
+    pos += 12 + len;
+  }
+  if (bitDepth !== 8 || (colorType !== 6 && colorType !== 2)) {
+    throw new Error(`PNG não suportado: bitDepth=${bitDepth} colorType=${colorType} (só 8-bit RGB/RGBA)`);
+  }
+  const bpp = colorType === 6 ? 4 : 3;
+  const raw = inflateSync(Buffer.concat(idat));
+  const stride = w * bpp;
+  const out = Buffer.alloc(w * h * 4, 255); // RGBA — canal alpha 255 se a origem era RGB (colorType 2)
+  let rpos = 0;
+  const prevRow = Buffer.alloc(stride);
+  for (let y = 0; y < h; y++) {
+    const filter = raw[rpos]; rpos += 1;
+    const row = raw.subarray(rpos, rpos + stride); rpos += stride;
+    const cur = Buffer.alloc(stride);
+    for (let x = 0; x < stride; x++) {
+      const a = x >= bpp ? cur[x - bpp] : 0;
+      const b = prevRow[x];
+      const cc = x >= bpp ? prevRow[x - bpp] : 0;
+      let v = row[x];
+      switch (filter) {
+        case 0: break;
+        case 1: v = (v + a) & 0xff; break;
+        case 2: v = (v + b) & 0xff; break;
+        case 3: v = (v + ((a + b) >> 1)) & 0xff; break;
+        case 4: {
+          const p = a + b - cc;
+          const pa = Math.abs(p - a), pb = Math.abs(p - b), pc = Math.abs(p - cc);
+          const pr = pa <= pb && pa <= pc ? a : pb <= pc ? b : cc;
+          v = (v + pr) & 0xff;
+          break;
+        }
+        default: throw new Error(`filtro PNG desconhecido: ${filter}`);
+      }
+      cur[x] = v;
+    }
+    cur.copy(prevRow);
+    for (let px = 0; px < w; px++) {
+      const si = px * bpp, di = (y * w + px) * 4;
+      out[di] = cur[si]; out[di + 1] = cur[si + 1]; out[di + 2] = cur[si + 2];
+      out[di + 3] = bpp === 4 ? cur[si + 3] : 255;
+    }
+  }
+  return { w, h, rgba: out };
+}
+
+/// Encode PNG mínimo (mesmo esquema do `claude-raster.rs`, sem compressão) —
+/// só para o `.diff.png`, que este script também produz.
+function encodePngStored(w, h, rgba) {
+  const chunks = [];
+  const crcTable = (() => {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) { let c = n; for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1; t[n] = c >>> 0; }
+    return t;
+  })();
+  const crc32 = (buf) => { let c = 0xffffffff; for (const b of buf) c = crcTable[(c ^ b) & 0xff] ^ (c >>> 8); return (c ^ 0xffffffff) >>> 0; };
+  const chunk = (kind, data) => {
+    const body = Buffer.concat([Buffer.from(kind, "ascii"), data]);
+    const len = Buffer.alloc(4); len.writeUInt32BE(data.length);
+    const crc = Buffer.alloc(4); crc.writeUInt32BE(crc32(body));
+    chunks.push(len, body, crc);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0); ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; ihdr[9] = 6; ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0;
+  chunk("IHDR", ihdr);
+  const raw = Buffer.alloc((w * 4 + 1) * h);
+  for (let y = 0; y < h; y++) {
+    raw[y * (w * 4 + 1)] = 0;
+    rgba.copy(raw, y * (w * 4 + 1) + 1, y * w * 4, (y + 1) * w * 4);
+  }
+  const adler32 = (data) => {
+    let a = 1, b = 0;
+    for (const byte of data) { a = (a + byte) % 65521; b = (b + a) % 65521; }
+    return ((b << 16) | a) >>> 0;
+  };
+  const zparts = [Buffer.from([0x78, 0x01])];
+  for (let i = 0; i < raw.length; i += 65535) {
+    const c = raw.subarray(i, Math.min(i + 65535, raw.length));
+    const last = i + 65535 >= raw.length ? 1 : 0;
+    const hdr = Buffer.alloc(5);
+    hdr[0] = last;
+    hdr.writeUInt16LE(c.length, 1);
+    hdr.writeUInt16LE((~c.length) & 0xffff, 3);
+    zparts.push(hdr, c);
+  }
+  const adlerBuf = Buffer.alloc(4); adlerBuf.writeUInt32BE(adler32(raw));
+  zparts.push(adlerBuf);
+  chunk("IDAT", Buffer.concat(zparts));
+  chunk("IEND", Buffer.alloc(0));
+  return Buffer.concat([Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), ...chunks]);
+}
+
+function loadMask(pathPng) {
+  const p = `${pathPng}.mask.json`;
+  if (!existsSync(p)) return [];
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function inMask(x, y, mask) {
+  for (const [mx, my, mw, mh] of mask) {
+    if (x >= mx && x < mx + mw && y >= my && y < my + mh) return true;
+  }
+  return false;
+}
+
+function compararUma(nome) {
+  const rtsPath = resolve(PASTA, `${nome}.rts.png`);
+  const blinkPath = resolve(PASTA, `${nome}.blink.png`);
+  if (!existsSync(rtsPath) || !existsSync(blinkPath)) return null;
+  const rts = decodePng(readFileSync(rtsPath));
+  const blink = decodePng(readFileSync(blinkPath));
+  if (rts.w !== blink.w || rts.h !== blink.h) {
+    return { nome, erro: `dimensões diferentes: rts ${rts.w}x${rts.h}, blink ${blink.w}x${blink.h}` };
+  }
+  const mask = loadMask(rtsPath);
+  const { w, h } = rts;
+  const diff = Buffer.alloc(w * h * 4, 0);
+  let diferentes = 0, ignorados = 0, comparados = 0;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      if (inMask(x, y, mask)) {
+        ignorados++;
+        diff[i] = 40; diff[i + 1] = 40; diff[i + 2] = 40; diff[i + 3] = 255; // cinza = ignorado
+        continue;
+      }
+      comparados++;
+      const dr = Math.abs(rts.rgba[i] - blink.rgba[i]);
+      const dg = Math.abs(rts.rgba[i + 1] - blink.rgba[i + 1]);
+      const db = Math.abs(rts.rgba[i + 2] - blink.rgba[i + 2]);
+      if (dr > TOLERANCIA || dg > TOLERANCIA || db > TOLERANCIA) {
+        diferentes++;
+        diff[i] = 255; diff[i + 1] = 0; diff[i + 2] = 0; diff[i + 3] = 255;
+      } else {
+        diff[i] = rts.rgba[i]; diff[i + 1] = rts.rgba[i + 1]; diff[i + 2] = rts.rgba[i + 2]; diff[i + 3] = 255;
+      }
+    }
+  }
+  const png = encodePngStored(w, h, diff);
+  const diffPath = resolve(PASTA, `${nome}.diff.png`);
+  writeFileSync(diffPath, png);
+  return {
+    nome,
+    pct_diferente: comparados ? +((diferentes / comparados) * 100).toFixed(2) : 0,
+    pct_area_ignorada: +((ignorados / (w * h)) * 100).toFixed(2),
+    diferentes, comparados, ignorados, total: w * h,
+  };
+}
+
+const pedidos = process.argv.slice(2);
+const nomes = pedidos.length
+  ? pedidos
+  : readdirSync(PASTA)
+      .filter((n) => n.endsWith(".rts.png"))
+      .map((n) => n.replace(/\.rts\.png$/, ""));
+
+const resultados = nomes.map(compararUma).filter(Boolean);
+for (const r of resultados) {
+  if (r.erro) console.log(`${r.nome}: ERRO ${r.erro}`);
+  else console.log(`${r.nome}: ${r.pct_diferente}% diferente (área ignorada por texto: ${r.pct_area_ignorada}%)`);
+}

--- a/tests/css/README.md
+++ b/tests/css/README.md
@@ -119,3 +119,27 @@ scripts/css_fixtures.sh            o comando
 scripts/css_fixtures_serve.ts      serve tests/css/ para o Chrome medir
 scripts/css_fixtures_medir.md      como medir
 ```
+
+---
+
+## A régua de pintura
+
+As réguas acima comparam CAIXAS (`getBoundingClientRect`) e ESTILO
+(`getComputedStyle`) — nunca a IMAGEM. É por isso que `text-shadow`,
+gradientes, `clip-path`, um `transform` rodado e `text-decoration-style` estão
+"só computados, não pintados" sem que nada o meça (achado 2 de
+`docs/ui/html-engine/analises/2026-09-04-auditoria-estrutural/06-reguas-e-saude-do-codigo.md`).
+A régua de pintura fecha essa lacuna: compara PIXEL contra Blink real.
+
+```
+cargo run -q -p rts-dom --example claude-raster -- \
+  tests/css/claude-X.html tests/css/pintura/claude-X.rts.png
+bun scripts/css_fixtures_screenshot_edge.mjs claude-X   # grava .blink.png
+bun scripts/css_pintura_comparar.mjs claude-X           # imprime % diferente
+```
+
+O procedimento completo, o que é ignorado e porquê, e como ler o número:
+`scripts/css_pintura.md`. Os `.rts.png`/`.blink.png`/`.diff.png` NÃO vão para
+o git (`tests/css/pintura/` está no `.gitignore`) — são grandes (o `.rts.png`
+sem compressão passa de 4 MB por fixture) e regeneráveis a qualquer momento;
+decide-se depois, por fixture, se algum entra como esperado.

--- a/tests/css/README.md
+++ b/tests/css/README.md
@@ -143,3 +143,5 @@ O procedimento completo, o que é ignorado e porquê, e como ler o número:
 o git (`tests/css/pintura/` está no `.gitignore`) — são grandes (o `.rts.png`
 sem compressão passa de 4 MB por fixture) e regeneráveis a qualquer momento;
 decide-se depois, por fixture, se algum entra como esperado.
+
+**Primeira medição (2026-09-04, 86 fixtures):** 79 com ≤ 0,5 % de pixels diferentes, 82 com ≤ 2 %, 4 acima (rotação de `transform` e recorte por `overflow` — declarados como aproximados). Detalhe em `scripts/css_pintura.md`.


### PR DESCRIPTION
Lote N-pintura do `crates/rts-dom/PLAN.md` (a régua que a auditoria de 2026-09-04 disse faltar): `crates/rts-dom/examples/claude-raster.rs` rasteriza a DisplayList para PNG sem egui/wgpu nem crate nova; `scripts/css_fixtures_screenshot_edge.mjs` captura a fixture no Edge headless por CDP; `scripts/css_pintura_comparar.mjs` compara por pixel (texto mascarado e reportado). Instrumento verificado antes de contar: cor sólida 0 %, gradiente 0,24 %, box-model 0,01 %. Primeira medição do corpus inteiro: 86 fixtures, 79 com ≤ 0,5 % de pixels diferentes, 4 acima de 2 % (rotação de transform, recorte por overflow) — os primeiros alvos de um lote de pintura. O comparador acusa ficheiros em falta com exit 2 (a primeira versão respondia silêncio). PNG não versionados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc