### PR TITLE
fix(dom): clip: rect(...) recorta de verdade — visufx 4 → 37/53

### DIFF
--- a/crates/rts-dom/src/layout/bloco.rs
+++ b/crates/rts-dom/src/layout/bloco.rs
@@ -1202,43 +1202,49 @@ pub(crate) fn layout_block(
         }
     }
 
-    // ── CLIP-PATH: recorta o elemento a um retângulo. SÓ `inset()` sem `round`
-    // chega aqui com um rect — as outras formas devolvem `None` e não recortam
-    // nada, porque recortar um `polygon()` pela caixa envolvente desenharia um
-    // quadrado onde devia estar um losango (ver `painteffects`).
-    //
-    // Emitido DEPOIS do bloco de overflow acima, e de propósito: inserir em
-    // `box_index` empurra tudo o que vem a partir dali, e fazê-lo antes
-    // desalinharia por um o `children_start` que aquele bloco calcula. Como o
-    // `EndClip` deste é empilhado no fim, o aninhamento sai certo — este abre
-    // primeiro e fecha por último, portanto envolve o clip de scroll.
-    //
-    // A diferença para o clip de overflow é onde ABRE: aquele recorta só os
-    // FILHOS (abre depois dos itens de caixa), este recorta o elemento INTEIRO,
-    // fundo e borda incluídos, que é o que o `clip-path` do CSS faz. Daí abrir
-    // em `box_index`.
-    if let Some(cp) = css.clip_path.as_deref() {
-        if let Some(rect) = crate::painteffects::clip_retangulo(cp, box_rect) {
-            insert_item(
-                list,
-                box_index,
-                filhos_antes_da_caixa,
-                DisplayItem::BeginClip {
-                    rect,
-                    node: id,
-                    offset_x: 0.0,
-                    offset_y: 0.0,
-                    // Os fragmentos-filhos que existiam quando a CAIXA foi
-                    // reservada — não `list.children.len()` de agora, que já
-                    // conta os desta subárvore. O clip abre conceptualmente
-                    // antes deles, mesmo sendo inserido depois de existirem.
-                    filhos_antes: filhos_antes_da_caixa,
-                },
-            );
-            list.items.push(DisplayItem::EndClip {
-                filhos_dentro: list.children.len(),
-            });
-        }
+    // `clip-path` — SÓ `inset()` sem `round` chega a devolver um rect (ver
+    // `painteffects`) — e o `clip` legado (CSS2.1 §11.1.2), que só se aplica a
+    // posicionados (`absolute`/`fixed`, a condição da spec) e reusa o MESMO
+    // par BeginClip/EndClip: dois retângulos possíveis, o mesmo emissor.
+    let clip_path_rect = css
+        .clip_path
+        .as_deref()
+        .and_then(|cp| crate::painteffects::clip_retangulo(cp, box_rect));
+    let legacy_clip_rect = css
+        .position
+        .is_some_and(|p| p.out_of_flow())
+        .then(|| css.clip)
+        .flatten()
+        .and_then(|clip| crate::painteffects::clip_legacy_retangulo(clip, box_rect));
+    for rect in [clip_path_rect, legacy_clip_rect].into_iter().flatten() {
+        // Emitido DEPOIS do bloco de overflow acima, e de propósito: inserir em
+        // `box_index` empurra tudo o que vem a partir dali, e fazê-lo antes
+        // desalinharia por um o `children_start` que aquele bloco calcula. Como
+        // o `EndClip` deste é empilhado no fim, o aninhamento sai certo — este
+        // abre primeiro e fecha por último, portanto envolve o clip de scroll.
+        //
+        // A diferença para o clip de overflow é onde ABRE: aquele recorta só
+        // os FILHOS (abre depois dos itens de caixa), este recorta o elemento
+        // INTEIRO, fundo e borda incluídos.
+        insert_item(
+            list,
+            box_index,
+            filhos_antes_da_caixa,
+            DisplayItem::BeginClip {
+                rect,
+                node: id,
+                offset_x: 0.0,
+                offset_y: 0.0,
+                // Os fragmentos-filhos que existiam quando a CAIXA foi
+                // reservada — não `list.children.len()` de agora, que já
+                // conta os desta subárvore. O clip abre conceptualmente antes
+                // deles, mesmo sendo inserido depois de existirem.
+                filhos_antes: filhos_antes_da_caixa,
+            },
+        );
+        list.items.push(DisplayItem::EndClip {
+            filhos_dentro: list.children.len(),
+        });
     }
 
     // POSITION:RELATIVE — porquê e o que desloca em `relativo.rs`. ANTES do

--- a/crates/rts-dom/src/painteffects/mod.rs
+++ b/crates/rts-dom/src/painteffects/mod.rs
@@ -420,6 +420,53 @@ pub fn clip_retangulo(valor: &str, caixa: Rect) -> Option<Rect> {
     Some(Rect::new(x, y, w, h))
 }
 
+/// `clip: rect(top, right, bottom, left)` (CSS2.1 §11.1.2) — SÓ para
+/// posicionados (`absolute`/`fixed`), o mesmo `BeginClip`/`EndClip` de
+/// `clip_retangulo` acima recebe o retângulo. A justificação em
+/// `style::vocab::tipos::Clip` que dizia não valer a pena recortar a sério
+/// ficou desatualizada: falava de "um retângulo de corte na lista de display,
+/// que hoje não existe", e passou a existir quando `clip-path` ganhou
+/// `BeginClip`/`EndClip` — este reusa o MESMO mecanismo.
+///
+/// Os quatro lados são OFFSETS a partir do canto superior-esquerdo do
+/// border-box (não do viewport): `auto` num lado é a borda desse lado da
+/// própria caixa (0 em cima/esquerda, largura/altura em baixo/direita). Só
+/// `Dimension::Px` resolve — `%`/`em`/`rem` no `clip` legado não aparecem no
+/// corpus WPT e exigiriam um eixo de referência que esta função não tem à
+/// mão; um lado nessas unidades cai para o comportamento de `auto` desse
+/// lado, que é seguro (não recorta mais do que devia).
+pub fn clip_legacy_retangulo(clip: crate::style::vocab::Clip, caixa: Rect) -> Option<Rect> {
+    use crate::style::values::Dimension;
+    let crate::style::vocab::Clip::Rect {
+        top,
+        right,
+        bottom,
+        left,
+    } = clip
+    else {
+        return None;
+    };
+    let px = |d: Option<Dimension>| -> Option<f32> {
+        match d {
+            None => None,
+            Some(Dimension::Px(v)) => Some(v),
+            Some(_) => None,
+        }
+    };
+    let t = px(top).unwrap_or(0.0);
+    let l = px(left).unwrap_or(0.0);
+    let r = px(right).unwrap_or(caixa.w);
+    let b = px(bottom).unwrap_or(caixa.h);
+    let x = caixa.x + l;
+    let y = caixa.y + t;
+    // Lados invertidos dão área zero, não negativa — mesma regra de
+    // `clip_retangulo` acima, e a mesma razão (largura negativa desenharia ao
+    // contrário em vez de não desenhar nada).
+    let w = (r - l).max(0.0);
+    let h = (b - t).max(0.0);
+    Some(Rect::new(x, y, w, h))
+}
+
 /// `12px`, `10%` ou `0` → px, dado o tamanho de referência do eixo. Recusa
 /// unidades relativas à fonte: resolver um `em` exige o estilo do elemento, que
 /// esta função não tem — e adivinhar 16 daria um recorte errado num elemento

--- a/crates/rts-dom/src/painteffects/tests.rs
+++ b/crates/rts-dom/src/painteffects/tests.rs
@@ -193,3 +193,45 @@
         assert!(clip_retangulo("inset(1em)", CAIXA).is_none());
         assert!(clip_retangulo("inset(2rem 1px)", CAIXA).is_none());
     }
+
+    /// `clip: rect(0,0,0,0)` (CSS2.1) recorta a caixa a NADA — a área em que
+    /// o WPT `visufx/clip-004..006` etc. falhavam: 9216px = 96×96 (1in²)
+    /// pintados onde o browser não pinta nada.
+    #[test]
+    fn clip_legado_todo_zero_da_area_zero() {
+        use crate::style::values::Dimension;
+        use crate::style::vocab::Clip;
+        let zero = Some(Dimension::Px(0.0));
+        let clip = Clip::Rect {
+            top: zero,
+            right: zero,
+            bottom: zero,
+            left: zero,
+        };
+        let r = clip_legacy_retangulo(clip, CAIXA).unwrap();
+        assert_eq!((r.w, r.h), (0.0, 0.0));
+    }
+
+    /// Um lado `auto` é a borda DESSA caixa, não a origem — `right: auto` vai
+    /// até `caixa.w`, não até 0.
+    #[test]
+    fn clip_legado_auto_e_a_borda_da_propria_caixa() {
+        use crate::style::values::Dimension;
+        use crate::style::vocab::Clip;
+        let clip = Clip::Rect {
+            top: Some(Dimension::Px(5.0)),
+            right: None,
+            bottom: None,
+            left: Some(Dimension::Px(5.0)),
+        };
+        let r = clip_legacy_retangulo(clip, CAIXA).unwrap();
+        assert_eq!((r.x, r.y), (CAIXA.x + 5.0, CAIXA.y + 5.0));
+        assert_eq!((r.w, r.h), (CAIXA.w - 5.0, CAIXA.h - 5.0));
+    }
+
+    /// `clip: auto` não recorta nada — é o valor inicial da propriedade.
+    #[test]
+    fn clip_legado_auto_geral_nao_recorta() {
+        use crate::style::vocab::Clip;
+        assert!(clip_legacy_retangulo(Clip::Auto, CAIXA).is_none());
+    }

--- a/crates/rts-dom/src/style/vocab/tipos.rs
+++ b/crates/rts-dom/src/style/vocab/tipos.rs
@@ -92,25 +92,21 @@ pub enum PointerEvents {
 /// canto SUPERIOR ESQUERDO da caixa (não é um `inset`: `bottom` cresce para
 /// baixo, ao contrário de `inset-bottom`).
 ///
-/// GUARDADA, SEM RECORTE — e a pergunta que decide isso foi verificada em vez de
-/// assumida. `clip` está obsoleta na spec há anos e mesmo assim aparece em 8 das
-/// 13 folhas do corpus, sempre com o mesmo papel: o `.sr-only`/`.visually-hidden`
-/// que esconde texto de quem vê e o deixa para o leitor de ecrã. **Se o recorte
-/// faltasse, esse texto aparecia na página** — um defeito visível é pior que uma
-/// propriedade ausente, que é a razão para não a reconhecer às cegas.
+/// GUARDADA **E RECORTADA** — este parágrafo dizia "sem recorte", e a razão
+/// dada não sobreviveu ao lote WPT `cluster-9216`: os 13 ficheiros do corpus
+/// de páginas reais são todos `.sr-only`/`.visually-hidden` com
+/// `width:1px; height:1px; overflow:hidden` ao lado, onde o `overflow:hidden`
+/// já escondia o conteúdo — mas os reftests `visufx/clip-*` do CSS2.1 usam
+/// `clip: rect(0,0,0,0)` SOZINHO, numa caixa `1in × 1in` SEM `overflow`, para
+/// testar exatamente o recorte. Guardar sem recortar pintava a caixa inteira
+/// onde o browser não pinta nada — 96×96px exatos, em 28 reftests.
 ///
-/// Não é o caso, e isto é a evidência: em TODAS as ocorrências do corpus o
-/// `clip: rect(…)` vem ao lado de `width:1px; height:1px; overflow:hidden`
-/// (Bootstrap, Tailwind, Bulma, Foundation, Primer, MediaWiki, WhatsApp). A
-/// caixa de 1px com `overflow:hidden` já esconde o conteúdo sozinha; o `clip` é
-/// cinto-e-suspensórios do tempo em que `overflow` não bastava. Guardar sem
-/// recortar não torna nada visível.
-///
-/// A alternativa — recortar a sério — pedia um retângulo de corte na lista de
-/// display, que hoje não existe (o `overflow` é resolvido pelo container de
-/// rolagem, não por um clip por item). Seria um segundo mecanismo de recorte ao
-/// lado do primeiro, para uma propriedade que a spec já substituiu por
-/// `clip-path`.
+/// A alternativa dita como não feita também ficou desatualizada: "um
+/// retângulo de corte na lista de display, que hoje não existe" deixou de ser
+/// verdade quando `clip-path` ganhou `BeginClip`/`EndClip`
+/// (`layout::bloco`/`painteffects::clip_retangulo`) — `clip_legacy_retangulo`
+/// reusa o MESMO par para este valor, restrito a posicionados
+/// (`absolute`/`fixed`, a condição da spec).
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Clip {
     Auto,


### PR DESCRIPTION
A propriedade era parseada e guardada no computed style e **nunca lida** pelo layout nem pela pintura. O comentário em `style/vocab/tipos.rs` dizia-o — *"GUARDADA, SEM RECORTE"* — com duas razões, e **as duas caducaram**:

1. *"no corpus de páginas reais, `.sr-only` vem sempre com `overflow:hidden` ao lado, que já esconde tudo"* — verdade para páginas reais; **falso para os reftests do CSS 2.1**, que usam `clip: rect(0,0,0,0)` **sozinho** numa caixa de uma polegada, precisamente para testar o recorte.
2. *"recortar a sério pedia um retângulo de corte na lista de display, que hoje não existe"* — passou a existir quando `clip-path: inset()` ganhou `BeginClip`/`EndClip`, e ninguém voltou ao `clip` legado depois disso.

O emissor de `BeginClip`/`EndClip` passa a servir os dois, **partilhado em vez de duplicado**, restrito a `position: absolute`/`fixed` (§11.1.2). O comentário desatualizado foi reescrito, para não voltar a enganar quem o ler.

## Medido

`CSS2/visufx`: **4/53 → 37/53** (+33 por nome, **zero perdidos**).
`cargo test -p rts-dom --lib`: 1035 passed, 0 failed (3 novos, que nomeiam o comportamento).

## Isolado antes de corrigir

`clip-min.xht` — um `div` com `background:red`, `position:absolute`, uma polegada de lado e `clip:rect(0,0,0,0)`: rasteriza **9216 pixels vermelhos exatos** (96²) onde o Blink não pinta nada.

## O que este lote não é, e o que isso ensina

O cluster `n=9216` tinha 80 casos e **só 28 eram `clip`**. Os outros ~50 são `*-applies-to-*` com `display: table-column-group` e afins — o motor não constrói a estrutura de tabela, que é a mesma feature grande em falta que outros dois agentes identificaram hoje. Não foi tocada.

Isso confirma um limite do método de agrupar falhas pelo número exato de pixels: **9216 é 96², o quadrado-padrão do corpus**, e agrega por coincidência testes de causas diferentes. Um cluster **concentrado numa pasta** é sinal; um **espalhado** com um `n` redondo é ruído.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x