### PR TITLE
fix(dom): o piso de min-content respeita max-width — o invariante min <= max

### DIFF
--- a/crates/rts-dom/src/table/widths/max_width_floor.rs
+++ b/crates/rts-dom/src/table/widths/max_width_floor.rs
@@ -1,0 +1,17 @@
+//! `d` (`width`/`max-width` absoluto) em caixa OUTER — extraído de `mod.rs`
+//! (teto de 500) para o `min_content` de lá poder clampar o PISO por
+//! `max-width` como já clampa o max-content em `intrinsic_outer_width`
+//! (`medida.rs`) — WPT `float-non-replaced-width-008..012`, invariante
+//! min-content ⩽ max-content.
+
+use crate::style::{ComputedStyle, ResolveCtx};
+
+pub(in crate::table::widths) fn comprimento_outer(
+    d: Option<crate::style::Dimension>,
+    css: &ComputedStyle,
+    resolve: &ResolveCtx,
+    frame: f32,
+) -> Option<f32> {
+    crate::style::dimensao_absoluta(d?, resolve)
+        .map(|w| w + if css.border_box.unwrap_or(false) { 0.0 } else { frame })
+}

--- a/crates/rts-dom/src/table/widths/mod.rs
+++ b/crates/rts-dom/src/table/widths/mod.rs
@@ -18,6 +18,8 @@
 
 mod reparticao;
 pub(crate) use reparticao::{resolve_colunas, resolve_fixo};
+mod max_width_floor;
+use max_width_floor::comprimento_outer;
 
 use crate::layout::LayoutCtx;
 use crate::style::ResolveCtx;
@@ -361,13 +363,9 @@ pub(in crate::table) fn min_content(
             // resposta, mais abaixo. É também o que o browser faz: uma largura
             // que não cabe é ignorada, não respeitada com o conteúdo a
             // transbordar.
-            let declarada = largura_absoluta(css.width, &resolve).map(|w| {
-                w + if css.border_box.unwrap_or(false) {
-                    0.0
-                } else {
-                    frame
-                }
-            });
+            let declarada = comprimento_outer(css.width, &css, &resolve, frame);
+            // clampa o PISO por `max-width` — ver `max_width_floor.rs`.
+            let max_width_cap = comprimento_outer(css.max_width, &css, &resolve, frame);
             // O `white-space` é herdado, por isso lê-se o do próprio nó em vez de
             // se propagar o do pai pela recursão: um descendente que volte a
             // `normal` PODE quebrar, e arrastar a bandeira para baixo negar-lhe-ia
@@ -395,7 +393,9 @@ pub(in crate::table) fn min_content(
                 }
             }
             if floor_width {
-                (m.max(linha) + frame).max(declarada.unwrap_or(0.0))
+                let piso = (m.max(linha) + frame).max(declarada.unwrap_or(0.0));
+                // teto nunca abaixo do `width` declarado (ordem de `clamp_size`).
+                max_width_cap.map_or(piso, |mx| piso.min(mx.max(declarada.unwrap_or(0.0))))
             } else {
                 m.max(linha) + frame
             }


### PR DESCRIPTION
`table::widths::min_content` — o piso que `flex_limites::largura_shrink_to_fit` usa para o shrink-to-fit de um float — calculava a largura declarada a partir de `css.width` e **nunca olhava para `css.max_width`**. Um elemento com `max-width` tinha o min-content medido pela palavra inteira sem quebra (8 caracteres em Ahem 30px = 240px) em vez de clampado ao `max-width` (120px), violando o invariante **min-content ≤ max-content** que `medida.rs::intrinsic_outer_width` já respeitava do outro lado.

O cálculo repartido saiu para `table/widths/max_width_floor.rs` (módulo novo, 17 linhas) porque `mod.rs` estava em 499 e o teto é 500.

## O número, dito antes de ser medido

`CSS2/floats-clear`: **34/214, igual ao main.** Zero ganhos, zero perdidos. `cargo test -p rts-dom --lib`: 1032 passed, 0 failed.

E o autor do lote **avisou disto antes de eu medir**: o rastreio manual mostrava que nestas cinco fixtures o `.min(content_natural_width(...))` de `largura_shrink_to_fit` já capava o resultado a 120px mesmo com o piso errado, porque a largura disponível do contentor é bem maior. Ter avisado vale tanto como o fix — poupou atribuir ao lote um ganho que não existe.

Entra na mesma, e a razão é simples: **é uma violação real de uma invariante que o resto do código já respeita.** Um fix correto que não move a régua continua a ser um fix correto; o que não se pode é vendê-lo como ganho.

## O que a investigação trocou em troca, e vale mais

Com o rasterizador na mão, o autor descobriu por que as cinco fixtures falham de verdade: **a largura do float já está certa (120px, bate com a referência)** — o que falta é a tinta. O diff dá a caixa envolvente 240×30 exatamente onde a referência tem uma faixa preta, e do nosso lado não há pixel preto nenhum. É o texto Ahem, que o rasterizador mascara de propósito.

Portanto as cinco são **inatingíveis por este rasterizador**, não por `float.rs`/`medida.rs`. Pintá-las exige que o raster deixe de mascarar Ahem — o que foi tentado hoje noutro lote e mediu **0 ganhos e 174 perdidos**, porque com o texto mascarado dos dois lados havia 169 testes de `css-text` a passar por *nenhum* dos lados pintar nada.

É o quarto caso do dia da mesma família: o limite estava no instrumento, não no motor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x