### PR TITLE
feat(dom): imagens data: chegam ao <img> — PNG na ponte, pixels no documento, tamanho natural e width/height usados (lote V-img)

### DIFF
--- a/crates/rts-dom-bridge/Cargo.toml
+++ b/crates/rts-dom-bridge/Cargo.toml
@@ -15,3 +15,7 @@ license.workspace = true
 [dependencies]
 rts-core = { path = "../rts-core" }
 rts-dom = { path = "../rts-dom" }
+# O `inflate` do PNG de um `<img src="data:…">` (lote V-img, `imagem.rs`). A
+# mesma crate e o mesmo pin do `rts-std` (`docs/reference/node/crates.md` §4.4):
+# backend puro Rust, sem C.
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }

--- a/crates/rts-dom-bridge/src/imagem.rs
+++ b/crates/rts-dom-bridge/src/imagem.rs
@@ -1,0 +1,230 @@
+//! `setImageDataUrl(doc, node, url)` — a IMAGEM de um `<img src="data:…">`
+//! descodificada e guardada no documento (lote V-img).
+//!
+//! O motor novo não tinha caminho nenhum para pixels chegarem a um `<img>`:
+//! `rts:imgdec` e `dom.setImage` eram do motor antigo, e `examples/claude-
+//! browser.ts` chamava-os no vazio. Este módulo é a peça mínima que fecha
+//! `claude-img-natural` e `claude-object-fit`: descodifica um PNG embutido
+//! numa `data:` URL e entrega os RGBA8 a `Dom::set_pixel_data` — o MESMO
+//! sítio onde um `<canvas>` desenhado pelo programa guarda os seus pixels, e
+//! por isso o mesmo `DisplayItem::Pixels` que o egui e o rasterizador da
+//! régua já pintam. A alternativa — um handle de Buffer no HandleTable como
+//! o `set_image` antigo — obrigava o rasterizador headless (que não tem motor)
+//! a continuar a mascarar imagens em vez de as medir.
+//!
+//! Só PNG, e só o subconjunto dito em [`png::decodificar`]. JPEG, GIF, WebP e
+//! SVG respondem `0` (nada guardado): a caixa continua a vir dos atributos ou
+//! do CSS, que é o que já acontecia. `http(s)` não entra aqui — o loader do
+//! documento (`dom.ts`) é quem busca bytes; quando o fizer, entrega-os pela
+//! mesma porta (`setImagePngBase64`).
+
+use rts_core::entry::Provided;
+
+use crate::nodes::node;
+use crate::value::{handle, int, text};
+
+pub const MEMBERS: &[(&str, Provided)] = &[
+    ("setImageDataUrl", set_image_data_url),
+    ("imageNaturalWidth", image_natural_width),
+    ("imageNaturalHeight", image_natural_height),
+];
+
+/// `setImageDataUrl(doc, node, url)` → 1 se guardou pixels, 0 se não
+/// (esquema que não é `data:`, formato que não é PNG, PNG fora do subconjunto).
+extern "C" fn set_image_data_url(_e: u64, _t: u64, doc: u64, n: u64, url: u64, _c: u64) -> u64 {
+    let url = text(url);
+    let Some(id) = node(n) else { return int(0) };
+    let Some(bytes) = bytes_da_data_url(&url) else { return int(0) };
+    let Some((rgba, w, h)) = png::decodificar(&bytes) else { return int(0) };
+    rts_dom::store::with_dom_mut(handle(doc), |d| d.set_pixel_data(id, rgba, w, h));
+    int(1)
+}
+
+extern "C" fn image_natural_width(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    int(dimensoes(doc, n).map_or(0, |(w, _)| i64::from(w)))
+}
+
+extern "C" fn image_natural_height(_e: u64, _t: u64, doc: u64, n: u64, _b: u64, _c: u64) -> u64 {
+    int(dimensoes(doc, n).map_or(0, |(_, h)| i64::from(h)))
+}
+
+fn dimensoes(doc: u64, n: u64) -> Option<(u32, u32)> {
+    let id = node(n)?;
+    rts_dom::store::with_dom(handle(doc), |d| {
+        d.resolve(id).and_then(|idx| d.image_dims(idx))
+    })
+    .flatten()
+}
+
+/// Os bytes de uma `data:image/png;base64,…`. Qualquer outro esquema, tipo ou
+/// codificação responde `None` — sem adivinhar.
+fn bytes_da_data_url(url: &str) -> Option<Vec<u8>> {
+    let resto = url.strip_prefix("data:")?;
+    let (meta, payload) = resto.split_once(',')?;
+    if !meta.starts_with("image/png") || !meta.ends_with(";base64") {
+        return None;
+    }
+    base64_decodificar(payload.trim())
+}
+
+/// Base64 padrão (RFC 4648), com ou sem `=` no fim; espaços e quebras de linha
+/// ignorados (um `src` multi-linha no HTML é legal). Vinte linhas em vez da
+/// crate `base64`: a ponte não tinha dependências além do motor e do DOM, e
+/// um alfabeto de 64 símbolos não justifica a primeira.
+fn base64_decodificar(s: &str) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    let (mut acc, mut bits) = (0u32, 0u32);
+    for c in s.bytes() {
+        let v = match c {
+            b'A'..=b'Z' => c - b'A',
+            b'a'..=b'z' => c - b'a' + 26,
+            b'0'..=b'9' => c - b'0' + 52,
+            b'+' | b'-' => 62,
+            b'/' | b'_' => 63,
+            b'=' | b' ' | b'\n' | b'\r' | b'\t' => continue,
+            _ => return None,
+        };
+        acc = (acc << 6) | u32::from(v);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((acc >> bits) & 0xff) as u8);
+        }
+    }
+    Some(out)
+}
+
+/// Um descodificador de PNG suficiente para ícones e fixtures.
+pub(crate) mod png {
+    use std::io::Read;
+
+    /// `Some((rgba8, w, h))` para um PNG de 8 bits por canal, não entrelaçado,
+    /// nos tipos de cor 0 (cinzento), 2 (RGB), 3 (paleta), 4 (cinzento+alfa) e
+    /// 6 (RGBA). `None` para 16 bits, entrelaçado (Adam7), ou um ficheiro que
+    /// não é PNG — ditos aqui em vez de aproximados: uma imagem mal
+    /// descodificada é um erro silencioso, uma que não aparece é visível.
+    pub fn decodificar(bytes: &[u8]) -> Option<(Vec<u8>, u32, u32)> {
+        let corpo = bytes.strip_prefix(b"\x89PNG\r\n\x1a\n")?;
+        let (mut w, mut h, mut profundidade, mut tipo, mut entrelacado) = (0u32, 0u32, 0u8, 0u8, 0u8);
+        let mut idat: Vec<u8> = Vec::new();
+        let mut paleta: Vec<[u8; 4]> = Vec::new();
+        let mut pos = 0usize;
+        while pos + 8 <= corpo.len() {
+            let len = u32::from_be_bytes(corpo[pos..pos + 4].try_into().ok()?) as usize;
+            let kind = &corpo[pos + 4..pos + 8];
+            let dados = corpo.get(pos + 8..pos + 8 + len)?;
+            match kind {
+                b"IHDR" => {
+                    w = u32::from_be_bytes(dados.get(0..4)?.try_into().ok()?);
+                    h = u32::from_be_bytes(dados.get(4..8)?.try_into().ok()?);
+                    profundidade = *dados.get(8)?;
+                    tipo = *dados.get(9)?;
+                    entrelacado = *dados.get(12)?;
+                }
+                b"PLTE" => {
+                    paleta = dados.chunks_exact(3).map(|c| [c[0], c[1], c[2], 255]).collect();
+                }
+                b"tRNS" if tipo == 3 => {
+                    for (i, a) in dados.iter().enumerate() {
+                        if let Some(p) = paleta.get_mut(i) {
+                            p[3] = *a;
+                        }
+                    }
+                }
+                b"IDAT" => idat.extend_from_slice(dados),
+                b"IEND" => break,
+                _ => {}
+            }
+            pos += 12 + len; // comprimento + tipo + dados + CRC
+        }
+        if w == 0 || h == 0 || profundidade != 8 || entrelacado != 0 {
+            return None;
+        }
+        let canais = match tipo {
+            0 => 1,
+            2 => 3,
+            3 => 1,
+            4 => 2,
+            6 => 4,
+            _ => return None,
+        };
+        let mut cru = Vec::new();
+        flate2::read::ZlibDecoder::new(&idat[..]).read_to_end(&mut cru).ok()?;
+        let passo = w as usize * canais;
+        if cru.len() < h as usize * (passo + 1) {
+            return None;
+        }
+        // Os cinco filtros do PNG (§9), linha a linha, contra a linha anterior.
+        let mut linhas: Vec<u8> = vec![0; h as usize * passo];
+        for y in 0..h as usize {
+            let filtro = cru[y * (passo + 1)];
+            let src = &cru[y * (passo + 1) + 1..(y + 1) * (passo + 1)];
+            let (antes, atual) = linhas.split_at_mut(y * passo);
+            let anterior: &[u8] = if y == 0 { &[] } else { &antes[(y - 1) * passo..] };
+            let atual = &mut atual[..passo];
+            for i in 0..passo {
+                let a = if i >= canais { atual[i - canais] } else { 0 };
+                let b = if y > 0 { anterior[i] } else { 0 };
+                let c = if y > 0 && i >= canais { anterior[i - canais] } else { 0 };
+                let previsto = match filtro {
+                    0 => 0,
+                    1 => a,
+                    2 => b,
+                    3 => ((u16::from(a) + u16::from(b)) / 2) as u8,
+                    4 => paeth(a, b, c),
+                    _ => return None,
+                };
+                atual[i] = src[i].wrapping_add(previsto);
+            }
+        }
+        let mut rgba = Vec::with_capacity(w as usize * h as usize * 4);
+        for px in linhas.chunks_exact(canais) {
+            match tipo {
+                0 => rgba.extend_from_slice(&[px[0], px[0], px[0], 255]),
+                2 => rgba.extend_from_slice(&[px[0], px[1], px[2], 255]),
+                3 => rgba.extend_from_slice(paleta.get(px[0] as usize)?),
+                4 => rgba.extend_from_slice(&[px[0], px[0], px[0], px[1]]),
+                _ => rgba.extend_from_slice(&[px[0], px[1], px[2], px[3]]),
+            }
+        }
+        Some((rgba, w, h))
+    }
+
+    fn paeth(a: u8, b: u8, c: u8) -> u8 {
+        let p = i16::from(a) + i16::from(b) - i16::from(c);
+        let (pa, pb, pc) = ((p - i16::from(a)).abs(), (p - i16::from(b)).abs(), (p - i16::from(c)).abs());
+        if pa <= pb && pa <= pc {
+            a
+        } else if pb <= pc {
+            b
+        } else {
+            c
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// O PNG de `tests/css/claude-img-natural.html`: 4×2, linha de cima
+    /// vermelha (200,30,30), linha de baixo azul (30,30,200), RGBA, filtro 0.
+    const PNG_4X2: &str = "iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAAFUlEQVR42mM4ISf3HxkzyMmd+I+MAQnlEBnT2GgUAAAAAElFTkSuQmCC";
+
+    #[test]
+    fn a_data_url_da_fixture_descodifica_em_4x2_rgba() {
+        let bytes = bytes_da_data_url(&format!("data:image/png;base64,{PNG_4X2}")).expect("base64");
+        let (rgba, w, h) = png::decodificar(&bytes).expect("png");
+        assert_eq!((w, h), (4, 2));
+        assert_eq!(&rgba[0..4], &[200, 30, 30, 255], "primeiro pixel vermelho");
+        assert_eq!(&rgba[16..20], &[30, 30, 200, 255], "primeiro pixel da segunda linha azul");
+        assert_eq!(rgba.len(), 4 * 2 * 4);
+    }
+
+    #[test]
+    fn o_que_nao_e_png_em_data_url_responde_none_sem_adivinhar() {
+        assert!(bytes_da_data_url("data:image/jpeg;base64,AAAA").is_none());
+        assert!(bytes_da_data_url("http://x/y.png").is_none());
+        assert!(png::decodificar(b"GIF89a").is_none());
+    }
+}

--- a/crates/rts-dom-bridge/src/lib.rs
+++ b/crates/rts-dom-bridge/src/lib.rs
@@ -38,6 +38,7 @@ use rts_core::entry::{self, Context, Provided};
 
 mod engine;
 mod events;
+mod imagem;
 mod location;
 mod nodes;
 mod scroll;
@@ -68,6 +69,7 @@ pub(crate) fn dom_members() -> Vec<(&'static str, Provided)> {
         .chain(events::MEMBERS)
         .chain(scroll::MEMBERS)
         .chain(location::MEMBERS)
+        .chain(imagem::MEMBERS)
         .copied()
         .collect()
 }

--- a/crates/rts-dom/PLAN.md
+++ b/crates/rts-dom/PLAN.md
@@ -52,6 +52,7 @@ linha aqui não existe.
 | S-inline-2 | inline com superfície por FRAGMENTOS de linha | 6 | ☑ `inline_por_fragmentos` (superfície sem width/height/margem) fica no fluxo: arestas como átomos (`ArestaInicio/Fim`), caixa = união dos fragmentos com padding/borda verticais, `inline_fragmentos::Superficies` pinta fundo e barras por linha (esquerda só no 1.º, direita só no último). A pergunta corrigida nos 5 sítios (`is_block_level`, `is_inline_block`, 3× `vertical.rs`). Cortes: cores cruas, sem radius nos fragmentos. Corpus 85/90, pintura 0,56 % → 0,06 %, suite 859/888 sem perdidos, 876 testes; paridade: 3 páginas 0 movidos, 3 movem os links da nav de 34 → 40,4px (= Blink: 14×1,6+18) | `feat/dom-lote-s-inline-2` → `add946b5e` (2026-09-04) | `claude-inline-fragmentos` |
 | img-fundo | fundo do `<img>` sem pixels | 6 | ☑ `layout_image` emite o `background` na caixa reservada, com ou sem pixels (cor crua: sem `filter`/`opacity`, sem borda/padding — dito). Pintura `object-fit` 1,95 % → 1,22 %; o resto é a imagem `data:` que nenhum loader entrega ao `<img>` (o mesmo de `list-style-image`). Suite 859/888 sem perdidos; 876 testes | `feat/dom-lote-img-fundo` → `53b96700f` (2026-09-04) | `claude-object-fit` (pintura) |
 | T | fontes: `ex`/`ch`, `line-height: normal`, `font-family` como lista | 6 | ☑ `Dimension::Ex`/`Ch` resolvem por `X_HEIGHT_RATIO`/`MONO_ADVANCE` (calibrados; `10ex` 78,6 vs 78,44 Blink, `10ch` 87,97 exacto; ABI `-1` como `calc`); `font-family` guarda a LISTA serializada como o Blink e `is_mono_family` percorre-a (a primeira família conhecida decide; desconhecida = indisponível). `line-height: normal` já batia (19px). NÃO feito, dito: fonte real (`@font-face`, `rustybuzz`, kerning, UAX#14) — a decisão de crate de §5.T fica aberta. Corpus 86/90 (só UA + cursor), pintura 2,45 % → 0,27 %, 878 testes, suite 859/888 sem perdidos | `feat/dom-lote-t-fontes` → `944161f7f` (2026-09-04) | `claude-font-unidades-ch-ex` |
+| V-img | imagens `data:` no `<img>` | 7 | ☑ ponte `setImageDataUrl` (base64 + PNG 8 bits, 5 tipos de cor, sem entrelaçado — o resto responde 0) → `Dom::set_pixel_data` (o caminho do canvas) → `DisplayItem::Pixels`; `Dom::image_dims` (pergunta única nos 5 sítios); loader no passo 3 de `loadResources` e no corredor; `getComputedStyle().width/height` = valor USADO (CSSOM); rasterizador pinta `Pixels` e mascara `<img>` sem pixels. NÃO feito, dito: `http(s)`/ficheiro local no loader, JPEG/GIF/WebP, `object-fit` além de `fill`, `list-style-image`/`background-image` por URL. Corpus 87/91 (`img-natural` passa), medições 2 152/2 168, 879 testes, bridge 6, suite sem perdidos, paridade 0 movidos | `feat/dom-lote-v-img` → `930c78df5` (2026-09-04) | `claude-img-natural`, `claude-object-fit` (pintura) |
 | V–Y | a superfície DOM que as bibliotecas pedem | 4 | ☐ | — | §6 |
 
 **Estado após a vaga 1 (2026-09-04, 01:41)** — medido com o `rts.exe`
@@ -172,8 +173,9 @@ passaram todas. O que fica: o loader de imagem `data:` para
 `<img>`/`list-style-image` (fecha `object-fit`), a fonte REAL de §5.T
 (decisão de crate), e as 3 da folha de UA que só uma fonte real fecha.
 
-**O próximo lote, já desenhado (2026-09-04, ~18:30) — V-img, imagens de
-verdade:** o `claude-object-fit` (1,22 % na pintura) e o `list-style-image`
+**O lote V-img, desenhado às 18:30 e FEITO às 21:00 (a decisão mudou no
+caminho: os pixels ficam no DOCUMENTO por `set_pixel_data`, não num handle de
+Buffer — ver a linha V-img em cima; o que segue é o desenho original):** o `claude-object-fit` (1,22 % na pintura) e o `list-style-image`
 param no mesmo sítio, e a investigação disse porquê: **`rts:imgdec` e
 `dom.setImage` NÃO existem no motor novo** — `examples/claude-browser.ts` e
 `claude-wa-app.ts` chamam-nos, mas são código do motor antigo (nenhum crate

--- a/crates/rts-dom/examples/claude-raster.rs
+++ b/crates/rts-dom/examples/claude-raster.rs
@@ -108,6 +108,28 @@ impl Canvas {
         }
     }
 
+    /// Um bitmap RGBA8 esticado a `r` por vizinho mais próximo — o suficiente
+    /// para uma régua de 1280×800 sobre ícones e fixtures; um filtro bilinear
+    /// mudaria pixels de borda que a tolerância por canal já absorve.
+    fn fill_pixels(&mut self, r: Rect, data: &[u8], w: u32, h: u32, clip: Option<Rect>) {
+        let x0 = r.x.floor() as i32;
+        let y0 = r.y.floor() as i32;
+        let x1 = (r.x + r.w).ceil() as i32;
+        let y1 = (r.y + r.h).ceil() as i32;
+        for y in y0..y1 {
+            let sy = (((y as f32 + 0.5 - r.y) / r.h) * h as f32).floor().clamp(0.0, (h - 1) as f32) as usize;
+            for x in x0..x1 {
+                let sx = (((x as f32 + 0.5 - r.x) / r.w) * w as f32).floor().clamp(0.0, (w - 1) as f32) as usize;
+                let i = (sy * w as usize + sx) * 4;
+                if i + 3 >= data.len() {
+                    continue;
+                }
+                let c = (u32::from(data[i]) << 24) | (u32::from(data[i + 1]) << 16) | (u32::from(data[i + 2]) << 8) | u32::from(data[i + 3]);
+                self.blend(x, y, c, clip);
+            }
+        }
+    }
+
     /// Um quadrilátero CONVEXO já em coordenadas de tela, por varrimento: em
     /// cada linha de pixels, o vão entre a menor e a maior intersecção das
     /// quatro arestas com o centro da linha. É o que pinta um lado de borda
@@ -438,6 +460,22 @@ fn main() {
         measurer: &layout::ApproxMeasurer,
     };
     let list: DisplayList = layout::layout_document(&dom, &ctx);
+    // Um `<img>` com `src` e SEM pixels: o Blink pinta a imagem, este exemplo
+    // não tem quem a descodifique (o PNG de `data:` vive na ponte, e a ponte
+    // traz o motor). A área vai para a máscara como o texto — o instrumento
+    // diz o que não vê em vez de o contar como diferença.
+    let mut mascara_de_imagens: Vec<[f32; 4]> = Vec::new();
+    for id in dom.query_all("img") {
+        let Some(idx) = dom.resolve(id) else { continue };
+        if dom.pixel_data_of(idx).is_some() || dom.node(idx).attr("src").is_none() {
+            continue;
+        }
+        // `bounding_rect` e não `node_rects`: as caixas vivem nas subárvores
+        // reusadas da lista, e é ele que as resolve.
+        if let Some(r) = layout::bounding_rect(&dom, idx, &ctx) {
+            mascara_de_imagens.push([r.x, r.y, r.w, r.h]);
+        }
+    }
 
     let mut canvas = Canvas::new(list.canvas_background);
     let mut clip_stack: Vec<Rect> = Vec::new();
@@ -447,7 +485,7 @@ fn main() {
     // transformado dentro doutro) compõem assim (ver a doc de
     // `DisplayItem::PushTransform`).
     let mut xform_stack: Vec<Mat2d> = Vec::new();
-    let mut mask: Vec<[f32; 4]> = Vec::new(); // [x,y,w,h] dos rects ignorados (texto, imagens)
+    let mut mask: Vec<[f32; 4]> = mascara_de_imagens; // [x,y,w,h] dos rects ignorados (texto, imagens)
     let mut pintados = 0usize;
     let mut saltados_texto = 0usize;
     let mut saltados_imagem = 0usize;
@@ -509,6 +547,13 @@ fn main() {
             // também não se COMPARA: a área vai para a máscara como o texto,
             // senão a régua mede o que o exemplo não tem em vez do que o motor
             // faz (`claude-object-fit` dava 1,95 % só disto).
+            // `Pixels` viajam DENTRO da lista: pintam-se, escalados à caixa por
+            // vizinho mais próximo (o `object-fit: fill` que o layout emite).
+            DisplayItem::Pixels { rect, data, w, h } if mat.is_none() && *w > 0 && *h > 0 => {
+                let r = shift(*rect, dx, dy);
+                canvas.fill_pixels(r, data, *w, *h, clip);
+                pintados += 1;
+            }
             DisplayItem::Image { rect, .. } | DisplayItem::Pixels { rect, .. } => {
                 let r = match mat {
                     Some(m) => {

--- a/crates/rts-dom/src/dom.ts
+++ b/crates/rts-dom/src/dom.ts
@@ -1650,7 +1650,26 @@ function loadResources(doc: Document, baseUrl: string): number {
     j = j + 1;
   }
 
+  // 3) <img src="data:image/png;base64,…"> — descodificado pela ponte e guardado
+  //    no documento (lote V-img). `http(s)` e ficheiros locais ficam para a fase
+  //    seguinte deste loader; sem pixels a caixa vem dos atributos/CSS como antes.
+  const imgCount = dom.getByTagCount(h, "img");
+  let k = 0;
+  while (k < imgCount) {
+    loaded = loaded + __loadImageAt(h, k);
+    k = k + 1;
+  }
+
   return loaded;
+}
+
+// Entrega à ponte o k-ésimo `<img>` cujo `src` é uma `data:` URL. Devolve 1/0.
+function __loadImageAt(h: i64, k: number): number {
+  const node = dom.getByTagAt(h, "img", k);
+  if (node === __DOM_NONE) return 0;
+  const src = dom.getAttribute(h, node, "src");
+  if (src.length < 11 || src.substring(0, 11) !== "data:image/") return 0;
+  return dom.setImageDataUrl(h, node, src) as number;
 }
 
 // Carrega o i-ésimo `<link>` se for uma folha de estilo com `href`. Devolve 1/0.

--- a/crates/rts-dom/src/dom/estilo.rs
+++ b/crates/rts-dom/src/dom/estilo.rs
@@ -164,7 +164,50 @@ impl Dom {
             }
         }
 
+        // `width`/`height` são o caso especial do CSSOM ("resolved value"): num
+        // elemento que gera caixa, `getComputedStyle` responde o valor USADO em
+        // px — `4px` para um `<img>` sem dimensões e com um PNG de 4×2, nunca
+        // `auto` (`claude-img-natural`). É a caixa do layout menos padding e
+        // borda (em `content-box`); em `border-box` é a própria caixa.
+        if tag.is_some()
+            && matches!(name.trim(), "width" | "height")
+            && style.effective_display() != Some(crate::style::DisplayKind::None)
+        {
+            if let Some(px) = self.used_size(id, &style, name.trim() == "width") {
+                return crate::style::fmt_values::fmt_px(px);
+            }
+        }
+
         style.computed_value(name, tag.as_deref())
+    }
+
+    /// O valor usado de `width` (ou `height`) de um elemento com caixa, como o
+    /// `getComputedStyle` o serializa. `None` se o layout não lhe deu caixa.
+    fn used_size(&self, id: NodeId, style: &crate::style::ComputedStyle, largura: bool) -> Option<f32> {
+        let idx = self.resolve(id)?;
+        let (vw, vh) = self.viewport.get();
+        let (w, h) = crate::layout::medidor_ativo::with_active(|measurer| {
+            let context = crate::layout::LayoutCtx { viewport_w: vw, viewport_h: vh, measurer };
+            crate::layout::bounding_rect(self, idx, &context).map(|r| (r.w, r.h))
+        })?;
+        if style.border_box.unwrap_or(false) {
+            return Some(if largura { w } else { h });
+        }
+        let font = crate::layout::font_px(style, crate::layout::DEFAULT_FONT_SIZE);
+        let rc = crate::style::ResolveCtx {
+            parent_content_w: vw,
+            node_font_size: font,
+            root_font_size: crate::style::root_font_size(),
+            viewport_w: vw,
+            viewport_h: vh,
+        };
+        let [bt, br, bb, bl] = crate::style::borders::used_widths(style);
+        let p = &style.padding;
+        Some(if largura {
+            (w - p.resolve_h(&rc) - bl - br).max(0.0)
+        } else {
+            (h - p.resolve_v(&rc) - bt - bb).max(0.0)
+        })
     }
 
     /// `el.style.<name>` (getPropertyValue) — o valor INLINE da propriedade (só o

--- a/crates/rts-dom/src/dom/formulario.rs
+++ b/crates/rts-dom/src/dom/formulario.rs
@@ -142,6 +142,18 @@ impl Dom {
         self.image_pixels.get(&idx).copied()
     }
 
+    /// As dimensões da imagem de um nó, venha ela por handle (`set_image`) ou
+    /// guardada no documento (`set_pixel_data`, o caminho de `data:` e do
+    /// `<canvas>`). É a pergunta que o layout faz — "tem tamanho natural?" — e
+    /// antes era feita só ao handle, por isso um PNG embutido não dava caixa.
+    pub fn image_dims(&self, idx: NodeIdx) -> Option<(u32, u32)> {
+        self.image_pixels
+            .get(&idx)
+            .map(|(_, _, w, h)| (*w, *h))
+            .or_else(|| self.own_pixels.get(&idx).map(|(_, w, h)| (*w, *h)))
+            .filter(|(w, h)| *w > 0 && *h > 0)
+    }
+
     /// `true` se o `NodeIdx` cru é um `<input>`/`<textarea>` (para o hit-test de foco).
     pub fn is_text_input_idx(&self, idx: NodeIdx) -> bool {
         matches!(&self.nodes.get(idx).map(|n| &n.kind),

--- a/crates/rts-dom/src/inline_box/substituido.rs
+++ b/crates/rts-dom/src/inline_box/substituido.rs
@@ -129,9 +129,8 @@ pub(crate) fn replaced_inline_size(
     // browser faz com uma imagem que FALHOU a carregar, e copiá-lo seria acertar
     // a régua contra o defeito de rede em vez de contra a página.
     let ratio = dom
-        .image_of(id)
-        .filter(|(_, _, iw, ih)| *iw > 0 && *ih > 0)
-        .map(|(_, _, iw, ih)| (iw as f32, ih as f32))
+        .image_dims(id)
+        .map(|(iw, ih)| (iw as f32, ih as f32))
         .or_else(|| match (attr_px("width"), attr_px("height")) {
             (Some(aw), Some(ah)) if aw > 0.0 && ah > 0.0 => Some((aw, ah)),
             _ => None,

--- a/crates/rts-dom/src/layout/caixa.rs
+++ b/crates/rts-dom/src/layout/caixa.rs
@@ -86,7 +86,7 @@ pub(in crate::layout) fn is_block_level(dom: &Dom, id: NodeIdx) -> bool {
             // Não é `return`: um `<img>` sem atributos ainda pode ganhar caixa
             // pelo CSS, e quem responde isso são as regras no fim desta função.
             if tag == "img"
-                && (dom.image_of(id).is_some()
+                && (dom.image_dims(id).is_some()
                     || dom.node(id).attr("width").is_some()
                     || dom.node(id).attr("height").is_some())
             {

--- a/crates/rts-dom/src/layout/linha.rs
+++ b/crates/rts-dom/src/layout/linha.rs
@@ -343,7 +343,7 @@ pub(in crate::layout) fn layout_inline_flow(
                         // tamanho já medido. Só se pinta quando há pixels — e aí é
                         // `layout_image` que o faz, o mesmo caminho do fluxo de bloco,
                         // em vez de um segundo emissor de imagem só para o inline.
-                        if dom.image_of(a_idx).is_some() {
+                        if dom.image_dims(a_idx).is_some() {
                             let icss = dom.computed_style_idx(a_idx).unwrap_or_default();
                             layout_image(dom, a_idx, &icss, seg_x, cy, seg.ww.max(1.0), ctx, list);
                         }
@@ -399,7 +399,7 @@ pub(in crate::layout) fn layout_inline_flow(
                 let ja_registado = matches!(
                     kind,
                     AtomicKind::Widget | AtomicKind::Block | AtomicKind::ArestaInicio | AtomicKind::ArestaFim
-                ) || (kind == AtomicKind::Replaced && dom.image_of(a_idx).is_some());
+                ) || (kind == AtomicKind::Replaced && dom.image_dims(a_idx).is_some());
                 if !ja_registado {
                     let propria = match kind {
                         // `Marker`: inline SEM conteúdo (`<span></span>`) —

--- a/crates/rts-dom/src/layout/replaced.rs
+++ b/crates/rts-dom/src/layout/replaced.rs
@@ -150,8 +150,14 @@ pub(in crate::layout) fn layout_image(
     }
     // O item de pintura, esse, PRECISA de pixels: uma caixa reservada com nada
     // dentro é o que o browser mostra enquanto a imagem não chega, e é a mesma
-    // doutrina do `<canvas>` logo abaixo.
-    if let Some((handle, off, iw, ih)) = dom
+    // doutrina do `<canvas>` logo abaixo. Pixels guardados NO documento (uma
+    // `data:` URL descodificada pela ponte) saem como `Pixels`, o item do
+    // canvas — o rasterizador da régua pinta-o sem handle table. CORTE dito:
+    // a imagem estica à caixa (`object-fit: fill`); `contain`/`cover`/`none`
+    // ainda não recortam nem centram.
+    if let Some((data, pw, ph)) = dom.pixel_data_of(id).filter(|(_, pw, ph)| *pw > 0 && *ph > 0) {
+        list.items.push(DisplayItem::Pixels { rect, data, w: pw, h: ph });
+    } else if let Some((handle, off, iw, ih)) = dom
         .image_of(id)
         .filter(|(h, _, iw, ih)| *h != 0 && *iw != 0 && *ih != 0)
     {

--- a/crates/rts-dom/src/layout/tests/mod.rs
+++ b/crates/rts-dom/src/layout/tests/mod.rs
@@ -25,6 +25,7 @@ mod pintura;
 mod pintura_transform_clip;
 mod pintura_juncao;
 mod replaced_fundo;
+mod replaced_pixels;
 mod posicionado;
 mod position_corpus;
 mod texto_lote_s;

--- a/crates/rts-dom/src/layout/tests/replaced_pixels.rs
+++ b/crates/rts-dom/src/layout/tests/replaced_pixels.rs
@@ -1,0 +1,29 @@
+//! Um `<img>` com pixels guardados NO documento (`set_pixel_data`, o caminho
+//! da `data:` URL do lote V-img) tem tamanho natural e pinta `Pixels` —
+//! `tests/css/claude-img-natural.html` no Blink: 4×2 sem atributos, 40×20 com
+//! `width: 40px` (a razão mantém-se), 8×8 quando os atributos mandam.
+
+use crate::layout::DisplayItem;
+use crate::table::tests::{geometria_com, rect};
+
+const HTML: &str = r#"<style>body{margin:0;font:16px/20px monospace}img{display:block}#so-largura{width:40px}</style>
+<img id="natural" src="x.png"><img id="so-largura" src="x.png"><img id="atributos" width="8" height="8" src="x.png">"#;
+
+#[test]
+fn img_com_pixels_no_documento_mede_o_natural_e_pinta_pixels() {
+    let (dom, list) = geometria_com(HTML, 1280.0, |d| {
+        for sel in ["#natural", "#so-largura", "#atributos"] {
+            let id = d.query(sel).expect(sel);
+            d.set_pixel_data(id, vec![200, 30, 30, 255].repeat(8), 4, 2);
+        }
+    });
+    let n = rect(&dom, &list, "#natural", 0);
+    let s = rect(&dom, &list, "#so-largura", 0);
+    let a = rect(&dom, &list, "#atributos", 0);
+    assert_eq!((n.w, n.h), (4.0, 2.0), "tamanho natural do PNG");
+    assert_eq!((s.w, s.h), (40.0, 20.0), "width sozinho mantém a razão");
+    assert_eq!((a.w, a.h), (8.0, 8.0), "os atributos vencem o natural");
+    assert_eq!((n.y, s.y, a.y), (0.0, 2.0, 22.0), "empilhados como blocos");
+    let pixels = list.materialized().iter().filter(|i| matches!(i, DisplayItem::Pixels { .. })).count();
+    assert_eq!(pixels, 3, "um item Pixels por imagem");
+}

--- a/crates/rts-dom/src/layout/vertical.rs
+++ b/crates/rts-dom/src/layout/vertical.rs
@@ -261,7 +261,7 @@ pub(in crate::layout) fn layout_children_vertical(
         }
         let (child_block, child_inline_block) = match &dom.node(child).kind {
             NodeKind::Element { tag } => {
-                let replaced = (tag == "img" && dom.image_of(child).is_some())
+                let replaced = (tag == "img" && dom.image_dims(child).is_some())
                     || tag == "svg"
                     || tag == "canvas";
                 let effective = child_css.as_ref().and_then(|c| c.effective_display());

--- a/crates/rts-dom/src/style/auditoria_lote_b.rs
+++ b/crates/rts-dom/src/style/auditoria_lote_b.rs
@@ -75,7 +75,11 @@ fn os_atributos_de_apresentacao_nao_entram() {
         "<html><body><table bgcolor=\"red\"><tr><td width=\"100\">x</td></tr></table></body></html>",
     );
     assert_eq!(prop(&d, "table", "background-color"), "rgba(0, 0, 0, 0)");
-    assert_eq!(prop(&d, "td", "width"), "auto");
+    // O `width="100"` não chega à cascade: a propriedade fica por declarar. (O
+    // `getComputedStyle().width` responde o valor USADO em px desde o lote
+    // V-img, como o Blink — por isso a pergunta é ao estilo, não à string.)
+    let td = d.query("td").expect("td");
+    assert_eq!(d.computed_style(td).expect("css").width, None);
 }
 
 /// `estilo.seletor.has` — **obsoleto**: o registo dizia que `:has()` não era

--- a/crates/rts-dom/src/table/tests/mod.rs
+++ b/crates/rts-dom/src/table/tests/mod.rs
@@ -22,6 +22,25 @@ pub(crate) fn geometria(html: &str, largura: f32) -> (crate::Dom, crate::layout:
     (dom, list)
 }
 
+/// Como [`geometria`], mas com uma passagem sobre o `Dom` ANTES do layout —
+/// para o que só a ponte faz numa página real (pixels de um `<img>`, valor de
+/// um `<input>`), sem trazer a ponte para os testes do crate.
+pub(crate) fn geometria_com(
+    html: &str,
+    largura: f32,
+    prepara: impl FnOnce(&mut crate::Dom),
+) -> (crate::Dom, crate::layout::DisplayList) {
+    let mut dom = parse_html_to_dom(&format!("<style>body{{margin:0}}</style>{html}"));
+    prepara(&mut dom);
+    let ctx = LayoutCtx {
+        viewport_w: largura,
+        viewport_h: 600.0,
+        measurer: &ApproxMeasurer,
+    };
+    let list = layout_document(&dom, &ctx);
+    (dom, list)
+}
+
 /// O rect do n-ésimo elemento que casa com o seletor.
 pub(crate) fn rect(
     dom: &crate::Dom,

--- a/examples/claude-css-runner.ts
+++ b/examples/claude-css-runner.ts
@@ -11,7 +11,7 @@
 // mão — o valor deste corpus está exatamente aí. Ver `tests/css/README.md`.
 import { readFileSync, readdirSync } from "node:fs";
 import {
-  parseHtml, free, querySelectorAllCount, querySelectorAllAt,
+  parseHtml, free, querySelectorAllCount, querySelectorAllAt, getByTagCount, getByTagAt, setImageDataUrl,
   getAttribute, boundingRect, computedProperty, setLocationHash,
 } from "rts:dom";
 
@@ -96,6 +96,14 @@ for (const nome of fixtures) {
 
   const fonte = readFileSync(PASTA + "/" + nome, "utf8") as string;
   const doc = parseHtml(fonte);
+  // As imagens `data:` da fixture — o mesmo passo 3 do `loadResources` da
+  // fachada, que este corredor não usa (lê o HTML cru pelo namespace).
+  const nImgs = getByTagCount(doc, "img");
+  for (let ii = 0; ii < nImgs; ii = ii + 1) {
+    const im = getByTagAt(doc, "img", ii);
+    const src = getAttribute(doc, im, "src") as string;
+    if (src.length > 11 && src.substring(0, 11) === "data:image/") { setImageDataUrl(doc, im, src); }
+  }
   // `<meta name="fixar-hash" content="x">` (lote O): o corredor não executa
   // `<script>` (não há `onload` aqui), então uma fixture sobre `:target`
   // precisa de um jeito honesto de dizer qual fragmento estava na URL — o

--- a/scripts/css_pintura.md
+++ b/scripts/css_pintura.md
@@ -140,3 +140,10 @@ cuja imagem não carregou. É um defeito de pintura do motor, o próximo alvo.
 **2026-09-04, lote img-fundo:** `claude-object-fit` 1,95 % → 1,22 % (o fundo do
 `<img>` pinta). O que fica é a IMAGEM: um `data:` de 1×1 que o loader do lado
 TS não entrega ao `<img>` — não é do rasterizador nem do layout.
+
+**2026-09-04, lote V-img:** o rasterizador pinta `DisplayItem::Pixels` (o
+`<canvas>` e o `<img>` com pixels no documento) e MASCARA os `<img>` com `src`
+e sem pixels — ele não tem a ponte, e é a ponte que descodifica o PNG de
+`data:`. `claude-object-fit`: 0 % diferente com 1,95 % de área mascarada;
+`claude-img-natural` 0,08 %. As imagens só se medem de verdade pela janela do
+egui, que tem a ponte.

--- a/tests/css/README.md
+++ b/tests/css/README.md
@@ -42,10 +42,9 @@ no laço de iteração.
 
 ## O número, hoje
 
-**2026-09-04 (vaga 6 fechada; régua da vaga 7): 86 das 91 fixtures passam**,
-a 1px de tolerância; as 5 que falham estão em `esperado-a-falhar.txt` com a
-razão: 1 medida ANTES do código da vaga 7 (`img-natural`, lote V-img), 3 da
-folha de UA
+**2026-09-04 (vaga 7, lote V-img): 87 das 91 fixtures passam**, a 1px de
+tolerância; as 4 que falham estão em `esperado-a-falhar.txt` com a razão:
+3 da folha de UA
 (largura de texto a negrito/controlos, fonte dos controlos, `tr` sem
 `border-spacing`) e `cursor: url()` (o Blink resolve a URL contra a base do
 documento; este motor não resolve URLs). O job `dom-rulers` do CI fica

--- a/tests/css/esperado-a-falhar.txt
+++ b/tests/css/esperado-a-falhar.txt
@@ -17,8 +17,5 @@ claude-cursor-pointer-events.html
 # `inline-fragmentos`, `font-unidades-ch-ex`) saíram daqui com os lotes S-hifen,
 # S-inline-2 e T.
 
-# vaga 7 — medida no Edge 152 ANTES do código (lote V-img: `rts:imgdec`,
-# `dom.setImage` e o loader de `data:` não existem no motor novo). Blink: o
-# `<img>` sem atributos mede o tamanho natural do PNG (4×2) e `width` sozinho
-# mantém a razão (40×20).
-claude-img-natural.html
+# vaga 7 — `claude-img-natural` (medida antes do código) saiu daqui com o lote
+# V-img: o PNG de `data:` chega ao `<img>` pela ponte.


### PR DESCRIPTION
## O que é

O motor novo não tinha caminho para pixels chegarem a um `<img>` (`rts:imgdec`/`dom.setImage` eram do motor antigo). Fecha-se pelo sítio que já existia — `Dom::set_pixel_data`, onde o `<canvas>` guarda os seus — e o mesmo `DisplayItem::Pixels` que o egui e o rasterizador da régua já pintam. A ponte ganha `setImageDataUrl` (base64 + PNG 8 bits, 5 tipos de cor, sem entrelaçado; o resto responde 0) e `imageNaturalWidth/Height`; o `dom.ts` entrega os `<img src="data:image/…">` no `loadResources`; `getComputedStyle().width/height` responde o valor usado (CSSOM). Não feito, dito no PLAN: `http(s)` no loader, JPEG/GIF/WebP, `object-fit` além de `fill`, `list-style-image` por URL.

## Medido

| régua | antes | depois |
|---|---|---|
| corpus CSS | 86/91 | **87/91** (`claude-img-natural` passa: 4×2, 40×20, 8×8); medições 2 147 → **2 152**/2 168 |
| pintura | `img-natural` —, `object-fit` 1,22 % | **0,08 %**, **0 %** (1,95 % mascarado: o rasterizador não tem a ponte) |
| suite por ficheiro | 859/888 | **859/888, nenhum perdido** |
| testes | rts-dom 878, bridge 4 | **879**, **6** (PNG da fixture descodificado; contrato) |
| paridade 6 páginas | — | 0 elementos movidos |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc