### PR TITLE
fix(reguas): o corredor apaga o PNG de quem passa e repete em serie quem nao rasterizou

### DIFF
--- a/scripts/wpt_css_todas.mjs
+++ b/scripts/wpt_css_todas.mjs
@@ -16,7 +16,7 @@
 // nada sobre o motor, e uma pasta que ele faz bem sobe-o do mesmo modo. A
 // tabela por pasta é o número; o total é a soma dela.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const args = process.argv.slice(2);
@@ -57,6 +57,11 @@ for (const nome of pastas) {
   const rel = join(saida, "relatorio.json");
   if (!existsSync(rel)) { linhas.push({ nome, passam: null, total: null, erro: "sem relatorio.json" }); continue; }
   const r = JSON.parse(readFileSync(rel, "utf8"));
+  // O `relatorio.json` e lido AQUI e os PNG dessa pasta deixam de ser precisos:
+  // a varredura larga quer o numero, e quem for investigar uma falha corre essa
+  // pasta sozinha. Guardados, o `css` inteiro deixou 103 GB numa so pasta e
+  // encheu o disco desta maquina a meio de uma medicao (2026-09-05).
+  for (const f of readdirSync(saida)) if (f.endsWith(".png") || f.endsWith(".mask.json")) rmSync(join(saida, f), { force: true });
   tp += r.passam; tf += r.falham; te += r.erros;
   const pct = r.total > 0 ? (r.passam / r.total) * 100 : 0;
   linhas.push({ nome, passam: r.passam, total: r.total, erros: r.erros, pct });

--- a/scripts/wpt_reftests.mjs
+++ b/scripts/wpt_reftests.mjs
@@ -6,7 +6,8 @@
 // o `wptrunner` avalia um reftest.
 //
 //   cargo build --release -p rts-dom --example claude-raster
-//   bun scripts/wpt_reftests.mjs <pasta-do-wpt>/css/css-flexbox [--tol 8] [--max N] [--out dir] [--filtro regex]
+//   bun scripts/wpt_reftests.mjs <pasta-do-wpt>/css/css-flexbox [--tol 8] [--max N] [--out dir]
+//                                 [--filtro regex] [--esperado N] [--pares match|sufixo] [--sem-png]
 //
 // O que este número NÃO é: a régua de Blink. Um reftest que passa aqui diz "o
 // motor é coerente consigo próprio nestes dois documentos"; um que falha diz
@@ -16,7 +17,7 @@
 // `rel="mismatch"` fica de fora; testes com `<script>` são corridos SEM JS
 // (o rasterizador não tem motor), e é dito na saída quantos são.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, relative, resolve, join } from "node:path";
 import { inflateSync } from "node:zlib";
 
@@ -43,7 +44,15 @@ if (!["match", "sufixo"].includes(PARES)) { console.error(`--pares ${PARES}: use
 const OUT = resolve(opt("out", join(process.env.TEMP ?? ".", "wpt-reftests")));
 const RASTER = ["target/release/examples/claude-raster.exe", "target/release/examples/claude-raster"].find(existsSync);
 if (!RASTER) { console.error("construa o rasterizador: cargo build --release -p rts-dom --example claude-raster"); process.exit(2); }
+// A pasta de saida e LIMPA no arranque. Sem isto ela acumula os PNG de todas as
+// corridas anteriores — e como o nome de um teste e estavel, uma falha antiga
+// que ja foi corrigida fica la a parecer actual. Uma medicao nova comeca vazia.
+if (existsSync(OUT)) rmSync(OUT, { recursive: true, force: true });
 mkdirSync(OUT, { recursive: true });
+// `--sem-png` nao guarda imagem nenhuma, nem das falhas. Para uma varredura
+// larga (o `css` inteiro sao 24 104 reftests) em que so interessa o numero;
+// para investigar uma falha, corre-se so essa pasta sem a flag.
+const SEM_PNG = args.includes("--sem-png");
 
 // --- PNG mínimo (o mesmo de css_pintura_comparar.mjs: inflate + os 5 filtros)
 function decodePng(buf) {
@@ -158,15 +167,21 @@ const paraRepetir = [];
 // (24 104 reftests) deixa ~50 mil imagens — 103 GB numa pasta so, medido em
 // 2026-09-05 depois de encher o disco desta maquina. Os das FALHAS ficam, que e
 // para o que servem: olhar para o que divergiu.
+// Cada PNG traz um `.mask.json` ao lado (o raster escreve-o para dizer o que
+// mascarou); apagar so o PNG deixava metade dos ficheiros para tras.
+function apaga(...paths) {
+  for (const f of paths) { try { unlinkSync(f); } catch {} try { unlinkSync(f + ".mask.json"); } catch {} }
+}
 function julga(t, nome, a, b) {
   const d = diff(decodePng(readFileSync(a)), decodePng(readFileSync(b)));
   if (d.n === 0) {
     passam++; resultados.push({ nome, estado: "passa" });
-    try { unlinkSync(a); unlinkSync(b); } catch {}
+    apaga(a, b);
   } else {
     falham++;
     piores.push({ nome, pct: d.pct, n: d.n, script: t.script });
     resultados.push({ nome, estado: "falha", pct: d.pct });
+    if (SEM_PNG) apaga(a, b);
   }
 }
 for (const t of lista) {

--- a/scripts/wpt_reftests.mjs
+++ b/scripts/wpt_reftests.mjs
@@ -16,7 +16,7 @@
 // `rel="mismatch"` fica de fora; testes com `<script>` são corridos SEM JS
 // (o rasterizador não tem motor), e é dito na saída quantos são.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, relative, resolve, join } from "node:path";
 import { inflateSync } from "node:zlib";
 
@@ -152,6 +152,23 @@ function rasterizar(htmlPath, png) {
 // razao pela qual `nao_rasterizaram` existe a parte — os tres conjuntos
 // juntos sao a medicao inteira; qualquer um sozinho e uma vista dela.
 let passam = 0, falham = 0, erros = 0; const piores = []; const nao_rasterizaram = []; const resultados = [];
+const paraRepetir = [];
+// Os PNG de um teste que PASSA sao apagados: sao dois ficheiros identicos que
+// ninguem vai abrir, e sao a maioria. Guardados, uma varredura do `css` inteiro
+// (24 104 reftests) deixa ~50 mil imagens — 103 GB numa pasta so, medido em
+// 2026-09-05 depois de encher o disco desta maquina. Os das FALHAS ficam, que e
+// para o que servem: olhar para o que divergiu.
+function julga(t, nome, a, b) {
+  const d = diff(decodePng(readFileSync(a)), decodePng(readFileSync(b)));
+  if (d.n === 0) {
+    passam++; resultados.push({ nome, estado: "passa" });
+    try { unlinkSync(a); unlinkSync(b); } catch {}
+  } else {
+    falham++;
+    piores.push({ nome, pct: d.pct, n: d.n, script: t.script });
+    resultados.push({ nome, estado: "falha", pct: d.pct });
+  }
+}
 for (const t of lista) {
   // O nome é RELATIVO à pasta, não o `basename`: com a varredura recursiva
   // dois testes de subpastas diferentes podem partilhar o basename, e o nome
@@ -164,10 +181,24 @@ for (const t of lista) {
   // existem — o raster falharia a escrever e o teste contaria como erro.
   const plano = nome.split("/").join("__");
   const a = join(OUT, plano + ".teste.png"), b = join(OUT, plano + ".ref.png");
-  if (!rasterizar(t.teste, a) || !rasterizar(t.ref, b)) { erros++; nao_rasterizaram.push(nome); resultados.push({ nome, estado: "erro" }); continue; }
-  const d = diff(decodePng(readFileSync(a)), decodePng(readFileSync(b)));
-  if (d.n === 0) { passam++; resultados.push({ nome, estado: "passa" }); }
-  else { falham++; piores.push({ nome, pct: d.pct, n: d.n, script: t.script }); resultados.push({ nome, estado: "falha", pct: d.pct }); }
+  if (!rasterizar(t.teste, a) || !rasterizar(t.ref, b)) { paraRepetir.push({ t, nome, a, b }); continue; }
+  julga(t, nome, a, b);
+}
+
+// Segunda passagem, EM SERIE e ja sem o resto da varredura a competir. O
+// timeout do raster mede tempo de RELOGIO, portanto uma maquina ocupada empurra
+// um teste lento para la dele e ele conta como erro — e um erro nao e um
+// resultado ausente, e o pior resultado, por isso mentia para baixo. Numa
+// medicao feita ao lado de outras tres, 310 dos 870 "nao rasterizaram" e o
+// total saiu 380 em vez de 586; os mesmos ficheiros passavam sozinhos. A
+// repeticao distingue as duas coisas: carga passa, encravamento real repete.
+if (paraRepetir.length > 0) {
+  console.log(`\n${paraRepetir.length} nao rasterizaram a primeira vez — a repetir em serie`);
+  for (const { t, nome, a, b } of paraRepetir) {
+    if (!rasterizar(t.teste, a) || !rasterizar(t.ref, b)) {
+      erros++; nao_rasterizaram.push(nome); resultados.push({ nome, estado: "erro" });
+    } else julga(t, nome, a, b);
+  }
 }
 piores.sort((x, y) => y.pct - x.pct);
 const total = passam + falham + erros;

--- a/scripts/wpt_reftests.mjs
+++ b/scripts/wpt_reftests.mjs
@@ -16,9 +16,10 @@
 // referência troca texto por caixas pode falhar por fonte e não por layout;
 // `rel="mismatch"` fica de fora; testes com `<script>` são corridos SEM JS
 // (o rasterizador não tem motor), e é dito na saída quantos são.
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, relative, resolve, join } from "node:path";
+import { availableParallelism } from "node:os";
 import { inflateSync } from "node:zlib";
 
 const args = process.argv.slice(2);
@@ -147,8 +148,7 @@ if (FILTRO) console.log(`--filtro ${FILTRO.source}: ${lista.length} de ${testes.
 console.log(`${pasta}: ${html.length} html, ${testes.length} reftests (pares por ${PARES === "sufixo" ? "-expected.html" : "rel=match"}), ${lista.filter((t) => t.script).length} com <script>`);
 
 function rasterizar(htmlPath, png) {
-  try { execFileSync(RASTER, [htmlPath, png], { stdio: ["ignore", "ignore", "pipe"], timeout: 20000 }); return true; }
-  catch { return false; }
+  return new Promise((res) => execFile(RASTER, [htmlPath, png], { timeout: 20000 }, (err) => res(!err)));
 }
 // `nao_rasterizaram` guarda os NOMES: um teste que ENCRAVA (timeout do raster)
 // não entra em `piores`, e uma comparação por nome entre dois relatórios
@@ -162,6 +162,24 @@ function rasterizar(htmlPath, png) {
 // juntos sao a medicao inteira; qualquer um sozinho e uma vista dela.
 let passam = 0, falham = 0, erros = 0; const piores = []; const nao_rasterizaram = []; const resultados = [];
 const paraRepetir = [];
+const guardadas = [];
+// So as PIORES falhas ficam em imagem: ninguem abre 283 pares de PNG, abre-se
+// meia duzia — os que mais divergem.
+const PNG_TOP = Number(opt("png-top", "20"));
+// N rasterizacoes em voo, e nao uma de cada vez. Cada uma custa ~90 ms de
+// trabalho (medido) num processo proprio, portanto o corredor passava quase
+// todo o tempo a espera de um unico CPU de dezasseis. METADE das threads do
+// sistema, com tecto de 8: o timeout do raster mede tempo de RELOGIO, e saturar
+// a maquina empurra testes lentos para la dele — foi assim que uma medicao deu
+// 310 erros em 870. A rede que torna isto seguro e a segunda passagem EM SERIE,
+// que distingue "estava lento" de "encravou".
+const JOBS = Math.max(1, Number(opt("jobs", String(Math.min(8, Math.max(2, Math.floor((availableParallelism?.() ?? 4) / 2)))))));
+async function paraCada(itens, n, fn) {
+  let i = 0;
+  await Promise.all(Array.from({ length: Math.min(n, itens.length) }, async () => {
+    for (;;) { const k = i++; if (k >= itens.length) return; await fn(itens[k]); }
+  }));
+}
 // Os PNG de um teste que PASSA sao apagados: sao dois ficheiros identicos que
 // ninguem vai abrir, e sao a maioria. Guardados, uma varredura do `css` inteiro
 // (24 104 reftests) deixa ~50 mil imagens — 103 GB numa pasta so, medido em
@@ -173,7 +191,23 @@ function apaga(...paths) {
   for (const f of paths) { try { unlinkSync(f); } catch {} try { unlinkSync(f + ".mask.json"); } catch {} }
 }
 function julga(t, nome, a, b) {
-  const d = diff(decodePng(readFileSync(a)), decodePng(readFileSync(b)));
+  // ATALHO: dois PNG identicos byte a byte sao a mesma imagem, e nao ha nada a
+  // descodificar. E o caso da MAIORIA — um reftest que passa produz exactamente
+  // os mesmos bytes dos dois lados — e `decodePng` custa 23 ms medidos (inflate
+  // mais o filtro Paeth, em JavaScript, a bloquear o thread principal) contra
+  // 0 ms de `Buffer.equals`. Sem isto o comparador era o gargalo do corredor:
+  // 46 ms de JS por teste contra 17 ms de rasterizacao em paralelo.
+  //
+  // So vale como atalho para IGUAIS. Bytes diferentes nao provam pixels
+  // diferentes (o mesmo raster podia comprimir de duas maneiras), por isso o
+  // ramo do else desce ao diff verdadeiro, com a tolerancia por canal.
+  const bytesA = readFileSync(a), bytesB = readFileSync(b);
+  if (bytesA.equals(bytesB)) {
+    passam++; resultados.push({ nome, estado: "passa" });
+    apaga(a, b);
+    return;
+  }
+  const d = diff(decodePng(bytesA), decodePng(bytesB));
   if (d.n === 0) {
     passam++; resultados.push({ nome, estado: "passa" });
     apaga(a, b);
@@ -181,10 +215,10 @@ function julga(t, nome, a, b) {
     falham++;
     piores.push({ nome, pct: d.pct, n: d.n, script: t.script });
     resultados.push({ nome, estado: "falha", pct: d.pct });
-    if (SEM_PNG) apaga(a, b);
+    if (SEM_PNG) apaga(a, b); else guardadas.push({ pct: d.pct, a, b });
   }
 }
-for (const t of lista) {
+await paraCada(lista, JOBS, async (t) => {
   // O nome é RELATIVO à pasta, não o `basename`: com a varredura recursiva
   // dois testes de subpastas diferentes podem partilhar o basename, e o nome
   // é a chave da comparação "que reftests perdi" entre dois relatórios —
@@ -196,9 +230,10 @@ for (const t of lista) {
   // existem — o raster falharia a escrever e o teste contaria como erro.
   const plano = nome.split("/").join("__");
   const a = join(OUT, plano + ".teste.png"), b = join(OUT, plano + ".ref.png");
-  if (!rasterizar(t.teste, a) || !rasterizar(t.ref, b)) { paraRepetir.push({ t, nome, a, b }); continue; }
+  const [okA, okB] = await Promise.all([rasterizar(t.teste, a), rasterizar(t.ref, b)]);
+  if (!okA || !okB) { paraRepetir.push({ t, nome, a, b }); return; }
   julga(t, nome, a, b);
-}
+});
 
 // Segunda passagem, EM SERIE e ja sem o resto da varredura a competir. O
 // timeout do raster mede tempo de RELOGIO, portanto uma maquina ocupada empurra
@@ -210,12 +245,18 @@ for (const t of lista) {
 if (paraRepetir.length > 0) {
   console.log(`\n${paraRepetir.length} nao rasterizaram a primeira vez — a repetir em serie`);
   for (const { t, nome, a, b } of paraRepetir) {
-    if (!rasterizar(t.teste, a) || !rasterizar(t.ref, b)) {
+    const okA = await rasterizar(t.teste, a), okB = await rasterizar(t.ref, b);
+    if (!okA || !okB) {
       erros++; nao_rasterizaram.push(nome); resultados.push({ nome, estado: "erro" });
     } else julga(t, nome, a, b);
   }
 }
 piores.sort((x, y) => y.pct - x.pct);
+if (!SEM_PNG) {
+  guardadas.sort((x, y) => y.pct - x.pct);
+  for (const g of guardadas.slice(PNG_TOP)) apaga(g.a, g.b);
+  if (guardadas.length > PNG_TOP) console.log(`imagens: as ${PNG_TOP} piores de ${guardadas.length} falhas (--png-top N para mais, --sem-png para nenhuma)`);
+}
 const total = passam + falham + erros;
 console.log(`\nWPT reftests — ${passam}/${total} passam (${((passam / Math.max(total, 1)) * 100).toFixed(1)}%), ${falham} falham, ${erros} não rasterizaram; tolerância ${TOL}/255 por canal`);
 console.log(`\nos 15 piores:`);


### PR DESCRIPTION
Duas correcções ao mesmo instrumento, ambas apanhadas por ele me ter mentido hoje.

## Os PNG de um teste que passa são apagados

São dois ficheiros idênticos que ninguém vai abrir, e são a maioria. Guardados, uma varredura do `css` inteiro (24 104 reftests) deixa ~50 mil imagens: `wpt-css-final` media **103 GB numa pasta só**, e o disco desta máquina encheu a 100 % no meio de uma medição — a partir daí nenhum comando corria, porque cada um precisa de escrever o seu próprio ficheiro de saída.

Os PNG das **falhas** ficam, que é para o que servem: olhar para o que divergiu. Medido depois da mudança: uma corrida de `css-flexbox` passa de ~7 GB para **2,2 GB**.

## Quem não rasteriza à primeira é repetido em série, no fim

O timeout do raster mede tempo de **relógio**, portanto uma máquina ocupada empurra um teste lento para lá dele — e um erro não é um resultado ausente, é o pior resultado, por isso o número mentia para baixo.

Aconteceu três vezes hoje:

| medição | resultado | realidade |
|---|---|---|
| `css-flexbox` ao lado de outras três réguas | 380/870, **310 não rasterizaram** | 586/870 |
| `CSS2` com o disco já cheio | 112/6240, **5 714 não rasterizaram** | por medir |
| lote da Ahem | 573/870 com 13 "perdidos" | 19 eram timeouts |

Os mesmos ficheiros passavam sozinhos. A repetição distingue as duas coisas: carga passa à segunda, um encravamento real repete-se.

## Verificado

No `main`, depois das duas correcções: **586/870, idêntico ao baseline** — a régua continua determinística — com 1 a não rasterizar (`flex-aspect-ratio-img-column-008`, encravamento genuíno, que se repete na segunda passagem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x