### PR TITLE
fix(dom): margem auto num float resolve para 0, nao centra (CSS 2.1 §10.3.5)

### DIFF
--- a/crates/rts-dom/src/layout/bloco.rs
+++ b/crates/rts-dom/src/layout/bloco.rs
@@ -546,8 +546,24 @@ pub(crate) fn layout_block(
     // auto — centralizando (ambos auto) ou empurrando (um só auto). Resolvido AQUI,
     // depois de saber o content_w. Só quando há largura explícita (senão o bloco já
     // ocupa avail_w e não há espaço a distribuir).
+    //
+    // UM FLOAT NUNCA CENTRALIZA (CSS2.1 §10.3.5): o valor usado de
+    // `margin-left`/`margin-right` quando `auto` é ZERO, não uma fração do
+    // espaço livre — a regra de distribuição acima é para blocos não-flutuantes
+    // no fluxo normal. Sem esta guarda, `float:left; margin-left:auto` central-
+    // izava o quadrado em vez de o colar no canto superior-esquerdo do
+    // container (WPT `floats-clear/float-non-replaced-width-001` e
+    // `float-replaced-width-001`, ambos com `n` idêntico — a mesma causa).
+    let is_float = super::float::float_of(dom, id) != crate::style::FloatSide::None;
     let has_width = css.width.is_some() || css.max_width.is_some();
-    if has_width {
+    if is_float {
+        if m.left.is_auto() {
+            margin_left = 0.0;
+        }
+        if m.right.is_auto() {
+            margin_right = 0.0;
+        }
+    } else if has_width {
         let box_outer = content_w + padding_h + border_h; // sem a margin
         // COM SINAL (não `.max(0.0)`): o ramo `direction:rtl` de
         // `rtl_bloco::margin_left_usado` precisa do valor negativo quando o


### PR DESCRIPTION
Um float com `margin-left:auto` ou `margin-right:auto` era **centrado**: o código genérico de `bloco.rs` distribui o espaço livre pelos lados `auto` sempre que há largura, e todo float passa por `layout_block` porque estabelece o seu próprio BFC. Mas a §10.3.5 é explícita — num elemento flutuante, um `auto` de margem computa-se como **zero**, e o quadrado fica no canto, não no meio.

## Medido, isolado

`CSS2/floats-clear` **33 → 34** (ganha `floats-005`), `CSS2/floats` 38/108 sem mudança, **zero perdidos**. `cargo test -p rts-dom --lib`: 1024, 0 falhas.

O número é pequeno, e a razão está medida: **sozinho este lote não move nada** — 30/214 antes e depois. Só rende com as unidades absolutas (#2706) no mesmo binário, porque os testes que ele visa declaram `height: 1in` e sem essa unidade falham antes de chegarem à margem. Foi por isso medido nas duas combinações, em vez de se atribuir a este lote um ganho que era de outro.

## O que este lote não faz, com a causa já localizada

A triagem das 184 falhas de `floats-clear` deu quatro causas. Uma está corrigida aqui; as outras três ficam, com o sítio identificado — que é o que faz o próximo lote começar já a saber onde ir:

- **~24 casos**: `float`/`clear` sobre um display interno de tabela não *blockifica* (§9.7). Vive em `style/props/metodos.rs::effective_display`, e `ComputedStyle` já tem os dois campos que a regra precisa (`float_side`, `position`). Não existe blockificação nenhuma no código hoje, nem parcial — é gap real, não duplicação.
- **shrink-to-fit de float com quebra de linha** (`float-non-replaced-width-008..012`, todos com o mesmo `n=7200` — assinatura de causa única).
- **clearance e colapso de margem com `clear`** — os piores do balde (32 %, 29 %, 23 %), e vivem em `layout/vertical.rs`, não em `clearfix.rs` como o nome sugeria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x