### PR TITLE
chore(dom): apaga os imports sem uso que os lotes de hoje deixaram

### DIFF
--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -78,7 +78,7 @@ use self::flex::layout_children_horizontal;
 use self::grid::layout_children_grid;
 use self::linha::layout_inline_flow;
 use self::quebra::wrap_runs;
-use self::runs::{InlineRun, collect_runs, inline_widget_size, pseudo_run};
+use self::runs::{InlineRun, collect_runs, pseudo_run};
 use self::segmento::{Segment, aplicar_elipse, collapse_ws, elipse_pedida, push_segment};
 mod coluna;
 mod coluna_rtl;
@@ -107,7 +107,6 @@ pub(crate) use self::fragmento::insert_item;
 use self::fragmento::{KeyBase, emit_fragment, layout_block_reusing};
 use self::vertical::layout_children_vertical;
 use self::linha_ib::layout_inline_block_line;
-use self::alinhamento_vertical::{envelope, topo_do_item};
 use self::relativo::aplica_offset_relativo;
 
 pub use self::display::{Corners, DisplayItem, DisplayList, Geometry, Rect, ScrollRegion};

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -18,8 +18,8 @@ pub(in crate::style::parse) use super::lengths::{
 pub(in crate::style::parse) use super::props::ComputedStyle;
 pub(in crate::style::parse) use super::stylesheet::DeclBlock;
 pub(in crate::style::parse) use super::values::{
-    AlignItems, BorderStyle, Dimension, DisplayKind, Edges, FlexDirection, FlexWrap, FloatSide,
-    JustifyContent, LineHeight, Position, Side, TextAlign, TextTransform, Visibility, WhiteSpace,
+    AlignItems, BorderStyle, Dimension, DisplayKind, FlexDirection, FlexWrap, FloatSide,
+    JustifyContent, LineHeight, Position, TextAlign, TextTransform, Visibility, WhiteSpace,
 };
 
 /// Parseia um `style="prop: valor; ..."` para um [`ComputedStyle`] (só a camada

--- a/crates/rts-dom/src/style/stylesheet/mod.rs
+++ b/crates/rts-dom/src/style/stylesheet/mod.rs
@@ -26,7 +26,6 @@
 //! `revert`, `revert-layer` (lote J — `stylesheet::revert`) e `!important` já
 //! atravessam o pipeline actual.
 
-pub(in crate::style::stylesheet) use super::parse::parse_inline_block;
 pub(in crate::style::stylesheet) use super::props::ComputedStyle;
 pub(in crate::style::stylesheet) use super::selector::{ComplexSelector, PseudoClass, Selector, compound_matches};
 


### PR DESCRIPTION
Só imports: `inline_widget_size`, `envelope`/`topo_do_item` (layout.rs), `Edges`/`Side` (style/parse/mod.rs), `parse_inline_block` (style/stylesheet/mod.rs). `cargo check -p rts-dom` sem avisos de import; ficam três avisos de lógica (`margin_right`, `css`, `cluster_w`) que não são imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fbbEdRXsxdiuqrFEppVxc