### PR TITLE
feat(scripts): --filtro no corredor de reftests do WPT

### DIFF
--- a/scripts/wpt_reftests.md
+++ b/scripts/wpt_reftests.md
@@ -17,6 +17,7 @@ cd $TEMP/wpt && git sparse-checkout set css/css-flexbox css/CSS2/floats css/css-
 cargo build --release -p rts-dom --example claude-raster
 bun scripts/wpt_reftests.mjs $TEMP/wpt/css/css-flexbox            # todos
 bun scripts/wpt_reftests.mjs $TEMP/wpt/css/css-flexbox --max 300  # os primeiros N, por ordem de nome
+bun scripts/wpt_reftests.mjs $TEMP/wpt/css/css-flexbox --filtro 'writing-mode'  # só os que casam, para ITERAR
 ```
 
 Saída: `passam/total`, os 15 piores por percentagem de pixels diferentes, e
@@ -36,6 +37,11 @@ shrink 27, writing-mode 21, wrap 19, justify 16, baseline 12. **Corre no CI**
 várias linhas (`flexbox-baseline-multi-line-horiz-003/004`, 36 %), tamanhos
 definidos (`flexbox-definite-sizes-005`, 30 %), `writing-mode` vertical
 (que este motor não tem) e os testes com `<script>` (corridos sem JS).
+
+`--filtro <regex>` corre só os reftests cujo NOME casa — serve para iterar num
+lote sem esperar pelos 489. O número que sai dele é PARCIAL e a saída diz-o:
+não se compara com `.github/wpt_report.json`, cujo denominador é a pasta
+inteira. O número do lote mede-se sempre sem filtro.
 
 ## O que este número NÃO é
 

--- a/scripts/wpt_reftests.mjs
+++ b/scripts/wpt_reftests.mjs
@@ -6,7 +6,7 @@
 // o `wptrunner` avalia um reftest.
 //
 //   cargo build --release -p rts-dom --example claude-raster
-//   bun scripts/wpt_reftests.mjs <pasta-do-wpt>/css/css-flexbox [--tol 8] [--max N] [--out dir]
+//   bun scripts/wpt_reftests.mjs <pasta-do-wpt>/css/css-flexbox [--tol 8] [--max N] [--out dir] [--filtro regex]
 //
 // O que este número NÃO é: a régua de Blink. Um reftest que passa aqui diz "o
 // motor é coerente consigo próprio nestes dois documentos"; um que falha diz
@@ -26,6 +26,11 @@ if (!pasta) { console.error("uso: bun scripts/wpt_reftests.mjs <pasta> [--tol 8]
 const opt = (n, d) => { const i = args.indexOf("--" + n); return i >= 0 ? args[i + 1] : d; };
 const TOL = Number(opt("tol", "8"));
 const MAX = Number(opt("max", "0"));
+// `--filtro` é para ITERAR num lote, nunca para produzir o número: a saída
+// diz-o na primeira linha, e um relatório filtrado não é comparável com o
+// `.github/wpt_report.json` do main (denominador diferente — a armadilha que
+// o honesty floor chama "verify the input"). Sem filtro, nada muda.
+const FILTRO = opt("filtro", "") ? new RegExp(opt("filtro", ""), "i") : null;
 const OUT = resolve(opt("out", join(process.env.TEMP ?? ".", "wpt-reftests")));
 const RASTER = ["target/release/examples/claude-raster.exe", "target/release/examples/claude-raster"].find(existsSync);
 if (!RASTER) { console.error("construa o rasterizador: cargo build --release -p rts-dom --example claude-raster"); process.exit(2); }
@@ -75,7 +80,9 @@ for (const f of html) {
   if (!existsSync(ref)) continue;
   testes.push({ teste: join(pasta, f), ref, script: /<script/i.test(src) });
 }
-const lista = MAX > 0 ? testes.slice(0, MAX) : testes;
+const filtrados = FILTRO ? testes.filter((t) => FILTRO.test(basename(t.teste))) : testes;
+const lista = MAX > 0 ? filtrados.slice(0, MAX) : filtrados;
+if (FILTRO) console.log(`--filtro ${FILTRO.source}: ${lista.length} de ${testes.length} — número PARCIAL, não comparável com o relatório do main`);
 console.log(`${pasta}: ${html.length} html, ${testes.length} reftests (rel=match com referência existente), ${lista.filter((t) => t.script).length} com <script>`);
 
 function rasterizar(htmlPath, png) {


### PR DESCRIPTION
Correr os 489 reftests para ver se dois mudaram custa a varredura inteira. `--filtro <regex>` corre so os que casam pelo nome — serve para ITERAR num lote.

O risco e o denominador: um relatorio filtrado nao e comparavel com `.github/wpt_report.json`. A saida imprime `numero PARCIAL, nao comparavel` e o `.md` diz que o numero do lote se mede sempre sem filtro. Sem `--filtro`, nada muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x