### PR TITLE
fix(dom): o shorthand border com um token invalido descarta a declaracao inteira

### DIFF
--- a/crates/rts-dom/src/style/borders.rs
+++ b/crates/rts-dom/src/style/borders.rs
@@ -191,6 +191,27 @@ pub fn parse_width_token(tok: &str) -> Option<f32> {
     super::lengths::parse_len_pub(&low)
 }
 
+/// `true` se TODOS os tokens do shorthand `border: <width> <style> <color>`
+/// classificam em largura, estilo ou cor.
+///
+/// CSS 2.1 não deixa "os componentes válidos aplicam-se, o inválido ignora-se
+/// sozinho": um valor que não corresponde à gramática da propriedade invalida
+/// a declaração INTEIRA, que fica como se não tivesse sido escrita — a
+/// cascata mantém o que já lá estava. `border: red solid -1px` tinha o
+/// inverso: `-1px` não classifica em nada (largura negativa é inválida em
+/// qualquer unidade), mas o resto do shorthand corria na mesma e escrevia
+/// style=solid/color=red por cima de um `border-width: 8px` de uma regra
+/// anterior — a parte INVÁLIDA "vencia" ao apagar a válida em vez de reprovar
+/// a linha toda (`border-width-010` do WPT).
+pub fn shorthand_tokens_all_valid(val: &str) -> bool {
+    val.split_whitespace().all(|tok| {
+        BorderStyle::parse(tok).is_some()
+            || parse_width_token(tok).is_some()
+            || parse_width_dim(tok).is_some()
+            || super::color::parse_color(tok).is_some()
+    })
+}
+
 /// `true` se o nome é uma longhand de borda POR LADO
 /// (`border-<lado>-<width|style|color>`). Reconhecer pela FORMA — e não com doze
 /// braços literais no `match` do parse — mantém o dispatch por nome num sítio só
@@ -252,6 +273,18 @@ pub fn apply_outline_shorthand(css: &mut ComputedStyle, val: &str) {
 /// As quatro bordas EFETIVAS (top, right, bottom, left), com o fallback para a
 /// borda uniforme por lado. É o que o paint consome.
 pub fn resolved_sides(css: &ComputedStyle) -> [SideBorder; 4] {
+    // REVERTIDO (medido 2026-09-05): pôr `medium` (3px) aqui parecia certo —
+    // é o inicial de `border-*-width` — mas este `SideBorder::width` sai bruto
+    // para o paint, e é `paints()`/`used_widths`, mais acima na cadeia, quem
+    // aplica a regra "estilo `none`/`hidden` força a largura USADA a zero".
+    // Um `unwrap_or(3.0)` aqui dava 3px de LARGURA a um lado sem estilo
+    // nenhum, e nada depois zera essa largura quando é o PRÓPRIO campo
+    // `width` que o paint lê — apareceu um quadrado cinzento de 3+3=6px onde
+    // não devia haver borda (`border-width-002`, medido: 36px de 255,255,255
+    // para 128,128,128, caixa 6×6). Regride `border-bottom-width-001..-078`
+    // (a família `flags: invalid`, que ficava sem largura nenhuma) até a
+    // regra "`none`/`hidden` ⇒ zero" ser aplicada ANTES deste default, não
+    // depois.
     let uw = css.border_width.unwrap_or(0.0);
     let us = css.border_style.unwrap_or(BorderStyle::None);
     let uc = css.border_color.unwrap_or(0x808080FF);

--- a/crates/rts-dom/src/style/newprops_tests/bordas_e_clip.rs
+++ b/crates/rts-dom/src/style/newprops_tests/bordas_e_clip.rs
@@ -257,3 +257,29 @@ fn filter_e_clip_path_chegam_crus_ao_paint() {
         Some("inset(10px)")
     );
 }
+
+// ── `border` inteiro cai quando um token não classifica (WPT border-width-010) ──
+
+#[test]
+fn border_shorthand_com_largura_negativa_nao_apaga_a_borda_ja_declarada() {
+    // `border: red solid -1px` é uma declaração INVÁLIDA (largura negativa não
+    // existe em nenhuma unidade) e o CSS 2.1 descarta-a por inteiro — não "os
+    // dois tokens válidos aplicam-se, o `-1px` ignora-se sozinho". O defeito:
+    // o laço por token escrevia style=solid/color=red mesmo assim, por cima de
+    // um `border-width: 8px` de uma declaração anterior na mesma regra —
+    // `clear_sides` corria primeiro e o `-1px` não corrigia nada.
+    let s = parse_inline(
+        "border-color: green; border-width: 8px; border-style: solid; border: red solid -1px",
+    );
+    assert_eq!(crate::style::borders::used_widths(&s), [8.0, 8.0, 8.0, 8.0]);
+    assert_eq!(s.border_color, Some(0x008000FF));
+}
+
+// `border-bottom-width: -1px` (WPT `border-bottom-width-001`..`-078`, a
+// família `flags: invalid`) fica sem teste aqui: o valor usado correto é
+// `medium` (3px), mas dar isso ao `resolved_sides::uw` por defeito regride
+// `border-width-002` — um lado sem NENHUM estilo passa a ter 3px de largura,
+// porque é este mesmo campo que o paint lê como largura bruta, antes de
+// `paints()`/`used_widths` zerarem pelo estilo. A correção certa aplica a
+// regra "`none`/`hidden` ⇒ zero" ANTES do default de `medium`, não depois —
+// falta fazer.

--- a/crates/rts-dom/src/style/parse/mod.rs
+++ b/crates/rts-dom/src/style/parse/mod.rs
@@ -673,6 +673,12 @@ fn parse_display(v: &str) -> Option<DisplayKind> {
 /// vier, a borda não aparece — o render checa `is_visible`), width=medium(3),
 /// color=currentColor (aqui deixamos `border_color` como veio / herdado).
 fn apply_border_shorthand(css: &mut ComputedStyle, val: &str) {
+    // Um token que não classifica em nada invalida a declaração INTEIRA — CSS
+    // 2.1 não aplica "os outros dois valem". Ver o porquê em
+    // `borders::shorthand_tokens_all_valid` (`border-width-010`).
+    if !crate::style::borders::shorthand_tokens_all_valid(val) {
+        return;
+    }
     // O curto escreve as DOZE longhands, não só as três uniformes: um lado
     // declarado antes dele é reposto (ver `borders::clear_sides`).
     crate::style::borders::clear_sides(css);


### PR DESCRIPTION
`apply_border_shorthand` classificava token a token e **ignorava em silêncio** o que não reconhecia — mas já tinha chamado `clear_sides` antes do laço. Resultado: `border: red solid -1px` é inválido por inteiro pela CSS 2.1 (`-1px` não é uma largura válida em unidade nenhuma), mas ainda escrevia `style=solid` e `color=red` por cima de um `border-width: 8px` declarado antes.

Passa a validar todos os tokens **antes** de aplicar (`shorthand_tokens_all_valid`, reusando os mesmos quatro classificadores do laço, para não divergir): ou a declaração inteira entra, ou não entra nada e o que já lá estava sobrevive.

## Medido, isolado

`CSS2/borders`: **227 → 228**, ganha `border-width-010`, **zero perdidos**.
`cargo test -p rts-dom --lib`: 1025 passed, 0 failed.

## O que foi tentado e revertido, porque a régua disse que não

A primeira versão deste lote trocava também o default de `resolved_sides` de `0.0` para `3.0`, com um argumento **correto**: o inicial de `border-*-width` é `medium` (3px), não zero.

Medido: **+1 e −13**. As treze foram classificadas uma a uma rasterizando cada lado com os dois binários — **todas regressão real**, nenhuma convergência trivial. E o diff em pixels de `border-width-002` disse porquê:

```
36 px diferem
caixa envolvente: x 8..13 (6 px), y 50..55 (6 px)
cores: 36 px  rgb(255,255,255) -> rgb(128,128,128)
```

Um quadrado cinzento de **6×6** — 3+3 — onde antes não havia nada.

O que o `unwrap_or(0.0)` codificava, e que o argumento da spec sozinho não vê: o inicial de `border-*-style` é `none`, e **`style: none` força a largura usada a zero** seja qual for a `border-width`. Trocar o default sem passar essa regra a montante põe uma borda de 3px em todo o elemento sem estilo de borda.

O teste que pinava o comportamento revertido foi removido, com um comentário a dizer o que falta para o fazer bem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x