### PR TITLE
ci(dom): os reftests do WPT correm no dom-rulers e o número entra no bloco do README

### DIFF
--- a/.github/css_parity_report.json
+++ b/.github/css_parity_report.json
@@ -1,31 +1,37 @@
 {
   "date": "2026-09-04",
   "fixtures": {
-    "passing": 92,
-    "total": 96,
-    "pct": 95.8
+    "passing": 93,
+    "total": 97,
+    "pct": 95.9
   },
   "measurements": {
-    "matching": 2250,
-    "total": 2266,
+    "matching": 2278,
+    "total": 2294,
     "pct": 99.3
+  },
+  "wpt": {
+    "suite": "css/css-flexbox",
+    "passing": 186,
+    "total": 489,
+    "pct": 38
   },
   "expected_failures": [
     {
       "fixture": "claude-ua-form-disabled.html",
-      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal"
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
     },
     {
       "fixture": "claude-ua-headings.html",
-      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal"
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
     },
     {
       "fixture": "claude-ua-th.html",
-      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal"
+      "razao": "folha de UA (lote I): largura de texto a negrito e de controlos no medidor\r aproximado, fonte dos controlos, <tr> sem border-spacing horizontal\r"
     },
     {
       "fixture": "claude-cursor-pointer-events.html",
-      "razao": "cursor: url(x.png) — o Blink resolve a URL contra a base do documento; nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)"
+      "razao": "cursor: url(x.png) — o Blink resolve a URL contra a base do documento;\r nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)\r"
     }
   ],
   "dom_lots": {
@@ -63,7 +69,10 @@
       "flex-item-bfc — um item de flex/grid contém os seus floats; o item de coluna que estica mede-se à largura do contentor",
       "load-resources — `loadResources` vivo no motor novo",
       "intrinseco-whitespace — a largura intrínseca colapsa o whitespace do HTML",
-      "svg-atributo — `width`/`height` do `<svg>` como comprimentos CSS; margens no placeholder"
+      "svg-atributo — `width`/`height` do `<svg>` como comprimentos CSS; margens no placeholder",
+      "borda-por-lado-intrinseca — a borda por lado na largura intrínseca e na base flex",
+      "inline-block-bfc — um inline-block flui os filhos como BLOCO; a corrida de inline-blocks alinha pela baseline própria",
+      "N-wpt — a régua dos REFTESTS do WPT"
     ],
     "parciais": [
       "S-inline — caixa inline por FRAGMENTOS de linha"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -290,6 +290,33 @@ jobs:
           if [ -n "$inesperadas" ]; then echo "::error::fixtures a falhar FORA da lista esperado-a-falhar: $inesperadas"; exit 1; fi
           echo "so falham as esperadas: $(wc -l < esperadas.txt) ficheiro(s)"
 
+      # A quarta régua: os REFTESTS do Web Platform Tests, rasterizados pelo
+      # nosso motor e comparados pixel a pixel (scripts/wpt_reftests.md). O WPT
+      # fica FIXADO num commit — uma régua que muda sozinha não é uma régua —
+      # e só as pastas usadas entram (checkout esparso). O rasterizador é um
+      # exemplo do rts-dom, que não tem dependências: constrói em ~1 min.
+      # Report-only: o número vai para o README; um dia que desça vê-se lá.
+      - name: Setup Rust (for the raster example)
+        if: always()
+        uses: ./.github/actions/setup-rust
+
+      - name: Build the headless raster
+        if: always()
+        run: cargo build --release -p rts-dom --example claude-raster
+
+      - name: WPT reftests (css-flexbox, pinned)
+        if: always()
+        shell: bash
+        run: |
+          set -e
+          WPT_SHA=972e0e100fa754629cd00e549d6fa20a243af2bd
+          git clone -q --filter=blob:none --sparse https://github.com/web-platform-tests/wpt.git "$RUNNER_TEMP/wpt"
+          git -C "$RUNNER_TEMP/wpt" sparse-checkout set css/css-flexbox resources
+          git -C "$RUNNER_TEMP/wpt" checkout -q "$WPT_SHA"
+          node scripts/wpt_reftests.mjs "$RUNNER_TEMP/wpt/css/css-flexbox" --out "$RUNNER_TEMP/wpt-out" | tee wpt.txt
+          { echo "### WPT reftests (css-flexbox @ ${WPT_SHA:0:9})"; echo; echo '```'; cat wpt.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          mkdir -p .github && cp "$RUNNER_TEMP/wpt-out/relatorio.json" .github/wpt_report.json
+
       # O número do README é o que ESTE job mediu (o mesmo padrão do bloco
       # cross-runtime): regiões CSS_PARITY_BADGE / CSS_DOM_STATS e o JSON em
       # .github/. `always()` porque o passo acima sai 1 quando cai uma fixture
@@ -304,7 +331,7 @@ jobs:
           node scripts/css_parity_readme.mjs corpus.txt
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md .github/css_parity_report.json
+          git add README.md .github/css_parity_report.json .github/wpt_report.json
           if git diff --cached --quiet; then echo "nada mudou"; exit 0; fi
           pct=$(node -e "console.log(require('./.github/css_parity_report.json').measurements.pct)")
           git commit -m "docs: auto-update CSS/DOM parity badge (${pct}%)"

--- a/.github/wpt_report.json
+++ b/.github/wpt_report.json
@@ -1,0 +1,1828 @@
+{
+  "pasta": "C:\\Users\\nexga\\AppData\\Local\\Temp/wpt/css/css-flexbox",
+  "total": 489,
+  "passam": 186,
+  "falham": 303,
+  "erros": 0,
+  "tol": 8,
+  "piores": [
+    {
+      "nome": "percentage-heights-002",
+      "pct": 37.65625,
+      "n": 385600,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-multi-line-horiz-003",
+      "pct": 35.859375,
+      "n": 367200,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-multi-line-horiz-004",
+      "pct": 35.859375,
+      "n": 367200,
+      "script": false
+    },
+    {
+      "nome": "flexbox-definite-sizes-005",
+      "pct": 29.625,
+      "n": 303360,
+      "script": false
+    },
+    {
+      "nome": "flex-direction-with-element-insert",
+      "pct": 24.491796875,
+      "n": 250796,
+      "script": true
+    },
+    {
+      "nome": "flex-aspect-ratio-resize-001",
+      "pct": 20.5078125,
+      "n": 210000,
+      "script": true
+    },
+    {
+      "nome": "percentage-size-subitems-001",
+      "pct": 19.90859375,
+      "n": 203864,
+      "script": false
+    },
+    {
+      "nome": "flex-direction",
+      "pct": 17.419531250000002,
+      "n": 178376,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-012",
+      "pct": 13.856347656250001,
+      "n": 141889,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-011",
+      "pct": 13.734863281250002,
+      "n": 140645,
+      "script": false
+    },
+    {
+      "nome": "flex-container-line-if-empty-vertical-writing-mode",
+      "pct": 12.1484375,
+      "n": 124400,
+      "script": false
+    },
+    {
+      "nome": "percentage-heights-015",
+      "pct": 11.71875,
+      "n": 120000,
+      "script": false
+    },
+    {
+      "nome": "flexbox_item-float",
+      "pct": 11.15,
+      "n": 114176,
+      "script": false
+    },
+    {
+      "nome": "flexbox_visibility-collapse",
+      "pct": 10.295703125,
+      "n": 105428,
+      "script": false
+    },
+    {
+      "nome": "flexbox_rtl-direction",
+      "pct": 9.6201171875,
+      "n": 98510,
+      "script": false
+    },
+    {
+      "nome": "table-item-flex-percentage-min-width",
+      "pct": 9.610058593749999,
+      "n": 98407,
+      "script": false
+    },
+    {
+      "nome": "flex-abspos-inset-nested-002",
+      "pct": 8.7890625,
+      "n": 90000,
+      "script": false
+    },
+    {
+      "nome": "cross-axis-scrollbar",
+      "pct": 8.26171875,
+      "n": 84600,
+      "script": false
+    },
+    {
+      "nome": "table-item-flex-percentage-width",
+      "pct": 8.25458984375,
+      "n": 84527,
+      "script": false
+    },
+    {
+      "nome": "flexbox_nested-flex",
+      "pct": 8.0232421875,
+      "n": 82158,
+      "script": false
+    },
+    {
+      "nome": "flexbox_visibility-collapse-line-wrapping",
+      "pct": 7.822265624999999,
+      "n": 80100,
+      "script": false
+    },
+    {
+      "nome": "multiline-reverse-wrap-baseline",
+      "pct": 6.904296875,
+      "n": 70700,
+      "script": false
+    },
+    {
+      "nome": "flexbox_stf-table-singleline-2",
+      "pct": 6.7046875,
+      "n": 68656,
+      "script": false
+    },
+    {
+      "nome": "percentage-heights-004",
+      "pct": 6.25,
+      "n": 64000,
+      "script": false
+    },
+    {
+      "nome": "aspect-ratio-intrinsic-size-012",
+      "pct": 6.171875,
+      "n": 63200,
+      "script": true
+    },
+    {
+      "nome": "aspect-ratio-intrinsic-size-013",
+      "pct": 6.171875,
+      "n": 63200,
+      "script": true
+    },
+    {
+      "nome": "flexbox_flex-basis",
+      "pct": 6,
+      "n": 61440,
+      "script": false
+    },
+    {
+      "nome": "fixed-table-layout-with-percentage-width-in-flex-item",
+      "pct": 5.248828125,
+      "n": 53748,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-013",
+      "pct": 5.203125,
+      "n": 53280,
+      "script": false
+    },
+    {
+      "nome": "flexbox_item-vertical-align",
+      "pct": 5.20234375,
+      "n": 53272,
+      "script": false
+    },
+    {
+      "nome": "flex-abspos-inset-nested-001",
+      "pct": 3.90625,
+      "n": 40000,
+      "script": false
+    },
+    {
+      "nome": "flexbox_writing_mode_vertical_lays_out_contents_from_top_to_bottom",
+      "pct": 3.90625,
+      "n": 40000,
+      "script": false
+    },
+    {
+      "nome": "flex-container-min-content-001",
+      "pct": 3.8240234375,
+      "n": 39158,
+      "script": false
+    },
+    {
+      "nome": "multiline-shrink-to-fit",
+      "pct": 3.80859375,
+      "n": 39000,
+      "script": false
+    },
+    {
+      "nome": "flexbox_wrap-long",
+      "pct": 3.566796875,
+      "n": 36524,
+      "script": false
+    },
+    {
+      "nome": "flexbox_item-top-float",
+      "pct": 3.35,
+      "n": 34304,
+      "script": false
+    },
+    {
+      "nome": "flex-aspect-ratio-intrinsic-padding-001",
+      "pct": 3.28125,
+      "n": 33600,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-natural-mixed-basis-auto",
+      "pct": 3.2,
+      "n": 32768,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-1-unitless-basis",
+      "pct": 2.990625,
+      "n": 30624,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-1-unitless-basis",
+      "pct": 2.9625,
+      "n": 30336,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-N-unitless-basis",
+      "pct": 2.9625,
+      "n": 30336,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-N-unitless-basis",
+      "pct": 2.9625,
+      "n": 30336,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-010",
+      "pct": 2.86875,
+      "n": 29376,
+      "script": false
+    },
+    {
+      "nome": "nested-orthogonal-flexbox-relayout",
+      "pct": 2.81328125,
+      "n": 28808,
+      "script": true
+    },
+    {
+      "nome": "flexbox-column-row-gap-004",
+      "pct": 2.8015624999999997,
+      "n": 28688,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-Npercent-shrink",
+      "pct": 2.709375,
+      "n": 27744,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-Npercent-shrink",
+      "pct": 2.709375,
+      "n": 27744,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-Npercent-shrink",
+      "pct": 2.709375,
+      "n": 27744,
+      "script": false
+    },
+    {
+      "nome": "flexbox_fbfc",
+      "pct": 2.7,
+      "n": 27648,
+      "script": false
+    },
+    {
+      "nome": "flex-aspect-ratio-img-row-014",
+      "pct": 2.65556640625,
+      "n": 27193,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-auto-shrink",
+      "pct": 2.5593749999999997,
+      "n": 26208,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-right-002",
+      "pct": 2.4,
+      "n": 24576,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-srl-row-mix",
+      "pct": 2.334375,
+      "n": 23904,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-row-wrap-reverse",
+      "pct": 2.2757812499999996,
+      "n": 23304,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-row-wrap",
+      "pct": 2.2757812499999996,
+      "n": 23304,
+      "script": false
+    },
+    {
+      "nome": "flexbox_wrap",
+      "pct": 2.2757812499999996,
+      "n": 23304,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-auto-shrink",
+      "pct": 2.25,
+      "n": 23040,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-auto-shrink",
+      "pct": 2.25,
+      "n": 23040,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-slr-row-mix",
+      "pct": 2.2015625,
+      "n": 22544,
+      "script": false
+    },
+    {
+      "nome": "flex-svg-no-intrinsic-column-001",
+      "pct": 2.197265625,
+      "n": 22500,
+      "script": false
+    },
+    {
+      "nome": "gap-collapse",
+      "pct": 2.0005859375,
+      "n": 20486,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-natural-mixed-basis",
+      "pct": 2,
+      "n": 20480,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-left-001",
+      "pct": 2,
+      "n": 20480,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-left-002",
+      "pct": 2,
+      "n": 20480,
+      "script": false
+    },
+    {
+      "nome": "flexbox-min-width-auto-006",
+      "pct": 1.953125,
+      "n": 20000,
+      "script": false
+    },
+    {
+      "nome": "align-items-006",
+      "pct": 1.82265625,
+      "n": 18664,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-N-shrink",
+      "pct": 1.7999999999999998,
+      "n": 18432,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-N-shrink",
+      "pct": 1.7999999999999998,
+      "n": 18432,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-N-shrink",
+      "pct": 1.7999999999999998,
+      "n": 18432,
+      "script": false
+    },
+    {
+      "nome": "flex-align-content-center",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-end-rtl",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-end",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-right-001",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-start-rtl",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-start",
+      "pct": 1.6,
+      "n": 16384,
+      "script": false
+    },
+    {
+      "nome": "dynamic-bsize-change",
+      "pct": 1.516796875,
+      "n": 15532,
+      "script": true
+    },
+    {
+      "nome": "flexbox_flex-1-0-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-0-unitless",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-0",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-Npercent",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-auto",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N",
+      "pct": 1.5,
+      "n": 15360,
+      "script": false
+    },
+    {
+      "nome": "flexbox-min-width-auto-005",
+      "pct": 1.474609375,
+      "n": 15100,
+      "script": false
+    },
+    {
+      "nome": "flexbox_order",
+      "pct": 1.4125,
+      "n": 14464,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-test1",
+      "pct": 1.3953125,
+      "n": 14288,
+      "script": false
+    },
+    {
+      "nome": "percentage-padding-002",
+      "pct": 1.388671875,
+      "n": 14220,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-stretch-2",
+      "pct": 1.3587890624999999,
+      "n": 13914,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-stretch",
+      "pct": 1.29951171875,
+      "n": 13307,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-stretch",
+      "pct": 1.2701171875,
+      "n": 13006,
+      "script": false
+    },
+    {
+      "nome": "flexbox_wrap-reverse",
+      "pct": 1.266015625,
+      "n": 12964,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-Npercent",
+      "pct": 1.2,
+      "n": 12288,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-Npercent",
+      "pct": 1.2,
+      "n": 12288,
+      "script": false
+    },
+    {
+      "nome": "flex-box-wrap",
+      "pct": 1.171875,
+      "n": 12000,
+      "script": false
+    },
+    {
+      "nome": "flexbox-collapsed-item-horiz-001",
+      "pct": 1.1375,
+      "n": 11648,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-001b",
+      "pct": 1.0927734375,
+      "n": 11190,
+      "script": false
+    },
+    {
+      "nome": "flexbox_stf-table-singleline",
+      "pct": 1.07578125,
+      "n": 11016,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-row-reverse-wrap-reverse",
+      "pct": 1.04296875,
+      "n": 10680,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-row-reverse-wrap",
+      "pct": 1.04296875,
+      "n": 10680,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-row-reverse",
+      "pct": 1.04296875,
+      "n": 10680,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-0-unitless",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0-0",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-0",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-0-unitless",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-0",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-0-unitless",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-0",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N",
+      "pct": 1.0406250000000001,
+      "n": 10656,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-center",
+      "pct": 0.9932617187499999,
+      "n": 10171,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-flex-end",
+      "pct": 0.9932617187499999,
+      "n": 10171,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-flex-start",
+      "pct": 0.9932617187499999,
+      "n": 10171,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-spacearound",
+      "pct": 0.9932617187499999,
+      "n": 10171,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-baseline",
+      "pct": 0.98310546875,
+      "n": 10067,
+      "script": false
+    },
+    {
+      "nome": "fieldset-as-item-overflow",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-007",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-008",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-009",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "flexbox-definite-sizes-001",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "flexbox-definite-sizes-002",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "inline-flex-column-image-load",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": true
+    },
+    {
+      "nome": "percentage-max-height-004",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": false
+    },
+    {
+      "nome": "position-absolute-scrollbar-freeze",
+      "pct": 0.9765625,
+      "n": 10000,
+      "script": true
+    },
+    {
+      "nome": "css-flexbox-row-wrap",
+      "pct": 0.90234375,
+      "n": 9240,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-basis-shrink",
+      "pct": 0.8999999999999999,
+      "n": 9216,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-center-2",
+      "pct": 0.88388671875,
+      "n": 9051,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-flexend-2",
+      "pct": 0.88115234375,
+      "n": 9023,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-flexstart-2",
+      "pct": 0.88115234375,
+      "n": 9023,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-center",
+      "pct": 0.87529296875,
+      "n": 8963,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-004",
+      "pct": 0.873046875,
+      "n": 8940,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-row-wrap-reverse",
+      "pct": 0.83642578125,
+      "n": 8565,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-005",
+      "pct": 0.81640625,
+      "n": 8360,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-srl-rtl",
+      "pct": 0.81640625,
+      "n": 8360,
+      "script": false
+    },
+    {
+      "nome": "flexbox_rtl-order",
+      "pct": 0.8125,
+      "n": 8320,
+      "script": false
+    },
+    {
+      "nome": "gap-007-lr",
+      "pct": 0.8085937499999999,
+      "n": 8280,
+      "script": false
+    },
+    {
+      "nome": "gap-007-ltr",
+      "pct": 0.8085937499999999,
+      "n": 8280,
+      "script": false
+    },
+    {
+      "nome": "gap-007-rl",
+      "pct": 0.8085937499999999,
+      "n": 8280,
+      "script": false
+    },
+    {
+      "nome": "gap-007-rtl",
+      "pct": 0.8085937499999999,
+      "n": 8280,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-003",
+      "pct": 0.8027343750000001,
+      "n": 8220,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-slr-rtl",
+      "pct": 0.8027343750000001,
+      "n": 8220,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-002",
+      "pct": 0.798828125,
+      "n": 8180,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-srl",
+      "pct": 0.798828125,
+      "n": 8180,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-baseline",
+      "pct": 0.7970703125,
+      "n": 8162,
+      "script": false
+    },
+    {
+      "nome": "flex-container-max-content-001",
+      "pct": 0.7905273437500001,
+      "n": 8095,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-006",
+      "pct": 0.7851562499999999,
+      "n": 8040,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-slr",
+      "pct": 0.7851562499999999,
+      "n": 8040,
+      "script": false
+    },
+    {
+      "nome": "flex-column-reverse-multiline-item-position",
+      "pct": 0.78125,
+      "n": 8000,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-row",
+      "pct": 0.779296875,
+      "n": 7980,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-011",
+      "pct": 0.771484375,
+      "n": 7900,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-012",
+      "pct": 0.771484375,
+      "n": 7900,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-auto",
+      "pct": 0.75,
+      "n": 7680,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-auto",
+      "pct": 0.75,
+      "n": 7680,
+      "script": false
+    },
+    {
+      "nome": "flexbox-collapsed-item-horiz-002",
+      "pct": 0.7490234375,
+      "n": 7670,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-001a",
+      "pct": 0.7117187500000001,
+      "n": 7288,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-single-item-001a",
+      "pct": 0.6890625,
+      "n": 7056,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-single-item-001b",
+      "pct": 0.6890625,
+      "n": 7056,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-spacearound-negative",
+      "pct": 0.67763671875,
+      "n": 6939,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-001",
+      "pct": 0.65625,
+      "n": 6720,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-stretch",
+      "pct": 0.65126953125,
+      "n": 6669,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-empty-001a",
+      "pct": 0.640625,
+      "n": 6560,
+      "script": false
+    },
+    {
+      "nome": "flexbox-baseline-empty-001b",
+      "pct": 0.640625,
+      "n": 6560,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-column-reverse-wrap-reverse",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-column-reverse-wrap",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-column-wrap-reverse",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flow-column-wrap",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_rtl-flow-reverse",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_rtl-flow",
+      "pct": 0.6125,
+      "n": 6272,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-N",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-auto-shrink",
+      "pct": 0.6,
+      "n": 6144,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-wrap-horiz-001",
+      "pct": 0.5931640625,
+      "n": 6074,
+      "script": false
+    },
+    {
+      "nome": "flexitem-stretch-range",
+      "pct": 0.5695312499999999,
+      "n": 5832,
+      "script": false
+    },
+    {
+      "nome": "flex-flow-010",
+      "pct": 0.56640625,
+      "n": 5800,
+      "script": false
+    },
+    {
+      "nome": "flex-item-min-width-min-content-max-width",
+      "pct": 0.48828125,
+      "n": 5000,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-spacearound",
+      "pct": 0.47763671875,
+      "n": 4891,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-spacebetween",
+      "pct": 0.47763671875,
+      "n": 4891,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-center",
+      "pct": 0.47763671875,
+      "n": 4891,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-009",
+      "pct": 0.46875,
+      "n": 4800,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-wrap-vert-001",
+      "pct": 0.45722656250000004,
+      "n": 4682,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-center",
+      "pct": 0.45283203124999993,
+      "n": 4637,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-flexend",
+      "pct": 0.45283203124999993,
+      "n": 4637,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-content-flexstart",
+      "pct": 0.45283203124999993,
+      "n": 4637,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-1-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-N-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-0-N-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-N-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-1-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-N-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-1-N-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-N-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-1-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-N-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox_flex-N-N-Npercent-shrink",
+      "pct": 0.44999999999999996,
+      "n": 4608,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-003b",
+      "pct": 0.44960937500000003,
+      "n": 4604,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-003a",
+      "pct": 0.42421875000000003,
+      "n": 4344,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-flow-002",
+      "pct": 0.4064453125,
+      "n": 4162,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-horiz-004",
+      "pct": 0.380859375,
+      "n": 3900,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-002a",
+      "pct": 0.3568359375,
+      "n": 3654,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-basis-content-002b",
+      "pct": 0.3568359375,
+      "n": 3654,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-flow-001",
+      "pct": 0.3388671875,
+      "n": 3470,
+      "script": false
+    },
+    {
+      "nome": "flexbox-paint-ordering-003",
+      "pct": 0.3,
+      "n": 3072,
+      "script": false
+    },
+    {
+      "nome": "flexbox-safe-overflow-position-001",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-flexend",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-items-flexstart",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-auto",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-flexend",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox_align-self-flexstart",
+      "pct": 0.29580078125,
+      "n": 3029,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-horiz-001",
+      "pct": 0.28125,
+      "n": 2880,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-horiz-001a",
+      "pct": 0.267578125,
+      "n": 2740,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-horiz-001b",
+      "pct": 0.267578125,
+      "n": 2740,
+      "script": false
+    },
+    {
+      "nome": "flexbox-dyn-resize-001",
+      "pct": 0.25146484375,
+      "n": 2575,
+      "script": true
+    },
+    {
+      "nome": "flex-item-position-relative-001",
+      "pct": 0.244140625,
+      "n": 2500,
+      "script": false
+    },
+    {
+      "nome": "min-size-auto-overflow-clip",
+      "pct": 0.244140625,
+      "n": 2500,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-008",
+      "pct": 0.234375,
+      "n": 2400,
+      "script": false
+    },
+    {
+      "nome": "flexbox-min-width-auto-001",
+      "pct": 0.21679687500000003,
+      "n": 2220,
+      "script": false
+    },
+    {
+      "nome": "flexbox_margin-auto-overflow",
+      "pct": 0.21533203125,
+      "n": 2205,
+      "script": false
+    },
+    {
+      "nome": "flexbox-column-row-gap-002",
+      "pct": 0.1861328125,
+      "n": 1906,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-vert-004",
+      "pct": 0.185546875,
+      "n": 1900,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-horiz-002",
+      "pct": 0.162109375,
+      "n": 1660,
+      "script": false
+    },
+    {
+      "nome": "flexbox-definite-sizes-003",
+      "pct": 0.15625,
+      "n": 1600,
+      "script": false
+    },
+    {
+      "nome": "flexbox-definite-sizes-004",
+      "pct": 0.15625,
+      "n": 1600,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-horiz-005",
+      "pct": 0.1435546875,
+      "n": 1470,
+      "script": false
+    },
+    {
+      "nome": "flexbox-column-row-gap-001",
+      "pct": 0.13457031249999998,
+      "n": 1378,
+      "script": false
+    },
+    {
+      "nome": "flexbox_inline",
+      "pct": 0.13007812500000002,
+      "n": 1332,
+      "script": false
+    },
+    {
+      "nome": "flexbox_object",
+      "pct": 0.13007812500000002,
+      "n": 1332,
+      "script": false
+    },
+    {
+      "nome": "flex-item-content-is-min-width-max-content",
+      "pct": 0.12578125,
+      "n": 1288,
+      "script": false
+    },
+    {
+      "nome": "gap-002-lr",
+      "pct": 0.1234375,
+      "n": 1264,
+      "script": false
+    },
+    {
+      "nome": "gap-002-ltr",
+      "pct": 0.1234375,
+      "n": 1264,
+      "script": false
+    },
+    {
+      "nome": "gap-002-rl",
+      "pct": 0.1234375,
+      "n": 1264,
+      "script": false
+    },
+    {
+      "nome": "gap-002-rtl",
+      "pct": 0.1234375,
+      "n": 1264,
+      "script": false
+    },
+    {
+      "nome": "flex-base-size-ignores-max-width",
+      "pct": 0.1220703125,
+      "n": 1250,
+      "script": false
+    },
+    {
+      "nome": "flex-item-z-ordering-001",
+      "pct": 0.1220703125,
+      "n": 1250,
+      "script": false
+    },
+    {
+      "nome": "flexbox-flex-wrap-horiz-002",
+      "pct": 0.1216796875,
+      "n": 1246,
+      "script": false
+    },
+    {
+      "nome": "flexbox_order-abspos-space-around",
+      "pct": 0.1212890625,
+      "n": 1242,
+      "script": false
+    },
+    {
+      "nome": "aspect-ratio-intrinsic-size-007",
+      "pct": 0.11249999999999999,
+      "n": 1152,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-spacebetween",
+      "pct": 0.1119140625,
+      "n": 1146,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-vert-001a",
+      "pct": 0.11132812499999999,
+      "n": 1140,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-vert-001b",
+      "pct": 0.11132812499999999,
+      "n": 1140,
+      "script": false
+    },
+    {
+      "nome": "flex-inline",
+      "pct": 0.10947265625,
+      "n": 1121,
+      "script": false
+    },
+    {
+      "nome": "position-fixed-001",
+      "pct": 0.101953125,
+      "n": 1044,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-vert-002a",
+      "pct": 0.099609375,
+      "n": 1020,
+      "script": false
+    },
+    {
+      "nome": "flexbox-break-request-vert-002b",
+      "pct": 0.099609375,
+      "n": 1020,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-vert-002",
+      "pct": 0.095703125,
+      "n": 980,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-spacebetween-negative",
+      "pct": 0.09316406249999999,
+      "n": 954,
+      "script": false
+    },
+    {
+      "nome": "flexbox-collapsed-item-baseline-001",
+      "pct": 0.0900390625,
+      "n": 922,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-014",
+      "pct": 0.07890625000000001,
+      "n": 808,
+      "script": false
+    },
+    {
+      "nome": "flexbox-writing-mode-015",
+      "pct": 0.07890625000000001,
+      "n": 808,
+      "script": false
+    },
+    {
+      "nome": "flex-vertical-align-effect",
+      "pct": 0.07705078125,
+      "n": 789,
+      "script": false
+    },
+    {
+      "nome": "flexbox-with-pseudo-elements-002",
+      "pct": 0.073828125,
+      "n": 756,
+      "script": false
+    },
+    {
+      "nome": "flex-aspect-ratio-percentage-height-stale-width",
+      "pct": 0.068359375,
+      "n": 700,
+      "script": true
+    },
+    {
+      "nome": "flexbox-single-line-clamp-1",
+      "pct": 0.068359375,
+      "n": 700,
+      "script": false
+    },
+    {
+      "nome": "flexbox_margin-auto",
+      "pct": 0.062109375,
+      "n": 636,
+      "script": false
+    },
+    {
+      "nome": "flexbox-collapsed-item-horiz-003",
+      "pct": 0.05859375,
+      "n": 600,
+      "script": false
+    },
+    {
+      "nome": "dynamic-isize-change-001",
+      "pct": 0.052734375,
+      "n": 540,
+      "script": true
+    },
+    {
+      "nome": "flexbox-flex-wrap-vert-002",
+      "pct": 0.041015625,
+      "n": 420,
+      "script": false
+    },
+    {
+      "nome": "flexbox-overflow-vert-005",
+      "pct": 0.0390625,
+      "n": 400,
+      "script": false
+    },
+    {
+      "nome": "flexbox_justifycontent-spacebetween-only",
+      "pct": 0.0373046875,
+      "n": 382,
+      "script": false
+    },
+    {
+      "nome": "stretch-flex-item-checkbox-input",
+      "pct": 0.033203125,
+      "n": 340,
+      "script": false
+    },
+    {
+      "nome": "stretch-flex-item-radio-input",
+      "pct": 0.033203125,
+      "n": 340,
+      "script": false
+    },
+    {
+      "nome": "css-flexbox-img-expand-evenly",
+      "pct": 0.029296875,
+      "n": 300,
+      "script": false
+    },
+    {
+      "nome": "flexbox-min-width-auto-003",
+      "pct": 0.028906249999999998,
+      "n": 296,
+      "script": false
+    },
+    {
+      "nome": "flexbox-min-width-auto-004",
+      "pct": 0.028906249999999998,
+      "n": 296,
+      "script": false
+    },
+    {
+      "nome": "flexbox-with-pseudo-elements-001",
+      "pct": 0.028124999999999997,
+      "n": 288,
+      "script": false
+    },
+    {
+      "nome": "flexbox-with-pseudo-elements-003",
+      "pct": 0.028124999999999997,
+      "n": 288,
+      "script": false
+    },
+    {
+      "nome": "flexbox-align-self-stretch-vert-002",
+      "pct": 0.025390625,
+      "n": 260,
+      "script": false
+    },
+    {
+      "nome": "flexbox_margin-left-ex",
+      "pct": 0.0244140625,
+      "n": 250,
+      "script": false
+    },
+    {
+      "nome": "dynamic-baseline-change-nested",
+      "pct": 0.01953125,
+      "n": 200,
+      "script": true
+    },
+    {
+      "nome": "dynamic-baseline-change",
+      "pct": 0.01953125,
+      "n": 200,
+      "script": true
+    },
+    {
+      "nome": "flexbox-min-height-auto-001",
+      "pct": 0.012109375,
+      "n": 124,
+      "script": false
+    },
+    {
+      "nome": "negative-margins-001",
+      "pct": 0.0107421875,
+      "n": 110,
+      "script": false
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -102,17 +102,20 @@ _Updated: 2026-08-24 — [como isto é medido](scripts/node_tests/README.md)_
 Layout and computed style measured against **Chrome/Blink** (Edge headless, 1280×800, 1 px tolerance) over the fixtures in `tests/css/`. Two numbers, on purpose: a *fixture* passes only when every measurement in it matches; *measurements* count each x/y/w/h and each computed property one by one. **Read it as "what we implemented is right", not as a share of CSS**: the corpus measures what has a fixture, and each new fixture is written to fail first (`tests/css/README.md`).
 
 ```
-[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰] 99.3%   2250/2266 measurements matching Blink
-[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱] 95.8%   92/96 fixtures passing
+[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰] 99.3%   2278/2294 measurements matching Blink
+[▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱] 95.9%   93/97 fixtures passing
+[▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱] 38%   186/489 WPT reftests (css-flexbox) rendering test == reference
 ```
 
-Fixtures that fail **on purpose** (each names a measured gap; `tests/css/esperado-a-falhar.txt`):
-- `claude-ua-form-disabled.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
-- `claude-ua-headings.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
-- `claude-ua-th.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
-- `claude-cursor-pointer-events.html` — cursor: url(x.png) — o Blink resolve a URL contra a base do documento; nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)
+The WPT line is **self-consistency**, the way browsers run reftests: test and reference are both rendered by this engine and compared pixel by pixel, no browser involved (`scripts/wpt_reftests.md`). It measures coherence, not Blink parity.
 
-**DOM engine state** (`crates/rts-dom/PLAN.md` §0): **34/38 lots done**, 1 partial, pending: Q, U, V–Y. The paint ruler (pixels against Blink, `scripts/css_pintura.md`) needs a browser and runs locally; its last number is recorded there.
+Fixtures that fail **on purpose** (each names a measured gap; `tests/css/esperado-a-falhar.txt`):
+- `claude-ua-form-disabled.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-ua-headings.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-ua-th.html` — folha de UA (lote I): largura de texto a negrito e de controlos no medidor aproximado, fonte dos controlos, <tr> sem border-spacing horizontal
+- `claude-cursor-pointer-events.html` — cursor: url(x.png) — o Blink resolve a URL contra a base do documento; nenhuma propriedade deste motor resolve URLs (lote S-decor, dito no teste)
+
+**DOM engine state** (`crates/rts-dom/PLAN.md` §0): **37/41 lots done**, 1 partial, pending: Q, U, V–Y. The paint ruler (pixels against Blink, `scripts/css_pintura.md`) needs a browser and runs locally; its last number is recorded there.
 
 *Updated 2026-09-04 by CI (`dom-rulers`).*
 <!-- CSS_DOM_STATS_END -->

--- a/scripts/css_parity_readme.mjs
+++ b/scripts/css_parity_readme.mjs
@@ -57,6 +57,11 @@ if (existsSync(planPath)) {
 }
 const totalLotes = lotes.feitos.length + lotes.parciais.length + lotes.pendentes.length;
 
+// A quarta régua, quando o job a correu: os reftests do WPT (auto-consistência,
+// `scripts/wpt_reftests.md`). Ausente = o bloco não a menciona.
+const wpt = existsSync(".github/wpt_report.json") ? JSON.parse(readFileSync(".github/wpt_report.json", "utf8")) : null;
+const pctWpt = wpt && wpt.total ? Math.round((wpt.passam / wpt.total) * 1000) / 10 : 0;
+
 function barra(pct) {
   const cheios = Math.round(pct / 5);
   return "[" + "▰".repeat(cheios) + "▱".repeat(20 - cheios) + "]";
@@ -82,8 +87,11 @@ Layout and computed style measured against **Chrome/Blink** (Edge headless, 1280
 
 \`\`\`
 ${barra(pctMed)} ${pctMed}%   ${batem}/${medicoes} measurements matching Blink
-${barra(pctFix)} ${pctFix}%   ${passam}/${fixtures} fixtures passing
-\`\`\`
+${barra(pctFix)} ${pctFix}%   ${passam}/${fixtures} fixtures passing${wpt ? `
+${barra(pctWpt)} ${pctWpt}%   ${wpt.passam}/${wpt.total} WPT reftests (css-flexbox) rendering test == reference` : ""}
+\`\`\`${wpt ? `
+
+The WPT line is **self-consistency**, the way browsers run reftests: test and reference are both rendered by this engine and compared pixel by pixel, no browser involved (\`scripts/wpt_reftests.md\`). It measures coherence, not Blink parity.` : ""}
 
 Fixtures that fail **on purpose** (each names a measured gap; \`tests/css/esperado-a-falhar.txt\`):
 ${linhasEsperadas}
@@ -112,6 +120,7 @@ writeFileSync(
   JSON.stringify(
     { date: hoje, fixtures: { passing: passam, total: fixtures, pct: pctFix },
       measurements: { matching: batem, total: medicoes, pct: pctMed },
+      wpt: wpt ? { suite: "css/css-flexbox", passing: wpt.passam, total: wpt.total, pct: pctWpt } : null,
       expected_failures: esperadas, dom_lots: lotes },
     null, 2) + "\n",
 );

--- a/scripts/wpt_reftests.md
+++ b/scripts/wpt_reftests.md
@@ -25,8 +25,12 @@ com os PNG de teste e referência lado a lado para olhar.
 
 ## O número, hoje
 
-**2026-09-04, `css/css-flexbox`, os primeiros 300 de 489 reftests: 114 passam
-(38 %)**, 0 falharam a rasterizar. Medido no motor da vaga 7 (main
+**2026-09-04, `css/css-flexbox`, os 489 reftests: 186 passam (38 %)**, 0
+falharam a rasterizar; 97 das 303 falhas têm menos de 0,5 % de pixels
+diferentes (anti-aliasing e fonte), 30 têm mais de 5 %. Por tema no nome:
+shrink 27, writing-mode 21, wrap 19, justify 16, baseline 12. **Corre no CI**
+(job `dom-rulers`, WPT fixado em `972e0e10`) e o número vai para o bloco
+"CSS and DOM parity" do README. Medido no motor da vaga 7 (main
 `4741b63d9` + o lote inline-block). Os piores são alinhamento por baseline em
 várias linhas (`flexbox-baseline-multi-line-horiz-003/004`, 36 %), tamanhos
 definidos (`flexbox-definite-sizes-005`, 30 %), `writing-mode` vertical


### PR DESCRIPTION
## O que é

A quarta régua do CSS no CI, pelo mesmo padrão das outras: o job `dom-rulers` constrói o rasterizador headless, faz um checkout esparso do WPT fixado num commit, corre `scripts/wpt_reftests.mjs` sobre `css/css-flexbox` (teste e referência rasterizados pelo nosso motor, comparados pixel a pixel) e o bloco «CSS and DOM parity» do README ganha a terceira barra, dita como auto-consistência e não paridade com o Blink. Report-only.

Hoje, localmente: **186/489 (38 %)**; 97 das falhas com menos de 0,5 % de pixels, 30 com mais de 5 %; por tema: shrink 27, writing-mode 21, wrap 19, justify 16, baseline 12 (`scripts/wpt_reftests.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc