### PR TITLE
fix(dom): `height: %` numa <img> não resolve contra a LARGURA do pai — CSS 2.1 §10.5

### DIFF
--- a/crates/rts-dom/src/inline_box/substituido.rs
+++ b/crates/rts-dom/src/inline_box/substituido.rs
@@ -134,12 +134,32 @@ pub(crate) fn replaced_inline_size(
         Some(d) => d.resolve(&resolve),
         None => attr_px(attr),
     };
+    // ALTURA declarada em PERCENTAGEM: esta função não recebe `avail_h` —
+    // nenhum dos seis chamadores (bloco.rs, linha.rs, medida.rs, este
+    // ficheiro, runs.rs, table/widths) o passa — e `Dimension::resolve` usa
+    // `ctx.parent_content_w` como base de QUALQUER percentagem, `Percent`
+    // incluído. Para `width` isso é a base certa (§10.2); para `height` é a
+    // LARGURA do containing block, não a altura, e nunca a base certa. Um
+    // `<img height:100%>` dentro de um `<div>` de altura auto virava um
+    // retângulo do tamanho da LARGURA do pai em vez do quadrado natural
+    // (`height-percentage-005`, WPT: 96×96 esperado, saía ~1230×739).
+    //
+    // CSS 2.1 §10.5: sem uma altura de containing block CONHECIDA a
+    // percentagem computa a `auto` — e é exactamente o caso aqui, porque a
+    // função não tem essa informação. Threading de `avail_h` por seis
+    // chamadores fica para quando um caso legítimo (CB de altura definida)
+    // precisar dele; até lá, tratar como o pedido não declarasse altura
+    // nenhuma é estritamente melhor do que herdar a largura por engano.
+    let declarado_altura = |d: Option<crate::style::Dimension>, attr: &str| match d {
+        Some(crate::style::Dimension::Percent(_)) => None,
+        d => declarado(d, attr),
+    };
     // O flex vence o CSS do mesmo jeito que já vence num bloco comum — é
     // por isso que entra ANTES de `declarado`, não depois: um `<img>` com
     // `width` declarado mas encolhido pelo `flex-shrink` tem de acabar na
     // largura que o flex decidiu, não na declarada.
     let w0 = forced.0.or_else(|| declarado(css.width, "width"));
-    let h0 = forced.1.or_else(|| declarado(css.height, "height"));
+    let h0 = forced.1.or_else(|| declarado_altura(css.height, "height"));
     // A razão de aspecto: a dos pixels quando existem e, quando não, a dos
     // ATRIBUTOS `width`/`height` do HTML.
     //


### PR DESCRIPTION
Um `<img style="height:100%">` dentro de um `<div>` de altura auto saía como um retângulo de **~1230×739** onde o esperado era o quadrado natural de **96×96**.

## A causa

`replaced_inline_size` não recebe `avail_h` — nenhum dos seis chamadores o passa — e a altura declarada ia por `Dimension::resolve`, cuja base para QUALQUER percentagem é `ctx.parent_content_w`. Para `width` essa base é a certa (§10.2); para `height` é a **largura** do bloco contentor, que nunca é a base certa.

CSS 2.1 §10.5: sem uma altura de contentor conhecida, a percentagem computa a `auto`.

## A alternativa rejeitada

Passar `avail_h` pelos seis chamadores. Fica para quando aparecer um caso legítimo (contentor de altura definida) que precise dele — o corpus inteiro não tem nenhum, e a medição confirma-o: zero perdidos.

## Régua

| | |
|---|---|
| antes | 4 149/6 240 |
| depois | **4 150/6 240** |
| ganhos | 1 (`normal-flow/height-percentage-005`) |
| perdidos | **0** |

É +1 porque a causa é rara no corpus, não porque a correção seja parcial.

## A hipótese refutada

Esta investigação abriu com outra hipótese: `height: 100%` não resolver contra o viewport, à qual estavam atribuídos ≥5 reftests incluindo o pior caso do corpus. Foi **refutada com um ficheiro mínimo antes de se escrever código** — a cadeia `html→body→div` já resolvia correctamente. Os reftests que lhe estavam atribuídos eram do §14.2 (PR #2715).

`cargo test -p rts-dom`: 1 035 passam, 0 falham.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x