### PR TITLE
feat(aot): o runtime AOT instala rts:dom e rts:egui — um .exe de UI arranca

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,8 +4868,10 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "rts-core",
+ "rts-dom-bridge",
  "rts-node",
  "rts-std",
+ "rts-ui",
 ]
 
 [[package]]

--- a/crates/rts-runtime/Cargo.toml
+++ b/crates/rts-runtime/Cargo.toml
@@ -32,4 +32,16 @@ crate-type = ["rlib", "staticlib"]
 rts-core = { path = "../rts-core" }
 rts-std = { path = "../rts-std" }
 rts-node = { path = "../rts-node" }
+# `rts:dom` e `rts:egui`: o host JIT instala-os (`rts-host/src/run.rs`) e o
+# programa AOT não os tinha — um `.exe` de UI morria à partida com "cannot
+# resolve module rts:egui". O `rts-adapters` que os trazia foi com o cutover de
+# 08-10 e ninguém os religou à fachada. Entram na ordem do host: o documento
+# (headless, sempre) antes da janela (opcional, como no host: um alvo sem
+# ecrã não a liga).
+rts-dom-bridge = { path = "../rts-dom-bridge" }
+rts-ui = { path = "../rts-ui", optional = true }
 libc = "0.2"
+
+[features]
+default = ["ui"]
+ui = ["dep:rts-ui"]

--- a/crates/rts-runtime/src/aot/mod.rs
+++ b/crates/rts-runtime/src/aot/mod.rs
@@ -340,6 +340,13 @@ pub extern "C" fn main(_argc: i32, _argv: *const *const i8) -> i32 {
 
     rts_std::install(&mut context);
     rts_node::install(&mut context);
+    // O mesmo par e a mesma ordem do host JIT (`rts-host/src/run.rs`): o
+    // documento é headless e vem sempre; a janela só com a feature `ui`. Sem
+    // isto um `.exe` compilado de uma app de UI morria em "cannot resolve
+    // module rts:egui" — o comparativo RTS vs Electron foi quem o apanhou.
+    rts_dom_bridge::install(&mut context);
+    #[cfg(feature = "ui")]
+    rts_ui::install(&mut context);
 
     let nothing = singletons.undefined as u64;
     let (_, exit_code) = rts_core::entry::with_context(context, || {
@@ -391,5 +398,10 @@ pub extern "C" fn main(_argc: i32, _argv: *const *const i8) -> i32 {
             0
         }
     });
+    // Depois do programa e antes de qualquer destrutor: um `wgpu::Device` solto
+    // num thread-local morre durante o descarregamento das DLLs do driver (ver
+    // `rts_ui::shutdown`; o host faz o mesmo). No-op sem janela aberta.
+    #[cfg(feature = "ui")]
+    rts_ui::shutdown();
     exit_code
 }

--- a/crates/rts-runtime/src/lib.rs
+++ b/crates/rts-runtime/src/lib.rs
@@ -45,5 +45,10 @@ pub fn keep() -> usize {
     let core = rts_core::entry::CORE_ENTRY_COUNT;
     let std_install = rts_std::install as usize;
     let node_install = rts_node::install as usize;
-    core + (std_install & 1) + (node_install & 1)
+    let dom_install = rts_dom_bridge::install as usize;
+    #[cfg(feature = "ui")]
+    let ui_install = rts_ui::install as usize;
+    #[cfg(not(feature = "ui"))]
+    let ui_install = 0usize;
+    core + (std_install & 1) + (node_install & 1) + (dom_install & 1) + (ui_install & 1)
 }


### PR DESCRIPTION
`rts-runtime` (a archive que um programa AOT liga) só instalava o núcleo, `rts-std` e `rts-node`; o DOM e a UI eram instalados só pelo host do JIT. Desde o cutover de 08-10 nenhum `.exe` de UI arrancava ("cannot resolve module rts:egui"). Agora a fachada depende de `rts-dom-bridge` e, sob a feature `ui` (default), de `rts-ui`; o arranque AOT instala os dois na ordem do host e faz o `shutdown` da UI à saída.

Medido: o `.exe` do comparativo RTS vs Electron (29 MB) abre a janela em ~220 ms e renderiza `examples/pagina.html` igual ao `rts run`. A página React fica branca por outra razão (os `<script>` da página precisam do compilador em runtime, que o AOT não leva) — dito no PR seguinte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc