### PR TITLE
fix(dom): overflow:hidden/clip num flex-wrap nao alarga o ponto de quebra (lote flex-scroll-overflow)

### DIFF
--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -125,7 +125,7 @@ use self::caixa::{css_display, em_contexto_inline, is_block_level, is_inline_blo
 use self::float::{banda_livre, fecha_a_corrida, float_of};
 use self::input::{layout_button, layout_input, medida_do_input};
 use self::itens::{translate_item, walk_items};
-use self::medida::{child_outer_height, child_outer_width, collect_text, content_natural_width, intrinsic_content_width};
+use self::medida::{child_outer_height, child_outer_width, collect_text, content_natural_width};
 use self::pintura::{apply_opacity, body_background, cor_visivel, decoration_code, deve_suprimir_fundo, is_text_input_tag, italico, tag_de};
 use self::posicionado::{collect_out_of_flow, e_display_none, layout_out_of_flow, resolve_height};
 use self::replaced::{layout_canvas, layout_image, layout_svg_placeholder};

--- a/crates/rts-dom/src/layout/bloco.rs
+++ b/crates/rts-dom/src/layout/bloco.rs
@@ -625,22 +625,14 @@ pub(crate) fn layout_block(
     };
     let ov_x = visible_vira_auto(ov_x_declarado);
     let ov_y = visible_vira_auto(ov_y_declarado);
-    let scrolls_x = ov_x.scrollable() || ov_x.clips();
-    // A inflação vale para o eixo do FLUXO HORIZONTAL, que é onde a compressão
-    // aconteceria (o flex encolhe os itens até caberem). Nos demais layouts ela
-    // vira base de PORCENTAGEM dos filhos, e aí está errada: `width:100%` dentro
-    // de um container que rola é 100% da CAIXA, não do conteúdo transbordado.
-    //
-    // Medido na página real do WhatsApp Web, que aninha vários containers com
-    // `overflow-y:auto`: cada nível multiplicava a largura do seguinte, e o
-    // conteúdo terminava em x = 2300 numa janela de 1100 — a tela abria vazia
-    // com tudo desenhado fora dela.
-    let scroll_children_w = if scrolls_x {
-        // largura que o conteúdo QUER (sem comprimir) — pode exceder content_w.
-        intrinsic_content_width(dom, id, font_size, ctx).max(content_w)
-    } else {
-        content_w
-    };
+    // `scroll_children_width` (overflow_viewport.rs, tecto): decide se os
+    // filhos recebem a largura NATURAL (sem comprimir — #1744) e se isso
+    // ainda vale quando `flex-wrap:wrap` precisa de saber ONDE quebrar linha
+    // (`flexbox-overflow-horiz-004`/`-005` do WPT — `overflow:hidden` não
+    // rola, então não há "deixar transbordar" para ele: a linha quebra na
+    // largura declarada e o excesso é só recortado na pintura).
+    let scroll_children_w =
+        overflow_viewport::scroll_children_width(dom, id, font_size, ctx, display, ov_x, content_w);
     let children_w = content_w;
 
     // `height` EXPLÍCITO resolve ANTES dos filhos (não depende deles): eles o

--- a/crates/rts-dom/src/layout/overflow_viewport.rs
+++ b/crates/rts-dom/src/layout/overflow_viewport.rs
@@ -19,6 +19,44 @@
 
 use super::*;
 
+/// A largura que os filhos de um flex-row/wrap recebem quando `overflow_x`
+/// não é `visible` — parte de `bloco.rs::layout_children` (movida para aqui
+/// por já estar no teto de 500/1000 linhas, RULE de tecto do `CLAUDE.md`).
+///
+/// Duas perguntas distintas partilhavam uma variável só (`scrolls_x`, #1744):
+/// "os filhos podem transbordar sem SER COMPRIMIDOS" (a resposta é sim para
+/// `auto`/`scroll` — rolam de verdade — E para `hidden`/`clip`, que também
+/// não devem cortar um item ao MEIO só porque escondem o excesso), e "onde é
+/// que uma linha de `flex-wrap:wrap` QUEBRA" — que é uma pergunta SÓ de
+/// `auto`/`scroll`: um scroll container real tem sentido "não quebrar, deixar
+/// rolar"; um `overflow:hidden`/`clip` não rola NUNCA (`Overflow::clips()`),
+/// então não há para onde "rolar" o excesso — a linha quebra na largura
+/// DECLARADA como sempre quebraria, e o que sobra do último item é só
+/// CORTADO na pintura. Fundir as duas perguntas fazia um `flex-wrap:wrap`
+/// com `overflow:hidden` e um item que não encolhe (`flex-shrink:0`) parar de
+/// quebrar linha (a largura "inflada" pela intrínseca cabia tudo numa só),
+/// que é o oposto do WPT `flexbox-overflow-horiz-004`/`-005` (o `align-content`
+/// da segunda linha, com container `wrap` mas UMA linha só, saía sem
+/// distribuição nenhuma — os itens colavam ao topo em vez do `space-around`
+/// das duas linhas que a referência espera).
+pub(in crate::layout) fn scroll_children_width(
+    dom: &Dom,
+    id: NodeIdx,
+    font_size: f32,
+    ctx: &LayoutCtx,
+    display: i64,
+    ov_x: crate::scrollbar::Overflow,
+    content_w: f32,
+) -> f32 {
+    let quebra_livre = display == crate::block::DISPLAY_WRAP && !ov_x.scrollable();
+    let nao_comprime = ov_x.scrollable() || ov_x.clips();
+    if nao_comprime && !quebra_livre {
+        super::medida::intrinsic_content_width(dom, id, font_size, ctx).max(content_w)
+    } else {
+        content_w
+    }
+}
+
 /// `true` quando o `overflow` de `id` (já sabido ≠ `visible`, é só essa
 /// pergunta que interessa aqui) PROPAGOU para a viewport em vez de contar
 /// para o próprio `<body>` — ou seja, quando `overflow_bfc` deve ser

--- a/crates/rts-dom/src/layout/tests/flex_scroll_overflow_corpus.rs
+++ b/crates/rts-dom/src/layout/tests/flex_scroll_overflow_corpus.rs
@@ -1,0 +1,84 @@
+//! Lote `flex-scroll-overflow`: `overflow:hidden`/`clip` num `flex-wrap:wrap`
+//! não deve mudar ONDE a linha quebra — só CORTA visualmente o que
+//! transborda depois (WPT `flexbox-overflow-horiz-004`/`-005`). A largura
+//! "não comprimida" que o container ganha quando `overflow_x` não é
+//! `visible` (#1744, `WhatsApp`) continua a valer para o orçamento de
+//! grow/shrink; o que muda é que ela NUNCA decide o ponto de quebra de uma
+//! linha `wrap` quando o eixo não é genuinamente rolável (`auto`/`scroll`) —
+//! `overflow_viewport::scroll_children_width` é o ponto único da distinção.
+
+use crate::table::tests::{geometria, rect};
+
+/// Duas linhas (não uma) num `flex-wrap:wrap` com `overflow:hidden` e um
+/// item que não encolhe: a largura intrínseca (sem comprimir) do item maior
+/// não deve alargar o ponto de quebra além da largura DECLARADA do
+/// container — `hidden` não rola, não há "deixar transbordar" que valha a
+/// pena aqui, e a segunda linha (o `smallItem`) precisa existir para o
+/// `align-content` ter DUAS linhas para distribuir.
+#[test]
+fn overflow_hidden_em_wrap_nao_alarga_o_ponto_de_quebra() {
+    const HTML: &str = r#"<style>
+  .c {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: hidden;
+    width: 70px;
+    height: 70px;
+  }
+  .big { width: 72px; height: 20px; flex: none; }
+  .small { width: 20px; height: 20px; }
+</style>
+<div class="c">
+  <div class="big" id="big"></div>
+  <div class="small" id="small"></div>
+</div>"#;
+    let (dom, list) = geometria(HTML, 200.0);
+    let big = rect(&dom, &list, "#big", 0);
+    let small = rect(&dom, &list, "#small", 0);
+    // Duas linhas: o `small` fica ABAIXO do `big`, não ao lado — se o
+    // ponto de quebra tivesse sido alargado pela largura intrínseca
+    // (72+20=92 > 70), as duas caberiam numa só linha e `small.y` seria
+    // igual a `big.y` (o defeito que este teste fixa: era exatamente isso).
+    assert!(
+        small.y > big.y,
+        "o item pequeno devia estar numa 2ª linha, abaixo do grande (y={} vs y={}) — \
+         indica que o wrap não quebrou na largura declarada",
+        small.y, big.y,
+    );
+}
+
+/// O mesmo HTML, mas com `overflow` NÃO declarado (`visible`): o
+/// comportamento de quebra tem de ser IDÊNTICO ao de cima — `overflow`
+/// nunca decide layout, só pintura (CSS 2.1 §11.1.1) — e é essa igualdade
+/// que o WPT mede por auto-consistência (reftest `hidden` vs uma referência
+/// cujo único objetivo é imitar o `visible`).
+#[test]
+fn overflow_visible_e_hidden_quebram_a_mesma_linha() {
+    let render = |overflow: &str| {
+        let html = format!(
+            r#"<style>
+  .c {{
+    display: flex;
+    flex-wrap: wrap;
+    {overflow}
+    width: 70px;
+    height: 70px;
+  }}
+  .big {{ width: 72px; height: 20px; flex: none; }}
+  .small {{ width: 20px; height: 20px; }}
+</style>
+<div class="c">
+  <div class="big" id="big"></div>
+  <div class="small" id="small"></div>
+</div>"#
+        );
+        let (dom, list) = geometria(&html, 200.0);
+        let big = rect(&dom, &list, "#big", 0);
+        let small = rect(&dom, &list, "#small", 0);
+        (big.y, small.y)
+    };
+    let (big_y_visible, small_y_visible) = render("");
+    let (big_y_hidden, small_y_hidden) = render("overflow: hidden;");
+    assert_eq!(big_y_visible, big_y_hidden);
+    assert_eq!(small_y_visible, small_y_hidden);
+}

--- a/crates/rts-dom/src/layout/tests/mod.rs
+++ b/crates/rts-dom/src/layout/tests/mod.rs
@@ -62,6 +62,7 @@ mod flex_reverse_order_corpus;
 mod flex_gap_2_corpus;
 mod aspect_ratio_replaced_corpus;
 mod posicao_estatica_corpus;
+mod flex_scroll_overflow_corpus;
     use super::*;
     use crate::dom::parse_html_to_dom;
 


### PR DESCRIPTION
`overflow:hidden`/`clip` num `flex-wrap:wrap` usava a largura INTRINSECA (a regra do #1744, escrita para scroll containers reais) tambem para decidir ONDE a linha quebra. Mas `hidden`/`clip` nunca rolam: nao ha "deixar transbordar" que valha a pena, e a linha deve quebrar na largura declarada, cortando so na pintura.

As duas perguntas — "que largura os filhos veem" e "onde quebra a linha" — passam a estar separadas em `layout/overflow_viewport.rs` (modulo novo). `bloco.rs` ENCOLHEU 1264 -> 1256 linhas: a logica saiu de la em vez de lhe ser acrescentada, que e o que o teto de 500 manda fazer a um ficheiro ja muito acima dele.

## Regua, medida por mim e nao aceite do relatorio

`css/css-flexbox`, corredor recursivo, corpus completo de 870 reftests:

| | |
|---|---|
| main `ce1d8f069` | 475/870 |
| este lote | **477/870** |

GANHOS: `flexbox-overflow-horiz-004`, `flexbox-overflow-horiz-005`.
PERDIDOS: **nenhum**, comparado por NOME e nao pelo numero liquido.
`flex-aspect-ratio-img-column-008` nao rasteriza — nas duas medicoes, e portanto pre-existente.

`cargo test -p rts-dom --lib --features metrics`: 1007 passed, 0 failed (2 novos, que nomeiam o comportamento que fixam: "duas linhas quando hidden alargaria o ponto de quebra" e "visible/hidden quebram a mesma linha").

## Fora de ambito, com prova

Dos 12 reftests do balde, 10 ficam, e cada um com a razao: 5 sao a familia `visibility:collapse` que o Chrome real nao implementa (ja medido no lote #2674, e a regua e o Chrome); 2 pedem uma scrollbar classica a ocupar espaco de layout, que e arquitetura por fazer e ja documentada; 1 so e decidivel com `&lt;script&gt;`, que o rasterizador nao corre; 1 pede o prefixo `safe`/`unsafe` do CSS Align 3, inexistente no motor; 1 e um residual de 0,10% noutro eixo, nao perseguido.

## Nota sobre o denominador

Os 870 nao sao os 489 de ontem com mais testes: sao os mesmos 489 mais 381 que estavam a ser descartados em silencio porque o checkout esparso nao trazia as pastas de referencia que eles apontam. O numero antigo (393/489) e este nao sao comparaveis por percentagem, so por nome — e por nome esta comparacao esta feita acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x