### PR TITLE
fix(dom): uma <img> nao tem descida — CSS 2.1 de 3568 para 4062/6240 (+494)

### DIFF
--- a/crates/rts-dom/src/layout/linha.rs
+++ b/crates/rts-dom/src/layout/linha.rs
@@ -269,7 +269,26 @@ pub(in crate::layout) fn layout_inline_flow(
         // mais alto que o strut, o texto mantém o ascent da fonte acima dessa
         // baseline e o descent do strut fica abaixo dela. É o contrato Blink que
         // dá, na fixture display, texto em y=55 e o bloco seguinte em y=75.
-        let text_top = if tall_inline_block {
+        // Sem TEXTO mas com um `<img>` mais alto do que a linha normal: ele senta
+        // na BASELINE (linha 344, `topo = text_top + ascent - wh`) mas — ao
+        // contrário de texto — não tem DESCIDA nenhuma (CSS 2.1 §10.8): toda a
+        // sua altura fica ACIMA da baseline. A meia-entrelinha simétrica reparte
+        // o excesso de `line_h` (que É a própria altura da imagem, pelo `fold`
+        // acima) igualmente acima/abaixo da content-area do texto — e sobe a
+        // caixa da imagem bem acima de `cy`, mesmo ELA sendo o motivo do
+        // `line_h` ter crescido. `<p>…</p><img/>` (o idioma-padrão de quadrado
+        // de referência do WPT) saía com o quadrado a começar 43px ANTES do fim
+        // do parágrafo — deslocando a REFERÊNCIA de qualquer reftest que o use.
+        // `tall_inline_block` já resolve o caso análogo COM texto (acima); esta
+        // é a mesma correção sem exigir `tem_texto`, e só toca `text_top` — não
+        // `line_advance`/`text_owner_anchor`, que são a distinção que aquele
+        // filtro já protege (ver o comentário do `tem_texto` acima).
+        let imagem_alta_sem_texto = line_h > lh + 0.001
+            && !tem_texto
+            && line
+                .iter()
+                .any(|segment| matches!(segment.atomic, Some((_, AtomicKind::Replaced))));
+        let text_top = if tall_inline_block || imagem_alta_sem_texto {
             cy + line_h - ctx.measurer.font_ascent_family(font_size, family)
         } else {
             cy + meia


### PR DESCRIPTION
Quando uma linha inline é só uma `<img>`, `line_h` cresce até à altura da imagem, mas `text_top` continuava a usar `meia_entrelinha` — que reparte esse excesso **simetricamente** acima e abaixo da área de conteúdo do texto. Uma imagem **não tem descida** (CSS 2.1 §10.8): toda a sua altura fica acima da baseline. A imagem subia `(line_h − conteúdo_da_fonte)/2` acima do cursor — **43 px** no idioma que o WPT usa em todo o lado.

O código já tinha a correção certa para o caso análogo **com** texto (`tall_inline_block`: `text_top = cy + line_h − ascent`). Só faltava aplicá-la quando não há texto e o item alto é `AtomicKind::Replaced`.

## Porque isto valeu tanto

`<p>instrução</p><div><img black96x96.png/></div>` é **o idioma padrão do WPT para o quadrado de referência**. Com o bug, o `<div>` começava em **y=7 em vez de y=50** — o parágrafo acima era ignorado. Muitos reftests passavam à mesma porque os *dois* lados estavam deslocados; os que não estavam falhavam por isto e não pelo que testam. São **576 ficheiros com `<img>`** só em `css/CSS2`.

## Medido, em seis baldes de uma vez

| balde | antes | depois | |
|---|---|---|---|
| `normal-flow` | 360/788 | **520** | +160 |
| `backgrounds` | 59/339 | **197** | +138 |
| `positioning` | 193/519 | **305** | +112 |
| `borders` | 274/504 | **321** | +47 |
| `floats-clear` | 34/214 | **61** | +27 |
| `linebox` | 24/191 | **29** | +5 |

**`css/CSS2` inteiro: 3 568 → 4 062/6 240 (65,1 %). +494 por nome, zero perdidos.**
`cargo test -p rts-dom --lib`: 1032 passed, 0 failed.

## Como foi encontrado — por isolamento, não por leitura

Três ficheiros mínimos: com texto simples dá y=50 (certo), com div aninhada dá y=50 (certo), **só com `<img>` dá y=7**. Isso eliminou o colapso de margem entre irmãos — que era a suspeita de duas investigações anteriores — e apontou para a via do elemento substituído.

Dois agentes chegaram a este bug por caminhos independentes no mesmo dia: um pelo `normal-flow` (a imagem sobe 43px), outro pelo `positioning` (o colapso de margem *"não se aplica"* quando a altura vem do conteúdo). São a mesma coisa vista dos dois lados.

## O corte, dito

Restrito a `AtomicKind::Replaced`. Não estendido a `Widget`/`Block` — não há medição isolada que confirme o mesmo para esses, e o honesty floor pede não generalizar sem verificar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x