### PR TITLE
fix(scripts): a app do comparativo bombeia eventos por frame — o React no .exe responde ao clique

### DIFF
--- a/scripts/rts_vs_electron/rts/app.ts
+++ b/scripts/rts_vs_electron/rts/app.ts
@@ -48,6 +48,12 @@ if (html === undefined || html.length === 0) {
     egui.beginFrame(win);
     egui.render(win, doc._dom);
     egui.endFrame(win);
+    // A mesma ordem de um frame do mini-browser e de `examples/claude-react-janela.ts`:
+    // teclado/edição, cliques, timers. Sem isto o React pinta mas o botão não
+    // responde — foi o que o Marcos viu no primeiro .exe.
+    pumpInputEvents(doc);
+    pumpEventCallbacks(doc);
+    pumpTimerCallbacks(doc);
   }
   egui.close(win);
 }


### PR DESCRIPTION
Faltavam `pumpInputEvents`/`pumpEventCallbacks`/`pumpTimerCallbacks` por frame no `app.ts` (como em `examples/claude-react-janela.ts`); o React pintava mas o botão não respondia. Validado no .exe de 34 MB compilado com `--html`: o contador responde ao clique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc