### PR TITLE
feat(cli): a casca de rts compile/run pagina.html carrega a página por loadDocumentFrom — o ciclo de vida da HTML spec em vez de parse+loadResources+runScriptsAt

### DIFF
--- a/crates/rts-cli/src/cli/html_entry.rs
+++ b/crates/rts-cli/src/cli/html_entry.rs
@@ -9,16 +9,18 @@
 //! never learn the entry was HTML at all; they see one more string of source
 //! text.
 //!
-//! # `casca()`, and why it exists instead of a call to `loadDocument`
+//! # `casca()`, and what loads the page
 //!
-//! The shape this shell wants is `loadDocument(html, url): Document` — parse
-//! + resources + scripts + `DOMContentLoaded`/`load` in one call — which
-//! another lot in flight is building in `rts-dom`. Until it lands, [`CASCA_FN`]
-//! composes the same result from what already exists:
-//! `parseDocument`+`loadResources`+`runScriptsAt`, exactly the sequence
-//! `app.ts` hand-writes today. Its own leading comment marks the one line to
-//! delete once `loadDocument` exists, so swapping it is a one-line change to
-//! this module rather than a rewrite of the generator.
+//! [`CASCA_FN`] loads the page through `loadDocumentFrom(html, url,
+//! resourceBase)` (`crates/rts-dom/src/lifecycle.ts`): the HTML spec's
+//! navigation — parse, resources, the parse-time `<script>`s in document
+//! order, `DOMContentLoaded`, `load` — after which a `<script>` appended by
+//! the page runs on its own. The DOM knows nothing of the compiler; the seam
+//! it runs script text through is the same one a JIT run and an AOT binary
+//! already fill (`docs/engine/aot-page-scripts.md`). It shipped first with
+//! `parseDocument`+`loadResources`+`runScriptsAt` composed by hand (#2684),
+//! while the lifecycle lot was in flight; the swap was the one-line change
+//! that comment promised.
 //!
 //! # Embedded vs read from disk
 //!
@@ -41,13 +43,12 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 /// The loop every generated program shares — `app.ts`'s own sequence, wrapped
-/// in a function whose `resourceBase`/`scriptUrl`/`title` arguments stand in
-/// for the single `loadDocument(html, url)` call this shell will make once
-/// that lot lands.
+/// in a function whose `resourceBase`/`scriptUrl`/`title` arguments feed one
+/// `loadDocumentFrom(html, scriptUrl, resourceBase)` call.
 ///
 /// `resourceBase` and `scriptUrl` stay two parameters rather than one `url`
-/// because they answer different questions: `loadResources` resolves a
-/// relative HREF against a filesystem/URL base, `runScriptsAt` publishes a
+/// because they answer different questions: the resource loader resolves a
+/// relative HREF against a filesystem/URL base, the script scope publishes a
 /// `window.location` a script may read — `app.ts` keeps them apart for the
 /// same reason, and a page whose scripts read `location.href` while its
 /// `<link>`s resolve against a local folder needs both answers to be real.

--- a/crates/rts-cli/src/cli/html_entry.rs
+++ b/crates/rts-cli/src/cli/html_entry.rs
@@ -52,14 +52,13 @@ use anyhow::{Context, Result};
 /// same reason, and a page whose scripts read `location.href` while its
 /// `<link>`s resolve against a local folder needs both answers to be real.
 const CASCA_FN: &str = r#"
-// TODO(loadDocument): troca isto por `const doc = loadDocument(html, scriptUrl);`
-// quando esse lote da DOM entregar parse + recursos + scripts +
-// DOMContentLoaded/load numa só chamada. Ate la, a mesma composicao feita a
-// mao em scripts/rts_vs_electron/rts/app.ts.
+// `loadDocumentFrom` (crates/rts-dom/src/lifecycle.ts) e a navegacao da HTML
+// spec: parse, recursos, os <script> do parse por ordem, DOMContentLoaded,
+// load — e a partir dai um <script> anexado por appendChild corre sozinho. A
+// base dos recursos e a pasta do HTML; a URL dos scripts e a de pagina.
 function casca(html: string, resourceBase: string, scriptUrl: string, title: string): void {
-  const doc = parseDocument(html);
-  loadResources(doc, resourceBase);
-  console.log("scripts da pagina corridos: " + runScriptsAt(doc, scriptUrl));
+  const doc = loadDocumentFrom(html, scriptUrl, resourceBase);
+  console.log("pagina carregada: " + doc.readyState + ", scripts: " + doc.querySelectorAll("script").length);
   const win = egui.openWindow(title, 1100, 750, 0);
   while (egui.isOpen(win)) {
     if (!egui.pump(win)) break;

--- a/crates/rts-cli/tests/html_entry.rs
+++ b/crates/rts-cli/tests/html_entry.rs
@@ -64,9 +64,8 @@ fn compile_shell_embeds_the_html_escaped_the_title_and_the_frame_loop() {
         "pumpInputEvents(doc)",
         "pumpEventCallbacks(doc)",
         "pumpTimerCallbacks(doc)",
-        "runScriptsAt",
-        "loadResources",
-        "scripts da pagina corridos: ",
+        "loadDocumentFrom(html, scriptUrl, resourceBase)",
+        "pagina carregada: ",
     ] {
         assert!(program.contains(needle), "faltou `{needle}` no programa gerado:\n{program}");
     }

--- a/crates/rts-dom/src/lifecycle.ts
+++ b/crates/rts-dom/src/lifecycle.ts
@@ -173,11 +173,20 @@ function __dropLifecycle(h: i64): void {
 // `runScriptsAt`: a wrapper continua a existir para quem já a chama (browser,
 // apps) — só `loadDocument` precisa da bomba movida para depois do evento.
 function loadDocument(html: string, url: string): Document {
+  return loadDocumentFrom(html, url, url);
+}
+
+// Como `loadDocument`, com a base dos recursos separada da URL dos scripts:
+// um `.exe` de `rts compile pagina.html` resolve `<link>`/`<img>` relativos
+// contra a pasta do HTML na máquina do build, mas publica `window.location`
+// como a URL de página que os bundles esperam. `loadDocument(html, url)` é o
+// caso em que as duas coincidem (navegação).
+function loadDocumentFrom(html: string, url: string, resourceBase: string): Document {
   const doc = parseDocument(html);
   __setUrlOf(doc._dom, url);
   dom.setScriptingEnabled(doc._dom, 1);
   dom.setReadyState(doc._dom, "loading");
-  loadResources(doc, url);
+  loadResources(doc, resourceBase);
 
   const scriptCount = dom.getByTagCount(doc._dom, "script");
   let j = 0;

--- a/crates/rts-host/src/run.rs
+++ b/crates/rts-host/src/run.rs
@@ -645,6 +645,13 @@ fn uses_dom_facade(source: &str) -> bool {
         // programa que precisava daqueles nomes era o teste de paridade entre
         // o scanner em Rust e o seu oráculo `.ts`, que foi apagado com eles.
         || source.contains("runScripts")
+        // E a navegação da HTML spec (`loadDocument`/`loadDocumentFrom`,
+        // `crates/rts-dom/src/lifecycle.ts`): a casca que `rts run pagina.html`
+        // gera só nomeia esta — sem a linha o JIT morria em
+        // "loadDocumentFrom is not defined" enquanto o AOT, que anexa a fachada
+        // por outro caminho, corria (medido a 05/09 com a fixture
+        // `tests/aot/claude-pagina-entrada.html`).
+        || source.contains("loadDocument")
 }
 
 /// The same, for a compilation that must agree with a numbering that already


### PR DESCRIPTION
## O que muda

A casca que `rts compile pagina.html` / `rts run pagina.html` gera carrega a página por **`loadDocumentFrom(html, url, resourceBase)`** — a navegação da HTML spec que o lote `dom-ciclo-de-vida-scripts` (#2686) entregou: parse, recursos, os `<script>` do parse por ordem, `DOMContentLoaded`, `load`, e a partir daí um `<script>` anexado pela página corre sozinho. Fecha o `TODO(loadDocument)` deixado pelo #2684, que compunha `parseDocument`+`loadResources`+`runScriptsAt` à mão.

- `crates/rts-dom/src/lifecycle.ts`: `loadDocumentFrom` separa a base dos recursos (a pasta do HTML na máquina do build) da URL de página que os bundles leem em `window.location`; `loadDocument(html, url)` é o caso em que coincidem.
- `crates/rts-cli/src/cli/html_entry.rs`: a casca chama `loadDocumentFrom` e imprime `pagina carregada: <readyState>, scripts: <n>`; cabeçalho do módulo atualizado.
- `crates/rts-host/src/run.rs`: um programa que nomeia `loadDocument`/`loadDocumentFrom` recebe a fachada do DOM — sem isto o JIT de `rts run pagina.html` morria em `loadDocumentFrom is not defined` enquanto o AOT, que anexa a fachada por outro caminho, corria. Apanhado pela medição, não pela fixture.
- `crates/rts-cli/tests/html_entry.rs`: os needles seguem a casca nova.

## Medido no fecho (release)

| | resultado |
|---|---|
| `rts run tests/aot/claude-pagina-entrada.html` (JIT) | `pagina carregada: complete, scripts: 1` |
| `rts run scripts/rts_vs_electron/app/index.html` (JIT) | `pagina carregada: complete, scripts: 3` |
| `rts compile scripts/rts_vs_electron/app/index.html ReactApp` (AOT) | 3 scripts pré-compilados, `pagina carregada: complete, scripts: 3` |
| fixture `tests/dom/claude-pagina-eventos` em release | ordem do Edge byte a byte; `parseDocument` inerte |
| `rts compile tests/aot/claude-pagina-eval.ts` sem `.rtsdata` | `3` |
| `cargo test --release -p rts-cli --test html_entry` | 5 passed |
| `cargo test -p rts-dom-bridge`, `-p rts-dom --lib --features metrics` | 4, 967 |

Lição de instrumento: o `rts run` de uma página deixa o processo da janela vivo depois do `timeout`; o fecho mata-o pelo nome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc
