### PR TITLE
ci(dom): paridade CSS/DOM no README escrita pelo CI — badge, medições contra o Blink, estado dos lotes

### DIFF
--- a/.github/css_parity_report.json
+++ b/.github/css_parity_report.json
@@ -1,0 +1,74 @@
+{
+  "date": "2026-09-04",
+  "fixtures": {
+    "passing": 86,
+    "total": 91,
+    "pct": 94.5
+  },
+  "measurements": {
+    "matching": 2142,
+    "total": 2168,
+    "pct": 98.8
+  },
+  "expected_failures": [
+    {
+      "fixture": "claude-ua-form-disabled.html",
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
+    },
+    {
+      "fixture": "claude-ua-headings.html",
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
+    },
+    {
+      "fixture": "claude-ua-th.html",
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
+    },
+    {
+      "fixture": "claude-cursor-pointer-events.html",
+      "razao": "cursor: url(x.png) — o Blink resolve a URL contra a base do documento;\r nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)\r"
+    },
+    {
+      "fixture": "claude-img-natural.html",
+      "razao": "vaga 7 — medida no Edge 152 ANTES do código (lote V-img: `rts:imgdec`,\r `dom.setImage` e o loader de `data:` não existem no motor novo). Blink: o\r `<img>` sem atributos mede o tamanho natural do PNG (4×2) e `width` sozinho\r mantém a razão (40×20).\r"
+    }
+  ],
+  "dom_lots": {
+    "feitos": [
+      "A — contrato DOM→JS",
+      "B — um medidor activo",
+      "C — `position` relative/absolute",
+      "D — grid: rows por áreas",
+      "E — BFC, floats, `clear`",
+      "F — baseline, `vertical-align`, `white-space`",
+      "G — scroll no documento",
+      "H — o escopo de página não vê o Node",
+      "I — folha de UA em CSS real",
+      "J — `DeclarationRecord` e `revert`",
+      "K — invalidação escopada para `:nth-child`",
+      "L — cache de fragmentos em flex/grid/tabela",
+      "M — ciclo de vida do nó",
+      "N — réguas no CI",
+      "O — selectores que faltam",
+      "P — at-rules",
+      "R — grid e flex completos",
+      "S — propriedades sem efeito — grupo TEXTO",
+      "S-transform — transformações 2D",
+      "U-pintura-1 — rotação e recorte na pintura",
+      "N-pintura — a régua de PINTURA (screenshot-diff contra o Blink)",
+      "réguas-6 — as réguas da vaga 6 ANTES do código",
+      "S-hifen — `hyphens: manual` — o hífen suave",
+      "U-pintura-2 — junção diagonal das bordas; imagens mascaradas na régua",
+      "S-inline-2 — inline com superfície por FRAGMENTOS de linha",
+      "img-fundo — fundo do `<img>` sem pixels",
+      "T — fontes: `ex`/`ch`, `line-height: normal`, `font-family` como lista"
+    ],
+    "parciais": [
+      "S-inline — caixa inline por FRAGMENTOS de linha"
+    ],
+    "pendentes": [
+      "Q — CSSOM",
+      "U — composição e pintura",
+      "V–Y — a superfície DOM que as bibliotecas pedem"
+    ]
+  }
+}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -290,6 +290,26 @@ jobs:
           if [ -n "$inesperadas" ]; then echo "::error::fixtures a falhar FORA da lista esperado-a-falhar: $inesperadas"; exit 1; fi
           echo "so falham as esperadas: $(wc -l < esperadas.txt) ficheiro(s)"
 
