### PR TITLE
fix(dom): um listener de DOM sobrevive ao coletor — a raiz que faltava

### DIFF
--- a/crates/rts-dom-bridge/src/events.rs
+++ b/crates/rts-dom-bridge/src/events.rs
@@ -112,6 +112,7 @@ extern "C" fn add_listener_cb_options(
     rts_dom::store::with_dom_mut(h, |d| {
         d.add_event_listener_cb_with_options(id, event, callback, options);
     });
+    crate::raizes::sincroniza(h);
     nothing()
 }
 
@@ -134,6 +135,7 @@ extern "C" fn remove_listener_cb(
     rts_dom::store::with_dom_mut(h, |d| {
         d.remove_event_listener_cb(id, event, cb as i64, capture);
     });
+    crate::raizes::sincroniza(h);
     nothing()
 }
 
@@ -147,6 +149,7 @@ extern "C" fn remove_listener(_e: u64, _t: u64, doc: u64, n: u64, event: u64, _c
             d.remove_event_listener(id, &event);
         }
     });
+    crate::raizes::sincroniza(h);
     nothing()
 }
 
@@ -187,6 +190,8 @@ extern "C" fn dispatch_collect(
         d.dispatch_event_collect(id, &event, integer(bubbles, 0) != 0)
     })
     .unwrap_or(0);
+    // O despacho é também uma REMOÇÃO: os `once` saem da lista aqui dentro.
+    crate::raizes::sincroniza(h);
     int(count)
 }
 

--- a/crates/rts-dom-bridge/src/lib.rs
+++ b/crates/rts-dom-bridge/src/lib.rs
@@ -42,6 +42,7 @@ mod imagem;
 mod lifecycle;
 mod location;
 mod nodes;
+mod raizes;
 mod recursos;
 mod scroll;
 mod travessia;

