### PR TITLE
fix(dom): o fundo do root/body propaga para a TELA — CSS 2.1 §14.2, +18 reftests

### DIFF
--- a/crates/rts-dom/src/layout/pintura.rs
+++ b/crates/rts-dom/src/layout/pintura.rs
@@ -129,19 +129,44 @@ pub fn emit_scrollbar_in(
     }
 }
 
-/// O `background` do `<body>` (ou, se ausente, do `<html>`) — a cor que o CSS
-/// PROPAGA para o viewport inteiro. `None` se nenhum dos dois tem fundo.
+/// O `background` do `<html>` (ou, se ausente/transparente e sem imagem, do
+/// `<body>` dentro dele) — a cor que o CSS PROPAGA para o viewport inteiro
+/// (CSS 2.1 §14.2). `None` se nenhum dos dois tem fundo (visível) algum.
+///
+/// **Precedência corrigida**: o `<html>` vence SEMPRE que declara fundo
+/// próprio (cor visível ou imagem) — `c45-bg-canvas-000` (`html:purple` +
+/// `body:navy`) espera a tela PURPLE, com o `<body>` a pintar a SUA navy por
+/// cima. A versão anterior tentava o `<body>` PRIMEIRO e só recorria ao
+/// `<html>` quando o body não tinha fundo — invertido face à cascata, e dava
+/// a tela errada sempre que os dois declaravam cores diferentes.
+///
+/// **E a falta que zerava o caso comum**: quando `<html>` não declara fundo
+/// nenhum, `bg_of_tag(html)` é `None` e o ramo nunca chegava a olhar para o
+/// `<body>` lá dentro — `background-body-001` (só `body{background:green}`)
+/// media 97,86% de pixels errados por isto: a tela ficava no branco por
+/// omissão em vez do verde do body.
 pub(in crate::layout) fn body_background(dom: &Dom) -> Option<u32> {
-    // procura body e html entre os descendentes da raiz.
     for &child in &dom.node(dom.root).children {
-        if let Some(bg) = bg_of_tag(dom, child, "body") {
-            return Some(bg);
-        }
-        if let Some(bg) = bg_of_tag(dom, child, "html") {
-            // o html pode ter o body dentro; tenta o body primeiro.
-            if let Some(body_bg) = find_body_bg(dom, child) {
-                return Some(body_bg);
+        if let NodeKind::Element { tag } = &dom.node(child).kind {
+            if tag == "html" {
+                let css = dom.computed_style_idx(child);
+                // Alpha zero (`background: transparent`, explícito ou o
+                // inicial) NÃO conta como fundo próprio para esta decisão —
+                // só bloqueia a propagação uma cor de facto visível.
+                let color = css.as_ref().and_then(|c| c.bg).filter(|c| c & 0xFF != 0);
+                let has_image = css.as_ref().is_some_and(|c| c.bg_image.is_some());
+                if color.is_some() || has_image {
+                    // Tem imagem mas não cor: devolve `None` (tela branca por
+                    // omissão) em vez de "roubar" a cor do `<body>`, que
+                    // perdeu a decisão — a imagem em si na tela é um corte à
+                    // parte (`fundo_imagem.rs` só desenha por caixa de
+                    // elemento, ainda não pela tela).
+                    return color;
+                }
+                return find_body_bg(dom, child);
             }
+        }
+        if let Some(bg) = bg_of_tag(dom, child, "body") {
             return Some(bg);
         }
     }


### PR DESCRIPTION
`body { background: green }` sozinho dava tela BRANCA.

Dois defeitos na mesma função `body_background`, e o primeiro é o caso comum:

1. o ramo que desce ao `<body>` quando o `<html>` não declara fundo estava **aninhado dentro** de `if let Some(bg) = bg_of_tag(html)` — logo só corria quando o `<html>` já tinha fundo, que é precisamente quando não é preciso;
2. a **precedência estava invertida**: tentava o `<body>` primeiro e o `<html>` como recurso. O §14.2 diz o contrário — o `<html>` vence sempre que declara fundo próprio.

## Régua

`css/CSS2` do WPT, 6 240 reftests, com a guarda `--esperado` a confirmar o tamanho do corpus. Baseline reproduzido duas vezes no mesmo número (4 149), portanto determinístico.

| | |
|---|---|
| antes | 4 149/6 240 |
| depois | **4 167/6 240** |
| ganhos | **18** |
| perdidos | **0** |

Comparado **por nome**, não pelo líquido — um `+18` líquido seria igualmente compatível com `+30/−12`.

Inclui o pior caso absoluto do corpus, `box-display/root-box-003` (100,00% dos pixels errados).

## Um resultado colateral que vale registar

`root-box-003`, `normal-flow/root-box-001` e `visudet/height-percentage-003a` estavam atribuídos a outra causa (`height: 100%` não resolver contra o viewport). Passaram aqui sem se lhes tocar — e a outra causa foi entretanto **refutada** com um ficheiro mínimo: a resolução contra o viewport já funcionava. A causa aparente não era a causa.

## O que fica por fazer, documentado em vez de disfarçado

A **imagem** de fundo tilada na tela. `fundo_imagem.rs` pinta por caixa de elemento e a tela não é uma caixa; `background-root-010/016/018` continuam a falhar por isso.

`cargo test -p rts-dom`: 1 035 passam, 0 falham.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x