### PR TITLE
feat(dom): background-image é PINTADO — CSS2/backgrounds 45 → 59/339

### DIFF
--- a/crates/rts-dom/examples/claude-paint-dump.rs
+++ b/crates/rts-dom/examples/claude-paint-dump.rs
@@ -88,6 +88,28 @@ fn carregar_imagens(dom: &mut Dom, base_dir: &Path) {
             dom.set_pixel_data(id, rgba, w, h);
         }
     }
+    carregar_fundos(dom, base_dir);
+}
+
+/// O mesmo carregamento acima, para `background-image: url(...)` — ver a
+/// doc gêmea em `claude-raster.rs` (lote `background-image-pintado`).
+fn carregar_fundos(dom: &mut Dom, base_dir: &Path) {
+    for id in dom.query_all("*") {
+        let Some(css) = dom.computed_style(id) else { continue };
+        let Some(url) = css.bg_image.as_deref().and_then(rts_dom::style::background::bg_image_url) else {
+            continue;
+        };
+        let decoded = if url.starts_with("data:") {
+            rts_dom::imagem::bytes_da_data_url(&url).and_then(|b| rts_dom::imagem::png::decodificar(&b))
+        } else if url.starts_with("http://") || url.starts_with("https://") {
+            None
+        } else {
+            std::fs::read(base_dir.join(&url)).ok().and_then(|b| rts_dom::imagem::png::decodificar(&b))
+        };
+        if let Some((rgba, w, h)) = decoded {
+            dom.set_pixel_data(id, rgba, w, h);
+        }
+    }
 }
 
 /// Escapar para JSON. O texto de um item de pintura é conteúdo do AUTOR — pode

--- a/crates/rts-dom/examples/claude-raster.rs
+++ b/crates/rts-dom/examples/claude-raster.rs
@@ -77,6 +77,31 @@ fn carregar_imagens(dom: &mut Dom, base_dir: &Path) {
             dom.set_pixel_data(id, rgba, w, h);
         }
     }
+    carregar_fundos(dom, base_dir);
+}
+
+/// O mesmo carregamento acima, para `background-image: url(...)` — o achado
+/// do lote `background-image-pintado`: nenhum elemento além de `<img>` tinha
+/// os seus pixels carregados, então `layout::fundo_imagem` nunca tinha o que
+/// pintar. `dom.query_all("*")` (em vez de uma tag) porque um fundo pode
+/// estar em QUALQUER elemento, não só numa lista fechada de tags.
+fn carregar_fundos(dom: &mut Dom, base_dir: &Path) {
+    for id in dom.query_all("*") {
+        let Some(css) = dom.computed_style(id) else { continue };
+        let Some(url) = css.bg_image.as_deref().and_then(rts_dom::style::background::bg_image_url) else {
+            continue;
+        };
+        let decoded = if url.starts_with("data:") {
+            rts_dom::imagem::bytes_da_data_url(&url).and_then(|b| rts_dom::imagem::png::decodificar(&b))
+        } else if url.starts_with("http://") || url.starts_with("https://") {
+            None
+        } else {
+            std::fs::read(base_dir.join(&url)).ok().and_then(|b| rts_dom::imagem::png::decodificar(&b))
+        };
+        if let Some((rgba, w, h)) = decoded {
+            dom.set_pixel_data(id, rgba, w, h);
+        }
+    }
 }
 
 const W: usize = 1280;

--- a/crates/rts-dom/src/layout.rs
+++ b/crates/rts-dom/src/layout.rs
@@ -66,6 +66,7 @@ mod posicao_estatica;
 mod posicionado;
 mod pseudo_bloco;
 mod relativo;
+mod fundo_imagem;
 mod replaced;
 mod replaced_transferido;
 mod bloco;

--- a/crates/rts-dom/src/layout/bloco.rs
+++ b/crates/rts-dom/src/layout/bloco.rs
@@ -1070,6 +1070,16 @@ pub(crate) fn layout_block(
             );
             at += 1;
         }
+        // IMAGEM DE FUNDO: sobre a cor/gradiente, atrás da borda — os pixels
+        // (quando já carregados; ver `fundo_imagem`) tapam o que a cor pintou,
+        // exatamente como o Blink compõe as camadas de `background`.
+        for item in super::fundo_imagem::background_pixels_items(
+            dom, id, &css, box_rect, border_top, border_right, border_bottom, border_left,
+            filhos_antes_da_caixa, list.children.len(),
+        ) {
+            insert_item(list, at, filhos_antes_da_caixa, item);
+            at += 1;
+        }
         for item in border_items(&css, box_rect, radius, op, fx) {
             insert_item(list, at, filhos_antes_da_caixa, item);
             at += 1;
@@ -1106,6 +1116,11 @@ pub(crate) fn layout_block(
             // o índice do clip quando uma borda por lado entra em jogo.
             css.box_shadow.is_some() as usize
                 + (css.gradient.is_some() || css.bg.is_some()) as usize
+                + super::fundo_imagem::background_pixels_items(
+                    dom, id, &css, box_rect, border_top, border_right, border_bottom, border_left,
+                    filhos_antes_da_caixa, list.children.len(),
+                )
+                .len()
                 + border_items(
                     &css,
                     box_rect,

--- a/crates/rts-dom/src/layout/fundo_imagem.rs
+++ b/crates/rts-dom/src/layout/fundo_imagem.rs
@@ -1,0 +1,165 @@
+//! `background-image: url(...)` PINTADA — o achado do lote
+//! `background-image-pintado`: 173 das 294 falhas de `css/CSS2/backgrounds`
+//! (WPT) erram por menos de 1% de pixels, muitas por exatamente 10 000 px
+//! (100×100) — um quadrado de `background-color: red` coberto por
+//! `background-image: url(...)` que nunca era desenhado. `DisplayItem::Pixels`
+//! só existia para `<img>`/`<canvas>` (`replaced.rs`); este módulo é o
+//! terceiro emissor, para a caixa de QUALQUER elemento.
+//!
+//! ## Onde os pixels vêm de
+//!
+//! Os bytes são carregados de FORA (o rasterizador da régua, em
+//! `carregar_imagens`; numa página a correr, `dom.ts::loadResources`) e
+//! guardados no PRÓPRIO nó por `Dom::set_pixel_data` — a MESMA API que
+//! `<img>` já usa (`dom.pixel_data_of`), porque um nó com fundo é um nó como
+//! outro qualquer para essa tabela: não há necessidade de uma segunda.
+//! Sem pixels carregados, nada é emitido — a cor/gradiente do fundo (já
+//! pintados por `bloco.rs`) continuam a mostrar-se por baixo, como um
+//! `<img>` sem `src` decodificado mostra só a caixa.
+//!
+//! ## O corte
+//!
+//! `repeat`/`repeat-x`/`repeat-y`/`no-repeat` com `background-position` (a
+//! forma que fecha a maioria dos 173) — TILING por ladrilhos de tamanho
+//! NATURAL da imagem, recortados à área de posicionamento (padding-box, o
+//! `background-origin` default) por um `BeginClip`/`EndClip`. NÃO
+//! implementado, dito: `background-size` (sempre o natural — `cover`/
+//! `contain`/comprimentos são lidos e ignorados), `background-attachment:
+//! fixed`, `background-clip`/`-origin` não-default, `background-blend-mode`,
+//! e mais de uma camada (o mesmo corte que `style::background` já assume —
+//! `bg_image` só guarda a PRIMEIRA).
+
+use super::*;
+use crate::style::BgRepeat;
+
+/// Os itens de `Pixels` (mais o `BeginClip`/`EndClip` que os recorta) para o
+/// `background-image` deste nó, na ordem em que `bloco.rs` os insere: depois
+/// da cor/gradiente, antes da borda. Vazio quando não há `background-image`
+/// declarado, quando é `none`, ou quando os pixels ainda não carregaram.
+///
+/// `area` é a ÁREA DE POSICIONAMENTO — o padding-box (border-box menos as
+/// quatro larguras de borda USADAS), que é o `background-origin` inicial da
+/// spec (CSS Backgrounds 3 §3.4) — nunca o border-box inteiro, ou uma borda
+/// arredondada pintaria por baixo do canto reto do fundo.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::layout) fn background_pixels_items(
+    dom: &Dom,
+    id: NodeIdx,
+    css: &ComputedStyle,
+    box_rect: Rect,
+    border_top: f32,
+    border_right: f32,
+    border_bottom: f32,
+    border_left: f32,
+    // Bookkeeping do CLIP — a mesma dupla que o clip de scroll (`bloco.rs`,
+    // logo abaixo neste ficheiro) já usa e pela mesma razão (ver
+    // `DisplayItem::BeginClip`/`EndClip`): quantas subárvores-filhas já
+    // existiam quando o clip abriu/fechou. Um clip de fundo não recorta
+    // nenhuma diferente das do scroll — os FILHOS deste nó já foram
+    // layoutados antes deste ponto — por isso os dois valores coincidem com
+    // os que o chamador já tem à mão.
+    filhos_antes: usize,
+    filhos_dentro: usize,
+) -> Vec<DisplayItem> {
+    let has_image = css
+        .bg_image
+        .as_deref()
+        .is_some_and(|v| v.trim().to_ascii_lowercase().starts_with("url("));
+    if !has_image {
+        return Vec::new();
+    }
+    let Some((data, img_w, img_h)) = dom.pixel_data_of(id).filter(|(_, w, h)| *w > 0 && *h > 0) else {
+        return Vec::new();
+    };
+    let area = Rect::new(
+        box_rect.x + border_left,
+        box_rect.y + border_top,
+        (box_rect.w - border_left - border_right).max(0.0),
+        (box_rect.h - border_top - border_bottom).max(0.0),
+    );
+    if area.w <= 0.0 || area.h <= 0.0 {
+        return Vec::new();
+    }
+    let repeat = css.bg_repeat.unwrap_or_default();
+    let pos = css.bg_position.unwrap_or_default();
+    let resolve = crate::style::ResolveCtx {
+        parent_content_w: area.w,
+        node_font_size: super::DEFAULT_FONT_SIZE,
+        root_font_size: crate::style::root_font_size(),
+        viewport_w: area.w,
+        viewport_h: area.h,
+    };
+    // A ORIGEM: uma percentagem escala pelo espaço LIVRE (área menos a imagem),
+    // não pela área inteira — é assim que `center`/`right`/`bottom` colam a
+    // imagem à borda oposta em vez de a deixarem a meio caminho.
+    let pos_x = area.x + resolve_bg_offset(pos.x, area.w, img_w as f32, &resolve);
+    let pos_y = area.y + resolve_bg_offset(pos.y, area.h, img_h as f32, &resolve);
+    let repeats_x = matches!(repeat, BgRepeat::Repeat | BgRepeat::RepeatX | BgRepeat::Space | BgRepeat::Round);
+    let repeats_y = matches!(repeat, BgRepeat::Repeat | BgRepeat::RepeatY | BgRepeat::Space | BgRepeat::Round);
+    let xs = tile_starts(area.x, area.w, pos_x, img_w as f32, repeats_x);
+    let ys = tile_starts(area.y, area.h, pos_y, img_h as f32, repeats_y);
+    if xs.is_empty() || ys.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(xs.len() * ys.len() + 2);
+    out.push(DisplayItem::BeginClip {
+        rect: area,
+        node: id,
+        offset_x: 0.0,
+        offset_y: 0.0,
+        filhos_antes,
+    });
+    for &ty in &ys {
+        for &tx in &xs {
+            out.push(DisplayItem::Pixels {
+                rect: Rect::new(tx, ty, img_w as f32, img_h as f32),
+                data: std::rc::Rc::clone(&data),
+                w: img_w,
+                h: img_h,
+            });
+        }
+    }
+    out.push(DisplayItem::EndClip { filhos_dentro });
+    out
+}
+
+/// A percentagem/comprimento de `background-position` num eixo, resolvida
+/// contra o espaço LIVRE (CSS Backgrounds 3 §3.8): `0%` cola ao início, `100%`
+/// ao fim, um comprimento é um deslocamento direto a partir do início.
+fn resolve_bg_offset(d: crate::style::Dimension, area_len: f32, img_len: f32, resolve: &crate::style::ResolveCtx) -> f32 {
+    match d {
+        crate::style::Dimension::Percent(p) => (area_len - img_len) * (p / 100.0),
+        other => other.resolve(resolve).unwrap_or(0.0),
+    }
+}
+
+/// Os pontos de início de cada ladrilho num eixo, cobrindo `[area_start,
+/// area_start+area_len)`. Sem repetição, um único ladrilho em `pos`. Um teto
+/// (`4096`) contra um `size` ínfimo/zero gerar um laço sem fim — mesma
+/// doutrina de qualquer laço orientado a geometria neste motor.
+fn tile_starts(area_start: f32, area_len: f32, pos: f32, size: f32, repeats: bool) -> Vec<f32> {
+    if size <= 0.0 {
+        return Vec::new();
+    }
+    if !repeats {
+        return vec![pos];
+    }
+    let mut first = pos;
+    if first > area_start {
+        let k = ((first - area_start) / size).ceil();
+        first -= k * size;
+    } else if first < area_start {
+        let k = ((area_start - first) / size).floor();
+        first += k * size;
+    }
+    let mut out = Vec::new();
+    let mut x = first;
+    let end = area_start + area_len;
+    let mut n = 0;
+    while x < end && n < 4096 {
+        out.push(x);
+        x += size;
+        n += 1;
+    }
+    out
+}

--- a/crates/rts-dom/src/style/background.rs
+++ b/crates/rts-dom/src/style/background.rs
@@ -178,6 +178,29 @@ impl BgSize {
     }
 }
 
+/// O caminho/URL cru de dentro de `url(...)`, sem aspas — o miolo que
+/// `fmt_url` (`style::fmt_values`) devolve ENTRE aspas para o CSSOM, aqui nu,
+/// para quem vai LER o recurso (o rasterizador da régua de pintura, o mesmo
+/// gesto que o `<img>` já faz a partir do atributo `src`). `None` quando
+/// `raw` não é `url(...)` ou é `none` — o chamador não tenta carregar nada.
+pub fn bg_image_url(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.eq_ignore_ascii_case("none") || raw.is_empty() {
+        return None;
+    }
+    let miolo = raw
+        .strip_prefix("url(")
+        .or_else(|| raw.strip_prefix("URL("))?
+        .strip_suffix(')')?
+        .trim();
+    let sem_aspas = miolo
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| miolo.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        .unwrap_or(miolo);
+    Some(sem_aspas.to_string())
+}
+
 /// O que uma declaração `background: ...` nomeou. Campos `None` = não nomeados
 /// (o chamador não os toca — ver o corte do reset no topo do módulo).
 #[derive(Default)]


### PR DESCRIPTION
`DisplayItem::Pixels` só era emitido por `layout/replaced.rs`, o caminho do `<img>`. O **fundo** de um elemento nunca emitia pixels, e no rasterizador `carregar_imagens` fazia `dom.query_all("img")` — portanto uma `url()` de `background-image` num `div` nunca chegava a ser lida do disco.

## Como apareceu

A árvore do CSS 2.1, medida depois do fix do CDATA, pôs `backgrounds` em **45/339 (13,3 %)** — 294 falhas numa área que é um mecanismo, não uma família de casos. A assinatura era inequívoca:

- **173 das 294 falhavam por menos de 1 % dos pixels**
- dezenas com **exatamente 10 000 px** de diferença

10 000 = 100×100. O padrão desses testes é `background-color: red` coberto por `background-image: url('support/green15x15.png')` repetida, contra uma referência verde lisa: o quadrado inteiro saía vermelho porque a imagem de fundo não era desenhada.

## O que muda

- `layout/fundo_imagem.rs` (novo, 165 linhas) emite os pixels da caixa de fundo, com `background-repeat` e `background-position`; `bloco.rs` chama-o depois da cor e do gradiente, antes da borda.
- `carregar_fundos` nos dois exemplos (`claude-raster`, `claude-paint-dump`) percorre todos os elementos, não só `<img>`.
- `style/background.rs` ganha `bg_image_url`.

Toda a restante infraestrutura já existia — `set_pixel_data`, o descodificador PNG, o parse das camadas de fundo. Era um lote de **ligação**.

## Régua, medida por mim e não aceite do relatório

| | main | lote |
|---|---|---|
| `CSS2/backgrounds` | 45/339 | **59/339** |
| `css-flexbox` | 598/870 | 598/870 |

**+15 ganhos por nome, 1 perdido.** `cargo test -p rts-dom --lib`: 1024 passed, 0 failed.

## O perdido, classificado pela verificação pixel a pixel

`background-position-152` sobrepõe um fundo vermelho de 100×100 com um `<img>` verde absoluto que o devia esconder. **Antes deste lote o vermelho nunca era desenhado** — os dois lados batiam por convergência trivial, não porque a geometria estivesse certa.

Medido agora: a posição do fundo bate exatamente a fórmula da spec (14 %/84 % → 42 px/168 px). O que falha é o `<img>` de cobertura, que só cobre ~56 px de altura em vez de 100 — um defeito **pré-existente** no dimensionamento de um `<img>` dentro de um `position:absolute` aninhado, que este lote apenas tornou visível.

É o terceiro caso hoje do mesmo padrão: um teste que passava porque os dois lados estavam igualmente errados.

## O corte, dito

`background-size` fica sempre auto/natural (`cover`/`contain` lidos e ignorados), sem `background-attachment: fixed`, sem `background-clip`/`-origin` não-default, uma só camada de imagem — o mesmo corte que `style::background` já assumia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x