--- a/crates/rts-dom-bridge/src/raizes.rs
+++ b/crates/rts-dom-bridge/src/raizes.rs
@@ -1,0 +1,113 @@
+//! Manter vivos os callbacks que o DOM guarda — a raiz que faltava.
+//!
+//! # O defeito que isto fecha
+//!
+//! `Dom` guarda cada handler como um `i64` opaco (`ListenerRecord::callback`).
+//! O coletor deste motor acha o que está vivo por duas vias: o que o `Context`
+//! segura e uma varredura CONSERVATIVA da pilha da máquina. Um inteiro dentro
+//! de um `HashMap` do Rust não é nenhuma das duas — `roots::scan_stack`
+//! procura palavras que sejam referências CODIFICADAS, e um índice cru não o
+//! é. Logo a célula do closure é varrida enquanto o listener continua
+//! registado, e a invocação seguinte (`engine.invoke_cb`) encontra o que ficou
+//! no lugar.
+//!
+//! O sintoma é `TypeError: object is not a function` — a mesma assinatura que
+//! `rts_core::entry::functions` documenta para uma raiz perdida — num
+//! `addEventListener` que NUNCA foi removido, sobre um elemento que continua
+//! na árvore. Não é raro nem exótico: chega assim que houver alocação
+//! suficiente para o coletor correr, o que numa página com um relógio são
+//! segundos. Reproduzido em 25 linhas sem React e sem janela: registar um
+//! listener, alocar 400 000 objectos, despachar o evento.
+//!
+//! É a terceira ocorrência da classe descrita em `docs/engine/lost-roots.md`,
+//! e a que esse documento previu por escrito: *cada tabela lateral nova é uma
+//! hipótese nova de faltar na lista*. Esta tabela foi escrita depois do aviso.
+//!
+//! # Porque uma RECONCILIAÇÃO e não um par take/release
+//!
+//! O óbvio seria segurar no `addEventListener` e largar no
+//! `removeEventListener`. Não chega, porque nem todas as remoções passam pela
+//! ponte: `once` remove o listener a meio do próprio despacho, dentro do
+//! `rts-dom`, e `removeEventListener(type)` apaga vários de uma vez. Um
+//! par simétrico deixaria posses penduradas — um vazamento silencioso, que é
+//! só o outro lado da moeda do defeito que se está a corrigir.
+//!
+//! Então em vez de contabilizar transições, compara-se ESTADOS: depois de
+//! qualquer operação que possa mexer na lista, pergunta-se ao documento que
+//! words tem, segura-se o que é novo e larga-se o que desapareceu. É O(n) sobre
+//! os listeners de um documento — dezenas, não milhares — e é robusto a
+//! remoções que a ponte não vê, que é a propriedade que interessa.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use rts_core::entry::external;
+
+thread_local! {
+    /// Por documento, o que já está seguro: word do callback → identificador da
+    /// posse. Por documento e não global porque `free(doc)` tem de poder largar
+    /// tudo o que era só dele sem tocar noutro que continue vivo.
+    static POSSE: RefCell<HashMap<u64, HashMap<i64, u32>>> = RefCell::new(HashMap::new());
+}
+
+/// Põe as posses deste documento de acordo com os listeners que ele tem agora.
+///
+/// Chamada depois de cada operação que possa acrescentar ou tirar um listener,
+/// incluindo o despacho — é lá que os `once` se removem sozinhos.
+pub fn sincroniza(h: u64) {
+    let Some(mut vivos) = rts_dom::store::with_dom(h, |d| {
+        // Os do lote em curso entram TAMBÉM: um `once` já saiu da lista de
+        // listeners quando foi coletado, e ainda vai ser invocado. Largá-lo
+        // aqui seria recriar o defeito exactamente na janela mais curta que
+        // ele tem.
+        let mut words = d.callback_words();
+        for word in d.pending_dispatch_words() {
+            if !words.contains(&word) {
+                words.push(word);
+            }
+        }
+        words
+    }) else {
+        // O documento já não existe: larga tudo o que era dele.
+        liberta_documento(h);
+        return;
+    };
+    POSSE.with(|posse| {
+        let mut posse = posse.borrow_mut();
+        let deste = posse.entry(h).or_default();
+        vivos.sort_unstable();
+        for word in &vivos {
+            if !deste.contains_key(word) {
+                // `hold` guarda os BITS do valor, que é o que o word já é.
+                // `hold` guarda os BITS do valor, que é o que o word já é.
+                deste.insert(*word, external::hold_current(*word as u64));
+            }
+        }
+        deste.retain(|word, id| {
+            if vivos.binary_search(word).is_ok() {
+                true
+            } else {
+                external::release_current(*id);
+                false
+            }
+        });
+        if deste.is_empty() {
+            posse.remove(&h);
+        }
+    });
+}
+
+/// Larga tudo o que este documento segurava. `free(doc)` chama isto.
+///
+/// Sem esta linha o defeito trocava de sinal: o documento morria e os handlers
+/// dele ficavam vivos para sempre, o que numa aplicação que abre e fecha
+/// páginas é um crescimento sem fim.
+pub fn liberta_documento(h: u64) {
+    POSSE.with(|posse| {
+        if let Some(deste) = posse.borrow_mut().remove(&h) {
+            for id in deste.values() {
+                external::release_current(*id);
+            }
+        }
+    });
+}

--- a/crates/rts-dom-bridge/src/tree.rs
+++ b/crates/rts-dom-bridge/src/tree.rs
@@ -51,6 +51,7 @@ extern "C" fn create_document(_e: u64, _t: u64, _a: u64, _b: u64, _c: u64, _d: u
 
 /// `free(doc)` — solta o documento. O handle fica inválido.
 extern "C" fn free(_e: u64, _t: u64, doc: u64, _a: u64, _b: u64, _c: u64) -> u64 {
+    crate::raizes::liberta_documento(handle(doc));
     rts_dom::store::remove(handle(doc));
     nothing()
 }

--- a/crates/rts-dom/src/dom/eventos.rs
+++ b/crates/rts-dom/src/dom/eventos.rs
@@ -104,6 +104,34 @@ impl Dom {
         self.listener_cbs.remove(&(idx, event_type.to_string()));
     }
 
+    /// Todos os words de callback que este documento ainda guarda.
+    ///
+    /// Existe para quem tem de os manter VIVOS. Um `ListenerRecord` guarda o
+    /// handler como `i64` opaco, e uma varredura conservativa da pilha não
+    /// reconhece um inteiro num `HashMap` do Rust como uma referência — logo o
+    /// coletor recolhe a célula do closure enquanto o listener continua
+    /// registado, e a invocação seguinte encontra o que ficou no índice. O
+    /// sintoma é `TypeError: object is not a function` num `addEventListener`
+    /// que nunca foi removido, e chega depois de alocação suficiente: uma
+    /// página com relógio perde os handlers em segundos.
+    ///
+    /// Este crate não pode enraizar nada — não tem dependências, e é isso que
+    /// o mantém portável. Responde QUE words tem; quem sabe falar com o
+    /// coletor (a ponte) é que os segura. A alternativa — guardar aqui um
+    /// identificador de posse — obrigaria este crate a conhecer o runtime, que
+    /// é exactamente a dependência que ele não tem.
+    pub fn callback_words(&self) -> Vec<i64> {
+        let mut words = Vec::new();
+        for records in self.listener_cbs.values() {
+            for record in records {
+                if !words.contains(&record.callback) {
+                    words.push(record.callback);
+                }
+            }
+        }
+        words
+    }
+
     /// `true` se o nó escuta o tipo de evento dado (case-sensitive).
     pub fn has_listener(&self, id: NodeId, event_type: &str) -> bool {
         let Some(idx) = self.resolve(id) else {
@@ -477,6 +505,18 @@ impl Dom {
     /// Nº de callbacks coletados pelo último [`Dom::dispatch_event_collect`].
     pub fn last_dispatch_len(&self) -> i64 {
         self.last_dispatch.len() as i64
+    }
+
+    /// Os words do lote de despacho AINDA POR INVOCAR.
+    ///
+    /// Um `once` é retirado da lista de listeners dentro do `dispatch_collect`,
+    /// antes de ser chamado — é essa a semântica do DOM. Quem mantém os
+    /// callbacks vivos não pode, portanto, olhar só para os listeners
+    /// registados: entre a coleta e a invocação há words que já não estão
+    /// registados em lado nenhum e que ainda vão ser chamados. Esta lista é
+    /// esses.
+    pub fn pending_dispatch_words(&self) -> Vec<i64> {
+        self.last_dispatch.iter().map(|&(_, cb)| cb).collect()
     }
 
     /// O i-ésimo par coletado: `(NodeId versionado do nó que escuta, callback-word)`.

--- a/tests/claude-dom-listener-sobrevive-ao-gc.test.ts
+++ b/tests/claude-dom-listener-sobrevive-ao-gc.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "rts:test";
+import dom from "rts:dom";
+
+// Um listener de DOM tem de sobreviver ao COLETOR — e não sobrevivia.
+//
+// O `Dom` guarda cada handler como um `i64` opaco (`ListenerRecord::callback`).
+// O coletor deste motor descobre o que está vivo por duas vias: o que o
+// `Context` segura, e uma varredura CONSERVATIVA da pilha da máquina. Um inteiro
+// dentro de um `HashMap` do Rust não é nenhuma das duas — `roots::scan_stack`
+// procura palavras que sejam referências CODIFICADAS, e um índice cru não o é.
+// A célula do closure era varrida com o listener ainda registado, e a invocação
+// seguinte encontrava o que tivesse ficado no lugar: `TypeError: object is not a
+// function`, num `addEventListener` que nunca foi removido, sobre um elemento
+// que continua na árvore.
+//
+// Este teste é a reprodução mínima, e o que ele pina é a ORDEM: registar,
+// alocar o suficiente para o coletor correr, e só então despachar. Sem a
+// alocação no meio ele passa mesmo com o defeito presente — foi assim que o
+// defeito viveu tanto tempo, porque toda a gente que escreve um teste de
+// eventos despacha logo a seguir a registar.
+//
+// O alcance era muito para além de um caso exótico: qualquer página com um
+// relógio e um `addEventListener` perde os handlers ao fim de segundos. Foi
+// encontrado num jogo em React que corre a 60 fps.
+
+const doc = parseDocument("<div id='alvo'>alvo</div>");
+const alvo = doc.getElementById("alvo");
+
+let entregues = 0;
+if (alvo !== null) {
+  alvo.addEventListener("click", () => {
+    entregues = entregues + 1;
+  });
+}
+
+// Antes de despachar, ALOCAR. O número é generoso de propósito: tem de forçar
+// pelo menos uma coleta em qualquer configuração de heap, e um teste que só
+// falha em metade das máquinas não pina nada.
+let lixo: any[] = [];
+let i = 0;
+while (i < 200000) {
+  lixo.push({ a: i, s: "x" + i });
+  if (i % 20000 === 0) lixo = [];
+  i = i + 1;
+}
+
+let entreguesDepois = 0;
+if (alvo !== null) {
+  alvo.dispatchEvent("click");
+  alvo.dispatchEvent("click");
+  entreguesDepois = entregues;
+}
+
+// E o mesmo para um listener registado por um `<script>` da página, que é o
+// caminho por onde uma página real regista os seus.
+const pagina = parseDocument(
+  "<button id='b'>x</button>" +
+    "<script>" +
+    "var n = 0;" +
+    "document.getElementById('b').addEventListener('click', function () { n = n + 1; });" +
+    "var lixo = [];" +
+    "var i = 0;" +
+    "while (i < 200000) { lixo.push({ a: i, s: 'x' + i }); if (i % 20000 === 0) { lixo = []; } i = i + 1; }" +
+    "document.getElementById('b').dispatchEvent('click');" +
+    "document.getElementById('st').textContent = '' + n;" +
+    "</script>" +
+    "<div id='st'>?</div>",
+);
+runScriptsAt(pagina, "https://localhost/");
+const estado = pagina.getElementById("st");
+const contadoNaPagina = estado === null ? "?" : estado.textContent;
+
+describe("um listener sobrevive à coleta de lixo", () => {
+  test("o callback continua a ser chamado depois de alocação pesada", () => {
+    expect(entreguesDepois).toBe(2);
+  });
+
+  test("o mesmo por um <script> da página", () => {
+    expect(contadoNaPagina).toBe("1");
+  });
+});


### PR DESCRIPTION
`body { addEventListener }` + um relógio = os handlers morrem em segundos.

## O defeito

O `Dom` guarda cada handler como um `i64` opaco (`ListenerRecord::callback`). O coletor deste motor descobre o que está vivo por duas vias — o que o `Context` segura, e uma varredura **conservativa** da pilha da máquina. Um inteiro dentro de um `HashMap` do Rust não é nenhuma das duas: `roots::scan_stack` procura palavras que sejam referências *codificadas*, e um índice cru não o é.

A célula do closure era varrida com o listener ainda registado, e a invocação seguinte encontrava o que tivesse ficado no lugar — `TypeError: object is not a function`, a assinatura que `entry/functions.rs` já documenta para uma raiz perdida.

**O alcance não é exótico.** Qualquer página com um relógio e um `addEventListener` perde os seus handlers ao fim de segundos, sobre elementos que continuam na árvore e listeners que nunca foram removidos.

## Como apareceu

Num jogo do dinossauro em React 18 a correr na janela nativa: o salto respondia durante uns segundos e depois o processo morria. As três experiências que isolaram a causa:

| experiência | resultado |
|---|---|
| janela aberta 20 s, sem tocar | ok |
| janela com cliques | rebenta |
| sem janela, 8 cliques por `element.click()` | ok |

O caminho do input estava inocente: o clique era o que *invocava* o callback já morto. Reproduzido depois em 25 linhas sem React e sem janela — registar o listener, alocar 400 000 objetos, despachar o evento.

## A correção

A ponte segura os words com `external::hold`, o mecanismo que já existia para o N-API guardar valores entre chamadas. O `rts-dom` continua sem dependências: responde **que** words tem (`callback_words`, `pending_dispatch_words`), e quem sabe falar com o coletor é que os segura.

**Rejeitado:** segurar no `addEventListener` e largar no `removeEventListener`. Nem todas as remoções passam pela ponte — um `once` remove-se a si próprio dentro do despacho, e `removeEventListener(type)` apaga vários de uma vez — e um par simétrico deixaria posses penduradas, que é só o outro lado da moeda do defeito. Em vez de contabilizar transições, compara-se **estados**. O lote de despacho em curso conta como vivo, senão largava-se um `once` entre a coleta e a invocação.

## O teste, e a razão de ele ser assim

`tests/claude-dom-listener-sobrevive-ao-gc.test.ts` pina a **ordem**: registar, ALOCAR, e só então despachar. Sem a alocação no meio passa mesmo com o defeito presente — que é como o defeito viveu tanto tempo, já que todo o teste de eventos que existia despacha logo a seguir a registar.

Verificado nos dois sentidos, e não só no verde:

```
fix desligado:  rts: uncaught exception (tag 1): TypeError: object is not a function
fix religado:   ✓ 2 tests passed
```

`cargo test -p rts-dom -p rts-dom-bridge`: **1 039 passam, 0 falham**.

## Contexto

Terceira ocorrência da classe de `docs/engine/lost-roots.md` — e a que esse documento previu por escrito: *cada tabela lateral nova é uma hipótese nova de faltar na lista*. Esta tabela foi escrita depois do aviso. As outras duas continuam abertas: #2035 (locais de função) e #419 (epic, do motor antigo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEoReGsdvLurjxUR3ZsL5x