### PR TITLE
fix(ci): a acao de build constroi rts-runtime-jit (o archive que rts compile liga por omissao)

### DIFF
--- a/.github/actions/build-rts/action.yml
+++ b/.github/actions/build-rts/action.yml
@@ -28,16 +28,17 @@ runs:
         # Both runtime archives are built as DIRECT targets before the workspace
         # build, because cargo emits a `staticlib` only for a package it was asked
         # for by name — a plain `cargo build` produces the rlib and no archive.
-        # `rts-runtime` is the old engine's; `rts-runtime` is the new one's,
-        # and `rts compile` now links against it, so leaving it out made the AOT
-        # smoke test fail with "no rts_runtime.lib under target/{debug,release}".
+        # `rts-runtime` is the archive without a compiler; `rts-runtime-jit` is
+        # the one `rts compile` links BY DEFAULT since #2681, so leaving it out
+        # made every AOT smoke fail with "no rts_runtime_jit.lib under
+        # target/{debug,release,fast}" — which is what it did on ce1d8f069.
         if [ "${{ inputs.profile }}" = "release" ]; then
           cargo build --release -p rts-runtime
-          cargo build --release -p rts-runtime
+          cargo build --release -p rts-runtime-jit
           cargo build --release
         else
           cargo build -p rts-runtime
-          cargo build -p rts-runtime
+          cargo build -p rts-runtime-jit
           cargo build
         fi
 
@@ -49,14 +50,14 @@ runs:
         if ('${{ inputs.profile }}' -eq 'release') {
           cargo build --release -p rts-runtime
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          cargo build --release -p rts-runtime
+          cargo build --release -p rts-runtime-jit
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo build --release
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         } else {
           cargo build -p rts-runtime
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          cargo build -p rts-runtime
+          cargo build -p rts-runtime-jit
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo build
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/crates/rts-cli/src/cli/mod.rs
+++ b/crates/rts-cli/src/cli/mod.rs
@@ -91,11 +91,20 @@ pub(crate) fn runtime_archive(embed_compiler: bool) -> Result<PathBuf> {
     if let Ok(path) = std::env::var("RTS_RUNTIME_RWK_ARCHIVE") {
         return Ok(PathBuf::from(path));
     }
-    let file_name = if embed_compiler {
-        "rts_runtime_jit.lib"
+    // O nome do `staticlib` é da PLATAFORMA, não uma constante: cargo escreve
+    // `rts_runtime_jit.lib` no Windows e `librts_runtime_jit.a` em todo o
+    // resto. Estavam aqui as duas strings do Windows, e o erro não aparecia
+    // porque o caminho SEM compilador tem um fallback embutido que respondia
+    // por ele — só `--embed-compiler`, que deliberadamente não tem fallback,
+    // é que ficava sem archive. Desde #2681 esse é o caminho por omissão, e o
+    // CI passou a falhar em Linux e macOS enquanto o Windows continuava verde.
+    let stem = if embed_compiler { "rts_runtime_jit" } else { "rts_runtime" };
+    let file_name = if cfg!(target_os = "windows") {
+        format!("{stem}.lib")
     } else {
-        "rts_runtime.lib"
+        format!("lib{stem}.a")
     };
+    let file_name = file_name.as_str();
     let workspace = std::env::current_dir().unwrap_or_default();
     // The profile the RUNNING `rts` was built under comes first, and it is what
     // this used to have no way of naming: the list was `["release", "debug"]`,


### PR DESCRIPTION
Os tres jobs `build` do workflow *Build Artifacts* estao vermelhos desde #2691 (`ce1d8f069`), nas tres plataformas, com a mesma linha:

```
error: no `rts_runtime_jit.lib` under target/{debug,release,fast} nor beside this binary
```

Causa: `.github/actions/build-rts/action.yml` diz "both archives are built as DIRECT targets" e nomeia **`rts-runtime` nas duas linhas**. Cargo so emite um `staticlib` para um pacote pedido pelo nome, por isso `rts-runtime-jit` nunca teve archive — e desde #2681 `rts compile` sem flag liga esse. O primeiro smoke de AOT e bloqueante, logo o unico sinal que gate este repo estava a falhar.

Rejeitado: passar `--sem-compilador` aos smokes — poria o CI a testar um caminho que ja nao e o default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x