+      # O número do README é o que ESTE job mediu (o mesmo padrão do bloco
+      # cross-runtime): regiões CSS_PARITY_BADGE / CSS_DOM_STATS e o JSON em
+      # .github/. `always()` porque o passo acima sai 1 quando cai uma fixture
+      # fora da lista — e é exactamente nesse dia que o número tem de descer à
+      # vista. `pull --rebase` antes do push: o job cross-runtime também
+      # escreve o README no mesmo run.
+      - name: Update README with CSS/DOM parity (main)
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          test -f corpus.txt || { echo "sem corpus.txt — o corredor não correu"; exit 0; }
+          node scripts/css_parity_readme.mjs corpus.txt
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md .github/css_parity_report.json
+          if git diff --cached --quiet; then echo "nada mudou"; exit 0; fi
+          pct=$(node -e "console.log(require('./.github/css_parity_report.json').measurements.pct)")
+          git commit -m "docs: auto-update CSS/DOM parity badge (${pct}%)"
+          for i in 1 2 3; do git pull --rebase && git push && break || sleep 10; done
+
   # Os testes Rust do rts-dom (sem dependências: segundos) e do rts-dom-bridge
   # (o teste de contrato que cruza o que a fachada chama com o que o bridge
   # regista — o que teria apanhado getBoundingClientRect morto). Perfil dev de

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 <!-- NODE_SUITE_BADGE_START -->
 [![Node test suite](https://img.shields.io/badge/Node%20test%20suite-52.4%25-yellow?style=flat-square)](scripts/node_tests/README.md)
 <!-- NODE_SUITE_BADGE_END -->
+<!-- CSS_PARITY_BADGE_START -->
+[![CSS vs Chrome](https://img.shields.io/badge/CSS%20vs%20Chrome-98.8%25-brightgreen?style=flat-square)](tests/css/README.md)
+<!-- CSS_PARITY_BADGE_END -->
 
 </div>
 
@@ -92,6 +95,28 @@ Os 374 de fora leem os módulos **internos** do Node (`internal/…`, `_http_com
 
 _Updated: 2026-08-24 — [como isto é medido](scripts/node_tests/README.md)_
 <!-- NODE_SUITE_STATS_END -->
+
+<!-- CSS_DOM_STATS_START -->
+## 🎨 CSS and DOM parity
+
+Layout and computed style measured against **Chrome/Blink** (Edge headless, 1280×800, 1 px tolerance) over the fixtures in `tests/css/`. Two numbers, on purpose: a *fixture* passes only when every measurement in it matches; *measurements* count each x/y/w/h and each computed property one by one. **Read it as "what we implemented is right", not as a share of CSS**: the corpus measures what has a fixture, and each new fixture is written to fail first (`tests/css/README.md`).
+
+```
+[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰] 98.8%   2142/2168 measurements matching Blink
+[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱] 94.5%   86/91 fixtures passing
+```
+
+Fixtures that fail **on purpose** (each names a measured gap; `tests/css/esperado-a-falhar.txt`):
+- `claude-ua-form-disabled.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-ua-headings.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-ua-th.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-cursor-pointer-events.html` — cursor: url(x.png) — o Blink resolve a URL contra a base do documento; nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)
+- `claude-img-natural.html` — vaga 7 — medida no Edge 152 ANTES do código (lote V-img: `rts:imgdec`, `dom.setImage` e o loader de `data:` não existem no motor novo). Blink: o `<img>` sem atributos mede o tamanho natural do PNG (4×2) e `width` sozinho mantém a razão (40×20).
+
+**DOM engine state** (`crates/rts-dom/PLAN.md` §0): **27/31 lots done**, 1 partial, pending: Q, U, V–Y. The paint ruler (pixels against Blink, `scripts/css_pintura.md`) needs a browser and runs locally; its last number is recorded there.
+
+*Updated 2026-09-04 by CI (`dom-rulers`).*
+<!-- CSS_DOM_STATS_END -->
 
 ---
 

--- a/examples/claude-css-runner.ts
+++ b/examples/claude-css-runner.ts
@@ -35,6 +35,13 @@ fixtures.sort();
 interface Desvio { fixture: string; onde: string; esperado: string; obtido: string; }
 
 const desvios: Desvio[] = [];
+// MEDIÇÕES: cada x/y/w/h e cada propriedade computada contam uma; `batem` é
+// quantas bateram. É o número fino que o README mostra (`scripts/
+// css_parity_readme.mjs`): sobe dentro de uma fixture que ainda falha, ao
+// contrário do "passa/falha" por ficheiro. Um elemento que o motor não
+// encontra conta as 4 do rect como falhadas.
+let medicoes = 0;
+let batem = 0;
 const semEsperado: string[] = [];
 const passam: string[] = [];
 const falham: string[] = [];
@@ -119,6 +126,7 @@ for (const nome of fixtures) {
     const alvo = nosso[id];
     if (alvo === undefined) {
       desvios.push({ fixture: nome, onde: "#" + id, esperado: "o elemento existe", obtido: "o motor não o encontrou" });
+      medicoes = medicoes + 4;
       continue;
     }
     const r: number[] = elementos[id].rect;
@@ -130,6 +138,8 @@ for (const nome of fixtures) {
     ];
     const rotulos = ["x", "y", "w", "h"];
     for (let k = 0; k < 4; k = k + 1) {
+      medicoes = medicoes + 1;
+      if (proximo(meu[k], r[k])) { batem = batem + 1; }
       if (!proximo(meu[k], r[k])) {
         desvios.push({
           fixture: nome, onde: "#" + id + "." + rotulos[k],
@@ -141,6 +151,7 @@ for (const nome of fixtures) {
     // fixture nomeia. Sem ele, comparam-se todos.
     if (idsDeEstilo.length > 0 && idsDeEstilo.indexOf(id) < 0) { continue; }
     for (const p of propsAqui) {
+      medicoes = medicoes + 1;
       if (elementos[id].estilo[p] === undefined) {
         // A fixture pede uma propriedade que a medição no Chrome não recolheu.
         // É uma falha do INSTRUMENTO e não do motor, e tem de se ver como tal.
@@ -150,6 +161,7 @@ for (const nome of fixtures) {
       }
       const querido = String(elementos[id].estilo[p]);
       const obtido = String(computedProperty(doc, alvo, p));
+      if (obtido === querido) { batem = batem + 1; }
       if (obtido !== querido) {
         desvios.push({ fixture: nome, onde: "#" + id + " {" + p + "}", esperado: querido, obtido: obtido });
       }
@@ -184,6 +196,7 @@ if (desvios.length > 0) { console.log(""); }
 console.log("passam: " + String(passam.length) +
             " | falham: " + String(falham.length + semEsperado.length) +
             " | desvios: " + String(desvios.length));
+console.log("medicoes: " + String(batem) + "/" + String(medicoes));
 if (verboso) {
   for (const n of passam) { console.log("  ok  " + n); }
 }

--- a/scripts/css_parity_readme.mjs
+++ b/scripts/css_parity_readme.mjs
@@ -1,0 +1,118 @@
+// Reescreve as regiões CSS_PARITY_BADGE / CSS_DOM_STATS do README.md com o
+// que o corpus de tests/css/ acabou de medir contra o Blink, e grava o mesmo
+// em .github/css_parity_report.json (histórico legível por máquina). Corre no
+// job `dom-rulers` do CI (push a main) — o mesmo padrão do bloco cross-runtime:
+// o número do README é o que o CI escreveu, nunca o que alguém digitou.
+//
+//   node scripts/css_parity_readme.mjs corpus.txt
+//
+// Duas percentagens, e as duas dizem coisas diferentes: FIXTURES que passam
+// (um ficheiro passa quando TODAS as suas medições batem a 1px) e MEDIÇÕES
+// que batem (cada x/y/w/h e cada propriedade computada, contadas uma a uma).
+// A segunda é a que sobe devagar e mede o progresso dentro de uma fixture que
+// ainda falha; a primeira é o contrato por ficheiro de tests/css/README.md.
+// O estado do DOM vem do PLAN §0 do rts-dom: os lotes ☑/◐/☐ da tabela.
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const corpusPath = process.argv[2] ?? "corpus.txt";
+const corpus = readFileSync(corpusPath, "utf8");
+const readmePath = "README.md";
+const planPath = "crates/rts-dom/PLAN.md";
+
+const mFix = corpus.match(/^passam: (\d+) \| falham: (\d+) \| desvios: (\d+)/m);
+const mMed = corpus.match(/^medicoes: (\d+)\/(\d+)/m);
+if (!mFix || !mMed) {
+  console.error("corpus.txt sem as linhas `passam:` e `medicoes:` — o corredor mudou?");
+  process.exit(2);
+}
+const passam = Number(mFix[1]);
+const fixtures = passam + Number(mFix[2]);
+const batem = Number(mMed[1]);
+const medicoes = Number(mMed[2]);
+const pctFix = fixtures ? Math.round((passam / fixtures) * 1000) / 10 : 0;
+const pctMed = medicoes ? Math.round((batem / medicoes) * 1000) / 10 : 0;
+
+// as fixtures que falham DE PROPÓSITO, com a razão (o comentário acima delas)
+const esperadas = [];
+if (existsSync("tests/css/esperado-a-falhar.txt")) {
+  let razao = [];
+  for (const l of readFileSync("tests/css/esperado-a-falhar.txt", "utf8").split("\n")) {
+    if (l.startsWith("#")) { razao.push(l.replace(/^#\s?/, "")); continue; }
+    if (!l.trim()) { razao = []; continue; }
+    esperadas.push({ fixture: l.trim(), razao: razao.join(" ") });
+  }
+}
+
+// o estado do DOM: os lotes do PLAN §0
+const lotes = { feitos: [], parciais: [], pendentes: [] };
+if (existsSync(planPath)) {
+  for (const l of readFileSync(planPath, "utf8").split("\n")) {
+    const m = l.match(/^\| ([^|]+?) \| ([^|]+?) \| [^|]+? \| (☑|◐|☐)/);
+    if (!m) continue;
+    const item = `${m[1].trim()} — ${m[2].trim()}`;
+    if (m[3] === "☑") lotes.feitos.push(item);
+    else if (m[3] === "◐") lotes.parciais.push(item);
+    else lotes.pendentes.push(item);
+  }
+}
+const totalLotes = lotes.feitos.length + lotes.parciais.length + lotes.pendentes.length;
+
+function barra(pct) {
+  const cheios = Math.round(pct / 5);
+  return "[" + "▰".repeat(cheios) + "▱".repeat(20 - cheios) + "]";
+}
+function cor(pct) {
+  if (pct >= 95) return "brightgreen";
+  if (pct >= 85) return "green";
+  if (pct >= 70) return "yellowgreen";
+  if (pct >= 50) return "yellow";
+  return "red";
+}
+const hoje = new Date().toISOString().slice(0, 10);
+
+const badge =
+  `[![CSS vs Chrome](https://img.shields.io/badge/CSS%20vs%20Chrome-${pctMed}%25-${cor(pctMed)}?style=flat-square)](tests/css/README.md)`;
+
+const linhasEsperadas = esperadas.length
+  ? esperadas.map((e) => `- \`${e.fixture}\` — ${e.razao}`).join("\n")
+  : "- nenhuma";
+const stats = `## 🎨 CSS and DOM parity
+
+Layout and computed style measured against **Chrome/Blink** (Edge headless, 1280×800, 1 px tolerance) over the fixtures in \`tests/css/\`. Two numbers, on purpose: a *fixture* passes only when every measurement in it matches; *measurements* count each x/y/w/h and each computed property one by one. **Read it as "what we implemented is right", not as a share of CSS**: the corpus measures what has a fixture, and each new fixture is written to fail first (\`tests/css/README.md\`).
+
+\`\`\`
+${barra(pctMed)} ${pctMed}%   ${batem}/${medicoes} measurements matching Blink
+${barra(pctFix)} ${pctFix}%   ${passam}/${fixtures} fixtures passing
+\`\`\`
+
+Fixtures that fail **on purpose** (each names a measured gap; \`tests/css/esperado-a-falhar.txt\`):
+${linhasEsperadas}
+
+**DOM engine state** (\`crates/rts-dom/PLAN.md\` §0): **${lotes.feitos.length}/${totalLotes} lots done**${lotes.parciais.length ? `, ${lotes.parciais.length} partial` : ""}${lotes.pendentes.length ? `, pending: ${lotes.pendentes.map((p) => p.split(" — ")[0]).join(", ")}` : ""}. The paint ruler (pixels against Blink, \`scripts/css_pintura.md\`) needs a browser and runs locally; its last number is recorded there.
+
+*Updated ${hoje} by CI (\`dom-rulers\`).*`;
+
+let readme = readFileSync(readmePath, "utf8");
+const antes = readme;
+readme = readme.replace(
+  /<!-- CSS_PARITY_BADGE_START -->[\s\S]*?<!-- CSS_PARITY_BADGE_END -->/,
+  `<!-- CSS_PARITY_BADGE_START -->\n${badge}\n<!-- CSS_PARITY_BADGE_END -->`,
+);
+readme = readme.replace(
+  /<!-- CSS_DOM_STATS_START -->[\s\S]*?<!-- CSS_DOM_STATS_END -->/,
+  `<!-- CSS_DOM_STATS_START -->\n${stats}\n<!-- CSS_DOM_STATS_END -->`,
+);
+if (readme === antes && !/CSS_DOM_STATS_START/.test(antes)) {
+  console.error("README.md sem as regiões CSS_PARITY_BADGE / CSS_DOM_STATS");
+  process.exit(2);
+}
+writeFileSync(readmePath, readme);
+writeFileSync(
+  ".github/css_parity_report.json",
+  JSON.stringify(
+    { date: hoje, fixtures: { passing: passam, total: fixtures, pct: pctFix },
+      measurements: { matching: batem, total: medicoes, pct: pctMed },
+      expected_failures: esperadas, dom_lots: lotes },
+    null, 2) + "\n",
+);
+console.log(`CSS vs Chrome: ${pctMed}% (${batem}/${medicoes}) | fixtures ${pctFix}% (${passam}/${fixtures}) | DOM ${lotes.feitos.length}/${totalLotes} lotes`);


### PR DESCRIPTION
## O que é

O mesmo mecanismo do bloco cross-runtime, para o CSS e o DOM: o job `dom-rulers` reescreve duas regiões do README (`CSS_PARITY_BADGE`, `CSS_DOM_STATS`) e grava `.github/css_parity_report.json` a cada push a `main`.

- **Badge** `CSS vs Chrome — 98.8%`: medições que batem com o Blink (cada x/y/w/h e propriedade computada, uma a uma; o corredor passa a imprimir `medicoes: B/T`).
- **Bloco**: as duas barras (medições 98,8 %, fixtures 94,5 %), as fixtures que falham de propósito com a razão, e o estado do DOM lido do PLAN §0 (27/31 lotes, pendentes Q, U, V–Y). Diz o que o número não é: uma fatia do CSS inteiro.

Testado localmente com o binário da main (o conteúdo commitado é o gerado). No CI o passo corre com `always()` e faz `pull --rebase` antes do push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc