### PR TITLE
fix(dom): has_box() conta background-image — uma referencia partilhada renderizava vazia

### DIFF
--- a/crates/rts-dom/src/style/props/metodos.rs
+++ b/crates/rts-dom/src/style/props/metodos.rs
@@ -10,6 +10,20 @@ impl ComputedStyle {
     /// nenhum, o render desenha direto (sem o overhead do Frame).
     pub fn has_box(&self) -> bool {
         self.bg.is_some()
+            // `background-image` SEM cor de fundo. Faltava, e o efeito era o
+            // mesmo do braço dos estilos de borda abaixo: um `<div>` que só
+            // declara `background: url(…)` — sem cor, sem largura, sem borda —
+            // dava `false` aqui, e o bloco que emite fundo e imagem era
+            // saltado inteiro. Os pixels estavam carregados e ninguém os
+            // pintava.
+            //
+            // Achado por uma REFERÊNCIA partilhada que renderizava vazia:
+            // `positioning/bottom-applies-to-001-ref.xht` é `html,body,div
+            // {height:100%}` mais `div{background:url(…) no-repeat 8px
+            // bottom}`, e 24 testes comparam-se contra ela. Uma referência
+            // errada faz falhar todos os testes que a usam, e não há nada no
+            // resultado desses testes que aponte para ela.
+            || self.bg_image.is_some()
             || self.gradient.is_some()
             || self.box_shadow.is_some()
             || self.padding.any_set()


### PR DESCRIPTION
`has_box()` é o gate único que decide se um nó chega ao caminho de pintura de fundo e borda. Testava `bg`, `gradient`, `box_shadow`, padding, margin, bordas, outline, raio e `width` — e **não `bg_image`**. Um `<div>` que só declara `background: url(…)`, sem cor, sem largura e sem borda, dava `false`, e o bloco inteiro que emite fundo e imagem era saltado. Os pixels já estavam carregados e ninguém os pintava.

**É a segunda vez hoje que esta função aparece com a lista incompleta** — a primeira foi `border_*_style`, no lote da borda. Um gate feito de uma lista de campos esquece campos.

## Como apareceu: uma referência partilhada a renderizar vazio

`positioning/bottom-applies-to-001-ref.xht` é `html,body,div{height:100%}` mais `div{background:url(…) no-repeat 8px bottom}` — nenhuma cor, nenhuma largura. **24 testes comparam-se contra ela.** Uma referência errada faz falhar todos os testes que a usam, e não há nada no resultado desses testes que aponte para lá.

O caminho até aqui vale a pena contar: um inventário mecânico contou, para cada ficheiro de referência, quantos testes o usam e quantos falham. Duas referências tinham **53 % e 26 %** de falhas contra 0–2 % das vizinhas. Rasterizadas sozinhas, **ambas estavam corretas** — a hipótese foi refutada. Foi a procurar *porque* é que os testes delas falhavam que esta causa apareceu.

## Medido

| | antes | depois | |
|---|---|---|---|
| `CSS2/positioning` | 313/519 | **327** | +18, −4 |
| `CSS2/backgrounds` | 197/339 | **198** | +1, −0 |

**+19.** Os 4 perdidos foram classificados um a um, rasterizando cada lado com os dois binários: **todos convergência trivial** — passavam porque a referência *também* estava vazia, e dois vazios batem.

`cargo test -p rts-dom --lib`: 1032 passed, 0 failed.

## Isolado antes de corrigir

Um `<div>` com só `background: url(…)`: **0 itens pintados**, devia dar 1. O mesmo HTML com `width:200px` já pintava — porque `width.is_some()` satisfazia o gate por outro caminho, mascarando o defeito. É o mesmo mascaramento acidental que escondeu o bug dos estilos de borda esta manhã.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x